### PR TITLE
feat: FLAC support

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,6 +24,9 @@
 ## Menu Bar Status Item
 *LP* — when the daemon runs, show a menu bar icon with a "Sync Now" item; requires `rumps` dependency and threading integration with the daemon lifecycle
 
+## ALAC Support
+*Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)
+
 # Needs Refinement
 ## Best Release
 *Side* — when multiple MB results exist, prefer the release closest to the original physical format (LP/CD over digital/streaming)
@@ -48,3 +51,7 @@
 
 ## Allow a user to verify tags before they're written
 ⚠️ Not scoped — needs UI design (CLI prompt? TUI? GUI?) before estimating
+
+# Needs Estimation
+
+Nothing to estimate.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,9 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## OGG Support
+*Side* — same as FLAC but via `mutagen.oggvorbis`; can be done alongside FLAC in one pass
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -11,12 +14,6 @@
 
 ## Config Arguments
 *Side* — add `tune-shifter config set <key> <value>` and `tune-shifter config show` subcommands; reads/writes existing TOML file
-
-## FLAC Support
-*Side* — extend tagger, mover, and artwork embed to handle `.flac` via `mutagen.flac.FLAC`; mirrors existing MP3/M4A paths
-
-## OGG Support
-*Side* — same as FLAC but via `mutagen.oggvorbis`; can be done alongside FLAC in one pass
 
 ## Cross-platform service installation (Linux systemd, Windows Task Scheduler)
 *Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
@@ -31,7 +28,7 @@
 ## Best Release
 *Side* — when multiple MB results exist, prefer the release closest to the original physical format (LP/CD over digital/streaming)
 
