### PR TITLE
feat: show pipeline stage in menu bar status item

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,9 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Menu Bar: Show Pipeline Status (Idle, Tagging, Updating Artwork, Moving)
-*Side* — requires threading a stage-change callback through `pipeline.py` (Watcher-owned) and the Syncer path; two separate status sources need to be reconciled in `MenuBarApp._refresh`
-
 ## ALAC Support
 *Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -395,3 +395,58 @@ class TestSkipAlreadyTagged:
             run(album_dir, config)
 
         mock_tag.assert_called_once()
+
+
+class TestStageCallback:
+    """stage_callback receives stage labels in order and is cleared in finally."""
+
+    def _setup_dir(self, config: Config) -> Path:
+        config.paths.staging.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        album_dir = config.paths.staging / "test-album"
+        album_dir.mkdir()
+        mp3 = album_dir / "01.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+        return album_dir
+
+    def test_stages_called_in_order_on_success(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """stage_callback receives Tagging→Updating artwork→Moving→'' in order."""
+        album_dir = self._setup_dir(config)
+        calls: list[str] = []
+
+        with (
+            patch("tune_shifter.pipeline.tag_directory", return_value=MOCK_RELEASE),
+            patch("tune_shifter.pipeline.fetch_and_embed"),
+            patch("tune_shifter.pipeline.move_to_library", return_value=[]),
+        ):
+            run(album_dir, config, stage_callback=calls.append)
+
+        assert calls == ["Extracting", "Tagging", "Updating artwork", "Moving", ""]
+
+    def test_finally_clears_on_extraction_failure(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """stage_callback('') fires even when extraction fails."""
+        config.paths.staging.mkdir(parents=True)
+        bad_zip = config.paths.staging / "bad.zip"
+        bad_zip.write_bytes(b"not a zip")
+        calls: list[str] = []
+
+        run(bad_zip, config, stage_callback=calls.append)
+
+        assert calls[-1] == ""
+
+    def test_finally_clears_on_tagging_failure(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """stage_callback('') fires even when tagging fails."""
+        album_dir = self._setup_dir(config)
+        calls: list[str] = []
+
+        with patch("musicbrainzngs.search_releases", return_value={"release-list": []}):
+            run(album_dir, config, stage_callback=calls.append)
+
+        assert calls[-1] == ""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -258,7 +258,7 @@ class TestInFlight:
         handler = _make_handler(config)
         album = config.paths.staging / "my-album"
         album.mkdir()
-        monkeypatch.setattr("tune_shifter.watcher.run", lambda path, cfg: None)
+        monkeypatch.setattr("tune_shifter.watcher.run", lambda path, cfg, **kw: None)
         handler._process(album)
 
         assert album not in handler._in_flight
@@ -422,7 +422,9 @@ class TestDuplicateRunPrevention:
 
         received_callbacks: list[object] = []
 
-        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+        def _fake_run(
+            path: Path, cfg: object, _on_directory: object = None, **kw: object
+        ) -> None:
             received_callbacks.append(_on_directory)
 
         monkeypatch.setattr("tune_shifter.watcher.run", _fake_run)
@@ -448,7 +450,9 @@ class TestDuplicateRunPrevention:
         pending_timer = MagicMock()
         handler._pending[extracted_dir] = pending_timer
 
-        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+        def _fake_run(
+            path: Path, cfg: object, _on_directory: object = None, **kw: object
+        ) -> None:
             # The pipeline calls the callback right after extraction
             if callable(_on_directory):
                 _on_directory(extracted_dir)
@@ -683,3 +687,39 @@ class TestWatcherReload:
         watcher.reload(new_config)
         assert reschedule_calls == [1]
         assert watcher._config.paths.staging == new_staging
+
+
+class TestStageCallback:
+    def test_stage_callback_forwarded_to_run(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_process passes handler.stage_callback as stage_callback kwarg to run()."""
+        handler = _make_handler(config)
+        album = config.paths.staging / "my-album"
+        album.mkdir()
+
+        received: dict[str, object] = {}
+
+        def _fake_run(
+            path: object,
+            cfg: object,
+            _on_directory: object = None,
+            stage_callback: object = None,
+        ) -> None:
+            received["stage_callback"] = stage_callback
+
+        cb = lambda stage: None  # noqa: E731
+        handler.stage_callback = cb
+        monkeypatch.setattr("tune_shifter.watcher.run", _fake_run)
+        handler._process(album)
+
+        assert received["stage_callback"] is cb
+
+    def test_watcher_stage_callback_setter_propagates_to_handler(
+        self, config: Config
+    ) -> None:
+        """Setting Watcher.stage_callback updates the live handler."""
+        watcher = Watcher(config)
+        cb = lambda stage: None  # noqa: E731
+        watcher.stage_callback = cb
+        assert watcher._handler.stage_callback is cb

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -63,9 +63,10 @@ class MenuBarApp(rumps.App):
         self._core = core
         self._sync_in_progress = False
         self._pulse_active = False
-        # Written by background sync thread; read only by the main-thread _refresh
-        # timer to avoid touching AppKit objects off the main thread.
+        # Written by background threads; read only by the main-thread _refresh timer
+        # to avoid touching AppKit objects off the main thread (trace trap risk).
         self._sync_status: str = ""
+        self._pipeline_status: str = ""
 
         # Replace the text title with an SF Symbol icon.
         self._set_sf_symbol_icon()
@@ -108,6 +109,11 @@ class MenuBarApp(rumps.App):
         # Apply initial enabled state for bandcamp-dependent items.
         self._refresh_bandcamp_items()
 
+        # Wire pipeline stage updates.  core.start() is called before
+        # MenuBarApp(core).run(), so the watcher is already running here.
+        if self._core.watcher:
+            self._core.watcher.stage_callback = self._on_pipeline_stage
+
     # ------------------------------------------------------------------
     # Menu callbacks
     # ------------------------------------------------------------------
@@ -147,6 +153,14 @@ class MenuBarApp(rumps.App):
         """
         self._sync_status = msg
 
+    def _on_pipeline_stage(self, stage: str) -> None:
+        """Store the current pipeline stage for the main-thread _refresh timer.
+
+        Called from the watcher's pipeline thread — same AppKit threading rule
+        applies: write to a plain Python str only.
+        """
+        self._pipeline_status = stage
+
     def _on_format(self, sender: rumps.MenuItem) -> None:
         """Write the selected download format to the config file."""
         fmt = next(k for k, v in self._format_items.items() if v is sender)
@@ -178,7 +192,12 @@ class MenuBarApp(rumps.App):
         else:
             self._toggle_item.title = "Stop"
 
-        if self._sync_in_progress:
+        if self._pipeline_status:
+            # Pipeline stage (Extracting / Tagging / Updating artwork / Moving)
+            # takes priority — it's more specific than the sync label.
+            self._status_item.title = f"Status: {self._pipeline_status}"
+            self._set_pulse(True)
+        elif self._sync_in_progress:
             label = self._sync_status or "Syncing\u2026"
             self._status_item.title = f"Status: {label}"
             self._set_pulse(True)

--- a/tune_shifter/pipeline.py
+++ b/tune_shifter/pipeline.py
@@ -20,89 +20,107 @@ def run(
     path: Path,
     config: Config,
     _on_directory: Callable[[Path], None] | None = None,
+    stage_callback: Callable[[str], None] | None = None,
 ) -> None:
     """Process a single staging item (ZIP or directory) end-to-end.
 
     On per-step failure the item is moved to staging/errors/ so the watcher
-    does not trigger on it again.
+    does not trigger on it again.  *stage_callback* (if provided) is called
+    with the current stage name ("Extracting", "Tagging", etc.) and with an
+    empty string in a finally block so the caller can always reset its display.
     """
     logger.info("Pipeline started for %s", path)
 
-    # --- 1. Extract -----------------------------------------------------------
     try:
-        directory = extract(path)
-    except ExtractionError as exc:
-        logger.error("Extraction failed: %s", exc)
-        _quarantine(path, config.paths.staging)
-        return
-
-    # Notify the watcher of the staging directory as early as possible so it
-    # can cancel any pending debounce timer for this directory.  Without this,
-    # extracting a ZIP creates the directory, the watcher schedules it for a
-    # second pipeline run, and that run races the first.
-    if _on_directory is not None:
-        _on_directory(directory)
-
-    audio_files = find_audio_files(directory)
-    if not audio_files:
-        logger.error("No audio files found in %s", directory)
-        _quarantine(directory, config.paths.staging)
-        return
-
-    # --- 2. Tag ---------------------------------------------------------------
-    # Skip the MusicBrainz lookup (and tag writes) when every file already has
-    # an MBID — the most expensive operation in the pipeline.  If even one file
-    # is untagged, run the full pass for the whole directory to stay consistent.
-    if all(is_tagged(f) for f in audio_files):
-        logger.info("All files already tagged — skipping MusicBrainz lookup")
-        mbid, rg_mbid = read_release_mbids(audio_files[0])
-        title = "(already tagged)"
-    else:
+        # --- 1. Extract -------------------------------------------------------
+        if stage_callback:
+            stage_callback("Extracting")
         try:
-            release = tag_directory(directory, audio_files)
-        except TaggingError as exc:
-            logger.error("Tagging failed: %s", exc)
+            directory = extract(path)
+        except ExtractionError as exc:
+            logger.error("Extraction failed: %s", exc)
+            _quarantine(path, config.paths.staging)
+            return
+
+        # Notify the watcher of the staging directory as early as possible so it
+        # can cancel any pending debounce timer for this directory.  Without this,
+        # extracting a ZIP creates the directory, the watcher schedules it for a
+        # second pipeline run, and that run races the first.
+        if _on_directory is not None:
+            _on_directory(directory)
+
+        audio_files = find_audio_files(directory)
+        if not audio_files:
+            logger.error("No audio files found in %s", directory)
             _quarantine(directory, config.paths.staging)
             return
-        mbid, rg_mbid = release.mbid, release.release_group_mbid
-        title = release.title
 
-    # --- 3. Artwork -----------------------------------------------------------
-    # Always run: even if art is already embedded, a higher-quality image may
-    # be available (e.g. a bundled cover.jpg in the ZIP that beats the art the
-    # original files shipped with).  fetch_and_embed handles the local-first
-    # fallback and is cheap when no network call is needed.
-    try:
-        fetch_and_embed(
-            mbid=mbid,
-            audio_files=audio_files,
-            min_dimension=config.artwork.min_dimension,
-            max_bytes=config.artwork.max_bytes,
-            release_group_mbid=rg_mbid,
-            directory=directory,
+        # --- 2. Tag -----------------------------------------------------------
+        # Skip the MusicBrainz lookup (and tag writes) when every file already has
+        # an MBID — the most expensive operation in the pipeline.  If even one file
+        # is untagged, run the full pass for the whole directory to stay consistent.
+        if stage_callback:
+            stage_callback("Tagging")
+        if all(is_tagged(f) for f in audio_files):
+            logger.info("All files already tagged — skipping MusicBrainz lookup")
+            mbid, rg_mbid = read_release_mbids(audio_files[0])
+            title = "(already tagged)"
+        else:
+            try:
+                release = tag_directory(directory, audio_files)
+            except TaggingError as exc:
+                logger.error("Tagging failed: %s", exc)
+                _quarantine(directory, config.paths.staging)
+                return
+            mbid, rg_mbid = release.mbid, release.release_group_mbid
+            title = release.title
+
+        # --- 3. Artwork -------------------------------------------------------
+        # Always run: even if art is already embedded, a higher-quality image may
+        # be available (e.g. a bundled cover.jpg in the ZIP that beats the art the
+        # original files shipped with).  fetch_and_embed handles the local-first
+        # fallback and is cheap when no network call is needed.
+        if stage_callback:
+            stage_callback("Updating artwork")
+        try:
+            fetch_and_embed(
+                mbid=mbid,
+                audio_files=audio_files,
+                min_dimension=config.artwork.min_dimension,
+                max_bytes=config.artwork.max_bytes,
+                release_group_mbid=rg_mbid,
+                directory=directory,
+            )
+        except ArtworkError as exc:
+            # Artwork failure is non-fatal: log and continue
+            logger.warning("Artwork step failed: %s", exc)
+
+        # --- 4. Move ----------------------------------------------------------
+        if stage_callback:
+            stage_callback("Moving")
+        try:
+            destinations = move_to_library(
+                audio_files=audio_files,
+                staging_dir=directory,
+                library_root=config.paths.library,
+                path_template=config.library.path_template,
+            )
+        except MoveError as exc:
+            logger.error("Move failed: %s", exc)
+            _quarantine(directory, config.paths.staging)
+            return
+
+        logger.info(
+            "Pipeline complete: %d file(s) moved to library for release %r",
+            len(destinations),
+            title,
         )
-    except ArtworkError as exc:
-        # Artwork failure is non-fatal: log and continue
-        logger.warning("Artwork step failed: %s", exc)
 
-    # --- 4. Move --------------------------------------------------------------
-    try:
-        destinations = move_to_library(
-            audio_files=audio_files,
-            staging_dir=directory,
-            library_root=config.paths.library,
-            path_template=config.library.path_template,
-        )
-    except MoveError as exc:
-        logger.error("Move failed: %s", exc)
-        _quarantine(directory, config.paths.staging)
-        return
-
-    logger.info(
-        "Pipeline complete: %d file(s) moved to library for release %r",
-        len(destinations),
-        title,
-    )
+    finally:
+        # Always clear the stage so the caller's display resets on success,
+        # quarantine, or unexpected error.
+        if stage_callback:
+            stage_callback("")
 
 
 def _quarantine(item: Path, staging_root: Path) -> None:

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from watchdog.events import (
@@ -34,6 +35,8 @@ class _StagingHandler(FileSystemEventHandler):
         # Track paths whose pipeline is currently running to prevent double-execution
         self._in_flight: set[Path] = set()
         self._lock = threading.Lock()
+        # Set by Watcher to surface current pipeline stage in the menu bar.
+        self.stage_callback: Callable[[str], None] | None = None
 
     def on_created(self, event: FileSystemEvent) -> None:
         if event.is_directory:
@@ -132,7 +135,12 @@ class _StagingHandler(FileSystemEventHandler):
 
             logger.info("Triggering pipeline for %s", path)
             try:
-                run(path, self._config, _on_directory=_claim_directory)
+                run(
+                    path,
+                    self._config,
+                    _on_directory=_claim_directory,
+                    stage_callback=self.stage_callback,
+                )
             except Exception:
                 logger.exception("Unhandled error in pipeline for %s", path)
         finally:
@@ -165,6 +173,16 @@ class Watcher:
         self._observer = Observer()
         self._handler = _StagingHandler(config)
         self._paused = False
+        self._stage_callback: Callable[[str], None] | None = None
+
+    @property
+    def stage_callback(self) -> Callable[[str], None] | None:
+        return self._stage_callback
+
+    @stage_callback.setter
+    def stage_callback(self, cb: Callable[[str], None] | None) -> None:
+        self._stage_callback = cb
+        self._handler.stage_callback = cb
 
     def start(self) -> None:
         staging = self._config.paths.staging
@@ -201,6 +219,7 @@ class Watcher:
         staging = self._config.paths.staging
         self._observer = Observer()
         self._handler = _StagingHandler(self._config)
+        self._handler.stage_callback = self._stage_callback
         self._observer.schedule(self._handler, str(staging), recursive=False)
         self._observer.start()
         self._handler._scan_staging_root()
@@ -234,6 +253,7 @@ class Watcher:
             new_staging = config.paths.staging
             new_staging.mkdir(parents=True, exist_ok=True)
             self._handler = _StagingHandler(config)
+            self._handler.stage_callback = self._stage_callback
             self._observer.schedule(self._handler, str(new_staging), recursive=False)
             self._handler._scan_staging_root()
         else:


### PR DESCRIPTION
## Summary
- Status item now cycles through **Extracting → Tagging → Updating artwork → Moving** as each ingest stage runs, then returns to **Idle**
- `stage_callback` threaded through `pipeline.run()` → `_StagingHandler` → `Watcher` property; `MenuBarApp` wires it in `__init__`
- All AppKit updates remain on the main thread: background pipeline thread writes to `_pipeline_status` (plain str), `_refresh` timer reads it every 5 s
- Pipeline status takes priority over Bandcamp sync status in the display hierarchy

## Test plan
- [x] `poetry run pytest tests/test_pipeline.py tests/test_watcher.py -v --no-cov` — all pass
- [x] `poetry run pytest` — full suite ≥ 95% coverage
- [x] `poetry run mypy tune_shifter/` — clean
- [x] `poetry run black --check tune_shifter/ tests/` — clean
- [x] macOS smoke: drop a ZIP into staging; status item cycles through each stage and returns to Idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)