### PR TITLE
fix: rename Tune-Shifter to Kamp in menu bar and notifications

### DIFF
--- a/kamp_daemon/menu_bar.py
+++ b/kamp_daemon/menu_bar.py
@@ -126,7 +126,7 @@ class MenuBarApp(rumps.App):
             self._format_menu,
             self._interval_menu,
             None,  # separator
-            rumps.MenuItem("About Tune-Shifter", callback=self._on_about),
+            rumps.MenuItem("About Kamp", callback=self._on_about),
             rumps.MenuItem("Quit", callback=self._on_quit),
         ]
 

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -46,9 +46,7 @@ def _notify(
     """
     if notify_callback is None:
         return
-    payload = json.dumps(
-        {"title": "Tune-Shifter", "subtitle": subtitle, "message": message}
-    )
+    payload = json.dumps({"title": "Kamp", "subtitle": subtitle, "message": message})
     notify_callback(f"{_NOTIFY_SENTINEL}{payload}")
 
 

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -330,7 +330,7 @@ class Syncer:
                 logger.exception("Unhandled error during Bandcamp sync")
                 if self.error_callback is not None:
                     self.error_callback(
-                        "Tune-Shifter",
+                        "Kamp",
                         "Bandcamp sync failed",
                         str(exc)[:120],
                     )

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -90,7 +90,7 @@ class TestNotifySentinel:
         self, subtitle: str = "Tagging failed", message: str = "album"
     ) -> str:
         payload = json.dumps(
-            {"title": "Tune-Shifter", "subtitle": subtitle, "message": message}
+            {"title": "Kamp", "subtitle": subtitle, "message": message}
         )
         return f"{_NOTIFY_SENTINEL}{payload}"
 
@@ -102,7 +102,7 @@ class TestNotifySentinel:
             on_directory=None,
             notification_callback=lambda t, s, m: received.append((t, s, m)),
         )
-        assert received == [("Tune-Shifter", "Tagging failed", "my-album")]
+        assert received == [("Kamp", "Tagging failed", "my-album")]
 
     def test_notify_sentinel_not_forwarded_to_stage_callback(self) -> None:
         stage_received: list[str] = []
@@ -361,7 +361,7 @@ class TestSyncerErrorCallback:
                 syncer._run()
 
         assert len(received) == 1
-        assert received[0][0] == "Tune-Shifter"
+        assert received[0][0] == "Kamp"
         assert received[0][1] == "Bandcamp sync failed"
 
     def test_error_callback_not_required(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `menu_bar.py`: "About Tune-Shifter" → "About Kamp"
- `syncer.py`: notification title "Tune-Shifter" → "Kamp"
- `pipeline_impl.py`: notification title "Tune-Shifter" → "Kamp"
- `test_notifications.py`: updated assertions to match

## Test plan
- [ ] macOS menu bar shows "About Kamp" in the menu
- [ ] Error notifications from sync/pipeline show "Kamp" as the title
- [ ] `poetry run pytest tests/test_notifications.py -v --no-cov` passes

Closes TASK-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)