### PR TITLE
fix: M4A tagging — full release details and release-group artwork fallback

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,5 +1,6 @@
 # Language
 - Python 3
+- Poetry for dependency management & packaging
 
 # Code Style
 - Follow PEP8 and use black for formatting
@@ -11,5 +12,5 @@
 # Workflow
 - Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance
-- Update documentation after new features are validated
+- Update documentation (README.md) after new features are validated
 - Document rationale in comments: succinctly explain *why* decisions are made

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -115,10 +115,54 @@ class TestFetchAndEmbed:
 
         with patch(
             "tune_shifter.artwork.requests.get",
-            side_effect=req_lib.RequestException("timeout"),
+            side_effect=req_lib.ConnectionError("timeout"),
         ):
             with pytest.raises(ArtworkError, match="Could not fetch cover art listing"):
                 fetch_and_embed("abc-123", [], min_dimension=1000, max_bytes=1_000_000)
+
+    def test_404_falls_back_to_release_group(self, tmp_path: Path) -> None:
+        """A 404 on the release MBID silently falls back to the release-group endpoint."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+
+        image_bytes = _make_jpeg(1200, 1200)
+        listing = _listing_response("http://example.com/cover.jpg")
+
+        import requests as req_lib
+
+        call_count = 0
+
+        def mock_get(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            if call_count == 1:
+                # First call: release MBID → 404
+                http_err = req_lib.HTTPError(response=MagicMock(status_code=404))
+                resp.raise_for_status.side_effect = http_err
+            elif call_count == 2:
+                # Second call: release-group listing
+                resp.raise_for_status.return_value = None
+                resp.json.return_value = listing
+            else:
+                # Third call: download the image
+                resp.raise_for_status.return_value = None
+                resp.content = image_bytes
+            return resp
+
+        with patch("tune_shifter.artwork.requests.get", mock_get):
+            fetch_and_embed(
+                "release-mbid",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                release_group_mbid="group-mbid",
+            )
+
+        import mutagen.id3 as id3
+
+        tags = id3.ID3(str(mp3))
+        assert any(k.startswith("APIC") for k in tags)
 
     def test_no_images_in_listing_is_graceful(self, tmp_path: Path) -> None:
         mp3 = tmp_path / "01.mp3"
@@ -133,3 +177,22 @@ class TestFetchAndEmbed:
         with patch("tune_shifter.artwork.requests.get", mock_get):
             # Should complete without raising
             fetch_and_embed("abc-123", [mp3], min_dimension=1000, max_bytes=1_000_000)
+
+    def test_embeds_qualifying_jpeg_in_m4a(self, tmp_path: Path) -> None:
+        m4a = tmp_path / "01.m4a"
+        m4a.write_bytes(b"\x00" * 64)
+
+        image_bytes = _make_jpeg(1200, 1200)
+        listing = _listing_response("http://example.com/cover.jpg")
+        mock_get = _mock_requests_get(listing, image_bytes)
+
+        mock_tags: dict = {}
+        mock_mp4 = MagicMock()
+        mock_mp4.tags = mock_tags
+
+        with patch("tune_shifter.artwork.mutagen.mp4.MP4", return_value=mock_mp4):
+            with patch("tune_shifter.artwork.requests.get", mock_get):
+                fetch_and_embed("abc-123", [m4a], min_dimension=1000, max_bytes=5_000_000)
+
+        assert "covr" in mock_tags
+        mock_mp4.save.assert_called_once()

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -192,7 +192,9 @@ class TestFetchAndEmbed:
 
         with patch("tune_shifter.artwork.mutagen.mp4.MP4", return_value=mock_mp4):
             with patch("tune_shifter.artwork.requests.get", mock_get):
-                fetch_and_embed("abc-123", [m4a], min_dimension=1000, max_bytes=5_000_000)
+                fetch_and_embed(
+                    "abc-123", [m4a], min_dimension=1000, max_bytes=5_000_000
+                )
 
         assert "covr" in mock_tags
         mock_mp4.save.assert_called_once()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -52,6 +52,7 @@ def _make_zip(path: Path, tracks: list[str]) -> Path:
 
 MOCK_RELEASE = ReleaseInfo(
     mbid="release-abc",
+    release_group_mbid="rg-abc",
     title="Great Album",
     artist="Cool Artist",
     album_artist="Cool Artist",
@@ -70,25 +71,36 @@ MB_SEARCH_RESULT: dict[str, Any] = {
             "date": "2020",
             "ext:score": "100",
             "artist-credit": [{"artist": {"name": "Cool Artist"}}],
-            "medium-list": [
-                {
-                    "position": "1",
-                    "track-list": [
-                        {
-                            "number": "1",
-                            "position": "1",
-                            "recording": {"title": "First Track"},
-                        },
-                        {
-                            "number": "2",
-                            "position": "2",
-                            "recording": {"title": "Second Track"},
-                        },
-                    ],
-                }
-            ],
+            "medium-list": [],
         }
     ]
+}
+
+MB_RELEASE_DETAIL: dict[str, Any] = {
+    "release": {
+        "id": "release-abc",
+        "title": "Great Album",
+        "date": "2020",
+        "artist-credit": [{"artist": {"name": "Cool Artist"}}],
+        "release-group": {"id": "rg-abc"},
+        "medium-list": [
+            {
+                "position": "1",
+                "track-list": [
+                    {
+                        "number": "1",
+                        "position": "1",
+                        "recording": {"title": "First Track"},
+                    },
+                    {
+                        "number": "2",
+                        "position": "2",
+                        "recording": {"title": "Second Track"},
+                    },
+                ],
+            }
+        ],
+    }
 }
 
 
@@ -119,6 +131,7 @@ class TestPipelineRun:
         # Patch network calls
         with (
             patch("musicbrainzngs.search_releases", return_value=MB_SEARCH_RESULT),
+            patch("musicbrainzngs.get_release_by_id", return_value=MB_RELEASE_DETAIL),
             patch("tune_shifter.artwork.requests.get") as mock_get,
         ):
             # Make artwork fetch return an empty listing (no art — that's fine)

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import mutagen.id3 as id3
 import mutagen.mp4
@@ -41,6 +41,34 @@ SAMPLE_RELEASE: dict[str, Any] = {
             ],
         }
     ]
+}
+
+# Full release detail returned by get_release_by_id — includes date, tracks, release-group.
+SAMPLE_RELEASE_DETAIL: dict[str, Any] = {
+    "release": {
+        "id": "abc-123",
+        "title": "Great Album",
+        "date": "2020-04-01",
+        "artist-credit": [{"artist": {"name": "Cool Artist"}}],
+        "release-group": {"id": "rg-456"},
+        "medium-list": [
+            {
+                "position": "1",
+                "track-list": [
+                    {
+                        "number": "1",
+                        "position": "1",
+                        "recording": {"title": "First Track"},
+                    },
+                    {
+                        "number": "2",
+                        "position": "2",
+                        "recording": {"title": "Second Track"},
+                    },
+                ],
+            }
+        ],
+    }
 }
 
 
@@ -101,9 +129,13 @@ class TestTagDirectory:
         _make_mp3(mp3, track=1)
 
         with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
-            release = tag_directory(tmp_path, [mp3])
+            with patch(
+                "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+            ):
+                release = tag_directory(tmp_path, [mp3])
 
         assert release.mbid == "abc-123"
+        assert release.release_group_mbid == "rg-456"
         assert release.title == "Great Album"
         assert release.year == "2020"
 
@@ -139,9 +171,13 @@ class TestTagDirectory:
         }
 
         with patch("musicbrainzngs.search_releases", return_value=multi_result):
-            release = tag_directory(tmp_path, [mp3])
+            with patch(
+                "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+            ) as mock_get:
+                tag_directory(tmp_path, [mp3])
 
-        assert release.mbid == "high"
+        # The winning MBID ("high") must be passed to get_release_by_id
+        assert mock_get.call_args[0][0] == "high"
 
 
 class TestEditionSuffixRetry:
@@ -156,7 +192,10 @@ class TestEditionSuffixRetry:
         with patch(
             "musicbrainzngs.search_releases", side_effect=[empty, SAMPLE_RELEASE]
         ) as mock_search:
-            release = tag_directory(tmp_path, [mp3])
+            with patch(
+                "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+            ):
+                release = tag_directory(tmp_path, [mp3])
 
         assert release.mbid == "abc-123"
         # First call used the full name; second used the stripped name
@@ -189,3 +228,54 @@ class TestEditionSuffixRetry:
         with patch("musicbrainzngs.search_releases", return_value=empty):
             with pytest.raises(TaggingError, match="No MusicBrainz results"):
                 tag_directory(tmp_path, [mp3])
+
+
+class TestReadExistingMetadata:
+    def test_raises_when_no_tags_and_directory_not_artist_album(
+        self, tmp_path: Path
+    ) -> None:
+        """No readable tags + directory name not 'Artist - Album' → TaggingError
+        raised before any MusicBrainz call is made."""
+        album_dir = tmp_path / "Psalm 69 The Way to Succeed"
+        album_dir.mkdir()
+        mp3 = album_dir / "01.mp3"
+        # Write a valid MP3 with no artist or album tag
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+
+        with patch("musicbrainzngs.search_releases") as mock_search:
+            with pytest.raises(TaggingError, match="Could not determine artist or album"):
+                tag_directory(album_dir, [mp3])
+
+        mock_search.assert_not_called()
+
+
+class TestTagDirectoryM4a:
+    def test_m4a_tags_written(self, tmp_path: Path) -> None:
+        """MusicBrainz metadata is written to M4A tag fields."""
+        m4a = tmp_path / "01.m4a"
+        m4a.write_bytes(b"\x00" * 64)
+
+        # Simulate an iTunes M4A that already has artist/album/track tags
+        initial_tags: dict[str, Any] = {
+            "\xa9ART": ["Old Artist"],
+            "\xa9alb": ["Old Album"],
+            "trkn": [(1, 0)],
+        }
+        mock_mp4 = MagicMock()
+        mock_mp4.tags = initial_tags
+
+        with patch("tune_shifter.tagger.mutagen.mp4.MP4", return_value=mock_mp4):
+            with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    release = tag_directory(tmp_path, [m4a])
+
+        assert release.mbid == "abc-123"
+        assert initial_tags["\xa9ART"] == ["Cool Artist"]
+        assert initial_tags["\xa9alb"] == ["Great Album"]
+        assert initial_tags["\xa9day"] == ["2020"]
+        assert "----:com.apple.iTunes:MusicBrainz Release Id" in initial_tags
+        mock_mp4.save.assert_called()

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -244,7 +244,9 @@ class TestReadExistingMetadata:
         id3.ID3().save(str(mp3))
 
         with patch("musicbrainzngs.search_releases") as mock_search:
-            with pytest.raises(TaggingError, match="Could not determine artist or album"):
+            with pytest.raises(
+                TaggingError, match="Could not determine artist or album"
+            ):
                 tag_directory(album_dir, [mp3])
 
         mock_search.assert_not_called()

--- a/tune_shifter/artwork.py
+++ b/tune_shifter/artwork.py
@@ -37,13 +37,17 @@ def fetch_and_embed(
     If no qualifying image is found, logs a warning but does not raise — the
     pipeline continues without artwork.
     """
