### PR TITLE
chore: rename distribution and CLI from kamp-daemon to kamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,14 @@ jobs:
           GH_USERNAME: eightyeighteyes
         run: |
           VERSION="${TAG#v}"
-          URL="https://github.com/${GH_USERNAME}/kamp-daemon/releases/download/${TAG}/${TARBALL_NAME}"
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GH_USERNAME}/homebrew-kamp-daemon.git" tap
-          cp Formula/kamp-daemon.rb tap/Formula/kamp-daemon.rb
+          URL="https://github.com/${GH_USERNAME}/kamp/releases/download/${TAG}/${TARBALL_NAME}"
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${GH_USERNAME}/homebrew-kamp.git" tap
+          cp Formula/kamp.rb tap/Formula/kamp.rb
           cd tap
-          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/kamp-daemon.rb
-          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/kamp-daemon.rb
+          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/kamp.rb
+          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/kamp.rb
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add Formula/kamp-daemon.rb
-          git commit -m "kamp-daemon ${VERSION}"
+          git add Formula/kamp.rb
+          git commit -m "kamp ${VERSION}"
           git push

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,21 +3,13 @@
 > Estimates use the vinyl scale: Single (<0.5), Side (0.5–1), LP (2), 2xLP (4), Box Set (4–8), Discography (>8)
 > ⚠️ = needs scoping before work can start
 
-## Prepare for creating a GUI
-*LP* — Rebrand installation and packaging from `kamp-daemon` to `kamp` in preparation for an Electron GUI app ("KAMP") that will bundle the daemon. The Python module (`kamp_daemon`) and its internals stay as-is; only the user-facing distribution layer moves. Breakdown:
+## If config doesn't exist before service is installed, run setup
+*Single* — guard `_cmd_install_service()` in `__main__.py`: check if the config file exists, and if not, bail with a message directing the user to run `kamp daemon` first (which triggers the interactive first-run setup). The interactive setup flow already exists in `config.py`.
 
-| Component | Notes |
-|---|---|
-| pyproject.toml: package name + entry point | `kamp-daemon` → `kamp` (name, console script) |
-| CLI command rename | `kamp-daemon` CLI → `kamp`; all help text, arg parser `prog=` |
-| Config + data paths | `~/.config/kamp-daemon/` → `~/.config/kamp/`; needs migration for existing users |
-| macOS service label + CFBundleIdentifier | `com.kamp-daemon` → `com.kamp` in `__main__.py` and `launcher/main.c`; requires uninstall/reinstall for existing users |
-| Homebrew formula | Rename `Formula/kamp-daemon.rb` → `Formula/kamp.rb`; update all internal references |
-| Homebrew tap repo | `homebrew-kamp-daemon` → `homebrew-kamp` (separate GitHub repo rename + CI update) |
-| CI/release workflow | Update tarball URL, tap clone path, commit message in `release.yml` |
-| Docs sweep | README.md, USAGE.md, completions/_kamp-daemon → completions/_kamp |
+## AcoustID Support (heavy tagging approach)
+*LP* — fingerprint audio with `fpcalc`/chromaprint, look up recording via AcoustID API, feed MBID into existing tagger. Prerequisite met: per-track lookup (`_lookup_release_by_recordings`) is already live. Fingerprinting should be its own subprocess pipeline phase.
 
-The GUI details (Electron app, library management) are forthcoming — this ticket is scoped to the packaging rebrand only.
+Priority order: AcoustID match → current tags (Artist/Album) → path (`staging/Artist/Album`).
 
 ## Full Windows Support
 *Box Set* — prerequisite: Rebrand must ship first. Breakdown:
@@ -47,11 +39,6 @@ Target: Windows 10/11 only. Distribution via Chocolatey.
 
 ⚠️ Needs scoping: what ranking heuristic? (release format field, country, date proximity?) and what's the fallback when no physical release exists? Note: date-based tie-breaking (earliest release wins) is already implemented; remaining work is format/country preference.
 
-## AcoustID Support (heavy tagging approach)
-*LP* — fingerprint audio with `fpcalc`/chromaprint, look up recording via AcoustID API, feed MBID into existing tagger. Prerequisite: per-track lookup (light approach) should ship first. Fingerprinting should be its own subprocess pipeline phase.
-
-⚠️ Needs scoping: how to handle mismatches between AcoustID result and existing MusicBrainz search? Which takes precedence?
-
 ## Nested Folders
 *Side* — when a folder-of-folders is dropped into staging, recurse into subdirectories and treat each leaf folder as an album
 
@@ -68,15 +55,3 @@ Target: Windows 10/11 only. Distribution via Chocolatey.
 
 # Needs Estimation
 -- don't discard this section --
-## bug: debug level log noise from asyncio (bandcamp) and PIL.TiffImagePlugin (artwork)
-
-2026-03-21 14:03:19  INFO      kamp_daemon.config_monitor  Watching config file for changes: /Users/theodore.terry/.config/kamp-daemon/config.toml
-2026-03-21 14:03:19  DEBUG     asyncio  Using selector: KqueueSelector
-2026-03-21 14:03:21  INFO      kamp_daemon.bandcamp  Fetched fan_id=4346318 for user 'tedd-e-terry'
-
-2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: XResolution (282) - type: rational (5) Tag Location: 22 - Data Location: 74 - value: b'\x00\x00\x00H\x00\x00\x00\x01'
-2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: YResolution (283) - type: rational (5) Tag Location: 34 - Data Location: 82 - value: b'\x00\x00\x00H\x00\x00\x00\x01'
-2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: ResolutionUnit (296) - type: short (3) - value: b'\x00\x01'
-2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: YCbCrPositioning (531) - type: short (3) - value: b'\x00\x01'
-2026-03-21 14:03:39  DEBUG     PIL.TiffImagePlugin  tag: ExifIFD (34665) - type: long (4) - value: b'\x00\x00\x00Z'
-2026-03-21 14:03:39  INFO      kamp_daemon.artwork  All 18 file(s) have qualifying embedded art — skipping Cover Art Archive fetch

