### PR TITLE
feat: config show/set subcommands

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,20 +3,17 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## Does Bandcamp auto-download actually work? Test poll_interval_minutes.
+*Single* — manual QA task; set a short poll interval and verify downloads trigger correctly
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
 ## One File At A Time
 *Single* — watcher already handles ZIPs; extend to schedule individual audio files (`.mp3`, `.m4a`, etc.) dropped directly into staging
 
-## Config Arguments
-*Side* — add `tune-shifter config set <key> <value>` and `tune-shifter config show` subcommands; reads/writes existing TOML file
-
 ## Cross-platform service installation (Linux systemd, Windows Task Scheduler)
 *Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
-
-## Does Bandcamp auto-download actually work? Test poll_interval_minutes.
-*Single* — manual QA task; set a short poll interval and verify downloads trigger correctly
 
 ## Menu Bar Status Item
 *LP* — when the daemon runs, show a menu bar icon with a "Sync Now" item; requires `rumps` dependency and threading integration with the daemon lifecycle

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,6 +18,12 @@
 ## ALAC Support
 *Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)
 
+## App Version shouldn't be configurable
+*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
+
+## Hotload config changes
+*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
+
 # Needs Refinement
 ## Best Release
 *Side* — when multiple MB results exist, prefer the release closest to the original physical format (LP/CD over digital/streaming)
@@ -43,8 +49,6 @@
 ## Allow a user to verify tags before they're written
 ⚠️ Not scoped — needs UI design (CLI prompt? TUI? GUI?) before estimating
 
-## App Version shouldn't be configurable
-*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
+# Needs Estimation
 
-## Hotload config changes
-*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
+*Too busy shipping to have bad ideas right now.*

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,12 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## App Version shouldn't be configurable
+*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
+
+## Hotload config changes
+*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -17,12 +23,6 @@
 
 ## ALAC Support
 *Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)
-
-## App Version shouldn't be configurable
-*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
-
-## Hotload config changes
-*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
 
 # Needs Refinement
 ## Best Release

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Does Bandcamp auto-download actually work? Test poll_interval_minutes.
-*Single* — manual QA task; set a short poll interval and verify downloads trigger correctly
-
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -46,6 +43,8 @@
 ## Allow a user to verify tags before they're written
 ⚠️ Not scoped — needs UI design (CLI prompt? TUI? GUI?) before estimating
 
-# Needs Estimation
+## App Version shouldn't be configurable
+*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
 
-Nothing to estimate.
+## Hotload config changes
+*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ launchctl load ~/Library/LaunchAgents/com.tune-shifter.plist   # restart the ser
 tune-shifter uninstall-service   # remove the service registration
 ```
 
+### View or update config from the command line
+
+```bash
+tune-shifter config show
+tune-shifter config set paths.staging ~/Downloads/staging
+tune-shifter config set musicbrainz.contact me@example.com
+tune-shifter config set artwork.min_dimension 500
+```
+
+Keys use dot notation (`section.field`). Run `tune-shifter config set --help` to see all valid keys.
+
 ### One-shot Bandcamp sync
 
 ```bash

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,3 +270,26 @@ class TestConfigSet:
         text = path.read_text()
         assert "path_template" in text  # library section untouched
         assert "~/NewLib" in text
+
+    def test_set_bandcamp_format_valid_value_succeeds(self, tmp_path: Path) -> None:
+        """config_set accepts a valid bandcamp.format value."""
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        config_set(path, "bandcamp.format", "flac")
+        assert 'format = "flac"' in path.read_text()
+
+    def test_set_bandcamp_format_invalid_value_raises(self, tmp_path: Path) -> None:
+        """config_set rejects an unrecognised bandcamp.format value."""
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        with pytest.raises(ValueError, match="Invalid value 'm5q'"):
+            config_set(path, "bandcamp.format", "m5q")
+
+    def test_set_bandcamp_format_error_lists_valid_choices(
+        self, tmp_path: Path
+    ) -> None:
+        """The ValueError message includes the supported formats."""
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        with pytest.raises(ValueError, match="mp3-v0"):
+            config_set(path, "bandcamp.format", "bad")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from tune_shifter.config import DEFAULT_CONFIG_CONTENT, Config
+from tune_shifter.config import (
+    DEFAULT_CONFIG_CONTENT,
+    Config,
+    config_set,
+    config_show,
+)
 
 
 class TestFirstRunSetup:
