### PR TITLE
feat: Now Playing view (TASK-7)

### DIFF
--- a/backlog/milestones/m-5 - listening-history.md
+++ b/backlog/milestones/m-5 - listening-history.md
@@ -1,0 +1,8 @@
+---
+id: m-5
+title: "Listening History"
+---
+
+## Description
+
+Milestone: Listening History

--- a/backlog/milestones/m-6 - daemon-refinement.md
+++ b/backlog/milestones/m-6 - daemon-refinement.md
@@ -1,0 +1,8 @@
+---
+id: m-6
+title: "Daemon Refinement"
+---
+
+## Description
+
+Milestone: Daemon Refinement

--- a/backlog/milestones/m-7 - tag-editor-view.md
+++ b/backlog/milestones/m-7 - tag-editor-view.md
@@ -1,0 +1,8 @@
+---
+id: m-7
+title: "Tag Editor View"
+---
+
+## Description
+
+Milestone: Tag Editor View

--- a/backlog/tasks/task-1 - bug-kamp-UI-cant-find-server-after-computer-sleeps.md
+++ b/backlog/tasks/task-1 - bug-kamp-UI-cant-find-server-after-computer-sleeps.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1
 title: 'bug: kamp UI can''t find server after computer sleeps'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 02:44'
-updated_date: '2026-03-29 14:03'
+updated_date: '2026-03-29 15:51'
 labels:
   - bug
   - ui

--- a/backlog/tasks/task-24 - refine-Library-picker-needs-styling.md
+++ b/backlog/tasks/task-24 - refine-Library-picker-needs-styling.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-24
 title: 'refine: Library picker needs styling'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 13:58'
-updated_date: '2026-03-29 14:10'
+updated_date: '2026-03-29 16:27'
 labels:
   - polish
   - ui

--- a/backlog/tasks/task-25 - Library-scan-progress-UI.md
+++ b/backlog/tasks/task-25 - Library-scan-progress-UI.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-25
 title: Library scan progress UI
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 14:14'
+updated_date: '2026-03-29 15:52'
 labels:
   - feature
   - ux

--- a/backlog/tasks/task-26 - Re-scan-library-trigger-in-main-UI.md
+++ b/backlog/tasks/task-26 - Re-scan-library-trigger-in-main-UI.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-26
 title: Re-scan library trigger in main UI
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 14:09'
-updated_date: '2026-03-29 14:10'
+updated_date: '2026-03-29 16:27'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-27 - last.fm-scrobble-integration.md
+++ b/backlog/tasks/task-27 - last.fm-scrobble-integration.md
@@ -1,0 +1,29 @@
+---
+id: TASK-27
+title: last.fm scrobble integration
+status: To Do
+assignee: []
+created_date: '2026-03-29 17:28'
+updated_date: '2026-03-29 17:42'
+labels:
+  - feature
+  - integration
+  - 'estimate: lp'
+milestone: m-5
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A user can supply their last.fm API key so listening data can be "scrobbled"
+
+A user has a quick link to creating or retrieving their last.fm API key.
+
+A song is scrobbled after 30 seconds of listening to it, or when the track finishes (whichever comes first).
+
+If playback is interrupted (pause, app quit and then playback start after restarting app), it is only scrobbled once.
+
+If a song is played twice on repeat (it finishes and then starts again), it is scrobbled twice.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-28 - track-listening-statistics-are-kept-in-the-Library.md
+++ b/backlog/tasks/task-28 - track-listening-statistics-are-kept-in-the-Library.md
@@ -1,0 +1,21 @@
+---
+id: TASK-28
+title: track listening statistics are kept in the Library
+status: To Do
+assignee: []
+created_date: '2026-03-29 17:29'
+updated_date: '2026-03-29 17:42'
+labels:
+  - feature
+  - library
+  - 'estimate: side'
+milestone: m-5
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Listening statistics such as "play count" and "last played" are kept on the track level.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-29 - redraw-issue-window-has-visible-white-gutters-while-shrinking.md
+++ b/backlog/tasks/task-29 - redraw-issue-window-has-visible-white-gutters-while-shrinking.md
@@ -1,0 +1,29 @@
+---
+id: TASK-29
+title: 'redraw issue: window has visible white gutters while shrinking'
+status: To Do
+assignee: []
+created_date: '2026-03-29 17:35'
+updated_date: '2026-03-29 17:50'
+labels:
+  - bug
+  - ui
+  - 'estimate: single'
+milestone: m-0
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+to repro:
+increase the size of the window
+decrease the size of the window
+
+expected:
+no visual artifacts while changing window dimensions
+
+actual:
+white gutters appear on the right and bottom of the window while dimensions shrink
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
+++ b/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
@@ -1,16 +1,16 @@
 ---
