### PR TITLE
feat: ask mark-synced question on first Bandcamp setup

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,38 @@
+"""Tests for tune_shifter.__main__ helpers."""
+
+import pytest
+
+from tune_shifter.__main__ import _yn_prompt
+
+
+class TestYnPrompt:
+    def test_empty_input_returns_default_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert _yn_prompt("Question?", default=True) is True
+
+    def test_empty_input_returns_default_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert _yn_prompt("Question?", default=False) is False
+
+    def test_y_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        assert _yn_prompt("Question?") is True
+
+    def test_yes_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "yes")
+        assert _yn_prompt("Question?") is True
+
+    def test_n_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        assert _yn_prompt("Question?") is False
+
+    def test_eof_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_eof(_: str) -> str:
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", raise_eof)
+        assert _yn_prompt("Question?", default=True) is True

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -147,10 +147,24 @@ def main() -> None:
         _cmd_daemon(config)
 
 
+def _yn_prompt(question: str, default: bool = True) -> bool:
+    """Print a yes/no prompt and return the user's answer as a bool."""
+    hint = "[Y/n]" if default else "[y/N]"
+    try:
+        raw = input(f"  {question} {hint}: ").strip().lower()
+    except EOFError:
+        return default
+    if not raw:
+        return default
+    return raw.startswith("y")
+
+
 def _cmd_sync(config: Config, config_path: Path, mark_synced: bool = False) -> None:
+    first_run = False
     if config.bandcamp is None:
         if sys.stdin.isatty():
             config = Config.bandcamp_setup(config_path)
+            first_run = True
         else:
             print(
                 f"No [bandcamp] section in {config_path}. "
@@ -158,6 +172,14 @@ def _cmd_sync(config: Config, config_path: Path, mark_synced: bool = False) -> N
                 file=sys.stderr,
             )
             sys.exit(1)
+
+    if first_run:
+        # Ask whether the collection is already downloaded so we don't re-download
+        # everything for users who have already fetched their Bandcamp purchases manually.
+        # Default to 'y' — most first-time users have prior downloads.
+        mark_synced = _yn_prompt(
+            "Have you already downloaded your Bandcamp collection?", default=True
+        )
 
     syncer = Syncer(config)
     if mark_synced:


### PR DESCRIPTION
## Summary

- After `bandcamp_setup` completes (first time running `tune-shifter sync`), immediately asks: `Have you already downloaded your Bandcamp collection? [Y/n]`
- Answering **yes** (default) calls `mark_synced` — records existing purchases without downloading anything
- Answering **no** runs a normal `sync_once` to fetch new purchases
- Adds `_yn_prompt()` helper in `__main__.py` with EOFError guard for non-interactive contexts

## Test plan

- [x] `pytest tests/test_main.py -v` — 6 tests pass
- [x] Manual: remove `[bandcamp]` from config, run `tune-shifter sync`, confirm question appears after credentials and both `y`/`n` paths behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)