### PR TITLE
feat: Phase 2 onboarding — native library picker and scan progress bar

### DIFF
--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -1,0 +1,16 @@
+project_name: "Kamp"
+default_status: "To Do"
+statuses: ["To Do", "In Progress", "Done"]
+labels: []
+definition_of_done: []
+date_format: yyyy-mm-dd
+max_column_width: 20
+default_editor: "code --wait"
+auto_open_browser: true
+default_port: 6420
+remote_operations: true
+auto_commit: false
+bypass_git_hooks: false
+check_active_branches: true
+active_branch_days: 30
+task_prefix: "task"

--- a/backlog/drafts/draft-1 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
+++ b/backlog/drafts/draft-1 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
@@ -1,0 +1,37 @@
+---
+id: DRAFT-1
+title: 'Investigate: main process inflates ~50 MB when Bandcamp sync starts'
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:02'
+labels:
+  - bug
+  - performance
+  - investigation
+  - 'estimate: lp'
+milestone: m-1
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Subprocess isolation is implemented (syncer and pipeline both spawn via `multiprocessing.get_context("spawn")`) but the main process grows from ~35 MB to ~83 MB when sync starts and stays there after sync ends. An additional ~8 MB subprocess also lingers after sync completes.
+
+The subprocess workers themselves are not the resident cost — something in the parent or IPC setup is loading heavy modules or retaining allocations.
+
+**Needs profiling before scoping.** Candidate causes:
+- Queues / pickling overhead of passing `Config` objects
+- A remaining import triggered at IPC setup time in the parent
+- OS-level page retention after multiprocessing fork-related copy-on-write
+
+**Profiling approach:** `tracemalloc`, `psutil` RSS snapshots before/after sync, `sys.modules` diff to identify what inflates memory in the parent and why it isn't released.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause of ~50 MB parent process growth identified via profiling
+- [ ] #2 Main process RSS after sync ends is within 5 MB of pre-sync baseline
+- [ ] #3 Lingering subprocess no longer present after sync completes
+<!-- AC:END -->

--- a/backlog/drafts/draft-2 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
+++ b/backlog/drafts/draft-2 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
@@ -1,0 +1,34 @@
+---
+id: DRAFT-2
+title: >-
+  Best Release: prefer physical format (LP/CD) over digital/streaming when
+  multiple MB results exist
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:00'
+labels:
+  - feature
+  - musicbrainz
+  - 'estimate: side'
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When multiple MusicBrainz releases match a lookup, prefer the release closest to the original physical format (LP/CD over digital/streaming).
+
+Date-based tie-breaking (earliest release wins) is already implemented. Remaining work is format/country preference on top of that.
+
+**Open scoping questions before this can start:**
+- What ranking heuristic? (release format field, country, date proximity?)
+- Fallback when no physical release exists?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When multiple MB results exist, physical formats (LP, CD) are preferred over digital/streaming releases
+- [ ] #2 Fallback behavior defined and implemented when no physical release exists
+- [ ] #3 Existing date-based tie-breaking is preserved
+<!-- AC:END -->

--- a/backlog/drafts/draft-3 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
+++ b/backlog/drafts/draft-3 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
@@ -1,0 +1,32 @@
+---
+id: DRAFT-3
+title: >-
+  Nested folders: recurse into subdirectories in staging and treat each leaf
+  folder as an album
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:00'
+labels:
+  - feature
+  - ingest
+  - 'estimate: side'
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When a folder-of-folders is dropped into staging, recurse into subdirectories and treat each leaf folder as an album rather than failing or ignoring nested structure.
+
+**Open scoping questions before this can start:**
+- Does each subfolder get its own MusicBrainz lookup?
+- How are mixed-album folders (multiple artists/albums in one tree) handled?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Dropping a folder-of-folders into staging processes each leaf folder as an album
+- [ ] #2 Each subfolder triggers its own MusicBrainz lookup (or decision documented if not)
+- [ ] #3 Mixed-album folder behavior defined and tested
+<!-- AC:END -->

--- a/backlog/drafts/draft-4 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
+++ b/backlog/drafts/draft-4 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
@@ -1,0 +1,29 @@
+---
+id: DRAFT-4
+title: 'Configurable album art search (Bandcamp, Apple, Spotify, Qobuz)'
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+labels:
+  - feature
+  - artwork
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow users to configure additional album art sources beyond the current default. Each source (Bandcamp, Apple, Spotify, Qobuz) requires its own API integration and auth flow; estimate per source is ~Side to LP.
+
+**Not scoped enough to start.** Needs a design pass on:
+- Config schema for source list and fallback order
+- Auth flow per source
+- How to handle sources that require API keys
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User can configure ordered list of art sources in config
+- [ ] #2 At least one additional source (TBD in design) implemented end-to-end
+- [ ] #3 Fallback order respected when preferred source returns no result
+<!-- AC:END -->

--- a/backlog/drafts/draft-5 - Allow-user-to-verify-tags-before-they-are-written.md
+++ b/backlog/drafts/draft-5 - Allow-user-to-verify-tags-before-they-are-written.md
@@ -1,0 +1,29 @@
+---
+id: DRAFT-5
+title: Allow user to verify tags before they are written
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+labels:
+  - feature
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Before tags are written to disk, give the user an opportunity to review and confirm (or reject) the proposed changes.
+
+**Not scoped — needs UI design before estimating.** Open questions:
+- Interface: CLI prompt, TUI, or GUI modal?
+- Granularity: per-file, per-album, or per-field?
+- What happens if the user rejects: skip file, queue for manual edit, abort pipeline?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User sees proposed tag changes before they are written to disk
+- [ ] #2 User can approve or reject changes (granularity TBD in design)
+- [ ] #3 Rejected files are handled gracefully (behavior TBD in design)
+<!-- AC:END -->

--- a/backlog/drafts/draft-6 - Library-scan-progress-UI.md
+++ b/backlog/drafts/draft-6 - Library-scan-progress-UI.md
@@ -1,0 +1,32 @@
+---
+id: DRAFT-6
+title: Library scan progress UI
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:02'
+labels:
+  - feature
+  - ux
+  - library
+milestone: m-0
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The `LibraryScanner` runs synchronously and returns a `ScanResult`, but there is no UI feedback during a scan. Large libraries can stall the UI without any indication of progress.
+
+**Not scoped — needs a design pass before estimating.** Open questions:
+- Progress bar in the first-run setup flow?
+- Status indicator during background re-scans?
+- Does the scan need to move to a worker thread/subprocess to avoid blocking the UI on large libraries?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User sees progress feedback during a library scan (form TBD in design)
+- [ ] #2 UI remains responsive during scan on large libraries
+- [ ] #3 First-run setup flow includes scan progress indicator
+<!-- AC:END -->

--- a/backlog/drafts/draft-7 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
+++ b/backlog/drafts/draft-7 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
@@ -1,0 +1,29 @@
+---
+id: DRAFT-7
+title: 'bug: MusicBrainz Release Id tag casing inconsistency'
+status: Draft
+assignee: []
+created_date: '2026-03-29 02:58'
+labels:
+  - bug
+  - musicbrainz
+  - tagging
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A lowercase `musicbrainz release id` tag was observed in the wild, but the tagger writes `MusicBrainz Release Id` (mixed case). May be a tag coming from MusicBrainz data rather than a write bug.
+
+**Needs a concrete repro before scoping a fix.** Required before this can move to To Do:
+- A concrete example file or log showing the bad tag
+- Confirmation of whether it's a write bug (our tagger) or a read issue (tag written by another tool)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause confirmed (write bug vs. foreign tag)
+- [ ] #2 If write bug: tagger consistently writes mixed-case `MusicBrainz Release Id`
+- [ ] #3 If foreign tag: reader normalises casing before comparison
+<!-- AC:END -->

--- a/backlog/milestones/m-0 - phase-2-search,-now-playing-&-polish.md
+++ b/backlog/milestones/m-0 - phase-2-search,-now-playing-&-polish.md
@@ -1,0 +1,8 @@
+---
+id: m-0
+title: "Phase 2: Search, Now Playing & Polish"
+---
+
+## Description
+
+Full-text search, Now Playing view, playback persistence, media key integration, panel layout persistence, keyboard shortcuts, and OS transport controls. Target: ~3–4 sessions.

--- a/backlog/milestones/m-1 - phase-3-bandcamp-gui.md
+++ b/backlog/milestones/m-1 - phase-3-bandcamp-gui.md
@@ -1,0 +1,8 @@
+---
+id: m-1
+title: "Phase 3: Bandcamp GUI"
+---
+
+## Description
+
+Surface the existing Bandcamp daemon work in the UI: sync status, new purchase highlights, storefront browser, and purchase flow. Target: ~4 sessions.