-id: DRAFT-1
+id: TASK-30
 title: 'Investigate: main process inflates ~50 MB when Bandcamp sync starts'
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:02'
+updated_date: '2026-03-29 17:47'
 labels:
   - bug
   - performance
   - investigation
   - 'estimate: lp'
-milestone: m-1
+milestone: m-6
 dependencies: []
 ---
 

--- a/backlog/tasks/task-31 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
+++ b/backlog/tasks/task-31 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
@@ -1,16 +1,17 @@
 ---
-id: DRAFT-2
+id: TASK-31
 title: >-
   Best Release: prefer physical format (LP/CD) over digital/streaming when
   multiple MB results exist
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:00'
+updated_date: '2026-03-29 17:47'
 labels:
   - feature
   - musicbrainz
   - 'estimate: side'
+milestone: m-5
 dependencies: []
 ---
 

--- a/backlog/tasks/task-32 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
+++ b/backlog/tasks/task-32 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
@@ -1,16 +1,17 @@
 ---
-id: DRAFT-3
+id: TASK-32
 title: >-
   Nested folders: recurse into subdirectories in staging and treat each leaf
   folder as an album
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:00'
+updated_date: '2026-03-29 17:47'
 labels:
   - feature
   - ingest
   - 'estimate: side'
+milestone: m-6
 dependencies: []
 ---
 

--- a/backlog/tasks/task-33 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
+++ b/backlog/tasks/task-33 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
@@ -1,12 +1,15 @@
 ---
-id: DRAFT-4
+id: TASK-33
 title: 'Configurable album art search (Bandcamp, Apple, Spotify, Qobuz)'
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 17:49'
 labels:
   - feature
   - artwork
+  - 'estimate: 2xlp'
+milestone: m-7
 dependencies: []
 ---
 

--- a/backlog/tasks/task-34 - Allow-user-to-verify-tags-before-they-are-written.md
+++ b/backlog/tasks/task-34 - Allow-user-to-verify-tags-before-they-are-written.md
@@ -1,12 +1,15 @@
 ---
-id: DRAFT-5
+id: TASK-34
 title: Allow user to verify tags before they are written
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 17:49'
 labels:
   - feature
   - ux
+  - 'estimate: lp'
+milestone: m-7
 dependencies: []
 ---
 

--- a/backlog/tasks/task-35 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
+++ b/backlog/tasks/task-35 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
@@ -1,13 +1,16 @@
 ---
-id: DRAFT-7
+id: TASK-35
 title: 'bug: MusicBrainz Release Id tag casing inconsistency'
 status: Draft
 assignee: []
 created_date: '2026-03-29 02:58'
+updated_date: '2026-03-29 17:49'
 labels:
   - bug
   - musicbrainz
   - tagging
+  - 'estimate: single'
+milestone: m-7
 dependencies: []
 ---
 

--- a/backlog/tasks/task-36 - preferences-panel.md
+++ b/backlog/tasks/task-36 - preferences-panel.md
@@ -1,5 +1,5 @@
 ---
-id: DRAFT-8
+id: TASK-36
 title: preferences panel
 status: Draft
 assignee: []

--- a/backlog/tasks/task-37 - window-dimension-states-arent-serialized-deserialized-on-app-reload.md
+++ b/backlog/tasks/task-37 - window-dimension-states-arent-serialized-deserialized-on-app-reload.md
@@ -1,0 +1,18 @@
+---
+id: TASK-37
+title: window dimension states aren't serialized / deserialized on app reload
+status: To Do
+assignee: []
+created_date: '2026-03-29 17:54'
+updated_date: '2026-03-29 17:59'
+labels:
+  - bug
+  - electron
+  - 'estimate: single'
+milestone: m-0
+dependencies: []
+priority: low
+ordinal: 4750
+---
+
+

