### PR TITLE
perf(syncer): isolate playwright in subprocess for true memory release

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,11 +3,6 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Memory Optimization
-*Side* — profile the running daemon to identify the dominant allocation (likely Playwright loaded at startup via `bandcamp.py` even when not syncing); implement targeted fix (lazy import or subprocess isolation). Could stretch to LP if Playwright requires architectural isolation.
-
-The daemon eats 120MB of RAM while running. What takes so much memory, and is there any way to reduce the memory footprint of this small application?
-
 ## Error Handling: when there's an error in the pipeline, send a system level notification
 *Single* — hook points already exist (`ExtractionError`, `TaggingError`, `ArtworkError`, `MoveError` in `pipeline.py`, bare `except Exception` in `watcher.py`); wire `rumps.notification()` to each failure site.
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,6 +3,9 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
+## Pipeline subprocess isolation: run each album ingest in an isolated process
+*Side* — same pattern as Bandcamp sync isolation: `watcher.py` spawns a subprocess per album drop, passes `path`/`config` as arguments, receives stage updates via a queue for the menu bar status item, and re-emits log records into the parent stream. Main process stays near 40 MB permanently regardless of how many albums have been processed (mutagen, musicbrainzngs, requests, Pillow are never resident in the parent). Key scoping question: stage-callback timing — the menu bar polls every 5 s so a small queue-drain latency is acceptable.
+
 ## Error Handling: when there's an error in the pipeline, send a system level notification
 *Single* — hook points already exist (`ExtractionError`, `TaggingError`, `ArtworkError`, `MoveError` in `pipeline.py`, bare `except Exception` in `watcher.py`); wire `rumps.notification()` to each failure site.
 

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,5 +1,6 @@
 """Tests for tune_shifter.syncer."""
 
+import logging.handlers
 import queue as _queue_module
 from pathlib import Path
 from typing import Any
@@ -58,28 +59,30 @@ class _FakeProc:
         return False
 
 
-def _inline_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any]:
+def _inline_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any, Any]:
     """Test helper: run the worker synchronously in-process.
 
     Patches on tune_shifter.bandcamp.* work because the target code runs in
     the same process and the same sys.modules as the test.
     """
     status_q: _queue_module.Queue[str] = _queue_module.Queue()
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
     result_q: _queue_module.Queue[Any] = _queue_module.Queue()
-    target(*args, status_q, result_q)
-    return _FakeProc(), status_q, result_q
+    target(*args, status_q, log_q, result_q)
+    return _FakeProc(), status_q, log_q, result_q
 
 
-def _noop_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any]:
+def _noop_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any, Any]:
     """Test helper: skip the worker entirely, return an empty-ok result.
 
     Use when you only need sync_once() / mark_synced() to complete without
     importing or running any bandcamp code (e.g. isolation assertions).
     """
     status_q: _queue_module.Queue[str] = _queue_module.Queue()
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
     result_q: _queue_module.Queue[Any] = _queue_module.Queue()
     result_q.put(("ok", []))
-    return _FakeProc(), status_q, result_q
+    return _FakeProc(), status_q, log_q, result_q
 
 
 class TestStart:
@@ -253,14 +256,15 @@ class TestStatusCallback:
 
         def _worker_with_two_messages(
             target: Any, args: tuple[Any, ...]
-        ) -> tuple[Any, Any, Any]:
+        ) -> tuple[Any, Any, Any, Any]:
             status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            log_q: _queue_module.Queue[Any] = _queue_module.Queue()
             result_q: _queue_module.Queue[Any] = _queue_module.Queue()
             # Two messages to exercise the loop-continues branch in the drain loop.
             status_q.put("Downloading: Album A")
             status_q.put("Downloading: Album B")
             result_q.put(("ok", []))
-            return _FakeProc(), status_q, result_q
+            return _FakeProc(), status_q, log_q, result_q
 
         with patch(
             "tune_shifter.syncer._spawn_worker", side_effect=_worker_with_two_messages
@@ -329,13 +333,14 @@ class TestWorkerExceptions:
 
         def _failing_then_stopping_worker(
             target: Any, args: tuple[Any, ...]
-        ) -> tuple[Any, Any, Any]:
+        ) -> tuple[Any, Any, Any, Any]:
             nonlocal call_count
             call_count += 1
             status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            log_q: _queue_module.Queue[Any] = _queue_module.Queue()
             result_q: _queue_module.Queue[Any] = _queue_module.Queue()
             result_q.put(("error", "boom"))
