### PR TITLE
feat(logout): add tune-shifter logout command and menu bar item

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,13 +1,5 @@
 # 0.17.0
 
-## Bandcamp Logout: Remove or replace the active Bandcamp session
-*Side* — two surfaces (CLI `tune-shifter sync logout` + menu bar Logout item); CLI deletes the session file and state file; menu bar item calls the same logic and refreshes Bandcamp item state
-```
-Bandcamp Sync
-Sync Status
-Logout
-```
-
 ## Improve Tagging Quality: Per-track lookup using existing tags (light approach)
 *Side* — instead of picking a single MusicBrainz release for the whole album based on the folder name, look up each track individually using its existing `artist`, `title`, and `album` tags, then reconcile to the most common release. Fixes track-count mismatches (e.g. 17-track vs 18-track editions) that cause title offsets. Known mis-tagged albums: De La Soul "Stakes is High", "3 Feet High and Rising" (MBID `0cb69f0f`), Converge "Love is Not Enough" (MBID `0fec265d`). See AcoustID item below for the heavier follow-on approach.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ On macOS the daemon shows a `music.note.list` status-bar icon by default. The me
 | **Stop / Play** | Pause or resume the ingest pipeline without stopping the process |
 | **Bandcamp Sync** | Trigger an immediate sync; grayed out if `[bandcamp]` is not configured |
 | **Sync Status** | Read-only: "Status: Idle" or "Status: Syncing…" (icon pulses during sync) |
+| **Bandcamp Logout** | Delete the saved session and sync state; the next sync will re-authenticate |
 | **About Tune-Shifter** | Opens the project GitHub page |
 | **Quit** | Shuts down the daemon and removes the menu bar icon |
 
