### PR TITLE
chore: add Menu Bar Status Item to backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,6 +27,9 @@
 ## Does Bandcamp auto-download actually work? Test poll_interval_minutes.
 *Single* — manual QA task; set a short poll interval and verify downloads trigger correctly
 
+## Menu Bar Status Item
+*LP* — when the daemon runs, show a menu bar icon with a "Sync Now" item; requires `rumps` dependency and threading integration with the daemon lifecycle
+
 # Needs Refinement
 ## Best Release
 *Side* — when multiple MB results exist, prefer the release closest to the original physical format (LP/CD over digital/streaming)


### PR DESCRIPTION
Shelved the Spotlight shortcut approach (feature/spotlight-shortcut, PR #32)
after hitting a Sequoia-level restriction: mds won't index apps created by
CLI processes without elevated privileges, and lsregister had a stale Trash
entry blocking registration. Multiple approaches tried: osacompile, manual
.app bundle, ~/Applications, /Applications.

Menu bar status item is the most natural macOS UX for this need and is
preserved in the backlog at LP effort.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