--- a/backlog/tasks/task-38 - bug-play-impossible-to-restart-after-stop.md
+++ b/backlog/tasks/task-38 - bug-play-impossible-to-restart-after-stop.md
@@ -1,0 +1,35 @@
+---
+id: TASK-38
+title: 'bug: play impossible to restart after stop'
+status: To Do
+assignee: []
+created_date: '2026-03-29 17:59'
+updated_date: '2026-03-29 18:00'
+labels:
+  - bug
+  - playback
+  - 'estimate: single'
+milestone: m-0
+dependencies: []
+priority: high
+ordinal: 875
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+to repro:
+start playing a track: play button changes to 'pause' state
+press stop: play button remains 'pause'
+press pause to get play button back
+press play
+
+expected:
+cursor index returns to 0 of track
+pause button becomes play button
+pressing play again starts track at beginning
+
+actual:
+track can't be restarted
+nothing can be played until a different track is selected
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-4 - bug-macOS-menu-bar-reads-About-Tune-Shifter-instead-of-About-Kamp.md
+++ b/backlog/tasks/task-4 - bug-macOS-menu-bar-reads-About-Tune-Shifter-instead-of-About-Kamp.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-4
 title: 'bug: macOS menu bar reads \"About Tune-Shifter\" instead of \"About Kamp\"'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:14'
+updated_date: '2026-03-29 16:14'
 labels:
   - bug
   - macos

--- a/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
+++ b/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-7
 title: 'Now Playing view (artwork-centered, view switching)'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 03:14'
+updated_date: '2026-03-29 16:28'
 labels:
   - feature
   - ui

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
 import { AlbumGrid } from './components/AlbumGrid'
+import { NowPlayingView } from './components/NowPlayingView'
 import { SetupScreen } from './components/SetupScreen'
 import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