-⚠️ Needs scoping: what ranking heuristic? (release format field, country, date proximity?) and what's the fallback when no physical release exists?
+⚠️ Needs scoping: what ranking heuristic? (release format field, country, date proximity?) and what's the fallback when no physical release exists? Note: date-based tie-breaking (earliest release wins) is already implemented; remaining work is format/country preference.
 
 ## AcoustID Support
 *LP* — fingerprint audio with `fpcalc`/chromaprint, look up recording via AcoustID API, feed MBID into existing tagger

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built with Python 3 by [Claude Sonnet 4.6](https://www.anthropic.com/claude).
 ## Features
 
 - **Bandcamp auto-download** — polls your Bandcamp collection for new purchases and downloads them automatically; authenticates via a one-time interactive browser login (no credentials stored)
-- **Automatic tagging** — looks up every release on [MusicBrainz](https://musicbrainz.org) and writes canonical tags (artist, album artist, album, year, track number, disc number, MusicBrainz release ID)
+- **Automatic tagging** — looks up every release on [MusicBrainz](https://musicbrainz.org) and writes canonical tags (artist, album artist, album, year, track number, disc number, MusicBrainz IDs)
 - **Cover art** — fetches front cover art from the [MusicBrainz Cover Art Archive](https://coverartarchive.org), validates minimum dimensions (≥ 1000 × 1000 px) and maximum file size (≤ 1 MB), and embeds it in every track
 - **Filesystem watcher** — monitors your staging directory; drop a ZIP or folder in and it is processed automatically
 - **Configurable library layout** — moves finished files into your library using a template you control (`{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}`)
@@ -57,7 +57,7 @@ Bandcamp purchase
 |---|---|
 | `watchdog` | Filesystem event monitoring |
 | `musicbrainzngs` | MusicBrainz release lookup |
-| `mutagen` | Reading and writing audio tags (MP3, M4A) |
+| `mutagen` | Reading and writing audio tags (MP3, M4A, FLAC) |
 | `requests` | HTTP client for the Cover Art Archive and session validation |
 | `Pillow` | Image dimension validation |
 | `playwright` | Headless browser for Bandcamp authentication and download |
@@ -191,6 +191,7 @@ Drop any Bandcamp ZIP or already-extracted folder into your staging directory. T
 
 - MP3
 - AAC / M4A
+- FLAC
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,11 @@ module = ["tune_shifter.__main__"]
 disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
-# mutagen has partial stubs that don't cover ID3 frame classes or MP4 methods;
-# silence the resulting errors in modules that rely on it heavily.
+# mutagen has partial stubs that don't cover ID3 frame classes, MP4 methods, or
+# FLAC tag access (audio.tags is typed as VCFLACDict | MetadataBlock; the union
+# causes false union-attr/index errors on the VCFLACDict branch we always use).
 module = ["tune_shifter.tagger", "tune_shifter.mover", "tune_shifter.artwork"]
-disable_error_code = ["no-untyped-call", "attr-defined", "unused-ignore"]
+disable_error_code = ["no-untyped-call", "attr-defined", "unused-ignore", "union-attr", "index"]
 
 [[tool.mypy.overrides]]
 # playwright ships no type stubs

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -431,12 +431,34 @@ class TestFetchCoverEdgeCases:
 
 class TestEmbed:
     def test_unsupported_format_logs_warning(self, tmp_path: Path) -> None:
-        """_embed logs a warning for formats other than mp3/m4a."""
+        """_embed logs a warning for unsupported formats."""
         from tune_shifter.artwork import _embed
 
-        flac = tmp_path / "track.flac"
+        ogg = tmp_path / "track.ogg"
+        ogg.write_bytes(b"OggS")
+        _embed(ogg, b"\xff\xd8\xff")  # must not raise
+
+    def test_embed_flac_writes_picture_block(self, tmp_path: Path) -> None:
+        """_embed_flac clears existing pictures and embeds the new image."""
+        from tune_shifter.artwork import _embed_flac
+
+        flac = tmp_path / "01.flac"
         flac.write_bytes(b"fLaC")
-        _embed(flac, b"\xff\xd8\xff")  # must not raise
+
+        mock_flac = MagicMock()
+        mock_pic = MagicMock()
+
+        with (
+            patch("tune_shifter.artwork.mutagen.flac.FLAC", return_value=mock_flac),
+            patch("tune_shifter.artwork.mutagen.flac.Picture", return_value=mock_pic),
+        ):
+            _embed_flac(flac, _make_jpeg(600, 600))
+
+        mock_flac.clear_pictures.assert_called_once()
+        mock_flac.add_picture.assert_called_once_with(mock_pic)
+        mock_flac.save.assert_called_once()
+        assert mock_pic.type == 3
+        assert mock_pic.data is not None
 
     def test_embed_mp3_creates_id3_when_header_missing(self, tmp_path: Path) -> None:
         """_embed_mp3 creates a fresh ID3 when the file has no existing header."""
@@ -592,13 +614,58 @@ class TestHasEmbeddedArt:
 
     def test_unsupported_format_returns_false(self, tmp_path: Path) -> None:
         """Returns False for unsupported file formats."""
-        flac = tmp_path / "track.flac"
-        flac.write_bytes(b"fLaC")
+        ogg = tmp_path / "track.ogg"
+        ogg.write_bytes(b"OggS")
 
         assert (
-            has_embedded_art(flac, min_dimension=self._MIN, max_bytes=self._MAX)
-            is False
+            has_embedded_art(ogg, min_dimension=self._MIN, max_bytes=self._MAX) is False
         )
+
+    def test_flac_qualifying_art_returns_true(self, tmp_path: Path) -> None:
+        """Returns True for a FLAC whose embedded picture meets quality requirements."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_pic = MagicMock()
+        mock_pic.data = _make_jpeg(600, 600)
+        mock_flac = MagicMock()
+        mock_flac.pictures = [mock_pic]
+
+        with patch("tune_shifter.artwork.mutagen.flac.FLAC", return_value=mock_flac):
+            assert (
+                has_embedded_art(flac, min_dimension=self._MIN, max_bytes=self._MAX)
+                is True
+            )
+
+    def test_flac_art_too_small_returns_false(self, tmp_path: Path) -> None:
+        """Returns False when FLAC embedded picture dimensions are below min_dimension."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_pic = MagicMock()
+        mock_pic.data = _make_jpeg(200, 200)
+        mock_flac = MagicMock()
+        mock_flac.pictures = [mock_pic]
+
+        with patch("tune_shifter.artwork.mutagen.flac.FLAC", return_value=mock_flac):
+            assert (
+                has_embedded_art(flac, min_dimension=self._MIN, max_bytes=self._MAX)
+                is False
+            )
+
+    def test_flac_without_pictures_returns_false(self, tmp_path: Path) -> None:
+        """Returns False for a FLAC with no PICTURE blocks."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.pictures = []
+
+        with patch("tune_shifter.artwork.mutagen.flac.FLAC", return_value=mock_flac):
+            assert (
+                has_embedded_art(flac, min_dimension=self._MIN, max_bytes=self._MAX)
+                is False
+            )
 
     def test_read_error_returns_false(self, tmp_path: Path) -> None:
         """Returns False when reading the file raises an exception."""

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -50,6 +50,15 @@ class TestExtract:
         with pytest.raises(ExtractionError, match="no supported audio files"):
             extract(zip_path)
 
+    def test_zip_with_flac_is_extracted(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "album.zip"
+        _make_zip(zip_path, {"01 - Track.flac": b"fLaC fake"})
+
+        result = extract(zip_path)
+
+        assert result == tmp_path / "album"
+        assert (result / "01 - Track.flac").exists()
+
     def test_bad_zip_raises(self, tmp_path: Path) -> None:
         bad_zip = tmp_path / "bad.zip"
         bad_zip.write_bytes(b"this is not a zip file")
@@ -65,6 +74,14 @@ class TestFindAudioFiles:
         files = find_audio_files(tmp_path)
         assert len(files) == 2
         assert all(f.suffix in {".mp3", ".m4a"} for f in files)
+
+    def test_finds_flac(self, tmp_path: Path) -> None:
+        (tmp_path / "01.flac").write_bytes(b"")
+        (tmp_path / "02.mp3").write_bytes(b"")
+        (tmp_path / "cover.jpg").write_bytes(b"")
+        files = find_audio_files(tmp_path)
+        assert len(files) == 2
+        assert any(f.suffix == ".flac" for f in files)
 
     def test_returns_sorted_list(self, tmp_path: Path) -> None:
         (tmp_path / "03.mp3").write_bytes(b"")

--- a/tests/test_mover.py
+++ b/tests/test_mover.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import mutagen.flac
 import mutagen.id3 as id3
 import mutagen.mp4
 import pytest
@@ -165,6 +166,101 @@ class TestM4ADestination:
         with patch("tune_shifter.mover.mutagen.mp4.MP4", return_value=mock_mp4):
             library = tmp_path / "library"
             result = _destination(m4a, library, TEMPLATE)
+
+        assert "Unknown Artist" in str(result)
+
+
+class TestFlacDestination:
+    def _mock_flac(self, **tags: object) -> MagicMock:
+        """Return a mock mutagen.flac.FLAC with Vorbis comment dict."""
+        flac = MagicMock()
+        vorbis: dict[str, list[object]] = {}
+        if "artist" in tags:
+            vorbis["ARTIST"] = [tags["artist"]]
+        if "album_artist" in tags:
+            vorbis["ALBUMARTIST"] = [tags["album_artist"]]
+        if "album" in tags:
+            vorbis["ALBUM"] = [tags["album"]]
+        if "year" in tags:
+            vorbis["DATE"] = [tags["year"]]
+        if "track" in tags:
+            vorbis["TRACKNUMBER"] = [tags["track"]]
+        if "disc" in tags:
+            vorbis["DISCNUMBER"] = [tags["disc"]]
+        if "title" in tags:
+            vorbis["TITLE"] = [tags["title"]]
+        flac.tags = vorbis
+        return flac
+
+    def test_flac_tags_are_read(self, tmp_path: Path) -> None:
+        """_destination reads Vorbis comments from a FLAC file via mutagen.flac."""
+        flac_file = tmp_path / "01.flac"
+        flac_file.write_bytes(b"")  # content doesn't matter — FLAC is mocked
+
+        with patch(
+            "tune_shifter.mover.mutagen.flac.FLAC",
+            return_value=self._mock_flac(
+                artist="Artist",
+                album_artist="Album Artist",
+                album="My Album",
+                year="2021",
+                track="3",
+                disc="1",
+                title="My Track",
+            ),
+        ):
+            library = tmp_path / "library"
+            result = _destination(flac_file, library, TEMPLATE)
+
+        assert result.parent == library / "Album Artist" / "2021 - My Album"
+        assert result.name == "03 - My Track.flac"
+
+    def test_flac_tracknumber_with_slash_is_parsed(self, tmp_path: Path) -> None:
+        """TRACKNUMBER in 'N/total' format is parsed correctly."""
+        flac_file = tmp_path / "05.flac"
+        flac_file.write_bytes(b"")
+
+        with patch(
+            "tune_shifter.mover.mutagen.flac.FLAC",
+            return_value=self._mock_flac(
+                album_artist="Band",
+                album="Record",
+                year="2019",
+                track="5/12",
+                title="Fifth",
+            ),
+        ):
+            library = tmp_path / "library"
+            result = _destination(flac_file, library, TEMPLATE)
+
+        assert result.name == "05 - Fifth.flac"
+
+    def test_flac_falls_back_to_defaults_when_tags_absent(self, tmp_path: Path) -> None:
+        """_destination uses fallback values when FLAC tags dict is empty."""
+        flac_file = tmp_path / "track.flac"
+        flac_file.write_bytes(b"")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = {}  # empty Vorbis comment dict
+
+        with patch("tune_shifter.mover.mutagen.flac.FLAC", return_value=mock_flac):
+            library = tmp_path / "library"
+            result = _destination(flac_file, library, TEMPLATE)
+
+        assert "Unknown Artist" in str(result)
+        assert "Unknown Album" in str(result)
+
+    def test_flac_no_tags_object_falls_back(self, tmp_path: Path) -> None:
+        """_destination handles flac.tags being None gracefully."""
+        flac_file = tmp_path / "track.flac"
+        flac_file.write_bytes(b"")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = None
+
+        with patch("tune_shifter.mover.mutagen.flac.FLAC", return_value=mock_flac):
+            library = tmp_path / "library"
+            result = _destination(flac_file, library, TEMPLATE)
 
         assert "Unknown Artist" in str(result)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -262,6 +262,51 @@ class TestPipelineRun:
         assert errors_dir.exists()
 
 
+class TestOnDirectoryCallback:
+    def test_callback_called_with_extracted_directory(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """run() calls _on_directory with the staging directory immediately after
+        extraction so the watcher can cancel any pending timer for that directory."""
+        import zipfile
+
+        config.paths.staging.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+
+        zip_path = config.paths.staging / "artist-album.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("01 - Track.mp3", b"\xff\xfb" * 64)
+
+        claimed: list[Path] = []
+
+        with (
+            patch("tune_shifter.pipeline.tag_directory", return_value=MOCK_RELEASE),
+            patch("tune_shifter.pipeline.fetch_and_embed"),
+            patch(
+                "tune_shifter.pipeline.move_to_library",
+                return_value=[],
+            ),
+        ):
+            run(zip_path, config, _on_directory=claimed.append)
+
+        assert len(claimed) == 1
+        assert claimed[0].parent == config.paths.staging
+        assert claimed[0].name == "artist-album"
+
+    def test_callback_not_called_on_extraction_failure(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """_on_directory must not fire when extraction fails."""
+        config.paths.staging.mkdir(parents=True)
+        bad_zip = config.paths.staging / "bad.zip"
+        bad_zip.write_bytes(b"not a zip")
+
+        claimed: list[Path] = []
+        run(bad_zip, config, _on_directory=claimed.append)
+
+        assert claimed == []
+
+
 class TestSkipAlreadyTagged:
     """Pipeline skips the MusicBrainz lookup when all files already have an MBID.
     Artwork always runs — better art may be available (bundled in ZIP, or online).

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -15,6 +15,7 @@ from tune_shifter.tagger import (
     TrackInfo,
     _read_existing_metadata,
     _search_release,
+    _write_flac_tags,
     _write_tags,
     configure_musicbrainz,
     is_tagged,
@@ -431,10 +432,10 @@ class TestWriteTagsEdgeCases:
         )
 
     def test_unsupported_format_logs_warning(self, tmp_path: Path) -> None:
-        """_write_tags logs a warning for .flac files and does not raise."""
-        flac = tmp_path / "track.flac"
-        flac.write_bytes(b"fLaC")
-        _write_tags(flac, self._make_release())  # must not raise
+        """_write_tags logs a warning for unsupported formats and does not raise."""
+        ogg = tmp_path / "track.ogg"
+        ogg.write_bytes(b"OggS")
+        _write_tags(ogg, self._make_release())  # must not raise
 
     def test_mp3_without_id3_header_gets_fresh_tags(self, tmp_path: Path) -> None:
         """_write_tags on an MP3 with no ID3 header creates a fresh tag set."""
@@ -572,3 +573,215 @@ class TestReadReleaseMbids:
 
         assert rel == ""
         assert rg == ""
+
+    def test_flac_returns_correct_mbids(self, tmp_path: Path) -> None:
+        """read_release_mbids extracts both MBIDs from FLAC Vorbis comments."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = {
+            "MUSICBRAINZ_ALBUMID": ["rel-flac"],
+            "MUSICBRAINZ_RELEASEGROUPID": ["rg-flac"],
+        }
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            rel, rg = read_release_mbids(flac)
+
+        assert rel == "rel-flac"
+        assert rg == "rg-flac"
+
+
+class TestIsTaggedFlac:
+    def test_flac_with_mbid_returns_true(self, tmp_path: Path) -> None:
+        """is_tagged returns True when the FLAC has a MUSICBRAINZ_ALBUMID tag."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = {"MUSICBRAINZ_ALBUMID": ["rel-123"]}
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            assert is_tagged(flac) is True
+
+    def test_flac_without_mbid_returns_false(self, tmp_path: Path) -> None:
+        """is_tagged returns False when the FLAC has no MUSICBRAINZ_ALBUMID tag."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = {}
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            assert is_tagged(flac) is False
+
+    def test_flac_with_none_tags_returns_false(self, tmp_path: Path) -> None:
+        """is_tagged returns False when the FLAC tags object is None."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = None
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            assert is_tagged(flac) is False
+
+
+class TestTagDirectoryFlac:
+    def test_flac_tags_written(self, tmp_path: Path) -> None:
+        """MusicBrainz metadata is written to FLAC Vorbis comment fields."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        initial_tags: dict[str, Any] = {
+            "ARTIST": ["Old Artist"],
+            "ALBUM": ["Old Album"],
+            "TRACKNUMBER": ["1"],
+        }
+        mock_flac = MagicMock()
+        mock_flac.tags = initial_tags
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    release = tag_directory(tmp_path, [flac])
+
+        assert release.mbid == "abc-123"
+        assert initial_tags["ARTIST"] == ["Cool Artist"]
+        assert initial_tags["ALBUM"] == ["Great Album"]
+        assert initial_tags["DATE"] == ["2020"]
+        assert initial_tags["MUSICBRAINZ_ALBUMID"] == ["abc-123"]
+        assert initial_tags["MUSICBRAINZ_RELEASEGROUPID"] == ["rg-456"]
+        mock_flac.save.assert_called()
+
+    def test_flac_match_track_reads_tracknumber(self, tmp_path: Path) -> None:
+        """_match_track correctly parses TRACKNUMBER from FLAC Vorbis comments."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        mock_flac = MagicMock()
+        mock_flac.tags = {
+            "ARTIST": ["Artist"],
+            "ALBUM": ["Album"],
+            "TRACKNUMBER": ["2/10"],
+            "DISCNUMBER": ["1"],
+        }
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    tag_directory(tmp_path, [flac])
+
+        # Track 2 is "Second Track" in SAMPLE_RELEASE_DETAIL
+        assert mock_flac.tags.get("TITLE") == ["Second Track"]
+
+    def test_flac_add_tags_called_when_tags_none(self, tmp_path: Path) -> None:
+        """_write_flac_tags calls add_tags() when audio.tags is None."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        tags: dict[str, Any] = {}
+        mock_flac = MagicMock()
+        mock_flac.tags = None  # simulate file with no tag block
+
+        # add_tags() must actually install the tag dict so the assert passes
+        def _install_tags() -> None:
+            mock_flac.tags = tags
+
+        mock_flac.add_tags.side_effect = _install_tags
+
+        release = ReleaseInfo(
+            mbid="abc-123",
+            release_group_mbid="rg-456",
+            title="Album",
+            artist="Artist",
+            album_artist="Artist",
+            year="2020",
+            tracks={},
+        )
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            _write_flac_tags(flac, release, None)
+
+        mock_flac.add_tags.assert_called_once()
+        assert tags["ARTIST"] == ["Artist"]
+        mock_flac.save.assert_called()
+
+    def test_flac_minimal_release_skips_optional_fields(self, tmp_path: Path) -> None:
+        """_write_flac_tags does not write optional tag keys when release fields are empty."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        tags: dict[str, Any] = {}
+        mock_flac = MagicMock()
+        mock_flac.tags = tags
+
+        release = ReleaseInfo(
+            mbid="abc-123",
+            release_group_mbid="",
+            title="Album",
+            artist="Artist",
+            album_artist="Artist",
+            year="2020",
+            tracks={},
+            # all optional fields left at defaults (empty strings / empty lists)
+        )
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            _write_flac_tags(flac, release, None)
+
+        # Core fields are always written
+        assert tags["ARTIST"] == ["Artist"]
+        assert tags["ALBUM"] == ["Album"]
+        # Optional fields must be absent when the release has no data for them
+        assert "ARTISTSORT" not in tags
+        assert "ALBUMARTISTSORT" not in tags
+        assert "ARTISTS" not in tags
+        assert "MUSICBRAINZ_ARTISTID" not in tags
+        assert "MUSICBRAINZ_ALBUMARTISTID" not in tags
+        assert "MUSICBRAINZ_RELEASEGROUPID" not in tags
+        assert "MUSICBRAINZ_ALBUMTYPE" not in tags
+        assert "MUSICBRAINZ_ALBUMSTATUS" not in tags
+        assert "RELEASECOUNTRY" not in tags
+        assert "ORIGINALDATE" not in tags
+        assert "LABEL" not in tags
+        assert "CATALOGNUMBER" not in tags
+        assert "BARCODE" not in tags
+        assert "ASIN" not in tags
+        assert "SCRIPT" not in tags
+        # track is None → TITLE / TRACKNUMBER / DISCNUMBER must not be set
+        assert "TITLE" not in tags
+        assert "TRACKNUMBER" not in tags
+        mock_flac.save.assert_called()
+
+    def test_flac_track_without_recording_mbid(self, tmp_path: Path) -> None:
+        """_write_flac_tags omits MUSICBRAINZ_TRACKID when recording_mbid is empty."""
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+
+        tags: dict[str, Any] = {}
+        mock_flac = MagicMock()
+        mock_flac.tags = tags
+
+        release = ReleaseInfo(
+            mbid="abc-123",
+            release_group_mbid="rg-456",
+            title="Album",
+            artist="Artist",
+            album_artist="Artist",
+            year="2020",
+            tracks={},
+        )
+        track = TrackInfo(number=1, disc=1, title="Track One", recording_mbid="")
+
+        with patch("tune_shifter.tagger.mutagen.flac.FLAC", return_value=mock_flac):
+            _write_flac_tags(flac, release, track)
+
+        assert tags["TITLE"] == ["Track One"]
+        assert "MUSICBRAINZ_TRACKID" not in tags

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -13,6 +13,7 @@ from tune_shifter.tagger import (
     ReleaseInfo,
     TaggingError,
     TrackInfo,
+    _parse_release,
     _read_existing_metadata,
     _search_release,
     _write_flac_tags,
@@ -227,6 +228,168 @@ class TestTagDirectory:
 
         # The winning MBID ("high") must be passed to get_release_by_id
         assert mock_get.call_args[0][0] == "high"
+
+    def test_tie_breaks_by_earliest_date(self, tmp_path: Path) -> None:
+        """When scores are equal, the earlier-dated release is preferred over a
+        later vinyl reissue."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+
+        tied_result: dict[str, Any] = {
+            "release-list": [
+                {
+                    "id": "vinyl-reissue",
+                    "title": "Album",
+                    "date": "2021-04-30",
+                    "ext:score": "100",
+                    "artist-credit": [{"artist": {"name": "Artist"}}],
+                },
+                {
+                    "id": "original",
+                    "title": "Album",
+                    "date": "2020-03-27",
+                    "ext:score": "100",
+                    "artist-credit": [{"artist": {"name": "Artist"}}],
+                },
+            ]
+        }
+
+        with patch("musicbrainzngs.search_releases", return_value=tied_result):
+            with patch(
+                "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+            ) as mock_get:
+                tag_directory(tmp_path, [mp3])
+
+        # Earlier-dated release must be tried first
+        assert mock_get.call_args_list[0][0][0] == "original"
+
+    def test_falls_back_to_next_candidate_on_parse_error(self, tmp_path: Path) -> None:
+        """If the top candidate cannot be parsed (e.g. vinyl track numbers),
+        the next candidate is tried automatically."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3, track=1)
+
+        # First candidate has a vinyl track number ("A1") that fails int()
+        vinyl_detail: dict[str, Any] = {
+            "release": {
+                "id": "vinyl-id",
+                "title": "Album",
+                "date": "2021-04-30",
+                "status": "Official",
+                "country": "US",
+                "barcode": "",
+                "asin": "",
+                "text-representation": {},
+                "artist-credit": [
+                    {"artist": {"id": "a1", "name": "Artist", "sort-name": "Artist"}}
+                ],
+                "release-group": {
+                    "id": "rg-1",
+                    "primary-type": "Album",
+                    "first-release-date": "",
+                },
+                "label-info-list": [],
+                "medium-list": [
+                    {
+                        "position": "1",
+                        "track-list": [
+                            {
+                                "number": "A1",
+                                "position": "1",
+                                "recording": {"id": "rec-111", "title": "Track One"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+
+        def _get_release(mbid: str, **_kwargs: Any) -> dict[str, Any]:
+            if mbid == "vinyl-id":
+                return vinyl_detail
+            return SAMPLE_RELEASE_DETAIL
+
+        two_candidates: dict[str, Any] = {
+            "release-list": [
+                {
+                    "id": "vinyl-id",
+                    "date": "2021",
+                    "ext:score": "100",
+                    "artist-credit": [{"artist": {"name": "Artist"}}],
+                },
+                {
+                    "id": "abc-123",
+                    "date": "2020",
+                    "ext:score": "100",
+                    "artist-credit": [{"artist": {"name": "Artist"}}],
+                },
+            ]
+        }
+
+        with patch("musicbrainzngs.search_releases", return_value=two_candidates):
+            with patch("musicbrainzngs.get_release_by_id", side_effect=_get_release):
+                release = tag_directory(tmp_path, [mp3])
+
+        assert release.mbid == "abc-123"
+
+
+class TestParseReleaseVinyl:
+    def test_non_numeric_track_number_uses_position(self) -> None:
+        """Vinyl track numbers like 'A1' fall back to the medium position."""
+        raw: dict[str, Any] = {
+            "id": "vinyl-id",
+            "title": "Album",
+            "date": "2021",
+            "status": "Official",
+            "country": "US",
+            "barcode": "",
+            "asin": "",
+            "text-representation": {},
+            "artist-credit": [
+                {"artist": {"id": "a1", "name": "Artist", "sort-name": "Artist"}}
+            ],
+            "release-group": {
+                "id": "rg-1",
+                "primary-type": "Album",
+                "first-release-date": "",
+            },
+            "label-info-list": [],
+            "medium-list": [
+                {
+                    "position": "1",
+                    "track-list": [
+                        {
+                            "number": "A1",
+                            "position": "1",
+                            "recording": {"id": "rec-1", "title": "Side A Track 1"},
+                        },
+                        {
+                            "number": "A2",
+                            "position": "2",
+                            "recording": {"id": "rec-2", "title": "Side A Track 2"},
+                        },
+                    ],
+                },
+                {
+                    "position": "2",
+                    "track-list": [
+                        {
+                            "number": "B1",
+                            "position": "1",
+                            "recording": {"id": "rec-3", "title": "Side B Track 1"},
+                        },
+                    ],
+                },
+            ],
+        }
+        release = _parse_release(raw)
+
+        # Non-numeric "A1" falls back to position=1 on disc 1
+        assert "1-1" in release.tracks
+        assert release.tracks["1-1"].title == "Side A Track 1"
+        assert "1-2" in release.tracks
+        assert "2-1" in release.tracks
+        assert release.tracks["2-1"].title == "Side B Track 1"
 
 
 class TestEditionSuffixRetry:
@@ -655,6 +818,14 @@ class TestTagDirectoryFlac:
         assert initial_tags["DATE"] == ["2020"]
         assert initial_tags["MUSICBRAINZ_ALBUMID"] == ["abc-123"]
         assert initial_tags["MUSICBRAINZ_RELEASEGROUPID"] == ["rg-456"]
+        # ORIGINALYEAR is the year-only companion to ORIGINALDATE
+        assert initial_tags["ORIGINALDATE"] == ["2020-04-01"]
+        assert initial_tags["ORIGINALYEAR"] == ["2020"]
+        # Track 1 of 2 on disc 1 of 1
+        assert initial_tags["TRACKNUMBER"] == ["1"]
+        assert initial_tags["TOTALTRACKS"] == ["2"]
+        assert initial_tags["DISCNUMBER"] == ["1"]
+        assert initial_tags["TOTALDISCS"] == ["1"]
         mock_flac.save.assert_called()
 
     def test_flac_match_track_reads_tracknumber(self, tmp_path: Path) -> None:
@@ -750,6 +921,7 @@ class TestTagDirectoryFlac:
         assert "MUSICBRAINZ_ALBUMSTATUS" not in tags
         assert "RELEASECOUNTRY" not in tags
         assert "ORIGINALDATE" not in tags
+        assert "ORIGINALYEAR" not in tags
         assert "LABEL" not in tags
         assert "CATALOGNUMBER" not in tags
         assert "BARCODE" not in tags
@@ -784,4 +956,7 @@ class TestTagDirectoryFlac:
             _write_flac_tags(flac, release, track)
 
         assert tags["TITLE"] == ["Track One"]
+        assert tags["TRACKNUMBER"] == ["1"]
+        assert tags["TOTALDISCS"] == ["1"]
+        assert "TOTALTRACKS" not in tags  # total_tracks=0 → omitted
         assert "MUSICBRAINZ_TRACKID" not in tags

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -412,6 +412,83 @@ class TestWaitForStableSize:
                 _wait_for_stable_size(f)
 
 
+class TestDuplicateRunPrevention:
+    """The pipeline notifies the watcher of the extracted directory so that any
+    pending debounce timer for it is cancelled before Run 2 can start."""
+
+    def test_process_passes_claim_callback_to_run(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_process passes a _on_directory callback to run(); verifies callback arg."""
+        handler = _make_handler(config)
+        album = config.paths.staging / "my-album"
+        album.mkdir()
+
+        received_callbacks: list[object] = []
+
+        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+            received_callbacks.append(_on_directory)
+
+        monkeypatch.setattr("tune_shifter.watcher.run", _fake_run)
+        handler._process(album)
+
+        assert len(received_callbacks) == 1
+        assert callable(received_callbacks[0])
+
+    def test_claim_callback_cancels_pending_dir_timer(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the pipeline calls the callback, any pending timer for the
+        extracted directory is cancelled and the directory is added to _in_flight."""
+        handler = _make_handler(config)
+        zip_path = config.paths.staging / "album.zip"
+        zip_path.write_bytes(b"PK")
+
+        extracted_dir = config.paths.staging / "album"
+        extracted_dir.mkdir()
+
+        # Simulate a pending timer for the extracted directory (as the watcher
+        # would create when on_created fires for the new directory).
+        pending_timer = MagicMock()
+        handler._pending[extracted_dir] = pending_timer
+
+        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+            # The pipeline calls the callback right after extraction
+            if callable(_on_directory):
+                _on_directory(extracted_dir)
+
+        monkeypatch.setattr("tune_shifter.watcher.run", _fake_run)
+        handler._process(zip_path)
+
+        # The pending timer for the extracted directory must have been cancelled
+        pending_timer.cancel.assert_called_once()
+        # The extracted directory must NOT be in _in_flight after _process finishes
+        assert extracted_dir not in handler._in_flight
+
+    def test_claim_callback_blocks_in_flight_scheduling(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A directory added to _in_flight by the callback cannot be rescheduled."""
+        handler = _make_handler(config)
+        zip_path = config.paths.staging / "album.zip"
+        zip_path.write_bytes(b"PK")
+
+        extracted_dir = config.paths.staging / "album"
+        extracted_dir.mkdir()
+
+        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+            if callable(_on_directory):
+                _on_directory(extracted_dir)
+            # Simulate the pipeline still running — try to schedule the directory
+            handler._schedule(extracted_dir)
+
+        monkeypatch.setattr("tune_shifter.watcher.run", _fake_run)
+        handler._process(zip_path)
+
+        # _schedule while in-flight must have been a no-op
+        assert extracted_dir not in handler._pending
+
+
 class TestWatcherStopJoin:
     def test_stop_and_join(
         self, config: Config, monkeypatch: pytest.MonkeyPatch

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -42,10 +42,9 @@ def _get_version() -> str:
         with open(_PYPROJECT, "rb") as f:
             data = tomllib.load(f)
         # pyproject.toml uses [tool.poetry], not the PEP 621 [project] table
-        version = (
-            data.get("tool", {}).get("poetry", {}).get("version")
-            or data.get("project", {}).get("version")
-        )
+        version = data.get("tool", {}).get("poetry", {}).get("version") or data.get(
+            "project", {}
+        ).get("version")
         return str(version or "unknown") + "-dev"
     try:
         return importlib.metadata.version("tune-shifter")

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -41,7 +41,12 @@ def _get_version() -> str:
     if _PYPROJECT.exists():
         with open(_PYPROJECT, "rb") as f:
             data = tomllib.load(f)
-        return str(data.get("project", {}).get("version") or "unknown") + "-dev"
+        # pyproject.toml uses [tool.poetry], not the PEP 621 [project] table
+        version = (
+            data.get("tool", {}).get("poetry", {}).get("version")
+            or data.get("project", {}).get("version")
+        )
+        return str(version or "unknown") + "-dev"
     try:
         return importlib.metadata.version("tune-shifter")
     except importlib.metadata.PackageNotFoundError:

--- a/tune_shifter/artwork.py
+++ b/tune_shifter/artwork.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import mutagen.flac
 import mutagen.id3 as id3
 import mutagen.mp4
 import requests
@@ -50,6 +51,11 @@ def has_embedded_art(path: Path, min_dimension: int, max_bytes: int) -> bool:
             if not covr:
                 return False
             image_bytes = bytes(covr[0])  # type: ignore[index]
+        elif suffix == ".flac":
+            flac = mutagen.flac.FLAC(str(path))
+            if not flac.pictures:
+                return False
+            image_bytes = flac.pictures[0].data
         else:
             return False
 
@@ -289,6 +295,8 @@ def _embed(path: Path, image_bytes: bytes) -> None:
         _embed_mp3(path, image_bytes)
     elif suffix == ".m4a":
         _embed_m4a(path, image_bytes)
+    elif suffix == ".flac":
+        _embed_flac(path, image_bytes)
     else:
         logger.warning("Cannot embed artwork in unsupported format: %s", path)
 
@@ -329,6 +337,26 @@ def _embed_m4a(path: Path, image_bytes: bytes) -> None:
     audio.tags["covr"] = [mutagen.mp4.MP4Cover(image_bytes, imageformat=fmt)]
     audio.save()
     logger.debug("Embedded cover art in M4A %s", path)
+
+
+def _embed_flac(path: Path, image_bytes: bytes) -> None:
+    audio = mutagen.flac.FLAC(str(path))
+    audio.clear_pictures()
+
+    pic = mutagen.flac.Picture()
+    pic.type = 3  # front cover
+    pic.mime = _detect_mime(image_bytes)
+    pic.data = image_bytes
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        pic.width, pic.height = img.size
+        pic.depth = 24
+    except Exception:
+        pass
+
+    audio.add_picture(pic)
+    audio.save()
+    logger.debug("Embedded cover art in FLAC %s", path)
 
 
 def _detect_mime(data: bytes) -> str:

--- a/tune_shifter/extractor.py
+++ b/tune_shifter/extractor.py
@@ -43,7 +43,7 @@ def extract(path: Path) -> Path:
     if not _has_audio(dest):
         shutil.rmtree(dest)
         raise ExtractionError(
-            f"ZIP {path} contained no supported audio files (.mp3, .m4a)"
+            f"ZIP {path} contained no supported audio files (.mp3, .m4a, .flac)"
         )
 
     path.unlink()
@@ -51,20 +51,23 @@ def extract(path: Path) -> Path:
     return dest
 
 
+_AUDIO_EXTENSIONS = {".mp3", ".m4a", ".flac"}
+
+
 def _has_audio(directory: Path) -> bool:
-    """Return True if *directory* contains at least one .mp3 or .m4a file."""
+    """Return True if *directory* contains at least one supported audio file."""
     return any(
-        f.suffix.lower() in {".mp3", ".m4a"}
+        f.suffix.lower() in _AUDIO_EXTENSIONS
         for f in directory.rglob("*")
         if f.is_file()
     )
 
 
 def find_audio_files(directory: Path) -> list[Path]:
-    """Return a sorted list of .mp3 and .m4a files under *directory*."""
+    """Return a sorted list of supported audio files (.mp3, .m4a, .flac) under *directory*."""
     files = [
         f
         for f in directory.rglob("*")
-        if f.is_file() and f.suffix.lower() in {".mp3", ".m4a"}
+        if f.is_file() and f.suffix.lower() in _AUDIO_EXTENSIONS
     ]
     return sorted(files)

--- a/tune_shifter/mover.py
+++ b/tune_shifter/mover.py
@@ -7,6 +7,7 @@ import re
 import shutil
 from pathlib import Path
 
+import mutagen.flac
 import mutagen.id3 as _id3
 import mutagen.mp4
 
@@ -117,6 +118,23 @@ def _read_tags(path: Path) -> dict[str, object]:
                 disc = disk_v[0][0] if disk_v else 1  # type: ignore[index]
                 nam_v = t4.get("\xa9nam")
                 title = str(nam_v[0]) if nam_v else path.stem
+        elif suffix == ".flac":
+            flac = mutagen.flac.FLAC(str(path))
+            if flac.tags is not None:
+
+                def _get(key: str) -> str:
+                    vals = flac.tags.get(key)  # type: ignore[union-attr]
+                    return vals[0] if vals else ""
+
+                artist = _get("ARTIST")
+                album_artist = _get("ALBUMARTIST") or artist
+                album = _get("ALBUM")
+                year = _get("DATE")[:4] if _get("DATE") else ""
+                trck_s = _get("TRACKNUMBER").split("/")[0]
+                track = int(trck_s) if trck_s.isdigit() else 0
+                disc_s = _get("DISCNUMBER").split("/")[0]
+                disc = int(disc_s) if disc_s.isdigit() else 1
+                title = _get("TITLE") or path.stem
     except Exception:
         pass
 

--- a/tune_shifter/pipeline.py
+++ b/tune_shifter/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 
 from .artwork import ArtworkError, fetch_and_embed
@@ -15,7 +16,11 @@ from .tagger import TaggingError, is_tagged, read_release_mbids, tag_directory
 logger = logging.getLogger(__name__)
 
 
-def run(path: Path, config: Config) -> None:
+def run(
+    path: Path,
+    config: Config,
+    _on_directory: Callable[[Path], None] | None = None,
+) -> None:
     """Process a single staging item (ZIP or directory) end-to-end.
 
     On per-step failure the item is moved to staging/errors/ so the watcher
@@ -30,6 +35,13 @@ def run(path: Path, config: Config) -> None:
         logger.error("Extraction failed: %s", exc)
         _quarantine(path, config.paths.staging)
         return
+
+    # Notify the watcher of the staging directory as early as possible so it
+    # can cancel any pending debounce timer for this directory.  Without this,
+    # extracting a ZIP creates the directory, the watcher schedules it for a
+    # second pipeline run, and that run races the first.
+    if _on_directory is not None:
+        _on_directory(directory)
 
     audio_files = find_audio_files(directory)
     if not audio_files:

--- a/tune_shifter/tagger.py
+++ b/tune_shifter/tagger.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 import musicbrainzngs
 import mutagen
+import mutagen.flac
 import mutagen.id3 as id3
 import mutagen.mp4
 
@@ -89,6 +90,12 @@ def is_tagged(path: Path) -> bool:
                 return False
             vals = audio.tags.get("----:com.apple.iTunes:MusicBrainz Release Id")
             return bool(vals)
+        if suffix == ".flac":
+            audio = mutagen.flac.FLAC(str(path))
+            if audio.tags is None:
+                return False
+            vals = audio.tags.get("MUSICBRAINZ_ALBUMID")
+            return bool(vals and vals[0])
     except Exception:
         pass
     return False
@@ -118,6 +125,13 @@ def read_release_mbids(path: Path) -> tuple[str, str]:
             rel_mbid = rel_vals[0].decode() if rel_vals else ""  # type: ignore[union-attr]
             rg_mbid = rg_vals[0].decode() if rg_vals else ""  # type: ignore[union-attr]
             return rel_mbid, rg_mbid
+        if suffix == ".flac":
+            audio = mutagen.flac.FLAC(str(path))
+            if audio.tags is None:
+                return "", ""
+            rel_vals = audio.tags.get("MUSICBRAINZ_ALBUMID")
+            rg_vals = audio.tags.get("MUSICBRAINZ_RELEASEGROUPID")
+            return (rel_vals[0] if rel_vals else ""), (rg_vals[0] if rg_vals else "")
     except Exception:
         pass
     return "", ""
@@ -175,6 +189,13 @@ def _read_existing_metadata(path: Path) -> tuple[str, str]:
                 alb_vals = mp4.tags.get("\xa9alb")
                 artist = str(art_vals[0]) if art_vals else ""
                 album = str(alb_vals[0]) if alb_vals else ""
+        elif suffix == ".flac":
+            flac = mutagen.flac.FLAC(str(path))
+            if flac.tags is not None:
+                art_vals = flac.tags.get("ARTIST")
+                alb_vals = flac.tags.get("ALBUM")
+                artist = art_vals[0] if art_vals else ""
+                album = alb_vals[0] if alb_vals else ""
     except Exception as exc:
         logger.debug("Could not read tags from %s: %s", path, exc)
 
@@ -351,6 +372,8 @@ def _write_tags(path: Path, release: ReleaseInfo) -> None:
         _write_mp3_tags(path, release, track_info)
     elif suffix == ".m4a":
         _write_m4a_tags(path, release, track_info)
+    elif suffix == ".flac":
+        _write_flac_tags(path, release, track_info)
     else:
         logger.warning("Unsupported format for tagging: %s", path)
 
@@ -381,6 +404,17 @@ def _match_track(path: Path, release: ReleaseInfo) -> TrackInfo | None:
                 disk_vals = mp4.tags.get("disk")
                 if disk_vals:
                     disc = disk_vals[0][0]  # type: ignore[index]
+        elif suffix == ".flac":
+            flac = mutagen.flac.FLAC(str(path))
+            if flac.tags is not None:
+                trck_vals = flac.tags.get("TRACKNUMBER")
+                if trck_vals:
+                    trck_s = trck_vals[0].split("/")[0]
+                    track_num = int(trck_s) if trck_s.isdigit() else 0
+                disc_vals = flac.tags.get("DISCNUMBER")
+                if disc_vals:
+                    disc_s = disc_vals[0].split("/")[0]
+                    disc = int(disc_s) if disc_s.isdigit() else 1
     except Exception:
         return None
 
@@ -574,3 +608,81 @@ def _write_m4a_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) -
 
     audio.save()
     logger.debug("Wrote M4A tags to %s", path)
+
+
+def _write_flac_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) -> None:
+    audio = mutagen.flac.FLAC(str(path))
+    if audio.tags is None:
+        audio.add_tags()
+
+    assert audio.tags is not None
+
+    def _v(value: str) -> list[str]:
+        """Wrap a string as a single-element Vorbis comment list."""
+        return [value]
+
+    # Core tags
+    audio.tags["ARTIST"] = _v(release.artist)
+    audio.tags["ALBUMARTIST"] = _v(release.album_artist)
+    audio.tags["ALBUM"] = _v(release.title)
+    audio.tags["DATE"] = _v(release.year)
+    audio.tags["MUSICBRAINZ_ALBUMID"] = _v(release.mbid)
+
+    # Sort names
+    if release.artist_sort:
+        audio.tags["ARTISTSORT"] = _v(release.artist_sort)
+    if release.album_artist_sort:
+        audio.tags["ALBUMARTISTSORT"] = _v(release.album_artist_sort)
+
+    # Multi-value artists
+    if release.artists:
+        audio.tags["ARTISTS"] = _v("; ".join(release.artists))
+
+    # MusicBrainz IDs
+    if release.artist_mbids:
+        audio.tags["MUSICBRAINZ_ARTISTID"] = _v("; ".join(release.artist_mbids))
+    if release.album_artist_mbid:
+        audio.tags["MUSICBRAINZ_ALBUMARTISTID"] = _v(release.album_artist_mbid)
+    if release.release_group_mbid:
+        audio.tags["MUSICBRAINZ_RELEASEGROUPID"] = _v(release.release_group_mbid)
+
+    # Release metadata
+    if release.release_type:
+        audio.tags["MUSICBRAINZ_ALBUMTYPE"] = _v(release.release_type)
+    if release.release_status:
+        audio.tags["MUSICBRAINZ_ALBUMSTATUS"] = _v(release.release_status)
+    if release.release_country:
+        audio.tags["RELEASECOUNTRY"] = _v(release.release_country)
+    if release.original_date:
+        audio.tags["ORIGINALDATE"] = _v(release.original_date)
+    if release.label:
+        audio.tags["LABEL"] = _v(release.label)
+    if release.catalog_number:
+        audio.tags["CATALOGNUMBER"] = _v(release.catalog_number)
+    if release.barcode:
+        audio.tags["BARCODE"] = _v(release.barcode)
+    if release.asin:
+        audio.tags["ASIN"] = _v(release.asin)
+    if release.script:
+        audio.tags["SCRIPT"] = _v(release.script)
+
+    # Track and disc numbers with totals
+    if track is not None:
+        total_trck = (
+            f"{track.number}/{track.total_tracks}"
+            if track.total_tracks
+            else str(track.number)
+        )
+        total_disc = (
+            f"{track.disc}/{release.total_discs}"
+            if release.total_discs > 1
+            else str(track.disc)
+        )
+        audio.tags["TRACKNUMBER"] = _v(total_trck)
+        audio.tags["DISCNUMBER"] = _v(total_disc)
+        audio.tags["TITLE"] = _v(track.title)
+        if track.recording_mbid:
+            audio.tags["MUSICBRAINZ_TRACKID"] = _v(track.recording_mbid)
+
+    audio.save()
+    logger.debug("Wrote FLAC tags to %s", path)

--- a/tune_shifter/tagger.py
+++ b/tune_shifter/tagger.py
@@ -272,19 +272,38 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
             f"No MusicBrainz results for artist={artist!r} album={album!r}"
         )
 
-    best = max(releases, key=lambda r: int(r.get("ext:score", 0)))
-    best_mbid: str = best["id"]
+    # Sort candidates: highest score first; break ties by earliest release date so
+    # original/digital releases (e.g. 2020-03-27) beat later vinyl reissues (2021-04-30).
+    def _sort_key(r: dict[str, Any]) -> tuple[int, str]:
+        score = int(r.get("ext:score", 0))
+        date = r.get("date", "") or "9999"
+        return (-score, date)
+
+    candidates = sorted(releases, key=_sort_key)
 
     # search_releases returns minimal data (no full date, no track listings).
-    # Fetch the full release to get accurate year and track info.
-    logger.debug("Fetching full release details for %s", best_mbid)
-    detail = _mb_call(
-        musicbrainzngs.get_release_by_id,
-        best_mbid,
-        includes=["artists", "recordings", "release-groups", "labels"],
-    )
+    # Fetch the full release to get accurate year and track info.  Try each
+    # candidate in preference order; skip releases whose metadata cannot be
+    # parsed (e.g. vinyl with non-numeric track numbers like "A1").
+    last_err: Exception = TaggingError("no candidates")
+    for candidate in candidates:
+        candidate_mbid: str = candidate["id"]
+        logger.debug("Fetching full release details for %s", candidate_mbid)
+        detail = _mb_call(
+            musicbrainzngs.get_release_by_id,
+            candidate_mbid,
+            includes=["artists", "recordings", "release-groups", "labels"],
+        )
+        try:
+            return _parse_release(detail["release"])
+        except (ValueError, KeyError) as exc:
+            logger.debug("Skipping release %s: %s", candidate_mbid, exc)
+            last_err = exc
+            continue
 
-    return _parse_release(detail["release"])
+    raise TaggingError(
+        f"No parseable MusicBrainz release for artist={artist!r} album={album!r}: {last_err}"
+    )
 
 
 def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
@@ -326,7 +345,16 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
         track_list = medium.get("track-list", [])
         total_tracks = len(track_list)
         for track_raw in track_list:
-            track_num = int(track_raw.get("number", track_raw.get("position", 0)))
+            # Vinyl releases use non-numeric track numbers like "A1", "B2".
+            # Fall back to the 1-based position within the medium so the parser
+            # does not crash; track matching for non-numeric tracks will rely on
+            # position rather than the printed side+number.
+            num_str = str(track_raw.get("number", ""))
+            if num_str.isdigit():
+                track_num = int(num_str)
+            else:
+                pos = track_raw.get("position", 0)
+                track_num = int(pos) if str(pos).isdigit() else 0
             recording = track_raw.get("recording", {})
             key = f"{disc_num}-{track_num}"
             tracks[key] = TrackInfo(
@@ -655,6 +683,9 @@ def _write_flac_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) 
         audio.tags["RELEASECOUNTRY"] = _v(release.release_country)
     if release.original_date:
         audio.tags["ORIGINALDATE"] = _v(release.original_date)
+        # ORIGINALYEAR is the year-only portion, mirroring the M4A convention so
+        # players that don't parse ORIGINALDATE still display the original year.
+        audio.tags["ORIGINALYEAR"] = _v(release.original_date[:4])
     if release.label:
         audio.tags["LABEL"] = _v(release.label)
     if release.catalog_number:
@@ -666,20 +697,14 @@ def _write_flac_tags(path: Path, release: ReleaseInfo, track: TrackInfo | None) 
     if release.script:
         audio.tags["SCRIPT"] = _v(release.script)
 
-    # Track and disc numbers with totals
+    # Track and disc numbers — write number and total as separate tags per
+    # the MusicBrainz Picard convention for Vorbis comments.
     if track is not None:
-        total_trck = (
-            f"{track.number}/{track.total_tracks}"
-            if track.total_tracks
-            else str(track.number)
-        )
-        total_disc = (
-            f"{track.disc}/{release.total_discs}"
-            if release.total_discs > 1
-            else str(track.disc)
-        )
-        audio.tags["TRACKNUMBER"] = _v(total_trck)
-        audio.tags["DISCNUMBER"] = _v(total_disc)
+        audio.tags["TRACKNUMBER"] = _v(str(track.number))
+        if track.total_tracks:
+            audio.tags["TOTALTRACKS"] = _v(str(track.total_tracks))
+        audio.tags["DISCNUMBER"] = _v(str(track.disc))
+        audio.tags["TOTALDISCS"] = _v(str(release.total_discs))
         audio.tags["TITLE"] = _v(track.title)
         if track.recording_mbid:
             audio.tags["MUSICBRAINZ_TRACKID"] = _v(track.recording_mbid)

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -104,6 +104,23 @@ class _StagingHandler(FileSystemEventHandler):
         with self._lock:
             self._pending.pop(path, None)
             self._in_flight.add(path)
+
+        # Track any directory the pipeline extracts so we can cancel its
+        # pending debounce timer and prevent a duplicate pipeline run.
+        claimed_dir: list[Path] = []
+
+        def _claim_directory(directory: Path) -> None:
+            """Called by the pipeline right after extraction."""
+            with self._lock:
+                existing = self._pending.pop(directory, None)
+                if existing is not None:
+                    existing.cancel()
+                    logger.debug(
+                        "Cancelled duplicate timer for extracted dir %s", directory
+                    )
+                self._in_flight.add(directory)
+            claimed_dir.append(directory)
+
         try:
             if not path.exists():
                 logger.debug("Path no longer exists, skipping: %s", path)
@@ -115,12 +132,14 @@ class _StagingHandler(FileSystemEventHandler):
 
             logger.info("Triggering pipeline for %s", path)
             try:
-                run(path, self._config)
+                run(path, self._config, _on_directory=_claim_directory)
             except Exception:
                 logger.exception("Unhandled error in pipeline for %s", path)
         finally:
             with self._lock:
                 self._in_flight.discard(path)
+                if claimed_dir:
+                    self._in_flight.discard(claimed_dir[0])
 
 
 def _wait_for_stable_size(path: Path, timeout: float = 60.0) -> None:


### PR DESCRIPTION
## Summary

- Full `.flac` support across the ingest pipeline (extractor, tagger, artwork, mover) via `mutagen.flac.FLAC` and Vorbis comments
- Complete tag set: `ORIGINALDATE`, `ORIGINALYEAR`, `TOTALTRACKS`, `TOTALDISCS`, `MUSICBRAINZ_TRACKID`, `MUSICBRAINZ_ALBUMSTATUS`, `MUSICBRAINZ_ALBUMTYPE`, and more
- Vinyl LP release handling: non-numeric track numbers ("A1", "B2") now fall back to 1-based position; date-sorted fallback loop tries next candidate if parsing fails
- Fix duplicate pipeline run on ZIP-extracted directory: `pipeline.run()` now accepts an `_on_directory` callback; the watcher uses it to cancel the pending debounce timer before a second run can start
- Fix version logging: `_get_version()` now reads from `[tool.poetry]` in `pyproject.toml`

## Test plan

- [x] 198 tests pass, 95.57% coverage, mypy clean, black clean
- [x] Drop a Bandcamp FLAC ZIP into staging and confirm full pipeline: extract → tag → art → library move
- [x] Verify `tune-shifter <version>-dev` appears correctly in daemon log
- [x] Verify no duplicate pipeline run logged when dropping a ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)