### PR TITLE
feat(pipeline): schedule individual audio files dropped into staging

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,12 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Tagging: Skip artwork fetch when existing art meets quality requirements
-*Single* — add a guard in `artwork.py` (or `pipeline.py`) that checks embedded art dimensions before making a Cover Art Archive request; saves a few seconds per ingest when Bandcamp art already meets the threshold
-
-## Pipeline: One File At A Time
-*Single* — watcher already handles ZIPs; extend to schedule individual audio files (`.mp3`, `.m4a`, etc.) dropped directly into staging
-
 ## Memory Optimization
 *Side* — profile the running daemon to identify the dominant allocation (likely Playwright loaded at startup via `bandcamp.py` even when not syncing); implement targeted fix (lazy import or subprocess isolation). Could stretch to LP if Playwright requires architectural isolation.
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -44,6 +44,27 @@ class TestExtract:
         with pytest.raises(ExtractionError, match="not a ZIP or folder"):
             extract(bad)
 
+    def test_single_audio_file_is_moved_to_sibling_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """A lone audio file is moved into a new sibling directory of the same stem."""
+        mp3 = tmp_path / "01 - Track.mp3"
+        mp3.write_bytes(b"fake mp3")
+
+        result = extract(mp3)
+
+        assert result == tmp_path / "01 - Track"
+        assert (result / "01 - Track.mp3").exists()
+
+    def test_single_audio_file_original_is_removed(self, tmp_path: Path) -> None:
+        """The original audio file is no longer at its source path after extract."""
+        mp3 = tmp_path / "track.mp3"
+        mp3.write_bytes(b"fake mp3")
+
+        extract(mp3)
+
+        assert not mp3.exists()
+
     def test_zip_with_no_audio_raises(self, tmp_path: Path) -> None:
         zip_path = tmp_path / "empty.zip"
         _make_zip(zip_path, {"cover.jpg": b"fake image"})

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -104,12 +104,22 @@ class TestOnMoved:
 
         mock_schedule.assert_not_called()
 
-    def test_non_zip_file_moved_in_is_ignored(self, config: Config) -> None:
+    def test_audio_file_moved_into_staging_is_scheduled(self, config: Config) -> None:
+        """Dragging a single audio file into staging fires a moved event; it must be scheduled."""
         handler = _make_handler(config)
         dest = str(config.paths.staging / "track.mp3")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_file_moved_event("/tmp/track.mp3", dest))
+
+        mock_schedule.assert_called_once_with(Path(dest))
+
+    def test_non_audio_non_zip_file_moved_in_is_ignored(self, config: Config) -> None:
+        handler = _make_handler(config)
+        dest = str(config.paths.staging / "cover.jpg")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(_file_moved_event("/tmp/cover.jpg", dest))
 
         mock_schedule.assert_not_called()
 
@@ -208,6 +218,25 @@ class TestStartupScan:
 
         assert any(p.name == "album.zip" for p in scheduled)
 
