### PR TITLE
style: Phase 1 UI polish

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -19,6 +19,8 @@
   --text-dim: #888;
   --accent: #e07c3c;
   --accent-dim: #7a3d1a;
+  --error: #e06c75;
+  --text-on-accent: #000;
   --transport-h: 88px;
   --panel-w: 200px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -128,7 +130,7 @@ body,
 .setup-scan-btn {
   background: var(--accent);
   border: none;
-  color: #000;
+  color: var(--text-on-accent);
   font-size: 14px;
   font-weight: 600;
   padding: 10px 28px;
@@ -170,7 +172,7 @@ body,
 
 .setup-error {
   font-size: 13px;
-  color: #e06c75;
+  color: var(--error);
   text-align: center;
   max-width: 380px;
   line-height: 1.6;
@@ -301,7 +303,7 @@ body,
   bottom: 6px;
   right: 6px;
   background: var(--accent);
-  color: #000;
+  color: var(--text-on-accent);
   font-size: 11px;
   padding: 2px 5px;
   border-radius: 3px;
@@ -524,7 +526,7 @@ body,
 .play-all-btn {
   background: var(--accent);
   border: none;
-  color: #000;
+  color: var(--text-on-accent);
   padding: 6px 14px;
   border-radius: 4px;
   cursor: pointer;

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -259,12 +259,14 @@ body,
   background: var(--surface);
   transition:
     transform 0.1s,
-    background 0.1s;
+    background 0.1s,
+    box-shadow 0.1s;
 }
 
 .album-card:hover {
   background: var(--surface-hover);
-  transform: translateY(-2px);
+  transform: translateY(-3px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .album-card.playing {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -426,7 +426,6 @@ body,
 
 .seek-bar {
   flex: 1;
-  accent-color: var(--accent);
   cursor: pointer;
 }
 
@@ -446,8 +445,69 @@ body,
 
 .volume-slider {
   width: 80px;
-  accent-color: var(--accent);
   cursor: pointer;
+}
+
+/* Custom range input styling ----------------------------------------------- */
+
+.seek-bar,
+.volume-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}
+
+.seek-bar::-webkit-slider-runnable-track,
+.volume-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--accent) 0%,
+    var(--accent) var(--range-progress, 0%),
+    var(--border) var(--range-progress, 0%),
+    var(--border) 100%
+  );
+}
+
+.seek-bar::-webkit-slider-thumb,
+.volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: -5px; /* center on 4px track: (14-4)/2 = 5 */
+  transition: transform 0.1s;
+}
+
+.seek-bar::-webkit-slider-thumb:hover,
+.volume-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+.seek-bar::-moz-range-track,
+.volume-slider::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+}
+
+.seek-bar::-moz-range-progress,
+.volume-slider::-moz-range-progress {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+
+.seek-bar::-moz-range-thumb,
+.volume-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
 }
 
 .volume-label {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -190,6 +190,8 @@ body,
   flex: 1;
   overflow-y: auto;
   padding: 16px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 /* Artist panel ------------------------------------------------------------- */
@@ -217,6 +219,8 @@ body,
   list-style: none;
   overflow-y: auto;
   flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .artist-list li {
@@ -546,6 +550,8 @@ body,
   list-style: none;
   overflow-y: auto;
   flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .track-row {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -603,6 +603,21 @@ body,
   max-width: 160px;
 }
 
+/* Focus-visible rings ----------------------------------------------------- */
+
+.artist-list li:focus-visible,
+.album-card:focus-visible,
+.transport-btn:focus-visible,
+.back-btn:focus-visible,
+.play-all-btn:focus-visible,
+.setup-scan-btn:focus-visible,
+.track-row:focus-visible,
+.seek-bar:focus-visible,
+.volume-slider:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* Active / press feedback ------------------------------------------------- */
 
 .transport-btn:active,

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -592,3 +592,23 @@ body,
   text-overflow: ellipsis;
   max-width: 160px;
 }
+
+/* Active / press feedback ------------------------------------------------- */
+
+.transport-btn:active,
+.back-btn:active,
+.play-all-btn:active,
+.setup-scan-btn:active {
+  opacity: 0.75;
+  transform: scale(0.96);
+}
+
+.album-card:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.track-row:active,
+.artist-list li:active {
+  opacity: 0.7;
+}

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -17,8 +17,8 @@
   --border: #2e2e2e;
   --text: #e0e0e0;
   --text-dim: #888;
-  --accent: #e07c3c;
-  --accent-dim: #7a3d1a;
+  --accent: #7c86e1;
+  --accent-dim: #252b5c;
   --error: #e06c75;
   --text-on-accent: #000;
   --transport-h: 88px;
@@ -274,11 +274,11 @@ body,
 }
 
 .album-card.playing {
-  box-shadow: 0 0 0 3px rgba(224, 124, 60, 0.35);
+  box-shadow: 0 0 0 3px rgba(124, 134, 225, 0.35);
 }
 
 .album-card.playing:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(224, 124, 60, 0.35);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(124, 134, 225, 0.35);
 }
 
 .album-art {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -274,8 +274,11 @@ body,
 }
 
 .album-card.playing {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  box-shadow: 0 0 0 3px rgba(224, 124, 60, 0.35);
+}
+
+.album-card.playing:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(224, 124, 60, 0.35);
 }
 
 .album-art {
@@ -311,6 +314,7 @@ body,
   background: var(--accent);
   color: var(--text-on-accent);
   font-size: 11px;
+  font-weight: 600;
   padding: 2px 5px;
   border-radius: 3px;
 }

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -13,7 +13,12 @@ function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
   return (
-    <div className={`album-card${isActive ? ' playing' : ''}`} onClick={() => selectAlbum(album)}>
+    <div
+      className={`album-card${isActive ? ' playing' : ''}`}
+      tabIndex={0}
+      onClick={() => selectAlbum(album)}
+      onKeyDown={(e) => e.key === 'Enter' && selectAlbum(album)}
+    >
       <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
           <img

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -10,14 +10,21 @@ export function ArtistPanel(): React.JSX.Element {
     <aside className="artist-panel">
       <div className="panel-header">Artists</div>
       <ul className="artist-list">
-        <li className={selected === null ? 'active' : ''} onClick={() => selectArtist(null)}>
+        <li
+          className={selected === null ? 'active' : ''}
+          tabIndex={0}
+          onClick={() => selectArtist(null)}
+          onKeyDown={(e) => e.key === 'Enter' && selectArtist(null)}
+        >
           All Artists
         </li>
         {artists.map((artist) => (
           <li
             key={artist}
             className={selected === artist ? 'active' : ''}
+            tabIndex={0}
             onClick={() => selectArtist(artist)}
+            onKeyDown={(e) => e.key === 'Enter' && selectArtist(artist)}
           >
             {artist}
           </li>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -51,12 +51,18 @@ export function TrackList(): React.JSX.Element | null {
             <li
               key={`${track.disc_number}-${track.track_number}`}
               className={`track-row${isCurrent ? ' current' : ''}`}
+              tabIndex={0}
               onClick={() => {
                 if (isCurrent) {
                   togglePlayPause()
                 } else {
                   playTrack(album.album_artist, album.album, i)
                 }
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return
+                if (isCurrent) togglePlayPause()
+                else playTrack(album.album_artist, album.album, i)
               }}
             >
               <span className="track-row-num">

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -60,6 +60,9 @@ export function TransportBar(): React.JSX.Element {
           step={0.5}
           value={position}
           onChange={(e) => seek(parseFloat(e.target.value))}
+          style={
+            { '--range-progress': `${(position / (duration || 1)) * 100}%` } as React.CSSProperties
+          }
         />
         <span className="time">{formatTime(duration)}</span>
       </div>
@@ -73,6 +76,7 @@ export function TransportBar(): React.JSX.Element {
           max={100}
           value={volume}
           onChange={(e) => setVolume(parseInt(e.target.value, 10))}
+          style={{ '--range-progress': `${volume}%` } as React.CSSProperties}
         />
         <span className="volume-label">{volume}</span>
       </div>


### PR DESCRIPTION
## Summary

- Add `--error` and `--text-on-accent` CSS variables; replace all hardcoded `#000` / `#e06c75` literals
- Album card hover lift: deepen translateY and add `box-shadow` for physical depth
- Active press feedback on buttons, album cards, and list rows
- Thin, styled scrollbars on artist panel, track rows, and main content
- Replace now-playing `outline` with an accent glow `box-shadow` that respects border-radius; bump badge `font-weight` to 600
- Focus-visible accent rings on all interactive elements; `tabIndex={0}` + `onKeyDown` Enter handlers on non-button elements (album cards, artist list items, track rows)
- Full custom range input styling (seek bar + volume): accent-coloured thumb, filled-left track via `--range-progress` CSS custom property set from `TransportBar`
- Swap accent colour from orange (`#e07c3c`) to periwinkle blue (`#7c86e1`)

## Test plan

- [x] Album grid: hover cards lift with shadow; active press resets lift; playing card shows blue glow ring
- [x] Transport bar: seek bar and volume slider show accent-coloured thumb and filled track; dragging updates fill in real time
- [x] Keyboard navigation: Tab moves focus through artist list, album cards, track rows, and transport controls with visible blue outline ring
- [x] Artist panel and track list: scrollbars appear thin and styled when content overflows
- [x] Now-playing badge is bold and readable on the blue background

🤖 Generated with [Claude Code](https://claude.com/claude-code)