### PR TITLE
feat: config reload fix, download status callback, format selector

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,26 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Menu Bar: Enable Bandcamp items when config gains [bandcamp] section
-*Single* — `DaemonCore._on_config_reload` never assigns `self._config = new_config`; fix that one line and the 5-second `_refresh` timer picks up the updated state automatically. No new wiring needed.
-
-## Menu Bar: Show What's Being Downloaded from Bandcamp in Sync Status
-*Single* — album title is already available in the `bandcamp.py` download loop; thread a status callback through `Syncer` → `MenuBarApp` and update `_status_item.title`
-
-## Menu Bar: Bandcamp Download Format Selector
-*Single* — add a `rumps` submenu under Bandcamp Sync with the supported format labels; selecting one calls `config_set` to update `bandcamp.format` and reloads config
-```
-Bandcamp Sync
-Sync Status
-Download Format -> AAC-HI
-                   ALAC
-                   FLAC
-                   MP3-320
-                   MP3-V0 ✓
-                   Ogg Vorbis
-                   WAV
-```
-
 ## Menu Bar: Show Pipeline Status (Idle, Tagging, Updating Artwork, Moving)
 *Side* — requires threading a stage-change callback through `pipeline.py` (Watcher-owned) and the Syncer path; two separate status sources need to be reconciled in `MenuBarApp._refresh`
 

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -134,6 +134,25 @@ class TestStart:
         mock_watcher.return_value.reload.assert_called_once_with(new_config)
         mock_syncer.return_value.reload.assert_called_once_with(new_config)
 
