### PR TITLE
feat: prefer bundled artwork from archive over Cover Art Archive

### DIFF
--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 
-from tune_shifter.artwork import ArtworkError, fetch_and_embed
+from tune_shifter.artwork import ArtworkError, fetch_and_embed, find_local_artwork
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -198,3 +198,108 @@ class TestFetchAndEmbed:
 
         assert "covr" in mock_tags
         mock_mp4.save.assert_called_once()
+
+
+class TestLocalArtwork:
+    def test_uses_local_cover_jpg_when_qualifying(self, tmp_path: Path) -> None:
+        """A qualifying cover.jpg in the directory is embedded with no network calls."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(_make_jpeg(1200, 1200))
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            fetch_and_embed(
+                "abc-123",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                directory=tmp_path,
+            )
+
+        mock_get.assert_not_called()
+        import mutagen.id3 as id3
+
+        tags = id3.ID3(str(mp3))
+        assert any(k.startswith("APIC") for k in tags)
+
+    def test_falls_back_to_online_when_local_too_small(self, tmp_path: Path) -> None:
+        """A sub-minimum local image triggers the online fallback."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(_make_jpeg(500, 500))
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"images": []}
+            mock_get.return_value = resp
+
+            fetch_and_embed(
+                "abc-123",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                directory=tmp_path,
+            )
+
+        assert mock_get.called
+
+    def test_resizes_oversized_local_art(self, tmp_path: Path) -> None:
+        """Local art exceeding max_bytes is re-encoded to fit within the limit."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        cover = tmp_path / "cover.jpg"
+        # Write a high-quality large JPEG
+        large_jpeg = _make_jpeg(2000, 2000)
+        cover.write_bytes(large_jpeg)
+        max_bytes = len(large_jpeg) // 2  # force re-encoding
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            fetch_and_embed(
+                "abc-123",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=max_bytes,
+                directory=tmp_path,
+            )
+
+        mock_get.assert_not_called()
+        import mutagen.id3 as id3
+
+        tags = id3.ID3(str(mp3))
+        apic_keys = [k for k in tags if k.startswith("APIC")]
+        assert apic_keys
+        embedded_bytes = tags[apic_keys[0]].data
+        assert len(embedded_bytes) <= max_bytes
+
+    def test_prefers_cover_jpg_over_other_images(self, tmp_path: Path) -> None:
+        """cover.jpg is chosen over a non-preferred filename."""
+        (tmp_path / "photo.jpg").write_bytes(_make_jpeg(1200, 1200))
+        (tmp_path / "cover.jpg").write_bytes(_make_jpeg(1200, 1200))
+
+        result = find_local_artwork(tmp_path)
+        assert result is not None
+        assert result.name == "cover.jpg"
+
+    def test_no_local_art_falls_back_to_online(self, tmp_path: Path) -> None:
+        """A directory with no images triggers the online artwork fetch."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"images": []}
+            mock_get.return_value = resp
+
+            fetch_and_embed(
+                "abc-123",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                directory=tmp_path,
+            )
+
+        assert mock_get.called

--- a/tune_shifter/artwork.py
+++ b/tune_shifter/artwork.py
@@ -17,9 +17,85 @@ logger = logging.getLogger(__name__)
 COVER_ART_ARCHIVE_URL = "https://coverartarchive.org/release/{mbid}"
 RELEASE_GROUP_ART_URL = "https://coverartarchive.org/release-group/{mbid}"
 
+_PREFERRED_ART_NAMES = ("cover", "folder", "artwork", "front")
+
 
 class ArtworkError(Exception):
     pass
