### PR TITLE
feat: Spotlight shortcut — Bandcamp Sync app via osacompile

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,15 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## Sync Outside of Terminal
+*Single* — ship a macOS Shortcuts app shortcut (`.shortcut` file) named "Bandcamp Sync" that runs `tune-shifter sync` via a shell script action; Spotlight indexes Shortcuts so no terminal needed. No CLI changes required.
+
+## FLAC Support
+*Side* — extend tagger, mover, and artwork embed to handle `.flac` via `mutagen.flac.FLAC`; mirrors existing MP3/M4A paths
+
+## OGG Support
+*Side* — same as FLAC but via `mutagen.oggvorbis`; can be done alongside FLAC in one pass
+
 ## Optimization: Check existing tags / embedded image to see if they even need to be updated
 *Single* — read tags before writing and skip files that are already correct
 
@@ -14,12 +23,6 @@
 
 ## Config Arguments
 *Side* — add `tune-shifter config set <key> <value>` and `tune-shifter config show` subcommands; reads/writes existing TOML file
-
-## FLAC Support
-*Side* — extend tagger, mover, and artwork embed to handle `.flac` via `mutagen.flac.FLAC`; mirrors existing MP3/M4A paths
-
-## OGG Support
-*Side* — same as FLAC but via `mutagen.oggvorbis`; can be done alongside FLAC in one pass
 
 ## Cross-platform service installation (Linux systemd, Windows Task Scheduler)
 *Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
@@ -46,8 +49,9 @@
 ## Configurable Album Art Search
 ⚠️ Not scoped enough to start — each source (Bandcamp, Apple, Spotify, Qobuz) requires its own API integration and auth flow; estimate per source is ~Side to LP. Needs a design pass on the config schema and fallback order before any source is implemented.
 
-## GUI / menu bar app for sync status
-*Box Set* — new surface area; needs technology choice (SwiftUI, Tauri, rumps, etc.) and design before scoping
-
 ## Allow a user to verify tags before they're written
 ⚠️ Not scoped — needs UI design (CLI prompt? TUI? GUI?) before estimating
+
+
+## GUI / menu bar app for sync status
+*Box Set* — new surface area; needs technology choice (SwiftUI, Tauri, rumps, etc.) and design before scoping

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,6 +30,9 @@
 ## Does Bandcamp auto-download actually work? Test poll_interval_minutes.
 *Single* — manual QA task; set a short poll interval and verify downloads trigger correctly
 
