### PR TITLE
feat: error states for server offline and reconnecting

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -9,25 +9,52 @@ import { TransportBar } from './components/TransportBar'
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
   const applyServerState = useStore((s) => s.applyServerState)
+  const setServerStatus = useStore((s) => s.setServerStatus)
+  const serverStatus = useStore((s) => s.serverStatus)
+  const hasAlbums = useStore((s) => s.library.albums.length > 0)
   const selectedAlbum = useStore((s) => s.library.selectedAlbum)
 
   useEffect(() => {
     loadLibrary()
 
-    // Connect WebSocket state stream. The cleanup function closes the
-    // socket and stops the polling interval when the component unmounts.
-    const disconnect = connectStateStream(applyServerState, () => {
-      // Reconnect after a short delay if the server closes the socket.
-      setTimeout(() => {
-        connectStateStream(applyServerState)
-      }, 2000)
-    })
+    // Connect WebSocket state stream. Re-establishes automatically when the
+    // server restarts. Each reconnect also reloads the library in case albums
+    // were added while the server was down.
+    const connect = (): (() => void) => {
+      return connectStateStream(
+        applyServerState,
+        () => {
+          setServerStatus('disconnected')
+          setTimeout(connect, 2000)
+        },
+        () => {
+          setServerStatus('connected')
+          loadLibrary()
+        }
+      )
+    }
 
+    const disconnect = connect()
     return disconnect
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  if (serverStatus === 'disconnected' && !hasAlbums) {
+    return (
+      <div className="server-offline">
+        <div className="server-offline-icon">⏻</div>
+        <div className="server-offline-title">kamp server is not running</div>
+        <div className="server-offline-hint">
+          Start it with <code>kamp server</code>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="app">
+      {serverStatus === 'disconnected' && (
+        <div className="reconnecting-banner">Reconnecting to server…</div>
+      )}
       <div className="app-body">
         <ArtistPanel />
         <main className="main-content">{selectedAlbum ? <TrackList /> : <AlbumGrid />}</main>

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -115,9 +115,12 @@ export type StateMessage = PlayerState & { type: 'player.state' }
 
 export function connectStateStream(
   onState: (state: PlayerState) => void,
-  onClose?: () => void
+  onClose?: () => void,
+  onOpen?: () => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
+
+  ws.onopen = () => onOpen?.()
 
   ws.onmessage = (event) => {
     try {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -42,6 +42,50 @@ body,
   height: 100%;
 }
 
+/* Server offline — full-screen prompt shown before any library data loads */
+.server-offline {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 12px;
+  color: var(--text-dim);
+}
+
+.server-offline-icon {
+  font-size: 48px;
+  opacity: 0.4;
+}
+
+.server-offline-title {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.server-offline-hint {
+  font-size: 13px;
+}
+
+.server-offline-hint code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: monospace;
+}
+
+/* Reconnecting banner — shown when connection drops but library is cached */
+.reconnecting-banner {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 4px 16px;
+  text-align: center;
+}
+
 .app-body {
   display: flex;
   flex: 1;

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -22,8 +22,10 @@ type LibraryState = {
 type PlayerStore = {
   player: PlayerState
   library: LibraryState
+  serverStatus: 'connected' | 'disconnected'
 
   // Actions
+  setServerStatus: (status: 'connected' | 'disconnected') => void
   loadLibrary: () => Promise<void>
   selectArtist: (artist: string | null) => void
   selectAlbum: (album: Album | null) => Promise<void>
@@ -60,12 +62,19 @@ export const useStore = create<PlayerStore>((set, get) => ({
     tracks: [],
     tracksAlbumKey: null
   },
+  serverStatus: 'disconnected',
+
+  setServerStatus: (status) => set({ serverStatus: status }),
 
   applyServerState: (state) => set({ player: state }),
 
   loadLibrary: async () => {
-    const [albums, artists] = await Promise.all([api.getAlbums(), api.getArtists()])
-    set((s) => ({ library: { ...s.library, albums, artists } }))
+    try {
+      const [albums, artists] = await Promise.all([api.getAlbums(), api.getArtists()])
+      set((s) => ({ library: { ...s.library, albums, artists }, serverStatus: 'connected' }))
+    } catch {
+      set({ serverStatus: 'disconnected' })
+    }
   },
 
   selectArtist: (artist) =>


### PR DESCRIPTION
## Summary

- Full-screen "kamp server is not running" prompt when the server is unreachable and no library data has been loaded yet
- Slim "Reconnecting to server…" banner when the connection drops mid-session (library stays browsable with stale data)
- `loadLibrary()` catches fetch errors and sets `serverStatus = 'disconnected'`
- `connectStateStream()` gains an `onOpen` callback; `App.tsx` uses it to mark connected and reload the library on each reconnect

## Test plan

- [x] With `kamp server` not running: full-screen offline prompt appears
- [x] Start `kamp server` after the prompt: UI connects and library loads without a refresh
- [x] Kill `kamp server` while the app is open: reconnecting banner appears; library still browsable
- [x] Restart `kamp server`: banner disappears, library refreshes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)