### PR TITLE
fix: stop button restarts track instead of locking up (TASK-38)

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -210,7 +210,11 @@ class MpvPlaybackEngine:
         self._send_command("seek", position, "absolute")
 
     def stop(self) -> None:
-        self._send_command("stop")
+        # Pause and seek to the beginning rather than unloading the file.
+        # mpv's "stop" command unloads the file, making resume() a no-op.
+        # Pausing + seeking keeps the track loaded so play() via resume() works.
+        self._send_command("set_property", "pause", True)
+        self._send_command("seek", 0, "absolute")
 
     @property
     def volume(self) -> int:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -209,10 +209,11 @@ class TestMpvPlaybackEngine:
         engine.volume = 75
         send.assert_called_once_with("set_property", "volume", 75)
 
-    def test_stop_sends_stop_command(self) -> None:
+    def test_stop_pauses_and_seeks_to_start(self) -> None:
         engine, send = _make_engine()
         engine.stop()
-        send.assert_called_once_with("stop")
+        send.assert_any_call("set_property", "pause", True)
+        send.assert_any_call("seek", 0, "absolute")
 
     def test_on_track_end_callback_is_called(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- `engine.stop()` previously sent mpv's `stop` command, which **unloads the file** — subsequent `resume()` call was a no-op since nothing was loaded
- Replace with `pause + seek(0)`: keeps the file loaded, resets position to 0, so pressing play works immediately
- mpv fires property-change events for both operations, so the UI receives `playing: false, position: 0` via WebSocket with no extra server changes needed

## Test plan

- [x] Play a track → press Stop → press Play — track restarts from the beginning
- [x] Play a track → press Stop → press Play — no "stuck" state, no need to re-select a track
- [ ] Play a track → press Pause → press Stop → press Play — still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)