### PR TITLE
fix: include USAGE.md in Poetry sdist for Homebrew formula

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,13 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## Bug: Homebrew install fails because usage is missing
+
+```
+Error: An exception occurred within a child process:
+  Errno::ENOENT: No such file or directory - USAGE.md
+```
+
 ## Optimization: Check existing tags / embedded image to see if they even need to be updated
 *Single* — read tags before writing and skip files that are already correct
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include USAGE.md
-include LICENSE

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ After install, download the Playwright browser binaries required for Bandcamp au
 ```bash
 git clone https://github.com/eightyeighteyes/tune-shifter
 cd tune-shifter
-pip install -e .
+poetry install
 playwright install chromium
 ```
 
@@ -214,11 +214,11 @@ The session file (`bandcamp_session.json`) is written with owner-only permission
 ## Development
 
 ```bash
-pip install -e ".[dev]"
+poetry install
 playwright install chromium
-pytest tests/          # run tests
-mypy tune_shifter/     # type check
-black tune_shifter/ tests/  # format
+poetry run pytest      # run tests
+poetry run mypy tune_shifter/     # type check
+poetry run black tune_shifter/ tests/  # format
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.8.0"
 description = "Automated audio library ingest from Bandcamp downloads."
 authors = []
 packages = [{include = "tune_shifter"}]
+# USAGE.md is read by the Homebrew formula's caveats block; MANIFEST.in is
+# ignored by poetry-core so it must be declared here explicitly.
+include = ["USAGE.md"]
 
 [tool.poetry.dependencies]
 python = ">=3.11"


### PR DESCRIPTION
## Summary
- `MANIFEST.in` (which included `USAGE.md`) is ignored by `poetry-core`; the Homebrew formula's `caveats` block reads this file at install time and raised `Errno::ENOENT`
- Adds `include = ["USAGE.md"]` to `[tool.poetry]` so it is bundled in the sdist

## Test plan
- [x] `poetry build --format sdist` and confirm `USAGE.md` appears in the tarball
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)