### PR TITLE
fix: suppress noisy musicbrainzngs INFO logs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,34 +1,4 @@
 # Backlog
-## Bug: Uncaught Attribute Type-Id
-
-Is this a problem?  If so, fix it. If not, put in debug level logging if possible (since it's from a different library).
-
-```
-26-03-15 12:14:58  INFO      tune_shifter.tagger  Searching MusicBrainz for artist='Earthless' album='Black Heaven'
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:58  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:release-group>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:label>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:artist>, uncaught attribute type-id
-2026-03-15 12:14:59  INFO      musicbrainzngs  in <ws2:recording>, uncaught <first-release-date>
-2026-03-15 12:14:59  INFO      tune_shifter.tagger  Matched release: 'Black Heaven' (mbid=b0562a95-2dbf-419a-85d9-eca1d082f682)
-```
-
 ## Optimization: Check existing tags / embedded image to see if they even need to be updated
 
 ## Best Release

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -102,9 +102,12 @@ def main() -> None:
         format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    # musicbrainzngs logs at INFO for every unrecognised XML attribute (normal schema
-    # evolution). Silence those; real warnings and errors will still surface.
-    logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
+    # At INFO (the default), musicbrainzngs emits noisy schema-evolution messages for
+    # every unrecognised XML attribute. Suppress those to WARNING so they don't clutter
+    # normal output. At DEBUG the user wants everything, so don't override; at WARNING/
+    # ERROR the root logger already handles filtering without our help.
+    if args.log_level == "INFO":
+        logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
 
     # Default to daemon when no subcommand given
     command = args.command or "daemon"

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -102,6 +102,9 @@ def main() -> None:
         format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+    # musicbrainzngs logs at INFO for every unrecognised XML attribute (normal schema
+    # evolution). Silence those; real warnings and errors will still surface.
+    logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
 
     # Default to daemon when no subcommand given
     command = args.command or "daemon"


### PR DESCRIPTION
## Summary

- `musicbrainzngs` logs at INFO for every XML attribute it doesn't have a handler for — this is normal schema evolution, not an error
- Lookups succeed despite the messages (confirmed by "Matched release" appearing after)
- Setting `logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)` after `basicConfig` silences the chatter while preserving any real warnings or errors from the library

## Test plan

- [x] Run daemon against a real album — "uncaught attribute type-id" lines should no longer appear
- [x] "Matched release" log line still appears, confirming lookup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)