### PR TITLE
feat: hardcode MusicBrainz app name, remove from config

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -45,4 +45,20 @@
 
 # Needs Estimation
 
-*Running out of excuses not to ship.*
+## zsh shortcuts
+I want tab completion for tune-shifter commands in zsh.
+
+## bug: tune-shifter somehow gets pip installed when homebrew installed
+after brew install i see 
+```
+[tune-shifter] which tune-shifter
+/Users/theodore.terry/.pyenv/shims/tune-shifter
+```
+
+but if i do `pip uninstall tune-shifter`, i see:
+```
+[tune-shifter] which tune-shifter
+/opt/homebrew/bin/tune-shifter
+```
+
+## 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## MusicBrainz app name shouldn't be configurable
-*Single* — hardcode `"tune-shifter"` as a constant; remove `app_name` from the config file and schema (same pattern as `app_version`)
-
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,7 +133,6 @@ staging = "~/Music/staging"
 library = "~/Music"
 
 [musicbrainz]
-app_name = "tune-shifter"
 contact = "user@example.com"  # Update with your contact email
 
 [artwork]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -32,10 +32,7 @@ def config(tmp_path: Path) -> Config:
             staging=tmp_path / "staging",
             library=tmp_path / "library",
         ),
-        musicbrainz=MusicBrainzConfig(
-            app_name="tune-shifter-test",
-            contact="test@example.com",
-        ),
+        musicbrainz=MusicBrainzConfig(contact="test@example.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -17,7 +17,7 @@ from tune_shifter.syncer import Syncer
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(app_name="test", contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -34,7 +34,7 @@ def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
 def _make_config_no_bandcamp(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(app_name="test", contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -22,10 +22,7 @@ def config(tmp_path: Path) -> Config:
             staging=tmp_path / "staging",
             library=tmp_path / "library",
         ),
-        musicbrainz=MusicBrainzConfig(
-            app_name="tune-shifter-test",
-            contact="test@example.com",
-        ),
+        musicbrainz=MusicBrainzConfig(contact="test@example.com"),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -168,10 +168,10 @@ def main() -> None:
             )
             sys.exit(1)
 
-    # app_version is not user-configurable — always use the running package version
-    # so the User-Agent we send to MusicBrainz accurately identifies the software.
+    # app_name and app_version are not user-configurable — hardcoded here so the
+    # User-Agent we send to MusicBrainz always accurately identifies the software.
     musicbrainzngs.set_useragent(
-        config.musicbrainz.app_name,
+        "tune-shifter",
         _get_version(),
         config.musicbrainz.contact,
     )

--- a/tune_shifter/config.py
+++ b/tune_shifter/config.py
@@ -36,7 +36,6 @@ staging = "~/Music/staging"
 library = "~/Music"
 
 [musicbrainz]
-app_name = "tune-shifter"
 contact = "user@example.com"  # Update with your contact email
 
 [artwork]
@@ -57,7 +56,6 @@ class PathsConfig:
 
 @dataclass
 class MusicBrainzConfig:
-    app_name: str
     contact: str
 
 
@@ -122,10 +120,7 @@ class Config:
 
         config = cls(
             paths=PathsConfig(staging=staging, library=library),
-            musicbrainz=MusicBrainzConfig(
-                app_name="tune-shifter",
-                contact=contact,
-            ),
+            musicbrainz=MusicBrainzConfig(contact=contact),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
             library=LibraryConfig(
                 path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -225,10 +220,7 @@ class Config:
                 staging=Path(p["staging"]).expanduser(),
                 library=Path(p["library"]).expanduser(),
             ),
-            musicbrainz=MusicBrainzConfig(
-                app_name=mb["app_name"],
-                contact=mb["contact"],
-            ),
+            musicbrainz=MusicBrainzConfig(contact=mb["contact"]),
             artwork=ArtworkConfig(
                 min_dimension=int(art["min_dimension"]),
                 max_bytes=int(art["max_bytes"]),
@@ -249,7 +241,6 @@ class Config:
 _CONFIG_KEY_TYPES: dict[str, type] = {
     "paths.staging": str,
     "paths.library": str,
-    "musicbrainz.app_name": str,
     "musicbrainz.contact": str,
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,


### PR DESCRIPTION
## Summary
- Removes `app_name` from `MusicBrainzConfig`, `DEFAULT_CONFIG_CONTENT`, and `_CONFIG_KEY_TYPES`
- `musicbrainzngs.set_useragent()` now always passes `"tune-shifter"` directly — users have no reason to change it
- Existing configs with `app_name` still load fine (TOML ignores unknown keys)

## Test plan
- [x] `poetry run pytest -q` — 250 passed, ≥95% coverage
- [x] `poetry run mypy tune_shifter/` — no issues
- [x] `poetry run black --check tune_shifter/ tests/` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)