### PR TITLE
fix: remove single-quote wrapping from -DVENV_PYTHON compiler flag

### DIFF
--- a/Formula/tune-shifter.rb
+++ b/Formula/tune-shifter.rb
@@ -45,7 +45,7 @@ class TuneShifter < Formula
                 "import sysconfig; print(sysconfig.get_config_var('LDVERSION') or '')").chomp
     system ENV.cc,
            buildpath/"launcher/main.c",
-           "-DVENV_PYTHON='\"#{venv_python}\"'",
+           "-DVENV_PYTHON=\"#{venv_python}\"",
            "-I#{include_dir}",
            *cflags.split,
            "-L#{lib_dir}", "-lpython#{py_ver}",


### PR DESCRIPTION
## Summary

The `-DVENV_PYTHON` flag was written as `"-DVENV_PYTHON='\"#{path}\"'"`. Ruby's `system()` passes array elements directly as `argv` — no shell is involved — so clang received the single quotes literally and interpreted `'"/path"'` as a multi-char character constant instead of a string literal:

```
error: incompatible integer to pointer conversion passing 'int' to parameter of type 'const char *'
```

Fix: use `"-DVENV_PYTHON=\"#{path}\""` which clang receives as `-DVENV_PYTHON="/path"` — correct C string literal syntax.

## Test plan

- [ ] `brew reinstall tune-shifter` compiles without error after 0.15.2 is cut
- [ ] Activity Monitor shows `tune-shifter` for the daemon process

🤖 Generated with [Claude Code](https://claude.com/claude-code)