@@ -116,3 +121,152 @@ class TestBandcampSetup:
 
         assert config.bandcamp is not None
         assert config.bandcamp.username == "realuser"
+
+
+# ---------------------------------------------------------------------------
+# config_show / config_set tests
+# ---------------------------------------------------------------------------
+
+_TOML_WITH_BANDCAMP = """\
+[paths]
+staging = "~/Music/staging"
+library = "~/Music"
+
+[musicbrainz]
+app_name = "tune-shifter"
+app_version = "0.1.0"
+contact = "user@example.com"  # Update with your contact email
+
+[artwork]
+min_dimension = 1000   # minimum width and height in pixels
+max_bytes = 1000000
+
+[library]
+path_template = "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+
+[bandcamp]
+username = "myuser"
+format = "mp3-v0"
+poll_interval_minutes = 60
+"""
+
+
+class TestConfigShow:
+    def test_show_includes_section_headers(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        output = config_show(path)
+        assert "[paths]" in output
+        assert "[musicbrainz]" in output
+        assert "[artwork]" in output
+
+    def test_show_includes_key_value_pairs(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        output = config_show(path)
+        assert "staging" in output
+        assert "user@example.com" in output
+
+    def test_show_includes_bandcamp_when_present(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)
+        output = config_show(path)
+        assert "[bandcamp]" in output
+        assert "myuser" in output
+
+    def test_show_omits_bandcamp_when_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        output = config_show(path)
+        assert "bandcamp" not in output
+
+
+class TestConfigSet:
+    def test_set_string_key_updates_value(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "musicbrainz.contact", "new@example.com")
+        assert "new@example.com" in path.read_text()
+        assert "user@example.com" not in path.read_text()
+
+    def test_set_int_key_updates_value(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "artwork.min_dimension", "500")
+        text = path.read_text()
+        assert "min_dimension = 500" in text
+
+    def test_set_preserves_other_keys(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "musicbrainz.contact", "new@example.com")
+        text = path.read_text()
+        assert "staging" in text
+        assert "library" in text
+        assert "path_template" in text
+
+    def test_set_preserves_comments(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "musicbrainz.contact", "new@example.com")
+        # Comments on other lines must survive
+        assert "# Available variables" in path.read_text()
+
+    def test_set_unknown_key_raises_key_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        with pytest.raises(KeyError, match="Unknown config key"):
+            config_set(path, "paths.nonexistent", "x")
+
+    def test_set_wrong_type_raises_value_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        with pytest.raises(ValueError, match="requires an integer"):
+            config_set(path, "artwork.min_dimension", "not-an-int")
+
+    def test_set_bandcamp_key_on_missing_section_raises(self, tmp_path: Path) -> None:
+        """config_set raises KeyError when [bandcamp] section is not in the file."""
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        with pytest.raises(KeyError, match="bandcamp"):
+            config_set(path, "bandcamp.username", "foo")
+
+    def test_round_trip_load_after_set(self, tmp_path: Path) -> None:
+        """Config.load() succeeds and reflects the new value after config_set."""
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "musicbrainz.contact", "round@trip.com")
+        loaded = Config.load(path)
+        assert loaded.musicbrainz.contact == "round@trip.com"
+
+    def test_set_path_value_round_trips(self, tmp_path: Path) -> None:
+        """A path set via config_set is written as a string and loaded back correctly."""
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "paths.staging", "~/new/staging")
+        loaded = Config.load(path)
+        assert "new/staging" in str(loaded.paths.staging)
+
+    def test_set_field_missing_from_section_raises_key_error(
+        self, tmp_path: Path
+    ) -> None:
+        """config_set raises KeyError when the field isn't present in the section."""
+        # Craft a TOML where [artwork] exists but min_dimension is missing
+        path = tmp_path / "config.toml"
+        path.write_text("[artwork]\nmax_bytes = 1000000\n")
+        with pytest.raises(KeyError, match="min_dimension"):
+            config_set(path, "artwork.min_dimension", "500")
+
+    def test_set_does_not_clobber_same_fieldname_in_other_section(
+        self, tmp_path: Path
+    ) -> None:
+        """Setting a key only modifies the correct section."""
+        # Both [paths] and [bandcamp] have a "format"-like naming; use a real
+        # example: [musicbrainz].app_version and [bandcamp].format are distinct.
+        # Here we verify that setting paths.library doesn't touch library.path_template.
+        path = tmp_path / "config.toml"
+        path.write_text(DEFAULT_CONFIG_CONTENT)
+        config_set(path, "paths.library", "~/NewLib")
+        text = path.read_text()
+        assert "path_template" in text  # library section untouched
+        assert "~/NewLib" in text

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import musicbrainzngs
 
