### PR TITLE
feat: auto-scan library after path is selected in setup

### DIFF
--- a/kamp_ui/src/renderer/src/components/SetupScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SetupScreen.tsx
@@ -20,7 +20,10 @@ export function SetupScreen(): React.JSX.Element {
       await setLibraryPath(dir)
     } catch {
       setPickError('Could not set library path. Check the server logs.')
+      return
     }
+    // Auto-trigger scan immediately after path is confirmed — scan manages its own error state.
+    scanLibrary()
   }
 
   return (
@@ -43,11 +46,6 @@ export function SetupScreen(): React.JSX.Element {
             </button>
           )}
           {pickError && <div className="setup-error">{pickError}</div>}
-          {configuredLibraryPath && (
-            <button className="setup-scan-btn" onClick={scanLibrary}>
-              Scan Library
-            </button>
-          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
- Removes the manual "Scan Library" button from the first-run setup flow
- `scanLibrary()` fires automatically once the user selects a directory and the path is saved to config
- Scan error state and Retry button are unchanged

## Test plan
- [ ] Fresh setup (no library configured): pick a folder → scan starts immediately, progress bar shows
- [ ] Change folder via "Change…" button → scan restarts automatically
- [ ] Simulate scan failure (point at empty/invalid dir) → error message and Retry button appear
- [ ] Cancel the directory picker (press Escape) → nothing happens, no scan triggered

Closes TASK-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)