### PR TITLE
fix: reconnect WebSocket with backoff after sleep/wake

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -18,17 +18,28 @@ export default function App(): React.JSX.Element {
   useEffect(() => {
     loadLibrary()
 
-    // Connect WebSocket state stream. Re-establishes automatically when the
-    // server restarts. Each reconnect also reloads the library in case albums
-    // were added while the server was down.
+    // Connect WebSocket state stream. On close, retry with exponential backoff
+    // (1 s, 2 s, 4 s … capped at 30 s). After 8 failed attempts we give up and
+    // show the offline screen. Attempts reset to 0 on every successful open so
+    // that a sleep/wake cycle always gets a fresh run of retries.
+    let attempts = 0
+    const MAX_ATTEMPTS = 8
+
     const connect = (): (() => void) => {
       return connectStateStream(
         applyServerState,
         () => {
-          setServerStatus('disconnected')
-          setTimeout(connect, 2000)
+          attempts++
+          if (attempts >= MAX_ATTEMPTS) {
+            setServerStatus('disconnected')
+          } else {
+            setServerStatus('reconnecting')
+            const delay = Math.min(1000 * 2 ** (attempts - 1), 30000)
+            setTimeout(connect, delay)
+          }
         },
         () => {
+          attempts = 0
           setServerStatus('connected')
           loadLibrary()
         }
@@ -39,7 +50,7 @@ export default function App(): React.JSX.Element {
     return disconnect
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (serverStatus === 'disconnected' && !hasAlbums) {
+  if (serverStatus === 'disconnected') {
     return (
       <div className="server-offline">
         <div className="server-offline-icon">⏻</div>
@@ -55,7 +66,7 @@ export default function App(): React.JSX.Element {
 
   return (
     <div className="app">
-      {serverStatus === 'disconnected' && (
+      {serverStatus === 'reconnecting' && (
         <div className="reconnecting-banner">Reconnecting to server…</div>
       )}
       <div className="app-body">

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -22,7 +22,7 @@ type LibraryState = {
 type PlayerStore = {
   player: PlayerState
   library: LibraryState
-  serverStatus: 'connected' | 'disconnected'
+  serverStatus: 'connected' | 'reconnecting' | 'disconnected'
   scanStatus: 'idle' | 'scanning' | 'done' | 'error'
   lastScanResult: ScanResult | null
   scanError: string | null
@@ -31,7 +31,7 @@ type PlayerStore = {
   configuredLibraryPath: string | null
 
   // Actions
-  setServerStatus: (status: 'connected' | 'disconnected') => void
+  setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   loadLibrary: () => Promise<void>
   selectArtist: (artist: string | null) => void
   selectAlbum: (album: Album | null) => Promise<void>
@@ -69,7 +69,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     tracks: [],
     tracksAlbumKey: null
   },
-  serverStatus: 'disconnected',
+  serverStatus: 'reconnecting',
   scanStatus: 'idle',
   lastScanResult: null,
   scanError: null,


### PR DESCRIPTION
## Summary
- Adds a `'reconnecting'` server status (alongside `'connected'` and `'disconnected'`)
- Initial status is now `'reconnecting'` instead of `'disconnected'`, so the offline screen never flashes on startup
- On WebSocket close, retries with exponential backoff: 1s, 2s, 4s, 8s … capped at 30s
- After 8 failed attempts, gives up and shows the offline screen
- Attempt counter resets to 0 on every successful open, so sleep/wake always gets a fresh retry run
- Reconnecting banner now triggers on `'reconnecting'` status (not `'disconnected'`)

## Test plan
- [ ] Sleep laptop with UI open, wake → reconnecting banner appears briefly, then resolves automatically
- [ ] Kill the server while UI is open → reconnecting banner appears; restart server → reconnects and banner disappears
- [ ] Kill the server and leave it down → offline screen appears after ~2 minutes (8 attempts)
- [ ] Open app with server not running → reconnecting banner shows (not offline screen) until retries exhausted

Closes TASK-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)