### PR TITLE
feat: zsh tab completion

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## zsh shortcuts
-*Side* — write a `_tune-shifter` zsh completion function covering all subcommands (`daemon`, `sync`, `install-service`, `uninstall-service`, `config show/set`) and global flags; install via Homebrew formula to `share/zsh/site-functions/`
-
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,9 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## zsh shortcuts
+*Side* — write a `_tune-shifter` zsh completion function covering all subcommands (`daemon`, `sync`, `install-service`, `uninstall-service`, `config show/set`) and global flags; install via Homebrew formula to `share/zsh/site-functions/`
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -43,22 +46,5 @@
 ## Allow a user to verify tags before they're written
 ⚠️ Not scoped — needs UI design (CLI prompt? TUI? GUI?) before estimating
 
-# Needs Estimation
-
-## zsh shortcuts
-I want tab completion for tune-shifter commands in zsh.
-
-## bug: tune-shifter somehow gets pip installed when homebrew installed
-after brew install i see 
-```
-[tune-shifter] which tune-shifter
-/Users/theodore.terry/.pyenv/shims/tune-shifter
-```
-
-but if i do `pip uninstall tune-shifter`, i see:
-```
-[tune-shifter] which tune-shifter
-/opt/homebrew/bin/tune-shifter
-```
-
-## 
+## bug: pyenv shim shadows Homebrew binary after dev/brew cycle
+*Single* — formula is clean (isolated venv). Root cause: a past dev practice (pre-Poetry) wrote `tune-shifter` to pyenv's global site-packages; `pyenv rehash` registered the shim and it persisted. Fix: audit current dev paths for any global pip writes; add `.python-version` to the repo so pyenv doesn't pick up executables from Poetry's cache venv; document the canonical dev workflow.

--- a/Formula/tune-shifter.rb
+++ b/Formula/tune-shifter.rb
@@ -26,6 +26,7 @@ class TuneShifter < Formula
     system venv/"bin/pip", "install", "--upgrade", "pip"
     system venv/"bin/pip", "install", buildpath
     bin.install_symlink venv/"bin/tune-shifter"
+    zsh_completion.install "completions/_tune-shifter"
     (share/"tune-shifter").install "USAGE.md"
   end
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ After install, download the Playwright browser binaries required for Bandcamp au
 /opt/homebrew/opt/tune-shifter/venv/bin/playwright install chromium
 ```
 
+zsh tab completion is included and activated automatically via Homebrew's shell integration.
+
 ### From source
 
 ```bash

--- a/claude.md
+++ b/claude.md
@@ -8,9 +8,11 @@
 - Write meaningful behavioral tests
 - The API should be expressive
 
-
 # Workflow
-- Be sure to typecheck when you're done making a series of code changes
+- Start work with a new branch created from a clean, updated main branch. Do not create files before creating a new branch.
+- Use red/green TDD
+- Before opening a PR, run all CI steps (testing, linting, type checks, etc) locally
+- Before opening a PR, scan through README.md to make sure it's still valid (nothing it says has drifted from what the application does)
 - Prefer running single tests, and not the whole test suite, for performance
 - Update documentation (README.md) after new features are validated
 - Document rationale in comments: succinctly explain *why* decisions are made

