### PR TITLE
feat: live-reload config without daemon restart

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Hotload config changes
-*Side* — watchdog (already a dep) can watch the config file cheaply; the complexity is safely propagating changes to the live `Syncer` (poll interval) and `Watcher` (paths) threads without a full restart
-
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,9 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## MusicBrainz app name shouldn't be configurable
+*Single* — hardcode `"tune-shifter"` as a constant; remove `app_name` from the config file and schema (same pattern as `app_version`)
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -45,4 +48,4 @@
 
 # Needs Estimation
 
-*Too busy shipping to have bad ideas right now.*
+*Running out of excuses not to ship.*

--- a/tests/test_config_monitor.py
+++ b/tests/test_config_monitor.py
@@ -1,0 +1,101 @@
+"""Tests for tune_shifter.config_monitor."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tune_shifter.config import DEFAULT_CONFIG_CONTENT, Config
+from tune_shifter.config_monitor import ConfigMonitor, _ConfigFileHandler
+
+
+def _make_event(path: str, is_directory: bool = False) -> MagicMock:
+    event = MagicMock()
+    event.src_path = path
+    event.is_directory = is_directory
+    return event
+
+
+class TestConfigFileHandler:
+    def test_on_modified_matching_path_calls_on_change(self, tmp_path: Path) -> None:
+        """on_modified fires the callback when the config file is the target."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(DEFAULT_CONFIG_CONTENT)
+        received: list[Config] = []
+        handler = _ConfigFileHandler(config_path, received.append)
+        handler.on_modified(_make_event(str(config_path)))
+        assert len(received) == 1
+
+    def test_on_created_matching_path_calls_on_change(self, tmp_path: Path) -> None:
+        """on_created also triggers reload (atomic-save editors write a new file)."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(DEFAULT_CONFIG_CONTENT)
+        received: list[Config] = []
+        handler = _ConfigFileHandler(config_path, received.append)
+        handler.on_created(_make_event(str(config_path)))
+        assert len(received) == 1
+
+    def test_on_modified_different_file_does_not_call_on_change(
+        self, tmp_path: Path
+    ) -> None:
+        """on_modified for an unrelated file is ignored."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(DEFAULT_CONFIG_CONTENT)
+        received: list[Config] = []
+        handler = _ConfigFileHandler(config_path, received.append)
+        handler.on_modified(_make_event(str(tmp_path / "other.toml")))
+        assert received == []
+
+    def test_on_modified_directory_event_is_ignored(self, tmp_path: Path) -> None:
+        """Directory-level modification events are ignored."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(DEFAULT_CONFIG_CONTENT)
+        received: list[Config] = []
+        handler = _ConfigFileHandler(config_path, received.append)
+        handler.on_modified(_make_event(str(config_path), is_directory=True))
+        assert received == []
+
+    def test_load_failure_does_not_call_on_change(self, tmp_path: Path) -> None:
+        """If Config.load() raises, on_change is not called."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("invalid toml [[[")
+        received: list[Config] = []
+        handler = _ConfigFileHandler(config_path, received.append)
+        handler.on_modified(_make_event(str(config_path)))
+        assert received == []
+
+    def test_on_change_exception_is_caught(self, tmp_path: Path) -> None:
+        """Exceptions raised by on_change are caught and logged, not propagated."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(DEFAULT_CONFIG_CONTENT)
+
+        def _bad_callback(cfg: Config) -> None:
+            raise RuntimeError("boom")
+
+        handler = _ConfigFileHandler(config_path, _bad_callback)
+        # Should not raise
+        handler.on_modified(_make_event(str(config_path)))
+
+
+class TestConfigMonitor:
+    def test_start_schedules_observer(self, tmp_path: Path) -> None:
+        """start() schedules the config file's parent directory with the observer."""
+        config_path = tmp_path / "config.toml"
+        monitor = ConfigMonitor(config_path, lambda cfg: None)
+        with patch.object(monitor._observer, "start") as mock_start:
+            with patch.object(monitor._observer, "schedule") as mock_schedule:
+                monitor.start()
+        mock_start.assert_called_once()
+        _, call_kwargs = mock_schedule.call_args
+        assert call_kwargs.get("recursive") is False
+        assert str(config_path.parent) in mock_schedule.call_args[0]
+
+    def test_stop_stops_and_joins_observer(self, tmp_path: Path) -> None:
+        """stop() calls stop() and join() on the underlying observer."""
+        config_path = tmp_path / "config.toml"
+        monitor = ConfigMonitor(config_path, lambda cfg: None)
+        with patch.object(monitor._observer, "stop") as mock_stop:
+            with patch.object(monitor._observer, "join") as mock_join:
+                monitor.stop()
+        mock_stop.assert_called_once()
+        mock_join.assert_called_once()

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -108,6 +108,50 @@ class TestSyncOnce:
                 syncer.sync_once()
 
 
+class TestReload:
+    def test_reload_updates_config(self, tmp_path: Path) -> None:
+        """reload() replaces the stored config."""
+        syncer = Syncer(_make_config(tmp_path, poll_interval=0))
+        new_config = _make_config(tmp_path, poll_interval=0)
+        new_config.musicbrainz.contact = "new@example.com"
+        syncer.reload(new_config)
+        assert syncer._config.musicbrainz.contact == "new@example.com"
+
+    def test_reload_same_interval_does_not_restart_thread(self, tmp_path: Path) -> None:
+        """reload() with unchanged poll_interval leaves the thread running."""
+        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                original_thread = syncer._thread
+                syncer.reload(_make_config(tmp_path, poll_interval=60))
+                assert syncer._thread is original_thread
+                syncer.stop()
+
+    def test_reload_changed_interval_restarts_thread(self, tmp_path: Path) -> None:
+        """reload() with a new poll_interval stops and restarts the thread."""
+        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                original_thread = syncer._thread
+                syncer.reload(_make_config(tmp_path, poll_interval=30))
+                assert syncer._thread is not original_thread
+                assert syncer._thread is not None
+                assert syncer._thread.is_alive()
+                syncer.stop()
+
+    def test_reload_interval_to_zero_stops_thread(self, tmp_path: Path) -> None:
+        """reload() with interval=0 stops the polling thread."""
+        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                assert syncer._thread is not None
+                syncer.reload(_make_config(tmp_path, poll_interval=0))
+                assert syncer._thread is None
+
+
 class TestMarkSynced:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """mark_synced() warns and returns when [bandcamp] is absent."""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -502,3 +502,66 @@ class TestWatcherStopJoin:
         watcher.start()
         watcher.stop()
         watcher.join()
+
+
+class TestWatcherReload:
+    def _patched_watcher(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> Watcher:
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        monkeypatch.setattr(watcher._observer, "stop", lambda: None)
+        monkeypatch.setattr(watcher._observer, "join", lambda **kw: None)
+        watcher.start()
+        return watcher
+
+    def test_reload_updates_config_on_handler(
+        self, config: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reload() propagates new config to the handler."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        new_config = Config(
+            paths=config.paths,
+            musicbrainz=config.musicbrainz,
+            artwork=ArtworkConfig(min_dimension=500, max_bytes=5_000_000),
+            library=config.library,
+        )
+        watcher.reload(new_config)
+        assert watcher._handler._config.artwork.min_dimension == 500
+
+    def test_reload_same_path_does_not_reschedule(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reload() with the same staging path does not touch the observer."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        reschedule_calls: list[int] = []
+        monkeypatch.setattr(
+            watcher._observer,
+            "unschedule_all",
+            lambda: reschedule_calls.append(1),
+        )
+        watcher.reload(config)
+        assert reschedule_calls == []
+
+    def test_reload_changed_path_reschedules_observer(
+        self, config: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reload() with a new staging path unschedules and reschedules the observer."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        reschedule_calls: list[int] = []
+        monkeypatch.setattr(
+            watcher._observer,
+            "unschedule_all",
+            lambda: reschedule_calls.append(1),
+        )
+        new_staging = tmp_path / "new_staging"
+        new_config = Config(
+            paths=PathsConfig(staging=new_staging, library=config.paths.library),
+            musicbrainz=config.musicbrainz,
+            artwork=config.artwork,
+            library=config.library,
+        )
+        watcher.reload(new_config)
+        assert reschedule_calls == [1]
+        assert watcher._config.paths.staging == new_staging

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import musicbrainzngs
 
 from .config import DEFAULT_CONFIG_PATH, Config, _state_dir, config_set, config_show
+from .config_monitor import ConfigMonitor
 from .syncer import Syncer
 from .watcher import Watcher
 
@@ -183,7 +184,7 @@ def main() -> None:
             config.paths.staging = args.staging
         if hasattr(args, "library") and args.library:
             config.paths.library = args.library
-        _cmd_daemon(config)
+        _cmd_daemon(config, args.config)
 
 
 def _cmd_config(
@@ -250,7 +251,7 @@ def _cmd_sync(config: Config, config_path: Path, mark_synced: bool = False) -> N
         syncer.sync_once()
 
 
-def _cmd_daemon(config: Config) -> None:
+def _cmd_daemon(config: Config, config_path: Path) -> None:
     _logger = logging.getLogger(__name__)
     pkg_version = _get_version()
     install_path = Path(__file__).resolve().parent
@@ -264,11 +265,19 @@ def _cmd_daemon(config: Config) -> None:
     watcher = Watcher(config)
     syncer = Syncer(config)
 
+    def _on_config_reload(new_config: Config) -> None:
+        watcher.reload(new_config)
+        syncer.reload(new_config)
+
+    monitor = ConfigMonitor(config_path, _on_config_reload)
+
     watcher.start()
     syncer.start()
+    monitor.start()
 
     def _shutdown(signum: int, frame: object) -> None:
         logging.getLogger(__name__).info("Shutting down…")
+        monitor.stop()
         syncer.stop()
         watcher.stop()
 

--- a/tune_shifter/config_monitor.py
+++ b/tune_shifter/config_monitor.py
@@ -1,0 +1,69 @@
+"""Watches the config file for changes and triggers a live reload."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from .config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class _ConfigFileHandler(FileSystemEventHandler):
+    def __init__(self, config_path: Path, on_change: Callable[[Config], None]) -> None:
+        super().__init__()
+        self._config_path = config_path.resolve()
+        self._on_change = on_change
+
+    def _handle(self, path: Path) -> None:
+        if path.resolve() != self._config_path:
+            return
+        logger.info("Config file changed — reloading.")
+        try:
+            config = Config.load(self._config_path)
+        except Exception:
+            logger.exception("Failed to reload config; keeping current settings.")
+            return
+        try:
+            self._on_change(config)
+        except Exception:
+            logger.exception("Error applying reloaded config.")
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._handle(Path(str(event.src_path)))
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        # Some editors save atomically (write temp → rename), which fires
+        # on_created for the destination instead of on_modified.
+        if not event.is_directory:
+            self._handle(Path(str(event.src_path)))
+
+
+class ConfigMonitor:
+    """Watch *config_path* for modifications and call *on_change* with the new Config.
+
+    Uses a watchdog Observer on the config file's parent directory (watchdog
+    cannot reliably watch a single file directly on all platforms).
+    """
+
+    def __init__(self, config_path: Path, on_change: Callable[[Config], None]) -> None:
+        self._config_path = config_path
+        self._on_change = on_change
+        self._observer = Observer()
+
+    def start(self) -> None:
+        handler = _ConfigFileHandler(self._config_path, self._on_change)
+        self._observer.schedule(handler, str(self._config_path.parent), recursive=False)
+        self._observer.start()
+        logger.info("Watching config file for changes: %s", self._config_path)
+
+    def stop(self) -> None:
+        self._observer.stop()
+        self._observer.join()
+        logger.info("Config monitor stopped.")

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -46,6 +46,34 @@ class Syncer:
         if self._thread is not None:
             self._thread.join(timeout=5)
 
+    def reload(self, config: Config) -> None:
+        """Apply a new config live.
+
+        If ``poll_interval_minutes`` changed the polling thread is restarted so
+        the new interval takes effect immediately rather than at the end of the
+        current sleep.
+        """
+        old_interval = (
+            self._config.bandcamp.poll_interval_minutes if self._config.bandcamp else 0
+        )
+        new_interval = config.bandcamp.poll_interval_minutes if config.bandcamp else 0
+        self._config = config
+
+        if old_interval != new_interval:
+            logger.info(
+                "Poll interval changed (%d → %d min); restarting syncer thread.",
+                old_interval,
+                new_interval,
+            )
+            self._stop_event.set()
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+            self._stop_event.clear()
+            self._thread = None
+            self.start()
+        else:
+            logger.info("Syncer config reloaded.")
+
     def sync_once(self) -> None:
         """Download any new purchases immediately (one-shot, blocking)."""
         bc = self._config.bandcamp

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -179,6 +179,32 @@ class Watcher:
         self._observer.join()
         logger.info("Watcher stopped")
 
+    def reload(self, config: Config) -> None:
+        """Apply a new config live.
+
+        Updates the handler's config so future pipeline runs see the new
+        settings.  If the staging path changed the observer is rescheduled to
+        the new directory immediately.
+        """
+        old_staging = self._config.paths.staging
+        self._config = config
+        self._handler._config = config
+
+        if config.paths.staging != old_staging:
+            logger.info(
+                "Staging path changed (%s → %s); rescheduling observer.",
+                old_staging,
+                config.paths.staging,
+            )
+            self._observer.unschedule_all()
+            new_staging = config.paths.staging
+            new_staging.mkdir(parents=True, exist_ok=True)
+            self._handler = _StagingHandler(config)
+            self._observer.schedule(self._handler, str(new_staging), recursive=False)
+            self._handler._scan_staging_root()
+        else:
+            logger.info("Watcher config reloaded.")
+
     def join(self) -> None:
         """Block until the observer thread exits (e.g. after stop())."""
         self._observer.join()


### PR DESCRIPTION
## Summary
- New `ConfigMonitor` class watches the config file using the existing `watchdog` dep; fires a callback whenever the file is written (handles both in-place saves and atomic-replace editors)
- `Syncer.reload(config)` — applies new config; if `poll_interval_minutes` changed, stops and restarts the poll thread so the new interval takes effect immediately
- `Watcher.reload(config)` — propagates new config to the handler (pipeline picks it up on next run); if `paths.staging` changed, unschedules and reschedules the watchdog observer to the new path
- Daemon wires everything together: `_cmd_daemon` creates a `ConfigMonitor` and stops it cleanly on shutdown

## Test plan
- [x] `poetry run pytest -q` — 250 passed, ≥95% coverage
- [x] `poetry run mypy tune_shifter/` — no issues
- [x] `poetry run black --check tune_shifter/ tests/` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)