@@ -234,6 +235,16 @@ tune-shifter sync --mark-synced
 ```
 
 This fetches your full collection and records every item ID in the state file without downloading any files. Subsequent `sync` runs (and the daemon) will only pick up purchases made after this point.
+
+### Log out of Bandcamp
+
+To delete the saved session and force re-authentication on the next sync:
+
+```bash
+tune-shifter logout
+```
+
+This also clears the sync state file, so the next sync will re-examine your full collection. Use this if your session expires or you want to switch accounts.
 
 ### Manual ingest
 

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -16,7 +16,7 @@ from tune_shifter.config import (
     MusicBrainzConfig,
     PathsConfig,
 )
-from tune_shifter.syncer import Syncer
+from tune_shifter.syncer import Syncer, logout
 
 
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
@@ -425,3 +425,26 @@ class TestMarkSynced:
                     syncer = Syncer(_make_config(tmp_path))
                     syncer.mark_synced()
         mock_mark.assert_called_once()
+
+
+class TestLogout:
+    def test_deletes_session_and_state_files(self, tmp_path: Path) -> None:
+        """logout() removes both files when both exist."""
+        (tmp_path / "bandcamp_session.json").write_text("{}")
+        (tmp_path / "bandcamp_state.json").write_text("{}")
+        with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+            logout()
+        assert not (tmp_path / "bandcamp_session.json").exists()
+        assert not (tmp_path / "bandcamp_state.json").exists()
+
+    def test_noop_when_no_files(self, tmp_path: Path) -> None:
+        """logout() does not raise when neither file exists."""
+        with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+            logout()  # must not raise
+
+    def test_deletes_only_existing_file(self, tmp_path: Path) -> None:
+        """logout() removes whichever file(s) exist without erroring on absent ones."""
+        (tmp_path / "bandcamp_session.json").write_text("{}")
+        with patch("tune_shifter.syncer._state_dir", return_value=tmp_path):
+            logout()
+        assert not (tmp_path / "bandcamp_session.json").exists()

--- a/tune_shifter/__main__.py
+++ b/tune_shifter/__main__.py
@@ -146,6 +146,10 @@ def main() -> None:
     subparsers.add_parser("stop", help="Stop the tune-shifter service.")
     subparsers.add_parser("play", help="Start the tune-shifter service.")
     subparsers.add_parser("status", help="Show whether tune-shifter is running.")
+    subparsers.add_parser(
+        "logout",
+        help="Delete saved Bandcamp session and sync state, requiring re-authentication on the next sync.",
+    )
 
     # test-notify subcommand (macOS only, no config file needed)
     test_notify_parser = subparsers.add_parser(
@@ -212,6 +216,10 @@ def main() -> None:
     # Config commands bypass daemon lifecycle (no musicbrainzngs setup needed).
     if command == "config":
         _cmd_config(args, config_parser)
+        return
+
+    if command == "logout":
+        _cmd_logout()
         return
 
     if command == "test-notify":
@@ -294,6 +302,13 @@ def _yn_prompt(question: str, default: bool = True) -> bool:
     if not raw:
         return default
     return raw.startswith("y")
+
+
+def _cmd_logout() -> None:
+    from .syncer import logout
+
+    logout()
+    print("Logged out. The next sync will require re-authentication.")
 
 
 _NOTIFY_SUBTITLES: dict[str, str] = {

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -88,6 +88,7 @@ class MenuBarApp(rumps.App):
         self._toggle_item = rumps.MenuItem("Stop", callback=self._on_toggle)
         self._sync_item = rumps.MenuItem("Bandcamp Sync", callback=self._on_sync)
         self._status_item = rumps.MenuItem("Status: Idle")
+        self._logout_item = rumps.MenuItem("Bandcamp Logout", callback=self._on_logout)
 
         # Build the Download Format submenu.
         self._format_menu = rumps.MenuItem("Download Format")
@@ -102,6 +103,7 @@ class MenuBarApp(rumps.App):
             None,  # separator
             self._sync_item,
             self._status_item,
+            self._logout_item,
             self._format_menu,
             None,  # separator
             rumps.MenuItem("About Tune-Shifter", callback=self._on_about),
@@ -150,6 +152,12 @@ class MenuBarApp(rumps.App):
                 self._sync_in_progress = False
 
         threading.Thread(target=_run, daemon=True).start()
+
+    def _on_logout(self, sender: rumps.MenuItem) -> None:
+        from .syncer import logout
+
+        logout()
+        self._refresh_bandcamp_items()
 
     def _on_notification(self, title: str, subtitle: str, message: str) -> None:
         """Fire a macOS notification.
@@ -320,10 +328,12 @@ class MenuBarApp(rumps.App):
             _logger.warning("Pulse animation failed: %s", exc)
 
     def _refresh_bandcamp_items(self) -> None:
-        """Disable Bandcamp Sync and Sync Status when config or conditions prevent use."""
+        """Disable Bandcamp items when config or conditions prevent use."""
         bc = self._core._config.bandcamp
         has_bandcamp = bc is not None
         sync_available = has_bandcamp and not self._sync_in_progress
+        # Logout is disabled mid-sync to avoid deleting the session while it's in use.
+        logout_available = has_bandcamp and not self._sync_in_progress
         current_fmt = bc.format if bc is not None else None
 
         if sync_available:
@@ -331,11 +341,17 @@ class MenuBarApp(rumps.App):
         else:
             self._sync_item.set_callback(None)
 
+        if logout_available:
+            self._logout_item.set_callback(self._on_logout)
+        else:
+            self._logout_item.set_callback(None)
+
         # setEnabled_ controls the visual gray-out at the AppKit level;
         # set_callback(None) alone only removes the click handler.
         try:
             self._sync_item._menuitem.setEnabled_(sync_available)
             self._status_item._menuitem.setEnabled_(has_bandcamp)
+            self._logout_item._menuitem.setEnabled_(logout_available)
             self._format_menu._menuitem.setEnabled_(has_bandcamp)
         except Exception:
             pass

--- a/tune_shifter/syncer.py
+++ b/tune_shifter/syncer.py
@@ -313,3 +313,27 @@ class Syncer:
                         str(exc)[:120],
                     )
             self._stop_event.wait(timeout=interval_seconds)
+
+
+def logout() -> None:
+    """Delete the Bandcamp session and sync-state files.
+
+    After logout the next sync will re-authenticate interactively and
+    re-examine the full collection.  Both files are removed together —
+    a session without state (or vice versa) would leave the system in
+    an inconsistent half-logged-in state.
+    """
+    state = _state_dir()
+    session_file = state / "bandcamp_session.json"
+    state_file = state / "bandcamp_state.json"
+
+    removed: list[str] = []
+    for f in (session_file, state_file):
+        if f.exists():
+            f.unlink()
+            removed.append(f.name)
+
+    if removed:
+        logger.info("Bandcamp logout: removed %s.", ", ".join(removed))
+    else:
+        logger.info("Bandcamp logout: no session or state files found.")


### PR DESCRIPTION
## Summary

- `syncer.logout()` — deletes `bandcamp_session.json` and `bandcamp_state.json` from the state directory; shared by CLI and menu bar
- `tune-shifter logout` — top-level CLI subcommand, no config file required
- Menu bar: **Bandcamp Logout** item below Bandcamp Sync, disabled while a sync is in progress

The next sync after logout will re-authenticate interactively and re-examine the full collection.

## Test plan

- [x] `poetry run pytest tests/test_syncer.py::TestLogout -v --no-cov` — 3 tests pass
- [x] `tune-shifter logout` with both files present → files deleted, confirmation printed
- [x] `tune-shifter logout` with no files → no error, "no session or state files found" logged
- [x] Menu bar: Bandcamp Logout item appears; clicking it removes files and item stays enabled
- [x] Menu bar: Bandcamp Logout item is grayed out while a sync is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)