### PR TITLE
feat(artwork): skip CAA fetch when all files have qualifying embedded art

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,18 +3,26 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## ALAC Support
-*Single* — add `"alac"` to `_FORMAT_LABELS` in `bandcamp.py`; the rest of the pipeline already handles `.m4a` containers (ALAC and AAC share the same container format and tag schema via `mutagen.mp4.MP4`)
-
 ## Tagging: Skip artwork fetch when existing art meets quality requirements
 *Single* — add a guard in `artwork.py` (or `pipeline.py`) that checks embedded art dimensions before making a Cover Art Archive request; saves a few seconds per ingest when Bandcamp art already meets the threshold
-
-## Tagging: Producer Support
-*Side* — add recording-rels include to `get_release_by_id` call and traverse relationships to extract producer credits
 
 ## Pipeline: One File At A Time
 *Single* — watcher already handles ZIPs; extend to schedule individual audio files (`.mp3`, `.m4a`, etc.) dropped directly into staging
 
+## Memory Optimization
+*Side* — profile the running daemon to identify the dominant allocation (likely Playwright loaded at startup via `bandcamp.py` even when not syncing); implement targeted fix (lazy import or subprocess isolation). Could stretch to LP if Playwright requires architectural isolation.
+
+The daemon eats 120MB of RAM while running. What takes so much memory, and is there any way to reduce the memory footprint of this small application?
+
+## Error Handling: when there's an error in the pipeline, send a system level notification
+*Single* — hook points already exist (`ExtractionError`, `TaggingError`, `ArtworkError`, `MoveError` in `pipeline.py`, bare `except Exception` in `watcher.py`); wire `rumps.notification()` to each failure site.
+
+Possible error states to inform the user about:
+- Download failure
+- Download timeout
+- Tagging failure
+- Unable to find image for release
+- Library folder doesn't exist
 ## Bandcamp Logout: Remove or replace the active Bandcamp session
 *Side* — two surfaces (CLI `tune-shifter sync logout` + menu bar Logout item); CLI deletes the session file and state file; menu bar item calls the same logic and refreshes Bandcamp item state
 ```
@@ -53,3 +61,4 @@ Logout
 
 # Needs Estimation
 -- don't discard this section --
+

--- a/claude.md
+++ b/claude.md
@@ -16,3 +16,22 @@
 - Prefer running single tests, and not the whole test suite, for performance; use `--no-cov` when running a single file to skip the coverage threshold check (e.g. `poetry run pytest tests/test_foo.py -v --no-cov`)
 - Update documentation (README.md) after new features are validated
 - Document rationale in comments: succinctly explain *why* decisions are made
+- After completing a feature, before closing a pull request, retrospect about the development experience and update claude.md with lessons learned.
+
+# Lessons Learned
+## Mutagen
+- **Never use `mutagen.File(path)` for MP3s** — use `mutagen.id3.ID3(str(path))` directly. `mutagen.File` parses the full MPEG audio stream and raises on files with minimal/fake audio data (common in tests).
+- `ID3NoHeaderError` and frame classes (`TPE1`, `TALB`, etc.) exist at runtime but not in type stubs — use `except Exception:` not `except id3.ID3NoHeaderError:`.
+- APIC frames are keyed `"APIC:Cover"`, not `"APIC:"` — check with `any(k.startswith("APIC") for k in tags)`.
+- `mp4.tags.get(key)` returns `None | value` — always check for None before indexing.
+
+## Testing
+- **Fake MP3 files:** write `b"\xff\xfb" * 64` then `id3.ID3().save(str(path))` — valid ID3 header without valid MPEG frames.
+- **Fake M4A files:** write `b"\x00" * 32` and patch `mutagen.mp4.MP4` — real MP4 containers aren't needed.
+- **Patching `Path.stat` in Python 3.12:** `patch.object(path_instance, "stat", ...)` fails (C-implemented method). Patch at class level: `patch("pathlib.Path.stat", fn)` where `fn` takes `self` as first arg.
+
+## Skip/optimization logic
+Before implementing "skip if already done," define precisely what *correct* means for the skip condition. "Present ≠ best available" — skipping based on presence alone can degrade quality (e.g., skipping artwork fetch because art is embedded, when embedded art is lower quality than what the Archive would return). Validate skip conditions against the regression case explicitly.
+
+## macOS system integration
+Budget at least a Side for any feature touching osacompile, Spotlight registration, or macOS app bundles. Corporate MDM/EDR (Falcon, Jamf) can silently block registration in ways that are hard to diagnose.

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -316,6 +316,74 @@ class TestLocalArtwork:
 
         assert mock_get.called
 
+    def test_skips_caa_fetch_when_all_files_have_qualifying_embedded_art(
+        self, tmp_path: Path
+    ) -> None:
+        """No network call is made when every file already has qualifying embedded art."""
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        # Embed qualifying art directly into the file
+        import mutagen.id3 as id3_
+
+        tags = id3_.ID3(str(mp3))
+        tags["APIC:Cover"] = id3_.APIC(
+            encoding=3,
+            mime="image/jpeg",
+            type=3,
+            desc="Cover",
+            data=_make_jpeg(1200, 1200),
+        )
+        tags.save(str(mp3))
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            fetch_and_embed(
+                "abc-123",
+                [mp3],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                directory=tmp_path,
+            )
+
+        mock_get.assert_not_called()
+
+    def test_still_fetches_caa_when_any_file_lacks_qualifying_art(
+        self, tmp_path: Path
+    ) -> None:
+        """If even one file has no qualifying embedded art, the CAA fetch still runs."""
+        mp3_good = tmp_path / "01.mp3"
+        mp3_bare = tmp_path / "02.mp3"
+        # 01.mp3 has qualifying art
+        _make_mp3(mp3_good)
+        import mutagen.id3 as id3_
+
+        tags = id3_.ID3(str(mp3_good))
+        tags["APIC:Cover"] = id3_.APIC(
+            encoding=3,
+            mime="image/jpeg",
+            type=3,
+            desc="Cover",
+            data=_make_jpeg(1200, 1200),
+        )
+        tags.save(str(mp3_good))
+        # 02.mp3 has no art at all
+        _make_mp3(mp3_bare)
+
+        with patch("tune_shifter.artwork.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"images": []}
+            mock_get.return_value = resp
+
+            fetch_and_embed(
+                "abc-123",
+                [mp3_good, mp3_bare],
+                min_dimension=1000,
+                max_bytes=5_000_000,
+                directory=tmp_path,
+            )
+
+        assert mock_get.called
+
 
 class TestFindLocalArtworkFallback:
     def test_returns_first_alphabetically_when_no_preferred_name(

--- a/tune_shifter/artwork.py
+++ b/tune_shifter/artwork.py
@@ -194,6 +194,18 @@ def fetch_and_embed(
                 logger.info("Using bundled artwork from %s", local)
 
     if image_bytes is None:
+        # Skip the Cover Art Archive network call when every file already has
+        # qualifying embedded art — no local image was found, so the online
+        # fetch is the only remaining source, and the embedded art already
+        # satisfies the quality threshold.
+        if audio_files and all(
+            has_embedded_art(f, min_dimension, max_bytes) for f in audio_files
+        ):
+            logger.info(
+                "All %d file(s) have qualifying embedded art — skipping Cover Art Archive fetch",
+                len(audio_files),
+            )
+            return
         image_bytes = _fetch_cover(
             COVER_ART_ARCHIVE_URL.format(mbid=mbid), min_dimension, max_bytes
         )


### PR DESCRIPTION
## Summary

- Adds a guard in `fetch_and_embed` that returns early when no local cover image was found **and** every audio file already has embedded art meeting the configured quality thresholds (min dimension + max bytes)
- Saves the Cover Art Archive listing request + image download on re-ingests where art was already embedded at adequate quality
- The local-first path is unaffected — a bundled `cover.jpg` in the ZIP still takes precedence over embedded art regardless of quality

## Test plan

- [x] `test_skips_caa_fetch_when_all_files_have_qualifying_embedded_art` — no network call when all files qualify
- [x] `test_still_fetches_caa_when_any_file_lacks_qualifying_art` — fetch still runs when at least one file doesn't qualify
- [x] Existing `TestLocalArtwork` suite confirms local cover.jpg path is unaffected
- [x] Full suite: 316 passed, 95.72% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)