### PR TITLE
fix: suppress asyncio and PIL.TiffImagePlugin debug log noise

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -190,6 +190,11 @@ def main() -> None:
     # ERROR the root logger already handles filtering without our help.
     if args.log_level == "INFO":
         logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
+        # asyncio emits "Using selector: KqueueSelector" at DEBUG on every startup.
+        logging.getLogger("asyncio").setLevel(logging.WARNING)
+        # PIL.TiffImagePlugin emits per-tag DEBUG lines when decoding TIFF/JPEG EXIF
+        # data, which floods the log during every artwork embed.
+        logging.getLogger("PIL.TiffImagePlugin").setLevel(logging.WARNING)
 
     # Default to daemon when no subcommand given
     command = args.command or "daemon"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 """Tests for kamp_daemon.__main__ helpers."""
 
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -247,3 +248,37 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "running" in out
         assert "1:23:45" in out
+
+
+class TestLogNoiseSuppression:
+    """Third-party loggers are silenced at INFO level to reduce noise."""
+
+    _NOISY_LOGGERS = ["asyncio", "PIL.TiffImagePlugin"]
+
+    def setup_method(self) -> None:
+        # Reset logger levels before each test so they don't bleed between runs.
+        for name in self._NOISY_LOGGERS:
+            logging.getLogger(name).setLevel(logging.NOTSET)
+
+    def _run_main_with_log_level(self, level: str) -> None:
+        from kamp_daemon.__main__ import main
+
+        with patch("sys.argv", ["kamp-daemon", "--log-level", level, "config", "show"]):
+            with patch("kamp_daemon.__main__._cmd_config"):
+                main()
+
+    def test_asyncio_suppressed_at_info(self) -> None:
+        self._run_main_with_log_level("INFO")
+        assert logging.getLogger("asyncio").level == logging.WARNING
+
+    def test_pil_tiff_suppressed_at_info(self) -> None:
+        self._run_main_with_log_level("INFO")
+        assert logging.getLogger("PIL.TiffImagePlugin").level == logging.WARNING
+
+    def test_asyncio_not_suppressed_at_debug(self) -> None:
+        self._run_main_with_log_level("DEBUG")
+        assert logging.getLogger("asyncio").level != logging.WARNING
+
+    def test_pil_tiff_not_suppressed_at_debug(self) -> None:
+        self._run_main_with_log_level("DEBUG")
+        assert logging.getLogger("PIL.TiffImagePlugin").level != logging.WARNING


### PR DESCRIPTION
## Summary

- At `INFO` level, `asyncio` emits `"Using selector: KqueueSelector"` on every startup
- `PIL.TiffImagePlugin` floods the log with one DEBUG line per EXIF tag during every artwork embed (typically 4–6 lines per file)
- Suppress both to `WARNING` at `INFO` log level, matching the existing `musicbrainzngs` suppression — at `DEBUG` the user still gets everything

## Test plan

- [x] 4 new tests in `TestLogNoiseSuppression` covering suppression at INFO and pass-through at DEBUG
- [x] 365 tests passing
- [x] `black --check` clean
- [x] `mypy` clean

Closes the "debug level log noise" item in Needs Estimation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)