--- a/backlog/milestones/m-2 - phase-4-extension-platform.md
+++ b/backlog/milestones/m-2 - phase-4-extension-platform.md
@@ -1,0 +1,8 @@
+---
+id: m-2
+title: "Phase 4: Extension Platform"
+---
+
+## Description
+
+Extension host, KampContext API, refactor built-ins as extensions, contextBridge frontend panel system, iframe sandboxing, extension settings UI. Target: ~5–8 sessions.

--- a/backlog/milestones/m-3 - windows-support.md
+++ b/backlog/milestones/m-3 - windows-support.md
@@ -1,0 +1,8 @@
+---
+id: m-3
+title: "Windows Support"
+---
+
+## Description
+
+Milestone: Windows Support

--- a/backlog/milestones/m-4 - linux-support.md
+++ b/backlog/milestones/m-4 - linux-support.md
@@ -1,0 +1,8 @@
+---
+id: m-4
+title: "Linux Support"
+---
+
+## Description
+
+Milestone: Linux Support

--- a/backlog/tasks/task-1 - bug-kamp-UI-cant-find-server-after-computer-sleeps.md
+++ b/backlog/tasks/task-1 - bug-kamp-UI-cant-find-server-after-computer-sleeps.md
@@ -1,0 +1,55 @@
+---
+id: TASK-1
+title: 'bug: kamp UI can''t find server after computer sleeps'
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:44'
+updated_date: '2026-03-29 03:14'
+labels: []
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 1000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+to repro:
+start `poetry run kamp server`
+load UI: `kamp_ui\npm run dev`
+confirm that UI and server are connected
+close or sleep laptop
+wake laptop
+
+expected: 
+UI and server are still conneted
+
+actual:
+UI says "kamp server is not running"
+
+server logs show:
+```
+INFO:     connection closed
+INFO:     connection closed
+INFO:     127.0.0.1:51295 - "WebSocket /api/v1/ws" [accepted]
+INFO:     connection open
+INFO:     127.0.0.1:51299 - "WebSocket /api/v1/ws" [accepted]
+INFO:     connection open
+INFO:     127.0.0.1:51297 - "GET /api/v1/albums HTTP/1.1" 200 OK
+INFO:     127.0.0.1:51298 - "GET /api/v1/artists HTTP/1.1" 200 OK
+INFO:     127.0.0.1:51297 - "GET /api/v1/artists HTTP/1.1" 200 OK
+INFO:     127.0.0.1:51300 - "GET /api/v1/albums HTTP/1.1" 200 OK
+```
+
+UI logs show:
+```
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+2026-03-28 23:02:05.106 Electron[73970:14927871] representedObject is not a WeakPtrToElectronMenuModelAsNSObject
+```
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-10 - Panel-layout-persistence-and-keyboard-shortcuts.md
+++ b/backlog/tasks/task-10 - Panel-layout-persistence-and-keyboard-shortcuts.md
@@ -1,0 +1,32 @@
+---
+id: TASK-10
+title: Panel layout persistence and keyboard shortcuts
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:15'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 1875
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Persist the user's panel layout (panel positions, sizes, visibility) across restarts. Add keyboard shortcuts for common actions (play/pause, next, previous, search focus, view switching).
+
+Layout state should be stored in `config.toml` on the daemon side, not in Electron (per ADR-4).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Panel layout is restored on app restart
+- [ ] #2 Layout is stored in config.toml, not in electron-store or localStorage
+- [ ] #3 Keyboard shortcuts cover: play/pause, next, previous, search focus, view switch
+- [ ] #4 Shortcuts are documented in the UI (e.g. tooltip or help overlay)
+<!-- AC:END -->

--- a/backlog/tasks/task-11 - Windows-taskbar-transport-controls.md
+++ b/backlog/tasks/task-11 - Windows-taskbar-transport-controls.md
@@ -1,0 +1,32 @@
+---
+id: TASK-11
+title: Windows taskbar transport controls
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:15'
+labels:
+  - feature
+  - windows
+  - os-integration
+  - 'estimate: side'
+milestone: m-3
+dependencies: []
+ordinal: 9000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the `MediaController` interface for Windows: populate the Windows System Media Transport Controls (SMTC) with current track info and respond to play/pause, next, previous from the taskbar and lock screen.
+
+Per ADR-7, implement as a `WinMediaController` in the platform dispatch table.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Windows taskbar shows play/pause, next, previous controls for kamp
+- [ ] #2 SMTC displays current track title, artist, album, and artwork
+- [ ] #3 Media key presses are handled correctly
+- [ ] #4 Implementation is isolated in WinMediaController behind the dispatch table
+<!-- AC:END -->

--- a/backlog/tasks/task-12 - Linux-MPRIS-support.md
+++ b/backlog/tasks/task-12 - Linux-MPRIS-support.md
@@ -1,0 +1,32 @@
+---
+id: TASK-12
+title: Linux MPRIS support
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:15'
+labels:
+  - feature
+  - linux
+  - os-integration
+  - 'estimate: side'
+milestone: m-4
+dependencies: []
+ordinal: 10000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the `MediaController` interface for Linux via MPRIS2 (D-Bus). This allows desktop environments (GNOME, KDE, etc.) to show and control kamp playback via their media widgets.
+
+Per ADR-7, implement as an `MPRISController` in the platform dispatch table. Adding this should require touching zero files that contain Bandcamp, playback, or library logic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 kamp exposes an MPRIS2 D-Bus interface
+- [ ] #2 Desktop environment media widgets show current track and allow play/pause/next/prev
+- [ ] #3 Implementation is isolated in MPRISController behind the dispatch table
+- [ ] #4 No Bandcamp/playback/library files modified
+<!-- AC:END -->

--- a/backlog/tasks/task-13 - Bandcamp-sync-status-in-GUI-idle-syncing-manual-trigger-recent-additions.md
+++ b/backlog/tasks/task-13 - Bandcamp-sync-status-in-GUI-idle-syncing-manual-trigger-recent-additions.md
@@ -1,0 +1,30 @@
+---
+id: TASK-13
+title: 'Bandcamp sync status in GUI (idle/syncing, manual trigger, recent additions)'
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+labels:
+  - feature
+  - bandcamp
+  - ui
+  - 'estimate: side'
+milestone: m-1
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surface the Bandcamp sync daemon state in the UI: show whether a sync is idle or in progress, allow the user to trigger a manual sync, and display recently added albums from the last sync.
+
+The daemon already does the sync work — this task is purely about exposing that state through the existing WebSocket event stream and wiring up a UI component.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 UI shows sync status (idle / syncing) in real time via WebSocket
+- [ ] #2 User can trigger a manual sync from the UI
+- [ ] #3 Recently synced albums are surfaced after sync completes
+- [ ] #4 UI handles sync errors gracefully with a visible error state
+<!-- AC:END -->

--- a/backlog/tasks/task-14 - New-purchase-highlight-watcher-→-library-re-scan-→-surfaced-in-UI.md
+++ b/backlog/tasks/task-14 - New-purchase-highlight-watcher-→-library-re-scan-→-surfaced-in-UI.md
@@ -1,0 +1,29 @@
+---
+id: TASK-14
+title: New purchase highlight (watcher → library re-scan → surfaced in UI)
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+labels:
+  - feature
+  - bandcamp
+  - ui
+  - 'estimate: side'
+milestone: m-1
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When the Bandcamp watcher detects a new download and the library re-scan completes, surface the new album prominently in the UI so the user notices their new purchase.
+
+This requires: watcher emits a library-changed event → library re-scan runs → new albums are flagged → UI highlights them (e.g. a "New" badge, a dedicated section, or a toast).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 New albums from a Bandcamp sync are visually highlighted in the library
+- [ ] #2 Highlight clears after the user visits/plays the album
+- [ ] #3 No manual refresh required — driven by WebSocket event
+<!-- AC:END -->

--- a/backlog/tasks/task-15 - Bandcamp-storefront-browser-collection-wishlist-followed-artists.md
+++ b/backlog/tasks/task-15 - Bandcamp-storefront-browser-collection-wishlist-followed-artists.md
@@ -1,0 +1,30 @@
+---
+id: TASK-15
+title: 'Bandcamp storefront browser (collection, wishlist, followed artists)'
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+labels:
+  - feature
+  - bandcamp
+  - ui
+  - 'estimate: lp'
+milestone: m-1
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Embed a Bandcamp storefront browser in kamp: let users browse their Bandcamp collection, wishlist, and followed artists without leaving the app. This is the "discovery" surface described in the vision statement.
+
+Design question to resolve: webview embedding vs API-driven UI (Bandcamp has no public API — a webview may be the only option).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User can browse their Bandcamp collection inside kamp
+- [ ] #2 User can browse their wishlist and followed artists
+- [ ] #3 Navigation between storefront and library is fluid
+- [ ] #4 Bandcamp session/auth is handled without requiring re-login on each launch
+<!-- AC:END -->

