### PR TITLE
feat: interactive Bandcamp setup when sync has no config

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,10 +1,16 @@
 # Backlog
-## Bug: No Bandcamp Section in Initial Config
 
-> [tune-shifter] python -m tune_shifter sync
-> tune_shifter.syncer  No [bandcamp] section in config — nothing to sync.
+## Optionally Mark Synced on First Bandcamp Sync
 
-If no bandcamp config exists when sync is one, give the user an interactive prompt to create it, and then run sync.
+*If this is my first time running tune-shifter sync, ask if I've already downloaded all my bandcamp purchases*
+
+If sync is "first run" (bandcamp config is missing), part of the config / onboarding should be asking the user the following question:
+
+> Have you already downloaded your Bandcamp collection (y/n)? [y]
+
+If `y`, then the first run of sync should be `mark-synced`.
+
+If `n`, then the first run of sync should be a normal Bandcamp sync.
 
 ## Process on Start
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from tune_shifter.config import Config
+from tune_shifter.config import DEFAULT_CONFIG_CONTENT, Config
 
 
 class TestFirstRunSetup:
@@ -59,3 +59,60 @@ class TestFirstRunSetup:
         path = tmp_path / "nested" / "dir" / "config.toml"
         Config.first_run_setup(path)
         assert path.exists()
+
+
+def _base_config(tmp_path: Path) -> Path:
+    """Write a minimal valid config (without [bandcamp]) and return its path."""
+    path = tmp_path / "config.toml"
+    path.write_text(
+        DEFAULT_CONFIG_CONTENT.replace('"~/Music/staging"', '"/staging"')
+        .replace('"~/Music"', '"/library"')
+        .replace('"user@example.com"', '"me@example.com"')
+    )
+    return path
+
+
+class TestBandcampSetup:
+    def test_appends_bandcamp_section_to_existing_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bandcamp_setup appends [bandcamp] without clobbering existing content."""
+        path = _base_config(tmp_path)
+        inputs = iter(["bcuser", "", "mp3-320", "60"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        config = Config.bandcamp_setup(path)
+
+        assert config.bandcamp is not None
+        assert config.bandcamp.username == "bcuser"
+        assert config.bandcamp.format == "mp3-320"
+        assert config.bandcamp.poll_interval_minutes == 60
+        assert config.bandcamp.cookie_file is None
+        assert "[paths]" in path.read_text()
+
+    def test_returns_config_with_cookie_file_when_provided(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cookie_file is written and parsed when the user provides a path."""
+        path = _base_config(tmp_path)
+        inputs = iter(["bcuser", "/tmp/cookie", "mp3-v0", "0"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        config = Config.bandcamp_setup(path)
+
+        assert config.bandcamp is not None
+        assert config.bandcamp.cookie_file == Path("/tmp/cookie")
+
+    def test_blank_username_reprompts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entering a blank username re-prompts rather than saving an empty string."""
+        path = _base_config(tmp_path)
+        # first two responses are blank (username reprompt), then a valid name
+        inputs = iter(["", "", "realuser", "", "mp3-v0", "0"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        config = Config.bandcamp_setup(path)
+
+        assert config.bandcamp is not None
+        assert config.bandcamp.username == "realuser"

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -137,7 +137,7 @@ def main() -> None:
     )
 
     if command == "sync":
-        _cmd_sync(config, mark_synced=getattr(args, "mark_synced", False))
+        _cmd_sync(config, args.config, mark_synced=getattr(args, "mark_synced", False))
     else:
         # daemon (with optional CLI overrides)
         if hasattr(args, "staging") and args.staging:
@@ -147,7 +147,18 @@ def main() -> None:
         _cmd_daemon(config)
 
 
-def _cmd_sync(config: Config, mark_synced: bool = False) -> None:
+def _cmd_sync(config: Config, config_path: Path, mark_synced: bool = False) -> None:
+    if config.bandcamp is None:
+        if sys.stdin.isatty():
+            config = Config.bandcamp_setup(config_path)
+        else:
+            print(
+                f"No [bandcamp] section in {config_path}. "
+                "Add one manually or run tune-shifter sync interactively.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     syncer = Syncer(config)
     if mark_synced:
         syncer.mark_synced()

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -149,6 +149,49 @@ class Config:
         return config
 
     @classmethod
+    def bandcamp_setup(cls, path: Path) -> "Config":
+        """Interactively collect Bandcamp credentials, append to config, and return Config.
+
+        Called when sync is run without a [bandcamp] section present.
+        Appends the new section to the existing file so comments and other
+        settings are preserved.
+        """
+        print("\nNo Bandcamp section found in config. Let's set it up.")
+        print(f"(Adding [bandcamp] to {path})\n")
+
+        # username is required — loop until non-empty
+        username = ""
+        while not username:
+            username = _prompt("Bandcamp username", "")
+            if not username:
+                print("  Username is required.")
+
+        cookie_file_str = _prompt(
+            "Cookie file path (leave blank to use interactive login)", ""
+        )
+        fmt = _prompt("Download format (mp3-v0, mp3-320, flac, …)", "mp3-v0")
+        poll_str = _prompt("Poll interval in minutes (0 = manual sync only)", "0")
+        poll_interval = int(poll_str) if poll_str.isdigit() else 0
+
+        # Build the TOML snippet — omit cookie_file when not provided
+        lines = [
+            "\n[bandcamp]",
+            f'username = "{username}"',
+        ]
+        if cookie_file_str:
+            lines.append(f'cookie_file = "{cookie_file_str}"')
+        lines += [
+            f'format = "{fmt}"',
+            f"poll_interval_minutes = {poll_interval}",
+            "",  # trailing newline
+        ]
+        with open(path, "a") as f:
+            f.write("\n".join(lines))
+
+        print(f"\nBandcamp config saved to {path}\n")
+        return cls.load(path)
+
+    @classmethod
     def load(cls, path: Path = DEFAULT_CONFIG_PATH) -> "Config":
         """Load config from a TOML file, creating it with defaults if absent."""
         if not path.exists():


### PR DESCRIPTION
## Summary

- Running `tune-shifter sync` with no `[bandcamp]` section now prompts for username, optional cookie file, download format (default `mp3-v0`), and poll interval
- The new `[bandcamp]` section is **appended** to the existing config file so comments and other settings are preserved
- In non-interactive contexts (script/service/CI) it prints a clear error and exits rather than silently doing nothing
- Mirrors the pattern of `first_run_setup()` for the initial daemon config

## Test plan

- [x] `pytest tests/test_config.py -v` — 8 tests pass
- [x] Manual: remove `[bandcamp]` from config, run `tune-shifter sync`, confirm prompts appear and sync proceeds
- [x] Confirm `[paths]` and other sections are still intact in config after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)