-    image_bytes = _fetch_cover(COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes)
+    image_bytes = _fetch_cover(
+        COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes
+    )
     if image_bytes is None and release_group_mbid:
         logger.debug(
             "No art for release %s; trying release-group %s", mbid, release_group_mbid
         )
         image_bytes = _fetch_cover(
-            RELEASE_GROUP_ART_URL.format(mbid=release_group_mbid), min_dimension, max_bytes
+            RELEASE_GROUP_ART_URL.format(mbid=release_group_mbid),
+            min_dimension,
+            max_bytes,
         )
     if image_bytes is None:
         logger.warning(
@@ -77,9 +81,13 @@ def _fetch_cover(url: str, min_dimension: int, max_bytes: int) -> bytes | None:
         if exc.response is not None and exc.response.status_code == 404:
             logger.debug("No cover art listing at %s (404)", url)
             return None
-        raise ArtworkError(f"Could not fetch cover art listing from {url}: {exc}") from exc
+        raise ArtworkError(
+            f"Could not fetch cover art listing from {url}: {exc}"
+        ) from exc
     except requests.RequestException as exc:
-        raise ArtworkError(f"Could not fetch cover art listing from {url}: {exc}") from exc
+        raise ArtworkError(
+            f"Could not fetch cover art listing from {url}: {exc}"
+        ) from exc
 
     listing: dict[str, Any] = resp.json()
     images: list[dict[str, Any]] = listing.get("images", [])

--- a/tune_shifter/artwork.py
+++ b/tune_shifter/artwork.py
@@ -15,6 +15,7 @@ from PIL import Image
 logger = logging.getLogger(__name__)
 
 COVER_ART_ARCHIVE_URL = "https://coverartarchive.org/release/{mbid}"
+RELEASE_GROUP_ART_URL = "https://coverartarchive.org/release-group/{mbid}"
 
 
 class ArtworkError(Exception):
@@ -26,17 +27,31 @@ def fetch_and_embed(
     audio_files: list[Path],
     min_dimension: int,
     max_bytes: int,
+    release_group_mbid: str = "",
 ) -> None:
     """Download qualifying front cover art and embed it in all audio files.
 
     A qualifying image must be at least *min_dimension* × *min_dimension* pixels
-    and no larger than *max_bytes* bytes.  If no qualifying image is found, logs
-    a warning but does not raise — the pipeline continues without artwork.
+    and no larger than *max_bytes* bytes.  If the release MBID has no art,
+    falls back to the release-group MBID (which aggregates art across all editions).
+    If no qualifying image is found, logs a warning but does not raise — the
+    pipeline continues without artwork.
     """
-    image_bytes = _fetch_cover(mbid, min_dimension, max_bytes)
+    image_bytes = _fetch_cover(COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes)
+    if image_bytes is None and release_group_mbid:
+        logger.debug(
+            "No art for release %s; trying release-group %s", mbid, release_group_mbid
+        )
+        image_bytes = _fetch_cover(
+            RELEASE_GROUP_ART_URL.format(mbid=release_group_mbid), min_dimension, max_bytes
+        )
     if image_bytes is None:
         logger.warning(
-            "No qualifying cover art found for release %s — skipping artwork", mbid
+            "No qualifying cover art found for release %s "
+            "(min %dpx, max %d bytes) — skipping artwork",
+            mbid,
+            min_dimension,
+            max_bytes,
         )
         return
 
@@ -49,16 +64,22 @@ def fetch_and_embed(
         _embed(path, image_bytes)
 
 
-def _fetch_cover(mbid: str, min_dimension: int, max_bytes: int) -> bytes | None:
-    """Return image bytes for the first front cover that meets size criteria."""
-    url = COVER_ART_ARCHIVE_URL.format(mbid=mbid)
+def _fetch_cover(url: str, min_dimension: int, max_bytes: int) -> bytes | None:
+    """Return image bytes for the first front cover at *url* that meets size criteria.
+
+    Returns None if the listing returns 404 (no art available at this URL).
+    Raises ArtworkError for other network failures.
+    """
     try:
         resp = requests.get(url, timeout=15)
         resp.raise_for_status()
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            logger.debug("No cover art listing at %s (404)", url)
+            return None
+        raise ArtworkError(f"Could not fetch cover art listing from {url}: {exc}") from exc
     except requests.RequestException as exc:
-        raise ArtworkError(
-            f"Could not fetch cover art listing for {mbid}: {exc}"
-        ) from exc
+        raise ArtworkError(f"Could not fetch cover art listing from {url}: {exc}") from exc
 
     listing: dict[str, Any] = resp.json()
     images: list[dict[str, Any]] = listing.get("images", [])
@@ -105,6 +126,11 @@ def _fetch_cover(mbid: str, min_dimension: int, max_bytes: int) -> bytes | None:
         )
         return raw
 
+    logger.debug(
+        "No qualifying cover art after checking %d candidate(s) at %s",
+        len(candidates),
+        url,
+    )
     return None
 
 

--- a/tune_shifter/pipeline.py
+++ b/tune_shifter/pipeline.py
@@ -52,6 +52,7 @@ def run(path: Path, config: Config) -> None:
             audio_files=audio_files,
             min_dimension=config.artwork.min_dimension,
             max_bytes=config.artwork.max_bytes,
+            release_group_mbid=release.release_group_mbid,
         )
     except ArtworkError as exc:
         # Artwork failure is non-fatal: log and continue