--- a/backlog/tasks/task-16 - Bandcamp-purchase-flow-Buy-→-checkout-→-daemon-picks-up-download.md
+++ b/backlog/tasks/task-16 - Bandcamp-purchase-flow-Buy-→-checkout-→-daemon-picks-up-download.md
@@ -1,0 +1,32 @@
+---
+id: TASK-16
+title: Bandcamp purchase flow (Buy → checkout → daemon picks up download)
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - bandcamp
+  - ui
+  - 'estimate: lp'
+milestone: m-1
+dependencies:
+  - TASK-15
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow users to purchase music on Bandcamp from within kamp and have it automatically land in their library. The intended flow: user clicks "Buy" in the storefront browser → Bandcamp checkout completes → daemon detects the new download → library re-scan runs → album appears in kamp.
+
+Depends on the storefront browser task being complete.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User can complete a Bandcamp purchase without leaving kamp
+- [ ] #2 After purchase, the new album appears in the library automatically (no manual sync)
+- [ ] #3 Purchase confirmation is shown in the UI
+- [ ] #4 Failure cases (payment failure, download delay) are handled gracefully
+<!-- AC:END -->

--- a/backlog/tasks/task-17 - Extension-host-and-KampContext-API.md
+++ b/backlog/tasks/task-17 - Extension-host-and-KampContext-API.md
@@ -1,0 +1,29 @@
+---
+id: TASK-17
+title: Extension host and KampContext API
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - 'estimate: lp'
+milestone: m-2
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Build the backend extension host and define the `KampContext` public API that extensions use to interact with the daemon. Backend extensions are Python packages declared via `[project.entry-points."kamp.extensions"]`, implementing abstract base classes (`BaseTagger`, `BaseArtworkSource`, etc.).
+
+Per the architecture invariant: the SDK surface must be extracted from two real working extensions, not designed in the abstract. Do not design the API first — implement two real extensions with it, then extract the surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Extension host discovers and loads backend extensions via entry points
+- [ ] #2 KampContext API covers at minimum: library access, playback control, event subscription
+- [ ] #3 API is documented with examples
+- [ ] #4 A crash in an extension worker does not take down the daemon
+<!-- AC:END -->

--- a/backlog/tasks/task-18 - Refactor-built-in-features-as-extensions-validate-KampContext-API.md
+++ b/backlog/tasks/task-18 - Refactor-built-in-features-as-extensions-validate-KampContext-API.md
@@ -1,0 +1,33 @@
+---
+id: TASK-18
+title: Refactor built-in features as extensions (validate KampContext API)
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - refactor
+  - 'estimate: lp'
+milestone: m-2
+dependencies:
+  - TASK-17
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Refactor the Bandcamp syncer, MusicBrainz tagger, and artwork fetcher to use the public `KampContext` API as if they were third-party extensions. This validates that the API is sufficient for real use.
+
+Per the architecture: if this is painful, stop and fix the API first before proceeding. The goal is to confirm that all built-in features are buildable using only the public extension SDK.
+
+Depends on the extension host and KampContext API task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Bandcamp syncer, MusicBrainz tagger, and artwork fetcher use only the public KampContext API
+- [ ] #2 No built-in feature accesses daemon internals directly
+- [ ] #3 All existing tests pass after refactor
+- [ ] #4 Any API gaps discovered during refactor are fixed in the KampContext API before this task closes
+<!-- AC:END -->

--- a/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
+++ b/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
@@ -1,0 +1,30 @@
+---
+id: TASK-19
+title: contextBridge API and frontend panel registration system
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - electron
+  - 'estimate: lp'
+milestone: m-2
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose the player API to frontend extensions via Electron's `contextBridge` as `window.KampAPI`. Extensions are npm packages discovered via the `kamp-extension` keyword in `package.json` and export a manifest declaring contributed panels/components.
+
+Extensions must never touch `ipcRenderer` or Node.js directly — only `window.KampAPI`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 window.KampAPI is injected via contextBridge in the preload script
+- [ ] #2 Frontend extensions are discovered via kamp-extension npm keyword
+- [ ] #3 An example first-party extension registers a panel successfully
+- [ ] #4 Extensions cannot access ipcRenderer or Node.js APIs directly
+<!-- AC:END -->

--- a/backlog/tasks/task-2 - Full-Windows-Support.md
+++ b/backlog/tasks/task-2 - Full-Windows-Support.md
@@ -1,0 +1,35 @@
+---
+id: TASK-2
+title: Full Windows Support
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:04'
+labels:
+  - platform
+  - windows
+  - 'estimate: box set'
+milestone: m-3
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Port kamp to Windows 10/11 with full feature parity: tray app, CI, Playwright tests, service install, packaging, and path conventions. Distribution via Chocolatey.
+
+**Prerequisite:** Rebrand must ship before this work begins.
+
+This is a parent task. Subtasks cover each component independently so they can be worked in sequence or parallel.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 kamp runs on Windows 10 and Windows 11 with full feature parity to macOS
+- [ ] #2 Tray app works via pystray with status animation and menu
+- [ ] #3 CI passes on GitHub Actions windows-latest
+- [ ] #4 Playwright E2E tests pass on Windows
+- [ ] #5 Service can be installed/uninstalled via NSSM
+- [ ] #6 Package published to Chocolatey
+- [ ] #7 All paths use %APPDATA% conventions correctly
+<!-- AC:END -->

--- a/backlog/tasks/task-2.1 - Windows-tray-app-pystray-full-parity-with-rumps.md
+++ b/backlog/tasks/task-2.1 - Windows-tray-app-pystray-full-parity-with-rumps.md
@@ -1,0 +1,35 @@
+---
+id: TASK-2.1
+title: 'Windows tray app (pystray, full parity with rumps)'
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:05'
+labels:
+  - platform
+  - windows
+  - tray
+  - 'estimate: lp'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Windows system tray app using pystray, matching the macOS rumps menu bar app in features and behavior.
+
+Key differences from rumps:
+- pystray is pull-based: menus are rebuilt on each open (not held in memory)
+- Status animation requires a background icon-swap thread (no inline status text like rumps)
+- No built-in notification support — wire up Windows notifications separately
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Tray icon appears in Windows system tray on startup
+- [ ] #2 Menu items match macOS menu bar app (open UI, sync, quit, etc.)
+- [ ] #3 Status animation works via background icon-swap thread
+- [ ] #4 Notifications work on Windows 10/11
+<!-- AC:END -->

--- a/backlog/tasks/task-2.2 - Windows-CI-GitHub-Actions-windows-latest.md
+++ b/backlog/tasks/task-2.2 - Windows-CI-GitHub-Actions-windows-latest.md
@@ -1,0 +1,29 @@
+---
+id: TASK-2.2
+title: Windows CI (GitHub Actions windows-latest)
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:04'
+labels:
+  - platform
+  - windows
+  - ci
+  - 'estimate: side'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a GitHub Actions CI job running on `windows-latest` so the test suite is verified on Windows. Expected work: subprocess spawn differences, path separator edge cases, and likely several test fixes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CI workflow includes a windows-latest job
+- [ ] #2 All existing tests pass on Windows
+- [ ] #3 Path separator issues resolved
+<!-- AC:END -->

--- a/backlog/tasks/task-2.3 - Playwright-E2E-tests-on-Windows.md
+++ b/backlog/tasks/task-2.3 - Playwright-E2E-tests-on-Windows.md
@@ -1,0 +1,28 @@
+---
+id: TASK-2.3
+title: Playwright E2E tests on Windows
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:04'
+labels:
+  - platform
+  - windows
+  - testing
+  - 'estimate: side'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Get the Playwright E2E test suite passing on Windows. Chromium download and DevTools Protocol over localhost should work; verify the subprocess isolation pattern holds on Windows spawn semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Playwright tests run and pass on Windows in CI
+- [ ] #2 Subprocess isolation pattern verified on Windows spawn
+<!-- AC:END -->

--- a/backlog/tasks/task-2.4 - Windows-service-install-via-NSSM.md
+++ b/backlog/tasks/task-2.4 - Windows-service-install-via-NSSM.md
@@ -1,0 +1,28 @@
+---
+id: TASK-2.4
+title: Windows service install via NSSM
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:05'
+labels:
+  - platform
+  - windows
+  - service
+  - 'estimate: side'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Use NSSM (Non-Sucking Service Manager) to wrap the kamp CLI as a Windows service. NSSM is simpler to manage than Task Scheduler for start/stop lifecycle.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 kamp can be installed/started/stopped/uninstalled as a Windows service via NSSM
+- [ ] #2 Install and uninstall scripts documented
+<!-- AC:END -->

