### PR TITLE
feat: re-scan trigger in panel footer; style library picker

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -198,6 +198,36 @@ body,
   line-height: 1.6;
 }
 
+.setup-path {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-dim);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 14px;
+  max-width: 380px;
+}
+
+.setup-change-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.setup-change-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
 /* App body ----------------------------------------------------------------- */
 
 .app-body {
@@ -260,6 +290,60 @@ body,
 .artist-list li.active {
   background: var(--accent-dim);
   color: var(--accent);
+}
+
+.panel-library-footer {
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.panel-library-path {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-library-change-btn,
+.panel-rescan-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.panel-library-change-btn:hover,
+.panel-rescan-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.panel-rescan-scanning {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.panel-rescan-progress {
+  height: 2px;
+  background: var(--border);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.panel-rescan-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 1px;
+  transition: width 0.3s ease;
 }
 
 /* Album grid --------------------------------------------------------------- */

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -7,12 +7,21 @@ export function ArtistPanel(): React.JSX.Element {
   const selectArtist = useStore((s) => s.selectArtist)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const setLibraryPath = useStore((s) => s.setLibraryPath)
+  const scanLibrary = useStore((s) => s.scanLibrary)
+  const scanStatus = useStore((s) => s.scanStatus)
+  const scanProgress = useStore((s) => s.scanProgress)
 
   async function handleChangeLibrary(): Promise<void> {
     const dir = await window.api.openDirectory()
     if (dir === null) return
     await setLibraryPath(dir)
   }
+
+  const scanning = scanStatus === 'scanning'
+  const progressPct =
+    scanProgress && scanProgress.total > 0
+      ? (scanProgress.current / scanProgress.total) * 100
+      : null
 
   return (
     <aside className="artist-panel">
@@ -42,6 +51,21 @@ export function ArtistPanel(): React.JSX.Element {
         <span className="panel-library-path" title={configuredLibraryPath ?? undefined}>
           {configuredLibraryPath ?? '—'}
         </span>
+        {/* TODO: move re-scan to preferences panel once DRAFT-8 ships */}
+        {scanning ? (
+          <>
+            <span className="panel-rescan-scanning">Scanning…</span>
+            {progressPct !== null && (
+              <div className="panel-rescan-progress">
+                <div className="panel-rescan-progress-fill" style={{ width: `${progressPct}%` }} />
+              </div>
+            )}
+          </>
+        ) : (
+          <button className="panel-rescan-btn" onClick={scanLibrary}>
+            Re-scan Library
+          </button>
+        )}
         <button className="panel-library-change-btn" onClick={handleChangeLibrary}>
           Change Library…
         </button>


### PR DESCRIPTION
## Summary
- **TASK-26:** Adds a "Re-scan Library" button to the `ArtistPanel` footer. Wires directly to the existing `scanLibrary` store action. While scanning, the button is replaced by a "Scanning…" label and a thin progress bar. Marked with a TODO comment to move to preferences panel once DRAFT-8 ships.
- **TASK-24:** Adds missing CSS for `setup-path` and `setup-change-btn` in the first-run setup screen (the path display + "Change…" button). Also adds all missing panel footer styles (`panel-library-footer`, `panel-library-path`, `panel-library-change-btn`, `panel-rescan-*`).

## Test plan
- [ ] Library picker in setup: selected path displays in a styled box with a "Change…" button; consistent with app typography and colours
- [ ] Panel footer: library path shown truncated with ellipsis; "Re-scan Library" and "Change Library…" buttons visible
- [ ] Click "Re-scan Library" → button replaced by "Scanning…" + progress bar; on completion library refreshes and button returns
- [ ] Focus rings visible on both new buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)