@@ -14,6 +15,8 @@ export default function App(): React.JSX.Element {
   const serverStatus = useStore((s) => s.serverStatus)
   const hasAlbums = useStore((s) => s.library.albums.length > 0)
   const selectedAlbum = useStore((s) => s.library.selectedAlbum)
+  const activeView = useStore((s) => s.activeView)
+  const setActiveView = useStore((s) => s.setActiveView)
 
   useEffect(() => {
     loadLibrary()
@@ -69,10 +72,34 @@ export default function App(): React.JSX.Element {
       {serverStatus === 'reconnecting' && (
         <div className="reconnecting-banner">Reconnecting to server…</div>
       )}
+      {!showSetup && (
+        <nav className="view-tabs">
+          <button
+            className={activeView === 'library' ? 'active' : ''}
+            onClick={() => setActiveView('library')}
+          >
+            Library
+          </button>
+          <button
+            className={activeView === 'now-playing' ? 'active' : ''}
+            onClick={() => setActiveView('now-playing')}
+          >
+            Now Playing
+          </button>
+        </nav>
+      )}
       <div className="app-body">
-        {!showSetup && <ArtistPanel />}
+        {!showSetup && activeView === 'library' && <ArtistPanel />}
         <main className="main-content">
-          {showSetup ? <SetupScreen /> : selectedAlbum ? <TrackList /> : <AlbumGrid />}
+          {showSetup ? (
+            <SetupScreen />
+          ) : activeView === 'now-playing' ? (
+            <NowPlayingView />
+          ) : selectedAlbum ? (
+            <TrackList />
+          ) : (
+            <AlbumGrid />
+          )}
         </main>
       </div>
       <TransportBar />

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -88,6 +88,38 @@ body,
   text-align: center;
 }
 
+/* View tabs ---------------------------------------------------------------- */
+
+.view-tabs {
+  display: flex;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0 8px;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.view-tabs button {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 8px 12px;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.view-tabs button:hover {
+  color: var(--text);
+}
+
+.view-tabs button.active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+}
+
 /* Setup screen ------------------------------------------------------------- */
 
 .setup-screen {
@@ -238,10 +270,17 @@ body,
 
 .main-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 16px;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+}
+
+/* Now-playing fills its own space — override the shared padding */
+.main-content:has(.now-playing) {
+  padding: 0;
+  overflow: hidden;
 }
 
 /* Artist panel ------------------------------------------------------------- */
@@ -767,6 +806,96 @@ body,
   max-width: 160px;
 }
 
+/* Now Playing view --------------------------------------------------------- */
+
+.now-playing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  height: 100%;
+  padding: 16px;
+}
+
+.now-playing-art {
+  position: relative;
+  /* Grow to fill available height, stay square, never exceed container width */
+  flex: 1;
+  min-height: 0;
+  aspect-ratio: 1;
+  max-width: 100%;
+  border-radius: 8px;
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.now-playing-art-placeholder {
+  font-size: 72px;
+  opacity: 0.15;
+}
+
+.now-playing-art img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.now-playing-art.has-art img {
+  opacity: 1;
+}
+
+.now-playing-meta {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.now-playing-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.now-playing-artist {
+  font-size: 14px;
+  color: var(--text-dim);
+}
+
+.now-playing-album {
+  font-size: 13px;
+  color: var(--text-dim);
+  opacity: 0.7;
+}
+
+.now-playing-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 12px;
+}
+
+.now-playing-empty-icon {
+  font-size: 52px;
+  opacity: 0.15;
+}
+
+.now-playing-empty-hint {
+  font-size: 14px;
+  color: var(--text-dim);
+}
+
 /* Focus-visible rings ----------------------------------------------------- */
 
 .artist-list li:focus-visible,
@@ -777,7 +906,8 @@ body,
 .setup-scan-btn:focus-visible,
 .track-row:focus-visible,
 .seek-bar:focus-visible,
-.volume-slider:focus-visible {
+.volume-slider:focus-visible,
+.view-tabs button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { useStore } from '../store'
+import { artUrl } from '../api/client'
+
+export function NowPlayingView(): React.JSX.Element {
+  const player = useStore((s) => s.player)
+  const { current_track } = player
+  const [artLoaded, setArtLoaded] = useState(false)
+
+  if (!current_track) {
+    return (
+      <div className="now-playing-empty">
+        <div className="now-playing-empty-icon">♫</div>
+        <div className="now-playing-empty-hint">Nothing playing</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="now-playing">
+      <div className={`now-playing-art${artLoaded ? ' has-art' : ''}`}>
+        <span className="now-playing-art-placeholder">♪</span>
+        <img
+          src={artUrl(current_track.album_artist, current_track.album)}
+          onLoad={() => setArtLoaded(true)}
+          onError={() => setArtLoaded(false)}
+        />
+      </div>
+      <div className="now-playing-meta">
+        <div className="now-playing-title">{current_track.title}</div>
+        <div className="now-playing-artist">{current_track.artist}</div>
+        <div className="now-playing-album">
+          {current_track.album}
+          {current_track.year ? ` · ${current_track.year}` : ''}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -29,9 +29,12 @@ type PlayerStore = {
   scanProgress: ScanProgress | null
 
   configuredLibraryPath: string | null
+  // TODO(TASK-10): move to config.toml via preferences API once DRAFT-8 ships
+  activeView: 'library' | 'now-playing'
 
   // Actions
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
+  setActiveView: (view: 'library' | 'now-playing') => void
   loadLibrary: () => Promise<void>
   selectArtist: (artist: string | null) => void
   selectAlbum: (album: Album | null) => Promise<void>
@@ -75,8 +78,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
   scanError: null,
   scanProgress: null,
   configuredLibraryPath: null,
+  activeView: (localStorage.getItem('kamp.activeView') as 'library' | 'now-playing') ?? 'library',
 
   setServerStatus: (status) => set({ serverStatus: status }),
+
+  setActiveView: (view) => {
+    localStorage.setItem('kamp.activeView', view)
+    set({ activeView: view })
+  },
 
   applyServerState: (state) => set({ player: state }),
 


### PR DESCRIPTION
## Summary

- Adds a **Now Playing** view with full-size album art that scales to fill available height (`flex: 1` + `aspect-ratio: 1`), plus track title, artist, album, and year
- Adds a **Library / Now Playing** tab switcher in a `<nav class="view-tabs">` bar, with active state persisted to `localStorage`
- Art fades in on load; placeholder glyph shown when no art is available
- Backlog: all tasks now have estimate labels; new milestones m-5–m-7 and tasks TASK-27 to TASK-36 committed

## Test plan

- [x] Play a track, switch to Now Playing — art loads and fills the panel height
- [x] Resize the window — art scales proportionally, metadata stays visible below
- [x] No art case (album with no cover) — placeholder glyph shown, no broken img
- [x] Tab state survives app reload (localStorage)
- [x] Library tab still works normally (artist panel visible, album grid / track list intact)
- [x] Nothing playing — empty state shows correctly in Now Playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)