-            return _FakeProc(), status_q, result_q
+            return _FakeProc(), status_q, log_q, result_q
 
         with patch(
             "tune_shifter.syncer._spawn_worker",
@@ -350,6 +355,51 @@ class TestWorkerExceptions:
                 syncer.stop()
         # _run caught the exception and logged it rather than crashing the thread.
         assert call_count >= 1
+
+
+class TestLogReplay:
+    def test_log_records_forwarded_to_parent(self, tmp_path: Path) -> None:
+        """Log records emitted in the subprocess are re-emitted in the parent."""
+        import logging
+
+        received: list[logging.LogRecord] = []
+
+        def _worker_with_log(
+            target: Any, args: tuple[Any, ...]
+        ) -> tuple[Any, Any, Any, Any]:
+            status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            # Simulate a log record put by QueueHandler in the subprocess.
+            record = logging.LogRecord(
+                name="tune_shifter.bandcamp",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="Fetched fan_id=12345",
+                args=(),
+                exc_info=None,
+            )
+            log_q.put(record)
+            result_q.put(("ok", []))
+            return _FakeProc(), status_q, log_q, result_q
+
+        handler = logging.handlers.MemoryHandler(
+            capacity=100, flushLevel=logging.CRITICAL
+        )
+        logging.getLogger("tune_shifter.bandcamp").addHandler(handler)
+        logging.getLogger("tune_shifter.bandcamp").setLevel(logging.DEBUG)
+        try:
+            with patch(
+                "tune_shifter.syncer._spawn_worker", side_effect=_worker_with_log
+            ):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    syncer.sync_once()
+        finally:
+            logging.getLogger("tune_shifter.bandcamp").removeHandler(handler)
+
+        assert any(r.getMessage() == "Fetched fan_id=12345" for r in handler.buffer)
 
 
 class TestMarkSynced:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -57,7 +57,7 @@ class TestStart:
 
     def test_launches_thread_when_interval_set(self, tmp_path: Path) -> None:
         """start() spawns a daemon thread when poll_interval_minutes > 0."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -75,7 +75,7 @@ class TestStop:
 
     def test_stop_joins_thread(self, tmp_path: Path) -> None:
         """stop() waits for the polling thread to finish."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -88,21 +88,21 @@ class TestSyncOnce:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """sync_once() logs a warning and returns when [bandcamp] is absent."""
         syncer = Syncer(_make_config_no_bandcamp(tmp_path))
-        with patch("tune_shifter.syncer.sync_new_purchases") as mock_sync:
+        with patch("tune_shifter.bandcamp.sync_new_purchases") as mock_sync:
             syncer.sync_once()
         mock_sync.assert_not_called()
 
     def test_logs_downloaded_count(self, tmp_path: Path) -> None:
         """sync_once() reports the number of downloaded files."""
         fake_paths = [tmp_path / "a.mp3", tmp_path / "b.mp3"]
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=fake_paths):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=fake_paths):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path))
                 syncer.sync_once()
 
     def test_logs_nothing_new(self, tmp_path: Path) -> None:
         """sync_once() handles an empty result without error."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path))
                 syncer.sync_once()
@@ -119,7 +119,7 @@ class TestReload:
 
     def test_reload_same_interval_does_not_restart_thread(self, tmp_path: Path) -> None:
         """reload() with unchanged poll_interval leaves the thread running."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -130,7 +130,7 @@ class TestReload:
 
     def test_reload_changed_interval_restarts_thread(self, tmp_path: Path) -> None:
         """reload() with a new poll_interval stops and restarts the thread."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -143,7 +143,7 @@ class TestReload:
 
     def test_reload_interval_to_zero_stops_thread(self, tmp_path: Path) -> None:
         """reload() with interval=0 stops the polling thread."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -155,7 +155,7 @@ class TestReload:
 class TestPauseResume:
     def test_pause_stops_polling_thread(self, tmp_path: Path) -> None:
         """pause() stops the polling thread."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -170,7 +170,7 @@ class TestPauseResume:
 
     def test_resume_restarts_polling_thread(self, tmp_path: Path) -> None:
         """resume() starts a new polling thread after a pause."""
-        with patch("tune_shifter.syncer.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -197,7 +197,7 @@ class TestStatusCallback:
         """sync_once() forwards status_callback to sync_new_purchases."""
         callback = lambda msg: None  # noqa: E731
         with patch(
-            "tune_shifter.syncer.sync_new_purchases", return_value=[]
+            "tune_shifter.bandcamp.sync_new_purchases", return_value=[]
         ) as mock_sync:
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path))
@@ -208,17 +208,38 @@ class TestStatusCallback:
         assert kwargs["status_callback"] is callback
 
 
