### PR TITLE
fix: sanitize tag values before path template rendering

### DIFF
--- a/tests/test_mover.py
+++ b/tests/test_mover.py
@@ -1,0 +1,68 @@
+"""Tests for tune_shifter.mover."""
+
+from pathlib import Path
+
+import mutagen.id3 as id3
+import pytest
+
+from tune_shifter.mover import _destination
+
+TEMPLATE = "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+
+
+def _make_mp3(path: Path, **tags: str) -> None:
+    """Write a minimal ID3-tagged MP3 stub."""
+    t = id3.ID3()
+    if "album_artist" in tags:
+        t["TPE2"] = id3.TPE2(encoding=3, text=tags["album_artist"])
+    if "album" in tags:
+        t["TALB"] = id3.TALB(encoding=3, text=tags["album"])
+    if "year" in tags:
+        t["TDRC"] = id3.TDRC(encoding=3, text=tags["year"])
+    if "track" in tags:
+        t["TRCK"] = id3.TRCK(encoding=3, text=tags["track"])
+    if "title" in tags:
+        t["TIT2"] = id3.TIT2(encoding=3, text=tags["title"])
+    path.write_bytes(b"\xff\xfb" * 64)
+    t.save(str(path))
+
+
+class TestDestination:
+    def test_slash_in_title_does_not_create_extra_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """A '/' in a track title must be replaced, not treated as a path separator."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(
+            mp3,
+            album_artist="Aesop Rock",
+            album="Bazooka Tooth",
+            year="2003",
+            track="1",
+            title="N.Y. Electric / Hunter Interlude",
+        )
+
+        library = tmp_path / "library"
+        result = _destination(mp3, library, TEMPLATE)
+
+        # The title slash must not split into a subdirectory
+        assert result.parent == library / "Aesop Rock" / "2003 - Bazooka Tooth"
+        assert "/" not in result.name
+
+    def test_sanitizes_colon_and_question_mark_in_tags(self, tmp_path: Path) -> None:
+        """Other unsafe chars (: ?) in tag values are also replaced."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album: The Sequel",
+            year="2020",
+            track="1",
+            title="Track?",
+        )
+
+        library = tmp_path / "library"
+        result = _destination(mp3, library, TEMPLATE)
+
+        assert ":" not in str(result)
+        assert "?" not in str(result)

--- a/tune_shifter/mover.py
+++ b/tune_shifter/mover.py
@@ -52,12 +52,15 @@ def move_to_library(
 
 def _destination(src: Path, library_root: Path, path_template: str) -> Path:
     tags = _read_tags(src)
+    # Sanitize string values before rendering so that unsafe characters (especially '/')
+    # in tag fields like title don't get interpreted as path separators.
+    safe_tags = {k: _sanitize(v) if isinstance(v, str) else v for k, v in tags.items()}
     try:
-        rendered = path_template.format(**tags)
+        rendered = path_template.format(**safe_tags)
     except (KeyError, ValueError) as exc:
         raise MoveError(f"Path template error for {src}: {exc}") from exc
 
-    # Sanitize each path component individually
+    # Sanitize each path component as a second layer of defence.
     parts = Path(rendered).parts
     safe_parts = [_sanitize(p) for p in parts]
     return library_root.joinpath(*safe_parts)


### PR DESCRIPTION
## Summary

- Track titles (or other tag values) containing `/` were being split into unintended subdirectories when the path template was rendered, because `Path(rendered).parts` treats `/` as a separator before `_sanitize` could replace it
- Fix: apply `_sanitize()` to all string tag values **before** `path_template.format()`, so e.g. `"N.Y. Electric / Hunter Interlude"` becomes `"N.Y. Electric _ Hunter Interlude"` in the rendered path
- The existing per-component sanitize pass is kept as a second layer of defence
- Adds `tests/test_mover.py` (no mover tests existed previously)

## Test plan

- [ ] `pytest tests/test_mover.py -v` — 2 tests pass
- [ ] `mypy tune_shifter/mover.py` clean
- [ ] Manual: drop Aesop Rock's *Bazooka Tooth* into staging and confirm `N.Y. Electric _ Hunter Interlude.mp3` lands correctly in the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)