### PR TITLE
fix: compile launcher to buildpath then bin.install

### DIFF
--- a/Formula/tune-shifter.rb
+++ b/Formula/tune-shifter.rb
@@ -43,6 +43,7 @@ class TuneShifter < Formula
                 "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')").chomp
     py_ver = Utils.safe_popen_read(venv_python, "-c",
                 "import sysconfig; print(sysconfig.get_config_var('LDVERSION') or '')").chomp
+    # Compile into buildpath first; bin/ doesn't exist until bin.install creates it.
     system ENV.cc,
            buildpath/"launcher/main.c",
            "-DVENV_PYTHON=\"#{venv_python}\"",
@@ -51,7 +52,8 @@ class TuneShifter < Formula
            "-L#{lib_dir}", "-lpython#{py_ver}",
            *ldflags.split,
            "-Wno-deprecated-declarations",
-           "-o", bin/"tune-shifter"
+           "-o", buildpath/"tune-shifter"
+    bin.install buildpath/"tune-shifter"
 
     zsh_completion.install "completions/_tune-shifter"
     (share/"tune-shifter").install "USAGE.md"


### PR DESCRIPTION
## Summary

`bin/` doesn't exist until Homebrew's `bin.install` creates it. Passing `bin/"tune-shifter"` directly as the `-o` target caused the linker to fail:

```
ld: open() failed, errno=2 for '.../bin/tune-shifter'
```

Fix: compile to `buildpath/"tune-shifter"`, then call `bin.install` to move it into place (which also creates the directory).

## Test plan

- [ ] `brew reinstall tune-shifter` compiles and installs successfully after 0.15.3 is cut
- [ ] Activity Monitor shows `tune-shifter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)