+class TestLazyImport:
+    def test_bandcamp_not_imported_at_construction(self, tmp_path: Path) -> None:
+        """Constructing a Syncer must not load bandcamp (and by extension playwright)."""
+        import sys
+
+        sys.modules.pop("tune_shifter.bandcamp", None)
+        _ = Syncer(_make_config(tmp_path))
+        assert "tune_shifter.bandcamp" not in sys.modules
+
+    def test_bandcamp_evicted_after_sync_once(self, tmp_path: Path) -> None:
+        """After sync_once() returns, bandcamp is removed from sys.modules."""
+        import sys
+
+        sys.modules.pop("tune_shifter.bandcamp", None)
+        syncer = Syncer(_make_config(tmp_path))
+        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer.sync_once()
+        assert "tune_shifter.bandcamp" not in sys.modules
+
+
 class TestMarkSynced:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """mark_synced() warns and returns when [bandcamp] is absent."""
         syncer = Syncer(_make_config_no_bandcamp(tmp_path))
-        with patch("tune_shifter.syncer.mark_collection_synced") as mock_mark:
+        with patch("tune_shifter.bandcamp.mark_collection_synced") as mock_mark:
             syncer.mark_synced()
         mock_mark.assert_not_called()
 
     def test_calls_mark_collection_synced(self, tmp_path: Path) -> None:
         """mark_synced() delegates to mark_collection_synced with correct args."""
-        with patch("tune_shifter.syncer.mark_collection_synced") as mock_mark:
+        with patch("tune_shifter.bandcamp.mark_collection_synced") as mock_mark:
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path))
                 syncer.mark_synced()

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,7 +1,11 @@
 """Tests for tune_shifter.syncer."""
 
+import queue as _queue_module
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
+
+import pytest
 
 from tune_shifter.config import (
     ArtworkConfig,
@@ -42,6 +46,42 @@ def _make_config_no_bandcamp(tmp_path: Path) -> Config:
     )
 
 
+class _FakeProc:
+    """Fake subprocess returned by _inline_worker / _noop_worker."""
+
+    exitcode = 0
+
+    def join(self, timeout: object = None) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return False
+
+
+def _inline_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any]:
+    """Test helper: run the worker synchronously in-process.
+
+    Patches on tune_shifter.bandcamp.* work because the target code runs in
+    the same process and the same sys.modules as the test.
+    """
+    status_q: _queue_module.Queue[str] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    target(*args, status_q, result_q)
+    return _FakeProc(), status_q, result_q
+
+
+def _noop_worker(target: Any, args: tuple[Any, ...]) -> tuple[Any, Any, Any]:
+    """Test helper: skip the worker entirely, return an empty-ok result.
+
+    Use when you only need sync_once() / mark_synced() to complete without
+    importing or running any bandcamp code (e.g. isolation assertions).
+    """
+    status_q: _queue_module.Queue[str] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    result_q.put(("ok", []))
+    return _FakeProc(), status_q, result_q
+
+
 class TestStart:
     def test_noop_when_no_bandcamp(self, tmp_path: Path) -> None:
         """start() does nothing when there is no [bandcamp] config."""
