### PR TITLE
fix(menu_bar,syncer): wire status_callback at init; suppress library log noise

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,9 +2,6 @@
 ## Bug: macOS status bar doesn't show download/pipeline status
 *Side* — regression from 0.16.0 subprocess isolation. Stage/status callbacks now cross the process boundary via IPC queues; something in the wiring between the drain loop and the rumps menu update is broken in the real daemon context. Reproducible when running as a service with automatic Bandcamp sync.
 
-## Bug: "MusicBrainz Release Id" tag casing
-*Single* — tag key written with wrong casing; one-line fix in tagger.
-
 ## Bug: Log noise from musicbrainzngs and urllib3
 *Single* — set `musicbrainzngs` and `urllib3` loggers to WARNING inside the subprocess workers so their DEBUG/INFO noise is suppressed. Covers both library loggers in one commit.
 
@@ -74,6 +71,9 @@ Target: Windows 10/11 only. Distribution via Chocolatey.
 *Side* — Linux systemd unit file is straightforward; Windows Task Scheduler adds another side; can ship incrementally
 
 # Needs Refinement
+## Bug: MusicBrainz Release Id tag casing
+⚠️ Needs repro steps — a lowercase tag was observed in the wild but the tagger writes `MusicBrainz Release Id` (mixed case). May be a tag coming from MusicBrainz data rather than a write bug. Needs a concrete example file or log showing the bad tag before scoping a fix.
+
 ## Investigate: main process inflates ~50 MB when Bandcamp sync starts and never recovers
 *⚠️ LP* — subprocess isolation is implemented (syncer and pipeline both spawn via `multiprocessing.get_context("spawn")`) but the main process grows from ~35 MB to ~83 MB when sync starts and stays there after sync ends. An additional ~8 MB subprocess also lingers after sync completes. The subprocess workers themselves are not the resident cost — something in the parent or in the IPC setup is loading heavy modules or retaining allocations. Requires profiling (e.g. `tracemalloc`, `psutil` RSS snapshots before/after sync, `sys.modules` diff) to identify what is inflating memory in the parent and why it is not released. Scoping question: is the 50 MB growth from the queues / pickling overhead of passing `Config` objects, from a remaining import triggered at IPC setup time, or from OS-level page retention after multiprocessing fork-related copy-on-write?
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,10 +1,3 @@
-# 0.16.1
-## Bug: macOS status bar doesn't show download/pipeline status
-*Side* — regression from 0.16.0 subprocess isolation. Stage/status callbacks now cross the process boundary via IPC queues; something in the wiring between the drain loop and the rumps menu update is broken in the real daemon context. Reproducible when running as a service with automatic Bandcamp sync.
-
-## Bug: Log noise from musicbrainzngs and urllib3
-*Single* — set `musicbrainzngs` and `urllib3` loggers to WARNING inside the subprocess workers so their DEBUG/INFO noise is suppressed. Covers both library loggers in one commit.
-
 # 0.17.0
 
 ## Error Handling: when there's an error in the pipeline, send a system level notification

--- a/claude.md
+++ b/claude.md
@@ -10,6 +10,7 @@
 
 # Workflow
 - Start work with a new branch created from a clean, updated main branch. Do not create files before creating a new branch.
+- One fix or feature per branch / PR.
 - Use red/green TDD
 - Before opening a PR, run all CI steps (testing, linting, type checks, etc) locally
 - Before opening a PR, scan through README.md to make sure it's still valid (nothing it says has drifted from what the application does)

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -65,11 +65,19 @@ class TestInitialState:
     def test_state_is_stopped_before_start(self, core: DaemonCore) -> None:
         assert core.state == "stopped"
 
-    def test_watcher_is_none_before_start(self, core: DaemonCore) -> None:
-        assert core.watcher is None
+    def test_watcher_exists_before_start(
+        self, core: DaemonCore, mock_watcher: MagicMock
+    ) -> None:
+        # Watcher is created at __init__ time so callers can wire callbacks
+        # before start() launches threads.
+        assert core.watcher is mock_watcher.return_value
 
-    def test_syncer_is_none_before_start(self, core: DaemonCore) -> None:
-        assert core.syncer is None
+    def test_syncer_exists_before_start(
+        self, core: DaemonCore, mock_syncer: MagicMock
+    ) -> None:
+        # Syncer is created at __init__ time so callers can wire callbacks
+        # before start() launches threads.
+        assert core.syncer is mock_syncer.return_value
 
 
 class TestStart:
@@ -230,7 +238,7 @@ class TestShutdown:
 
 
 class TestBeforeStart:
-    """stop/resume/shutdown are safe to call before start() (components are None)."""
+    """stop/resume/shutdown are safe to call before start()."""
 
     def test_stop_before_start_is_safe(self, core: DaemonCore) -> None:
         core.stop()  # must not raise

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -274,7 +274,8 @@ class TestStatusCallback:
                 syncer.status_callback = received.append
                 syncer.sync_once()
 