+## Menu Bar Status Item
+*LP* — when the daemon runs, show a menu bar icon with a "Sync Now" item; requires `rumps` dependency and threading integration with the daemon lifecycle
+
 # Needs Refinement
 ## Best Release
 *Side* — when multiple MB results exist, prefer the release closest to the original physical format (LP/CD over digital/streaming)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built with Python 3 by [Claude Sonnet 4.6](https://www.anthropic.com/claude).
 - **Configurable library layout** — moves finished files into your library using a template you control (`{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}`)
 - **Error quarantine** — failed items are moved to `staging/errors/` so nothing loops or blocks the queue
 - **Background service** — one command registers the daemon as a system service that starts at login (macOS launchd)
+- **Spotlight shortcut** — `tune-shifter install-shortcut` creates a "Bandcamp Sync" app in `~/Applications` so you can trigger a sync from Spotlight without opening a terminal (macOS)
 - **Cross-platform** — macOS, Linux, and Windows (Python 3.11+)
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,6 @@ Bandcamp sync:
 
 Spotlight shortcut (macOS):
 
-  tune-shifter install-shortcut      # opens Shortcuts app — click "Add Shortcut"
-                                     # then find "Bandcamp Sync" in Spotlight
+  tune-shifter install-shortcut      # adds "Bandcamp Sync" to Spotlight
                                      # run 'tune-shifter sync' in a terminal first
                                      # to set up Bandcamp credentials

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,20 +1,17 @@
-Welcome to tune-shifter!
+Quick start:
 
-To get started, run:
-   tune-shifter
+  tune-shifter                  # first-run setup + start daemon
+  tune-shifter install-service  # auto-start at login
 
-On first run, you'll be asked for your staging directory, library directory,
-and contact email (used in the MusicBrainz User-Agent). Press Enter at each
-prompt to accept the shown default. The config is saved automatically and the
-daemon starts right away.
+Drop a ZIP or folder into your staging directory — tune-shifter handles the rest.
 
-Then install the service so it starts at login:
-  tune-shifter install-service
+Bandcamp sync:
 
-Now move a zip or folder into your staging folder and tune-shifter will take care of the rest!
+  tune-shifter sync                  # download new purchases
+  tune-shifter sync --mark-synced    # first time: skip existing collection
 
-To sync your collection from Bandcamp, run:
-  tune-shifter sync
+Spotlight shortcut (macOS):
 
-If most of your Bandcamp collection is already in your local library, run this first to avoid redownloading everything:
-  tune-shifter sync --mark-synced
+  tune-shifter install-shortcut      # adds "Bandcamp Sync" to Spotlight
+                                     # run 'tune-shifter sync' in a terminal first
+                                     # to set up Bandcamp credentials

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,6 +12,7 @@ Bandcamp sync:
 
 Spotlight shortcut (macOS):
 
-  tune-shifter install-shortcut      # adds "Bandcamp Sync" to Spotlight
+  tune-shifter install-shortcut      # opens Shortcuts app — click "Add Shortcut"
+                                     # then find "Bandcamp Sync" in Spotlight
                                      # run 'tune-shifter sync' in a terminal first
                                      # to set up Bandcamp credentials

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -310,8 +310,22 @@ end try"""
         cwd=str(_SHORTCUT_APP.parent),
         check=True,
     )
-    # Force Spotlight to index the new app immediately; without this it may not
-    # appear in search until the next scheduled mdworker pass.
+    # osacompile omits CFBundleIdentifier, which Spotlight requires to index an app
+    # as an Application. Inject it with PlistBuddy, then re-sign so the bundle
+    # signature covers the updated plist, then force Spotlight to index it.
+    _info_plist = _SHORTCUT_APP / "Contents" / "Info.plist"
+    subprocess.run(
+        [
+            "/usr/libexec/PlistBuddy",
+            "-c",
+            "Add :CFBundleIdentifier string com.tune-shifter.bandcamp-sync",
+            str(_info_plist),
+        ],
+        check=False,
+    )
+    subprocess.run(
+        ["codesign", "--force", "--sign", "-", str(_SHORTCUT_APP)], check=False
+    )
     subprocess.run(["mdimport", str(_SHORTCUT_APP)], check=False)
     print(f"Shortcut installed: {_SHORTCUT_APP}")
     print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -326,6 +326,13 @@ end try"""
     subprocess.run(
         ["codesign", "--force", "--sign", "-", str(_SHORTCUT_APP)], check=False
     )
+    # Register with Launch Services (the app database Spotlight queries for applications).
+    # mdimport alone is insufficient — lsregister is what makes an app appear in Spotlight.
+    _LS_REGISTER = Path(
+        "/System/Library/Frameworks/CoreServices.framework"
+        "/Frameworks/LaunchServices.framework/Support/lsregister"
+    )
+    subprocess.run([str(_LS_REGISTER), "-f", str(_SHORTCUT_APP)], check=False)
     subprocess.run(["mdimport", str(_SHORTCUT_APP)], check=False)
     print(f"Shortcut installed: {_SHORTCUT_APP}")
     print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -16,9 +16,9 @@ import logging
 import plistlib
 import shutil
 import signal
+import stat
 import subprocess
 import sys
-import tempfile
 import tomllib
 from pathlib import Path
 
@@ -31,8 +31,7 @@ from .watcher import Watcher
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
-_SHORTCUT_NAME = "Bandcamp Sync"
-_SHORTCUT_FILE = _state_dir() / "Bandcamp Sync.shortcut"
+_SHORTCUT_APP = Path.home() / "Applications" / "Bandcamp Sync.app"
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over
@@ -293,68 +292,61 @@ def _cmd_uninstall_service() -> None:
 
 
 def _cmd_install_shortcut() -> None:
-    # Build a minimal Shortcuts action that runs tune-shifter sync via a login
-    # shell so the PATH is populated regardless of install method.
-    shortcut_data = {
-        "WFWorkflowActions": [
-            {
-                "WFWorkflowActionIdentifier": "is.workflow.actions.runshellscript",
-                "WFWorkflowActionParameters": {
-                    "WFShellScriptActionScript": ("/bin/zsh -l -c 'tune-shifter sync'"),
-                    "WFShellScriptShell": "/bin/zsh",
-                },
-            }
-        ],
-        "WFWorkflowClientVersion": "1130",
-        "WFWorkflowHasShortcutInputVariables": False,
-        "WFWorkflowIcon": {
-            "WFWorkflowIconGlyphNumber": 59511,
-            "WFWorkflowIconStartColor": 1925823743,
-        },
-        "WFWorkflowImportQuestions": [],
-        "WFWorkflowInputContentItemClasses": [],
-        "WFWorkflowMinimumClientVersion": 900,
-        "WFWorkflowMinimumClientVersionString": "900",
-        "WFWorkflowOutputContentItemClasses": [],
-        "WFWorkflowTypes": [],
+    macos_dir = _SHORTCUT_APP / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True, exist_ok=True)
+
+    # LaunchServices (and therefore Spotlight) requires CFBundleIdentifier,
+    # CFBundleVersion, CFBundleDisplayName, and NSHighResolutionCapable to
+    # classify a bundle as an indexable application. osacompile omits several
+    # of these, which is why osacompile-produced apps are silently skipped by
+    # Spotlight on macOS Sequoia. We build the bundle ourselves so we control
+    # the full plist. LSUIElement suppresses a Dock icon while the sync runs.
+    info: dict[str, object] = {
+        "CFBundleExecutable": "BandcampSync",
+        "CFBundleIdentifier": "local.tune-shifter.bandcamp-sync",
+        "CFBundleName": "Bandcamp Sync",
+        "CFBundleDisplayName": "Bandcamp Sync",
+        "CFBundlePackageType": "APPL",
+        "CFBundleVersion": "1.0.0",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
     }
+    with open(_SHORTCUT_APP / "Contents" / "Info.plist", "wb") as f:
+        plistlib.dump(info, f)
 
-    _SHORTCUT_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write unsigned plist to a temp file, sign it, write signed copy to state dir.
-    # The signed file persists so uninstall can locate it and reinstalls are idempotent.
-    with tempfile.NamedTemporaryFile(suffix=".shortcut", delete=False) as f:
-        unsigned = Path(f.name)
-        plistlib.dump(shortcut_data, f, fmt=plistlib.FMT_BINARY)
-
-    try:
-        # shortcuts sign emits spurious ObjC runtime warnings to stderr that
-        # are internal to Apple's tool and not actionable; suppress them.
-        subprocess.run(
-            [
-                "shortcuts",
-                "sign",
-                "--mode",
-                "anyone",
-                "--input",
-                str(unsigned),
-                "--output",
-                str(_SHORTCUT_FILE),
-            ],
-            check=True,
-            stderr=subprocess.DEVNULL,
-        )
-    finally:
-        unsigned.unlink(missing_ok=True)
-
-    # Opening the signed .shortcut file launches the Shortcuts app with a
-    # one-click "Add Shortcut" confirmation dialog; no programmatic install
-    # path exists on this macOS version.
-    subprocess.run(["open", str(_SHORTCUT_FILE)], check=True)
-    print(
-        'The Shortcuts app will open — click "Add Shortcut" to complete installation.'
+    # The executable is a plain shell script. /bin/zsh -l loads the login
+    # profile so tune-shifter is on PATH regardless of install method.
+    # osascript surfaces a notification on completion since the app runs
+    # silently in the background with no visible window.
+    exe = macos_dir / "BandcampSync"
+    exe.write_text(
+        "#!/bin/zsh\n"
+        "/bin/zsh -l -c 'tune-shifter sync'"
+        " && osascript -e"
+        ' \'display notification "Bandcamp sync complete"'
+        ' with title "tune-shifter"\''
+        " || osascript -e"
+        ' \'display notification "Sync failed \u2014 check the log"'
+        ' with title "tune-shifter"\'\n'
     )
-    print(f'\nThen open Spotlight (\u2318 Space) and type "{_SHORTCUT_NAME}".')
+    exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Ad-hoc sign (no Apple Developer account required). Bundles created
+    # locally never receive a quarantine xattr, so Gatekeeper won't prompt.
+    # --deep signs nested code; --force overwrites any prior signature.
+    subprocess.run(
+        ["codesign", "--force", "--deep", "--sign", "-", str(_SHORTCUT_APP)],
+        check=True,
+    )
+
+    # Nudge Spotlight to index the bundle immediately rather than waiting for
+    # the next mds polling cycle (known to be slow on macOS Sequoia).
+    subprocess.run(["mdimport", str(_SHORTCUT_APP)], check=False)
+
+    print(f"Shortcut installed: {_SHORTCUT_APP}")
+    print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')
     print(
         "\nNote: run 'tune-shifter sync' in a terminal first to set up Bandcamp credentials."
     )
@@ -362,24 +354,11 @@ def _cmd_install_shortcut() -> None:
 
 
 def _cmd_uninstall_shortcut() -> None:
-    # Use the Shortcuts Events scripting bridge to delete by name.
-    result = subprocess.run(
-        [
-            "osascript",
-            "-e",
-            f'tell application "Shortcuts Events" to delete '
-            f'(shortcuts whose name is "{_SHORTCUT_NAME}")',
-        ],
-        capture_output=True,
-    )
-    _SHORTCUT_FILE.unlink(missing_ok=True)
-    if result.returncode == 0:
-        print("Shortcut removed.")
-    else:
-        print(
-            f'Shortcut "{_SHORTCUT_NAME}" not found in Shortcuts app '
-            "(may have already been removed)."
-        )
+    if not _SHORTCUT_APP.exists():
+        print("Shortcut is not installed.")
+        return
+    shutil.rmtree(_SHORTCUT_APP)
+    print("Shortcut removed.")
 
 
 if __name__ == "__main__":

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -29,6 +29,7 @@ from .watcher import Watcher
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
+_SHORTCUT_APP = Path.home() / "Applications" / "Bandcamp Sync.app"
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over
@@ -102,6 +103,14 @@ def main() -> None:
         "uninstall-service",
         help="Remove the launchd user agent registration.",
     )
+    subparsers.add_parser(
+        "install-shortcut",
+        help="Create a 'Bandcamp Sync' Spotlight app in ~/Applications (macOS).",
+    )
+    subparsers.add_parser(
+        "uninstall-shortcut",
+        help="Remove the Bandcamp Sync Spotlight app.",
+    )
 
     args = parser.parse_args()
 
@@ -126,6 +135,12 @@ def main() -> None:
         return
     if command == "uninstall-service":
         _cmd_uninstall_service()
+        return
+    if command == "install-shortcut":
+        _cmd_install_shortcut()
+        return
+    if command == "uninstall-shortcut":
+        _cmd_uninstall_shortcut()
         return
 
     try:
@@ -272,6 +287,36 @@ def _cmd_uninstall_service() -> None:
     subprocess.run(["launchctl", "unload", str(_PLIST_PATH)], check=False)
     _PLIST_PATH.unlink()
     print("Service removed.")
+
+
+def _cmd_install_shortcut() -> None:
+    _SHORTCUT_APP.parent.mkdir(parents=True, exist_ok=True)
+    # /bin/zsh -l loads the login profile so tune-shifter is on PATH regardless
+    # of install method (Homebrew, pipx, source checkout, etc.).
+    # try/on error surfaces failures — including a missing [bandcamp] config —
+    # as a notification instead of silently doing nothing.
+    script = """\
+try
+    do shell script "/bin/zsh -l -c 'tune-shifter sync'"
+    display notification "Bandcamp sync complete" with title "tune-shifter"
+on error msg
+    display notification msg with title "tune-shifter: sync failed"
+end try"""
+    subprocess.run(["osacompile", "-o", str(_SHORTCUT_APP), "-e", script], check=True)
+    print(f"Shortcut installed: {_SHORTCUT_APP}")
+    print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')
+    print(
+        "\nNote: run 'tune-shifter sync' in a terminal first to set up Bandcamp credentials."
+    )
+    print(f"\nTo remove it:\n  tune-shifter uninstall-shortcut")
+
+
+def _cmd_uninstall_shortcut() -> None:
+    if not _SHORTCUT_APP.exists():
+        print("Shortcut is not installed.")
+        return
+    shutil.rmtree(_SHORTCUT_APP)
+    print("Shortcut removed.")
 
 
 if __name__ == "__main__":

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -31,7 +31,7 @@ from .watcher import Watcher
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
-_SHORTCUT_APP = Path.home() / "Applications" / "Bandcamp Sync.app"
+_SHORTCUT_APP = Path("/Applications/Bandcamp Sync.app")
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -310,6 +310,9 @@ end try"""
         cwd=str(_SHORTCUT_APP.parent),
         check=True,
     )
+    # Force Spotlight to index the new app immediately; without this it may not
+    # appear in search until the next scheduled mdworker pass.
+    subprocess.run(["mdimport", str(_SHORTCUT_APP)], check=False)
     print(f"Shortcut installed: {_SHORTCUT_APP}")
     print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')
     print(

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 import logging
+import plistlib
 import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import tomllib
 from pathlib import Path
 
@@ -29,7 +31,8 @@ from .watcher import Watcher
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
-_SHORTCUT_APP = Path.home() / "Applications" / "Bandcamp Sync.app"
+_SHORTCUT_NAME = "Bandcamp Sync"
+_SHORTCUT_FILE = _state_dir() / "Bandcamp Sync.shortcut"
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over
@@ -290,52 +293,65 @@ def _cmd_uninstall_service() -> None:
 
 
 def _cmd_install_shortcut() -> None:
-    _SHORTCUT_APP.parent.mkdir(parents=True, exist_ok=True)
-    # /bin/zsh -l loads the login profile so tune-shifter is on PATH regardless
-    # of install method (Homebrew, pipx, source checkout, etc.).
-    # try/on error surfaces failures — including a missing [bandcamp] config —
-    # as a notification instead of silently doing nothing.
-    script = """\
-try
-    do shell script "/bin/zsh -l -c 'tune-shifter sync'"
-    display notification "Bandcamp sync complete" with title "tune-shifter"
-on error msg
-    display notification msg with title "tune-shifter: sync failed"
-end try"""
-    # osacompile mishandles spaces in the -o path even in list-form subprocess calls,
-    # signing "." instead of the bundle. Running from within the target directory with
-    # a relative name avoids the issue entirely.
-    subprocess.run(
-        ["osacompile", "-o", _SHORTCUT_APP.name, "-e", script],
-        cwd=str(_SHORTCUT_APP.parent),
-        check=True,
-    )
-    # osacompile omits CFBundleIdentifier, which Spotlight requires to index an app
-    # as an Application. Inject it with PlistBuddy, then re-sign so the bundle
-    # signature covers the updated plist, then force Spotlight to index it.
-    _info_plist = _SHORTCUT_APP / "Contents" / "Info.plist"
-    subprocess.run(
-        [
-            "/usr/libexec/PlistBuddy",
-            "-c",
-            "Add :CFBundleIdentifier string com.tune-shifter.bandcamp-sync",
-            str(_info_plist),
+    # Build a minimal Shortcuts action that runs tune-shifter sync via a login
+    # shell so the PATH is populated regardless of install method.
+    shortcut_data = {
+        "WFWorkflowActions": [
+            {
+                "WFWorkflowActionIdentifier": "is.workflow.actions.runshellscript",
+                "WFWorkflowActionParameters": {
+                    "WFShellScriptActionScript": ("/bin/zsh -l -c 'tune-shifter sync'"),
+                    "WFShellScriptShell": "/bin/zsh",
+                },
+            }
         ],
-        check=False,
+        "WFWorkflowClientVersion": "1130",
+        "WFWorkflowHasShortcutInputVariables": False,
+        "WFWorkflowIcon": {
+            "WFWorkflowIconGlyphNumber": 59511,
+            "WFWorkflowIconStartColor": 1925823743,
+        },
+        "WFWorkflowImportQuestions": [],
+        "WFWorkflowInputContentItemClasses": [],
+        "WFWorkflowMinimumClientVersion": 900,
+        "WFWorkflowMinimumClientVersionString": "900",
+        "WFWorkflowOutputContentItemClasses": [],
+        "WFWorkflowTypes": [],
+    }
+
+    _SHORTCUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write unsigned plist to a temp file, sign it, write signed copy to state dir.
+    # The signed file persists so uninstall can locate it and reinstalls are idempotent.
+    with tempfile.NamedTemporaryFile(suffix=".shortcut", delete=False) as f:
+        unsigned = Path(f.name)
+        plistlib.dump(shortcut_data, f, fmt=plistlib.FMT_BINARY)
+
+    try:
+        subprocess.run(
+            [
+                "shortcuts",
+                "sign",
+                "--mode",
+                "anyone",
+                "--input",
+                str(unsigned),
+                "--output",
+                str(_SHORTCUT_FILE),
+            ],
+            check=True,
+        )
+    finally:
+        unsigned.unlink(missing_ok=True)
+
+    # Opening the signed .shortcut file launches the Shortcuts app with a
+    # one-click "Add Shortcut" confirmation dialog; no programmatic install
+    # path exists on this macOS version.
+    subprocess.run(["open", str(_SHORTCUT_FILE)], check=True)
+    print(
+        'The Shortcuts app will open — click "Add Shortcut" to complete installation.'
     )
-    subprocess.run(
-        ["codesign", "--force", "--sign", "-", str(_SHORTCUT_APP)], check=False
-    )
-    # Register with Launch Services (the app database Spotlight queries for applications).
-    # mdimport alone is insufficient — lsregister is what makes an app appear in Spotlight.
-    _LS_REGISTER = Path(
-        "/System/Library/Frameworks/CoreServices.framework"
-        "/Frameworks/LaunchServices.framework/Support/lsregister"
-    )
-    subprocess.run([str(_LS_REGISTER), "-f", str(_SHORTCUT_APP)], check=False)
-    subprocess.run(["mdimport", str(_SHORTCUT_APP)], check=False)
-    print(f"Shortcut installed: {_SHORTCUT_APP}")
-    print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')
+    print(f'\nThen open Spotlight (\u2318 Space) and type "{_SHORTCUT_NAME}".')
     print(
         "\nNote: run 'tune-shifter sync' in a terminal first to set up Bandcamp credentials."
     )
@@ -343,11 +359,24 @@ end try"""
 
 
 def _cmd_uninstall_shortcut() -> None:
-    if not _SHORTCUT_APP.exists():
-        print("Shortcut is not installed.")
-        return
-    shutil.rmtree(_SHORTCUT_APP)
-    print("Shortcut removed.")
+    # Use the Shortcuts Events scripting bridge to delete by name.
+    result = subprocess.run(
+        [
+            "osascript",
+            "-e",
+            f'tell application "Shortcuts Events" to delete '
+            f'(shortcuts whose name is "{_SHORTCUT_NAME}")',
+        ],
+        capture_output=True,
+    )
+    _SHORTCUT_FILE.unlink(missing_ok=True)
+    if result.returncode == 0:
+        print("Shortcut removed.")
+    else:
+        print(
+            f'Shortcut "{_SHORTCUT_NAME}" not found in Shortcuts app '
+            "(may have already been removed)."
+        )
 
 
 if __name__ == "__main__":

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -328,6 +328,8 @@ def _cmd_install_shortcut() -> None:
         plistlib.dump(shortcut_data, f, fmt=plistlib.FMT_BINARY)
 
     try:
+        # shortcuts sign emits spurious ObjC runtime warnings to stderr that
+        # are internal to Apple's tool and not actionable; suppress them.
         subprocess.run(
             [
                 "shortcuts",
@@ -340,6 +342,7 @@ def _cmd_install_shortcut() -> None:
                 str(_SHORTCUT_FILE),
             ],
             check=True,
+            stderr=subprocess.DEVNULL,
         )
     finally:
         unsigned.unlink(missing_ok=True)

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -302,7 +302,14 @@ try
 on error msg
     display notification msg with title "tune-shifter: sync failed"
 end try"""
-    subprocess.run(["osacompile", "-o", str(_SHORTCUT_APP), "-e", script], check=True)
+    # osacompile mishandles spaces in the -o path even in list-form subprocess calls,
+    # signing "." instead of the bundle. Running from within the target directory with
+    # a relative name avoids the issue entirely.
+    subprocess.run(
+        ["osacompile", "-o", _SHORTCUT_APP.name, "-e", script],
+        cwd=str(_SHORTCUT_APP.parent),
+        check=True,
+    )
     print(f"Shortcut installed: {_SHORTCUT_APP}")
     print('Open Spotlight (\u2318 Space), type "Bandcamp Sync", and press Enter.')
     print(


### PR DESCRIPTION
## Summary

- Adds `tune-shifter install-shortcut` — creates `~/Applications/Bandcamp Sync.app` via `osacompile` so Spotlight can launch `tune-shifter sync` without a terminal
- Adds `tune-shifter uninstall-shortcut` — removes the app
- AppleScript wraps the shell call in `try/on error` to surface failures (including missing Bandcamp config) as a macOS notification rather than silently doing nothing
- `/bin/zsh -l` loads the login profile so `tune-shifter` is on PATH regardless of install method
- Trims `USAGE.md` to essentials; adds Spotlight shortcut section
- Adds Spotlight shortcut bullet to README features list

## Test plan

- [ ] `tune-shifter install-shortcut` — `~/Applications/Bandcamp Sync.app` is created
- [ ] Open Spotlight (⌘ Space), type "Bandcamp" — app appears in results
- [ ] Press Enter — sync runs, notification fires on success
- [ ] Run without Bandcamp config — notification fires with error message
- [ ] `tune-shifter uninstall-shortcut` — app is removed
- [ ] `tune-shifter uninstall-shortcut` (again) — prints "Shortcut is not installed."
- [ ] CI passes (mypy, black, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)