--- a/backlog/tasks/task-2.5 - Chocolatey-packaging.md
+++ b/backlog/tasks/task-2.5 - Chocolatey-packaging.md
@@ -1,0 +1,29 @@
+---
+id: TASK-2.5
+title: Chocolatey packaging
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:05'
+labels:
+  - platform
+  - windows
+  - packaging
+  - 'estimate: side'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Package kamp for distribution via Chocolatey. Includes writing the `.nuspec`, install/uninstall scripts, and submitting to the Chocolatey community repo. Note: community repo review queue can take weeks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 .nuspec and install/uninstall scripts authored
+- [ ] #2 Package passes choco pack and choco install locally
+- [ ] #3 Package submitted to Chocolatey community repo
+<!-- AC:END -->

--- a/backlog/tasks/task-2.6 - Windows-path-config-conventions-APPDATA-audit.md
+++ b/backlog/tasks/task-2.6 - Windows-path-config-conventions-APPDATA-audit.md
@@ -1,0 +1,28 @@
+---
+id: TASK-2.6
+title: Windows path/config conventions (%APPDATA% audit)
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 03:05'
+labels:
+  - platform
+  - windows
+  - 'estimate: single'
+milestone: m-3
+dependencies: []
+parent_task_id: TASK-2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Audit all path and config file handling to ensure Windows conventions are followed. `pathlib` handles most separators already; focus on ensuring config/data directories resolve to `%APPDATA%` (or `%LOCALAPPDATA%`) rather than Unix paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Config and data files resolve to %APPDATA% on Windows
+- [ ] #2 No hardcoded Unix paths remain
+- [ ] #3 Audit documented in a code comment or PR description
+<!-- AC:END -->

--- a/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
+++ b/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
@@ -1,0 +1,30 @@
+---
+id: TASK-20
+title: 'UI slot API: declarative panel manifests rendered by Electron host'
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - ui
+  - 'estimate: lp'
+milestone: m-2
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the panel slot system so extensions can declaratively register panels that the Electron host renders in the layout. Extensions declare their panels in a manifest; the host places them in the panel grid.
+
+This is the mechanism described in the vision statement: transport panel, artist panel, album browser, etc. are all panels that can be added, removed, and repositioned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Extensions declare panels in a manifest (title, component, default slot)
+- [ ] #2 Host renders extension panels in the panel layout
+- [ ] #3 User can add/remove/reposition panels including those from extensions
+- [ ] #4 Built-in panels (transport, artist list, album grid) are registered through the same slot API
+<!-- AC:END -->

--- a/backlog/tasks/task-21 - iframe-sandboxing-and-CSP-for-community-extensions.md
+++ b/backlog/tasks/task-21 - iframe-sandboxing-and-CSP-for-community-extensions.md
@@ -1,0 +1,28 @@
+---
+id: TASK-21
+title: iframe sandboxing and CSP for community extensions
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - security
+  - 'estimate: side'
+milestone: m-2
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Render community (third-party) extensions in `<iframe sandbox="allow-scripts">` communicating via `postMessage`, with a strict Content Security Policy on the renderer window. First-party extensions use contextBridge directly; this sandboxing is only for untrusted community extensions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Community extensions render in sandboxed iframes
+- [ ] #2 Extensions communicate with the host only via postMessage (no direct DOM or API access)
+- [ ] #3 Strict CSP is enforced on the renderer window
+- [ ] #4 First-party extensions continue to work via contextBridge unaffected
+<!-- AC:END -->

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -1,0 +1,28 @@
+---
+id: TASK-22
+title: Extension settings UI
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - feature
+  - extensions
+  - ui
+  - 'estimate: side'
+milestone: m-2
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a settings UI where users can view installed extensions, enable/disable them, and configure per-extension settings. Extensions declare their settings schema in their manifest; the host renders the settings form.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Settings screen lists all installed extensions with name, version, and enabled state
+- [ ] #2 User can enable/disable extensions from the UI
+- [ ] #3 Per-extension settings are rendered from the extension's declared schema
+- [ ] #4 Settings changes take effect without requiring an app restart
+<!-- AC:END -->

--- a/backlog/tasks/task-23 - Extension-developer-documentation.md
+++ b/backlog/tasks/task-23 - Extension-developer-documentation.md
@@ -1,0 +1,30 @@
+---
+id: TASK-23
+title: Extension developer documentation
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:12'
+labels:
+  - docs
+  - extensions
+  - 'estimate: side'
+milestone: m-2
+dependencies:
+  - TASK-18
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write developer documentation for the kamp extension system: how to build both backend (Python) and frontend (npm) extensions, the KampContext API reference, the panel manifest format, and how to publish to npm/PyPI.
+
+Documentation should be written after the built-in refactor (TASK-18) confirms the API is stable, so examples reflect real usage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Backend extension guide covers: entry points, BaseTagger/BaseArtworkSource ABCs, KampContext API
+- [ ] #2 Frontend extension guide covers: package.json manifest, window.KampAPI, panel registration
+- [ ] #3 At least one complete worked example (end-to-end) for each layer
+- [ ] #4 Publishing guide covers npm and PyPI distribution
+<!-- AC:END -->

--- a/backlog/tasks/task-3 - Cross-platform-service-installation-Linux-systemd-Windows-NSSM.md
+++ b/backlog/tasks/task-3 - Cross-platform-service-installation-Linux-systemd-Windows-NSSM.md
@@ -1,0 +1,29 @@
+---
+id: TASK-3
+title: 'Cross-platform service installation (Linux systemd, Windows NSSM)'
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:13'
+labels:
+  - platform
+  - infrastructure
+  - 'estimate: side'
+milestone: m-4
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add service installation support so kamp can run as a background service on Linux (systemd unit file) and Windows (NSSM wrapper). Can ship incrementally — Linux first, then Windows.
+
+Linux systemd unit file is straightforward. Windows NSSM wraps the CLI and is simpler to manage than Task Scheduler.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Linux: systemd unit file ships and kamp can be enabled/started/stopped via systemctl
+- [ ] #2 Windows: NSSM install/uninstall scripts provided
+- [ ] #3 README documents service install steps for both platforms
+<!-- AC:END -->

--- a/backlog/tasks/task-4 - bug-macOS-menu-bar-reads-About-Tune-Shifter-instead-of-About-Kamp.md
+++ b/backlog/tasks/task-4 - bug-macOS-menu-bar-reads-About-Tune-Shifter-instead-of-About-Kamp.md
@@ -1,0 +1,28 @@
+---
+id: TASK-4
+title: 'bug: macOS menu bar reads \"About Tune-Shifter\" instead of \"About Kamp\"'
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:14'
+labels:
+  - bug
+  - macos
+  - 'estimate: single'
+milestone: m-0
+dependencies: []
+priority: low
+ordinal: 3000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The macOS menu bar app shows "About Tune-Shifter" in the menu — a leftover hardcoded string from the rebrand. Likely in `menu_bar.py` or `__main__.py`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 macOS menu bar shows "About Kamp" (not "About Tune-Shifter")
+- [ ] #2 No other rebrand remnants found in the same area
+<!-- AC:END -->

--- a/backlog/tasks/task-5 - Automatic-library-watching.md
+++ b/backlog/tasks/task-5 - Automatic-library-watching.md
@@ -1,0 +1,35 @@
+---
+id: TASK-5
+title: Automatic library watching
+status: To Do
+assignee: []
+created_date: '2026-03-29 02:57'
+updated_date: '2026-03-29 03:14'
+labels:
+  - feature
+  - library
+  - 'estimate: side'
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The LibraryScanner is incremental but must be triggered manually. Extend the existing watchdog infrastructure in `watcher.py` to also watch the library directory (in addition to staging) and call `LibraryScanner.scan()` when changes are detected.
+
+Open scoping questions to resolve during implementation:
+- Debounce strategy (avoid rapid re-scans on bulk file moves)
+- Full rescan vs path-targeted upsert
+- How to avoid re-scanning during an active ingest pipeline run
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Adding or removing files from the library directory triggers an automatic re-scan without manual intervention
+- [ ] #2 Re-scan is debounced to avoid thrashing on bulk changes
+- [ ] #3 No re-scan fires while an ingest pipeline run is active
+- [ ] #4 Existing watchdog tests remain green
+<!-- AC:END -->

--- a/backlog/tasks/task-6 - Full-text-search-backend-endpoint-search-bar-UI.md
+++ b/backlog/tasks/task-6 - Full-text-search-backend-endpoint-search-bar-UI.md
@@ -1,0 +1,32 @@
+---
+id: TASK-6
+title: Full-text search (backend endpoint + search bar UI)
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:15'
+labels:
+  - feature
+  - search
+  - 'estimate: side'
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 2750
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add full-text search across the library: a `GET /api/v1/search?q=` endpoint on the backend and a search bar in the UI that filters albums and tracks in real time.
+
+SQLite FTS5 is the natural fit for the backend index.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GET /api/v1/search?q= returns matching albums and tracks
+- [ ] #2 Search bar in UI filters results as the user types
+- [ ] #3 Results include album art thumbnails and are clickable to play
+- [ ] #4 Empty query returns no results (not the full library)
+<!-- AC:END -->

