### PR TITLE
feat: first-run setup screen with library scan

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
 import { AlbumGrid } from './components/AlbumGrid'
+import { SetupScreen } from './components/SetupScreen'
 import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
 
@@ -50,14 +51,18 @@ export default function App(): React.JSX.Element {
     )
   }
 
+  const showSetup = serverStatus === 'connected' && !hasAlbums
+
   return (
     <div className="app">
       {serverStatus === 'disconnected' && (
         <div className="reconnecting-banner">Reconnecting to server…</div>
       )}
       <div className="app-body">
-        <ArtistPanel />
-        <main className="main-content">{selectedAlbum ? <TrackList /> : <AlbumGrid />}</main>
+        {!showSetup && <ArtistPanel />}
+        <main className="main-content">
+          {showSetup ? <SetupScreen /> : selectedAlbum ? <TrackList /> : <AlbumGrid />}
+        </main>
       </div>
       <TransportBar />
     </div>

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -86,6 +86,98 @@ body,
   text-align: center;
 }
 
+/* Setup screen ------------------------------------------------------------- */
+
+.setup-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 16px;
+  color: var(--text-dim);
+}
+
+.setup-icon {
+  font-size: 52px;
+  opacity: 0.3;
+}
+
+.setup-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.setup-hint {
+  font-size: 13px;
+  text-align: center;
+  max-width: 380px;
+  line-height: 1.6;
+}
+
+.setup-hint code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.setup-scan-btn {
+  background: var(--accent);
+  border: none;
+  color: #000;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 28px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.setup-scan-btn:hover {
+  opacity: 0.85;
+}
+
+.setup-scanning {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.setup-spinner {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.setup-result {
+  font-size: 14px;
+  color: var(--accent);
+}
+
+.setup-error {
+  font-size: 13px;
+  color: #e06c75;
+  text-align: center;
+  max-width: 380px;
+  line-height: 1.6;
+}
+
+/* App body ----------------------------------------------------------------- */
+
 .app-body {
   display: flex;
   flex: 1;

--- a/kamp_ui/src/renderer/src/components/SetupScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SetupScreen.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { useStore } from '../store'
+
+export function SetupScreen(): React.JSX.Element {
+  const scanLibrary = useStore((s) => s.scanLibrary)
+  const scanStatus = useStore((s) => s.scanStatus)
+  const lastScanResult = useStore((s) => s.lastScanResult)
+  const scanError = useStore((s) => s.scanError)
+
+  return (
+    <div className="setup-screen">
+      <div className="setup-icon">♫</div>
+      <div className="setup-title">Your library is empty</div>
+
+      {scanStatus === 'idle' && (
+        <>
+          <div className="setup-hint">
+            Point <code>paths.library</code> at your music folder in{' '}
+            <code>~/.config/kamp/config.toml</code>, then scan to index it.
+          </div>
+          <button className="setup-scan-btn" onClick={scanLibrary}>
+            Scan Library
+          </button>
+        </>
+      )}
+
+      {scanStatus === 'scanning' && (
+        <div className="setup-scanning">
+          <span className="setup-spinner" />
+          Scanning…
+        </div>
+      )}
+
+      {scanStatus === 'done' && lastScanResult && (
+        <div className="setup-result">
+          Added {lastScanResult.added} track
+          {lastScanResult.added !== 1 ? 's' : ''}
+          {lastScanResult.removed > 0 ? `, removed ${lastScanResult.removed}` : ''}.
+        </div>
+      )}
+
+      {scanStatus === 'error' && scanError && (
+        <>
+          <div className="setup-error">{scanError}</div>
+          <button className="setup-scan-btn" onClick={scanLibrary}>
+            Retry
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -8,7 +8,7 @@
 
 import { create } from 'zustand'
 import * as api from './api/client'
-import type { Album, PlayerState, Track } from './api/client'
+import type { Album, PlayerState, ScanResult, Track } from './api/client'
 
 type LibraryState = {
   albums: Album[]
@@ -23,6 +23,9 @@ type PlayerStore = {
   player: PlayerState
   library: LibraryState
   serverStatus: 'connected' | 'disconnected'
+  scanStatus: 'idle' | 'scanning' | 'done' | 'error'
+  lastScanResult: ScanResult | null
+  scanError: string | null
 
   // Actions
   setServerStatus: (status: 'connected' | 'disconnected') => void
@@ -63,6 +66,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
     tracksAlbumKey: null
   },
   serverStatus: 'disconnected',
+  scanStatus: 'idle',
+  lastScanResult: null,
+  scanError: null,
 
   setServerStatus: (status) => set({ serverStatus: status }),
 
@@ -139,7 +145,17 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   scanLibrary: async () => {
-    await api.scanLibrary()
-    await get().loadLibrary()
+    set({ scanStatus: 'scanning', scanError: null })
+    try {
+      const result = await api.scanLibrary()
+      set({ scanStatus: 'done', lastScanResult: result })
+      await get().loadLibrary()
+    } catch (err) {
+      const msg =
+        err instanceof Error && err.message.includes('503')
+          ? 'Library path not configured. Set paths.library in your config.toml and restart the server.'
+          : 'Scan failed. Check the server logs for details.'
+      set({ scanStatus: 'error', scanError: msg })
+    }
   }
 }))


### PR DESCRIPTION
## Summary

- `SetupScreen` component shown when the server is reachable but the library index is empty
- Scan Library button calls `POST /api/v1/library/scan` with spinner → result → normal library view
- Handles 503 (library path not configured) with a message pointing to `config.toml`
- `scanStatus` / `lastScanResult` / `scanError` tracked in the store
- Artist panel hidden during setup (nothing to filter yet)

## Test plan

- [x] Fresh index: setup screen appears with Scan Library button
- [x] Click Scan Library: spinner while scanning, then result count, then library appears
- [x] Start server without `paths.library` set: error message with config.toml hint
- [x] Retry button re-triggers the scan
- [x] Already-indexed library: setup screen is skipped entirely
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)