@@ -57,7 +97,7 @@ class TestStart:
 
     def test_launches_thread_when_interval_set(self, tmp_path: Path) -> None:
         """start() spawns a daemon thread when poll_interval_minutes > 0."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -75,7 +115,7 @@ class TestStop:
 
     def test_stop_joins_thread(self, tmp_path: Path) -> None:
         """stop() waits for the polling thread to finish."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -88,24 +128,26 @@ class TestSyncOnce:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """sync_once() logs a warning and returns when [bandcamp] is absent."""
         syncer = Syncer(_make_config_no_bandcamp(tmp_path))
-        with patch("tune_shifter.bandcamp.sync_new_purchases") as mock_sync:
+        with patch("tune_shifter.syncer._spawn_worker") as mock_spawn:
             syncer.sync_once()
-        mock_sync.assert_not_called()
+        mock_spawn.assert_not_called()
 
     def test_logs_downloaded_count(self, tmp_path: Path) -> None:
         """sync_once() reports the number of downloaded files."""
         fake_paths = [tmp_path / "a.mp3", tmp_path / "b.mp3"]
         with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=fake_paths):
-            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
-                syncer = Syncer(_make_config(tmp_path))
-                syncer.sync_once()
+            with patch("tune_shifter.syncer._spawn_worker", side_effect=_inline_worker):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    syncer.sync_once()
 
     def test_logs_nothing_new(self, tmp_path: Path) -> None:
         """sync_once() handles an empty result without error."""
         with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
-            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
-                syncer = Syncer(_make_config(tmp_path))
-                syncer.sync_once()
+            with patch("tune_shifter.syncer._spawn_worker", side_effect=_inline_worker):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    syncer.sync_once()
 
 
 class TestReload:
@@ -117,9 +159,21 @@ class TestReload:
         syncer.reload(new_config)
         assert syncer._config.musicbrainz.contact == "new@example.com"
 
+    def test_reload_changed_interval_no_existing_thread(self, tmp_path: Path) -> None:
+        """reload() with interval change when no thread was running starts one."""
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                # interval=0 means no thread is started initially
+                syncer = Syncer(_make_config(tmp_path, poll_interval=0))
+                assert syncer._thread is None
+                syncer.reload(_make_config(tmp_path, poll_interval=60))
+                assert syncer._thread is not None
+                assert syncer._thread.is_alive()
+                syncer.stop()
+
     def test_reload_same_interval_does_not_restart_thread(self, tmp_path: Path) -> None:
         """reload() with unchanged poll_interval leaves the thread running."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -130,7 +184,7 @@ class TestReload:
 
     def test_reload_changed_interval_restarts_thread(self, tmp_path: Path) -> None:
         """reload() with a new poll_interval stops and restarts the thread."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -143,7 +197,7 @@ class TestReload:
 
     def test_reload_interval_to_zero_stops_thread(self, tmp_path: Path) -> None:
         """reload() with interval=0 stops the polling thread."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -155,7 +209,7 @@ class TestReload:
 class TestPauseResume:
     def test_pause_stops_polling_thread(self, tmp_path: Path) -> None:
         """pause() stops the polling thread."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -170,7 +224,7 @@ class TestPauseResume:
 
     def test_resume_restarts_polling_thread(self, tmp_path: Path) -> None:
         """resume() starts a new polling thread after a pause."""
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path, poll_interval=60))
                 syncer.start()
@@ -193,19 +247,30 @@ class TestStatusCallback:
         syncer = Syncer(_make_config(tmp_path))
         assert syncer.status_callback is None
 
-    def test_status_callback_passed_to_sync_new_purchases(self, tmp_path: Path) -> None:
-        """sync_once() forwards status_callback to sync_new_purchases."""
-        callback = lambda msg: None  # noqa: E731
+    def test_status_callback_receives_messages(self, tmp_path: Path) -> None:
+        """Status messages put by the worker are forwarded to status_callback."""
+        received: list[str] = []
+
+        def _worker_with_two_messages(
+            target: Any, args: tuple[Any, ...]
+        ) -> tuple[Any, Any, Any]:
+            status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            # Two messages to exercise the loop-continues branch in the drain loop.
+            status_q.put("Downloading: Album A")
+            status_q.put("Downloading: Album B")
+            result_q.put(("ok", []))
+            return _FakeProc(), status_q, result_q
+
         with patch(
-            "tune_shifter.bandcamp.sync_new_purchases", return_value=[]
-        ) as mock_sync:
+            "tune_shifter.syncer._spawn_worker", side_effect=_worker_with_two_messages
+        ):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer = Syncer(_make_config(tmp_path))
-                syncer.status_callback = callback
+                syncer.status_callback = received.append
                 syncer.sync_once()
-        mock_sync.assert_called_once()
-        _, kwargs = mock_sync.call_args
-        assert kwargs["status_callback"] is callback
+
+        assert received == ["Downloading: Album A", "Downloading: Album B"]
 
 
 class TestLazyImport:
@@ -217,30 +282,89 @@ class TestLazyImport:
         _ = Syncer(_make_config(tmp_path))
         assert "tune_shifter.bandcamp" not in sys.modules
 
-    def test_bandcamp_evicted_after_sync_once(self, tmp_path: Path) -> None:
-        """After sync_once() returns, bandcamp is removed from sys.modules."""
+    def test_bandcamp_not_imported_in_parent_after_sync(self, tmp_path: Path) -> None:
+        """sync_once() never imports bandcamp into the parent process.
+
+        With subprocess isolation the bandcamp module lives only inside the
+        child process; the parent's sys.modules stays clean throughout.
+        """
         import sys
 
         sys.modules.pop("tune_shifter.bandcamp", None)
         syncer = Syncer(_make_config(tmp_path))
-        with patch("tune_shifter.bandcamp.sync_new_purchases", return_value=[]):
+        with patch("tune_shifter.syncer._spawn_worker", side_effect=_noop_worker):
             with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
                 syncer.sync_once()
         assert "tune_shifter.bandcamp" not in sys.modules
+
+
+class TestWorkerExceptions:
+    def test_sync_worker_exception_propagates(self, tmp_path: Path) -> None:
+        """Exceptions raised inside the sync worker are re-raised by sync_once()."""
+        with patch(
+            "tune_shifter.bandcamp.sync_new_purchases",
+            side_effect=RuntimeError("network failure"),
+        ):
+            with patch("tune_shifter.syncer._spawn_worker", side_effect=_inline_worker):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    with pytest.raises(RuntimeError, match="network failure"):
+                        syncer.sync_once()
+
+    def test_mark_synced_worker_exception_propagates(self, tmp_path: Path) -> None:
+        """Exceptions raised inside the mark-synced worker are re-raised."""
+        with patch(
+            "tune_shifter.bandcamp.mark_collection_synced",
+            side_effect=RuntimeError("auth error"),
+        ):
+            with patch("tune_shifter.syncer._spawn_worker", side_effect=_inline_worker):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    with pytest.raises(RuntimeError, match="auth error"):
+                        syncer.mark_synced()
+
+    def test_run_logs_exception_and_continues(self, tmp_path: Path) -> None:
+        """_run() catches sync_once() failures and keeps polling."""
+        call_count = 0
+
+        def _failing_then_stopping_worker(
+            target: Any, args: tuple[Any, ...]
+        ) -> tuple[Any, Any, Any]:
+            nonlocal call_count
+            call_count += 1
+            status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q.put(("error", "boom"))
+            return _FakeProc(), status_q, result_q
+
+        with patch(
+            "tune_shifter.syncer._spawn_worker",
+            side_effect=_failing_then_stopping_worker,
+        ):
+            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path, poll_interval=60))
+                syncer.start()
+                import time
+
+                time.sleep(0.1)
+                syncer.stop()
+        # _run caught the exception and logged it rather than crashing the thread.
+        assert call_count >= 1
 
 
 class TestMarkSynced:
     def test_warns_when_no_bandcamp(self, tmp_path: Path) -> None:
         """mark_synced() warns and returns when [bandcamp] is absent."""
         syncer = Syncer(_make_config_no_bandcamp(tmp_path))
-        with patch("tune_shifter.bandcamp.mark_collection_synced") as mock_mark:
+        with patch("tune_shifter.syncer._spawn_worker") as mock_spawn:
             syncer.mark_synced()
-        mock_mark.assert_not_called()
+        mock_spawn.assert_not_called()
 
     def test_calls_mark_collection_synced(self, tmp_path: Path) -> None:
         """mark_synced() delegates to mark_collection_synced with correct args."""
         with patch("tune_shifter.bandcamp.mark_collection_synced") as mock_mark:
-            with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
-                syncer = Syncer(_make_config(tmp_path))
-                syncer.mark_synced()
+            with patch("tune_shifter.syncer._spawn_worker", side_effect=_inline_worker):
+                with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+                    syncer = Syncer(_make_config(tmp_path))
+                    syncer.mark_synced()
         mock_mark.assert_called_once()

--- a/tune_shifter/bandcamp.py
+++ b/tune_shifter/bandcamp.py
@@ -436,6 +436,9 @@ def _paginate(page: Any, endpoint: str, fan_id: int) -> list[dict[str, Any]]:
                     headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify(body)
                 });
+                if (r.status === 401 || r.status === 403 || r.status === 302) {
+                    return {__auth_error: true, status: r.status};
+                }
                 if (!r.ok) {
                     const preview = (await r.text()).slice(0, 200);
                     throw new Error(`HTTP ${r.status} from ${url}: ${preview}`);
@@ -444,6 +447,14 @@ def _paginate(page: Any, endpoint: str, fan_id: int) -> list[dict[str, Any]]:
             }""",
             [endpoint, payload],
         )