--- a/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
+++ b/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
@@ -1,0 +1,32 @@
+---
+id: TASK-7
+title: 'Now Playing view (artwork-centered, view switching)'
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:14'
+labels:
+  - feature
+  - ui
+  - 'estimate: lp'
+milestone: m-0
+dependencies: []
+priority: high
+ordinal: 1500
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a Now Playing view that centers the current album artwork and track metadata. The app should support switching between the Library view (album grid + artist panel) and the Now Playing view.
+
+This is the second of the two out-of-box views described in the vision statement.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Now Playing view shows large album artwork, track title, artist, album, and playback position
+- [ ] #2 User can switch between Library view and Now Playing view
+- [ ] #3 View state persists across app restarts
+- [ ] #4 Transport controls are accessible in both views
+<!-- AC:END -->

--- a/backlog/tasks/task-8 - Playback-persistence-resume-last-track-and-position-on-restart.md
+++ b/backlog/tasks/task-8 - Playback-persistence-resume-last-track-and-position-on-restart.md
@@ -1,0 +1,29 @@
+---
+id: TASK-8
+title: Playback persistence (resume last track and position on restart)
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:14'
+labels:
+  - feature
+  - playback
+  - 'estimate: single'
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 1750
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When the app restarts, resume the last playing track at the last known position. The daemon owns all player state (per ADR-4), so last track/position should be persisted in the daemon (SQLite or config), not in Electron.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 On restart, the last track and position are restored in the player state
+- [ ] #2 Playback does not auto-resume on restart (user must press play)
+- [ ] #3 State is stored in the daemon, not in Electron localStorage or electron-store
+<!-- AC:END -->

--- a/backlog/tasks/task-9 - MediaController-macOS-media-keys-and-Now-Playing-widget.md
+++ b/backlog/tasks/task-9 - MediaController-macOS-media-keys-and-Now-Playing-widget.md
@@ -1,0 +1,33 @@
+---
+id: TASK-9
+title: 'MediaController: macOS media keys and Now Playing widget'
+status: To Do
+assignee: []
+created_date: '2026-03-29 03:11'
+updated_date: '2026-03-29 03:15'
+labels:
+  - feature
+  - macos
+  - os-integration
+  - 'estimate: side'
+milestone: m-0
+dependencies: []
+priority: medium
+ordinal: 2500
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the `MediaController` interface for macOS: respond to media keys (play/pause, next, previous) and populate the macOS Now Playing widget (Control Center / lock screen) with current track metadata and artwork.
+
+Per ADR-7, implement as a `CoreAudioMediaController` registered in the platform dispatch table — no `if platform == "darwin"` conditionals outside the dispatch table.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Play/pause, next, previous media keys control playback
+- [ ] #2 macOS Now Playing widget shows current track title, artist, album, and artwork
+- [ ] #3 Seek position updates in the Now Playing widget during playback
+- [ ] #4 Implementation is isolated behind the MediaController dispatch table
+<!-- AC:END -->

--- a/claude.md
+++ b/claude.md
@@ -52,3 +52,32 @@ Budget at least a Side for any feature touching osacompile, Spotlight registrati
 
 ## Scope discipline
 If the same sub-problem fails twice in a row, stop and check in before attempting a third approach. Two failures signal a wrong level of abstraction or an environment constraint — not a fixable bug. This applies especially to test fixtures and dev-environment workarounds, which have no user value on their own.
+
+<!-- BACKLOG.MD MCP GUIDELINES START -->
+
+<CRITICAL_INSTRUCTION>
+
+## BACKLOG WORKFLOW INSTRUCTIONS
+
+This project uses Backlog.md MCP for all task and project management activities.
+
+**CRITICAL GUIDANCE**
+
+- If your client supports MCP resources, read `backlog://workflow/overview` to understand when and how to use Backlog for this project.
+- If your client only supports tools or the above request fails, call `backlog.get_backlog_instructions()` to load the tool-oriented overview. Use the `instruction` selector when you need `task-creation`, `task-execution`, or `task-finalization`.
+
+- **First time working here?** Read the overview resource IMMEDIATELY to learn the workflow
+- **Already familiar?** You should have the overview cached ("## Backlog.md Overview (MCP)")
+- **When to read it**: BEFORE creating tasks, or when you're unsure whether to track work
+
+These guides cover:
+- Decision framework for when to create tasks
+- Search-first workflow to avoid duplicates
+- Links to detailed guides for task creation, execution, and finalization
+- MCP tools reference
+
+You MUST read the overview resource to understand the complete workflow. The information is NOT summarized here.
+
+</CRITICAL_INSTRUCTION>
+
+<!-- BACKLOG.MD MCP GUIDELINES END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -446,12 +447,19 @@ class LibraryScanner:
     def __init__(self, index: LibraryIndex) -> None:
         self._index = index
 
