### PR TITLE
chore: remove release-as override now that 1.0.0 has shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
   "release-type": "python",
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## Summary

- `release-as` is a one-time override — once the target version ships it should be removed
- Leaving it in place causes release-please to keep proposing 1.0.0 instead of computing the next version from commits
- The manifest stays at `1.0.0` (correct baseline); release-please will derive 1.0.1 / 1.1.0 from new commits as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)