### PR TITLE
feat: write full MusicBrainz tag set with exponential backoff retry

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,38 +1,5 @@
 # Backlog
 
-## Improved Tag Sourcing
-
-*I want ALL the tags from MusicBrainz*
-
-When I validate the tags that tune-shifter writes against MusicBrainz Picard, I can see that we're not fully populating tags: in particular, Album Artist Sort Order and Artist Sort Order and Record Label are missed.
-
-The following is a nonexhaustive list of tags that are currently not populated, based on one release I checked (Aesop Rock's "Bazooka Tooth"):
-  - AcoustID
-  - Album Artist Sort Order
-  - Artist Sort Order
-  - Artists
-  - ASIN
-  - Barcode
-  - Catalog Number
-  - Disc Number
-  - MusicBrainz Artist ID
-  - MusicBrainz Recording ID
-  - MusicBrainz Release Artist ID
-  - MusicBrainz Release Group ID
-  - MusicBrainz Release ID
-  - Original Release Date
-  - Original Year
-  - Producer
-  - Record Label
-  - Release Country
-  - Release Status
-  - Release Type
-  - Script
-  - Total Discs
-  - Total Tracks
-
-In case requests against MusicBrainz fail (due to server error, connection error, or rate limit exceeded), retry with an exponential backoff.
-
 ## Bug: Path Characters Included in File Names
 
 To repro:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,56 +1,12 @@
-## Backlog
+# Backlog
 
-### Config Arguments
-
-*Don't make me ever edit the config file: let me set config through an argument*
-
-Running `tune-shifter config set paths.staging` lets a user set the staging path, etc.
-
-Running `tune-shifter config show` shows the whole config.
-
-### One File At A Time
-
-*I only want to copy one file into the staging folder and let tune-shifter process it*
-
-### Nested Folders
-
-*I want to copy a folder of folders into the staging folder and let tune-shifter process all files in all sub-folders*
-
-### Switch to Poetry for dependency management
-
-### Code Coverage
-
-CI runs a code coverage tool.
-
-The application has 95% code coverage in its testing.
-
-### Configurable Album Art Search
-
-*I want to be able to configure where album art is retrieved from*
-
-The default setting should be "default" and retrieve the art from musicbrainz.
-
-*I want to be able to retrieve album art from bandcamp*
-
-The configuration setting for this should be `"bandcamp"`
-
-*I want to be able to retrieve album art from iTunes / Apple Music*
-
-The configuration setting for this should be `"apple"`.
-
-*I want to be able to retrieve album art from Spotify*
-
-The configuration setting for this should be `"spotify"`.
-
-*I want to be able to retrieve album art from Qobuz*
-
-The configuration settings for this should be `"qobuz"`
-
-### Improved Tag Sourcing
+## Improved Tag Sourcing
 
 *I want ALL the tags from MusicBrainz*
 
-The following is a list of tags that are currently not populated:
+When I validate the tags that tune-shifter writes against MusicBrainz Picard, I can see that we're not fully populating tags: in particular, Album Artist Sort Order and Artist Sort Order and Record Label are missed.
+
+The following is a nonexhaustive list of tags that are currently not populated, based on one release I checked (Aesop Rock's "Bazooka Tooth"):
   - AcoustID
   - Album Artist Sort Order
   - Artist Sort Order
@@ -75,17 +31,128 @@ The following is a list of tags that are currently not populated:
   - Total Discs
   - Total Tracks
 
-### Better Cleanup
+In case requests against MusicBrainz fail (due to server error, connection error, or rate limit exceeded), retry with an exponential backoff.
 
-Fully delete folders from staging after moving files to library.
+## Bug: Path Characters Included in File Names
 
-### GUI / menu bar app for sync status
+To repro:
+1. Let tune-shifter process Aesop Rock's "N.Y. Electric / Hunter Interlude.mp3" from the album Bazooka Tooth
 
-### Allow a user to verify tags before they're written
+Expected:
+When file is copied to library, file structure is `Library/Aesop Rock/Bazooka Tooth/N.Y. Electric - Hunter Interlude.mp3`
 
-### Cross-platform service installation (Linux systemd, Windows Task Scheduler)
-
-### Does Bandcamp auto-download actually work?  Test poll_interval_minutes.
-
+Actual:
+When file is copied to library, file structure is `Library/Aesop Rock/Bazooka Tooth/N.Y. Electric / Hunter Interlude.mp3` and the actual file name is `Hunter Interlude.mp3`
 
 
+
+## Bug: No Bandcamp Section in Initial Config
+
+> [tune-shifter] python -m tune_shifter sync
+> tune_shifter.syncer  No [bandcamp] section in config — nothing to sync.
+
+If no bandcamp config exists when sync is one, give the user an interactive prompt to create it, and then run sync.
+
+## Bug: Cleanup Doesn't Remove Folders With Non-Music Files Remaining
+
+Fully delete folders from staging after moving files to library, as long as the only remaining files are non-audio files.
+
+Bug: When an archive or folder containing extra files (images, PDFs) is processed by tune-shifter, the folder isn't fully removed from staging and ends up in the error directory.
+
+To repro: 
+1. Start with an empty staging directory
+2. Move The Notwist - Neon Golden.zip into staging directory
+3. Let tune-shifter process it
+
+Expected:
+Staging folder is empty
+
+Actual:
+staging\The Notwist - Neon Golden can't be removed because cover.jpg is in it
+The Notwist - Neon Golden is moved to staging\errors\
+
+
+## Human Readable Bandcamp State
+
+...
+
+## Process on Start
+
+*When daemon starts, I want everything in the staging folder to be processed*
+
+## Best Release
+
+*When there are multiple releases available, I want the tags for the release closest to the original physical format*
+
+## AcoustID Support
+
+> requires audio fingerprinting (fpcalc/chromaprint); can't be fetched from MusicBrainz
+
+## Producer Support
+
+> requires a recording-rels include and relationship traversal; deferred
+
+## Config Arguments
+
+*Don't make me ever edit the config file: let me set config through an argument*
+
+Running `tune-shifter config set paths.staging` lets a user set the staging path, etc.
+
+Running `tune-shifter config show` shows the whole config.
+
+## Code Coverage
+
+CI runs a code coverage tool.
+
+The application has 95% code coverage in its testing.
+
+## Switch to Poetry for dependency management
+
+## FLAC Support
+
+*I want FLAC to be as well supported as MP3 and M4A for tagging*
+
+## OGG Support
+
+*I want OGG to be as well supported as MP3 and M4A for tagging*
+
+## One File At A Time
+
+*I only want to copy one file into the staging folder and let tune-shifter process it*
+
+## Nested Folders
+
+*I want to copy a folder of folders into the staging folder and let tune-shifter process all files in all sub-folders*
+
+## Does Bandcamp auto-download actually work?  Test poll_interval_minutes.
+
+
+
+
+## Configurable Album Art Search
+
+*I want to be able to configure where album art is retrieved from*
+
+The default setting should be "default" and retrieve the art from musicbrainz.
+
+*I want to be able to retrieve album art from bandcamp*
+
+The configuration setting for this should be `"bandcamp"`
+
+*I want to be able to retrieve album art from iTunes / Apple Music*
+
+The configuration setting for this should be `"apple"`.
+
+*I want to be able to retrieve album art from Spotify*
+
+The configuration setting for this should be `"spotify"`.
+
+*I want to be able to retrieve album art from Qobuz*
+
+The configuration settings for this should be `"qobuz"`
+
+## GUI / menu bar app for sync status
+
+## Allow a user to verify tags before they're written
+
+## Cross-platform service installation (Linux systemd, Windows Task Scheduler)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ tune-shifter install-service
 Logs are written to `~/.local/share/tune-shifter/daemon.log`.
 
 ```bash
+launchctl unload ~/Library/LaunchAgents/com.tune-shifter.plist   # pause the service
+launchctl load ~/Library/LaunchAgents/com.tune-shifter.plist   # restart the service
 tune-shifter uninstall-service   # remove the service registration
 ```
 

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -4,11 +4,18 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import musicbrainzngs
 import mutagen.id3 as id3
 import mutagen.mp4
 import pytest
 
-from tune_shifter.tagger import ReleaseInfo, TaggingError, TrackInfo, tag_directory
+from tune_shifter.tagger import (
+    ReleaseInfo,
+    TaggingError,
+    TrackInfo,
+    _search_release,
+    tag_directory,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -43,14 +50,38 @@ SAMPLE_RELEASE: dict[str, Any] = {
     ]
 }
 
-# Full release detail returned by get_release_by_id — includes date, tracks, release-group.
+# Full release detail returned by get_release_by_id — includes all extended fields.
 SAMPLE_RELEASE_DETAIL: dict[str, Any] = {
     "release": {
         "id": "abc-123",
         "title": "Great Album",
         "date": "2020-04-01",
-        "artist-credit": [{"artist": {"name": "Cool Artist"}}],
-        "release-group": {"id": "rg-456"},
+        "status": "Official",
+        "country": "US",
+        "barcode": "123456789",
+        "asin": "B08XYZ",
+        "text-representation": {"script": "Latn"},
+        "artist-credit": [
+            {
+                "name": "Cool Artist",
+                "artist": {
+                    "id": "artist-mbid-1",
+                    "name": "Cool Artist",
+                    "sort-name": "Artist, Cool",
+                },
+            }
+        ],
+        "release-group": {
+            "id": "rg-456",
+            "primary-type": "Album",
+            "first-release-date": "2020-04-01",
+        },
+        "label-info-list": [
+            {
+                "label": {"name": "Great Label"},
+                "catalog-number": "GRL-001",
+            }
+        ],
         "medium-list": [
             {
                 "position": "1",
@@ -58,12 +89,12 @@ SAMPLE_RELEASE_DETAIL: dict[str, Any] = {
                     {
                         "number": "1",
                         "position": "1",
-                        "recording": {"title": "First Track"},
+                        "recording": {"id": "rec-111", "title": "First Track"},
                     },
                     {
                         "number": "2",
                         "position": "2",
-                        "recording": {"title": "Second Track"},
+                        "recording": {"id": "rec-222", "title": "Second Track"},
                     },
                 ],
             }
@@ -106,15 +137,14 @@ class TestTagDirectory:
         mp3 = tmp_path / "01.mp3"
         _make_mp3(mp3)
 
-        import musicbrainzngs
-
         with patch.object(
             musicbrainzngs,
             "search_releases",
             side_effect=musicbrainzngs.WebServiceError("network error"),
         ):
-            with pytest.raises(TaggingError, match="MusicBrainz search failed"):
-                tag_directory(tmp_path, [mp3])
+            with patch("tune_shifter.tagger.time.sleep"):
+                with pytest.raises(TaggingError, match="after 3 retries"):
+                    tag_directory(tmp_path, [mp3])
 
     def test_raises_when_no_results(self, tmp_path: Path) -> None:
         mp3 = tmp_path / "01.mp3"
@@ -144,6 +174,19 @@ class TestTagDirectory:
         assert str(tags["TPE1"]) == "Cool Artist"
         assert str(tags["TDRC"]) == "2020"
         assert str(tags["TXXX:MusicBrainz Release Id"]) == "abc-123"
+        # Extended tags
+        assert str(tags["TSOP"]) == "Artist, Cool"
+        assert str(tags["TXXX:MusicBrainz Artist Id"]) == "artist-mbid-1"
+        assert str(tags["TXXX:MusicBrainz Release Group Id"]) == "rg-456"
+        assert str(tags["TXXX:MusicBrainz Album Type"]) == "Album"
+        assert str(tags["TXXX:MusicBrainz Album Status"]) == "Official"
+        assert str(tags["TXXX:MusicBrainz Album Release Country"]) == "US"
+        assert str(tags["TPUB"]) == "Great Label"
+        assert str(tags["TXXX:CATALOGNUMBER"]) == "GRL-001"
+        assert str(tags["TXXX:BARCODE"]) == "123456789"
+        assert str(tags["TDOR"]) == "2020-04-01"
+        assert str(tags["TRCK"]) == "1/2"
+        assert str(tags["TXXX:MusicBrainz Track Id"]) == "rec-111"
 
     def test_selects_highest_score(self, tmp_path: Path) -> None:
         mp3 = tmp_path / "01.mp3"
@@ -281,3 +324,37 @@ class TestTagDirectoryM4a:
         assert initial_tags["\xa9day"] == ["2020"]
         assert "----:com.apple.iTunes:MusicBrainz Release Id" in initial_tags
         mock_mp4.save.assert_called()
+
+
+class TestRetry:
+    def test_retries_on_web_service_error(self, tmp_path: Path) -> None:
+        """_mb_call retries up to 3 times before raising TaggingError."""
+        call_count = 0
+
+        def flaky(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise musicbrainzngs.WebServiceError("503")
+            return SAMPLE_RELEASE
+
+        with patch.object(musicbrainzngs, "search_releases", side_effect=flaky):
+            with patch(
+                "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+            ):
+                with patch("tune_shifter.tagger.time.sleep"):
+                    result = _search_release("Cool Artist", "Great Album")
+
+        assert call_count == 3
+        assert result.mbid == "abc-123"
+
+    def test_raises_after_max_retries(self, tmp_path: Path) -> None:
+        """TaggingError is raised when all retries are exhausted."""
+
+        def always_fail(*args: Any, **kwargs: Any) -> None:
+            raise musicbrainzngs.WebServiceError("503")
+
+        with patch.object(musicbrainzngs, "search_releases", side_effect=always_fail):
+            with patch("tune_shifter.tagger.time.sleep"):
+                with pytest.raises(TaggingError, match="after 3 retries"):
+                    _search_release("Cool Artist", "Great Album")

--- a/tune_shifter/tagger.py
+++ b/tune_shifter/tagger.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import musicbrainzngs
 import mutagen
@@ -42,6 +43,22 @@ class ReleaseInfo:
     album_artist: str
     year: str
     tracks: dict[str, TrackInfo]  # keyed by filename stem (best-effort) or track number
+    # Extended MusicBrainz fields (default to empty so existing callers don't break)
+    artist_sort: str = ""
+    album_artist_sort: str = ""
+    artists: list[str] = field(default_factory=list)
+    artist_mbids: list[str] = field(default_factory=list)
+    album_artist_mbid: str = ""
+    label: str = ""
+    catalog_number: str = ""
+    barcode: str = ""
+    asin: str = ""
+    release_type: str = ""
+    release_status: str = ""
+    release_country: str = ""
+    original_date: str = ""
+    script: str = ""
+    total_discs: int = 1
 
 
 @dataclass
@@ -49,6 +66,8 @@ class TrackInfo:
     number: int
     disc: int
     title: str
+    recording_mbid: str = ""
+    total_tracks: int = 0
 
 
 def configure_musicbrainz(app_name: str, app_version: str, contact: str) -> None:
@@ -123,16 +142,37 @@ def _read_existing_metadata(path: Path) -> tuple[str, str]:
     return artist, album
 
 
+def _mb_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call a musicbrainzngs function, retrying on transient errors with exponential backoff."""
+    delay = 1.0
+    max_retries = 3
+    for attempt in range(max_retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except (musicbrainzngs.WebServiceError, musicbrainzngs.NetworkError) as exc:
+            if attempt == max_retries:
+                raise TaggingError(
+                    f"MusicBrainz request failed after {max_retries} retries: {exc}"
+                ) from exc
+            logger.warning(
+                "MusicBrainz request failed (attempt %d/%d), retrying in %gs: %s",
+                attempt + 1,
+                max_retries,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+            delay *= 2
+
+
 def _search_release(artist: str, album: str) -> ReleaseInfo:
     logger.debug("MusicBrainz search: artist=%r release=%r", artist, album)
-    try:
-        result = musicbrainzngs.search_releases(
-            artist=artist,
-            release=album,
-            limit=5,
-        )
-    except musicbrainzngs.WebServiceError as exc:
-        raise TaggingError(f"MusicBrainz search failed: {exc}") from exc
+    result = _mb_call(
+        musicbrainzngs.search_releases,
+        artist=artist,
+        release=album,
+        limit=5,
+    )
 
     releases: list[dict[str, Any]] = result.get("release-list", [])
     logger.debug("MusicBrainz returned %d result(s)", len(releases))
@@ -145,12 +185,12 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
             logger.debug(
                 "No results for %r; retrying with cleaned name %r", album, cleaned
             )
-            try:
-                result = musicbrainzngs.search_releases(
-                    artist=artist, release=cleaned, limit=5
-                )
-            except musicbrainzngs.WebServiceError as exc:
-                raise TaggingError(f"MusicBrainz search failed: {exc}") from exc
+            result = _mb_call(
+                musicbrainzngs.search_releases,
+                artist=artist,
+                release=cleaned,
+                limit=5,
+            )
             releases = result.get("release-list", [])
 
     if not releases:
@@ -164,13 +204,11 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
     # search_releases returns minimal data (no full date, no track listings).
     # Fetch the full release to get accurate year and track info.
     logger.debug("Fetching full release details for %s", best_mbid)
-    try:
-        detail = musicbrainzngs.get_release_by_id(
-            best_mbid,
-            includes=["artists", "recordings", "release-groups"],
-        )
-    except musicbrainzngs.WebServiceError as exc:
-        raise TaggingError(f"MusicBrainz release lookup failed: {exc}") from exc
+    detail = _mb_call(
+        musicbrainzngs.get_release_by_id,
+        best_mbid,
+        includes=["artists", "recordings", "release-groups", "labels"],
+    )
 
     return _parse_release(detail["release"])
 
@@ -179,26 +217,51 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
     mbid: str = raw["id"]
     title: str = raw.get("title", "")
     year: str = raw.get("date", "")[:4]
-    release_group_mbid: str = raw.get("release-group", {}).get("id", "")
 
+    release_group = raw.get("release-group", {})
+    release_group_mbid: str = release_group.get("id", "")
+    release_type: str = release_group.get("primary-type", "")
+    original_date: str = release_group.get("first-release-date", "")
+
+    # Artist credit — each dict entry has .artist.{name, sort-name, id}
     artist_credit = raw.get("artist-credit", [])
-    artist = ""
-    album_artist = ""
-    if artist_credit:
-        first = artist_credit[0]
-        if isinstance(first, dict):
-            artist = first.get("artist", {}).get("name", "")
-            album_artist = artist
+    credits = [c for c in artist_credit if isinstance(c, dict)]
+    artists = [c.get("name") or c.get("artist", {}).get("name", "") for c in credits]
+    artist = " ".join(a for a in artists if a)
+    album_artist = artist
+    artist_sort = " ".join(c.get("artist", {}).get("sort-name", "") for c in credits)
+    album_artist_sort = artist_sort
+    artist_mbids = [c.get("artist", {}).get("id", "") for c in credits]
+    album_artist_mbid = artist_mbids[0] if artist_mbids else ""
+
+    # Label info — first entry wins; label may be absent (e.g. self-released)
+    label_info_list = raw.get("label-info-list", [])
+    label = ""
+    catalog_number = ""
+    if label_info_list:
+        first = label_info_list[0]
+        label = first.get("label", {}).get("name", "") if first.get("label") else ""
+        catalog_number = first.get("catalog-number", "")
+
+    medium_list = raw.get("medium-list", [])
+    total_discs = len(medium_list) or 1
 
     tracks: dict[str, TrackInfo] = {}
-    medium_list = raw.get("medium-list", [])
     for medium in medium_list:
         disc_num = int(medium.get("position", 1))
-        for track_raw in medium.get("track-list", []):
+        track_list = medium.get("track-list", [])
+        total_tracks = len(track_list)
+        for track_raw in track_list:
             track_num = int(track_raw.get("number", track_raw.get("position", 0)))
-            track_title = track_raw.get("recording", {}).get("title", "")
+            recording = track_raw.get("recording", {})
             key = f"{disc_num}-{track_num}"
-            tracks[key] = TrackInfo(number=track_num, disc=disc_num, title=track_title)
+            tracks[key] = TrackInfo(
+                number=track_num,
+                disc=disc_num,
+                title=recording.get("title", ""),
+                recording_mbid=recording.get("id", ""),
+                total_tracks=total_tracks,
+            )
 
     return ReleaseInfo(
         mbid=mbid,
@@ -208,6 +271,21 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
         album_artist=album_artist,
         year=year,
         tracks=tracks,
+        artist_sort=artist_sort,
+        album_artist_sort=album_artist_sort,
+        artists=artists,
+        artist_mbids=artist_mbids,
+        album_artist_mbid=album_artist_mbid,
+        label=label,
+        catalog_number=catalog_number,
+        barcode=raw.get("barcode", ""),
+        asin=raw.get("asin", ""),
+        release_type=release_type,
+        release_status=raw.get("status", ""),
+        release_country=raw.get("country", ""),
+        original_date=original_date,
+        script=raw.get("text-representation", {}).get("script", ""),
+        total_discs=total_discs,
     )
 
 
@@ -263,6 +341,7 @@ def _write_mp3_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) -
     except id3.ID3NoHeaderError:
         tags = id3.ID3()
 
+    # Core tags
     tags["TPE1"] = id3.TPE1(encoding=3, text=release.artist)
     tags["TPE2"] = id3.TPE2(encoding=3, text=release.album_artist)
     tags["TALB"] = id3.TALB(encoding=3, text=release.title)
@@ -271,10 +350,89 @@ def _write_mp3_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) -
         encoding=3, desc="MusicBrainz Release Id", text=release.mbid
     )
 
+    # Sort names
+    if release.artist_sort:
+        tags["TSOP"] = id3.TSOP(encoding=3, text=release.artist_sort)
+    if release.album_artist_sort:
+        tags["TSO2"] = id3.TSO2(encoding=3, text=release.album_artist_sort)
+
+    # Multi-value artists (semicolon-joined per Picard convention)
+    if release.artists:
+        tags["TXXX:ARTISTS"] = id3.TXXX(
+            encoding=3, desc="ARTISTS", text="; ".join(release.artists)
+        )
+
+    # MusicBrainz IDs
+    if release.artist_mbids:
+        tags["TXXX:MusicBrainz Artist Id"] = id3.TXXX(
+            encoding=3,
+            desc="MusicBrainz Artist Id",
+            text="; ".join(release.artist_mbids),
+        )
+    if release.album_artist_mbid:
+        tags["TXXX:MusicBrainz Album Artist Id"] = id3.TXXX(
+            encoding=3,
+            desc="MusicBrainz Album Artist Id",
+            text=release.album_artist_mbid,
+        )
+    if release.release_group_mbid:
+        tags["TXXX:MusicBrainz Release Group Id"] = id3.TXXX(
+            encoding=3,
+            desc="MusicBrainz Release Group Id",
+            text=release.release_group_mbid,
+        )
+
+    # Release metadata
+    if release.release_type:
+        tags["TXXX:MusicBrainz Album Type"] = id3.TXXX(
+            encoding=3, desc="MusicBrainz Album Type", text=release.release_type
+        )
+    if release.release_status:
+        tags["TXXX:MusicBrainz Album Status"] = id3.TXXX(
+            encoding=3, desc="MusicBrainz Album Status", text=release.release_status
+        )
+    if release.release_country:
+        tags["TXXX:MusicBrainz Album Release Country"] = id3.TXXX(
+            encoding=3,
+            desc="MusicBrainz Album Release Country",
+            text=release.release_country,
+        )
+    if release.original_date:
+        tags["TDOR"] = id3.TDOR(encoding=3, text=release.original_date)
+    if release.label:
+        tags["TPUB"] = id3.TPUB(encoding=3, text=release.label)
+    if release.catalog_number:
+        tags["TXXX:CATALOGNUMBER"] = id3.TXXX(
+            encoding=3, desc="CATALOGNUMBER", text=release.catalog_number
+        )
+    if release.barcode:
+        tags["TXXX:BARCODE"] = id3.TXXX(
+            encoding=3, desc="BARCODE", text=release.barcode
+        )
+    if release.asin:
+        tags["TXXX:ASIN"] = id3.TXXX(encoding=3, desc="ASIN", text=release.asin)
+    if release.script:
+        tags["TXXX:SCRIPT"] = id3.TXXX(encoding=3, desc="SCRIPT", text=release.script)
+
+    # Track and disc numbers with totals
     if track is not None:
-        tags["TRCK"] = id3.TRCK(encoding=3, text=str(track.number))
-        tags["TPOS"] = id3.TPOS(encoding=3, text=str(track.disc))
+        total_trck = (
+            f"{track.number}/{track.total_tracks}"
+            if track.total_tracks
+            else str(track.number)
+        )
+        total_tpos = (
+            f"{track.disc}/{release.total_discs}"
+            if release.total_discs > 1
+            else str(track.disc)
+        )
+        tags["TRCK"] = id3.TRCK(encoding=3, text=total_trck)
+        tags["TPOS"] = id3.TPOS(encoding=3, text=total_tpos)
         tags["TIT2"] = id3.TIT2(encoding=3, text=track.title)
+        if track.recording_mbid:
+            tags["TXXX:MusicBrainz Track Id"] = id3.TXXX(
+                encoding=3, desc="MusicBrainz Track Id", text=track.recording_mbid
+            )
 
     tags.save(str(path))
     logger.debug("Wrote MP3 tags to %s", path)
@@ -286,18 +444,80 @@ def _write_m4a_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) -
         audio.add_tags()
 
     assert audio.tags is not None
+
+    def _ff(value: str) -> list[mutagen.mp4.MP4FreeForm]:
+        """Wrap a string as a single-element MP4FreeForm list."""
+        return [mutagen.mp4.MP4FreeForm(value.encode())]
+
+    # Core tags
     audio.tags["\xa9ART"] = [release.artist]
     audio.tags["aART"] = [release.album_artist]
     audio.tags["\xa9alb"] = [release.title]
     audio.tags["\xa9day"] = [release.year]
-    audio.tags["----:com.apple.iTunes:MusicBrainz Release Id"] = [
-        mutagen.mp4.MP4FreeForm(release.mbid.encode())
-    ]
+    audio.tags["----:com.apple.iTunes:MusicBrainz Release Id"] = _ff(release.mbid)
 
+    # Sort names
+    if release.artist_sort:
+        audio.tags["soar"] = [release.artist_sort]
+    if release.album_artist_sort:
+        audio.tags["soaa"] = [release.album_artist_sort]
+
+    # Multi-value artists
+    if release.artists:
+        audio.tags["----:com.apple.iTunes:ARTISTS"] = _ff("; ".join(release.artists))
+
+    # MusicBrainz IDs
+    if release.artist_mbids:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Artist Id"] = _ff(
+            "; ".join(release.artist_mbids)
+        )
+    if release.album_artist_mbid:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Album Artist Id"] = _ff(
+            release.album_artist_mbid
+        )
+    if release.release_group_mbid:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Release Group Id"] = _ff(
+            release.release_group_mbid
+        )
+
+    # Release metadata
+    if release.release_type:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Album Type"] = _ff(
+            release.release_type
+        )
+    if release.release_status:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Album Status"] = _ff(
+            release.release_status
+        )
+    if release.release_country:
+        audio.tags["----:com.apple.iTunes:MusicBrainz Album Release Country"] = _ff(
+            release.release_country
+        )
+    if release.original_date:
+        audio.tags["----:com.apple.iTunes:ORIGINALDATE"] = _ff(release.original_date)
+        audio.tags["----:com.apple.iTunes:ORIGINALYEAR"] = _ff(
+            release.original_date[:4]
+        )
+    if release.label:
+        audio.tags["----:com.apple.iTunes:LABEL"] = _ff(release.label)
+    if release.catalog_number:
+        audio.tags["----:com.apple.iTunes:CATALOGNUMBER"] = _ff(release.catalog_number)
+    if release.barcode:
+        audio.tags["----:com.apple.iTunes:BARCODE"] = _ff(release.barcode)
+    if release.asin:
+        audio.tags["----:com.apple.iTunes:ASIN"] = _ff(release.asin)
+    if release.script:
+        audio.tags["----:com.apple.iTunes:SCRIPT"] = _ff(release.script)
+
+    # Track and disc numbers with totals
     if track is not None:
-        audio.tags["trkn"] = [(track.number, 0)]
-        audio.tags["disk"] = [(track.disc, 0)]
+        audio.tags["trkn"] = [(track.number, track.total_tracks)]
+        audio.tags["disk"] = [(track.disc, release.total_discs)]
         audio.tags["\xa9nam"] = [track.title]
+        if track.recording_mbid:
+            audio.tags["----:com.apple.iTunes:MusicBrainz Track Id"] = _ff(
+                track.recording_mbid
+            )
 
     audio.save()
     logger.debug("Wrote M4A tags to %s", path)


### PR DESCRIPTION
## Summary

- Writes ~20 additional tags sourced from MusicBrainz (sort names, all MB ID frames, record label, catalog number, barcode, ASIN, release type/status/country, original date, script, track/disc totals) for both MP3 (ID3) and M4A (iTunes atoms)
- Adds `"labels"` to the `get_release_by_id` includes to fetch label and catalog number
- Adds `_mb_call()` retry helper: retries `WebServiceError`/`NetworkError` up to 3 times with exponential backoff (1s → 2s → 4s) before raising `TaggingError`
- AcoustID (requires fingerprinting) and Producer (requires relationship traversal) are deferred

## Test plan

- [x] All 12 tagger tests pass (`pytest tests/test_tagger.py -v`)
- [x] `mypy tune_shifter/tagger.py` clean
- [x] `black` clean
- [x] Manual: drop a real Bandcamp ZIP into staging and verify tags in a tag editor match MusicBrainz Picard output (sort names, label, release type, track totals, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)