+
+
+def find_local_artwork(directory: Path) -> Path | None:
+    """Return the best image file found directly in *directory*, or None.
+
+    Prefers filenames whose stem contains a recognised art keyword
+    (cover, folder, artwork, front) in that priority order.  Falls back to
+    the alphabetically first image if no keyword matches.
+    """
+    candidates: list[Path] = []
+    for pattern in ("*.jpg", "*.jpeg", "*.png"):
+        candidates.extend(directory.glob(pattern))
+    if not candidates:
+        return None
+    for hint in _PREFERRED_ART_NAMES:
+        for p in sorted(candidates):
+            if hint in p.stem.lower():
+                return p
+    return sorted(candidates)[0]
+
+
+def _load_local_artwork(path: Path, min_dimension: int, max_bytes: int) -> bytes | None:
+    """Load *path* and return qualifying image bytes, resizing if necessary.
+
+    Returns None if the image cannot be opened or its dimensions are below
+    *min_dimension* (caller should fall back to online sources).  If the raw
+    file exceeds *max_bytes*, re-encodes as JPEG at progressively lower quality;
+    if still too large, scales dimensions down to *min_dimension* on the short
+    edge before a final encode.
+    """
+    raw = path.read_bytes()
+    try:
+        img = Image.open(io.BytesIO(raw))
+        w, h = img.size
+    except Exception as exc:
+        logger.debug("Could not open local artwork %s: %s", path, exc)
+        return None
+
+    if w < min_dimension or h < min_dimension:
+        logger.debug(
+            "Local artwork %s too small (%dx%d < %dpx) — will try online",
+            path,
+            w,
+            h,
+            min_dimension,
+        )
+        return None
+
+    if len(raw) <= max_bytes:
+        logger.debug("Using local artwork %s (%dx%d, %d bytes)", path, w, h, len(raw))
+        return raw
+
+    # Re-encode as JPEG at progressively lower quality to fit within max_bytes
+    rgb = img.convert("RGB")
+    for quality in (85, 70, 55, 40):
+        buf = io.BytesIO()
+        rgb.save(buf, format="JPEG", quality=quality)
+        if buf.tell() <= max_bytes:
+            logger.debug(
+                "Re-encoded local artwork %s to %d bytes (quality=%d)",
+                path,
+                buf.tell(),
+                quality,
+            )
+            return buf.getvalue()
+
+    # Quality reduction wasn't enough: scale dimensions down to min_dimension
+    # on the short edge and try one more time at quality=75
+    scale = min_dimension / min(w, h)
+    resized = rgb.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+    buf = io.BytesIO()
+    resized.save(buf, format="JPEG", quality=75)
+    logger.debug("Scaled and re-encoded local artwork %s to %d bytes", path, buf.tell())
+    return buf.getvalue()
 
 
 def fetch_and_embed(
@@ -28,18 +104,30 @@ def fetch_and_embed(
     min_dimension: int,
     max_bytes: int,
     release_group_mbid: str = "",
+    directory: Path | None = None,
 ) -> None:
-    """Download qualifying front cover art and embed it in all audio files.
+    """Embed front cover art into all audio files.
 
-    A qualifying image must be at least *min_dimension* × *min_dimension* pixels
-    and no larger than *max_bytes* bytes.  If the release MBID has no art,
-    falls back to the release-group MBID (which aggregates art across all editions).
-    If no qualifying image is found, logs a warning but does not raise — the
-    pipeline continues without artwork.
+    Checks *directory* for a bundled image first (e.g. cover.jpg from a
+    Bandcamp ZIP).  If no qualifying local image is found, falls back to the
+    MusicBrainz Cover Art Archive (release MBID, then release-group MBID).
+    A qualifying image must be at least *min_dimension* × *min_dimension* px;
+    oversized images are resized to fit within *max_bytes*.  If no art is
+    found at all, logs a warning but does not raise — the pipeline continues.
     """
-    image_bytes = _fetch_cover(
-        COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes
-    )
+    image_bytes: bytes | None = None
+
+    if directory is not None:
+        local = find_local_artwork(directory)
+        if local is not None:
+            image_bytes = _load_local_artwork(local, min_dimension, max_bytes)
+            if image_bytes is not None:
+                logger.info("Using bundled artwork from %s", local)
+
+    if image_bytes is None:
+        image_bytes = _fetch_cover(
+            COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes
+        )
     if image_bytes is None and release_group_mbid:
         logger.debug(
             "No art for release %s; trying release-group %s", mbid, release_group_mbid

--- a/tune_shifter/pipeline.py
+++ b/tune_shifter/pipeline.py
@@ -53,6 +53,7 @@ def run(path: Path, config: Config) -> None:
             min_dimension=config.artwork.min_dimension,
             max_bytes=config.artwork.max_bytes,
             release_group_mbid=release.release_group_mbid,
+            directory=directory,
         )
     except ArtworkError as exc:
         # Artwork failure is non-fatal: log and continue


### PR DESCRIPTION
## Summary

- If the extracted directory contains a cover image (`cover.jpg`, `folder.jpg`, `artwork.jpg`, etc.), it is embedded directly without any network request
- Images exceeding `max_bytes` are re-encoded as JPEG at progressively lower quality (85→70→55→40); if still over budget, dimensions are scaled down to `min_dimension` on the short edge
- Images below `min_dimension` fall back to Cover Art Archive as before
- Preferred filenames are checked in priority order: `cover` > `folder` > `artwork` > `front`; falls back to alphabetically first image if none match

## Test plan

- [x] Drop a Bandcamp ZIP into staging; confirm log shows `"Using bundled artwork from ..."` and no Cover Art Archive request is made
- [x] Confirm embedded art is present in output files
- [x] Drop a folder with an oversized image; confirm it's resized to within `max_bytes`
- [x] Drop a folder with no image; confirm online fallback still works
- [x] `pytest tests/test_artwork.py -v`
- [x] `mypy tune_shifter/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)