### PR TITLE
feat: daemon pause/resume for internal pipeline control

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,7 +13,43 @@
 *Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
 
 ## Menu Bar Status Item
-*LP* — when the daemon runs, show a menu bar icon with a "Sync Now" item; requires `rumps` dependency and threading integration with the daemon lifecycle
+*LP* — when the daemon runs, show a menu bar icon with pipeline start/stop and Bandcamp sync controls.
+
+Icon: SF Symbol `music.note.square.stack`; pulse animation while a Bandcamp sync is in progress.
+
+Menu:
+- **Play / Stop** — toggles the internal pipeline (watcher + syncer) on/off within the running process. Becomes Stop when pipeline is running, Play when paused.
+- *(separator)*
+- **Bandcamp Sync** — triggers an immediate Bandcamp sync on a background thread; grayed out if `[bandcamp]` config is absent or a sync is already in progress
+- **Sync Status** — read-only label: "Status: Syncing…" or "Status: Idle"
+- *(separator)*
+- **About Tune-Shifter** — opens project GitHub page
+
+Broken down into delivery units:
+
+**Single: Add `rumps` dependency**
+Add `rumps>=0.4` to `pyproject.toml` and `Formula/tune-shifter.rb`. Add a `platform.system() == "Darwin"` guard so the import is skipped on Linux/Windows and the rest of the codebase stays cross-platform. Update CI to skip rumps-dependent tests on non-macOS runners (the existing `ci.yml` runs on `ubuntu-latest`; add a conditional or skip marker).
+
+**Side: Refactor daemon lifecycle into `DaemonCore`**
+`_cmd_daemon()` currently blocks the main thread on `watcher.join()`. `rumps` requires the main thread for its AppKit run loop, so the blocking join must move off-main. Extract a `DaemonCore` class that starts/stops `Watcher`, `Syncer`, and `ConfigMonitor` and exposes `start()`, `stop()`, and `shutdown()` methods, plus a `state` property (`"running"` / `"paused"` / `"stopped"`). The existing `_cmd_daemon` path calls this then blocks on `watcher.join()` as before; the menu bar path calls this then hands the main thread to `rumps.App.run()`. Signal handling (`SIGINT`/`SIGTERM`) moves into `DaemonCore`.
+
+**Side: `MenuBarApp` class (`tune_shifter/menu_bar.py`)**
+`rumps.App` subclass holding a reference to `DaemonCore`. Before `rumps.App.__init__` runs, sets `NSApplicationActivationPolicyAccessory` so the process gets Window Server access from launchd without a bundle:
+
+```python
+if platform.system() == "Darwin":
+    from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
+    NSApplication.sharedApplication().setActivationPolicy_(
+        NSApplicationActivationPolicyAccessory
+    )
+```
+
+Ships the menu described above. Play/Stop calls `DaemonCore.start()` / `DaemonCore.stop()` and updates the item title. Bandcamp Sync calls `syncer.sync_once()` on a background thread. A `@rumps.timer(5)` callback refreshes Sync Status and the icon pulse state. Quit calls `DaemonCore.shutdown()` then `rumps.quit_application()`.
+
+**Single: Wire menu bar into `_cmd_daemon`**
+Add a `--menu-bar` flag to the `daemon` subcommand. When set (and on macOS), call `MenuBarApp.run()` instead of `watcher.join()`. When `--menu-bar` is used, `_cmd_install_service` appends `daemon --menu-bar` to `ProgramArguments`. No behavioural change on Linux/Windows or when flag is omitted.
+
+*launchd + AppKit compatibility spiked — no bundle required, estimate unchanged at LP.*
 
 ## ALAC Support
 *Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -152,6 +152,42 @@ class TestReload:
                 assert syncer._thread is None
 
 
