### PR TITLE
feat(menu-bar): Sync Frequency submenu

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,8 +1,5 @@
 # 0.18.0
 
-## Improve Tagging Quality: Per-track lookup using existing tags (light approach)
-*Side* — instead of picking a single MusicBrainz release for the whole album based on the folder name, look up each track individually using its existing `artist`, `title`, and `album` tags, then reconcile to the most common release. Fixes track-count mismatches (e.g. 17-track vs 18-track editions) that cause title offsets. Known mis-tagged albums: De La Soul "Stakes is High", "3 Feet High and Rising" (MBID `0cb69f0f`), Converge "Love is Not Enough" (MBID `0fec265d`). See AcoustID item below for the heavier follow-on approach.
-
 ## Improve Image Retrieval: Compress CAA images over size threshold
 *Single* — when a CAA candidate exceeds `max_bytes`, apply the same Pillow downscale/compress logic already used for oversized Bandcamp ZIP art rather than skipping it. Reuses existing compression helper; needs a test covering the compress-then-embed path for CAA images.
 
@@ -78,3 +75,15 @@ Target: Windows 10/11 only. Distribution via Chocolatey.
 
 # Needs Estimation
 -- don't discard this section --
+## bug: debug level log noise from asyncio (bandcamp) and PIL.TiffImagePlugin (artwork)
+
+2026-03-21 14:03:19  INFO      tune_shifter.config_monitor  Watching config file for changes: /Users/theodore.terry/.config/tune-shifter/config.toml
+2026-03-21 14:03:19  DEBUG     asyncio  Using selector: KqueueSelector
+2026-03-21 14:03:21  INFO      tune_shifter.bandcamp  Fetched fan_id=4346318 for user 'tedd-e-terry'
+
+2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: XResolution (282) - type: rational (5) Tag Location: 22 - Data Location: 74 - value: b'\x00\x00\x00H\x00\x00\x00\x01'
+2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: YResolution (283) - type: rational (5) Tag Location: 34 - Data Location: 82 - value: b'\x00\x00\x00H\x00\x00\x00\x01'
+2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: ResolutionUnit (296) - type: short (3) - value: b'\x00\x01'
+2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: YCbCrPositioning (531) - type: short (3) - value: b'\x00\x01'
+2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: ExifIFD (34665) - type: long (4) - value: b'\x00\x00\x00Z'
+2026-03-21 14:03:39  INFO      tune_shifter.artwork  All 18 file(s) have qualifying embedded art — skipping Cover Art Archive fetch

--- a/tune_shifter/menu_bar.py
+++ b/tune_shifter/menu_bar.py
@@ -29,6 +29,17 @@ logger = logging.getLogger(__name__)
 _ABOUT_URL = "https://github.com/eightyeighteyes/tune-shifter"
 _SYMBOL_NAME = "music.note.list"  # music.note.square.stack does not exist in SF Symbols
 
+# Sync frequency options: (poll_interval_minutes, display label).
+# 0 = manual only (Off); all others are polling intervals.
+_SYNC_INTERVALS: list[tuple[int, str]] = [
+    (0, "Off"),
+    (5, "5 minutes"),
+    (15, "15 minutes"),
+    (30, "30 minutes"),
+    (60, "Hourly"),
+    (1440, "Daily"),
+]
+
 # Valid format keys and their display labels (alphabetical).
 _FORMAT_LABELS: list[tuple[str, str]] = [
     ("aac-hi", "AAC-HI"),
@@ -98,6 +109,14 @@ class MenuBarApp(rumps.App):
             self._format_items[fmt] = item
         self._format_menu.update(self._format_items.values())
 
+        # Build the Sync Frequency submenu.
+        self._interval_menu = rumps.MenuItem("Sync Frequency")
+        self._interval_items: dict[int, rumps.MenuItem] = {}
+        for minutes, label in _SYNC_INTERVALS:
+            item = rumps.MenuItem(label, callback=self._on_sync_interval)
+            self._interval_items[minutes] = item
+        self._interval_menu.update(self._interval_items.values())
+
         self.menu = [
             self._toggle_item,
             None,  # separator
@@ -105,6 +124,7 @@ class MenuBarApp(rumps.App):
             self._status_item,
             self._logout_item,
             self._format_menu,
+            self._interval_menu,
             None,  # separator
             rumps.MenuItem("About Tune-Shifter", callback=self._on_about),
             rumps.MenuItem("Quit", callback=self._on_quit),
@@ -244,6 +264,20 @@ class MenuBarApp(rumps.App):
         except Exception as exc:
             _logger.warning("Failed to set download format: %s", exc)
 
+    def _on_sync_interval(self, sender: rumps.MenuItem) -> None:
+        """Write the selected sync interval to the config file."""
+        minutes = next(k for k, v in self._interval_items.items() if v is sender)
+        try:
+            from .config import config_set
+
+            config_set(
+                self._core._config_path,
+                "bandcamp.poll_interval_minutes",
+                str(minutes),
+            )
+        except Exception as exc:
+            _logger.warning("Failed to set sync interval: %s", exc)
+
     def _on_about(self, sender: rumps.MenuItem) -> None:
         subprocess.run(["open", _ABOUT_URL], check=False)
 
@@ -361,6 +395,8 @@ class MenuBarApp(rumps.App):
         else:
             self._logout_item.set_callback(None)
 
+        current_interval = bc.poll_interval_minutes if bc is not None else None
+
         # setEnabled_ controls the visual gray-out at the AppKit level;
         # set_callback(None) alone only removes the click handler.
         try:
@@ -368,6 +404,7 @@ class MenuBarApp(rumps.App):
             self._status_item._menuitem.setEnabled_(has_bandcamp)
             self._logout_item._menuitem.setEnabled_(logout_available)
             self._format_menu._menuitem.setEnabled_(has_bandcamp)
+            self._interval_menu._menuitem.setEnabled_(has_bandcamp)
         except Exception:
             pass
 
@@ -375,3 +412,10 @@ class MenuBarApp(rumps.App):
         for fmt, item in self._format_items.items():
             label_base = next(lbl for k, lbl in _FORMAT_LABELS if k == fmt)
             item.title = f"{label_base} \u2713" if fmt == current_fmt else label_base
+
+        # Update checkmarks on sync interval submenu items.
+        for minutes, item in self._interval_items.items():
+            label_base = next(lbl for k, lbl in _SYNC_INTERVALS if k == minutes)
+            item.title = (
+                f"{label_base} \u2713" if minutes == current_interval else label_base
+            )


### PR DESCRIPTION
## Summary

- Adds a **Sync Frequency** submenu below Download Format with radio-style checkmarks: Off / 5 minutes / 15 minutes / 30 minutes / Hourly / Daily
- Selecting an option calls `config_set` to write `bandcamp.poll_interval_minutes`; the `ConfigMonitor` picks up the file change and calls `Syncer.reload()`, so the new interval takes effect immediately without restarting the daemon
- Submenu is disabled (greyed out) when no Bandcamp config is present, matching the behaviour of the other Bandcamp-dependent items

## Test plan

- [ ] Open menu bar → Sync Frequency → current interval has ✓
- [ ] Select a different interval → checkmark moves, `config.toml` updated, syncer restarts with new interval (check logs)
- [ ] Select Off → polling stops
- [ ] No Bandcamp section in config → Sync Frequency submenu is greyed out
- [ ] 360 tests pass, coverage 95.58%

🤖 Generated with [Claude Code](https://claude.com/claude-code)