+    def test_config_reload_updates_core_config(
+        self,
+        config: Config,
+        config_path: Path,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        mock_monitor: MagicMock,
+        mock_pid: Path,
+    ) -> None:
+        core = DaemonCore(config, config_path)
+        with patch.object(core, "_install_signal_handlers"):
+            core.start()
+
+        _, reload_cb = mock_monitor.call_args.args
+        new_config = MagicMock(spec=Config)
+        reload_cb(new_config)
+
+        assert core._config is new_config
+
 
 class TestStop:
     def test_pauses_watcher_and_syncer(

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -188,6 +188,26 @@ class TestPauseResume:
         assert syncer._thread is None
 
 
+class TestStatusCallback:
+    def test_status_callback_default_is_none(self, tmp_path: Path) -> None:
+        syncer = Syncer(_make_config(tmp_path))
+        assert syncer.status_callback is None
+
+    def test_status_callback_passed_to_sync_new_purchases(self, tmp_path: Path) -> None:
+        """sync_once() forwards status_callback to sync_new_purchases."""
+        callback = lambda msg: None  # noqa: E731
+        with patch(
+            "tune_shifter.syncer.sync_new_purchases", return_value=[]
+        ) as mock_sync:
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+                syncer.status_callback = callback
+                syncer.sync_once()
+        mock_sync.assert_called_once()
+        _, kwargs = mock_sync.call_args
+        assert kwargs["status_callback"] is callback
+
+
 class TestMarkSynced:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """mark_synced() warns and returns when [bandcamp] is absent."""

--- a/tune_shifter/bandcamp.py
+++ b/tune_shifter/bandcamp.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -106,6 +107,7 @@ def sync_new_purchases(
     bc_config: BandcampConfig,
     staging_dir: Path,
     state_file: Path,
+    status_callback: Callable[[str], None] | None = None,
 ) -> list[Path]:
     """Download any purchases not yet recorded in *state_file* to *staging_dir*.
 
@@ -161,6 +163,10 @@ def sync_new_purchases(
             continue
         item["redownload_url"] = dl_url
         try:
+            if status_callback:
+                status_callback(
+                    f"{item.get('item_title', '?')} by {item.get('band_name', '?')}"
+                )
             path = _download_item(item, bc_config, staging_dir, session_file)
             downloaded.append(path)
             state[str(item["sale_item_id"])] = time.time()

--- a/tune_shifter/daemon_core.py
+++ b/tune_shifter/daemon_core.py
@@ -72,6 +72,7 @@ class DaemonCore:
         self._syncer = Syncer(self._config)
 
         def _on_config_reload(new_config: Config) -> None:
+            self._config = new_config
             if self._watcher:
                 self._watcher.reload(new_config)
             if self._syncer:

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -63,6 +63,9 @@ class MenuBarApp(rumps.App):
         self._core = core
         self._sync_in_progress = False
         self._pulse_active = False
+        # Written by background sync thread; read only by the main-thread _refresh
+        # timer to avoid touching AppKit objects off the main thread.
+        self._sync_status: str = ""
 
         # Replace the text title with an SF Symbol icon.
         self._set_sf_symbol_icon()
@@ -137,8 +140,12 @@ class MenuBarApp(rumps.App):
         threading.Thread(target=_run, daemon=True).start()
 
     def _on_sync_status(self, msg: str) -> None:
-        """Update the status item title with the current download target."""
-        self._status_item.title = f"Status: {msg}"
+        """Store the current download target for the main-thread _refresh timer.
+
+        Called from the background sync thread — must not touch AppKit objects
+        directly, as AppKit requires all UI mutations on the main thread.
+        """
+        self._sync_status = msg
 
     def _on_format(self, sender: rumps.MenuItem) -> None:
         """Write the selected download format to the config file."""
@@ -172,9 +179,11 @@ class MenuBarApp(rumps.App):
             self._toggle_item.title = "Stop"
 
         if self._sync_in_progress:
-            self._status_item.title = "Status: Syncing\u2026"
+            label = self._sync_status or "Syncing\u2026"
+            self._status_item.title = f"Status: {label}"
             self._set_pulse(True)
         else:
+            self._sync_status = ""
             self._status_item.title = "Status: Idle"
             self._set_pulse(False)
 

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -27,6 +27,17 @@ from .daemon_core import DaemonCore, _PID_PATH
 _ABOUT_URL = "https://github.com/eightyeighteyes/tune-shifter"
 _SYMBOL_NAME = "music.note.list"  # music.note.square.stack does not exist in SF Symbols
 
+# Valid format keys and their display labels (alphabetical).
+_FORMAT_LABELS: list[tuple[str, str]] = [
+    ("aac-hi", "AAC-HI"),
+    ("alac", "ALAC"),
+    ("flac", "FLAC"),
+    ("mp3-320", "MP3-320"),
+    ("mp3-v0", "MP3-V0"),
+    ("vorbis", "Ogg Vorbis"),
+    ("wav", "WAV"),
+]
+
 
 class MenuBarApp(rumps.App):
     """rumps-based menu bar application for the tune-shifter daemon.
@@ -72,11 +83,20 @@ class MenuBarApp(rumps.App):
         self._sync_item = rumps.MenuItem("Bandcamp Sync", callback=self._on_sync)
         self._status_item = rumps.MenuItem("Status: Idle")
 
+        # Build the Download Format submenu.
+        self._format_menu = rumps.MenuItem("Download Format")
+        self._format_items: dict[str, rumps.MenuItem] = {}
+        for fmt, label in _FORMAT_LABELS:
+            item = rumps.MenuItem(label, callback=self._on_format)
+            self._format_items[fmt] = item
+        self._format_menu.update(self._format_items.values())
+
         self.menu = [
             self._toggle_item,
             None,  # separator
             self._sync_item,
             self._status_item,
+            self._format_menu,
             None,  # separator
             rumps.MenuItem("About Tune-Shifter", callback=self._on_about),
             rumps.MenuItem("Quit", callback=self._on_quit),
@@ -108,11 +128,27 @@ class MenuBarApp(rumps.App):
 
         def _run() -> None:
             try:
+                syncer.status_callback = self._on_sync_status
                 syncer.sync_once()
             finally:
+                syncer.status_callback = None
                 self._sync_in_progress = False
 
         threading.Thread(target=_run, daemon=True).start()
+
+    def _on_sync_status(self, msg: str) -> None:
+        """Update the status item title with the current download target."""
+        self._status_item.title = f"Status: {msg}"
+
+    def _on_format(self, sender: rumps.MenuItem) -> None:
+        """Write the selected download format to the config file."""
+        fmt = next(k for k, v in self._format_items.items() if v is sender)
+        try:
+            from .config import config_set
+
+            config_set(self._core._config_path, "bandcamp.format", fmt)
+        except Exception as exc:
+            _logger.warning("Failed to set download format: %s", exc)
 
     def _on_about(self, sender: rumps.MenuItem) -> None:
         subprocess.run(["open", _ABOUT_URL], check=False)
@@ -207,8 +243,10 @@ class MenuBarApp(rumps.App):
 
     def _refresh_bandcamp_items(self) -> None:
         """Disable Bandcamp Sync and Sync Status when config or conditions prevent use."""
-        has_bandcamp = self._core._config.bandcamp is not None
+        bc = self._core._config.bandcamp
+        has_bandcamp = bc is not None
         sync_available = has_bandcamp and not self._sync_in_progress
+        current_fmt = bc.format if bc is not None else None
 
         if sync_available:
             self._sync_item.set_callback(self._on_sync)
@@ -220,5 +258,11 @@ class MenuBarApp(rumps.App):
         try:
             self._sync_item._menuitem.setEnabled_(sync_available)
             self._status_item._menuitem.setEnabled_(has_bandcamp)
+            self._format_menu._menuitem.setEnabled_(has_bandcamp)
         except Exception:
             pass
+
+        # Update checkmarks on format submenu items.
+        for fmt, item in self._format_items.items():
+            label_base = next(lbl for k, lbl in _FORMAT_LABELS if k == fmt)
+            item.title = f"{label_base} \u2713" if fmt == current_fmt else label_base

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Callable
 from pathlib import Path
 
 from .bandcamp import mark_collection_synced, sync_new_purchases
@@ -23,6 +24,7 @@ class Syncer:
         self._config = config
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        self.status_callback: Callable[[str], None] | None = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -105,6 +107,7 @@ class Syncer:
             bc_config=bc,
             staging_dir=self._config.paths.staging,
             state_file=state_file,
+            status_callback=self.status_callback,
         )
         if paths:
             logger.info("Sync complete: %d file(s) downloaded to staging.", len(paths))


### PR DESCRIPTION
## Summary
- **Config reload bug fix** — `DaemonCore._on_config_reload` now sets `self._config = new_config`; Bandcamp menu items enable/disable correctly when `[bandcamp]` is added or removed from the config file
- **Download status** — Sync Status item shows the album being downloaded (e.g. "Status: Felt Mountain by Goldfrapp") instead of a static "Syncing…"; callback threads through `Syncer.status_callback` → `sync_new_purchases` → `MenuBarApp`
- **Format selector** — new "Download Format" submenu in the menu bar exposes all 7 supported formats; selecting one calls `config_set`; checkmark tracks the current format and updates within 5 seconds via the existing `_refresh` timer

## Test plan
- [x] `poetry run pytest tests/test_daemon_core.py tests/test_syncer.py -v --no-cov` — all pass
- [x] `poetry run pytest` — full suite ≥ 95% coverage
- [x] `poetry run mypy tune_shifter/` — clean
- [x] `poetry run black --check tune_shifter/ tests/` — clean
- [x] macOS smoke: add `[bandcamp]` to config while daemon runs → Bandcamp items enable within 5s
- [x] macOS smoke: trigger sync → status item shows album title during download
- [x] macOS smoke: open Download Format submenu → checkmark on current format; select another → TOML updated + checkmark moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)