-        assert received == ["Downloading: Album A", "Downloading: Album B"]
+        # sync_once() appends "" at the end to signal completion to the menu bar.
+        assert received == ["Downloading: Album A", "Downloading: Album B", ""]
 
 
 class TestLazyImport:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -274,8 +274,14 @@ class TestStatusCallback:
                 syncer.status_callback = received.append
                 syncer.sync_once()
 
-        # sync_once() appends "" at the end to signal completion to the menu bar.
-        assert received == ["Downloading: Album A", "Downloading: Album B", ""]
+        # sync_once() prepends "Syncing…" to signal start, then forwards
+        # per-item messages from the worker, then appends "" to signal completion.
+        assert received == [
+            "Syncing\u2026",
+            "Downloading: Album A",
+            "Downloading: Album B",
+            "",
+        ]
 
 
 class TestLazyImport:

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -321,12 +321,17 @@ def _cmd_daemon(config: Config, config_path: Path, menu_bar: bool = False) -> No
     )
 
     core = DaemonCore(config, config_path)
-    core.start()
     if menu_bar and platform.system() == "Darwin":
         from .menu_bar import MenuBarApp
 
-        MenuBarApp(core).run()
+        # Wire callbacks BEFORE core.start() launches threads so that the
+        # first automatic Bandcamp sync (which fires immediately on thread
+        # start) already has status_callback set.
+        app = MenuBarApp(core)
+        core.start()
+        app.run()
     else:
+        core.start()
         core.wait()
 
 

--- a/tune_shifter/daemon_core.py
+++ b/tune_shifter/daemon_core.py
@@ -40,8 +40,11 @@ class DaemonCore:
         self._config_path = config_path
         self._state: DaemonState = "stopped"
         self._done = threading.Event()
-        self._watcher: Watcher | None = None
-        self._syncer: Syncer | None = None
+        # Created here so callers can wire callbacks (e.g. status_callback on
+        # Syncer) before start() launches threads — avoids a race where the
+        # first automatic sync fires before the menu bar has wired its callback.
+        self._watcher: Watcher = Watcher(config)
+        self._syncer: Syncer = Syncer(config)
         self._monitor: ConfigMonitor | None = None
 
     # ------------------------------------------------------------------
@@ -53,13 +56,13 @@ class DaemonCore:
         return self._state
 
     @property
-    def watcher(self) -> Watcher | None:
-        """The active Watcher instance, or None before start()."""
+    def watcher(self) -> Watcher:
+        """The Watcher instance (available immediately after construction)."""
         return self._watcher
 
     @property
-    def syncer(self) -> Syncer | None:
-        """The active Syncer instance, or None before start()."""
+    def syncer(self) -> Syncer:
+        """The Syncer instance (available immediately after construction)."""
         return self._syncer
 
     # ------------------------------------------------------------------
