### PR TITLE
feat: album art

### DIFF
--- a/development/kamp.postman_collection.json
+++ b/development/kamp.postman_collection.json
@@ -35,8 +35,16 @@
           "name": "Get Tracks for Album",
           "request": {
             "method": "GET",
-            "url": "{{base_url}}/api/v1/albums/Aesop Rock/Labor Days/tracks",
-            "description": "Returns tracks for a given album sorted by disc then track number. Replace the artist and album path segments with real values."
+            "url": "{{base_url}}/api/v1/tracks?album_artist=Aesop+Rock&album=Labor+Days",
+            "description": "Returns tracks for a given album sorted by disc then track number. Artist/album are query params (not path segments) to support names containing slashes (e.g. AC/DC)."
+          }
+        },
+        {
+          "name": "Get Album Art",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/album-art?album_artist=Aesop+Rock&album=Labor+Days",
+            "description": "Returns the embedded cover image as image/jpeg or image/png. Returns 404 if no art is embedded. Same query-param pattern as Get Tracks for Album."
           }
         },
         {

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -65,6 +65,7 @@ class AlbumInfo:
     album: str
     year: str
     track_count: int
+    has_art: bool = False
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -146,7 +147,8 @@ class LibraryIndex:
     def albums(self) -> list[AlbumInfo]:
         """Return one AlbumInfo per (album_artist, album) pair, sorted."""
         rows = self._conn.execute("""
-            SELECT album_artist, album, year, COUNT(*) AS track_count
+            SELECT album_artist, album, year, COUNT(*) AS track_count,
+                   MAX(embedded_art) AS has_art
             FROM tracks
             GROUP BY album_artist, album
             ORDER BY album_artist COLLATE NOCASE, album COLLATE NOCASE
@@ -157,6 +159,7 @@ class LibraryIndex:
                 album=r["album"],
                 year=r["year"],
                 track_count=r["track_count"],
+                has_art=bool(r["has_art"]),
             )
             for r in rows
         ]
@@ -224,6 +227,56 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         mb_release_id=row["mb_release_id"],
         mb_recording_id=row["mb_recording_id"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Artwork extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_art(path: Path) -> tuple[bytes, str] | None:
+    """Extract the first embedded cover image from an audio file.
+
+    Returns (data, mime_type) or None if no art is found or the file
+    cannot be read.  Supports MP3, M4A, FLAC, and OGG.
+    """
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".mp3":
+            tags = id3.ID3(str(path))
+            for key in tags:
+                if key.startswith("APIC"):
+                    frame = tags[key]
+                    return bytes(frame.data), str(frame.mime)
+        elif suffix == ".m4a":  # pragma: no branch
+            audio = mutagen.mp4.MP4(str(path))
+            covr = (audio.tags or {}).get("covr")
+            if covr:
+                img = covr[0]
+                mime = (
+                    "image/jpeg"
+                    if img.imageformat == mutagen.mp4.MP4Cover.FORMAT_JPEG
+                    else "image/png"
+                )
+                return bytes(img), mime
+        elif suffix == ".flac":
+            audio = mutagen.flac.FLAC(str(path))
+            if audio.pictures:
+                pic = audio.pictures[0]
+                return bytes(pic.data), str(pic.mime)
+        elif suffix == ".ogg":
+            import base64
+
+            from mutagen.flac import Picture
+
+            audio = mutagen.oggvorbis.OggVorbis(str(path))
+            blocks = (audio.tags or {}).get("metadata_block_picture", [])
+            if blocks:
+                pic = Picture(base64.b64decode(blocks[0]))
+                return bytes(pic.data), str(pic.mime)
+    except Exception:
+        pass
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, WebSocket
+from fastapi import FastAPI, HTTPException, Response, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from kamp_core.library import LibraryIndex, LibraryScanner, Track
+from kamp_core.library import LibraryIndex, LibraryScanner, Track, extract_art
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
 # ---------------------------------------------------------------------------
@@ -64,6 +64,7 @@ class AlbumOut(BaseModel):
     album: str
     year: str
     track_count: int
+    has_art: bool
 
 
 class PlayerStateOut(BaseModel):
@@ -152,6 +153,7 @@ def create_app(
                 album=a.album,
                 year=a.year,
                 track_count=a.track_count,
+                has_art=a.has_art,
             )
             for a in index.albums()
         ]
@@ -168,6 +170,17 @@ def create_app(
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
         ]
+
+    @app.get("/api/v1/albums/{album_artist}/{album}/art")
+    def get_album_art(album_artist: str, album: str) -> Response:
+        tracks = index.tracks_for_album(album_artist, album)
+        for track in tracks:
+            if track.embedded_art:
+                result = extract_art(track.file_path)
+                if result:
+                    data, mime = result
+                    return Response(content=data, media_type=mime)
+        raise HTTPException(status_code=404, detail="No art found")
 
     @app.post("/api/v1/library/scan", response_model=ScanResult)
     def scan_library() -> ScanResult:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -162,16 +162,15 @@ def create_app(
     def get_artists() -> list[str]:
         return index.artists()
 
-    @app.get(
-        "/api/v1/albums/{album_artist}/{album}/tracks",
-        response_model=list[TrackOut],
-    )
+    @app.get("/api/v1/tracks", response_model=list[TrackOut])
     def get_tracks(album_artist: str, album: str) -> list[TrackOut]:
+        # Query parameters instead of path segments — artist/album names may
+        # contain slashes (e.g. "AC/DC") which would break URL path routing.
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
         ]
 
-    @app.get("/api/v1/albums/{album_artist}/{album}/art")
+    @app.get("/api/v1/album-art")
     def get_album_art(album_artist: str, album: str) -> Response:
         tracks = index.tracks_for_album(album_artist, album)
         for track in tracks:

--- a/kamp_ui/src/renderer/index.html
+++ b/kamp_ui/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
     />
   </head>
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -26,6 +26,7 @@ export type Album = {
   album: string
   year: string
   track_count: number
+  has_art: boolean
 }
 
 export type PlayerState = {
@@ -68,6 +69,11 @@ async function get<T>(path: string): Promise<T> {
 // ---------------------------------------------------------------------------
 
 export const getAlbums = (): Promise<Album[]> => get('/api/v1/albums')
+
+// Returns the URL for an album's cover art; load it in an <img> src.
+// The server returns 404 when no art is embedded — handle with onError.
+export const artUrl = (albumArtist: string, album: string): string =>
+  `${BASE_URL}/api/v1/albums/${encodeURIComponent(albumArtist)}/${encodeURIComponent(album)}/art`
 
 export const getArtists = (): Promise<string[]> => get('/api/v1/artists')
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -73,12 +73,14 @@ export const getAlbums = (): Promise<Album[]> => get('/api/v1/albums')
 // Returns the URL for an album's cover art; load it in an <img> src.
 // The server returns 404 when no art is embedded — handle with onError.
 export const artUrl = (albumArtist: string, album: string): string =>
-  `${BASE_URL}/api/v1/albums/${encodeURIComponent(albumArtist)}/${encodeURIComponent(album)}/art`
+  `${BASE_URL}/api/v1/album-art?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
 
 export const getArtists = (): Promise<string[]> => get('/api/v1/artists')
 
 export const getTracksForAlbum = (albumArtist: string, album: string): Promise<Track[]> =>
-  get(`/api/v1/albums/${encodeURIComponent(albumArtist)}/${encodeURIComponent(album)}/tracks`)
+  get(
+    `/api/v1/tracks?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
+  )
 
 export const scanLibrary = (): Promise<ScanResult> => post('/api/v1/library/scan')
 

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -144,11 +144,20 @@ body,
   font-size: 28px;
   color: var(--text-dim);
   position: relative;
+  overflow: hidden;
 }
 
-/* Placeholder art — replaced in Phase 2 when artwork embedding is surfaced */
-.album-art::before {
+/* Placeholder glyph — hidden once real art loads */
+.album-art:not(.has-art)::before {
   content: '♪';
+}
+
+.album-art-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .now-playing-badge {
@@ -336,9 +345,25 @@ body,
 
 .track-list-album-info {
   display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  overflow: hidden;
+}
+
+.track-list-album-art {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.track-list-album-text {
+  display: flex;
   flex-direction: column;
   gap: 2px;
-  flex: 1;
   overflow: hidden;
 }
 

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -1,18 +1,29 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
+import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
 
 function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
+  const [artLoaded, setArtLoaded] = useState(false)
 
   const isActive =
     currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
   return (
     <div className={`album-card${isActive ? ' playing' : ''}`} onClick={() => selectAlbum(album)}>
-      <div className="album-art">
+      <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
+        {album.has_art && (
+          <img
+            className="album-art-img"
+            src={artUrl(album.album_artist, album.album)}
+            alt=""
+            onLoad={() => setArtLoaded(true)}
+            onError={() => setArtLoaded(false)}
+          />
+        )}
         {playing && isActive && <div className="now-playing-badge">▶</div>}
       </div>
       <div className="album-info">

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useStore } from '../store'
+import { artUrl } from '../api/client'
 
 export function TrackList(): React.JSX.Element | null {
   const album = useStore((s) => s.library.selectedAlbum)
@@ -22,9 +23,18 @@ export function TrackList(): React.JSX.Element | null {
           ← Albums
         </button>
         <div className="track-list-album-info">
-          <span className="track-list-album-title">{album.album}</span>
-          <span className="track-list-album-artist">{album.album_artist}</span>
-          <span className="track-list-album-year">{album.year}</span>
+          {album.has_art && (
+            <img
+              className="track-list-album-art"
+              src={artUrl(album.album_artist, album.album)}
+              alt=""
+            />
+          )}
+          <div className="track-list-album-text">
+            <span className="track-list-album-title">{album.album}</span>
+            <span className="track-list-album-artist">{album.album_artist}</span>
+            <span className="track-list-album-year">{album.year}</span>
+          </div>
         </div>
         <button
           className="play-all-btn"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -15,6 +15,7 @@ from kamp_core.library import (
     LibraryScanner,
     ScanResult,
     Track,
+    extract_art,
     _read_mp3_tags,
     _read_m4a_tags,
     _read_vorbis_tags,
@@ -225,6 +226,74 @@ class TestLibraryIndex:
         index.upsert_track(_sample_track(tmp_path / "01.mp3"))
         assert len(index.all_tracks()) == 1
         index.close()
+
+    def test_albums_has_art_true_when_track_has_embedded_art(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "1.mp3")
+        t.embedded_art = True
+        index.upsert_track(t)
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_art is True
+
+    def test_albums_has_art_false_when_no_embedded_art(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_track(_sample_track(tmp_path / "1.mp3"))
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_art is False
+
+    def test_albums_has_art_true_when_any_track_has_art(self, tmp_path: Path) -> None:
+        """has_art is True if at least one track in the album has embedded art."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "1.mp3")
+        t1.track_number = 1
+        t1.embedded_art = False
+        t2 = _sample_track(tmp_path / "2.mp3")
+        t2.track_number = 2
+        t2.embedded_art = True
+        index.upsert_many([t1, t2])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_art is True
+
+
+# ---------------------------------------------------------------------------
+# extract_art
+# ---------------------------------------------------------------------------
+
+
+class TestExtractArt:
+    def test_mp3_with_apic_returns_data_and_mime(self, tmp_path: Path) -> None:
+        path = tmp_path / "track.mp3"
+        path.write_bytes(b"\xff\xfb" * 64)
+        img_data = b"\xff\xd8\xff\xe0" + b"\x00" * 16
+        tags = id3.ID3()
+        tags.add(
+            id3.APIC(encoding=3, mime="image/jpeg", type=3, desc="Cover", data=img_data)
+        )
+        tags.save(str(path))
+
+        result = extract_art(path)
+
+        assert result is not None
+        data, mime = result
+        assert data == img_data
+        assert mime == "image/jpeg"
+
+    def test_mp3_without_art_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "track.mp3"
+        _make_mp3(path, title="No Art")
+
+        assert extract_art(path) is None
+
+    def test_nonexistent_path_returns_none(self, tmp_path: Path) -> None:
+        assert extract_art(tmp_path / "ghost.mp3") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,8 +35,12 @@ def _track(n: int, album: str = "Album", artist: str = "Artist") -> Track:
     )
 
 
-def _album(artist: str, album: str, year: str = "2024", count: int = 10) -> AlbumInfo:
-    return AlbumInfo(album_artist=artist, album=album, year=year, track_count=count)
+def _album(
+    artist: str, album: str, year: str = "2024", count: int = 10, has_art: bool = False
+) -> AlbumInfo:
+    return AlbumInfo(
+        album_artist=artist, album=album, year=year, track_count=count, has_art=has_art
+    )
 
 
 @pytest.fixture()
@@ -103,7 +107,65 @@ class TestAlbumsEndpoint:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         album = c.get("/api/v1/albums").json()[0]
-        assert set(album.keys()) >= {"album_artist", "album", "year", "track_count"}
+        assert set(album.keys()) >= {
+            "album_artist",
+            "album",
+            "year",
+            "track_count",
+            "has_art",
+        }
+
+    def test_album_has_art_field(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.albums.return_value = [_album("Artist", "Record", has_art=True)]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        album = c.get("/api/v1/albums").json()[0]
+        assert album["has_art"] is True
+
+
+class TestAlbumArtEndpoint:
+    def test_returns_art_bytes_when_embedded(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.embedded_art = True
+        mock_index.tracks_for_album.return_value = [track]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with patch(
+            "kamp_core.server.extract_art", return_value=(b"IMGDATA", "image/jpeg")
+        ):
+            res = c.get("/api/v1/albums/Artist/Album/art")
+        assert res.status_code == 200
+        assert res.content == b"IMGDATA"
+        assert "image/jpeg" in res.headers["content-type"]
+
+    def test_returns_404_when_no_tracks(self, client: TestClient) -> None:
+        res = client.get("/api/v1/albums/Unknown/Ghost/art")
+        assert res.status_code == 404
+
+    def test_returns_404_when_no_tracks_have_art(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]  # embedded_art=False
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        res = c.get("/api/v1/albums/Artist/Album/art")
+        assert res.status_code == 404
+
+    def test_returns_404_when_extract_returns_none(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.embedded_art = True
+        mock_index.tracks_for_album.return_value = [track]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with patch("kamp_core.server.extract_art", return_value=None):
+            res = c.get("/api/v1/albums/Artist/Album/art")
+        assert res.status_code == 404
 
 
 class TestArtistsEndpoint:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,13 +137,13 @@ class TestAlbumArtEndpoint:
         with patch(
             "kamp_core.server.extract_art", return_value=(b"IMGDATA", "image/jpeg")
         ):
-            res = c.get("/api/v1/albums/Artist/Album/art")
+            res = c.get("/api/v1/album-art?album_artist=Artist&album=Album")
         assert res.status_code == 200
         assert res.content == b"IMGDATA"
         assert "image/jpeg" in res.headers["content-type"]
 
     def test_returns_404_when_no_tracks(self, client: TestClient) -> None:
-        res = client.get("/api/v1/albums/Unknown/Ghost/art")
+        res = client.get("/api/v1/album-art?album_artist=Unknown&album=Ghost")
         assert res.status_code == 404
 
     def test_returns_404_when_no_tracks_have_art(
@@ -152,7 +152,7 @@ class TestAlbumArtEndpoint:
         mock_index.tracks_for_album.return_value = [_track(1)]  # embedded_art=False
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
-        res = c.get("/api/v1/albums/Artist/Album/art")
+        res = c.get("/api/v1/album-art?album_artist=Artist&album=Album")
         assert res.status_code == 404
 
     def test_returns_404_when_extract_returns_none(
@@ -164,7 +164,7 @@ class TestAlbumArtEndpoint:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         with patch("kamp_core.server.extract_art", return_value=None):
-            res = c.get("/api/v1/albums/Artist/Album/art")
+            res = c.get("/api/v1/album-art?album_artist=Artist&album=Album")
         assert res.status_code == 404
 
 
@@ -193,7 +193,7 @@ class TestTracksForAlbumEndpoint:
         ]
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
-        data = c.get("/api/v1/albums/Aesop Rock/Labor Days/tracks").json()
+        data = c.get("/api/v1/tracks?album_artist=Aesop+Rock&album=Labor+Days").json()
         assert len(data) == 2
         assert data[0]["title"] == "Track 1"
         mock_index.tracks_for_album.assert_called_once_with("Aesop Rock", "Labor Days")
@@ -204,7 +204,7 @@ class TestTracksForAlbumEndpoint:
         mock_index.tracks_for_album.return_value = [_track(1)]
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
-        track = c.get("/api/v1/albums/Artist/Album/tracks").json()[0]
+        track = c.get("/api/v1/tracks?album_artist=Artist&album=Album").json()[0]
         assert set(track.keys()) >= {
             "title",
             "artist",
@@ -216,7 +216,7 @@ class TestTracksForAlbumEndpoint:
         }
 
     def test_returns_empty_list_for_unknown_album(self, client: TestClient) -> None:
-        response = client.get("/api/v1/albums/Unknown/Ghost/tracks")
+        response = client.get("/api/v1/tracks?album_artist=Unknown&album=Ghost")
         assert response.status_code == 200
         assert response.json() == []
 


### PR DESCRIPTION
## Summary

- `extract_art()` extracts embedded cover images from MP3 (APIC), M4A (covr), FLAC (pictures), and OGG (METADATA_BLOCK_PICTURE)
- `GET /api/v1/album-art?album_artist=&album=` serves the raw image bytes; returns 404 when none embedded
- `AlbumOut` gains `has_art: bool` (derived from `MAX(embedded_art)` in the albums query) so the UI skips the request for art-free albums
- Album grid cards display the cover image; placeholder ♪ glyph shown when no art
- Track list header shows a 56px thumbnail next to the album title
- CSP `img-src` extended to allow `http://127.0.0.1:*`
- Tracks and art endpoints use query parameters instead of path segments — fixes lookups for artists with slashes in their name (e.g. AC/DC)

## Test plan

- [ ] Album grid shows cover art for albums with embedded art; ♪ placeholder for albums without
- [ ] Track list header shows thumbnail
- [ ] AC/DC (or any artist with `/` in the name) loads tracks and art correctly
- [ ] `GET /api/v1/album-art?album_artist=...&album=...` returns image bytes with correct Content-Type
- [ ] `GET /api/v1/album-art` returns 404 for an album with no embedded art
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)