### PR TITLE
fix: include completions/_tune-shifter in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ version = "0.12.0"
 description = "Automated audio library ingest from Bandcamp downloads."
 authors = []
 packages = [{include = "tune_shifter"}]
-# USAGE.md is read by the Homebrew formula's caveats block; MANIFEST.in is
-# ignored by poetry-core so it must be declared here explicitly.
-include = ["USAGE.md"]
+# USAGE.md is read by the Homebrew formula's caveats block; completions/ is
+# installed by the Homebrew formula's zsh_completion.install call. MANIFEST.in
+# is ignored by poetry-core so both must be declared here explicitly.
+include = ["USAGE.md", "completions/_tune-shifter"]
 
 [tool.poetry.dependencies]
 python = ">=3.11"


### PR DESCRIPTION
## Summary

- Adds `completions/_tune-shifter` to the `include` list in `pyproject.toml` so it ships inside the sdist tarball

## Root cause

`poetry-core` only packages `tune_shifter/` by default. The Homebrew formula calls `zsh_completion.install "completions/_tune-shifter"` against `buildpath`, which resolves to the extracted sdist — so the file must be explicitly included.

## Test plan

```bash
poetry build --format sdist
tar -tzf dist/tune_shifter-*.tar.gz | grep completion
# → tune_shifter-x.y.z/completions/_tune-shifter
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)