--- a/Formula/kamp.rb
+++ b/Formula/kamp.rb
@@ -1,17 +1,17 @@
-# This formula lives in the homebrew-kamp-daemon tap repo (Formula/kamp-daemon.rb).
+# This formula lives in the homebrew-kamp tap repo (Formula/kamp.rb).
 # A copy is kept here as source of truth. The release workflow patches `url` and
 # `sha256` in the tap repo automatically on each tagged release.
 #
 # One-time tap setup:
-#   brew tap GITHUB_USERNAME/kamp-daemon
-#   brew install kamp-daemon
+#   brew tap GITHUB_USERNAME/kamp
+#   brew install kamp
 #
-# (Requires a GitHub repo named `homebrew-kamp-daemon` containing this file.)
+# (Requires a GitHub repo named `homebrew-kamp` containing this file.)
 
-class KampDaemon < Formula
+class Kamp < Formula
   desc "Automated audio library ingest daemon for Bandcamp downloads"
-  homepage "https://github.com/eightyeighteyes/kamp-daemon"
-  url "https://github.com/eightyeighteyes/kamp-daemon/releases/download/v0.1.0/kamp_daemon-0.1.0.tar.gz"
+  homepage "https://github.com/eightyeighteyes/kamp"
+  url "https://github.com/eightyeighteyes/kamp/releases/download/v0.1.0/kamp_daemon-0.1.0.tar.gz"
   sha256 "PLACEHOLDER"
 
   license "GPL-3.0-only"
@@ -27,11 +27,11 @@ class KampDaemon < Formula
     system venv/"bin/pip", "install", "--upgrade", "pip"
     system venv/"bin/pip", "install", buildpath
 
-    # Compile a native launcher binary so macOS sets p_comm to "kamp-daemon"
+    # Compile a native launcher binary so macOS sets p_comm to "kamp"
     # at exec time.  A symlink to the Python shebang script would leave p_comm
     # as "python3.11", which shows up in Activity Monitor.  The compiled binary
     # embeds Python (Py_SetProgramName + Py_Main) and stays alive as the
-    # top-level process, so the kernel-level name is always "kamp-daemon".
+    # top-level process, so the kernel-level name is always "kamp".
     venv_python = venv/"bin/python3"
     cflags  = Utils.safe_popen_read(venv_python, "-c",
                 "import sysconfig; print(sysconfig.get_config_var('CFLAGS') or '')").chomp
@@ -52,15 +52,15 @@ class KampDaemon < Formula
            "-L#{lib_dir}", "-lpython#{py_ver}",
            *ldflags.split,
            "-Wno-deprecated-declarations",
-           "-o", buildpath/"kamp-daemon"
-    bin.install buildpath/"kamp-daemon"
+           "-o", buildpath/"kamp"
+    bin.install buildpath/"kamp"
 
-    zsh_completion.install "completions/_kamp-daemon"
-    (share/"kamp-daemon").install "USAGE.md"
+    zsh_completion.install "completions/_kamp"
+    (share/"kamp").install "USAGE.md"
   end
 
   def caveats
-    usage = (share/"kamp-daemon"/"USAGE.md").read
+    usage = (share/"kamp"/"USAGE.md").read
     <<~EOS
       #{usage}
       Bandcamp auto-download requires Playwright browser binaries.
@@ -72,6 +72,6 @@ class KampDaemon < Formula
   end
 
   test do
-    system bin/"kamp-daemon", "--help"
+    system bin/"kamp", "--help"
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kamp-daemon
+# kamp
 
 A background daemon that automates the full ingest pipeline for a digital audio library — from Bandcamp purchase to tagged, art-embedded, organized file in your library — with no manual steps.
 
@@ -72,14 +72,14 @@ Bandcamp purchase
 ### Homebrew (recommended)
 
 ```bash
-brew tap eightyeighteyes/kamp-daemon
-brew install kamp-daemon
+brew tap eightyeighteyes/kamp
+brew install kamp
 ```
 
 After install, download the Playwright browser binaries required for Bandcamp auto-download:
 
 ```bash
-/opt/homebrew/opt/kamp-daemon/venv/bin/playwright install chromium
+/opt/homebrew/opt/kamp/venv/bin/playwright install chromium
 ```
 
 zsh tab completion is included and activated automatically via Homebrew's shell integration.
@@ -87,8 +87,8 @@ zsh tab completion is included and activated automatically via Homebrew's shell 
 ### From source
 
 ```bash
-git clone https://github.com/eightyeighteyes/kamp-daemon
-cd kamp-daemon
+git clone https://github.com/eightyeighteyes/kamp
+cd kamp
 poetry install
 playwright install chromium
 ```
@@ -97,22 +97,22 @@ playwright install chromium
 
 ## Configuration
 
-On first run, kamp-daemon creates a config file with defaults at:
+On first run, kamp creates a config file with defaults at:
 
 | Platform | Path |
 |---|---|
-| macOS / Linux | `~/.config/kamp-daemon/config.toml` |
-| Windows | `%APPDATA%\kamp-daemon\config.toml` |
+| macOS / Linux | `~/.config/kamp/config.toml` |
+| Windows | `%APPDATA%\kamp\config.toml` |
 
 Edit it before starting:
 
 ```toml
 [paths]
-staging = "~/Music/staging"   # drop ZIPs here; kamp-daemon watches this directory
+staging = "~/Music/staging"   # drop ZIPs here; kamp watches this directory
 library = "~/Music"           # finished files land here
 
 [musicbrainz]
-app_name = "kamp-daemon"
+app_name = "kamp"
 app_version = "0.1.0"
 contact = "you@example.com"   # required by MusicBrainz API policy
 
@@ -128,8 +128,8 @@ path_template = "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
 [bandcamp]
 username = "your-bandcamp-username"
 format = "mp3-v0"             # mp3-v0 | mp3-320 | flac
-poll_interval_minutes = 60    # 0 = polling disabled; use `kamp-daemon sync` manually
-# cookie_file = "~/.config/kamp-daemon/cookies.txt"  # advanced: bypass interactive login
+poll_interval_minutes = 60    # 0 = polling disabled; use `kamp sync` manually
+# cookie_file = "~/.config/kamp/cookies.txt"  # advanced: bypass interactive login
 ```
 
 ---