+    def test_existing_audio_file_is_scheduled_on_start(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A lone audio file already in staging when the daemon starts gets scheduled."""
+        config.paths.staging.mkdir(parents=True, exist_ok=True)
+        (config.paths.staging / "track.mp3").write_bytes(b"fake mp3")
+
+        scheduled: list[Path] = []
+        monkeypatch.setattr(
+            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+        )
+
+        watcher = Watcher(config)
+        monkeypatch.setattr(watcher._observer, "start", lambda: None)
+        monkeypatch.setattr(watcher._observer, "schedule", lambda *a, **kw: None)
+        watcher.start()
+
+        assert any(p.name == "track.mp3" for p in scheduled)
+
     def test_errors_directory_is_not_scheduled_on_start(
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -303,6 +332,18 @@ class TestOnCreated:
         """A ZIP file created in staging is scheduled for processing."""
         handler = _make_handler(config)
         path = str(config.paths.staging / "album.zip")
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            from watchdog.events import FileCreatedEvent
+
+            handler.on_created(FileCreatedEvent(path))
+
+        mock_schedule.assert_called_once_with(Path(path))
+
+    def test_audio_file_created_in_staging_is_scheduled(self, config: Config) -> None:
+        """A single audio file created in staging is scheduled for processing."""
+        handler = _make_handler(config)
+        path = str(config.paths.staging / "track.mp3")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             from watchdog.events import FileCreatedEvent

--- a/tune_shifter/extractor.py
+++ b/tune_shifter/extractor.py
@@ -28,6 +28,16 @@ def extract(path: Path) -> Path:
         logger.info("Staging item is already a directory: %s", path)
         return path
 
+    if path.suffix.lower() in AUDIO_EXTENSIONS:
+        # A lone audio file: move it into a sibling directory so the rest of
+        # the pipeline (find_audio_files, tagger, mover) operates on a folder
+        # as expected.
+        dest = path.parent / path.stem
+        dest.mkdir(exist_ok=True)
+        shutil.move(str(path), dest / path.name)
+        logger.info("Moved single audio file %s → %s/", path.name, dest)
+        return dest
+
     if not path.suffix.lower() == ".zip":
         raise ExtractionError(f"Unsupported staging item (not a ZIP or folder): {path}")
 
@@ -51,7 +61,10 @@ def extract(path: Path) -> Path:
     return dest
 
 
-_AUDIO_EXTENSIONS = {".mp3", ".m4a", ".flac", ".ogg"}
+AUDIO_EXTENSIONS = {".mp3", ".m4a", ".flac", ".ogg"}
+
+# Keep the private alias so internal helpers don't need updating
+_AUDIO_EXTENSIONS = AUDIO_EXTENSIONS
 
 
 def _has_audio(directory: Path) -> bool:

--- a/tune_shifter/watcher.py
+++ b/tune_shifter/watcher.py
@@ -17,6 +17,7 @@ from watchdog.events import (
 from watchdog.observers import Observer
 
 from .config import Config
+from .extractor import AUDIO_EXTENSIONS
 from .pipeline import run
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class _StagingHandler(FileSystemEventHandler):
             self._schedule(path)
         elif isinstance(event, FileCreatedEvent):
             path = Path(str(event.src_path))
-            if path.suffix.lower() == ".zip":
+            if path.suffix.lower() == ".zip" or path.suffix.lower() in AUDIO_EXTENSIONS:
                 self._schedule(path)
 
     def on_modified(self, event: FileSystemEvent) -> None:
@@ -75,7 +76,10 @@ class _StagingHandler(FileSystemEventHandler):
                 continue
             if child.is_dir() and child.name != "errors":
                 self._schedule(child)
-            elif child.is_file() and child.suffix.lower() == ".zip":
+            elif child.is_file() and (
+                child.suffix.lower() == ".zip"
+                or child.suffix.lower() in AUDIO_EXTENSIONS
+            ):
                 self._schedule(child)
 
     def on_moved(self, event: FileSystemMovedEvent) -> None:
@@ -87,7 +91,9 @@ class _StagingHandler(FileSystemEventHandler):
             return
         if event.is_directory and dest.name != "errors":
             self._schedule(dest)
-        elif not event.is_directory and dest.suffix.lower() == ".zip":
+        elif not event.is_directory and (
+            dest.suffix.lower() == ".zip" or dest.suffix.lower() in AUDIO_EXTENSIONS
+        ):
             self._schedule(dest)
 
     def _schedule(self, path: Path) -> None:


### PR DESCRIPTION
## Summary

- A lone `.mp3`, `.m4a`, `.flac`, or `.ogg` file dropped directly into staging is now picked up by the watcher and processed through the full pipeline
- `extract()` handles single audio files by moving them into a new sibling directory of the same stem, normalising the input to the directory shape the rest of the pipeline already expects
- `AUDIO_EXTENSIONS` promoted to a public constant in `extractor.py` so `watcher.py` can import it without duplicating the set
- All three watcher entry points updated: `on_created`, `on_moved`, and `_scan_staging_root` (startup scan)

## Test plan

- [ ] `test_single_audio_file_is_moved_to_sibling_directory` — extract creates sibling dir and moves file into it
- [ ] `test_single_audio_file_original_is_removed` — original path is gone after extract
- [ ] `test_audio_file_created_in_staging_is_scheduled` — `on_created` schedules audio files
- [ ] `test_audio_file_moved_into_staging_is_scheduled` — `on_moved` schedules audio files
- [ ] `test_existing_audio_file_is_scheduled_on_start` — startup scan picks up audio files already in staging
- [ ] Full suite: 321 passed, 95.74% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)