### PR TITLE
fix: include launcher/main.c in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,10 @@ description = "Automated audio library ingest from Bandcamp downloads."
 authors = []
 packages = [{include = "tune_shifter"}]
 # USAGE.md is read by the Homebrew formula's caveats block; completions/ is
-# installed by the Homebrew formula's zsh_completion.install call. MANIFEST.in
-# is ignored by poetry-core so both must be declared here explicitly.
-include = ["USAGE.md", "completions/_tune-shifter"]
+# installed by the Homebrew formula's zsh_completion.install call; launcher/main.c
+# is compiled by the formula into the native binary. MANIFEST.in is ignored by
+# poetry-core so all three must be declared here explicitly.
+include = ["USAGE.md", "completions/_tune-shifter", "launcher/main.c"]
 
 [tool.poetry.dependencies]
 python = ">=3.11"


### PR DESCRIPTION
## Summary

`launcher/main.c` was not listed in `pyproject.toml`'s `include` array, so it was absent from the published tarball. The Homebrew formula's compile step failed immediately with:

```
clang: error: no such file or directory: '.../launcher/main.c'
```

Adds it alongside the existing `USAGE.md` and `completions/_tune-shifter` entries.

## Test plan

- [x] `poetry build --format sdist && tar -tzf dist/*.tar.gz | grep launcher` shows `launcher/main.c`
- [ ] `brew reinstall tune-shifter` succeeds after 0.15.1 is cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)