-from .config import DEFAULT_CONFIG_PATH, Config, _state_dir
+from .config import DEFAULT_CONFIG_PATH, Config, _state_dir, config_set, config_show
 from .syncer import Syncer
 from .watcher import Watcher
 
@@ -107,6 +107,20 @@ def main() -> None:
         help="Remove the launchd user agent registration.",
     )
 
+    # config subcommand
+    config_parser = subparsers.add_parser(
+        "config",
+        help="Read or update configuration values.",
+    )
+    config_sub = config_parser.add_subparsers(dest="config_command")
+    config_sub.add_parser("show", help="Print current configuration.")
+    set_parser = config_sub.add_parser(
+        "set",
+        help="Set a config value. Keys use dot notation, e.g. paths.staging",
+    )
+    set_parser.add_argument("key", help="Dot-notation key (e.g. paths.staging)")
+    set_parser.add_argument("value", help="New value")
+
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -130,6 +144,11 @@ def main() -> None:
         return
     if command == "uninstall-service":
         _cmd_uninstall_service()
+        return
+
+    # Config commands bypass daemon lifecycle (no musicbrainzngs setup needed).
+    if command == "config":
+        _cmd_config(args, config_parser)
         return
 
     try:
@@ -163,6 +182,29 @@ def main() -> None:
         if hasattr(args, "library") and args.library:
             config.paths.library = args.library
         _cmd_daemon(config)
+
+
+def _cmd_config(
+    args: argparse.Namespace, config_parser: argparse.ArgumentParser
+) -> None:
+    config_command = getattr(args, "config_command", None)
+    if config_command == "show":
+        if not args.config.exists():
+            print(f"No config file found at {args.config}.", file=sys.stderr)
+            sys.exit(1)
+        print(config_show(args.config))
+    elif config_command == "set":
+        if not args.config.exists():
+            print(f"No config file found at {args.config}.", file=sys.stderr)
+            sys.exit(1)
+        try:
+            config_set(args.config, args.key, args.value)
+            print(f"Set {args.key} = {args.value}")
+        except (KeyError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        config_parser.print_help()
 
 
 def _yn_prompt(question: str, default: bool = True) -> bool:

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 import tomllib
 from dataclasses import dataclass
@@ -241,3 +242,119 @@ class Config:
             ),
             bandcamp=bandcamp,
         )
