### PR TITLE
feat: automatic library watching (TASK-5)

### DIFF
--- a/backlog/tasks/task-5 - Automatic-library-watching.md
+++ b/backlog/tasks/task-5 - Automatic-library-watching.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-5
 title: Automatic library watching
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:14'
+updated_date: '2026-03-29 20:59'
 labels:
   - feature
   - library

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -133,11 +133,22 @@ def create_app(
     # Mutable containers for runtime-updatable state.
     # library_path can be changed via POST /api/v1/config/library-path.
     # scan_progress is written by the scan thread and read by GET /api/v1/library/scan/progress.
+    # library_version is incremented by background scans; WebSocket connections
+    # detect the bump on the next ping and push a "library.changed" notification.
     _state: dict[str, Any] = {
         "library_path": library_path,
         "scan_progress": {"active": False, "current": 0, "total": 0},
         "ui_active_view": ui_active_view,
+        "library_version": 0,
     }
+
+    def _notify_library_changed() -> None:
+        """Increment the library version so connected WebSocket clients are notified."""
+        _state["library_version"] += 1
+
+    # Expose the notifier on app.state so the caller (__main__.py) can trigger
+    # it after background (watcher-driven) scans complete.
+    app.state.notify_library_changed = _notify_library_changed
 
     # Allow requests from the Electron renderer (Vite dev server and file://).
     # This server only binds to 127.0.0.1, so wildcard origins are safe.
@@ -335,15 +346,20 @@ def create_app(
         await ws.accept()
         # Push initial snapshot immediately on connect.
         await ws.send_json({"type": "player.state", **_state_snapshot().model_dump()})
+        last_library_version: int = _state["library_version"]
         try:
             while True:
                 # Each "ping" from the client triggers a fresh snapshot.
-                # This keeps the protocol simple for Phase 1; a push-based
-                # approach (asyncio task + event) can replace it later.
                 await ws.receive_text()
                 await ws.send_json(
                     {"type": "player.state", **_state_snapshot().model_dump()}
                 )
+                # Notify the client if a background scan updated the library
+                # since the last ping so it can refresh the album list.
+                current_version = _state["library_version"]
+                if current_version != last_library_version:
+                    last_library_version = current_version
+                    await ws.send_json({"type": "library.changed"})
         except Exception:
             pass
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -519,18 +519,6 @@ def _cmd_server(
 
     threading.Thread(target=_state_saver, daemon=True, name="state-saver").start()
 
-    # Watch the library directory and re-scan when audio files are added or
-    # removed, so the UI stays current without requiring a manual scan trigger.
-    from kamp_daemon.watcher import LibraryWatcher
-
-    def _on_library_change() -> None:
-        from kamp_core.library import LibraryScanner
-
-        LibraryScanner(index).scan(lib_path)
-
-    lib_watcher = LibraryWatcher(lib_path, _on_library_change)
-    lib_watcher.start()
-
     # Persist library path changes back to config.toml so the next server start
     # picks up the user's choice without requiring a manual config edit.
     def _on_library_path_set(path: Path) -> None:
@@ -548,6 +536,21 @@ def _cmd_server(
         ui_active_view=config.ui.active_view,
         on_ui_state_set=_on_ui_state_set,
     )
+
+    # Watch the library directory and re-scan when audio files are added or
+    # removed, so the UI stays current without requiring a manual scan trigger.
+    from kamp_daemon.watcher import LibraryWatcher
+
+    def _on_library_change() -> None:
+        from kamp_core.library import LibraryScanner
+
+        LibraryScanner(index).scan(lib_path)
+        # Bump the server's library version so connected WebSocket clients
+        # receive a "library.changed" push and reload the album list.
+        app.state.notify_library_changed()
+
+    lib_watcher = LibraryWatcher(lib_path, _on_library_change)
+    lib_watcher.start()
 
     print(f"Kamp API server starting on http://{host}:{port}")
     print(f"  Docs  → http://{host}:{port}/docs")

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -519,6 +519,18 @@ def _cmd_server(
 
     threading.Thread(target=_state_saver, daemon=True, name="state-saver").start()
 
+    # Watch the library directory and re-scan when audio files are added or
+    # removed, so the UI stays current without requiring a manual scan trigger.
+    from kamp_daemon.watcher import LibraryWatcher
+
+    def _on_library_change() -> None:
+        from kamp_core.library import LibraryScanner
+
+        LibraryScanner(index).scan(lib_path)
+
+    lib_watcher = LibraryWatcher(lib_path, _on_library_change)
+    lib_watcher.start()
+
     # Persist library path changes back to config.toml so the next server start
     # picks up the user's choice without requiring a manual config edit.
     def _on_library_path_set(path: Path) -> None:
@@ -542,6 +554,7 @@ def _cmd_server(
     print(f"  Library → {lib_path}")
     uvicorn.run(app, host=host, port=port)
 
+    lib_watcher.stop()
     engine.shutdown()
     index.close()
 

--- a/kamp_daemon/watcher.py
+++ b/kamp_daemon/watcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from collections.abc import Callable
@@ -10,6 +11,8 @@ from pathlib import Path
 
 from watchdog.events import (
     FileCreatedEvent,
+    FileDeletedEvent,
+    FileMovedEvent,
     FileSystemEvent,
     FileSystemEventHandler,
     FileSystemMovedEvent,
@@ -283,3 +286,85 @@ class Watcher:
     def join(self) -> None:
         """Block until the observer thread exits (e.g. after stop())."""
         self._observer.join()
+
+
+class _LibraryHandler(FileSystemEventHandler):
+    """Debounced handler that fires a callback when audio files change in the library.
+
+    Unlike _StagingHandler (one timer per path), a single timer is sufficient
+    here because LibraryScanner.scan() always does a full recursive walk; there
+    is no benefit to tracking individual paths.
+
+    Events caused by an active ingest pipeline (files being moved into the
+    library) continuously reset the timer, so the scan cannot fire until 2 s
+    after the last change — satisfying AC#3 without cross-process coordination.
+    """
+
+    def __init__(self, library_root: Path, on_scan: Callable[[], None]) -> None:
+        super().__init__()
+        self._library_root = library_root
+        self._on_scan = on_scan
+        self._pending: threading.Timer | None = None
+        self._lock = threading.Lock()
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if isinstance(event, FileCreatedEvent) and self._is_audio(event.src_path):
+            self._schedule()
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if isinstance(event, FileDeletedEvent) and self._is_audio(event.src_path):
+            self._schedule()
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        if isinstance(event, FileMovedEvent) and (
+            self._is_audio(event.src_path) or self._is_audio(event.dest_path)
+        ):
+            self._schedule()
+
+    def _is_audio(self, path: bytes | str) -> bool:
+        return Path(os.fsdecode(path)).suffix.lower() in AUDIO_EXTENSIONS
+
+    def _schedule(self) -> None:
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+            self._pending = threading.Timer(_SETTLE_SECONDS, self._fire)
+            self._pending.start()
+        logger.debug("Library re-scan scheduled in %.1fs", _SETTLE_SECONDS)
+
+    def _fire(self) -> None:
+        with self._lock:
+            self._pending = None
+        logger.info("Library change detected — triggering re-scan")
+        try:
+            self._on_scan()
+        except Exception:
+            logger.exception("Unhandled error in library re-scan")
+
+    def cancel_pending(self) -> None:
+        """Cancel any pending debounce timer without firing the scan."""
+        with self._lock:
+            if self._pending is not None:
+                self._pending.cancel()
+                self._pending = None
+
+
+class LibraryWatcher:
+    """Watch the library directory and trigger a re-scan on audio file changes."""
+
+    def __init__(self, library_path: Path, on_change: Callable[[], None]) -> None:
+        self._library_path = library_path
+        self._observer = Observer()
+        self._handler = _LibraryHandler(library_path, on_change)
+
+    def start(self) -> None:
+        self._library_path.mkdir(parents=True, exist_ok=True)
+        self._observer.schedule(self._handler, str(self._library_path), recursive=True)
+        self._observer.start()
+        logger.info("Watching library directory: %s", self._library_path)
+
+    def stop(self) -> None:
+        self._handler.cancel_pending()
+        self._observer.stop()
+        self._observer.join()
+        logger.info("Library watcher stopped")

--- a/kamp_daemon/watcher.py
+++ b/kamp_daemon/watcher.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from pathlib import Path
 
 from watchdog.events import (
+    DirDeletedEvent,
+    DirMovedEvent,
     FileCreatedEvent,
     FileDeletedEvent,
     FileMovedEvent,
@@ -312,11 +314,17 @@ class _LibraryHandler(FileSystemEventHandler):
             self._schedule()
 
     def on_deleted(self, event: FileSystemEvent) -> None:
-        if isinstance(event, FileDeletedEvent) and self._is_audio(event.src_path):
+        # Directory deletions (e.g. entire album folder removed) are caught here
+        # in addition to individual audio file deletions.
+        if isinstance(event, (FileDeletedEvent, DirDeletedEvent)):
             self._schedule()
 
     def on_moved(self, event: FileSystemEvent) -> None:
-        if isinstance(event, FileMovedEvent) and (
+        # Catch both individual audio file moves and whole directory moves (e.g.
+        # album folder dragged out of the library).
+        if isinstance(event, DirMovedEvent):
+            self._schedule()
+        elif isinstance(event, FileMovedEvent) and (
             self._is_audio(event.src_path) or self._is_audio(event.dest_path)
         ):
             self._schedule()

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { TransportBar } from './components/TransportBar'
 
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
+  const refreshOpenAlbum = useStore((s) => s.refreshOpenAlbum)
   const loadUiState = useStore((s) => s.loadUiState)
   const applyServerState = useStore((s) => s.applyServerState)
   const setServerStatus = useStore((s) => s.setServerStatus)
@@ -53,8 +54,9 @@ export default function App(): React.JSX.Element {
           loadUiState()
         },
         () => {
-          // Background scan completed — refresh the album list.
+          // Background scan completed — refresh album list and open track list.
           void loadLibrary()
+          void refreshOpenAlbum()
         }
       )
     }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -51,6 +51,10 @@ export default function App(): React.JSX.Element {
           setServerStatus('connected')
           loadLibrary()
           loadUiState()
+        },
+        () => {
+          // Background scan completed — refresh the album list.
+          void loadLibrary()
         }
       )
     }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -54,9 +54,10 @@ export default function App(): React.JSX.Element {
           loadUiState()
         },
         () => {
-          // Background scan completed — refresh album list and open track list.
-          void loadLibrary()
-          void refreshOpenAlbum()
+          // Background scan completed — refresh album list then open track list.
+          // Sequential: loadLibrary and refreshOpenAlbum both spread library state,
+          // so running them concurrently risks one overwriting the other's update.
+          void loadLibrary().then(() => refreshOpenAlbum())
         }
       )
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -125,11 +125,14 @@ export const setRepeat = (repeat: boolean): Promise<unknown> =>
 // ---------------------------------------------------------------------------
 
 export type StateMessage = PlayerState & { type: 'player.state' }
+export type LibraryChangedMessage = { type: 'library.changed' }
+export type ServerMessage = StateMessage | LibraryChangedMessage
 
 export function connectStateStream(
   onState: (state: PlayerState) => void,
   onClose?: () => void,
-  onOpen?: () => void
+  onOpen?: () => void,
+  onLibraryChanged?: () => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -137,8 +140,9 @@ export function connectStateStream(
 
   ws.onmessage = (event) => {
     try {
-      const msg = JSON.parse(event.data as string) as StateMessage
+      const msg = JSON.parse(event.data as string) as ServerMessage
       if (msg.type === 'player.state') onState(msg)
+      else if (msg.type === 'library.changed') onLibraryChanged?.()
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -49,6 +49,7 @@ type PlayerStore = {
   setVolume: (volume: number) => Promise<void>
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
+  refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
   applyServerState: (state: PlayerState) => void
@@ -106,15 +107,31 @@ export const useStore = create<PlayerStore>((set, get) => ({
     try {
       const [albums, artists] = await Promise.all([api.getAlbums(), api.getArtists()])
       set((s) => ({ library: { ...s.library, albums, artists }, serverStatus: 'connected' }))
-      // If an album is open, force-refresh its track list so deletions are
-      // reflected immediately (bypass the key guard by clearing it first).
-      const { selectedAlbum } = get().library
-      if (selectedAlbum) {
-        set((s) => ({ library: { ...s.library, tracksAlbumKey: null } }))
-        await get().loadTracks(selectedAlbum.album_artist, selectedAlbum.album)
-      }
     } catch {
       set({ serverStatus: 'disconnected' })
+    }
+  },
+
+  refreshOpenAlbum: async () => {
+    // Force-reload the track list for the currently open album, bypassing the
+    // key guard in loadTracks. Called after background scans so additions and
+    // deletions are reflected immediately without the user having to navigate away.
+    const { selectedAlbum } = get().library
+    if (!selectedAlbum) return
+    try {
+      const tracks = await api.getTracksForAlbum(
+        selectedAlbum.album_artist,
+        selectedAlbum.album
+      )
+      set((s) => ({
+        library: {
+          ...s.library,
+          tracks,
+          tracksAlbumKey: `${selectedAlbum.album_artist}\0${selectedAlbum.album}`
+        }
+      }))
+    } catch {
+      // Best-effort — stale track list is better than a broken UI.
     }
   },
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -119,10 +119,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const { selectedAlbum } = get().library
     if (!selectedAlbum) return
     try {
-      const tracks = await api.getTracksForAlbum(
-        selectedAlbum.album_artist,
-        selectedAlbum.album
-      )
+      const tracks = await api.getTracksForAlbum(selectedAlbum.album_artist, selectedAlbum.album)
       set((s) => ({
         library: {
           ...s.library,

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -106,6 +106,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
     try {
       const [albums, artists] = await Promise.all([api.getAlbums(), api.getArtists()])
       set((s) => ({ library: { ...s.library, albums, artists }, serverStatus: 'connected' }))
+      // If an album is open, force-refresh its track list so deletions are
+      // reflected immediately (bypass the key guard by clearing it first).
+      const { selectedAlbum } = get().library
+      if (selectedAlbum) {
+        set((s) => ({ library: { ...s.library, tracksAlbumKey: null } }))
+        await get().loadTracks(selectedAlbum.album_artist, selectedAlbum.album)
+      }
     } catch {
       set({ serverStatus: 'disconnected' })
     }

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -12,7 +12,14 @@ from kamp_daemon.config import (
     MusicBrainzConfig,
     PathsConfig,
 )
-from kamp_daemon.watcher import _StagingHandler, Watcher
+from watchdog.events import FileCreatedEvent, FileDeletedEvent, FileMovedEvent
+
+from kamp_daemon.watcher import (
+    LibraryWatcher,
+    _LibraryHandler,
+    _StagingHandler,
+    Watcher,
+)
 
 
 @pytest.fixture
@@ -767,3 +774,118 @@ class TestStageCallback:
         cb = lambda stage: None  # noqa: E731
         watcher.stage_callback = cb
         assert watcher._handler.stage_callback is cb
+
+
+# ---------------------------------------------------------------------------
+# _LibraryHandler / LibraryWatcher
+# ---------------------------------------------------------------------------
+
+
+def _make_library_handler(
+    tmp_path: Path, on_scan: MagicMock | None = None
+) -> _LibraryHandler:
+    if on_scan is None:
+        on_scan = MagicMock()
+    lib = tmp_path / "library"
+    lib.mkdir(parents=True, exist_ok=True)
+    return _LibraryHandler(lib, on_scan)
+
+
+class TestLibraryHandler:
+    def test_fires_scan_on_audio_file_created(self, tmp_path: Path) -> None:
+        """Creating an audio file in the library schedules a re-scan."""
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_created(
+                FileCreatedEvent(str(tmp_path / "library" / "track.mp3"))
+            )
+
+        mock_schedule.assert_called_once()
+
+    def test_ignores_non_audio_file_created(self, tmp_path: Path) -> None:
+        handler = _make_library_handler(tmp_path)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_created(
+                FileCreatedEvent(str(tmp_path / "library" / "cover.jpg"))
+            )
+
+        mock_schedule.assert_not_called()
+
+    def test_fires_scan_on_audio_file_deleted(self, tmp_path: Path) -> None:
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_deleted(
+                FileDeletedEvent(str(tmp_path / "library" / "track.flac"))
+            )
+
+        mock_schedule.assert_called_once()
+
+    def test_fires_scan_on_audio_file_moved(self, tmp_path: Path) -> None:
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(
+                FileMovedEvent(
+                    str(tmp_path / "elsewhere" / "track.mp3"),
+                    str(tmp_path / "library" / "track.mp3"),
+                )
+            )
+
+        mock_schedule.assert_called_once()
+
+    def test_debounces_rapid_events(self, tmp_path: Path) -> None:
+        """Multiple rapid events collapse into a single scan call."""
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+        lib = tmp_path / "library"
+
+        with patch("kamp_daemon.watcher._SETTLE_SECONDS", 0.05):
+            for i in range(5):
+                handler.on_created(FileCreatedEvent(str(lib / f"track{i}.mp3")))
+            import time
+
+            time.sleep(0.2)
+
+        on_scan.assert_called_once()
+
+    def test_cancel_pending_prevents_scan(self, tmp_path: Path) -> None:
+        """cancel_pending() stops the timer before it fires."""
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+        lib = tmp_path / "library"
+
+        with patch("kamp_daemon.watcher._SETTLE_SECONDS", 0.1):
+            handler.on_created(FileCreatedEvent(str(lib / "track.mp3")))
+            handler.cancel_pending()
+            import time
+
+            time.sleep(0.3)
+
+        on_scan.assert_not_called()
+
+
+class TestLibraryWatcher:
+    def test_stop_before_timer_fires_does_not_call_callback(
+        self, tmp_path: Path
+    ) -> None:
+        """Stopping the watcher before the debounce timer fires prevents the callback."""
+        on_change = MagicMock()
+        lib = tmp_path / "library"
+        lib.mkdir()
+        watcher = LibraryWatcher(lib, on_change)
+        watcher.start()
+
+        with patch("kamp_daemon.watcher._SETTLE_SECONDS", 0.2):
+            watcher._handler.on_created(FileCreatedEvent(str(lib / "track.mp3")))
+            watcher.stop()
+            import time
+
+            time.sleep(0.4)
+
+        on_change.assert_not_called()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -12,7 +12,13 @@ from kamp_daemon.config import (
     MusicBrainzConfig,
     PathsConfig,
 )
-from watchdog.events import FileCreatedEvent, FileDeletedEvent, FileMovedEvent
+from watchdog.events import (
+    DirDeletedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileMovedEvent,
+)
 
 from kamp_daemon.watcher import (
     LibraryWatcher,
@@ -834,6 +840,31 @@ class TestLibraryHandler:
                 FileMovedEvent(
                     str(tmp_path / "elsewhere" / "track.mp3"),
                     str(tmp_path / "library" / "track.mp3"),
+                )
+            )
+
+        mock_schedule.assert_called_once()
+
+    def test_fires_scan_on_directory_deleted(self, tmp_path: Path) -> None:
+        """Removing an entire album directory triggers a re-scan."""
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_deleted(DirDeletedEvent(str(tmp_path / "library" / "My Album")))
+
+        mock_schedule.assert_called_once()
+
+    def test_fires_scan_on_directory_moved_out(self, tmp_path: Path) -> None:
+        """Moving an entire album directory out of the library triggers a re-scan."""
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(
+                DirMovedEvent(
+                    str(tmp_path / "library" / "My Album"),
+                    str(tmp_path / "elsewhere" / "My Album"),
                 )
             )
 


### PR DESCRIPTION
## Summary

- Adds `_LibraryHandler` and `LibraryWatcher` to `watcher.py` — a recursive watchdog observer that fires `LibraryScanner.scan()` when audio files change in the library directory
- 2-second debounce collapses rapid/bulk changes into a single scan; events from an active ingest pipeline continuously reset the timer (AC#3)
- Wired into `_cmd_server()` so it starts and stops with the server process

## Test plan

- [x] Drop an audio file into the library directory — confirm the server log shows `Library change detected — triggering re-scan` after ~2s
- [x] `GET /api/v1/library` — confirm track count reflects the new file
- [x] Remove a file — confirm it disappears from the index after ~2s
- [x] Drop many files at once — confirm only one re-scan fires (debounce working)
- [x] `poetry run pytest tests/test_watcher.py -v --no-cov` — 52 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)