### PR TITLE
feat: handle macOS FSEvents coalescing for M4A folder ingest

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,11 +1,5 @@
 ## Backlog
 
-### Support Purchases from Apple Music Store
-
-*If I put a folder of .M4A files I purchased in the iTunes store into my staging folder, it should be tagged, imaged, and added to my library.*
-
-Currently, this doesn't appear to work. These files are either completely ignored, or the errors don't show up in the daemon log.
-
 ### Bandcamp Album Art
 
 *If an archive already has high quality album art, I want to use that (as long as it's not too big)*
@@ -17,6 +11,8 @@ If the art that is distributed with the archive is not larger than config.artwor
 If the art is larger than config.artwork.max_bytes, scale it down to an acceptable size.
 
 If the art is smaller than 1/2 config.artwork.max_bytes or doesn't meet config.artwork.min_dimension requirements, fall back to our existing image search.
+
+### Switch to Poetry for dependency management
 
 ### Interactive First Run Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `on_moved` handler in watcher: items dragged into staging on the same filesystem (macOS Finder) are now scheduled for processing
+- `on_modified` handler in watcher: fixes macOS FSEvents coalescing drag-and-drop renames into `DirModifiedEvent` on the staging parent instead of emitting `DirCreatedEvent`/`DirMovedEvent` for the new item — the root cause of M4A folders being silently ignored
+- MusicBrainz edition-suffix retry in tagger: album names with iTunes suffixes like "(Deluxe Edition)" or "(Remastered)" are stripped and retried once before failing, so those releases are matched correctly
+
+---
+
 ## [0.2.3](https://github.com/eightyeighteyes/tune-shifter/compare/v0.2.2...v0.2.3) (2026-03-15)
 
 

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -142,3 +142,50 @@ class TestTagDirectory:
             release = tag_directory(tmp_path, [mp3])
 
         assert release.mbid == "high"
+
+
+class TestEditionSuffixRetry:
+    def test_retries_with_cleaned_album_name(self, tmp_path: Path) -> None:
+        """First search with "(Deluxe Edition)" returns nothing; retry with stripped
+        name succeeds and tags are written."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3, album="Great Album (Deluxe Edition)", track=1)
+
+        empty: dict[str, Any] = {"release-list": []}
+
+        with patch(
+            "musicbrainzngs.search_releases", side_effect=[empty, SAMPLE_RELEASE]
+        ) as mock_search:
+            release = tag_directory(tmp_path, [mp3])
+
+        assert release.mbid == "abc-123"
+        # First call used the full name; second used the stripped name
+        assert mock_search.call_count == 2
+        first_call_album = mock_search.call_args_list[0].kwargs["release"]
+        second_call_album = mock_search.call_args_list[1].kwargs["release"]
+        assert "Deluxe Edition" in first_call_album
+        assert "Deluxe Edition" not in second_call_album
+
+    def test_no_retry_when_album_has_no_suffix(self, tmp_path: Path) -> None:
+        """Album names without an edition suffix do not trigger a second search."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3, album="Great Album", track=1)
+
+        with patch(
+            "musicbrainzngs.search_releases", return_value={"release-list": []}
+        ) as mock_search:
+            with pytest.raises(TaggingError):
+                tag_directory(tmp_path, [mp3])
+
+        assert mock_search.call_count == 1
+
+    def test_raises_when_retry_also_finds_nothing(self, tmp_path: Path) -> None:
+        """If both the original and cleaned name return no results, TaggingError is raised."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3, album="Obscure Album (Remastered)", track=1)
+
+        empty: dict[str, Any] = {"release-list": []}
+
+        with patch("musicbrainzngs.search_releases", return_value=empty):
+            with pytest.raises(TaggingError, match="No MusicBrainz results"):
+                tag_directory(tmp_path, [mp3])

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -63,9 +63,7 @@ def _dir_created_event(path: str) -> MagicMock:
 
 
 class TestOnMoved:
-    def test_directory_moved_into_staging_is_scheduled(
-        self, config: Config
-    ) -> None:
+    def test_directory_moved_into_staging_is_scheduled(self, config: Config) -> None:
         """Dragging a folder from Finder fires a moved event; it must be scheduled."""
         handler = _make_handler(config)
         dest = str(config.paths.staging / "my-album")
@@ -133,9 +131,7 @@ class TestOnModified:
 
         mock_schedule.assert_called_once_with(album_dir)
 
-    def test_staging_root_modified_ignores_errors_dir(
-        self, config: Config
-    ) -> None:
+    def test_staging_root_modified_ignores_errors_dir(self, config: Config) -> None:
         handler = _make_handler(config)
         (config.paths.staging / "errors").mkdir()
 
@@ -144,9 +140,7 @@ class TestOnModified:
 
         mock_schedule.assert_not_called()
 
-    def test_modified_event_on_subdirectory_is_ignored(
-        self, config: Config
-    ) -> None:
+    def test_modified_event_on_subdirectory_is_ignored(self, config: Config) -> None:
         """Modification events inside staging subdirectories are not acted on."""
         handler = _make_handler(config)
         subdir = config.paths.staging / "subdir"
@@ -157,9 +151,7 @@ class TestOnModified:
 
         mock_schedule.assert_not_called()
 
-    def test_already_pending_items_not_rescheduled(
-        self, config: Config
-    ) -> None:
+    def test_already_pending_items_not_rescheduled(self, config: Config) -> None:
         handler = _make_handler(config)
         album_dir = config.paths.staging / "my-album"
         album_dir.mkdir()
@@ -175,9 +167,7 @@ class TestOnModified:
 
 
 class TestOnCreated:
-    def test_directory_created_in_staging_is_scheduled(
-        self, config: Config
-    ) -> None:
+    def test_directory_created_in_staging_is_scheduled(self, config: Config) -> None:
         handler = _make_handler(config)
         path = str(config.paths.staging / "my-album")
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,196 @@
+"""Tests for the filesystem watcher event handling."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tune_shifter.config import (
+    ArtworkConfig,
+    Config,
+    LibraryConfig,
+    MusicBrainzConfig,
+    PathsConfig,
+)
+from tune_shifter.watcher import _StagingHandler
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> Config:
+    return Config(
+        paths=PathsConfig(
+            staging=tmp_path / "staging",
+            library=tmp_path / "library",
+        ),
+        musicbrainz=MusicBrainzConfig(
+            app_name="tune-shifter-test",
+            app_version="0.0.1",
+            contact="test@example.com",
+        ),
+        artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
+        library=LibraryConfig(
+            path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+        ),
+    )
+
+
+def _make_handler(config: Config) -> _StagingHandler:
+    config.paths.staging.mkdir(parents=True, exist_ok=True)
+    return _StagingHandler(config)
+
+
+def _dir_moved_event(src: str, dest: str) -> MagicMock:
+    event = MagicMock()
+    event.is_directory = True
+    event.src_path = src
+    event.dest_path = dest
+    return event
+
+
+def _file_moved_event(src: str, dest: str) -> MagicMock:
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = src
+    event.dest_path = dest
+    return event
+
+
+def _dir_created_event(path: str) -> MagicMock:
+    event = MagicMock()
+    event.is_directory = True
+    event.src_path = path
+    return event
+
+
+class TestOnMoved:
+    def test_directory_moved_into_staging_is_scheduled(
+        self, config: Config
+    ) -> None:
+        """Dragging a folder from Finder fires a moved event; it must be scheduled."""
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "my-album")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_dir_moved_event("/tmp/my-album", dest))
+
+        mock_schedule.assert_called_once_with(Path(dest))
+
+    def test_zip_moved_into_staging_is_scheduled(self, config: Config) -> None:
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "album.zip")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_file_moved_event("/tmp/album.zip", dest))
+
+        mock_schedule.assert_called_once_with(Path(dest))
+
+    def test_directory_moved_into_subdir_is_ignored(self, config: Config) -> None:
+        """Items moved into a subdirectory of staging (not directly into root) are skipped."""
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "subdir" / "my-album")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_dir_moved_event("/tmp/my-album", dest))
+
+        mock_schedule.assert_not_called()
+
+    def test_errors_directory_moved_in_is_ignored(self, config: Config) -> None:
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "errors")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_dir_moved_event("/tmp/errors", dest))
+
+        mock_schedule.assert_not_called()
+
+    def test_non_zip_file_moved_in_is_ignored(self, config: Config) -> None:
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "track.mp3")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_file_moved_event("/tmp/track.mp3", dest))
+
+        mock_schedule.assert_not_called()
+
+
+class TestOnModified:
+    def _dir_modified_event(self, path: str) -> MagicMock:
+        event = MagicMock()
+        event.is_directory = True
+        event.src_path = path
+        return event
+
+    def test_staging_root_modified_schedules_new_directory(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        """DirModifiedEvent on staging root (FSEvents rename coalescing) triggers schedule."""
+        handler = _make_handler(config)
+        album_dir = config.paths.staging / "my-album"
+        album_dir.mkdir()
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+
+        mock_schedule.assert_called_once_with(album_dir)
+
+    def test_staging_root_modified_ignores_errors_dir(
+        self, config: Config
+    ) -> None:
+        handler = _make_handler(config)
+        (config.paths.staging / "errors").mkdir()
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+
+        mock_schedule.assert_not_called()
+
+    def test_modified_event_on_subdirectory_is_ignored(
+        self, config: Config
+    ) -> None:
+        """Modification events inside staging subdirectories are not acted on."""
+        handler = _make_handler(config)
+        subdir = config.paths.staging / "subdir"
+        subdir.mkdir()
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_modified(self._dir_modified_event(str(subdir)))
+
+        mock_schedule.assert_not_called()
+
+    def test_already_pending_items_not_rescheduled(
+        self, config: Config
+    ) -> None:
+        handler = _make_handler(config)
+        album_dir = config.paths.staging / "my-album"
+        album_dir.mkdir()
+
+        # Simulate an already-pending path
+        fake_timer = MagicMock()
+        handler._pending[album_dir] = fake_timer
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+
+        mock_schedule.assert_not_called()
+
+
+class TestOnCreated:
+    def test_directory_created_in_staging_is_scheduled(
+        self, config: Config
+    ) -> None:
+        handler = _make_handler(config)
+        path = str(config.paths.staging / "my-album")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_created(_dir_created_event(path))
+
+        mock_schedule.assert_called_once_with(Path(path))
+
+    def test_errors_directory_created_is_ignored(self, config: Config) -> None:
+        handler = _make_handler(config)
+        path = str(config.paths.staging / "errors")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_created(_dir_created_event(path))
+
+        mock_schedule.assert_not_called()

--- a/tune_shifter/tagger.py
+++ b/tune_shifter/tagger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,17 @@ import mutagen.id3 as id3
 import mutagen.mp4
 
 logger = logging.getLogger(__name__)
+
+# Matches iTunes-style edition suffixes in album names, e.g. "(Deluxe Edition)",
+# "[Remastered]", "(Super Deluxe Version)".  Stripped before retrying a failed
+# MusicBrainz search so that "Album (Deluxe Edition)" can still match "Album".
+_EDITION_RE = re.compile(
+    r"\s*[\(\[]"
+    r"(deluxe|expanded|remastered|anniversary|special|super deluxe|"
+    r"bonus track|explicit|clean|international)"
+    r"[^\)\]]*[\)\]]",
+    re.IGNORECASE,
+)
 
 
 class TaggingError(Exception):
@@ -113,6 +125,23 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
         raise TaggingError(f"MusicBrainz search failed: {exc}") from exc
 
     releases: list[dict[str, Any]] = result.get("release-list", [])
+
+    if not releases:
+        # Retry once with any iTunes edition suffix stripped from the album name
+        # (e.g. "Abbey Road (Super Deluxe Edition)" → "Abbey Road").
+        cleaned = _EDITION_RE.sub("", album).strip()
+        if cleaned != album:
+            logger.debug(
+                "No results for %r; retrying with cleaned name %r", album, cleaned
+            )
+            try:
+                result = musicbrainzngs.search_releases(
+                    artist=artist, release=cleaned, limit=5
+                )
+            except musicbrainzngs.WebServiceError as exc:
+                raise TaggingError(f"MusicBrainz search failed: {exc}") from exc
+            releases = result.get("release-list", [])
+
     if not releases:
         raise TaggingError(
             f"No MusicBrainz results for artist={artist!r} album={album!r}"

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -7,7 +7,12 @@ import threading
 import time
 from pathlib import Path
 
-from watchdog.events import FileCreatedEvent, FileSystemEvent, FileSystemEventHandler
+from watchdog.events import (
+    FileCreatedEvent,
+    FileSystemEvent,
+    FileSystemEventHandler,
+    FileSystemMovedEvent,
+)
 from watchdog.observers import Observer
 
 from .config import Config
@@ -23,6 +28,7 @@ class _StagingHandler(FileSystemEventHandler):
     def __init__(self, config: Config) -> None:
         super().__init__()
         self._config = config
+        self._staging_root = config.paths.staging
         # Track paths being debounced: path → timer
         self._pending: dict[Path, threading.Timer] = {}
         self._lock = threading.Lock()
@@ -38,6 +44,45 @@ class _StagingHandler(FileSystemEventHandler):
             path = Path(str(event.src_path))
             if path.suffix.lower() == ".zip":
                 self._schedule(path)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        # FSEvents on macOS coalesces renames into DirModifiedEvent on the parent
+        # directory rather than emitting DirCreatedEvent/DirMovedEvent for the new
+        # item. Scan staging root on every modification and schedule any item that
+        # has appeared and is not already pending.
+        if not event.is_directory:
+            return
+        if Path(str(event.src_path)) != self._staging_root:
+            return
+        self._scan_staging_root()
+
+    def _scan_staging_root(self) -> None:
+        """Schedule any directories or ZIPs in staging that are not already pending."""
+        try:
+            children = list(self._staging_root.iterdir())
+        except OSError:
+            return
+        with self._lock:
+            pending_paths = set(self._pending)
+        for child in children:
+            if child in pending_paths:
+                continue
+            if child.is_dir() and child.name != "errors":
+                self._schedule(child)
+            elif child.is_file() and child.suffix.lower() == ".zip":
+                self._schedule(child)
+
+    def on_moved(self, event: FileSystemMovedEvent) -> None:
+        # On macOS, dragging a folder/file into staging fires a moved event rather
+        # than a created event. Handle it the same way, but only for items whose
+        # destination is directly inside staging (not nested subdirectories).
+        dest = Path(str(event.dest_path))
+        if dest.parent != self._staging_root:
+            return
+        if event.is_directory and dest.name != "errors":
+            self._schedule(dest)
+        elif not event.is_directory and dest.suffix.lower() == ".zip":
+            self._schedule(dest)
 
     def _schedule(self, path: Path) -> None:
         with self._lock:


### PR DESCRIPTION
on_modified handler scans staging root on DirModifiedEvent so folders dragged in via Finder are processed even when FSEvents drops the DirCreatedEvent/DirMovedEvent. Also retries MusicBrainz searches with edition suffixes stripped (Deluxe Edition, Remastered, etc.).