+
+
+# ---------------------------------------------------------------------------
+# CLI config management helpers
+# ---------------------------------------------------------------------------
+
+# Explicit allowlist of every settable key with its expected Python/TOML type.
+# Drives validation and type coercion in config_set(), and ordering in config_show().
+_CONFIG_KEY_TYPES: dict[str, type] = {
+    "paths.staging": str,
+    "paths.library": str,
+    "musicbrainz.app_name": str,
+    "musicbrainz.app_version": str,
+    "musicbrainz.contact": str,
+    "artwork.min_dimension": int,
+    "artwork.max_bytes": int,
+    "library.path_template": str,
+    "bandcamp.username": str,
+    "bandcamp.cookie_file": str,
+    "bandcamp.format": str,
+    "bandcamp.poll_interval_minutes": int,
+}
+
+
+def config_show(path: Path) -> str:
+    """Return a formatted, human-readable representation of the config file.
+
+    Reads the raw TOML so values reflect the file exactly (paths not expanded).
+    """
+    with open(path, "rb") as f:
+        raw = tomllib.load(f)
+
+    lines: list[str] = []
+    for section, values in raw.items():
+        if lines:
+            lines.append("")
+        lines.append(f"[{section}]")
+        for key, value in values.items():
+            lines.append(f"  {key} = {value}")
+    return "\n".join(lines)
+
+
+def config_set(path: Path, key: str, value: str) -> None:
+    """Update a single key in the TOML config file.
+
+    *key* must be a dot-notation string like ``paths.staging`` or
+    ``artwork.min_dimension``.  *value* is always provided as a string and
+    coerced to the appropriate type.  Raises KeyError for unknown or missing
+    keys, ValueError for type mismatches.
+    """
+    if key not in _CONFIG_KEY_TYPES:
+        valid = ", ".join(sorted(_CONFIG_KEY_TYPES))
+        raise KeyError(f"Unknown config key {key!r}. Valid keys: {valid}")
+
+    target_type = _CONFIG_KEY_TYPES[key]
+    if target_type == int:
+        try:
+            int_value = int(value)
+        except ValueError:
+            raise ValueError(f"Key {key!r} requires an integer value, got {value!r}")
+        toml_value = str(int_value)
+    else:
+        toml_value = f'"{_toml_escape(value)}"'
+
+    section, field = key.split(".", 1)
+    text = path.read_text()
+    new_text = _replace_in_section(text, section, field, toml_value)
+    path.write_text(new_text)
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a string for embedding in a TOML double-quoted string."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _replace_in_section(text: str, section: str, field: str, toml_value: str) -> str:
+    """Replace *field*'s value inside *section* in raw TOML text.
+
+    Raises KeyError if the section or field is not found — callers can
+    surface a helpful message pointing users to the right setup command.
+    """
+    # Locate the target [section] header
+    section_re = re.compile(r"^\[" + re.escape(section) + r"\]", re.MULTILINE)
+    section_match = section_re.search(text)
+    if not section_match:
+        raise KeyError(
+            f"Section [{section}] not found in config. "
+            f"Run 'tune-shifter sync' to add [bandcamp], or check your config file."
+        )
+
+    # Find where this section ends: the next [header] or EOF
+    next_section_re = re.compile(r"^\[[\w-]+\]", re.MULTILINE)
+    next_match = next_section_re.search(text, section_match.end())
+    section_end = next_match.start() if next_match else len(text)
+
+    section_slice = text[section_match.end() : section_end]
+
+    # Replace the field's value line within this section only.
+    # Use a lambda to avoid regex backreference interpretation of toml_value.
+    field_re = re.compile(r"^(" + re.escape(field) + r"\s*=\s*).*$", re.MULTILINE)
+    replacement_count = 0
+
+    def _replacer(m: re.Match[str]) -> str:
+        nonlocal replacement_count
+        replacement_count += 1
+        return m.group(1) + toml_value
+
+    new_slice = field_re.sub(_replacer, section_slice, count=1)
+
+    if replacement_count == 0:
+        raise KeyError(
+            f"Key {field!r} not found in [{section}] section. "
+            f"It may need to be added to the config file manually."
+        )
+
+    return text[: section_match.end()] + new_slice + text[section_end:]

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -265,6 +265,13 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "bandcamp.poll_interval_minutes": int,
 }
 
+# Keys whose values must come from a fixed set of choices.
+_CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
+    "bandcamp.format": frozenset(
+        {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
+    ),
+}
+
 
 def config_show(path: Path) -> str:
     """Return a formatted, human-readable representation of the config file.
@@ -304,6 +311,13 @@ def config_set(path: Path, key: str, value: str) -> None:
             raise ValueError(f"Key {key!r} requires an integer value, got {value!r}")
         toml_value = str(int_value)
     else:
+        if key in _CONFIG_KEY_CHOICES:
+            valid_choices = sorted(_CONFIG_KEY_CHOICES[key])
+            if value not in _CONFIG_KEY_CHOICES[key]:
+                raise ValueError(
+                    f"Invalid value {value!r} for {key!r}. "
+                    f"Supported values: {', '.join(valid_choices)}"
+                )
         toml_value = f'"{_toml_escape(value)}"'
 
     section, field = key.split(".", 1)


### PR DESCRIPTION
## Summary

- `tune-shifter config show` — prints all current config values grouped by section
- `tune-shifter config set <key> <value>` — updates a single key in the TOML file using dot notation (e.g. `paths.staging`, `artwork.min_dimension`)
- Write-back uses section-aware regex so comments and formatting in the config file are preserved; no new runtime dependencies
- Keys are validated against an explicit allowlist with type coercion (`str`/`int`)
- Helpful errors for unknown keys, type mismatches, and missing sections (e.g. `[bandcamp]` not yet configured)

## Test plan

- [x] 232 tests pass, 95.51% coverage, mypy clean, black clean
- [x] `tune-shifter config show` displays current values correctly
- [x] `tune-shifter config set musicbrainz.contact new@email.com` updates the file and `show` reflects it
- [x] `tune-shifter config set artwork.min_dimension notanint` prints a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)