+class TestPauseResume:
+    def test_pause_stops_polling_thread(self, tmp_path: Path) -> None:
+        """pause() stops the polling thread."""
+        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                assert syncer._thread is not None and syncer._thread.is_alive()
+                syncer.pause()
+                assert syncer._thread is None or not syncer._thread.is_alive()
+
+    def test_pause_when_no_thread_is_safe(self, tmp_path: Path) -> None:
+        """pause() is safe when no polling thread was ever started."""
+        syncer = Syncer(_make_config_no_bandcamp(tmp_path))
+        syncer.pause()  # must not raise
+
+    def test_resume_restarts_polling_thread(self, tmp_path: Path) -> None:
+        """resume() starts a new polling thread after a pause."""
+        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                syncer.pause()
+                syncer.resume()
+                assert syncer._thread is not None
+                assert syncer._thread.is_alive()
+                syncer.stop()
+
+    def test_resume_noop_when_no_bandcamp(self, tmp_path: Path) -> None:
+        """resume() is a no-op when there is no [bandcamp] config."""
+        syncer = Syncer(_make_config_no_bandcamp(tmp_path))
+        syncer.pause()
+        syncer.resume()
+        assert syncer._thread is None
+
+
 class TestMarkSynced:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """mark_synced() warns and returns when [bandcamp] is absent."""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -501,6 +501,127 @@ class TestWatcherStopJoin:
         watcher.join()
 
 