@@ -139,9 +139,9 @@ poll_interval_minutes = 60    # 0 = polling disabled; use `kamp-daemon sync` man
 ### Run the daemon
 
 ```bash
-kamp-daemon
+kamp
 # or explicitly:
-kamp-daemon daemon
+kamp daemon
 ```
 
 Watches the staging directory for new ZIPs and folders, and (if `[bandcamp]` is configured) polls Bandcamp for new purchases on the configured interval.
@@ -149,7 +149,7 @@ Watches the staging directory for new ZIPs and folders, and (if `[bandcamp]` is 
 Override paths without editing the config:
 
 ```bash
-kamp-daemon daemon --staging ~/Downloads/staging --library ~/Music
+kamp daemon --staging ~/Downloads/staging --library ~/Music
 ```
 
 ### macOS menu bar
@@ -168,50 +168,50 @@ On macOS the daemon shows a `music.note.list` status-bar icon by default. The me
 To run without the menu bar icon:
 
 ```bash
-kamp-daemon daemon --no-menu-bar
-kamp-daemon install-service --no-menu-bar  # persists the preference in the launchd plist
+kamp daemon --no-menu-bar
+kamp install-service --no-menu-bar  # persists the preference in the launchd plist
 ```
 
 ---
 
 ### Run as a background service (macOS)
 
-Register kamp-daemon as a launchd user agent so it starts at login and runs silently in the background:
+Register kamp as a launchd user agent so it starts at login and runs silently in the background:
 
 ```bash
-kamp-daemon install-service
+kamp install-service
 ```
 
-Logs are written to `~/.local/share/kamp-daemon/daemon.log`.
+Logs are written to `~/.local/share/kamp/daemon.log`.
 
 ```bash
-kamp-daemon stop              # pause the service
-kamp-daemon play              # resume the service
-kamp-daemon status            # check if it's running
-kamp-daemon uninstall-service # remove it permanently
+kamp stop              # pause the service
+kamp play              # resume the service
+kamp status            # check if it's running
+kamp uninstall-service # remove it permanently
 ```
 
 ### View or update config from the command line
 
 ```bash
-kamp-daemon config show
-kamp-daemon config set paths.staging ~/Downloads/staging
-kamp-daemon config set musicbrainz.contact me@example.com
-kamp-daemon config set artwork.min_dimension 500
+kamp config show
+kamp config set paths.staging ~/Downloads/staging
+kamp config set musicbrainz.contact me@example.com
+kamp config set artwork.min_dimension 500
 ```
 
-Keys use dot notation (`section.field`). Run `kamp-daemon config set --help` to see all valid keys.
+Keys use dot notation (`section.field`). Run `kamp config set --help` to see all valid keys.
 
 ### Test notifications (macOS)
 
 Verify that macOS notification permissions are granted and the full notification path works by simulating a failure at a specific pipeline stage:
 
 ```bash
-kamp-daemon test-notify --type extraction  # simulate extraction failure
-kamp-daemon test-notify --type tagging     # simulate MusicBrainz tagging failure
-kamp-daemon test-notify --type artwork     # simulate cover art warning
-kamp-daemon test-notify --type move        # simulate library move failure
-kamp-daemon test-notify --type download    # simulate Bandcamp sync failure
+kamp test-notify --type extraction  # simulate extraction failure
+kamp test-notify --type tagging     # simulate MusicBrainz tagging failure
+kamp test-notify --type artwork     # simulate cover art warning
+kamp test-notify --type move        # simulate library move failure
+kamp test-notify --type download    # simulate Bandcamp sync failure
 ```
 
 Each command runs the real pipeline (or syncer) up to the named stage, injects a failure, and fires a notification via the same code path the daemon uses — so if the notification appears, the full chain is working.
@@ -221,19 +221,19 @@ Each command runs the real pipeline (or syncer) up to the named stage, injects a
 ### One-shot Bandcamp sync
 
 ```bash
-kamp-daemon sync
+kamp sync
 ```
 
 Downloads any purchases not yet in your local state, places them in staging, and exits. The watcher (if running) picks them up automatically.
 
 ### First sync behaviour
 
-On the first sync (no state file yet), kamp-daemon assumes you already have your Bandcamp purchases in your local library and marks your entire collection as synced before downloading. Only purchases made after that point will be downloaded.
+On the first sync (no state file yet), kamp assumes you already have your Bandcamp purchases in your local library and marks your entire collection as synced before downloading. Only purchases made after that point will be downloaded.
 
 To override this and re-download your entire collection from scratch:
 
 ```bash
-kamp-daemon sync --download-all
+kamp sync --download-all
 ```
 
 This clears the local sync state and downloads everything.
@@ -243,7 +243,7 @@ This clears the local sync state and downloads everything.
 To delete the saved session and force re-authentication on the next sync:
 
 ```bash
-kamp-daemon logout
+kamp logout
 ```
 
 This also clears the sync state file, so the next sync will re-examine your full collection. Use this if your session expires or you want to switch accounts.
@@ -267,14 +267,14 @@ Drop any Bandcamp ZIP or already-extracted folder into your staging directory. T
 
 > **Note:** Bandcamp has no public API. The collection endpoints used here are reverse-engineered and could change without notice. No passwords are stored.
 
-On first sync, kamp-daemon opens a browser window and prompts you to log in to Bandcamp. Once you complete login the window closes automatically and the session is saved. Subsequent syncs (and the background daemon) reuse the saved session without opening a browser — you only need to log in again if your Bandcamp session expires.
+On first sync, kamp opens a browser window and prompts you to log in to Bandcamp. Once you complete login the window closes automatically and the session is saved. Subsequent syncs (and the background daemon) reuse the saved session without opening a browser — you only need to log in again if your Bandcamp session expires.
 
 The session file and download state are stored alongside each other:
 
 | Platform | Directory |
 |---|---|
-| macOS / Linux | `~/.local/share/kamp-daemon/` |
-| Windows | `%LOCALAPPDATA%\kamp-daemon\` |
+| macOS / Linux | `~/.local/share/kamp/` |
+| Windows | `%LOCALAPPDATA%\kamp\` |
 
 The session file (`bandcamp_session.json`) is written with owner-only permissions (`0600`). The state file (`bandcamp_state.json`) tracks which purchases have been downloaded so nothing is ever re-downloaded.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,7 +1,7 @@
-Welcome to kamp-daemon!
+Welcome to kamp!
 
 To get started, run:
-   kamp-daemon
+   kamp
 
 On first run, you'll be asked for your staging directory, library directory,
 and contact email (used in the MusicBrainz User-Agent). Press Enter at each
@@ -9,18 +9,18 @@ prompt to accept the shown default. The config is saved automatically and the
 daemon starts right away.
 
 Then install the service so it starts at login:
-  kamp-daemon install-service
+  kamp install-service
 
-Now move a zip or folder into your staging folder and kamp-daemon will take care of the rest!
+Now move a zip or folder into your staging folder and kamp will take care of the rest!
 
 To manage the service:
-  kamp-daemon stop     # pause
-  kamp-daemon play     # resume
-  kamp-daemon status   # check if it's running
+  kamp stop     # pause
+  kamp play     # resume
+  kamp status   # check if it's running
 
 To sync your collection from Bandcamp, run:
-  kamp-daemon sync
+  kamp sync
 
-On first sync, kamp-daemon will capture the state of your Bandcamp account. 
+On first sync, kamp will capture the state of your Bandcamp account. 
 If you want to download your whole Bandcamp collection in one go, you need to run:
-  kamp-daemon sync --download-all
+  kamp sync --download-all

--- a/completions/_kamp
+++ b/completions/_kamp
@@ -1,9 +1,9 @@
-#compdef kamp-daemon
+#compdef kamp
 
-# zsh completion for kamp-daemon
+# zsh completion for kamp
 # Installed to share/zsh/site-functions/ via the Homebrew formula.
 
-_kamp_daemon() {
+_kamp() {
   local state line
   typeset -A opt_args
 
@@ -25,11 +25,11 @@ _kamp_daemon() {
       subcommands=(
         'daemon:Watch staging directory and poll Bandcamp (default)'
         'sync:One-shot Bandcamp download, then exit'
-        'install-service:Register kamp-daemon as a launchd user agent (macOS)'
+        'install-service:Register kamp as a launchd user agent (macOS)'
         'uninstall-service:Remove the launchd user agent registration'
-        'stop:Stop the kamp-daemon service'
-        'play:Start the kamp-daemon service'
-        'status:Show whether kamp-daemon is running'
+        'stop:Stop the kamp service'
+        'play:Start the kamp service'
+        'status:Show whether kamp is running'
         'config:Read or update configuration values'
       )
       _describe 'subcommand' subcommands
@@ -106,4 +106,4 @@ _kamp_daemon() {
   esac
 }
 
-_kamp_daemon "$@"
+_kamp "$@"

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for the kamp-daemon daemon.
+"""Entry point for the kamp daemon.
 
 Excluded from coverage (see pyproject.toml [tool.coverage.run] omit list) because
 this module is pure CLI/daemon lifecycle glue: argparse dispatch, launchctl subprocess
@@ -29,7 +29,7 @@ from .config import DEFAULT_CONFIG_PATH, Config, _state_dir, config_set, config_
 from .daemon_core import DaemonCore, _PID_PATH
 from .syncer import Syncer
 
-_SERVICE_LABEL = "com.kamp-daemon"
+_SERVICE_LABEL = "com.kamp"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
 
@@ -50,13 +50,13 @@ def _get_version() -> str:
         ).get("version")
         return str(version or "unknown") + "-dev"
     try:
-        return importlib.metadata.version("kamp-daemon")
+        return importlib.metadata.version("kamp")
     except importlib.metadata.PackageNotFoundError:
         return "unknown"
 
 
 def main() -> None:
-    # Rename the process so `ps` output shows "kamp-daemon" instead of
+    # Rename the process so `ps` output shows "kamp" instead of
     # "Python".  setproctitle updates argv[0] which is sufficient on Linux;
     # on macOS it also helps ps, but Activity Monitor reads the kernel-level
     # p_comm (set from the executable path at exec time and not writable from
@@ -65,12 +65,12 @@ def main() -> None:
     try:
         import setproctitle
 
-        setproctitle.setproctitle("kamp-daemon")
+        setproctitle.setproctitle("kamp")
     except Exception:
         pass
 
     parser = argparse.ArgumentParser(
-        prog="kamp-daemon",
+        prog="kamp",
         description="Automated audio library ingest from Bandcamp.",
     )
     parser.add_argument(
@@ -122,7 +122,7 @@ def main() -> None:
         action="store_true",
         help=(
             "Clear the local sync state and re-download your entire Bandcamp "
-            "collection.  By default, kamp-daemon assumes you already have "
+            "collection.  By default, kamp assumes you already have "
             "your collection on first sync and only downloads new purchases "
             "going forward."
         ),
@@ -131,7 +131,7 @@ def main() -> None:
     # service subcommands (macOS launchd)
     install_parser = subparsers.add_parser(
         "install-service",
-        help="Register kamp-daemon as a launchd user agent (macOS). Starts at login, runs in background.",
+        help="Register kamp as a launchd user agent (macOS). Starts at login, runs in background.",
     )
     install_parser.add_argument(
         "--no-menu-bar",
@@ -143,9 +143,9 @@ def main() -> None:
         "uninstall-service",
         help="Remove the launchd user agent registration.",
     )
-    subparsers.add_parser("stop", help="Stop the kamp-daemon service.")
-    subparsers.add_parser("play", help="Start the kamp-daemon service.")
-    subparsers.add_parser("status", help="Show whether kamp-daemon is running.")
+    subparsers.add_parser("stop", help="Stop the kamp service.")
+    subparsers.add_parser("play", help="Start the kamp service.")
+    subparsers.add_parser("status", help="Show whether kamp is running.")
     subparsers.add_parser(
         "logout",
         help="Delete saved Bandcamp session and sync state, requiring re-authentication on the next sync.",
@@ -242,7 +242,7 @@ def main() -> None:
             print(
                 f"Config file created at {args.config}. "
                 "Edit it with your staging/library paths and contact email, "
-                "then re-run kamp-daemon.",
+                "then re-run kamp.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -250,7 +250,7 @@ def main() -> None:
     # app_name and app_version are not user-configurable — hardcoded here so the
     # User-Agent we send to MusicBrainz always accurately identifies the software.
     musicbrainzngs.set_useragent(
-        "kamp-daemon",
+        "kamp",
         _get_version(),
         config.musicbrainz.contact,
     )
@@ -430,7 +430,7 @@ def _cmd_sync(config: Config, config_path: Path, download_all: bool = False) -> 
         else:
             print(
                 f"No [bandcamp] section in {config_path}. "
-                "Add one manually or run kamp-daemon sync interactively.",
+                "Add one manually or run kamp sync interactively.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -453,7 +453,7 @@ def _cmd_daemon(config: Config, config_path: Path, menu_bar: bool = False) -> No
     pkg_version = _get_version()
     install_path = Path(__file__).resolve().parent
     _logger.info(
-        "kamp-daemon %s (Python %s, %s)",
+        "kamp %s (Python %s, %s)",
         pkg_version,
         sys.version.split()[0],
         install_path,
@@ -479,7 +479,7 @@ def _cmd_daemon_signal(sig: int, action: str) -> None:
     try:
         pid = int(_PID_PATH.read_text().strip())
     except (FileNotFoundError, ValueError):
-        print("No running kamp-daemon daemon found.", file=sys.stderr)
+        print("No running kamp daemon found.", file=sys.stderr)
         sys.exit(1)
     try:
         os.kill(pid, sig)
@@ -511,7 +511,7 @@ def _launchctl_list() -> subprocess.CompletedProcess[str]:
 # Matches simple scalar entries in launchctl list output, e.g.:
 #     "PID" = 12345;
 #     "LastExitStatus" = 256;
-#     "Label" = "com.kamp-daemon";
+#     "Label" = "com.kamp";
 # Skips complex values (arrays, nested dicts) that span multiple lines.
 _LAUNCHCTL_ENTRY_RE = re.compile(r'^\s*"(\w+)"\s*=\s*(?:"([^"]*)"|([\w./\-]+));\s*$')
 
@@ -528,7 +528,7 @@ def _parse_launchctl_info(output: str) -> dict[str, str]:
 
 
 def _service_registered() -> bool:
-    """Return True if kamp-daemon is registered in the launchd namespace.
+    """Return True if kamp is registered in the launchd namespace.
 
     A non-zero exit from `launchctl list` means the label is unknown to launchd.
     Zero exit means the service is registered (running or stopped).
@@ -537,7 +537,7 @@ def _service_registered() -> bool:
 
 
 def _service_pid() -> int | None:
-    """Return the PID of the running kamp-daemon service, or None if not running.
+    """Return the PID of the running kamp service, or None if not running.
 
     Queries launchctl for the service label. A positive PID means the process is
     alive; absent or 0 means the service is registered but not currently running.
@@ -555,29 +555,25 @@ def _service_pid() -> int | None:
 
 def _cmd_stop() -> None:
     if not _PLIST_PATH.exists():
-        print(
-            "kamp-daemon is not installed as a service. Run kamp-daemon install-service first."
-        )
+        print("kamp is not installed as a service. Run kamp install-service first.")
         return
     if _service_pid() is None:
-        print("kamp-daemon is already stopped.")
+        print("kamp is already stopped.")
         return
     # bootout stops and unregisters the service; use check=False so a
     # non-zero exit (e.g. already unloaded) doesn't raise.
     subprocess.run(
         ["launchctl", "bootout", _launchd_domain(), str(_PLIST_PATH)], check=False
     )
-    print("kamp-daemon stopped.")
+    print("kamp stopped.")
 
 
 def _cmd_play() -> None:
     if not _PLIST_PATH.exists():
-        print(
-            "kamp-daemon is not installed as a service. Run kamp-daemon install-service first."
-        )
+        print("kamp is not installed as a service. Run kamp install-service first.")
         return
     if _service_pid() is not None:
-        print("kamp-daemon is already running.")
+        print("kamp is already running.")
         return
     if _service_registered():
         # Registered but not running (PID = "-"): bootstrap would fail with EIO
@@ -591,12 +587,12 @@ def _cmd_play() -> None:
         subprocess.run(
             ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
         )
-    print("kamp-daemon started.")
+    print("kamp started.")
 
 
 def _cmd_status() -> None:
     if not _PLIST_PATH.exists():
-        print("kamp-daemon is not installed as a service.")
+        print("kamp is not installed as a service.")
         return
     pid = _service_pid()
     if pid is None:
@@ -607,10 +603,10 @@ def _cmd_status() -> None:
             info = _parse_launchctl_info(result.stdout)
             last_exit = info.get("LastExitStatus", "0")
             if last_exit != "0":
-                print(f"kamp-daemon is not running (crashed, last exit: {last_exit})")
+                print(f"kamp is not running (crashed, last exit: {last_exit})")
                 print(f"  Logs → {_LOG_PATH}")
                 return
-        print("kamp-daemon is not running.")
+        print("kamp is not running.")
         return
     ps = subprocess.run(
         ["ps", "-p", str(pid), "-o", "etime="],
@@ -618,11 +614,11 @@ def _cmd_status() -> None:
         text=True,
     )
     uptime = ps.stdout.strip() if ps.returncode == 0 else "unknown"
-    print(f"kamp-daemon is running (pid {pid}, uptime {uptime})")
+    print(f"kamp is running (pid {pid}, uptime {uptime})")
 
 
 def _cmd_install_service(config_path: Path, menu_bar: bool = False) -> None:
-    exec_path = shutil.which("kamp-daemon") or sys.argv[0]
+    exec_path = shutil.which("kamp") or sys.argv[0]
     _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     menu_bar_arg = "" if menu_bar else "\n        <string>--no-menu-bar</string>"
     plist = f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -649,13 +645,13 @@ def _cmd_install_service(config_path: Path, menu_bar: bool = False) -> None:
     subprocess.run(
         ["launchctl", "bootstrap", _launchd_domain(), str(_PLIST_PATH)], check=True
     )
-    print("kamp-daemon installed and started.")
+    print("kamp installed and started.")
     print(f"  Logs → {_LOG_PATH}")
     print("\nUseful commands:")
-    print("  kamp-daemon stop             # pause the service")
-    print("  kamp-daemon play             # resume the service")
-    print("  kamp-daemon status           # check if it's running")
-    print("  kamp-daemon uninstall-service  # remove it permanently")
+    print("  kamp stop             # pause the service")
+    print("  kamp play             # resume the service")
+    print("  kamp status           # check if it's running")
+    print("  kamp uninstall-service  # remove it permanently")
 
 
 def _cmd_uninstall_service() -> None:

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -267,7 +267,7 @@ def _validate_session(session_file: Path) -> bool:
 def _run_interactive_login(session_file: Path) -> None:
     """Open a headed Playwright browser for the user to log in, then save the session."""
     print(
-        "\n[kamp-daemon] Opening browser — please log in to Bandcamp.\n"
+        "\n[kamp] Opening browser — please log in to Bandcamp.\n"
         "The window will close automatically once login is detected.\n"
     )
 
@@ -331,7 +331,7 @@ def _session_from_cookie_file(cookie_file: Path) -> Path:
         raise CookieError(f"No Bandcamp cookies found in {cookie_file}")
 
     state: dict[str, Any] = {"cookies": cookies, "origins": []}
-    fd, tmp = tempfile.mkstemp(suffix=".json", prefix="kamp-daemon-session-")
+    fd, tmp = tempfile.mkstemp(suffix=".json", prefix="kamp-session-")
     tf = Path(tmp)
     os.close(fd)
     tf.write_text(json.dumps(state))
@@ -453,7 +453,7 @@ def _paginate(page: Any, endpoint: str, fan_id: int) -> list[dict[str, Any]]:
             _session_file().unlink(missing_ok=True)
             raise BandcampAPIError(
                 f"Bandcamp session expired (HTTP {result.get('status')}) — "
-                "session cleared. Run 'kamp-daemon sync' to re-authenticate."
+                "session cleared. Run 'kamp sync' to re-authenticate."
             )
 
         if result.get("error"):

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading and defaults for kamp-daemon."""
+"""Configuration loading and defaults for kamp."""
 
 from __future__ import annotations
 
@@ -15,8 +15,8 @@ def _state_dir() -> Path:
     if sys.platform == "win32":  # pragma: no cover
         localappdata = os.environ.get("LOCALAPPDATA")
         base = Path(localappdata) if localappdata else Path.home() / "AppData" / "Local"
-        return base / "kamp-daemon"
-    return Path("~/.local/share/kamp-daemon").expanduser()
+        return base / "kamp"
+    return Path("~/.local/share/kamp").expanduser()
 
 
 def _default_config_path() -> Path:
@@ -24,8 +24,8 @@ def _default_config_path() -> Path:
     if sys.platform == "win32":  # pragma: no cover
         appdata = os.environ.get("APPDATA")
         base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
-        return base / "kamp-daemon" / "config.toml"
-    return Path("~/.config/kamp-daemon/config.toml").expanduser()
+        return base / "kamp" / "config.toml"
+    return Path("~/.config/kamp/config.toml").expanduser()
 
 
 DEFAULT_CONFIG_PATH = _default_config_path()
@@ -104,7 +104,7 @@ class Config:
         the TOML file (substituting into DEFAULT_CONFIG_CONTENT to preserve
         comments and formatting) and returns the ready-to-use Config.
         """
-        print("\nWelcome to kamp-daemon! Let's set up your configuration.")
+        print("\nWelcome to kamp! Let's set up your configuration.")
         print(f"(Config will be saved to {path})\n")
 
         staging = Path(
@@ -193,7 +193,7 @@ class Config:
             raise FileNotFoundError(
                 f"Config file created at {path}. "
                 "Please edit it with your staging/library paths and contact email, "
-                "then re-run kamp-daemon."
+                "then re-run kamp."
             )
 
         with open(path, "rb") as f:
@@ -329,7 +329,7 @@ def _replace_in_section(text: str, section: str, field: str, toml_value: str) ->
     if not section_match:
         raise KeyError(
             f"Section [{section}] not found in config. "
-            f"Run 'kamp-daemon sync' to add [bandcamp], or check your config file."
+            f"Run 'kamp sync' to add [bandcamp], or check your config file."
         )
 
     # Find where this section ends: the next [header] or EOF

--- a/kamp_daemon/daemon_core.py
+++ b/kamp_daemon/daemon_core.py
@@ -1,4 +1,4 @@
-"""DaemonCore: lifecycle management for the kamp-daemon daemon.
+"""DaemonCore: lifecycle management for the kamp daemon.
 
 Encapsulates Watcher, Syncer, and ConfigMonitor start/stop/pause/resume,
 signal handler installation, and PID-file management so that __main__.py

--- a/kamp_daemon/menu_bar.py
+++ b/kamp_daemon/menu_bar.py
@@ -1,4 +1,4 @@
-"""macOS menu bar application for the kamp-daemon daemon.
+"""macOS menu bar application for the kamp daemon.
 
 Excluded from coverage: requires AppKit/rumps runtime (macOS only).
 Meaningfully unit-testing this module would require mocking all AppKit
@@ -26,7 +26,7 @@ from .daemon_core import DaemonCore, _PID_PATH
 
 logger = logging.getLogger(__name__)
 
-_ABOUT_URL = "https://github.com/eightyeighteyes/kamp-daemon"
+_ABOUT_URL = "https://github.com/eightyeighteyes/kamp"
 _SYMBOL_NAME = "music.note.list"  # music.note.square.stack does not exist in SF Symbols
 
 # Sync frequency options: (poll_interval_minutes, display label).
@@ -53,7 +53,7 @@ _FORMAT_LABELS: list[tuple[str, str]] = [
 
 
 class MenuBarApp(rumps.App):
-    """rumps-based menu bar application for the kamp-daemon daemon.
+    """rumps-based menu bar application for the kamp daemon.
 
     Holds a DaemonCore reference and exposes pipeline start/stop and
     Bandcamp sync controls in the macOS menu bar.
@@ -71,7 +71,7 @@ class MenuBarApp(rumps.App):
 
         # quit_button=None — we supply our own Quit item so we can call
         # DaemonCore.shutdown() before exiting the AppKit run loop.
-        super().__init__("kamp-daemon", icon=None, quit_button=None)
+        super().__init__("kamp", icon=None, quit_button=None)
 
         self._core = core
         self._sync_in_progress = False
@@ -331,7 +331,7 @@ class MenuBarApp(rumps.App):
             from AppKit import NSImage
 
             img = NSImage.imageWithSystemSymbolName_accessibilityDescription_(
-                _SYMBOL_NAME, "kamp-daemon"
+                _SYMBOL_NAME, "kamp"
             )
             if img:
                 img.setTemplate_(True)  # adapts to light/dark menu bar

--- a/kamp_daemon/pipeline.py
+++ b/kamp_daemon/pipeline.py
@@ -65,8 +65,8 @@ def _pipeline_worker(
         # called here because the parent's call does not carry over across the
         # process boundary.
         musicbrainzngs.set_useragent(
-            "kamp-daemon",
-            importlib.metadata.version("kamp-daemon"),
+            "kamp",
+            importlib.metadata.version("kamp"),
             config.musicbrainz.contact,
         )
 

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -17,7 +17,7 @@ from .tagger import TaggingError, is_tagged, read_release_mbids, tag_directory
 logger = logging.getLogger(__name__)
 
 # Marker embedded in a staging item's name to inject a failure at a specific
-# pipeline stage.  Used exclusively by `kamp-daemon test-notify` so the full
+# pipeline stage.  Used exclusively by `kamp test-notify` so the full
 # IPC notification path (pipeline_impl → stage_q → notification_callback) can
 # be exercised without a real audio file or network access.
 _TEST_INJECT = {

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -119,7 +119,7 @@ class Syncer:
     """Run Bandcamp collection sync on a configurable interval.
 
     If ``poll_interval_minutes`` is 0 the syncer is a no-op daemon — use
-    ``sync_once()`` directly (e.g. from the ``kamp-daemon sync`` subcommand).
+    ``sync_once()`` directly (e.g. from the ``kamp sync`` subcommand).
     """
 
     def __init__(self, config: Config) -> None:
@@ -209,7 +209,7 @@ class Syncer:
         collection is marked as already synced before downloading.  This
         prevents re-downloading the full collection on a first run where the
         user already has their Bandcamp purchases locally.  Pass
-        ``skip_auto_mark=True`` (e.g. via ``kamp-daemon sync --download-all``)
+        ``skip_auto_mark=True`` (e.g. via ``kamp sync --download-all``)
         to bypass this behaviour and download everything from scratch.
         """
         bc = self._config.bandcamp

--- a/launcher/main.c
+++ b/launcher/main.c
@@ -1,9 +1,9 @@
 /*
- * kamp-daemon launcher
+ * kamp launcher
  *
  * A minimal C binary that embeds Python and runs `python -m kamp_daemon`.
  * Because this binary stays alive as the top-level process (no exec), macOS
- * sets p_comm to "kamp-daemon" at exec time and it never changes — so both
+ * sets p_comm to "kamp" at exec time and it never changes — so both
  * Activity Monitor and `ps` show the correct name without any userspace tricks.
  *
  * Build (handled by the Homebrew formula):
@@ -12,7 +12,7 @@
  *     $(python3-config --cflags) \
  *     $(python3-config --ldflags --embed) \
  *     -Wno-deprecated-declarations \
- *     -o kamp-daemon
+ *     -o kamp
  *
  * VENV_PYTHON tells Python which prefix/site-packages to use so the venv's
  * packages are importable even though the binary lives outside the venv.
@@ -36,8 +36,8 @@ static const char _info_plist[] =
     "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\""
     " \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
     "<plist version=\"1.0\"><dict>"
-    "<key>CFBundleIdentifier</key><string>com.kamp-daemon</string>"
-    "<key>CFBundleName</key><string>kamp-daemon</string>"
+    "<key>CFBundleIdentifier</key><string>com.kamp</string>"
+    "<key>CFBundleName</key><string>kamp</string>"
     "<key>CFBundleVersion</key><string>1</string>"
     "</dict></plist>";
 
@@ -49,14 +49,14 @@ int main(int argc, char *argv[]) {
     /* Tell Python which interpreter prefix to use — picks up venv site-packages. */
     wchar_t *program = Py_DecodeLocale(VENV_PYTHON, NULL);
     if (program == NULL) {
-        fprintf(stderr, "kamp-daemon: Py_DecodeLocale failed\n");
+        fprintf(stderr, "kamp: Py_DecodeLocale failed\n");
         return 1;
     }
     Py_SetProgramName(program);
 
     /*
      * Inject "-m kamp_daemon" after argv[0] so the effect is:
-     *   kamp-daemon [user args]  →  python -m kamp_daemon [user args]
+     *   kamp [user args]  →  python -m kamp_daemon [user args]
      *
      * Py_Main takes wchar_t **, so each char * argument must be decoded via
      * Py_DecodeLocale.  We free them with PyMem_RawFree after Py_Main returns.
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
     for (int i = 0; i < new_argc; i++) {
         w_argv[i] = Py_DecodeLocale(char_argv[i], NULL);
         if (w_argv[i] == NULL) {
-            fprintf(stderr, "kamp-daemon: Py_DecodeLocale failed for arg %d\n", i);
+            fprintf(stderr, "kamp: Py_DecodeLocale failed for arg %d\n", i);
             for (int j = 0; j < i; j++) PyMem_RawFree(w_argv[j]);
             free(w_argv);
             PyMem_RawFree(program);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "kamp-daemon"
+name = "kamp"
 version = "1.0.1"
 description = "Automated audio library ingest from Bandcamp downloads."
 authors = []
@@ -8,7 +8,7 @@ packages = [{include = "kamp_daemon"}]
 # installed by the Homebrew formula's zsh_completion.install call; launcher/main.c
 # is compiled by the formula into the native binary. MANIFEST.in is ignored by
 # poetry-core so all three must be declared here explicitly.
-include = ["USAGE.md", "completions/_kamp-daemon", "launcher/main.c"]
+include = ["USAGE.md", "completions/_kamp", "launcher/main.c"]
 
 [tool.poetry.dependencies]
 python = ">=3.11"
@@ -31,7 +31,7 @@ types-requests = ">=2.31"
 types-Pillow = ">=10.0"
 
 [tool.poetry.scripts]
-kamp-daemon = "kamp_daemon.__main__:main"
+kamp = "kamp_daemon.__main__:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -19,14 +19,14 @@ class TestDefaultConfigPath:
             from kamp_daemon.config import _default_config_path
 
             path = _default_config_path()
-        assert path == Path.home() / ".config" / "kamp-daemon" / "config.toml"
+        assert path == Path.home() / ".config" / "kamp" / "config.toml"
 
     def test_macos_uses_xdg_config(self) -> None:
         with patch.object(sys, "platform", "darwin"):
             from kamp_daemon.config import _default_config_path
 
             path = _default_config_path()
-        assert path == Path.home() / ".config" / "kamp-daemon" / "config.toml"
+        assert path == Path.home() / ".config" / "kamp" / "config.toml"
 
     def test_windows_uses_appdata(self) -> None:
         fake_appdata = r"C:\Users\User\AppData\Roaming"
@@ -37,7 +37,7 @@ class TestDefaultConfigPath:
             from kamp_daemon.config import _default_config_path
 
             path = _default_config_path()
-        assert path == Path(fake_appdata) / "kamp-daemon" / "config.toml"
+        assert path == Path(fake_appdata) / "kamp" / "config.toml"
 
     def test_windows_fallback_without_appdata(self) -> None:
         with (
@@ -47,9 +47,7 @@ class TestDefaultConfigPath:
             from kamp_daemon.config import _default_config_path
 
             path = _default_config_path()
-        assert (
-            path == Path.home() / "AppData" / "Roaming" / "kamp-daemon" / "config.toml"
-        )
+        assert path == Path.home() / "AppData" / "Roaming" / "kamp" / "config.toml"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,7 +99,7 @@ class TestServicePid:
 
 class TestCmdStop:
     def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         with patch("kamp_daemon.__main__._PLIST_PATH", plist):
             _cmd_stop()
         assert "not installed" in capsys.readouterr().out
@@ -107,7 +107,7 @@ class TestCmdStop:
     def test_already_stopped(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         with (
             patch("kamp_daemon.__main__._PLIST_PATH", plist),
@@ -119,7 +119,7 @@ class TestCmdStop:
     def test_stops_running_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         with (
             patch("kamp_daemon.__main__._PLIST_PATH", plist),
@@ -135,7 +135,7 @@ class TestCmdStop:
 
 class TestCmdPlay:
     def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         with patch("kamp_daemon.__main__._PLIST_PATH", plist):
             _cmd_play()
         out = capsys.readouterr().out
@@ -144,7 +144,7 @@ class TestCmdPlay:
     def test_already_running(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         with (
             patch("kamp_daemon.__main__._PLIST_PATH", plist),
@@ -156,7 +156,7 @@ class TestCmdPlay:
     def test_starts_unregistered_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         with (
             patch("kamp_daemon.__main__._PLIST_PATH", plist),
@@ -173,7 +173,7 @@ class TestCmdPlay:
     def test_kickstarts_registered_but_stopped_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         domain = _launchd_domain()
         with (
@@ -191,7 +191,7 @@ class TestCmdPlay:
 
 class TestCmdStatus:
     def test_not_installed(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         with patch("kamp_daemon.__main__._PLIST_PATH", plist):
             _cmd_status()
         assert "not installed" in capsys.readouterr().out
@@ -199,7 +199,7 @@ class TestCmdStatus:
     def test_stopped_cleanly(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         # returncode=1 → not registered; no crash info, no subprocess needed
         with (
@@ -216,7 +216,7 @@ class TestCmdStatus:
     def test_crashed_shows_exit_code(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         with (
             patch("kamp_daemon.__main__._PLIST_PATH", plist),
@@ -234,7 +234,7 @@ class TestCmdStatus:
     def test_running_shows_uptime(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        plist = tmp_path / "com.kamp-daemon.plist"
+        plist = tmp_path / "com.kamp.plist"
         plist.touch()
         ps_result = MagicMock()
         ps_result.returncode = 0
@@ -263,7 +263,7 @@ class TestLogNoiseSuppression:
     def _run_main_with_log_level(self, level: str) -> None:
         from kamp_daemon.__main__ import main
 
-        with patch("sys.argv", ["kamp-daemon", "--log-level", level, "config", "show"]):
+        with patch("sys.argv", ["kamp", "--log-level", level, "config", "show"]):
             with patch("kamp_daemon.__main__._cmd_config"):
                 main()
 


### PR DESCRIPTION
## Summary

Renames every user-facing identifier from `kamp-daemon` to `kamp`. The Python module (`kamp_daemon`) is unchanged.

- **CLI:** `kamp-daemon` → `kamp`
- **Config/data paths:** `~/.config/kamp-daemon/` → `~/.config/kamp/`
- **macOS service label:** `com.kamp-daemon` → `com.kamp`
- **Process name / CFBundleIdentifier / CFBundleName:** updated in `launcher/main.c`
- **Homebrew formula:** `Formula/kamp-daemon.rb` → `Formula/kamp.rb`, class `Kamp`
- **Release workflow:** tap repo reference updated to `homebrew-kamp`
- **Docs:** all CLI examples, paths, and install instructions updated

## ⚠️ Manual step required before next release

The Homebrew tap repo must be renamed from `homebrew-kamp-daemon` → `homebrew-kamp` on GitHub before the release workflow fires, otherwise the `git clone` in `release.yml` will fail.

## Test plan

- [x] 366 tests pass: `poetry run pytest tests/ --no-cov`
- [x] `poetry run mypy kamp_daemon/` — no issues
- [x] `poetry run black --check kamp_daemon/ tests/` — clean
- [x] Manual smoke test: `poetry run kamp --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)