+
+        if result.get("__auth_error"):
+            # Session expired mid-sync — clear it so the next run triggers re-login.
+            _session_file().unlink(missing_ok=True)
+            raise BandcampAPIError(
+                f"Bandcamp session expired (HTTP {result.get('status')}) — "
+                "session cleared. Run 'tune-shifter sync' to re-authenticate."
+            )
 
         if result.get("error"):
             raise BandcampAPIError(

--- a/tune_shifter/bandcamp.py
+++ b/tune_shifter/bandcamp.py
@@ -436,6 +436,10 @@ def _paginate(page: Any, endpoint: str, fan_id: int) -> list[dict[str, Any]]:
                     headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify(body)
                 });
+                if (!r.ok) {
+                    const preview = (await r.text()).slice(0, 200);
+                    throw new Error(`HTTP ${r.status} from ${url}: ${preview}`);
+                }
                 return await r.json();
             }""",
             [endpoint, payload],

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -24,6 +24,8 @@ import rumps  # noqa: E402 — guarded above
 
 from .daemon_core import DaemonCore, _PID_PATH
 
+logger = logging.getLogger(__name__)
+
 _ABOUT_URL = "https://github.com/eightyeighteyes/tune-shifter"
 _SYMBOL_NAME = "music.note.list"  # music.note.square.stack does not exist in SF Symbols
 
@@ -139,6 +141,8 @@ class MenuBarApp(rumps.App):
             try:
                 syncer.status_callback = self._on_sync_status
                 syncer.sync_once()
+            except Exception:
+                logger.exception("Unhandled error during manual Bandcamp sync")
             finally:
                 syncer.status_callback = None
                 self._sync_in_progress = False

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import logging.handlers
 import multiprocessing
 import queue
 import threading
@@ -31,9 +32,14 @@ def _sync_worker(
     staging_dir: Path,
     state_file: Path,
     status_q: Any,
+    log_q: Any,
     result_q: Any,
 ) -> None:
     """Entry point for the sync subprocess."""
+    # Route all log records to the parent via log_q for a consolidated log stream.
+    _root = logging.getLogger()
+    _root.setLevel(logging.DEBUG)
+    _root.addHandler(logging.handlers.QueueHandler(log_q))
     try:
         from .bandcamp import sync_new_purchases
 
@@ -52,9 +58,13 @@ def _mark_synced_worker(
     bc_config: BandcampConfig,
     state_file: Path,
     status_q: Any,
+    log_q: Any,
     result_q: Any,
 ) -> None:
     """Entry point for the mark-synced subprocess."""
+    _root = logging.getLogger()
+    _root.setLevel(logging.DEBUG)
+    _root.addHandler(logging.handlers.QueueHandler(log_q))
     try:
         from .bandcamp import mark_collection_synced
 
@@ -67,23 +77,38 @@ def _mark_synced_worker(
 def _spawn_worker(  # pragma: no cover
     target: Any,
     args: tuple[Any, ...],
-) -> tuple[Any, Any, Any]:
-    """Spawn an isolated subprocess running target(*args, status_q, result_q).
+) -> tuple[Any, Any, Any, Any]:
+    """Spawn an isolated subprocess running target(*args, status_q, log_q, result_q).
 
     Uses 'spawn' (not 'fork') so the child starts with a clean interpreter —
     no inherited file descriptors, threads, or loaded modules.
 
-    Returns (proc, status_q, result_q).
+    Returns (proc, status_q, log_q, result_q).
     """
     ctx = multiprocessing.get_context("spawn")
     status_q: Any = ctx.Queue()