+class TestWatcherPauseResume:
+    def _patched_watcher(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> Watcher:
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        monkeypatch.setattr(watcher._observer, "stop", lambda: None)
+        monkeypatch.setattr(watcher._observer, "join", lambda **kw: None)
+        watcher.start()
+        return watcher
+
+    def test_pause_cancels_pending_timers(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pause() cancels any in-flight debounce timers."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        timer = MagicMock()
+        watcher._handler._pending[config.paths.staging / "album"] = timer
+
+        watcher.pause()
+
+        timer.cancel.assert_called_once()
+
+    def test_pause_stops_observer(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pause() stops the watchdog observer."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        stop_calls: list[int] = []
+        monkeypatch.setattr(watcher._observer, "stop", lambda: stop_calls.append(1))
+
+        watcher.pause()
+
+        assert stop_calls == [1]
+
+    def test_pause_is_idempotent(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling pause() twice does not double-stop the observer."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        stop_calls: list[int] = []
+        monkeypatch.setattr(watcher._observer, "stop", lambda: stop_calls.append(1))
+
+        watcher.pause()
+        watcher.pause()
+
+        assert stop_calls == [1]
+
+    def test_resume_creates_new_observer_and_starts(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resume() creates a fresh observer and starts watching again."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        watcher.pause()
+
+        start_calls: list[int] = []
+        # Patch Observer class so the new instance is controllable
+        mock_observer = MagicMock()
+        mock_observer.start = lambda: start_calls.append(1)
+        mock_observer.schedule = lambda *a, **kw: None
+        monkeypatch.setattr("tune_shifter.watcher.Observer", lambda: mock_observer)
+
+        watcher.resume()
+
+        assert start_calls == [1]
+
+    def test_resume_scans_staging_for_existing_items(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resume() picks up items already in staging."""
+        config.paths.staging.mkdir(parents=True, exist_ok=True)
+        (config.paths.staging / "Artist - Album").mkdir()
+        watcher = self._patched_watcher(config, monkeypatch)
+        watcher.pause()
+
+        scheduled: list[Path] = []
+        monkeypatch.setattr(
+            "tune_shifter.watcher.Observer",
+            lambda: MagicMock(start=lambda: None, schedule=lambda *a, **kw: None),
+        )
+        monkeypatch.setattr(
+            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+        )
+
+        watcher.resume()
+
+        assert any(p.name == "Artist - Album" for p in scheduled)
+
+    def test_resume_is_idempotent(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling resume() when not paused does nothing."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        start_calls: list[int] = []
+        monkeypatch.setattr(
+            "tune_shifter.watcher.Observer",
+            lambda: MagicMock(
+                start=lambda: start_calls.append(1), schedule=lambda *a, **kw: None
+            ),
+        )
+
+        watcher.resume()  # not paused — should be a no-op
+
+        assert start_calls == []
+
+    def test_stop_when_paused_is_safe(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """stop() after pause() does not attempt to stop an already-stopped observer."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        stop_calls: list[int] = []
+        monkeypatch.setattr(watcher._observer, "stop", lambda: stop_calls.append(1))
+        watcher.pause()
+        stop_calls.clear()
+
+        watcher.stop()  # must not raise or double-stop
+
+        assert stop_calls == []
+
+
 class TestWatcherReload:
     def _patched_watcher(
         self, config: Config, monkeypatch: pytest.MonkeyPatch

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -19,6 +19,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import tomllib
 from pathlib import Path
 
@@ -32,6 +33,7 @@ from .watcher import Watcher
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
+_PID_PATH = _state_dir() / "daemon.pid"
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over
@@ -76,13 +78,22 @@ def main() -> None:
 
     subparsers = parser.add_subparsers(dest="command")
 
-    # daemon subcommand (default)
+    # daemon subcommand (default) with pause/resume subcommands
     daemon_parser = subparsers.add_parser(
         "daemon",
         help="Watch staging directory and (optionally) poll Bandcamp. Default when no subcommand given.",
     )
     daemon_parser.add_argument("--staging", metavar="DIR", type=Path, default=None)
     daemon_parser.add_argument("--library", metavar="DIR", type=Path, default=None)
+    daemon_sub = daemon_parser.add_subparsers(dest="daemon_command")
+    daemon_sub.add_parser(
+        "pause",
+        help="Pause the running daemon's pipeline (watcher + Bandcamp polling).",
+    )
+    daemon_sub.add_parser(
+        "resume",
+        help="Resume the running daemon's pipeline after a pause.",
+    )
 
     # sync subcommand
     sync_parser = subparsers.add_parser(
@@ -193,12 +204,18 @@ def main() -> None:
     if command == "sync":
         _cmd_sync(config, args.config, mark_synced=getattr(args, "mark_synced", False))
     else:
-        # daemon (with optional CLI overrides)
-        if hasattr(args, "staging") and args.staging:
-            config.paths.staging = args.staging
-        if hasattr(args, "library") and args.library:
-            config.paths.library = args.library
-        _cmd_daemon(config, args.config)
+        daemon_command = getattr(args, "daemon_command", None)
+        if daemon_command == "pause":
+            _cmd_daemon_signal(signal.SIGUSR1, "pause")
+        elif daemon_command == "resume":
+            _cmd_daemon_signal(signal.SIGUSR2, "resume")
+        else:
+            # daemon (with optional CLI overrides)
+            if hasattr(args, "staging") and args.staging:
+                config.paths.staging = args.staging
+            if hasattr(args, "library") and args.library:
+                config.paths.library = args.library
+            _cmd_daemon(config, args.config)
 
 
 def _cmd_config(
@@ -289,17 +306,57 @@ def _cmd_daemon(config: Config, config_path: Path) -> None:
     syncer.start()
     monitor.start()
 
+    # Write pidfile so `daemon pause` / `daemon resume` can signal this process.
+    _PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _PID_PATH.write_text(str(os.getpid()))
+
+    _done = threading.Event()
+
     def _shutdown(signum: int, frame: object) -> None:
         logging.getLogger(__name__).info("Shutting down…")
         monitor.stop()
         syncer.stop()
         watcher.stop()
+        _done.set()
+
+    def _pause(signum: int, frame: object) -> None:
+        logging.getLogger(__name__).info("Pipeline pausing…")
+        watcher.pause()
+        syncer.pause()
+
+    def _resume(signum: int, frame: object) -> None:
+        logging.getLogger(__name__).info("Pipeline resuming…")
+        watcher.resume()
+        syncer.resume()
 
     signal.signal(signal.SIGINT, _shutdown)
     if hasattr(signal, "SIGTERM"):
         signal.signal(signal.SIGTERM, _shutdown)  # not available on Windows
+    if hasattr(signal, "SIGUSR1"):
+        signal.signal(signal.SIGUSR1, _pause)
+    if hasattr(signal, "SIGUSR2"):
+        signal.signal(signal.SIGUSR2, _resume)
 
-    watcher.join()
+    try:
+        _done.wait()
+    finally:
+        _PID_PATH.unlink(missing_ok=True)
+
+
+def _cmd_daemon_signal(sig: int, action: str) -> None:
+    """Send *sig* to the running daemon process identified by the pidfile."""
+    try:
+        pid = int(_PID_PATH.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        print("No running tune-shifter daemon found.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        os.kill(pid, sig)
+    except ProcessLookupError:
+        print("Daemon process not found (stale PID file?).", file=sys.stderr)
+        _PID_PATH.unlink(missing_ok=True)
+        sys.exit(1)
+    print(f"Daemon pipeline {action}d.")
 
 
 def _launchd_domain() -> str:

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -74,6 +74,24 @@ class Syncer:
         else:
             logger.info("Syncer config reloaded.")
 
+    def pause(self) -> None:
+        """Stop the polling thread temporarily.
+
+        The stop event is set and the thread is joined, but the event is *not*
+        cleared — call resume() to restart polling.
+        """
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._thread = None
+        logger.info("Syncer paused")
+
+    def resume(self) -> None:
+        """Restart the polling thread after a pause."""
+        self._stop_event.clear()
+        self.start()
+        logger.info("Syncer resumed")
+
     def sync_once(self) -> None:
         """Download any new purchases immediately (one-shot, blocking)."""
         bc = self._config.bandcamp

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -164,6 +164,7 @@ class Watcher:
         self._config = config
         self._observer = Observer()
         self._handler = _StagingHandler(config)
+        self._paused = False
 
     def start(self) -> None:
         staging = self._config.paths.staging
@@ -174,9 +175,42 @@ class Watcher:
         # Process any items already present when the daemon starts.
         self._handler._scan_staging_root()
 
-    def stop(self) -> None:
+    def pause(self) -> None:
+        """Stop pipeline processing without tearing down the daemon.
+
+        Cancels pending debounce timers and stops the observer thread.
+        Items dropped into staging while paused are picked up on resume()
+        via _scan_staging_root().
+        """
+        if self._paused:
+            return
+        self._paused = True
+        with self._handler._lock:
+            for timer in self._handler._pending.values():
+                timer.cancel()
+            self._handler._pending.clear()
         self._observer.stop()
         self._observer.join()
+        logger.info("Watcher paused")
+
+    def resume(self) -> None:
+        """Restart watching after a pause."""
+        if not self._paused:
+            return
+        self._paused = False
+        staging = self._config.paths.staging
+        self._observer = Observer()
+        self._handler = _StagingHandler(self._config)
+        self._observer.schedule(self._handler, str(staging), recursive=False)
+        self._observer.start()
+        self._handler._scan_staging_root()
+        logger.info("Watcher resumed")
+
+    def stop(self) -> None:
+        # Observer is already stopped when paused; avoid a redundant stop/join.
+        if not self._paused:
+            self._observer.stop()
+            self._observer.join()
         logger.info("Watcher stopped")
 
     def reload(self, config: Config) -> None:


### PR DESCRIPTION
## Summary

- Adds `Watcher.pause()` / `resume()` — cancels pending debounce timers and stops/restarts the watchdog observer; items in staging during a pause are picked up on resume via `_scan_staging_root()`
- Adds `Syncer.pause()` / `resume()` — stops/restarts the Bandcamp polling thread; safe when no bandcamp config or thread is present
- Updates `_cmd_daemon` to write a pidfile, block on a `threading.Event` instead of `watcher.join()` (so pause doesn't exit the process), and handle SIGUSR1 (pause) / SIGUSR2 (resume)
- Adds `tune-shifter daemon pause` and `tune-shifter daemon resume` subcommands that signal the running daemon via the pidfile
- Updates BACKLOG.md to reflect resolved menu bar design decisions (play/stop controls internal pipeline, not launchd service)

## Test plan

- [x] `poetry run pytest tests/test_watcher.py::TestWatcherPauseResume` — 7 new tests pass
- [x] `poetry run pytest tests/test_syncer.py::TestPauseResume` — 4 new tests pass
- [x] `poetry run pytest` — full suite green, coverage ≥ 95%
- [x] Manual: start daemon, run `tune-shifter daemon pause`, drop a file into staging, run `tune-shifter daemon resume` — file processes after resume
- [x] Manual: `tune-shifter daemon pause` with no daemon running exits with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)