### PR TITLE
feat: add rumps dep and extract DaemonCore for menu bar support

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,16 +3,7 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Producer Support
-*Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
-
-## One File At A Time
-*Single* — watcher already handles ZIPs; extend to schedule individual audio files (`.mp3`, `.m4a`, etc.) dropped directly into staging
-
-## Cross-platform service installation (Linux systemd, Windows Task Scheduler)
-*Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
-
-## Menu Bar Status Item
+## Menu Bar Status Item - Epic
 *LP* — when the daemon runs, show a menu bar icon with pipeline start/stop and Bandcamp sync controls.
 
 Icon: SF Symbol `music.note.square.stack`; pulse animation while a Bandcamp sync is in progress.
@@ -50,6 +41,15 @@ Ships the menu described above. Play/Stop calls `DaemonCore.start()` / `DaemonCo
 Add a `--menu-bar` flag to the `daemon` subcommand. When set (and on macOS), call `MenuBarApp.run()` instead of `watcher.join()`. When `--menu-bar` is used, `_cmd_install_service` appends `daemon --menu-bar` to `ProgramArguments`. No behavioural change on Linux/Windows or when flag is omitted.
 
 *launchd + AppKit compatibility spiked — no bundle required, estimate unchanged at LP.*
+
+## Producer Support
+*Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
+
+## One File At A Time
+*Single* — watcher already handles ZIPs; extend to schedule individual audio files (`.mp3`, `.m4a`, etc.) dropped directly into staging
+
+## Cross-platform service installation (Linux systemd, Windows Task Scheduler)
+*Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
 
 ## ALAC Support
 *Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,6 +864,47 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyobjc-core"
+version = "12.1"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7"},
+    {file = "pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6"},
+    {file = "pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962"},
+    {file = "pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a"},
+    {file = "pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc"},
+    {file = "pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43"},
+    {file = "pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882"},
+    {file = "pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21"},
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+description = "Wrappers for the Cocoa frameworks on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48"},
+    {file = "pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6"},
+    {file = "pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858"},
+    {file = "pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118"},
+    {file = "pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44"},
+    {file = "pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a"},
+    {file = "pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc"},
+    {file = "pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 description = "pytest: simple powerful testing with Python"
@@ -1001,6 +1042,24 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rumps"
+version = "0.4.0"
+description = "Ridiculously Uncomplicated MacOS Python Statusbar apps."
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596"},
+]
+
+[package.dependencies]
+pyobjc-framework-Cocoa = "*"
+
+[package.extras]
+dev = ["pytest (>=4.3)", "pytest-mock (>=2.0.0)", "tox (>=3.8)"]
+
+[[package]]
 name = "types-pillow"
 version = "10.2.0.20240822"
 description = "Typing stubs for Pillow"
@@ -1103,4 +1162,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "243cbc56c96fd60adc9335f8d46a169aa08bbe7f40133a1857446229f451d634"
+content-hash = "4367943dd20265a9dfd4538331e8ad0430b4af528e8a9e528313b163ab570023"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ mutagen = ">=1.47"
 requests = ">=2.31"
 Pillow = ">=10.0"
 playwright = ">=1.44"
+rumps = {version = ">=0.4", markers = "sys_platform == 'darwin'"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"
@@ -76,6 +77,11 @@ disable_error_code = ["import-untyped"]
 # causes false union-attr/index errors on the VCFLACDict branch we always use).
 module = ["tune_shifter.tagger", "tune_shifter.mover", "tune_shifter.artwork"]
 disable_error_code = ["no-untyped-call", "attr-defined", "unused-ignore", "union-attr", "index"]
+
+[[tool.mypy.overrides]]
+# rumps ships no type stubs
+module = ["rumps", "rumps.*"]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 # playwright ships no type stubs

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -1,0 +1,317 @@
+"""Tests for DaemonCore lifecycle management."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tune_shifter.config import Config
+from tune_shifter.daemon_core import DaemonCore, _PID_PATH
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> Config:
+    cfg = MagicMock(spec=Config)
+    cfg.paths = MagicMock()
+    return cfg
+
+
+@pytest.fixture
+def config_path(tmp_path: Path) -> Path:
+    return tmp_path / "config.toml"
+
+
+@pytest.fixture
+def mock_watcher():
+    with patch("tune_shifter.daemon_core.Watcher") as cls:
+        yield cls
+
+
+@pytest.fixture
+def mock_syncer():
+    with patch("tune_shifter.daemon_core.Syncer") as cls:
+        yield cls
+
+
+@pytest.fixture
+def mock_monitor():
+    with patch("tune_shifter.daemon_core.ConfigMonitor") as cls:
+        yield cls
+
+
+@pytest.fixture
+def mock_pid(tmp_path: Path):
+    pid_path = tmp_path / "daemon.pid"
+    with patch("tune_shifter.daemon_core._PID_PATH", pid_path):
+        yield pid_path
+
+
+@pytest.fixture
+def core(
+    config: Config,
+    config_path: Path,
+    mock_watcher: MagicMock,
+    mock_syncer: MagicMock,
+    mock_monitor: MagicMock,
+    mock_pid: Path,
+) -> DaemonCore:
+    return DaemonCore(config, config_path)
+
+
+class TestInitialState:
+    def test_state_is_stopped_before_start(self, core: DaemonCore) -> None:
+        assert core.state == "stopped"
+
+    def test_watcher_is_none_before_start(self, core: DaemonCore) -> None:
+        assert core.watcher is None
+
+    def test_syncer_is_none_before_start(self, core: DaemonCore) -> None:
+        assert core.syncer is None
+
+
+class TestStart:
+    def test_starts_watcher_syncer_monitor(
+        self,
+        core: DaemonCore,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_monitor: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+
+        mock_watcher.return_value.start.assert_called_once()
+        mock_syncer.return_value.start.assert_called_once()
+        mock_monitor.return_value.start.assert_called_once()
+
+    def test_state_becomes_running(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        assert core.state == "running"
+
+    def test_exposes_watcher_after_start(
+        self, core: DaemonCore, mock_watcher: MagicMock, mock_pid: Path
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        assert core.watcher is mock_watcher.return_value
+
+    def test_exposes_syncer_after_start(
+        self, core: DaemonCore, mock_syncer: MagicMock, mock_pid: Path
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        assert core.syncer is mock_syncer.return_value
+
+    def test_writes_pidfile(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        assert mock_pid.exists()
+        assert mock_pid.read_text().strip().isdigit()
+
+    def test_config_reload_propagates_to_watcher_and_syncer(
+        self,
+        config: Config,
+        config_path: Path,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_monitor: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        core = DaemonCore(config, config_path)
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+
+        # Capture the reload callback passed to ConfigMonitor
+        _, reload_cb = mock_monitor.call_args.args
+        new_config = MagicMock(spec=Config)
+        reload_cb(new_config)
+
+        mock_watcher.return_value.reload.assert_called_once_with(new_config)
+        mock_syncer.return_value.reload.assert_called_once_with(new_config)
+
+
+class TestStop:
+    def test_pauses_watcher_and_syncer(
+        self,
+        core: DaemonCore,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.stop()
+        mock_watcher.return_value.pause.assert_called_once()
+        mock_syncer.return_value.pause.assert_called_once()
+
+    def test_state_becomes_paused(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.stop()
+        assert core.state == "paused"
+
+
+class TestResume:
+    def test_resumes_watcher_and_syncer(
+        self,
+        core: DaemonCore,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.stop()
+        core.resume()
+        mock_watcher.return_value.resume.assert_called_once()
+        mock_syncer.return_value.resume.assert_called_once()
+
+    def test_state_becomes_running_again(
+        self, core: DaemonCore, mock_pid: Path
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.stop()
+        core.resume()
+        assert core.state == "running"
+
+
+class TestShutdown:
+    def test_stops_all_components(
+        self,
+        core: DaemonCore,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_monitor: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.shutdown()
+        mock_monitor.return_value.stop.assert_called_once()
+        mock_syncer.return_value.stop.assert_called_once()
+        mock_watcher.return_value.stop.assert_called_once()
+
+    def test_state_becomes_stopped(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.shutdown()
+        assert core.state == "stopped"
+
+    def test_sets_done_event(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+        core.shutdown()
+        assert core._done.is_set()
+
+
+class TestBeforeStart:
+    """stop/resume/shutdown are safe to call before start() (components are None)."""
+
+    def test_stop_before_start_is_safe(self, core: DaemonCore) -> None:
+        core.stop()  # must not raise
+        assert core.state == "paused"
+
+    def test_resume_before_start_is_safe(self, core: DaemonCore) -> None:
+        core.resume()  # must not raise
+        assert core.state == "running"
+
+    def test_shutdown_before_start_is_safe(self, core: DaemonCore) -> None:
+        core.shutdown()  # must not raise
+        assert core.state == "stopped"
+
+
+class TestSignalHandlers:
+    def test_sigint_triggers_shutdown(self, core: DaemonCore, mock_pid: Path) -> None:
+        import signal as _signal
+
+        installed: dict[int, object] = {}
+
+        def capture(sig: int, handler: object) -> None:
+            installed[sig] = handler
+
+        with patch("tune_shifter.daemon_core.signal.signal", side_effect=capture):
+            with patch.object(core, "start", wraps=core.start):
+                # Call _install_signal_handlers directly to avoid real signal changes
+                core._install_signal_handlers()
+
+        sigint_handler = installed[_signal.SIGINT]
+        assert callable(sigint_handler)
+        with patch.object(core, "shutdown") as mock_shutdown:
+            sigint_handler(int(_signal.SIGINT), None)  # type: ignore[call-arg]
+            mock_shutdown.assert_called_once()
+
+    def test_sigusr1_triggers_stop(self, core: DaemonCore) -> None:
+        import signal as _signal
+
+        installed: dict[int, object] = {}
+
+        with patch(
+            "tune_shifter.daemon_core.signal.signal",
+            side_effect=lambda s, h: installed.update({s: h}),
+        ):
+            core._install_signal_handlers()
+
+        handler = installed[_signal.SIGUSR1]
+        with patch.object(core, "stop") as mock_stop:
+            handler(int(_signal.SIGUSR1), None)  # type: ignore[call-arg]
+            mock_stop.assert_called_once()
+
+    def test_sigusr2_triggers_resume(self, core: DaemonCore) -> None:
+        import signal as _signal
+
+        installed: dict[int, object] = {}
+
+        with patch(
+            "tune_shifter.daemon_core.signal.signal",
+            side_effect=lambda s, h: installed.update({s: h}),
+        ):
+            core._install_signal_handlers()
+
+        handler = installed[_signal.SIGUSR2]
+        with patch.object(core, "resume") as mock_resume:
+            handler(int(_signal.SIGUSR2), None)  # type: ignore[call-arg]
+            mock_resume.assert_called_once()
+
+
+class TestWait:
+    def test_returns_after_shutdown(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+
+        # Trigger shutdown from a background thread after a brief delay
+        def _delayed_shutdown() -> None:
+            import time
+
+            time.sleep(0.05)
+            core.shutdown()
+
+        t = threading.Thread(target=_delayed_shutdown, daemon=True)
+        t.start()
+        core.wait()  # should unblock
+        t.join(timeout=1)
+        assert not t.is_alive()
+
+    def test_removes_pidfile_on_exit(self, core: DaemonCore, mock_pid: Path) -> None:
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+
+        assert mock_pid.exists()
+
+        def _shutdown() -> None:
+            import time
+
+            time.sleep(0.02)
+            core.shutdown()
+
+        t = threading.Thread(target=_shutdown, daemon=True)
+        t.start()
+        core.wait()
+        t.join(timeout=1)
+
+        assert not mock_pid.exists()

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -19,21 +19,18 @@ import shutil
 import signal
 import subprocess
 import sys
-import threading
 import tomllib
 from pathlib import Path
 
 import musicbrainzngs
 
 from .config import DEFAULT_CONFIG_PATH, Config, _state_dir, config_set, config_show
-from .config_monitor import ConfigMonitor
+from .daemon_core import DaemonCore, _PID_PATH
 from .syncer import Syncer
-from .watcher import Watcher
 
 _SERVICE_LABEL = "com.tune-shifter"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
-_PID_PATH = _state_dir() / "daemon.pid"
 
 # pyproject.toml lives one level above the package directory and is the canonical
 # version source kept up to date by release-please.  Prefer it over
@@ -293,54 +290,9 @@ def _cmd_daemon(config: Config, config_path: Path) -> None:
         install_path,
     )
 
-    watcher = Watcher(config)
-    syncer = Syncer(config)
-
-    def _on_config_reload(new_config: Config) -> None:
-        watcher.reload(new_config)
-        syncer.reload(new_config)
-
-    monitor = ConfigMonitor(config_path, _on_config_reload)
-
-    watcher.start()
-    syncer.start()
-    monitor.start()
-
-    # Write pidfile so `daemon pause` / `daemon resume` can signal this process.
-    _PID_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _PID_PATH.write_text(str(os.getpid()))
-
-    _done = threading.Event()
-
-    def _shutdown(signum: int, frame: object) -> None:
-        logging.getLogger(__name__).info("Shutting down…")
-        monitor.stop()
-        syncer.stop()
-        watcher.stop()
-        _done.set()
-
-    def _pause(signum: int, frame: object) -> None:
-        logging.getLogger(__name__).info("Pipeline pausing…")
-        watcher.pause()
-        syncer.pause()
-
-    def _resume(signum: int, frame: object) -> None:
-        logging.getLogger(__name__).info("Pipeline resuming…")
-        watcher.resume()
-        syncer.resume()
-
-    signal.signal(signal.SIGINT, _shutdown)
-    if hasattr(signal, "SIGTERM"):
-        signal.signal(signal.SIGTERM, _shutdown)  # not available on Windows
-    if hasattr(signal, "SIGUSR1"):
-        signal.signal(signal.SIGUSR1, _pause)
-    if hasattr(signal, "SIGUSR2"):
-        signal.signal(signal.SIGUSR2, _resume)
-
-    try:
-        _done.wait()
-    finally:
-        _PID_PATH.unlink(missing_ok=True)
+    core = DaemonCore(config, config_path)
+    core.start()
+    core.wait()
 
 
 def _cmd_daemon_signal(sig: int, action: str) -> None:

--- a/tune_shifter/daemon_core.py
+++ b/tune_shifter/daemon_core.py
@@ -1,0 +1,155 @@
+"""DaemonCore: lifecycle management for the tune-shifter daemon.
+
+Encapsulates Watcher, Syncer, and ConfigMonitor start/stop/pause/resume,
+signal handler installation, and PID-file management so that __main__.py
+remains thin CLI glue and the menu bar path can hand the main thread to
+the rumps AppKit run loop instead of blocking here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+from pathlib import Path
+from typing import Literal
+
+from .config import Config, _state_dir
+from .config_monitor import ConfigMonitor
+from .syncer import Syncer
+from .watcher import Watcher
+
+_PID_PATH: Path = _state_dir() / "daemon.pid"
+
+DaemonState = Literal["running", "paused", "stopped"]
+
+_logger = logging.getLogger(__name__)
+
+
+class DaemonCore:
+    """Manage the daemon pipeline lifecycle.
+
+    Owns Watcher, Syncer, and ConfigMonitor instances and coordinates their
+    start/stop/pause/resume. Installs OS signal handlers so that SIGINT/SIGTERM
+    trigger a clean shutdown and SIGUSR1/SIGUSR2 pause and resume the pipeline.
+    """
+
+    def __init__(self, config: Config, config_path: Path) -> None:
+        self._config = config
+        self._config_path = config_path
+        self._state: DaemonState = "stopped"
+        self._done = threading.Event()
+        self._watcher: Watcher | None = None
+        self._syncer: Syncer | None = None
+        self._monitor: ConfigMonitor | None = None
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> DaemonState:
+        return self._state
+
+    @property
+    def watcher(self) -> Watcher | None:
+        """The active Watcher instance, or None before start()."""
+        return self._watcher
+
+    @property
+    def syncer(self) -> Syncer | None:
+        """The active Syncer instance, or None before start()."""
+        return self._syncer
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Create and start all pipeline components, write pidfile, install signals."""
+        self._watcher = Watcher(self._config)
+        self._syncer = Syncer(self._config)
+
+        def _on_config_reload(new_config: Config) -> None:
+            if self._watcher:
+                self._watcher.reload(new_config)
+            if self._syncer:
+                self._syncer.reload(new_config)
+
+        self._monitor = ConfigMonitor(self._config_path, _on_config_reload)
+
+        self._watcher.start()
+        self._syncer.start()
+        self._monitor.start()
+
+        # Write pidfile so `daemon pause` / `daemon resume` can signal this process.
+        _PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _PID_PATH.write_text(str(os.getpid()))
+
+        self._state = "running"
+        self._install_signal_handlers()
+
+    def stop(self) -> None:
+        """Pause the pipeline (watcher + syncer). Used by the Play/Stop menu toggle."""
+        _logger.info("Pipeline pausing…")
+        if self._watcher:
+            self._watcher.pause()
+        if self._syncer:
+            self._syncer.pause()
+        self._state = "paused"
+
+    def resume(self) -> None:
+        """Resume the pipeline after stop()."""
+        _logger.info("Pipeline resuming…")
+        if self._watcher:
+            self._watcher.resume()
+        if self._syncer:
+            self._syncer.resume()
+        self._state = "running"
+
+    def shutdown(self) -> None:
+        """Stop all components and unblock wait()."""
+        _logger.info("Shutting down…")
+        if self._monitor:
+            self._monitor.stop()
+        if self._syncer:
+            self._syncer.stop()
+        if self._watcher:
+            self._watcher.stop()
+        self._state = "stopped"
+        self._done.set()
+
+    def wait(self) -> None:
+        """Block until shutdown() is called. Used by the headless daemon path.
+
+        The pidfile is removed here (in finally) rather than in shutdown() so
+        that a caller who manages the main-thread run loop (e.g. rumps) can
+        call shutdown() and then clean up the pidfile itself at a natural point.
+        """
+        try:
+            self._done.wait()
+        finally:
+            _PID_PATH.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Signal handling
+    # ------------------------------------------------------------------
+
+    def _install_signal_handlers(self) -> None:
+        def _shutdown(signum: int, frame: object) -> None:
+            self.shutdown()
+
+        def _pause(signum: int, frame: object) -> None:
+            self.stop()
+
+        def _resume(signum: int, frame: object) -> None:
+            self.resume()
+
+        signal.signal(signal.SIGINT, _shutdown)
+        if hasattr(signal, "SIGTERM"):
+            signal.signal(signal.SIGTERM, _shutdown)  # not available on Windows
+        if hasattr(signal, "SIGUSR1"):
+            signal.signal(signal.SIGUSR1, _pause)
+        if hasattr(signal, "SIGUSR2"):
+            signal.signal(signal.SIGUSR2, _resume)


### PR DESCRIPTION
## Summary

- Adds `rumps>=0.4` to `pyproject.toml` with a `sys_platform == 'darwin'` PEP 508 marker — macOS-only install, Linux CI unaffected; mypy override added for missing stubs
- Extracts `DaemonCore` from `_cmd_daemon` into `tune_shifter/daemon_core.py` — owns Watcher/Syncer/ConfigMonitor lifecycle, signal handlers (SIGINT/SIGTERM/SIGUSR1/SIGUSR2), PID-file management, and a `state` property (`"running"` / `"paused"` / `"stopped"`)
- `_cmd_daemon` in `__main__.py` shrinks from 58 lines to 3; upcoming menu bar step calls `core.start()` then hands the main thread to `rumps.App.run()` instead of `core.wait()`

## Test plan

- [x] 24 new unit tests in `tests/test_daemon_core.py` cover all state transitions, component wiring, config-reload callback, signal handler closures, and safe no-op calls before `start()`
- [x] 306 tests pass, coverage 95.73% (above 95% threshold), mypy clean, black clean
- [x] `tune-shifter daemon --help` smoke-tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)