+    log_q: Any = ctx.Queue()
     result_q: Any = ctx.Queue()
     # Not daemon=True: daemon subprocesses on macOS can have localhost networking
     # issues that break Playwright's Node.js ↔ Chromium DevTools Protocol channel.
     # The parent cleans up via proc.join() and the process terminates naturally.
-    proc = ctx.Process(target=target, args=(*args, status_q, result_q))
+    proc = ctx.Process(target=target, args=(*args, status_q, log_q, result_q))
     proc.start()
-    return proc, status_q, result_q
+    return proc, status_q, log_q, result_q
+
+
+def _replay_log_queue(log_q: Any) -> None:
+    """Re-emit log records from the subprocess into the parent's log handlers.
+
+    Called after the subprocess exits.  QueueHandler.prepare() serialises
+    exc_info into exc_text before pickling, so every record is safe to handle.
+    """
+    while True:
+        try:
+            record = log_q.get_nowait()
+            logging.getLogger(record.name).handle(record)
+        except queue.Empty:
+            break
 
 
 class Syncer:
@@ -172,6 +197,8 @@ class Syncer:
 
         Playwright and bandcamp modules are loaded only inside the child
         process; when it exits the OS reclaims all of their memory.
+        Log records emitted inside the subprocess are replayed into the
+        parent's log stream after the process exits.
         """
         bc = self._config.bandcamp
         if bc is None:
@@ -181,7 +208,7 @@ class Syncer:
         state_file = _state_dir() / "bandcamp_state.json"
         logger.info("Starting Bandcamp sync…")
 
-        proc, status_q, result_q = _spawn_worker(
+        proc, status_q, log_q, result_q = _spawn_worker(
             _sync_worker,
             (bc, self._config.paths.staging, state_file),
         )
@@ -206,6 +233,7 @@ class Syncer:
                 break
 
         proc.join(timeout=10)
+        _replay_log_queue(log_q)
 
         try:
             status, value = result_q.get_nowait()
@@ -229,11 +257,12 @@ class Syncer:
             return
         state_file = _state_dir() / "bandcamp_state.json"
 
-        proc, _status_q, result_q = _spawn_worker(
+        proc, _status_q, log_q, result_q = _spawn_worker(
             _mark_synced_worker,
             (bc, state_file),
         )
         proc.join(timeout=30)
+        _replay_log_queue(log_q)
 
         try:
             status, value = result_q.get_nowait()

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -3,31 +3,84 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing
+import queue
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
-from .config import Config, _state_dir
+from .config import BandcampConfig, Config, _state_dir
 
 logger = logging.getLogger(__name__)
 
 
-def _evict_bandcamp_modules() -> None:
-    """Remove bandcamp and playwright modules from sys.modules after sync.
+# ------------------------------------------------------------------
+# Subprocess worker functions
+#
+# These run inside an isolated child process spawned by _spawn_worker.
+# Playwright and the bandcamp module are imported only inside the
+# subprocess — when the process exits the OS reclaims all of their
+# memory, which the parent process's pymalloc allocator would not
+# release even after sys.modules eviction.
+# ------------------------------------------------------------------
 
