### PR TITLE
feat: scan staging directory for existing items on daemon start

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,34 +1,4 @@
 # Backlog
-## Bug: Uncaught Attribute Type-Id
-
-Is this a problem?  If so, fix it. If not, put in debug level logging if possible (since it's from a different library).
-
-```
-26-03-15 12:14:58  INFO      tune_shifter.tagger  Searching MusicBrainz for artist='Earthless' album='Black Heaven'
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:label>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      tune_shifter.tagger  Matched release: 'Black Heaven' (mbid=b0562a95-2dbf-419a-85d9-eca1d082f682)
-```
-
 ## Bug: File Operations on an already moved file
 
 It looks like occasionally tag writing or analysis is attempted after a file has already been moved. This should never happen: file operations after tagging should only happen after all tagging operations are completed.
@@ -78,6 +48,36 @@ Traceback (most recent call last):
   File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 272, in _openfile
     raise MutagenError(e)
 mutagen.MutagenError: [Errno 2] No such file or directory: '/Users/theodore.terry/Downloads/_music_staging/Earthless - Black Heaven/Earthless - Black Heaven - 01 Gifted by the Wind.mp3'
+```
+
+## Bug: Uncaught Attribute Type-Id
+
+Is this a problem?  If so, fix it. If not, put in debug level logging if possible (since it's from a different library).
+
+```
+26-03-15 12:14:58  INFO      tune_shifter.tagger  Searching MusicBrainz for artist='Earthless' album='Black Heaven'
+2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:label>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
+2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
+2026-03-15 12:14:59  INFO      tune_shifter.tagger  Matched release: 'Black Heaven' (mbid=b0562a95-2dbf-419a-85d9-eca1d082f682)
 ```
 
 ## Optimization: Check existing tags / embedded image to see if they even need to be updated

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,4 @@
 # Backlog
-## Process on Start
-
-*When daemon starts, I want everything in the staging folder to be processed*
-
 ## Bug: Uncaught Attribute Type-Id
 
 Is this a problem?  If so, fix it. If not, put in debug level logging if possible (since it's from a different library).
@@ -32,6 +28,59 @@ Is this a problem?  If so, fix it. If not, put in debug level logging if possibl
 2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
 2026-03-15 12:14:59  INFO      tune_shifter.tagger  Matched release: 'Black Heaven' (mbid=b0562a95-2dbf-419a-85d9-eca1d082f682)
 ```
+
+## Bug: File Operations on an already moved file
+
+It looks like occasionally tag writing or analysis is attempted after a file has already been moved. This should never happen: file operations after tagging should only happen after all tagging operations are completed.
+
+This is an occasional bug that results in an uncaught exception that halts the daemon:
+
+```
+2026-03-15 14:02:34  ERROR     tune_shifter.watcher  Unhandled error in pipeline for /Users/theodore.terry/Downloads/_music_staging/Earthless - Black Heaven
+Traceback (most recent call last):
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 251, in _openfile
+    fileobj = open(filename, "rb+" if writable else "rb")
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: '/Users/theodore.terry/Downloads/_music_staging/Earthless - Black Heaven/Earthless - Black Heaven - 01 Gifted by the Wind.mp3'
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/Users/theodore.terry/repos/tune-shifter/tune_shifter/watcher.py", line 111, in _process
+    run(path, self._config)
+  File "/Users/theodore.terry/repos/tune-shifter/tune_shifter/pipeline.py", line 42, in run
+    release = tag_directory(directory, audio_files)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/theodore.terry/repos/tune-shifter/tune_shifter/tagger.py", line 96, in tag_directory
+    _write_tags(audio_file, release)
+  File "/Users/theodore.terry/repos/tune-shifter/tune_shifter/tagger.py", line 298, in _write_tags
+    _write_mp3_tags(path, release, track_info)
+  File "/Users/theodore.terry/repos/tune-shifter/tune_shifter/tagger.py", line 340, in _write_mp3_tags
+    tags = id3.ID3(str(path))
+           ^^^^^^^^^^^^^^^^^^
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/id3/_file.py", line 76, in __init__
+    super(ID3, self).__init__(*args, **kwargs)
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/id3/_tags.py", line 175, in __init__
+    super(ID3Tags, self).__init__(*args, **kwargs)
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 534, in __init__
+    super(DictProxy, self).__init__(*args, **kwargs)
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_tags.py", line 110, in __init__
+    self.load(*args, **kwargs)
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 185, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 154, in wrapper
+    with _openfile(self, filething, filename, fileobj,
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/contextlib.py", line 137, in __enter__
+    return next(self.gen)
+           ^^^^^^^^^^^^^^
+  File "/Users/theodore.terry/.pyenv/versions/3.12.10/lib/python3.12/site-packages/mutagen/_util.py", line 272, in _openfile
+    raise MutagenError(e)
+mutagen.MutagenError: [Errno 2] No such file or directory: '/Users/theodore.terry/Downloads/_music_staging/Earthless - Black Heaven/Earthless - Black Heaven - 01 Gifted by the Wind.mp3'
+```
+
+## Optimization: Check existing tags / embedded image to see if they even need to be updated
 
 ## Best Release
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -12,7 +12,7 @@ from tune_shifter.config import (
     MusicBrainzConfig,
     PathsConfig,
 )
-from tune_shifter.watcher import _StagingHandler
+from tune_shifter.watcher import _StagingHandler, Watcher
 
 
 @pytest.fixture
@@ -164,6 +164,65 @@ class TestOnModified:
             handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
 
         mock_schedule.assert_not_called()
+
+
+class TestStartupScan:
+    def test_existing_directory_is_scheduled_on_start(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A directory already in staging when the daemon starts gets scheduled."""
+        config.paths.staging.mkdir(parents=True, exist_ok=True)
+        (config.paths.staging / "Artist - Album").mkdir()
+
+        scheduled: list[Path] = []
+        monkeypatch.setattr(
+            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+        )
+
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        watcher.start()
+
+        assert any(p.name == "Artist - Album" for p in scheduled)
+
+    def test_existing_zip_is_scheduled_on_start(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ZIP already in staging when the daemon starts gets scheduled."""
+        config.paths.staging.mkdir(parents=True, exist_ok=True)
+        (config.paths.staging / "album.zip").write_bytes(b"PK")
+
+        scheduled: list[Path] = []
+        monkeypatch.setattr(
+            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+        )
+
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        watcher.start()
+
+        assert any(p.name == "album.zip" for p in scheduled)
+
+    def test_errors_directory_is_not_scheduled_on_start(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The errors/ subdirectory is not scheduled on startup."""
+        config.paths.staging.mkdir(parents=True, exist_ok=True)
+        (config.paths.staging / "errors").mkdir()
+
+        scheduled: list[Path] = []
+        monkeypatch.setattr(
+            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+        )
+
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        watcher.start()
+
+        assert not any(p.name == "errors" for p in scheduled)
 
 
 class TestOnCreated:

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -142,6 +142,8 @@ class Watcher:
         self._observer.schedule(self._handler, str(staging), recursive=False)
         self._observer.start()
         logger.info("Watching staging directory: %s", staging)
+        # Process any items already present when the daemon starts.
+        self._handler._scan_staging_root()
 
     def stop(self) -> None:
         self._observer.stop()


### PR DESCRIPTION
## Summary

- `Watcher.start()` now calls `_scan_staging_root()` after the observer starts
- Pre-existing directories and ZIPs in staging are scheduled immediately at startup
- The `errors/` subdirectory continues to be skipped

## Test plan

- [x] `TestStartupScan` class added to `tests/test_watcher.py` with three cases: existing directory scheduled, existing ZIP scheduled, `errors/` not scheduled
- [x] All 14 watcher tests pass
- [x] `mypy` clean
- [x] `black` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)