-    def scan(self, library_path: Path) -> ScanResult:
+    def scan(
+        self,
+        library_path: Path,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> ScanResult:
         """Scan *library_path* recursively and update the index.
 
         Files already in the index are left untouched (unchanged).
         New files are read and added. Index entries whose files no longer
         exist on disk are removed.
+
+        *on_progress*, if provided, is called after each new file's tags are
+        read with (current, total) where total = number of new files to index.
         """
         if not library_path.exists():
             return ScanResult(added=0, removed=0, unchanged=0)
@@ -464,13 +472,17 @@ class LibraryScanner:
         in_index = self._index.indexed_paths()
 
         # Read tags for all new files, then commit in one transaction.
+        to_add = on_disk - in_index
+        total = len(to_add)
         new_tracks: list[Track] = []
-        for path in on_disk - in_index:
+        for current, path in enumerate(to_add, start=1):
             track = _read_tags(path)
             if track is not None:
                 new_tracks.append(track)
             else:
                 logger.warning("Skipped unreadable file: %s", path)
+            if on_progress is not None:
+                on_progress(current, total)
         self._index.upsert_many(new_tracks)
         added = len(new_tracks)
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -201,11 +201,17 @@ def create_app(
             raise HTTPException(status_code=503, detail="Library path not configured")
 
         def _on_progress(current: int, total: int) -> None:
-            _state["scan_progress"] = {"active": True, "current": current, "total": total}
+            _state["scan_progress"] = {
+                "active": True,
+                "current": current,
+                "total": total,
+            }
 
         _state["scan_progress"] = {"active": True, "current": 0, "total": 0}
         try:
-            result = LibraryScanner(index).scan(_state["library_path"], on_progress=_on_progress)
+            result = LibraryScanner(index).scan(
+                _state["library_path"], on_progress=_on_progress
+            )
         finally:
             _state["scan_progress"] = {"active": False, "current": 0, "total": 0}
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -12,6 +12,7 @@ WebSocket:  /api/v1/ws   — client sends "ping", server replies with a
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -103,6 +104,10 @@ class ScanResult(BaseModel):
     unchanged: int
 
 
+class LibraryPathRequest(BaseModel):
+    path: str
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -114,6 +119,7 @@ def create_app(
     engine: MpvPlaybackEngine,
     queue: PlaybackQueue,
     library_path: Path | None = None,
+    on_library_path_set: Callable[[Path], None] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -121,6 +127,14 @@ def create_app(
     makes the app easy to test: pass mock objects, use TestClient, done.
     """
     app = FastAPI(title="Kamp", version="1")
+
+    # Mutable containers for runtime-updatable state.
+    # library_path can be changed via POST /api/v1/config/library-path.
+    # scan_progress is written by the scan thread and read by GET /api/v1/library/scan/progress.
+    _state: dict[str, Any] = {
+        "library_path": library_path,
+        "scan_progress": {"active": False, "current": 0, "total": 0},
+    }
 
     # Allow requests from the Electron renderer (Vite dev server and file://).
     # This server only binds to 127.0.0.1, so wildcard origins are safe.
@@ -183,12 +197,37 @@ def create_app(
 
     @app.post("/api/v1/library/scan", response_model=ScanResult)
     def scan_library() -> ScanResult:
-        if library_path is None:
+        if _state["library_path"] is None:
             raise HTTPException(status_code=503, detail="Library path not configured")
-        result = LibraryScanner(index).scan(library_path)
+
+        def _on_progress(current: int, total: int) -> None:
+            _state["scan_progress"] = {"active": True, "current": current, "total": total}
+
+        _state["scan_progress"] = {"active": True, "current": 0, "total": 0}
+        try:
+            result = LibraryScanner(index).scan(_state["library_path"], on_progress=_on_progress)
+        finally:
+            _state["scan_progress"] = {"active": False, "current": 0, "total": 0}
+
         return ScanResult(
             added=result.added, removed=result.removed, unchanged=result.unchanged
         )
+
+    @app.get("/api/v1/library/scan/progress")
+    def get_scan_progress() -> dict[str, Any]:
+        return _state["scan_progress"]
+
+    @app.post("/api/v1/config/library-path")
+    def set_library_path(req: LibraryPathRequest) -> dict[str, Any]:
+        candidate = Path(req.path).expanduser().resolve()
+        if not candidate.exists():
+            raise HTTPException(status_code=422, detail="Path does not exist")
+        if not candidate.is_dir():
+            raise HTTPException(status_code=422, detail="Path is not a directory")
+        _state["library_path"] = candidate
+        if on_library_path_set is not None:
+            on_library_path_set(candidate)
+        return {"ok": True}
 
     # -----------------------------------------------------------------------
     # Player

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -286,6 +286,7 @@ def main() -> None:
         library_override = getattr(args, "library", None)
         _cmd_server(
             config,
+            config_path=args.config,
             host=args.host,
             port=args.port,
             library_path=library_override,
@@ -462,6 +463,7 @@ def _write_test_mp3(path: Path, *, with_mbid: bool = False) -> None:
 
 def _cmd_server(
     config: Config,
+    config_path: Path,
     host: str = "127.0.0.1",
     port: int = 8000,
     library_path: Path | None = None,
@@ -471,6 +473,7 @@ def _cmd_server(
     from kamp_core.library import LibraryIndex
     from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
     from kamp_core.server import create_app
+    from kamp_daemon.config import config_set as _config_set
 
     lib_path = (library_path or config.paths.library).expanduser().resolve()
     db_path = _state_dir() / "library.db"
@@ -489,7 +492,18 @@ def _cmd_server(
 
     engine.on_track_end = _on_track_end
 
-    app = create_app(index=index, engine=engine, queue=queue, library_path=lib_path)
+    # Persist library path changes back to config.toml so the next server start
+    # picks up the user's choice without requiring a manual config edit.
+    def _on_library_path_set(path: Path) -> None:
+        _config_set(config_path, "paths.library", str(path))
+
+    app = create_app(
+        index=index,
+        engine=engine,
+        queue=queue,
+        library_path=lib_path,
+        on_library_path_set=_on_library_path_set,
+    )
 
     print(f"Kamp API server starting on http://{host}:{port}")
     print(f"  Docs  → http://{host}:{port}/docs")

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
@@ -51,6 +51,14 @@ app.whenReady().then(() => {
 
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
+
+  ipcMain.handle('open-directory', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openDirectory'],
+      title: 'Choose Music Library Folder'
+    })
+    return result.canceled ? null : result.filePaths[0]
+  })
 
   createWindow()
 

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -3,6 +3,8 @@ import { ElectronAPI } from '@electron-toolkit/preload'
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    api: {
+      openDirectory: () => Promise<string | null>
+    }
   }
 }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -1,8 +1,10 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  openDirectory: (): Promise<string | null> => ipcRenderer.invoke('open-directory')
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -89,8 +89,7 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
 
 export type ScanProgress = { active: boolean; current: number; total: number }
 
-export const getScanProgress = (): Promise<ScanProgress> =>
-  get('/api/v1/library/scan/progress')
+export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')
 
 // ---------------------------------------------------------------------------
 // Player

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -84,6 +84,14 @@ export const getTracksForAlbum = (albumArtist: string, album: string): Promise<T
 
 export const scanLibrary = (): Promise<ScanResult> => post('/api/v1/library/scan')
 
+export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
+  post('/api/v1/config/library-path', { path })
+
+export type ScanProgress = { active: boolean; current: number; total: number }
+
+export const getScanProgress = (): Promise<ScanProgress> =>
+  get('/api/v1/library/scan/progress')
+
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -165,6 +165,26 @@ body,
   animation: spin 0.8s linear infinite;
 }
 
+.setup-progress-bar {
+  width: 260px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.setup-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.setup-progress-label {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
 .setup-result {
   font-size: 14px;
   color: var(--accent);

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -19,6 +19,8 @@
   --text-dim: #888;
   --accent: #e07c3c;
   --accent-dim: #7a3d1a;
+  --error: #e06c75;
+  --text-on-accent: #000;
   --transport-h: 88px;
   --panel-w: 200px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -128,7 +130,7 @@ body,
 .setup-scan-btn {
   background: var(--accent);
   border: none;
-  color: #000;
+  color: var(--text-on-accent);
   font-size: 14px;
   font-weight: 600;
   padding: 10px 28px;
@@ -170,7 +172,7 @@ body,
 
 .setup-error {
   font-size: 13px;
-  color: #e06c75;
+  color: var(--error);
   text-align: center;
   max-width: 380px;
   line-height: 1.6;
@@ -301,7 +303,7 @@ body,
   bottom: 6px;
   right: 6px;
   background: var(--accent);
-  color: #000;
+  color: var(--text-on-accent);
   font-size: 11px;
   padding: 2px 5px;
   border-radius: 3px;
@@ -524,7 +526,7 @@ body,
 .play-all-btn {
   background: var(--accent);
   border: none;
-  color: #000;
+  color: var(--text-on-accent);
   padding: 6px 14px;
   border-radius: 4px;
   cursor: pointer;

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -259,12 +259,14 @@ body,
   background: var(--surface);
   transition:
     transform 0.1s,
-    background 0.1s;
+    background 0.1s,
+    box-shadow 0.1s;
 }
 
 .album-card:hover {
   background: var(--surface-hover);
-  transform: translateY(-2px);
+  transform: translateY(-3px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .album-card.playing {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -426,7 +426,6 @@ body,
 
 .seek-bar {
   flex: 1;
-  accent-color: var(--accent);
   cursor: pointer;
 }
 
@@ -446,8 +445,69 @@ body,
 
 .volume-slider {
   width: 80px;
-  accent-color: var(--accent);
   cursor: pointer;
+}
+
+/* Custom range input styling ----------------------------------------------- */
+
+.seek-bar,
+.volume-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}
+
+.seek-bar::-webkit-slider-runnable-track,
+.volume-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--accent) 0%,
+    var(--accent) var(--range-progress, 0%),
+    var(--border) var(--range-progress, 0%),
+    var(--border) 100%
+  );
+}
+
+.seek-bar::-webkit-slider-thumb,
+.volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: -5px; /* center on 4px track: (14-4)/2 = 5 */
+  transition: transform 0.1s;
+}
+
+.seek-bar::-webkit-slider-thumb:hover,
+.volume-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+.seek-bar::-moz-range-track,
+.volume-slider::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+}
+
+.seek-bar::-moz-range-progress,
+.volume-slider::-moz-range-progress {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+
+.seek-bar::-moz-range-thumb,
+.volume-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
 }
 
 .volume-label {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -190,6 +190,8 @@ body,
   flex: 1;
   overflow-y: auto;
   padding: 16px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 /* Artist panel ------------------------------------------------------------- */
@@ -217,6 +219,8 @@ body,
   list-style: none;
   overflow-y: auto;
   flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .artist-list li {
@@ -546,6 +550,8 @@ body,
   list-style: none;
   overflow-y: auto;
   flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .track-row {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -603,6 +603,21 @@ body,
   max-width: 160px;
 }
 
+/* Focus-visible rings ----------------------------------------------------- */
+
+.artist-list li:focus-visible,
+.album-card:focus-visible,
+.transport-btn:focus-visible,
+.back-btn:focus-visible,
+.play-all-btn:focus-visible,
+.setup-scan-btn:focus-visible,
+.track-row:focus-visible,
+.seek-bar:focus-visible,
+.volume-slider:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* Active / press feedback ------------------------------------------------- */
 
 .transport-btn:active,

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -592,3 +592,23 @@ body,
   text-overflow: ellipsis;
   max-width: 160px;
 }
+
+/* Active / press feedback ------------------------------------------------- */
+
+.transport-btn:active,
+.back-btn:active,
+.play-all-btn:active,
+.setup-scan-btn:active {
+  opacity: 0.75;
+  transform: scale(0.96);
+}
+
+.album-card:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.track-row:active,
+.artist-list li:active {
+  opacity: 0.7;
+}

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -17,8 +17,8 @@
   --border: #2e2e2e;
   --text: #e0e0e0;
   --text-dim: #888;
-  --accent: #e07c3c;
-  --accent-dim: #7a3d1a;
+  --accent: #7c86e1;
+  --accent-dim: #252b5c;
   --error: #e06c75;
   --text-on-accent: #000;
   --transport-h: 88px;
@@ -274,11 +274,11 @@ body,
 }
 
 .album-card.playing {
-  box-shadow: 0 0 0 3px rgba(224, 124, 60, 0.35);
+  box-shadow: 0 0 0 3px rgba(124, 134, 225, 0.35);
 }
 
 .album-card.playing:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(224, 124, 60, 0.35);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(124, 134, 225, 0.35);
 }
 
 .album-art {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -274,8 +274,11 @@ body,
 }
 
 .album-card.playing {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  box-shadow: 0 0 0 3px rgba(224, 124, 60, 0.35);
+}
+
+.album-card.playing:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(224, 124, 60, 0.35);
 }
 
 .album-art {
@@ -311,6 +314,7 @@ body,
   background: var(--accent);
   color: var(--text-on-accent);
   font-size: 11px;
+  font-weight: 600;
   padding: 2px 5px;
   border-radius: 3px;
 }

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -13,7 +13,12 @@ function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
   return (
-    <div className={`album-card${isActive ? ' playing' : ''}`} onClick={() => selectAlbum(album)}>
+    <div
+      className={`album-card${isActive ? ' playing' : ''}`}
+      tabIndex={0}
+      onClick={() => selectAlbum(album)}
+      onKeyDown={(e) => e.key === 'Enter' && selectAlbum(album)}
+    >
       <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
           <img

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -5,6 +5,14 @@ export function ArtistPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
   const selected = useStore((s) => s.library.selectedArtist)
   const selectArtist = useStore((s) => s.selectArtist)
+  const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
+  const setLibraryPath = useStore((s) => s.setLibraryPath)
+
+  async function handleChangeLibrary(): Promise<void> {
+    const dir = await window.api.openDirectory()
+    if (dir === null) return
+    await setLibraryPath(dir)
+  }
 
   return (
     <aside className="artist-panel">
@@ -30,6 +38,14 @@ export function ArtistPanel(): React.JSX.Element {
           </li>
         ))}
       </ul>
+      <div className="panel-library-footer">
+        <span className="panel-library-path" title={configuredLibraryPath ?? undefined}>
+          {configuredLibraryPath ?? '—'}
+        </span>
+        <button className="panel-library-change-btn" onClick={handleChangeLibrary}>
+          Change Library…
+        </button>
+      </div>
     </aside>
   )
 }

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -10,14 +10,21 @@ export function ArtistPanel(): React.JSX.Element {
     <aside className="artist-panel">
       <div className="panel-header">Artists</div>
       <ul className="artist-list">
-        <li className={selected === null ? 'active' : ''} onClick={() => selectArtist(null)}>
+        <li
+          className={selected === null ? 'active' : ''}
+          tabIndex={0}
+          onClick={() => selectArtist(null)}
+          onKeyDown={(e) => e.key === 'Enter' && selectArtist(null)}
+        >
           All Artists
         </li>
         {artists.map((artist) => (
           <li
             key={artist}
             className={selected === artist ? 'active' : ''}
+            tabIndex={0}
             onClick={() => selectArtist(artist)}
+            onKeyDown={(e) => e.key === 'Enter' && selectArtist(artist)}
           >
             {artist}
           </li>

--- a/kamp_ui/src/renderer/src/components/SetupScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SetupScreen.tsx
@@ -1,11 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
 
 export function SetupScreen(): React.JSX.Element {
-  const scanLibrary = useStore((s) => s.scanLibrary)
   const scanStatus = useStore((s) => s.scanStatus)
   const lastScanResult = useStore((s) => s.lastScanResult)
   const scanError = useStore((s) => s.scanError)
+  const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
+  const setLibraryPath = useStore((s) => s.setLibraryPath)
+  const scanLibrary = useStore((s) => s.scanLibrary)
+  const scanProgress = useStore((s) => s.scanProgress)
+
+  const [pickError, setPickError] = useState<string | null>(null)
+
+  async function handleChoose(): Promise<void> {
+    setPickError(null)
+    const dir = await window.api.openDirectory()
+    if (dir === null) return // user cancelled
+    try {
+      await setLibraryPath(dir)
+    } catch {
+      setPickError('Could not set library path. Check the server logs.')
+    }
+  }
 
   return (
     <div className="setup-screen">
@@ -14,20 +30,47 @@ export function SetupScreen(): React.JSX.Element {
 
       {scanStatus === 'idle' && (
         <>
-          <div className="setup-hint">
-            Point <code>paths.library</code> at your music folder in{' '}
-            <code>~/.config/kamp/config.toml</code>, then scan to index it.
-          </div>
-          <button className="setup-scan-btn" onClick={scanLibrary}>
-            Scan Library
-          </button>
+          {configuredLibraryPath ? (
+            <div className="setup-path">
+              {configuredLibraryPath}
+              <button className="setup-change-btn" onClick={handleChoose}>
+                Change…
+              </button>
+            </div>
+          ) : (
+            <button className="setup-scan-btn" onClick={handleChoose}>
+              Choose Library Folder
+            </button>
+          )}
+          {pickError && <div className="setup-error">{pickError}</div>}
+          {configuredLibraryPath && (
+            <button className="setup-scan-btn" onClick={scanLibrary}>
+              Scan Library
+            </button>
+          )}
         </>
       )}
 
       {scanStatus === 'scanning' && (
         <div className="setup-scanning">
-          <span className="setup-spinner" />
-          Scanning…
+          {scanProgress && scanProgress.total > 0 ? (
+            <>
+              <div className="setup-progress-bar">
+                <div
+                  className="setup-progress-fill"
+                  style={{ width: `${(scanProgress.current / scanProgress.total) * 100}%` }}
+                />
+              </div>
+              <div className="setup-progress-label">
+                {scanProgress.current} / {scanProgress.total}
+              </div>
+            </>
+          ) : (
+            <>
+              <span className="setup-spinner" />
+              Scanning…
+            </>
+          )}
         </div>
       )}
 

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -51,12 +51,18 @@ export function TrackList(): React.JSX.Element | null {
             <li
               key={`${track.disc_number}-${track.track_number}`}
               className={`track-row${isCurrent ? ' current' : ''}`}
+              tabIndex={0}
               onClick={() => {
                 if (isCurrent) {
                   togglePlayPause()
                 } else {
                   playTrack(album.album_artist, album.album, i)
                 }
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return
+                if (isCurrent) togglePlayPause()
+                else playTrack(album.album_artist, album.album, i)
               }}
             >
               <span className="track-row-num">

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -60,6 +60,9 @@ export function TransportBar(): React.JSX.Element {
           step={0.5}
           value={position}
           onChange={(e) => seek(parseFloat(e.target.value))}
+          style={
+            { '--range-progress': `${(position / (duration || 1)) * 100}%` } as React.CSSProperties
+          }
         />
         <span className="time">{formatTime(duration)}</span>
       </div>
@@ -73,6 +76,7 @@ export function TransportBar(): React.JSX.Element {
           max={100}
           value={volume}
           onChange={(e) => setVolume(parseInt(e.target.value, 10))}
+          style={{ '--range-progress': `${volume}%` } as React.CSSProperties}
         />
         <span className="volume-label">{volume}</span>
       </div>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -8,7 +8,7 @@
 
 import { create } from 'zustand'
 import * as api from './api/client'
-import type { Album, PlayerState, ScanResult, Track } from './api/client'
+import type { Album, PlayerState, ScanProgress, ScanResult, Track } from './api/client'
 
 type LibraryState = {
   albums: Album[]
@@ -26,6 +26,9 @@ type PlayerStore = {
   scanStatus: 'idle' | 'scanning' | 'done' | 'error'
   lastScanResult: ScanResult | null
   scanError: string | null
+  scanProgress: ScanProgress | null
+
+  configuredLibraryPath: string | null
 
   // Actions
   setServerStatus: (status: 'connected' | 'disconnected') => void
@@ -44,6 +47,7 @@ type PlayerStore = {
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
   scanLibrary: () => Promise<void>
+  setLibraryPath: (path: string) => Promise<void>
   applyServerState: (state: PlayerState) => void
 }
 
@@ -69,6 +73,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   scanStatus: 'idle',
   lastScanResult: null,
   scanError: null,
+  scanProgress: null,
+  configuredLibraryPath: null,
 
   setServerStatus: (status) => set({ serverStatus: status }),
 
@@ -144,18 +150,36 @@ export const useStore = create<PlayerStore>((set, get) => ({
     await api.setRepeat(repeat)
   },
 
+  setLibraryPath: async (path) => {
+    await api.setLibraryPath(path)
+    set({ configuredLibraryPath: path })
+  },
+
   scanLibrary: async () => {
-    set({ scanStatus: 'scanning', scanError: null })
+    set({ scanStatus: 'scanning', scanError: null, scanProgress: null })
+
+    // Poll the server for progress at ~2 Hz while the scan runs.
+    const pollInterval = setInterval(async () => {
+      try {
+        const progress = await api.getScanProgress()
+        set({ scanProgress: progress })
+      } catch {
+        // Ignore transient poll errors — the scan result is what matters.
+      }
+    }, 500)
+
     try {
       const result = await api.scanLibrary()
-      set({ scanStatus: 'done', lastScanResult: result })
+      set({ scanStatus: 'done', lastScanResult: result, scanProgress: null })
       await get().loadLibrary()
     } catch (err) {
       const msg =
         err instanceof Error && err.message.includes('503')
-          ? 'Library path not configured. Set paths.library in your config.toml and restart the server.'
+          ? 'Library path not configured. Use the "Choose Library Folder" button.'
           : 'Scan failed. Check the server logs for details.'
-      set({ scanStatus: 'error', scanError: msg })
+      set({ scanStatus: 'error', scanError: msg, scanProgress: null })
+    } finally {
+      clearInterval(pollInterval)
     }
   }
 }))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -587,6 +587,51 @@ class TestLibraryScanner:
 
         assert result.added == 0
 
+    def test_scan_calls_on_progress_for_each_new_file(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3")
+        _make_mp3(lib / "02.mp3")
+        _make_mp3(lib / "03.mp3")
+
+        calls: list[tuple[int, int]] = []
+        index = LibraryIndex(tmp_path / "library.db")
+        LibraryScanner(index).scan(lib, on_progress=lambda c, t: calls.append((c, t)))
+        index.close()
+
+        # One call per new file; total is always 3.
+        assert len(calls) == 3
+        assert all(total == 3 for _, total in calls)
+        assert sorted(current for current, _ in calls) == [1, 2, 3]
+
+    def test_scan_on_progress_not_called_when_no_new_files(
+        self, tmp_path: Path
+    ) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        # First scan indexes the file.
+        LibraryScanner(index).scan(lib)
+        # Second scan: nothing new — callback must not be called.
+        calls: list[tuple[int, int]] = []
+        LibraryScanner(index).scan(lib, on_progress=lambda c, t: calls.append((c, t)))
+        index.close()
+
+        assert calls == []
+
+    def test_scan_without_on_progress_still_works(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        result = LibraryScanner(index).scan(lib)  # no on_progress arg
+        index.close()
+
+        assert result.added == 1
+
 
 # ---------------------------------------------------------------------------
 # Tag reader helpers

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -248,6 +248,60 @@ class TestLibraryScanEndpoint:
         assert response.status_code == 503
 
 
+class TestScanProgressEndpoint:
+    def test_progress_idle_by_default(self, client: TestClient) -> None:
+        res = client.get("/api/v1/library/scan/progress")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["active"] is False
+        assert data["current"] == 0
+        assert data["total"] == 0
+
+    def test_progress_callback_updates_state(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        # Capture the on_progress callback that scan_library passes to LibraryScanner.
+        captured: list[MagicMock] = []
+
+        def _fake_scan(path: object, on_progress: object = None) -> MagicMock:
+            captured.append(on_progress)  # type: ignore[arg-type]
+            return MagicMock(added=2, removed=0, unchanged=0)
+
+        with patch("kamp_core.server.LibraryScanner") as MockScanner:
+            MockScanner.return_value.scan.side_effect = _fake_scan
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                library_path=Path("/music"),
+            )
+            c = TestClient(app)
+            c.post("/api/v1/library/scan")
+
+        # The callback was passed into scan().
+        assert len(captured) == 1
+        assert callable(captured[0])
+
+    def test_progress_resets_to_idle_after_scan(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        with patch("kamp_core.server.LibraryScanner") as MockScanner:
+            MockScanner.return_value.scan.return_value = MagicMock(
+                added=1, removed=0, unchanged=0
+            )
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                library_path=Path("/music"),
+            )
+            c = TestClient(app)
+            c.post("/api/v1/library/scan")
+            data = c.get("/api/v1/library/scan/progress").json()
+
+        assert data["active"] is False
+
+
 # ---------------------------------------------------------------------------
 # Player endpoints
 # ---------------------------------------------------------------------------
@@ -413,3 +467,126 @@ class TestPlayerWebSocket:
             msg = ws.receive_json()
         assert msg["playing"] is True
         assert msg["position"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Config: set library path
+# ---------------------------------------------------------------------------
+
+
+class TestSetLibraryPathEndpoint:
+    def _make_client(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        *,
+        on_library_path_set: object = None,
+    ) -> TestClient:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_library_path_set=on_library_path_set,
+        )
+        return TestClient(app)
+
+    def test_valid_directory_returns_ok(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        c = self._make_client(mock_index, mock_engine, mock_queue)
+        res = c.post("/api/v1/config/library-path", json={"path": str(tmp_path)})
+        assert res.status_code == 200
+        assert res.json() == {"ok": True}
+
+    def test_valid_path_unblocks_scan(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # Start with no library_path — scan should return 503.
+        c = self._make_client(mock_index, mock_engine, mock_queue)
+        assert c.post("/api/v1/library/scan").status_code == 503
+
+        # Set a valid path — scan should now succeed.
+        c.post("/api/v1/config/library-path", json={"path": str(tmp_path)})
+        with patch("kamp_core.server.LibraryScanner") as MockScanner:
+            MockScanner.return_value.scan.return_value = MagicMock(
+                added=0, removed=0, unchanged=0
+            )
+            res = c.post("/api/v1/library/scan")
+        assert res.status_code == 200
+
+    def test_nonexistent_path_returns_422(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        c = self._make_client(mock_index, mock_engine, mock_queue)
+        res = c.post(
+            "/api/v1/config/library-path",
+            json={"path": "/this/does/not/exist/at/all"},
+        )
+        assert res.status_code == 422
+
+    def test_file_path_returns_422(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "notadir.txt"
+        f.touch()
+        c = self._make_client(mock_index, mock_engine, mock_queue)
+        res = c.post("/api/v1/config/library-path", json={"path": str(f)})
+        assert res.status_code == 422
+
+    def test_callback_invoked_on_success(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        callback = MagicMock()
+        c = self._make_client(
+            mock_index, mock_engine, mock_queue, on_library_path_set=callback
+        )
+        c.post("/api/v1/config/library-path", json={"path": str(tmp_path)})
+        callback.assert_called_once_with(tmp_path.resolve())
+
+    def test_callback_not_invoked_on_invalid_path(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        callback = MagicMock()
+        c = self._make_client(
+            mock_index, mock_engine, mock_queue, on_library_path_set=callback
+        )
+        c.post(
+            "/api/v1/config/library-path",
+            json={"path": "/this/does/not/exist/at/all"},
+        )
+        callback.assert_not_called()
+
+    def test_no_callback_is_fine(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # on_library_path_set=None (the default) — should not raise
+        c = self._make_client(mock_index, mock_engine, mock_queue)
+        res = c.post("/api/v1/config/library-path", json={"path": str(tmp_path)})
+        assert res.status_code == 200


### PR DESCRIPTION
## Summary

- **Native library picker**: replaces the "edit config.toml" hint in `SetupScreen` with a button that opens `dialog.showOpenDialog` via Electron IPC. The chosen path is persisted to `config.toml` at runtime via a new `POST /api/v1/config/library-path` endpoint — no server restart required.
- **Post-setup access**: `ArtistPanel` footer shows the current library path and a "Change Library…" button once the library is populated.
- **Scan progress bar**: `LibraryScanner.scan()` now accepts an `on_progress(current, total)` callback. The server exposes `GET /api/v1/library/scan/progress`; the frontend polls it at 500 ms during a scan and replaces the spinner with a filled progress bar + `n / total` label. Falls back to the spinner for re-scans with no new files.

## Test plan

- [x] **Cold start (no library configured):** launch `kamp server`, open UI → SetupScreen shows "Choose Library Folder" button (no `config.toml` mention)
- [x] **Directory picker:** click button → native macOS sheet opens → cancel → nothing changes; pick a folder → path appears with "Change…" link and "Scan Library" button
- [x] **Scan progress:** click "Scan Library" with a large library → spinner briefly appears, then progress bar fills with `n / total` label; small library → completes fast but bar is visible
- [ ] **Re-scan (no new files):** trigger scan again after indexing → falls back to spinner (total = 0), completes quickly
- [x] **Config persistence:** after picking a folder, check `~/.config/kamp/config.toml` — `paths.library` should reflect the chosen path; restart server → path is already set
- [x] **Post-setup "Change Library…":** with albums loaded, `ArtistPanel` footer shows path and button; click → picker → choose different folder → re-scan triggers
- [x] **Error path:** point picker at an empty folder → scan completes with `Added 0 tracks`; point at a non-directory (if possible) → 422 from server, error shown in UI

## Checklist

- [x] `poetry run pytest tests/test_library.py tests/test_server.py` — 86 passed
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [x] Pre-commit hook (black + mypy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)