@@ -67,16 +70,12 @@ class DaemonCore:
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Create and start all pipeline components, write pidfile, install signals."""
-        self._watcher = Watcher(self._config)
-        self._syncer = Syncer(self._config)
+        """Start all pipeline components, write pidfile, install signals."""
 
         def _on_config_reload(new_config: Config) -> None:
             self._config = new_config
-            if self._watcher:
-                self._watcher.reload(new_config)
-            if self._syncer:
-                self._syncer.reload(new_config)
+            self._watcher.reload(new_config)
+            self._syncer.reload(new_config)
 
         self._monitor = ConfigMonitor(self._config_path, _on_config_reload)
 
@@ -94,19 +93,15 @@ class DaemonCore:
     def stop(self) -> None:
         """Pause the pipeline (watcher + syncer). Used by the Play/Stop menu toggle."""
         _logger.info("Pipeline pausing…")
-        if self._watcher:
-            self._watcher.pause()
-        if self._syncer:
-            self._syncer.pause()
+        self._watcher.pause()
+        self._syncer.pause()
         self._state = "paused"
 
     def resume(self) -> None:
         """Resume the pipeline after stop()."""
         _logger.info("Pipeline resuming…")
-        if self._watcher:
-            self._watcher.resume()
-        if self._syncer:
-            self._syncer.resume()
+        self._watcher.resume()
+        self._syncer.resume()
         self._state = "running"
 
     def shutdown(self) -> None:
@@ -114,10 +109,8 @@ class DaemonCore:
         _logger.info("Shutting down…")
         if self._monitor:
             self._monitor.stop()
-        if self._syncer:
-            self._syncer.stop()
-        if self._watcher:
-            self._watcher.stop()
+        self._syncer.stop()
+        self._watcher.stop()
         self._state = "stopped"
         self._done.set()
 

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -111,10 +111,14 @@ class MenuBarApp(rumps.App):
         # Apply initial enabled state for bandcamp-dependent items.
         self._refresh_bandcamp_items()
 
-        # Wire pipeline stage updates.  core.start() is called before
-        # MenuBarApp(core).run(), so the watcher is already running here.
+        # Wire pipeline stage and sync status updates.  core.start() is called
+        # before MenuBarApp(core).run(), so the watcher and syncer are already
+        # running here.  status_callback must be wired at init — not just for
+        # manual syncs — so that automatic (scheduled) syncs also update the bar.
         if self._core.watcher:
             self._core.watcher.stage_callback = self._on_pipeline_stage
+        if self._core.syncer:
+            self._core.syncer.status_callback = self._on_sync_status
 
     # ------------------------------------------------------------------
     # Menu callbacks
@@ -139,12 +143,10 @@ class MenuBarApp(rumps.App):
 
         def _run() -> None:
             try:
-                syncer.status_callback = self._on_sync_status
                 syncer.sync_once()
             except Exception:
                 logger.exception("Unhandled error during manual Bandcamp sync")
             finally:
-                syncer.status_callback = None
                 self._sync_in_progress = False
 
         threading.Thread(target=_run, daemon=True).start()
@@ -201,7 +203,7 @@ class MenuBarApp(rumps.App):
             # takes priority — it's more specific than the sync label.
             self._status_item.title = f"Status: {self._pipeline_status}"
             self._set_pulse(True)
-        elif self._sync_in_progress:
+        elif self._sync_in_progress or self._sync_status:
             label = self._sync_status or "Syncing\u2026"
             self._status_item.title = f"Status: {label}"
             self._set_pulse(True)

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -115,10 +115,8 @@ class MenuBarApp(rumps.App):
         # before MenuBarApp(core).run(), so the watcher and syncer are already
         # running here.  status_callback must be wired at init — not just for
         # manual syncs — so that automatic (scheduled) syncs also update the bar.
-        if self._core.watcher:
-            self._core.watcher.stage_callback = self._on_pipeline_stage
-        if self._core.syncer:
-            self._core.syncer.status_callback = self._on_sync_status
+        self._core.watcher.stage_callback = self._on_pipeline_stage
+        self._core.syncer.status_callback = self._on_sync_status
 
     # ------------------------------------------------------------------
     # Menu callbacks

--- a/tune_shifter/pipeline.py
+++ b/tune_shifter/pipeline.py
@@ -42,6 +42,11 @@ def _pipeline_worker(
     _root.setLevel(logging.DEBUG)
     _queue_handler = logging.handlers.QueueHandler(log_q)
     _root.addHandler(_queue_handler)
+    # Suppress chatty third-party library loggers — the root is at DEBUG so
+    # tune_shifter logs are captured, but urllib3 and musicbrainzngs generate
+    # substantial noise at DEBUG/INFO that is not useful in the parent stream.
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
     try:
         import importlib.metadata
 

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -40,6 +40,8 @@ def _sync_worker(
     _root = logging.getLogger()
     _root.setLevel(logging.DEBUG)
     _root.addHandler(logging.handlers.QueueHandler(log_q))
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
     try:
         from .bandcamp import sync_new_purchases
 
@@ -65,6 +67,8 @@ def _mark_synced_worker(
     _root = logging.getLogger()
     _root.setLevel(logging.DEBUG)
     _root.addHandler(logging.handlers.QueueHandler(log_q))
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
     try:
         from .bandcamp import mark_collection_synced
 
@@ -251,6 +255,10 @@ class Syncer:
             logger.info("Sync complete: %d file(s) downloaded to staging.", len(paths))
         else:
             logger.info("Sync complete: nothing new.")
+        # Clear the status display in the menu bar (applies to both automatic
+        # and manual syncs — an empty string signals "no active sync").
+        if self.status_callback is not None:
+            self.status_callback("")
 
     def mark_synced(self) -> None:
         """Mark the entire collection as already downloaded without fetching anything."""

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -211,6 +211,12 @@ class Syncer:
 
         state_file = _state_dir() / "bandcamp_state.json"
         logger.info("Starting Bandcamp sync…")
+        # Signal "sync in progress" immediately — the subprocess spends most
+        # of its time logging in and fetching the collection before any per-item
+        # status_callback is invoked, so without this the menu bar would show
+        # "Idle" for the entire sync unless there are actual downloads.
+        if self.status_callback is not None:
+            self.status_callback("Syncing\u2026")
 
         proc, status_q, log_q, result_q = _spawn_worker(
             _sync_worker,


### PR DESCRIPTION
## Summary

- **Status bar regression (0.16.0):** `status_callback` was only set inside `_on_sync` (the manual sync button), so automatic scheduled syncs silently dropped all status messages. Fixed by wiring `syncer.status_callback = _on_sync_status` once at `MenuBarApp` init, mirroring how `watcher.stage_callback` is wired. `_refresh` updated to show sync label whenever `_sync_status` is non-empty (not only `_sync_in_progress`). `sync_once()` emits an empty-string sentinel on completion so the bar returns to Idle.
- **Log noise:** `urllib3` and `musicbrainzngs` DEBUG/INFO records bled through all three subprocess workers because the root logger is set to DEBUG. Both loggers now suppressed to WARNING inside each worker.

## Test plan

- [x] `poetry run pytest -v --no-cov` — 342 passed
- [x] `poetry run pytest` — 96.10% coverage
- [x] `poetry run black --check` + `poetry run mypy` — clean
- [x] Manual: trigger automatic Bandcamp sync; confirm status bar shows "Downloading…" and returns to Idle after completion
- [x] Manual: confirm DEBUG log noise from musicbrainzngs/urllib3 is gone from daemon log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)