--- a/completions/_tune-shifter
+++ b/completions/_tune-shifter
@@ -1,0 +1,106 @@
+#compdef tune-shifter
+
+# zsh completion for tune-shifter
+# Installed to share/zsh/site-functions/ via the Homebrew formula.
+
+_tune_shifter() {
+  local state line
+  typeset -A opt_args
+
+  # Global options available at the top level
+  local -a global_opts
+  global_opts=(
+    '--config[Path to config file]:config file:_files -g "*.toml"'
+    '--log-level[Log verbosity]:level:(DEBUG INFO WARNING ERROR)'
+  )
+
+  _arguments -C \
+    $global_opts \
+    '1:subcommand:->subcommand' \
+    '*::args:->args'
+
+  case $state in
+    subcommand)
+      local -a subcommands
+      subcommands=(
+        'daemon:Watch staging directory and poll Bandcamp (default)'
+        'sync:One-shot Bandcamp download, then exit'
+        'install-service:Register tune-shifter as a launchd user agent (macOS)'
+        'uninstall-service:Remove the launchd user agent registration'
+        'config:Read or update configuration values'
+      )
+      _describe 'subcommand' subcommands
+      ;;
+
+    args)
+      case $line[1] in
+        daemon)
+          _arguments \
+            $global_opts \
+            '--staging[Staging directory to watch]:directory:_files -/' \
+            '--library[Library directory for finished files]:directory:_files -/'
+          ;;
+
+        sync)
+          _arguments \
+            $global_opts \
+            '--mark-synced[Mark entire collection as synced without downloading]'
+          ;;
+
+        install-service|uninstall-service)
+          # No subcommand-specific options
+          _arguments $global_opts
+          ;;
+
+        config)
+          _arguments -C \
+            $global_opts \
+            '1:config-command:->config_command' \
+            '*::config-args:->config_args'
+
+          case $state in
+            config_command)
+              local -a config_cmds
+              config_cmds=(
+                'show:Print current configuration'
+                'set:Set a config value (dot-notation key)'
+              )
+              _describe 'config command' config_cmds
+              ;;
+
+            config_args)
+              case $line[1] in
+                set)
+                  # Complete KEY on first positional, VALUE on second
+                  if (( CURRENT == 2 )); then
+                    local -a config_keys
+                    config_keys=(
+                      'paths.staging:Path to the staging directory'
+                      'paths.library:Path to the music library directory'
+                      'musicbrainz.contact:Contact email for MusicBrainz User-Agent'
+                      'artwork.min_dimension:Minimum cover art dimension in pixels'
+                      'artwork.max_bytes:Maximum cover art file size in bytes'
+                      'library.path_template:Path template for library files'
+                      'bandcamp.username:Bandcamp username'
+                      'bandcamp.cookie_file:Path to Bandcamp cookie file'
+                      'bandcamp.format:Preferred download format'
+                      'bandcamp.poll_interval_minutes:Polling interval in minutes (0 = manual)'
+                    )
+                    _describe 'config key' config_keys
+                  elif (( CURRENT == 3 )) && [[ $line[2] == 'bandcamp.format' ]]; then
+                    # Enumerate valid format choices for this specific key
+                    local -a formats
+                    formats=(mp3-v0 mp3-320 flac aac-hi vorbis alac wav)
+                    _values 'format' $formats
+                  fi
+                  ;;
+              esac
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_tune_shifter "$@"


### PR DESCRIPTION
## Summary

- Adds `completions/_tune-shifter` — a `#compdef` zsh completion script covering all subcommands (`daemon`, `sync`, `install-service`, `uninstall-service`, `config show/set`), global flags (`--config`, `--log-level`), all `config set` keys, and enumerated value completion for `bandcamp.format`
- Updates `Formula/tune-shifter.rb` to install the completion file via `zsh_completion.install`, activating it automatically after `brew install`
- Adds a one-line note to the Homebrew installation section of `README.md`
- Moves both previously-unestimated `BACKLOG.md` items to the main backlog with estimates and refined descriptions

## Test plan

To test completions without a brew install (session-local, no production impact — open a new terminal to reset):

```zsh
# From the repo root:
fpath=(completions $fpath)
autoload -Uz compinit && compinit -u

tune-shifter <TAB>                             # → daemon sync install-service uninstall-service config
tune-shifter --log-level <TAB>                 # → DEBUG INFO WARNING ERROR
tune-shifter daemon --staging <TAB>            # → directory completion
tune-shifter sync --<TAB>                      # → --mark-synced
tune-shifter config <TAB>                      # → show set
tune-shifter config set <TAB>                  # → 10 known config keys
tune-shifter config set bandcamp.format <TAB>  # → mp3-v0 mp3-320 flac aac-hi vorbis alac wav
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)