### PR TITLE
feat: interactive first-run configuration setup

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,23 +1,5 @@
 ## Backlog
 
-### Bandcamp Album Art
-
-*If an archive already has high quality album art, I want to use that (as long as it's not too big)*
-
-The ideal album art dimensions are at least 1000x1000 and the ideal album art size is around 1MB (or whatever the user has configured).
-
-If the art that is distributed with the archive is not larger than config.artwork.max_bytes, use that.
-
-If the art is larger than config.artwork.max_bytes, scale it down to an acceptable size.
-
-If the art is smaller than 1/2 config.artwork.max_bytes or doesn't meet config.artwork.min_dimension requirements, fall back to our existing image search.
-
-### Switch to Poetry for dependency management
-
-### Interactive First Run Configuration
-
-*Don't make me find the config file: on first run, as me for the config values*
-
 ### Config Arguments
 
 *Don't make me ever edit the config file: let me set config through an argument*
@@ -25,6 +7,16 @@ If the art is smaller than 1/2 config.artwork.max_bytes or doesn't meet config.a
 Running `tune-shifter config set paths.staging` lets a user set the staging path, etc.
 
 Running `tune-shifter config show` shows the whole config.
+
+### One File At A Time
+
+*I only want to copy one file into the staging folder and let tune-shifter process it*
+
+### Nested Folders
+
+*I want to copy a folder of folders into the staging folder and let tune-shifter process all files in all sub-folders*
+
+### Switch to Poetry for dependency management
 
 ### Code Coverage
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,11 +1,14 @@
 Welcome to tune-shifter!
 
-To get started, create the config by running:
+To get started, run:
    tune-shifter
 
-This will create a config file. Define your `staging` and `library` folders.
+On first run, you'll be asked for your staging directory, library directory,
+and contact email (used in the MusicBrainz User-Agent). Press Enter at each
+prompt to accept the shown default. The config is saved automatically and the
+daemon starts right away.
 
-Then install the service:
+Then install the service so it starts at login:
   tune-shifter install-service
 
 Now move a zip or folder into your staging folder and tune-shifter will take care of the rest!

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for tune_shifter.config."""
+
+from pathlib import Path
+
+import pytest
+
+from tune_shifter.config import Config
+
+
+class TestFirstRunSetup:
+    def test_creates_config_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """first_run_setup writes a TOML file at the given path."""
+        inputs = iter(["~/staging", "~/music", "me@example.com"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        path = tmp_path / "config.toml"
+        Config.first_run_setup(path)
+        assert path.exists()
+        assert "me@example.com" in path.read_text()
+
+    def test_returns_config_with_user_values(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returned Config reflects the prompted values."""
+        inputs = iter(["~/staging", "~/lib", "test@test.com"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        config = Config.first_run_setup(tmp_path / "config.toml")
+        assert config.musicbrainz.contact == "test@test.com"
+        assert "staging" in str(config.paths.staging)
+
+    def test_blank_input_uses_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pressing Enter at a prompt accepts the shown default."""
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        config = Config.first_run_setup(tmp_path / "config.toml")
+        assert config.musicbrainz.contact == "user@example.com"
+        assert config.paths.staging == Path("~/Music/staging").expanduser()
+        assert config.paths.library == Path("~/Music").expanduser()
+
+    def test_written_toml_is_valid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The written TOML file can be loaded back by Config.load()."""
+        inputs = iter(["~/staging", "~/music", "me@example.com"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        path = tmp_path / "config.toml"
+        Config.first_run_setup(path)
+        # Round-trip: load should succeed without error
+        loaded = Config.load(path)
+        assert loaded.musicbrainz.contact == "me@example.com"
+
+    def test_creates_parent_directories(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """first_run_setup creates intermediate directories if needed."""
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        path = tmp_path / "nested" / "dir" / "config.toml"
+        Config.first_run_setup(path)
+        assert path.exists()

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -97,9 +97,19 @@ def main() -> None:
 
     try:
         config = Config.load(args.config)
-    except FileNotFoundError as exc:
-        print(exc, file=sys.stderr)
-        sys.exit(1)
+    except FileNotFoundError:
+        if sys.stdin.isatty():
+            config = Config.first_run_setup(args.config)
+        else:
+            # Non-interactive (script/service): default file was already written
+            # by Config.load(); print guidance and exit.
+            print(
+                f"Config file created at {args.config}. "
+                "Edit it with your staging/library paths and contact email, "
+                "then re-run tune-shifter.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     musicbrainzngs.set_useragent(
         config.musicbrainz.app_name,

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -81,6 +81,15 @@ class BandcampConfig:
     poll_interval_minutes: int  # 0 = manual only
 
 
+def _prompt(label: str, default: str) -> str:
+    """Print a prompt and return the user's input, or *default* if blank."""
+    try:
+        value = input(f"  {label} [{default}]: ").strip()
+    except EOFError:
+        value = ""
+    return value if value else default
+
+
 @dataclass
 class Config:
     paths: PathsConfig
@@ -88,6 +97,56 @@ class Config:
     artwork: ArtworkConfig
     library: LibraryConfig
     bandcamp: BandcampConfig | None = None
+
+    @classmethod
+    def first_run_setup(cls, path: Path) -> "Config":
+        """Interactively collect key config values, write *path*, and return Config.
+
+        Prompts for the three fields with no sensible universal default —
+        staging dir, library dir, and MusicBrainz contact email — then writes
+        the TOML file (substituting into DEFAULT_CONFIG_CONTENT to preserve
+        comments and formatting) and returns the ready-to-use Config.
+        """
+        print("\nWelcome to tune-shifter! Let's set up your configuration.")
+        print(f"(Config will be saved to {path})\n")
+
+        staging = Path(
+            _prompt("Staging directory (drop ZIPs/folders here)", "~/Music/staging")
+        ).expanduser()
+        library = Path(
+            _prompt("Library directory (finished files land here)", "~/Music")
+        ).expanduser()
+        contact = _prompt(
+            "Your email (sent in MusicBrainz User-Agent; required by their policy)",
+            "user@example.com",
+        )
+
+        config = cls(
+            paths=PathsConfig(staging=staging, library=library),
+            musicbrainz=MusicBrainzConfig(
+                app_name="tune-shifter",
+                app_version="0.1.0",
+                contact=contact,
+            ),
+            artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
+            library=LibraryConfig(
+                path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+            ),
+        )
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Substitute user values into the canonical TOML template so the file
+        # retains its comments and familiar structure rather than being
+        # machine-generated.  Order matters: staging is a prefix of library, so
+        # replace the longer string first.
+        toml_content = (
+            DEFAULT_CONFIG_CONTENT.replace('"~/Music/staging"', f'"{staging}"')
+            .replace('"~/Music"', f'"{library}"')
+            .replace('"user@example.com"', f'"{contact}"')
+        )
+        path.write_text(toml_content)
+        print(f"\nConfiguration saved to {path}\n")
+        return config
 
     @classmethod
     def load(cls, path: Path = DEFAULT_CONFIG_PATH) -> "Config":


### PR DESCRIPTION
## Summary

- When `config.toml` is missing and stdin is a tty, prompt the user for staging dir, library dir, and MusicBrainz contact email
- Accepted defaults are the existing coded defaults (e.g. `~/Music/staging`), so pressing Enter at every prompt gives a sensible starting config
- Non-interactive contexts (launchd service, scripts) retain the existing write-and-exit behaviour
- Config is written by substituting user values into `DEFAULT_CONFIG_CONTENT`, preserving comments and formatting

## Test plan

- [x] `pytest tests/test_config.py -v` — all 5 tests pass
- [x] Delete (or rename) `~/.config/tune-shifter/config.toml`, then run `python -m tune_shifter daemon` — prompts appear; daemon starts after answering
- [x] Accept all defaults (press Enter each time) — daemon starts, TOML file contains default paths
- [ ] Non-tty path: `echo "" | python -m tune_shifter daemon` after deleting config — prints guidance to stderr and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)