### PR TITLE
feat: derive MusicBrainz app version from package, not config

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## App Version shouldn't be configurable
-*Single* — `musicbrainz.app_version` is part of our contract with MB; remove it from the config file and schema, and derive it from `_get_version()` at startup instead
-
 ## Hotload config changes
 *Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,7 +134,6 @@ library = "~/Music"
 
 [musicbrainz]
 app_name = "tune-shifter"
-app_version = "0.1.0"
 contact = "user@example.com"  # Update with your contact email
 
 [artwork]
@@ -261,9 +260,7 @@ class TestConfigSet:
         self, tmp_path: Path
     ) -> None:
         """Setting a key only modifies the correct section."""
-        # Both [paths] and [bandcamp] have a "format"-like naming; use a real
-        # example: [musicbrainz].app_version and [bandcamp].format are distinct.
-        # Here we verify that setting paths.library doesn't touch library.path_template.
+        # Verify that setting paths.library doesn't touch library.path_template.
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
         config_set(path, "paths.library", "~/NewLib")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -34,7 +34,6 @@ def config(tmp_path: Path) -> Config:
         ),
         musicbrainz=MusicBrainzConfig(
             app_name="tune-shifter-test",
-            app_version="0.0.1",
             contact="test@example.com",
         ),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -17,9 +17,7 @@ from tune_shifter.syncer import Syncer
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(
-            app_name="test", app_version="0.0.1", contact="t@t.com"
-        ),
+        musicbrainz=MusicBrainzConfig(app_name="test", contact="t@t.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -36,9 +34,7 @@ def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
 def _make_config_no_bandcamp(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(
-            app_name="test", app_version="0.0.1", contact="t@t.com"
-        ),
+        musicbrainz=MusicBrainzConfig(app_name="test", contact="t@t.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -24,7 +24,6 @@ def config(tmp_path: Path) -> Config:
         ),
         musicbrainz=MusicBrainzConfig(
             app_name="tune-shifter-test",
-            app_version="0.0.1",
             contact="test@example.com",
         ),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -167,9 +167,11 @@ def main() -> None:
             )
             sys.exit(1)
 
+    # app_version is not user-configurable — always use the running package version
+    # so the User-Agent we send to MusicBrainz accurately identifies the software.
     musicbrainzngs.set_useragent(
         config.musicbrainz.app_name,
-        config.musicbrainz.app_version,
+        _get_version(),
         config.musicbrainz.contact,
     )
 

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -37,7 +37,6 @@ library = "~/Music"
 
 [musicbrainz]
 app_name = "tune-shifter"
-app_version = "0.1.0"
 contact = "user@example.com"  # Update with your contact email
 
 [artwork]
@@ -59,7 +58,6 @@ class PathsConfig:
 @dataclass
 class MusicBrainzConfig:
     app_name: str
-    app_version: str
     contact: str
 
 
@@ -126,7 +124,6 @@ class Config:
             paths=PathsConfig(staging=staging, library=library),
             musicbrainz=MusicBrainzConfig(
                 app_name="tune-shifter",
-                app_version="0.1.0",
                 contact=contact,
             ),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
@@ -230,7 +227,6 @@ class Config:
             ),
             musicbrainz=MusicBrainzConfig(
                 app_name=mb["app_name"],
-                app_version=mb["app_version"],
                 contact=mb["contact"],
             ),
             artwork=ArtworkConfig(
@@ -254,7 +250,6 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "paths.staging": str,
     "paths.library": str,
     "musicbrainz.app_name": str,
-    "musicbrainz.app_version": str,
     "musicbrainz.contact": str,
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,


### PR DESCRIPTION
## Summary
- Removes `app_version` from `[musicbrainz]` config section and `MusicBrainzConfig` dataclass
- `musicbrainzngs.set_useragent()` now uses `_get_version()` (reads from `pyproject.toml` or installed package metadata), so the User-Agent header always reflects the actual running version
- Existing configs with `app_version` still load fine — TOML ignores unknown keys

## Test plan
- [x] `poetry run pytest -q` — 235 passed, ≥95% coverage
- [x] `poetry run mypy tune_shifter/` — no issues
- [x] `poetry run black --check tune_shifter/ tests/` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)