### PR TITLE
feat: restore last track and position on daemon restart (TASK-8)

### DIFF
--- a/backlog/tasks/task-38 - bug-play-impossible-to-restart-after-stop.md
+++ b/backlog/tasks/task-38 - bug-play-impossible-to-restart-after-stop.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-38
 title: 'bug: play impossible to restart after stop'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 17:59'
-updated_date: '2026-03-29 18:00'
+updated_date: '2026-03-29 18:46'
 labels:
   - bug
   - playback

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -41,6 +41,12 @@ CREATE TABLE IF NOT EXISTS tracks (
     mb_release_id    TEXT    NOT NULL DEFAULT '',
     mb_recording_id  TEXT    NOT NULL DEFAULT ''
 );
+
+CREATE TABLE IF NOT EXISTS player_state (
+    id         INTEGER PRIMARY KEY CHECK (id = 1),  -- single-row table
+    track_path TEXT    NOT NULL,
+    position   REAL    NOT NULL DEFAULT 0
+);
 """
 
 
@@ -216,6 +222,33 @@ class LibraryIndex:
         """Return the set of all file paths currently in the index."""
         rows = self._conn.execute("SELECT file_path FROM tracks").fetchall()
         return {Path(r["file_path"]) for r in rows}
+
+    def get_track_by_path(self, path: Path) -> "Track | None":
+        """Return the track for *path*, or None if not indexed."""
+        row = self._conn.execute(
+            "SELECT * FROM tracks WHERE file_path = ?", (str(path),)
+        ).fetchone()
+        return _row_to_track(row) if row else None
+
+    def save_player_state(self, track_path: Path, position: float) -> None:
+        """Persist the current track path and playback position."""
+        self._conn.execute(
+            """
+            INSERT INTO player_state (id, track_path, position) VALUES (1, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                track_path = excluded.track_path,
+                position   = excluded.position
+            """,
+            (str(track_path), position),
+        )
+        self._conn.commit()
+
+    def load_player_state(self) -> "tuple[Path, float] | None":
+        """Return (track_path, position) from the last session, or None."""
+        row = self._conn.execute(
+            "SELECT track_path, position FROM player_state WHERE id = 1"
+        ).fetchone()
+        return (Path(row["track_path"]), row["position"]) if row else None
 
     def close(self) -> None:
         with self._all_conns_lock:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -243,6 +243,11 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def clear_player_state(self) -> None:
+        """Remove the persisted player state (e.g. after the queue is exhausted)."""
+        self._conn.execute("DELETE FROM player_state WHERE id = 1")
+        self._conn.commit()
+
     def load_player_state(self) -> "tuple[Path, float] | None":
         """Return (track_path, position) from the last session, or None."""
         row = self._conn.execute(

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -200,6 +200,17 @@ class MpvPlaybackEngine:
         # Explicitly unpause so calling play() after pause() always starts playback.
         self._send_command("set_property", "pause", False)
 
+    def load_paused(self, path: Path, position: float = 0.0) -> None:
+        """Load *path* into mpv, paused at *position*, without starting playback.
+
+        Used on daemon startup to restore the previous session state without
+        auto-resuming — the user must press play explicitly.
+        """
+        self._send_command("loadfile", str(path), "replace")
+        self._send_command("set_property", "pause", True)
+        if position > 0:
+            self._send_command("seek", position, "absolute")
+
     def pause(self) -> None:
         self._send_command("set_property", "pause", True)
 

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -205,11 +205,14 @@ class MpvPlaybackEngine:
 
         Used on daemon startup to restore the previous session state without
         auto-resuming — the user must press play explicitly.
+
+        The start position is passed as a loadfile option rather than a
+        subsequent seek command, because mpv silently drops seek commands that
+        arrive before the demuxer is ready.
         """
-        self._send_command("loadfile", str(path), "replace")
+        options = f"start={position}" if position > 0 else ""
+        self._send_command("loadfile", str(path), "replace", options)
         self._send_command("set_property", "pause", True)
-        if position > 0:
-            self._send_command("seek", position, "absolute")
 
     def pause(self) -> None:
         self._send_command("set_property", "pause", True)

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -140,6 +140,7 @@ class MpvPlaybackEngine:
     def __init__(self, mpv_bin: str = "mpv") -> None:
         self.state = PlaybackState()
         self.on_track_end: Callable[[], None] | None = None
+        self.on_file_loaded: Callable[[], None] | None = None
         self._mpv_bin = mpv_bin
         self._proc: subprocess.Popen[bytes] | None = None
         self._sock: socket.socket | None = None
@@ -206,12 +207,18 @@ class MpvPlaybackEngine:
         Used on daemon startup to restore the previous session state without
         auto-resuming — the user must press play explicitly.
 
-        The start position is passed as a loadfile option rather than a
-        subsequent seek command, because mpv silently drops seek commands that
-        arrive before the demuxer is ready.
+        The seek is deferred to the ``file-loaded`` event callback so it only
+        runs after the demuxer is ready — seek commands sent before that point
+        are silently dropped by mpv.
         """
-        options = f"start={position}" if position > 0 else ""
-        self._send_command("loadfile", str(path), "replace", options)
+        if position > 0:
+            # One-shot: seek to position when mpv confirms the file is ready.
+            def _seek_then_clear() -> None:
+                self.seek(position)
+                self.on_file_loaded = None
+
+            self.on_file_loaded = _seek_then_clear
+        self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
 
     def pause(self) -> None:
@@ -299,6 +306,10 @@ class MpvPlaybackEngine:
                 self.state.duration = float(data)
             elif prop == "pause" and isinstance(data, bool):
                 self.state.playing = not data
+
+        elif name == "file-loaded":
+            if self.on_file_loaded is not None:
+                self.on_file_loaded()
 
         elif name == "end-file":
             # Only fire on natural end-of-file, not user-initiated stops.

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -482,6 +482,16 @@ def _cmd_server(
     engine = MpvPlaybackEngine()
     queue: PlaybackQueue = PlaybackQueue()
 
+    # Restore the last session's track and position, paused, so the user can
+    # resume with a single press of play rather than hunting for the album again.
+    saved = index.load_player_state()
+    if saved:
+        saved_path, saved_pos = saved
+        track = index.get_track_by_path(saved_path)
+        if track:
+            queue.load([track], 0)
+            engine.load_paused(track.file_path, saved_pos)
+
     # Advance the queue automatically at end-of-track; stop cleanly at the end.
     def _on_track_end() -> None:
         track = queue.next()
@@ -491,6 +501,20 @@ def _cmd_server(
             engine.stop()
 
     engine.on_track_end = _on_track_end
+
+    # Persist current track and position every 5 s so restarts can resume.
+    def _state_saver() -> None:
+        import time
+
+        while True:
+            time.sleep(5)
+            current = queue.current()
+            if current:
+                index.save_player_state(current.file_path, engine.state.position)
+
+    import threading
+
+    threading.Thread(target=_state_saver, daemon=True, name="state-saver").start()
 
     # Persist library path changes back to config.toml so the next server start
     # picks up the user's choice without requiring a manual config edit.

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -499,6 +499,9 @@ def _cmd_server(
             engine.play(track.file_path)
         else:
             engine.stop()
+            # Queue exhausted — clear saved state so restart starts fresh
+            # rather than restoring the last track a few seconds from the end.
+            index.clear_player_state()
 
     engine.on_track_end = _on_track_end
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -293,6 +293,55 @@ class TestLibraryIndex:
 
         assert albums[0].has_art is True
 
+    def test_get_track_by_path_returns_track(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(tmp_path / "01.mp3")
+        index.upsert_track(track)
+        result = index.get_track_by_path(tmp_path / "01.mp3")
+        index.close()
+
+        assert result is not None
+        assert result.title == "A Song"
+
+    def test_get_track_by_path_returns_none_for_missing_path(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.get_track_by_path(tmp_path / "missing.mp3")
+        index.close()
+
+        assert result is None
+
+    def test_save_and_load_player_state(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_player_state(tmp_path / "track.mp3", 42.5)
+        result = index.load_player_state()
+        index.close()
+
+        assert result is not None
+        path, position = result
+        assert path == tmp_path / "track.mp3"
+        assert position == 42.5
+
+    def test_load_player_state_returns_none_when_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.load_player_state()
+        index.close()
+
+        assert result is None
+
+    def test_save_player_state_overwrites_previous(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_player_state(tmp_path / "first.mp3", 10.0)
+        index.save_player_state(tmp_path / "second.mp3", 99.0)
+        result = index.load_player_state()
+        index.close()
+
+        assert result is not None
+        path, position = result
+        assert path == tmp_path / "second.mp3"
+        assert position == 99.0
+
 
 # ---------------------------------------------------------------------------
 # extract_art

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -330,6 +330,15 @@ class TestLibraryIndex:
 
         assert result is None
 
+    def test_clear_player_state_removes_saved_state(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_player_state(tmp_path / "track.mp3", 42.5)
+        index.clear_player_state()
+        result = index.load_player_state()
+        index.close()
+
+        assert result is None
+
     def test_save_player_state_overwrites_previous(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.save_player_state(tmp_path / "first.mp3", 10.0)

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -215,6 +215,23 @@ class TestMpvPlaybackEngine:
         send.assert_any_call("set_property", "pause", True)
         send.assert_any_call("seek", 0, "absolute")
 
+    def test_load_paused_loads_and_pauses(self) -> None:
+        engine, send = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"))
+        send.assert_any_call("loadfile", "/music/track.mp3", "replace")
+        send.assert_any_call("set_property", "pause", True)
+
+    def test_load_paused_seeks_when_position_nonzero(self) -> None:
+        engine, send = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"), 42.5)
+        send.assert_any_call("seek", 42.5, "absolute")
+
+    def test_load_paused_does_not_seek_when_position_is_zero(self) -> None:
+        engine, send = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"), 0.0)
+        calls = [c.args for c in send.call_args_list]
+        assert ("seek", 0.0, "absolute") not in calls
+
     def test_on_track_end_callback_is_called(self) -> None:
         engine, _ = _make_engine()
         callback = MagicMock()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -218,19 +218,20 @@ class TestMpvPlaybackEngine:
     def test_load_paused_loads_and_pauses(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"))
-        send.assert_any_call("loadfile", "/music/track.mp3", "replace")
+        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "")
         send.assert_any_call("set_property", "pause", True)
 
-    def test_load_paused_seeks_when_position_nonzero(self) -> None:
+    def test_load_paused_passes_start_position_in_loadfile_options(self) -> None:
+        # Position is passed as a loadfile option, not a separate seek command,
+        # to avoid a race with the demuxer not being ready yet.
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 42.5)
-        send.assert_any_call("seek", 42.5, "absolute")
+        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "start=42.5")
 
-    def test_load_paused_does_not_seek_when_position_is_zero(self) -> None:
+    def test_load_paused_empty_options_when_position_is_zero(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 0.0)
-        calls = [c.args for c in send.call_args_list]
-        assert ("seek", 0.0, "absolute") not in calls
+        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "")
 
     def test_on_track_end_callback_is_called(self) -> None:
         engine, _ = _make_engine()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -218,20 +218,35 @@ class TestMpvPlaybackEngine:
     def test_load_paused_loads_and_pauses(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"))
-        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "")
+        send.assert_any_call("loadfile", "/music/track.mp3", "replace")
         send.assert_any_call("set_property", "pause", True)
 
-    def test_load_paused_passes_start_position_in_loadfile_options(self) -> None:
-        # Position is passed as a loadfile option, not a separate seek command,
-        # to avoid a race with the demuxer not being ready yet.
+    def test_load_paused_registers_file_loaded_callback_when_position_nonzero(
+        self,
+    ) -> None:
+        engine, _ = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"), 42.5)
+        assert engine.on_file_loaded is not None
+
+    def test_load_paused_no_callback_when_position_is_zero(self) -> None:
+        engine, _ = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"), 0.0)
+        assert engine.on_file_loaded is None
+
+    def test_load_paused_callback_seeks_and_clears_itself(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 42.5)
-        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "start=42.5")
+        assert engine.on_file_loaded is not None
+        engine.on_file_loaded()  # simulate file-loaded event
+        send.assert_any_call("seek", 42.5, "absolute")
+        assert engine.on_file_loaded is None  # one-shot: cleared after firing
 
-    def test_load_paused_empty_options_when_position_is_zero(self) -> None:
-        engine, send = _make_engine()
-        engine.load_paused(Path("/music/track.mp3"), 0.0)
-        send.assert_any_call("loadfile", "/music/track.mp3", "replace", "")
+    def test_file_loaded_event_triggers_on_file_loaded_callback(self) -> None:
+        engine, _ = _make_engine()
+        callback = MagicMock()
+        engine.on_file_loaded = callback
+        engine._handle_event({"event": "file-loaded"})
+        callback.assert_called_once()
 
     def test_on_track_end_callback_is_called(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- On daemon startup, the last track and playback position are restored from SQLite — the transport bar shows the track loaded and paused at the right position, ready to resume with one press of play
- Playback does **not** auto-resume on restart (AC#2)
- State is saved in the daemon's `library.db`, not in Electron (AC#3)

## Implementation

- New `player_state` table in `library.db` — single-row upsert keyed on `id=1`
- `LibraryIndex`: `save_player_state`, `load_player_state`, `get_track_by_path`
- `MpvPlaybackEngine.load_paused(path, position)`: loads the file into mpv paused at the given position, no audio blip
- Background daemon thread saves state every 5 s while a track is in the queue

## Test plan

- [x] Play a track partway through, kill the daemon, restart — transport bar shows the track at the saved position, paused
- [x] Press play — resumes from the saved position
- [x] Restart with no prior state (fresh DB) — app starts normally with no track loaded
- [ ] Play to end of album, restart — no track restored (queue was empty at end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)