-    Evicting drops the module objects' reference counts so the GC can reclaim
-    their memory once all local references are gone.  The next sync re-imports
-    cleanly.  This keeps playwright out of memory while the daemon is idle.
+
+def _sync_worker(
+    bc_config: BandcampConfig,
+    staging_dir: Path,
+    state_file: Path,
+    status_q: Any,
+    result_q: Any,
+) -> None:
+    """Entry point for the sync subprocess."""
+    try:
+        from .bandcamp import sync_new_purchases
+
+        paths = sync_new_purchases(
+            bc_config=bc_config,
+            staging_dir=staging_dir,
+            state_file=state_file,
+            status_callback=lambda msg: status_q.put(msg),
+        )
+        result_q.put(("ok", paths))
+    except Exception as exc:  # noqa: BLE001
+        result_q.put(("error", str(exc)))
+
+
+def _mark_synced_worker(
+    bc_config: BandcampConfig,
+    state_file: Path,
+    status_q: Any,
+    result_q: Any,
+) -> None:
+    """Entry point for the mark-synced subprocess."""
+    try:
+        from .bandcamp import mark_collection_synced
+
+        mark_collection_synced(bc_config=bc_config, state_file=state_file)
+        result_q.put(("ok", None))
+    except Exception as exc:  # noqa: BLE001
+        result_q.put(("error", str(exc)))
+
+
+def _spawn_worker(  # pragma: no cover
+    target: Any,
+    args: tuple[Any, ...],
+) -> tuple[Any, Any, Any]:
+    """Spawn an isolated subprocess running target(*args, status_q, result_q).
+
+    Uses 'spawn' (not 'fork') so the child starts with a clean interpreter —
+    no inherited file descriptors, threads, or loaded modules.
+
+    Returns (proc, status_q, result_q).
     """
-    import sys
-
-    to_evict = [
-        k
-        for k in sys.modules
-        if k == "tune_shifter.bandcamp" or k.startswith("playwright")
-    ]
-    for key in to_evict:
-        sys.modules.pop(key, None)
+    ctx = multiprocessing.get_context("spawn")
+    status_q: Any = ctx.Queue()
+    result_q: Any = ctx.Queue()
+    proc = ctx.Process(target=target, args=(*args, status_q, result_q), daemon=True)
+    proc.start()
+    return proc, status_q, result_q
 
 
 class Syncer:
@@ -112,7 +165,11 @@ class Syncer:
         logger.info("Syncer resumed")
 
     def sync_once(self) -> None:
-        """Download any new purchases immediately (one-shot, blocking)."""
+        """Download any new purchases in an isolated subprocess.
+
+        Playwright and bandcamp modules are loaded only inside the child
+        process; when it exits the OS reclaims all of their memory.
+        """
         bc = self._config.bandcamp
         if bc is None:
             logger.warning("No [bandcamp] section in config — nothing to sync.")
@@ -120,17 +177,42 @@ class Syncer:
 
         state_file = _state_dir() / "bandcamp_state.json"
         logger.info("Starting Bandcamp sync…")
-        try:
-            from .bandcamp import sync_new_purchases
 
-            paths = sync_new_purchases(
-                bc_config=bc,
-                staging_dir=self._config.paths.staging,
-                state_file=state_file,
-                status_callback=self.status_callback,
-            )
-        finally:
-            _evict_bandcamp_modules()
+        proc, status_q, result_q = _spawn_worker(
+            _sync_worker,
+            (bc, self._config.paths.staging, state_file),
+        )
+
+        # Drain status messages while the subprocess runs, forwarding each
+        # to the caller's callback so the menu bar can update in real time.
+        while proc.is_alive():  # pragma: no cover
+            try:
+                msg = status_q.get(timeout=0.5)
+                if self.status_callback is not None:
+                    self.status_callback(msg)
+            except queue.Empty:
+                pass
+
+        # Drain any messages that arrived just before the process exited.
+        while True:
+            try:
+                msg = status_q.get_nowait()
+                if self.status_callback is not None:
+                    self.status_callback(msg)
+            except queue.Empty:
+                break
+
+        proc.join(timeout=10)
+
+        try:
+            status, value = result_q.get_nowait()
+        except queue.Empty:  # pragma: no cover
+            raise RuntimeError("Sync subprocess exited without returning a result")
+
+        if status == "error":
+            raise RuntimeError(f"Bandcamp sync failed: {value}")
+
+        paths = value or []
         if paths:
             logger.info("Sync complete: %d file(s) downloaded to staging.", len(paths))
         else:
@@ -143,12 +225,22 @@ class Syncer:
             logger.warning("No [bandcamp] section in config — nothing to mark.")
             return
         state_file = _state_dir() / "bandcamp_state.json"
-        try:
-            from .bandcamp import mark_collection_synced
 
-            mark_collection_synced(bc_config=bc, state_file=state_file)
-        finally:
-            _evict_bandcamp_modules()
+        proc, _status_q, result_q = _spawn_worker(
+            _mark_synced_worker,
+            (bc, state_file),
+        )
+        proc.join(timeout=30)
+
+        try:
+            status, value = result_q.get_nowait()
+        except queue.Empty:  # pragma: no cover
+            raise RuntimeError(
+                "Mark-synced subprocess exited without returning a result"
+            )
+
+        if status == "error":
+            raise RuntimeError(f"Bandcamp mark-synced failed: {value}")
 
     # ------------------------------------------------------------------
     # Internal

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -7,10 +7,27 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from .bandcamp import mark_collection_synced, sync_new_purchases
 from .config import Config, _state_dir
 
 logger = logging.getLogger(__name__)
+
+
+def _evict_bandcamp_modules() -> None:
+    """Remove bandcamp and playwright modules from sys.modules after sync.
+
+    Evicting drops the module objects' reference counts so the GC can reclaim
+    their memory once all local references are gone.  The next sync re-imports
+    cleanly.  This keeps playwright out of memory while the daemon is idle.
+    """
+    import sys
+
+    to_evict = [
+        k
+        for k in sys.modules
+        if k == "tune_shifter.bandcamp" or k.startswith("playwright")
+    ]
+    for key in to_evict:
+        sys.modules.pop(key, None)
 
 
 class Syncer:
@@ -103,12 +120,17 @@ class Syncer:
 
         state_file = _state_dir() / "bandcamp_state.json"
         logger.info("Starting Bandcamp sync…")
-        paths = sync_new_purchases(
-            bc_config=bc,
-            staging_dir=self._config.paths.staging,
-            state_file=state_file,
-            status_callback=self.status_callback,
-        )
+        try:
+            from .bandcamp import sync_new_purchases
+
+            paths = sync_new_purchases(
+                bc_config=bc,
+                staging_dir=self._config.paths.staging,
+                state_file=state_file,
+                status_callback=self.status_callback,
+            )
+        finally:
+            _evict_bandcamp_modules()
         if paths:
             logger.info("Sync complete: %d file(s) downloaded to staging.", len(paths))
         else:
@@ -121,7 +143,12 @@ class Syncer:
             logger.warning("No [bandcamp] section in config — nothing to mark.")
             return
         state_file = _state_dir() / "bandcamp_state.json"
-        mark_collection_synced(bc_config=bc, state_file=state_file)
+        try:
+            from .bandcamp import mark_collection_synced
+
+            mark_collection_synced(bc_config=bc, state_file=state_file)
+        finally:
+            _evict_bandcamp_modules()
 
     # ------------------------------------------------------------------
     # Internal

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -78,7 +78,10 @@ def _spawn_worker(  # pragma: no cover
     ctx = multiprocessing.get_context("spawn")
     status_q: Any = ctx.Queue()
     result_q: Any = ctx.Queue()
-    proc = ctx.Process(target=target, args=(*args, status_q, result_q), daemon=True)
+    # Not daemon=True: daemon subprocesses on macOS can have localhost networking
+    # issues that break Playwright's Node.js ↔ Chromium DevTools Protocol channel.
+    # The parent cleans up via proc.join() and the process terminates naturally.
+    proc = ctx.Process(target=target, args=(*args, status_q, result_q))
     proc.start()
     return proc, status_q, result_q
 


### PR DESCRIPTION
## Summary

- **Root cause**: `sys.modules` eviction (prior approach) is insufficient — Python's `pymalloc` allocator holds freed pages and does not return them to the OS, so playwright stayed resident even after eviction.
- **Fix**: `sync_once()` and `mark_synced()` now spawn an isolated child process via `multiprocessing.get_context("spawn")`. Playwright and bandcamp are imported only inside the subprocess — when the process exits, the OS reclaims all of their memory unconditionally.
- Status messages are forwarded from the subprocess queue to the parent's `status_callback` so the menu bar continues to show live sync progress.
- Errors raised inside the worker are serialised through the result queue and re-raised in the parent.

## Test plan

- [x] `poetry run pytest tests/test_syncer.py -v --no-cov` — all 26 pass
- [x] `poetry run pytest --cov` — 327 passed, 95.93% coverage
- [x] `poetry run black --check tune_shifter/ tests/` — clean
- [x] `poetry run mypy tune_shifter/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)