--- a/tune_shifter/tagger.py
+++ b/tune_shifter/tagger.py
@@ -36,6 +36,7 @@ class ReleaseInfo:
     """Canonical metadata resolved from MusicBrainz."""
 
     mbid: str
+    release_group_mbid: str
     title: str
     artist: str
     album_artist: str
@@ -102,19 +103,28 @@ def _read_existing_metadata(path: Path) -> tuple[str, str]:
                 alb_vals = mp4.tags.get("\xa9alb")
                 artist = str(art_vals[0]) if art_vals else ""
                 album = str(alb_vals[0]) if alb_vals else ""
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Could not read tags from %s: %s", path, exc)
 
     if not artist and not album:
         # Fall back to filename heuristics: "Artist - Album/01 - Title.mp3"
+        logger.debug("Falling back to directory name heuristic for %s", path)
         parts = path.parent.name.split(" - ", 1)
         if len(parts) == 2:
             artist, album = parts[0].strip(), parts[1].strip()
+
+    logger.debug("Read metadata from %s: artist=%r album=%r", path, artist, album)
+
+    if not artist and not album:
+        raise TaggingError(
+            f"Could not determine artist or album from {path} or its directory name"
+        )
 
     return artist, album
 
 
 def _search_release(artist: str, album: str) -> ReleaseInfo:
+    logger.debug("MusicBrainz search: artist=%r release=%r", artist, album)
     try:
         result = musicbrainzngs.search_releases(
             artist=artist,
@@ -125,6 +135,7 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
         raise TaggingError(f"MusicBrainz search failed: {exc}") from exc
 
     releases: list[dict[str, Any]] = result.get("release-list", [])
+    logger.debug("MusicBrainz returned %d result(s)", len(releases))
 
     if not releases:
         # Retry once with any iTunes edition suffix stripped from the album name
@@ -148,13 +159,27 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
         )
 
     best = max(releases, key=lambda r: int(r.get("ext:score", 0)))
-    return _parse_release(best)
+    best_mbid: str = best["id"]
+
+    # search_releases returns minimal data (no full date, no track listings).
+    # Fetch the full release to get accurate year and track info.
+    logger.debug("Fetching full release details for %s", best_mbid)
+    try:
+        detail = musicbrainzngs.get_release_by_id(
+            best_mbid,
+            includes=["artists", "recordings", "release-groups"],
+        )
+    except musicbrainzngs.WebServiceError as exc:
+        raise TaggingError(f"MusicBrainz release lookup failed: {exc}") from exc
+
+    return _parse_release(detail["release"])
 
 
 def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
     mbid: str = raw["id"]
     title: str = raw.get("title", "")
     year: str = raw.get("date", "")[:4]
+    release_group_mbid: str = raw.get("release-group", {}).get("id", "")
 
     artist_credit = raw.get("artist-credit", [])
     artist = ""
@@ -177,6 +202,7 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
 
     return ReleaseInfo(
         mbid=mbid,
+        release_group_mbid=release_group_mbid,
         title=title,
         artist=artist,
         album_artist=album_artist,


### PR DESCRIPTION
## Summary

- Calls `get_release_by_id` after `search_releases` to get accurate year and full track listings (the search API returns incomplete data for these fields)
- Adds `release_group_mbid` to `ReleaseInfo` and passes it to `fetch_and_embed`; Cover Art Archive 404s on the release MBID now fall back to the release-group endpoint, which aggregates art across all editions
- Adds debug logging throughout tagger and artwork so failures are visible in the daemon log
- Guards against empty artist+album raising `TaggingError` early rather than making a useless MusicBrainz query

## Test plan

- [x] Drop an Apple Music M4A folder into staging; confirm year, track titles, and cover art are all present in the output files
- [x] Drop a folder whose release MBID has no Cover Art Archive entry; confirm it falls back to the release-group art
- [x] `pytest tests/test_tagger.py tests/test_artwork.py -v`
- [x] `mypy tune_shifter/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)