### PR TITLE
feat: add stop, play, status service commands

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Config commands for managing the service
-*Side* — add `stop`, `play`, and `status` subcommands wrapping launchctl unload/load/list; guard against already-stopped/already-running states with friendly messages; `status` shows uptime when running. Update zsh completion, USAGE.md, and README (remove raw launchctl instructions).
-
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,9 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## Config commands for managing the service
+*Side* — add `stop`, `play`, and `status` subcommands wrapping launchctl unload/load/list; guard against already-stopped/already-running states with friendly messages; `status` shows uptime when running. Update zsh completion, USAGE.md, and README (remove raw launchctl instructions).
+
 ## Producer Support
 *Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
@@ -45,3 +48,6 @@
 
 ## bug: pyenv shim shadows Homebrew binary after dev/brew cycle
 *Single* — formula is clean (isolated venv). Root cause: a past dev practice (pre-Poetry) wrote `tune-shifter` to pyenv's global site-packages; `pyenv rehash` registered the shim and it persisted. Fix: audit current dev paths for any global pip writes; add `.python-version` to the repo so pyenv doesn't pick up executables from Poetry's cache venv; document the canonical dev workflow.
+
+# Needs Estimation
+-- don't discard this section --

--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ tune-shifter install-service
 Logs are written to `~/.local/share/tune-shifter/daemon.log`.
 
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.tune-shifter.plist   # pause the service
-launchctl load ~/Library/LaunchAgents/com.tune-shifter.plist   # restart the service
-tune-shifter uninstall-service   # remove the service registration
+tune-shifter stop              # pause the service
+tune-shifter play              # resume the service
+tune-shifter status            # check if it's running
+tune-shifter uninstall-service # remove it permanently
 ```
 
 ### View or update config from the command line

--- a/USAGE.md
+++ b/USAGE.md
@@ -13,6 +13,11 @@ Then install the service so it starts at login:
 
 Now move a zip or folder into your staging folder and tune-shifter will take care of the rest!
 
+To manage the service:
+  tune-shifter stop     # pause
+  tune-shifter play     # resume
+  tune-shifter status   # check if it's running
+
 To sync your collection from Bandcamp, run:
   tune-shifter sync
 

--- a/claude.md
+++ b/claude.md
@@ -13,6 +13,6 @@
 - Use red/green TDD
 - Before opening a PR, run all CI steps (testing, linting, type checks, etc) locally
 - Before opening a PR, scan through README.md to make sure it's still valid (nothing it says has drifted from what the application does)
-- Prefer running single tests, and not the whole test suite, for performance
+- Prefer running single tests, and not the whole test suite, for performance; use `--no-cov` when running a single file to skip the coverage threshold check (e.g. `poetry run pytest tests/test_foo.py -v --no-cov`)
 - Update documentation (README.md) after new features are validated
 - Document rationale in comments: succinctly explain *why* decisions are made

--- a/completions/_tune-shifter
+++ b/completions/_tune-shifter
@@ -27,6 +27,9 @@ _tune_shifter() {
         'sync:One-shot Bandcamp download, then exit'
         'install-service:Register tune-shifter as a launchd user agent (macOS)'
         'uninstall-service:Remove the launchd user agent registration'
+        'stop:Stop the tune-shifter service'
+        'play:Start the tune-shifter service'
+        'status:Show whether tune-shifter is running'
         'config:Read or update configuration values'
       )
       _describe 'subcommand' subcommands
@@ -47,7 +50,7 @@ _tune_shifter() {
             '--mark-synced[Mark entire collection as synced without downloading]'
           ;;
 
-        install-service|uninstall-service)
+        install-service|uninstall-service|stop|play|status)
           # No subcommand-specific options
           _arguments $global_opts
           ;;

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,19 @@
 """Tests for tune_shifter.__main__ helpers."""
 
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from tune_shifter.__main__ import _yn_prompt
+from tune_shifter.__main__ import (
+    _SERVICE_LABEL,
+    _cmd_play,
+    _cmd_status,
+    _cmd_stop,
+    _service_pid,
+    _yn_prompt,
+)
 
 
 class TestYnPrompt:
@@ -36,3 +47,140 @@ class TestYnPrompt:
 
         monkeypatch.setattr("builtins.input", raise_eof)
         assert _yn_prompt("Question?", default=True) is True
+
+
+def _launchctl_result(stdout: str, returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    return result
+
+
+class TestServicePid:
+    def test_returns_pid_when_running(self) -> None:
+        output = f"PID\tStatus\tLabel\n12345\t0\t{_SERVICE_LABEL}\n"
+        with patch("subprocess.run", return_value=_launchctl_result(output)):
+            assert _service_pid() == 12345
+
+    def test_returns_none_when_not_loaded(self) -> None:
+        # launchctl list returns non-zero when the label isn't known
+        with patch("subprocess.run", return_value=_launchctl_result("", returncode=1)):
+            assert _service_pid() is None
+
+    def test_returns_none_when_pid_is_dash(self) -> None:
+        # Service is registered but not currently running (e.g. crashed + KeepAlive delay)
+        output = f"PID\tStatus\tLabel\n-\t0\t{_SERVICE_LABEL}\n"
+        with patch("subprocess.run", return_value=_launchctl_result(output)):
+            assert _service_pid() is None
+
+    def test_returns_none_when_pid_is_zero(self) -> None:
+        output = f"PID\tStatus\tLabel\n0\t0\t{_SERVICE_LABEL}\n"
+        with patch("subprocess.run", return_value=_launchctl_result(output)):
+            assert _service_pid() is None
+
+
+class TestCmdStop:
+    def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        with patch("tune_shifter.__main__._PLIST_PATH", plist):
+            _cmd_stop()
+        assert "not installed" in capsys.readouterr().out
+
+    def test_already_stopped(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=None),
+        ):
+            _cmd_stop()
+        assert "already stopped" in capsys.readouterr().out
+
+    def test_stops_running_service(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=42),
+            patch("subprocess.run") as mock_run,
+        ):
+            _cmd_stop()
+        mock_run.assert_called_once_with(
+            ["launchctl", "unload", str(plist)], check=True
+        )
+        assert "stopped" in capsys.readouterr().out
+
+
+class TestCmdPlay:
+    def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        with patch("tune_shifter.__main__._PLIST_PATH", plist):
+            _cmd_play()
+        out = capsys.readouterr().out
+        assert "not installed" in out
+
+    def test_already_running(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=42),
+        ):
+            _cmd_play()
+        assert "already running" in capsys.readouterr().out
+
+    def test_starts_stopped_service(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=None),
+            patch("subprocess.run") as mock_run,
+        ):
+            _cmd_play()
+        mock_run.assert_called_once_with(["launchctl", "load", str(plist)], check=True)
+        assert "started" in capsys.readouterr().out
+
+
+class TestCmdStatus:
+    def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        with patch("tune_shifter.__main__._PLIST_PATH", plist):
+            _cmd_status()
+        assert "not installed" in capsys.readouterr().out
+
+    def test_stopped(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=None),
+        ):
+            _cmd_status()
+        assert "not running" in capsys.readouterr().out
+
+    def test_running_shows_uptime(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "  1:23:45\n"
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=99),
+            patch("subprocess.run", return_value=ps_result),
+        ):
+            _cmd_status()
+        out = capsys.readouterr().out
+        assert "running" in out
+        assert "1:23:45" in out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ from tune_shifter.__main__ import (
     _cmd_play,
     _cmd_status,
     _cmd_stop,
+    _launchd_domain,
     _service_pid,
     _yn_prompt,
 )
@@ -110,7 +111,7 @@ class TestCmdStop:
         ):
             _cmd_stop()
         mock_run.assert_called_once_with(
-            ["launchctl", "unload", str(plist)], check=True
+            ["launchctl", "bootout", _launchd_domain(), str(plist)], check=False
         )
         assert "stopped" in capsys.readouterr().out
 
@@ -146,7 +147,9 @@ class TestCmdPlay:
             patch("subprocess.run") as mock_run,
         ):
             _cmd_play()
-        mock_run.assert_called_once_with(["launchctl", "load", str(plist)], check=True)
+        mock_run.assert_called_once_with(
+            ["launchctl", "bootstrap", _launchd_domain(), str(plist)], check=True
+        )
         assert "started" in capsys.readouterr().out
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@ from tune_shifter.__main__ import (
     _cmd_status,
     _cmd_stop,
     _launchd_domain,
+    _parse_launchctl_info,
     _service_pid,
     _service_registered,
     _yn_prompt,
@@ -58,10 +59,42 @@ def _launchctl_result(stdout: str, returncode: int = 0) -> MagicMock:
     return result
 
 
+def _launchctl_output(pid: int | None = None, last_exit: int = 0) -> str:
+    """Build realistic launchctl list <label> dict-style output for tests."""
+    lines = [
+        "{",
+        f'\t"Label" = "{_SERVICE_LABEL}";',
+        f'\t"LastExitStatus" = {last_exit};',
+    ]
+    if pid is not None:
+        lines.append(f'\t"PID" = {pid};')
+    lines.append("};")
+    return "\n".join(lines) + "\n"
+
+
+class TestParseLaunchctlInfo:
+    def test_parses_pid(self) -> None:
+        assert _parse_launchctl_info(_launchctl_output(pid=12345))["PID"] == "12345"
+
+    def test_parses_last_exit_status(self) -> None:
+        assert (
+            _parse_launchctl_info(_launchctl_output(last_exit=256))["LastExitStatus"]
+            == "256"
+        )
+
+    def test_no_pid_key_when_not_running(self) -> None:
+        assert "PID" not in _parse_launchctl_info(_launchctl_output(pid=None))
+
+    def test_parses_quoted_string_value(self) -> None:
+        assert _parse_launchctl_info(_launchctl_output())["Label"] == _SERVICE_LABEL
+
+
 class TestServiceRegistered:
     def test_returns_true_when_registered(self) -> None:
-        output = f"PID\tStatus\tLabel\n-\t0\t{_SERVICE_LABEL}\n"
-        with patch("subprocess.run", return_value=_launchctl_result(output)):
+        with patch(
+            "subprocess.run",
+            return_value=_launchctl_result(_launchctl_output()),
+        ):
             assert _service_registered() is True
 
     def test_returns_false_when_not_registered(self) -> None:
@@ -71,24 +104,29 @@ class TestServiceRegistered:
 
 class TestServicePid:
     def test_returns_pid_when_running(self) -> None:
-        output = f"PID\tStatus\tLabel\n12345\t0\t{_SERVICE_LABEL}\n"
-        with patch("subprocess.run", return_value=_launchctl_result(output)):
+        with patch(
+            "subprocess.run",
+            return_value=_launchctl_result(_launchctl_output(pid=12345)),
+        ):
             assert _service_pid() == 12345
 
     def test_returns_none_when_not_loaded(self) -> None:
-        # launchctl list returns non-zero when the label isn't known
         with patch("subprocess.run", return_value=_launchctl_result("", returncode=1)):
             assert _service_pid() is None
 
-    def test_returns_none_when_pid_is_dash(self) -> None:
-        # Service is registered but not currently running (e.g. crashed + KeepAlive delay)
-        output = f"PID\tStatus\tLabel\n-\t0\t{_SERVICE_LABEL}\n"
-        with patch("subprocess.run", return_value=_launchctl_result(output)):
+    def test_returns_none_when_no_pid_key(self) -> None:
+        # Registered but not running — PID key absent from output
+        with patch(
+            "subprocess.run",
+            return_value=_launchctl_result(_launchctl_output(pid=None)),
+        ):
             assert _service_pid() is None
 
     def test_returns_none_when_pid_is_zero(self) -> None:
-        output = f"PID\tStatus\tLabel\n0\t0\t{_SERVICE_LABEL}\n"
-        with patch("subprocess.run", return_value=_launchctl_result(output)):
+        with patch(
+            "subprocess.run",
+            return_value=_launchctl_result(_launchctl_output(pid=0)),
+        ):
             assert _service_pid() is None
 
 
@@ -191,15 +229,36 @@ class TestCmdStatus:
             _cmd_status()
         assert "not installed" in capsys.readouterr().out
 
-    def test_stopped(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    def test_stopped_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
         plist = tmp_path / "com.tune-shifter.plist"
         plist.touch()
         with (
             patch("tune_shifter.__main__._PLIST_PATH", plist),
             patch("tune_shifter.__main__._service_pid", return_value=None),
+            patch("tune_shifter.__main__._service_registered", return_value=False),
         ):
             _cmd_status()
         assert "not running" in capsys.readouterr().out
+
+    def test_crashed_shows_exit_code(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=None),
+            patch(
+                "subprocess.run",
+                return_value=_launchctl_result(_launchctl_output(last_exit=256)),
+            ),
+        ):
+            _cmd_status()
+        out = capsys.readouterr().out
+        assert "crashed" in out
+        assert "256" in out
 
     def test_running_shows_uptime(
         self, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ from tune_shifter.__main__ import (
     _cmd_stop,
     _launchd_domain,
     _service_pid,
+    _service_registered,
     _yn_prompt,
 )
 
@@ -55,6 +56,17 @@ def _launchctl_result(stdout: str, returncode: int = 0) -> MagicMock:
     result.returncode = returncode
     result.stdout = stdout
     return result
+
+
+class TestServiceRegistered:
+    def test_returns_true_when_registered(self) -> None:
+        output = f"PID\tStatus\tLabel\n-\t0\t{_SERVICE_LABEL}\n"
+        with patch("subprocess.run", return_value=_launchctl_result(output)):
+            assert _service_registered() is True
+
+    def test_returns_false_when_not_registered(self) -> None:
+        with patch("subprocess.run", return_value=_launchctl_result("", returncode=1)):
+            assert _service_registered() is False
 
 
 class TestServicePid:
@@ -136,7 +148,7 @@ class TestCmdPlay:
             _cmd_play()
         assert "already running" in capsys.readouterr().out
 
-    def test_starts_stopped_service(
+    def test_starts_unregistered_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         plist = tmp_path / "com.tune-shifter.plist"
@@ -144,11 +156,30 @@ class TestCmdPlay:
         with (
             patch("tune_shifter.__main__._PLIST_PATH", plist),
             patch("tune_shifter.__main__._service_pid", return_value=None),
+            patch("tune_shifter.__main__._service_registered", return_value=False),
             patch("subprocess.run") as mock_run,
         ):
             _cmd_play()
         mock_run.assert_called_once_with(
             ["launchctl", "bootstrap", _launchd_domain(), str(plist)], check=True
+        )
+        assert "started" in capsys.readouterr().out
+
+    def test_kickstarts_registered_but_stopped_service(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        plist = tmp_path / "com.tune-shifter.plist"
+        plist.touch()
+        domain = _launchd_domain()
+        with (
+            patch("tune_shifter.__main__._PLIST_PATH", plist),
+            patch("tune_shifter.__main__._service_pid", return_value=None),
+            patch("tune_shifter.__main__._service_registered", return_value=True),
+            patch("subprocess.run") as mock_run,
+        ):
+            _cmd_play()
+        mock_run.assert_called_once_with(
+            ["launchctl", "kickstart", f"{domain}/{_SERVICE_LABEL}"], check=True
         )
         assert "started" in capsys.readouterr().out
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,10 +234,14 @@ class TestCmdStatus:
     ) -> None:
         plist = tmp_path / "com.tune-shifter.plist"
         plist.touch()
+        # returncode=1 → not registered; no crash info, no subprocess needed
         with (
             patch("tune_shifter.__main__._PLIST_PATH", plist),
             patch("tune_shifter.__main__._service_pid", return_value=None),
-            patch("tune_shifter.__main__._service_registered", return_value=False),
+            patch(
+                "tune_shifter.__main__._launchctl_list",
+                return_value=_launchctl_result("", returncode=1),
+            ),
         ):
             _cmd_status()
         assert "not running" in capsys.readouterr().out

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -107,6 +107,9 @@ def main() -> None:
         "uninstall-service",
         help="Remove the launchd user agent registration.",
     )
+    subparsers.add_parser("stop", help="Stop the tune-shifter service.")
+    subparsers.add_parser("play", help="Start the tune-shifter service.")
+    subparsers.add_parser("status", help="Show whether tune-shifter is running.")
 
     # config subcommand
     config_parser = subparsers.add_parser(
@@ -145,6 +148,15 @@ def main() -> None:
         return
     if command == "uninstall-service":
         _cmd_uninstall_service()
+        return
+    if command == "stop":
+        _cmd_stop()
+        return
+    if command == "play":
+        _cmd_play()
+        return
+    if command == "status":
+        _cmd_status()
         return
 
     # Config commands bypass daemon lifecycle (no musicbrainzngs setup needed).
@@ -288,6 +300,72 @@ def _cmd_daemon(config: Config, config_path: Path) -> None:
     watcher.join()
 
 
+def _service_pid() -> int | None:
+    """Return the PID of the running tune-shifter service, or None if not running.
+
+    Queries launchctl for the service label. A positive PID means the process is
+    alive; "-" or 0 means the service is registered but not currently running.
+    """
+    result = subprocess.run(
+        ["launchctl", "list", _SERVICE_LABEL],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    lines = result.stdout.strip().splitlines()
+    if len(lines) < 2:
+        return None
+    pid_str = lines[1].split("\t")[0]
+    if not pid_str.isdigit():
+        return None
+    pid = int(pid_str)
+    return pid if pid > 0 else None
+
+
+def _cmd_stop() -> None:
+    if not _PLIST_PATH.exists():
+        print(
+            "tune-shifter is not installed as a service. Run tune-shifter install-service first."
+        )
+        return
+    if _service_pid() is None:
+        print("tune-shifter is already stopped.")
+        return
+    subprocess.run(["launchctl", "unload", str(_PLIST_PATH)], check=True)
+    print("tune-shifter stopped.")
+
+
+def _cmd_play() -> None:
+    if not _PLIST_PATH.exists():
+        print(
+            "tune-shifter is not installed as a service. Run tune-shifter install-service first."
+        )
+        return
+    if _service_pid() is not None:
+        print("tune-shifter is already running.")
+        return
+    subprocess.run(["launchctl", "load", str(_PLIST_PATH)], check=True)
+    print("tune-shifter started.")
+
+
+def _cmd_status() -> None:
+    if not _PLIST_PATH.exists():
+        print("tune-shifter is not installed as a service.")
+        return
+    pid = _service_pid()
+    if pid is None:
+        print("tune-shifter is not running.")
+        return
+    ps = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "etime="],
+        capture_output=True,
+        text=True,
+    )
+    uptime = ps.stdout.strip() if ps.returncode == 0 else "unknown"
+    print(f"tune-shifter is running (pid {pid}, uptime {uptime})")
+
+
 def _cmd_install_service(config_path: Path) -> None:
     exec_path = shutil.which("tune-shifter") or sys.argv[0]
     _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -313,13 +391,13 @@ def _cmd_install_service(config_path: Path) -> None:
     _PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
     _PLIST_PATH.write_text(plist)
     subprocess.run(["launchctl", "load", str(_PLIST_PATH)], check=True)
-    print(f"Service installed and started.")
-    print(f"  Logs  → {_LOG_PATH}")
-    print(f"  Plist → {_PLIST_PATH}")
-    print(f"\nTo stop the service temporarily:")
-    print(f"  launchctl unload {_PLIST_PATH}")
-    print(f"To remove it permanently:")
-    print(f"  tune-shifter uninstall-service")
+    print("tune-shifter installed and started.")
+    print(f"  Logs → {_LOG_PATH}")
+    print("\nUseful commands:")
+    print("  tune-shifter stop             # pause the service")
+    print("  tune-shifter play             # resume the service")
+    print("  tune-shifter status           # check if it's running")
+    print("  tune-shifter uninstall-service  # remove it permanently")
 
 
 def _cmd_uninstall_service() -> None:

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 import logging
+import os
 import shutil
 import signal
 import subprocess
@@ -300,6 +301,15 @@ def _cmd_daemon(config: Config, config_path: Path) -> None:
     watcher.join()
 
 
+def _launchd_domain() -> str:
+    """Return the launchd domain for the current user's GUI session (macOS).
+
+    bootstrap/bootout require an explicit domain; gui/<uid> is the correct
+    target for user agents in ~/Library/LaunchAgents.
+    """
+    return f"gui/{os.getuid()}"
+
+
 def _service_pid() -> int | None:
     """Return the PID of the running tune-shifter service, or None if not running.
 
@@ -332,7 +342,11 @@ def _cmd_stop() -> None:
     if _service_pid() is None:
         print("tune-shifter is already stopped.")
         return
-    subprocess.run(["launchctl", "unload", str(_PLIST_PATH)], check=True)
+    # bootout stops and unregisters the service; use check=False so a
+    # non-zero exit (e.g. already unloaded) doesn't raise.
+    subprocess.run(
+        ["launchctl", "bootout", _launchd_domain(), str(_PLIST_PATH)], check=False
+    )
     print("tune-shifter stopped.")
 
 
@@ -345,7 +359,11 @@ def _cmd_play() -> None:
     if _service_pid() is not None:
         print("tune-shifter is already running.")
         return
-    subprocess.run(["launchctl", "load", str(_PLIST_PATH)], check=True)
+    # bootstrap registers and starts the service; it returns a proper non-zero
+    # exit code on failure, unlike the deprecated `launchctl load`.
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
+    )
     print("tune-shifter started.")
 
 
@@ -390,7 +408,9 @@ def _cmd_install_service(config_path: Path) -> None:
 </plist>"""
     _PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
     _PLIST_PATH.write_text(plist)
-    subprocess.run(["launchctl", "load", str(_PLIST_PATH)], check=True)
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
+    )
     print("tune-shifter installed and started.")
     print(f"  Logs → {_LOG_PATH}")
     print("\nUseful commands:")
@@ -404,7 +424,9 @@ def _cmd_uninstall_service() -> None:
     if not _PLIST_PATH.exists():
         print("Service is not installed.")
         return
-    subprocess.run(["launchctl", "unload", str(_PLIST_PATH)], check=False)
+    subprocess.run(
+        ["launchctl", "bootout", _launchd_domain(), str(_PLIST_PATH)], check=False
+    )
     _PLIST_PATH.unlink()
     print("Service removed.")
 

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -14,6 +14,7 @@ import argparse
 import importlib.metadata
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -319,6 +320,25 @@ def _launchctl_list() -> subprocess.CompletedProcess[str]:
     )
 
 
+# Matches simple scalar entries in launchctl list output, e.g.:
+#     "PID" = 12345;
+#     "LastExitStatus" = 256;
+#     "Label" = "com.tune-shifter";
+# Skips complex values (arrays, nested dicts) that span multiple lines.
+_LAUNCHCTL_ENTRY_RE = re.compile(r'^\s*"(\w+)"\s*=\s*(?:"([^"]*)"|([\w./\-]+));\s*$')
+
+
+def _parse_launchctl_info(output: str) -> dict[str, str]:
+    """Extract scalar key/value pairs from launchctl dict output."""
+    info: dict[str, str] = {}
+    for line in output.splitlines():
+        m = _LAUNCHCTL_ENTRY_RE.match(line)
+        if m:
+            # group(2) is a quoted string value; group(3) is an unquoted value
+            info[m.group(1)] = m.group(2) if m.group(2) is not None else m.group(3)
+    return info
+
+
 def _service_registered() -> bool:
     """Return True if tune-shifter is registered in the launchd namespace.
 
@@ -332,15 +352,13 @@ def _service_pid() -> int | None:
     """Return the PID of the running tune-shifter service, or None if not running.
 
     Queries launchctl for the service label. A positive PID means the process is
-    alive; "-" or 0 means the service is registered but not currently running.
+    alive; absent or 0 means the service is registered but not currently running.
     """
     result = _launchctl_list()
     if result.returncode != 0:
         return None
-    lines = result.stdout.strip().splitlines()
-    if len(lines) < 2:
-        return None
-    pid_str = lines[1].split("\t")[0]
+    info = _parse_launchctl_info(result.stdout)
+    pid_str = info.get("PID", "")
     if not pid_str.isdigit():
         return None
     pid = int(pid_str)
@@ -394,6 +412,16 @@ def _cmd_status() -> None:
         return
     pid = _service_pid()
     if pid is None:
+        result = _launchctl_list()
+        if result.returncode == 0:
+            # Registered but not running — surface the last exit code so the
+            # user can tell whether it crashed or was cleanly stopped.
+            info = _parse_launchctl_info(result.stdout)
+            last_exit = info.get("LastExitStatus", "0")
+            if last_exit != "0":
+                print(f"tune-shifter is not running (crashed, last exit: {last_exit})")
+                print(f"  Logs → {_LOG_PATH}")
+                return
         print("tune-shifter is not running.")
         return
     ps = subprocess.run(

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -310,17 +310,31 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchctl_list() -> subprocess.CompletedProcess[str]:
+    """Run `launchctl list <label>` and return the result."""
+    return subprocess.run(
+        ["launchctl", "list", _SERVICE_LABEL],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _service_registered() -> bool:
+    """Return True if tune-shifter is registered in the launchd namespace.
+
+    A non-zero exit from `launchctl list` means the label is unknown to launchd.
+    Zero exit means the service is registered (running or stopped).
+    """
+    return _launchctl_list().returncode == 0
+
+
 def _service_pid() -> int | None:
     """Return the PID of the running tune-shifter service, or None if not running.
 
     Queries launchctl for the service label. A positive PID means the process is
     alive; "-" or 0 means the service is registered but not currently running.
     """
-    result = subprocess.run(
-        ["launchctl", "list", _SERVICE_LABEL],
-        capture_output=True,
-        text=True,
-    )
+    result = _launchctl_list()
     if result.returncode != 0:
         return None
     lines = result.stdout.strip().splitlines()
@@ -359,11 +373,18 @@ def _cmd_play() -> None:
     if _service_pid() is not None:
         print("tune-shifter is already running.")
         return
-    # bootstrap registers and starts the service; it returns a proper non-zero
-    # exit code on failure, unlike the deprecated `launchctl load`.
-    subprocess.run(
-        ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
-    )
+    if _service_registered():
+        # Registered but not running (PID = "-"): bootstrap would fail with EIO
+        # because the label is already in launchd's namespace. Use kickstart instead.
+        subprocess.run(
+            ["launchctl", "kickstart", f"{_launchd_domain()}/{_SERVICE_LABEL}"],
+            check=True,
+        )
+    else:
+        # Not registered at all: bootstrap from the plist.
+        subprocess.run(
+            ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
+        )
     print("tune-shifter started.")
 
 


### PR DESCRIPTION
## Summary

- Adds `tune-shifter stop` — pauses the service; tells you if it's already stopped
- Adds `tune-shifter play` — resumes the service; tells you if it's already running
- Adds `tune-shifter status` — reports running/not-running, with uptime when running
- Updates `install-service` output to reference new commands instead of raw launchctl invocations
- Removes raw launchctl commands from README and replaces with the new CLI equivalents
- Updates USAGE.md with the new commands
- Adds `stop`, `play`, `status` to the zsh completion script

## Test plan

```bash
# Unit tests — all guards and happy paths are covered
poetry run pytest tests/test_main.py -v

# Manual smoke test (session-local, open new terminal to reset completions)
fpath=(completions $fpath) && autoload -Uz compinit && compinit -u
tune-shifter <TAB>   # should now show stop, play, status alongside existing subcommands

# With service installed:
tune-shifter status
tune-shifter stop
tune-shifter stop    # should say "already stopped"
tune-shifter play
tune-shifter play    # should say "already running"
tune-shifter status  # should show pid + uptime
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)