### PR TITLE
fix: window bounds persistence and white gutter on resize (TASK-29, TASK-37)

### DIFF
--- a/backlog/completed/task-5 - Automatic-library-watching.md
+++ b/backlog/completed/task-5 - Automatic-library-watching.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-5
 title: Automatic library watching
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 20:59'
+updated_date: '2026-03-30 00:35'
 labels:
   - feature
   - library

--- a/backlog/tasks/task-10 - Panel-layout-persistence-and-keyboard-shortcuts.md
+++ b/backlog/tasks/task-10 - Panel-layout-persistence-and-keyboard-shortcuts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-10
 title: Panel layout persistence and keyboard shortcuts
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 03:15'
+updated_date: '2026-03-30 01:30'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-0
 dependencies: []
 priority: medium
-ordinal: 1875
+ordinal: 7000
 ---
 
 ## Description

--- a/backlog/tasks/task-26 - Re-scan-library-trigger-in-main-UI.md
+++ b/backlog/tasks/task-26 - Re-scan-library-trigger-in-main-UI.md
@@ -4,7 +4,7 @@ title: Re-scan library trigger in main UI
 status: Done
 assignee: []
 created_date: '2026-03-29 14:09'
-updated_date: '2026-03-29 16:27'
+updated_date: '2026-03-30 00:46'
 labels:
   - feature
   - ui
@@ -13,6 +13,7 @@ labels:
 milestone: m-0
 dependencies: []
 priority: low
+ordinal: 5000
 ---
 
 ## Description

--- a/backlog/tasks/task-29 - redraw-issue-window-has-visible-white-gutters-while-shrinking.md
+++ b/backlog/tasks/task-29 - redraw-issue-window-has-visible-white-gutters-while-shrinking.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-29
 title: 'redraw issue: window has visible white gutters while shrinking'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 17:35'
-updated_date: '2026-03-29 17:50'
+updated_date: '2026-03-30 00:35'
 labels:
   - bug
   - ui

--- a/backlog/tasks/task-37 - window-dimension-states-arent-serialized-deserialized-on-app-reload.md
+++ b/backlog/tasks/task-37 - window-dimension-states-arent-serialized-deserialized-on-app-reload.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-37
 title: window dimension states aren't serialized / deserialized on app reload
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 17:54'
-updated_date: '2026-03-29 17:59'
+updated_date: '2026-03-30 00:35'
 labels:
   - bug
   - electron

--- a/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
+++ b/backlog/tasks/task-7 - Now-Playing-view-artwork-centered-view-switching.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-7
 title: 'Now Playing view (artwork-centered, view switching)'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 16:28'
+updated_date: '2026-03-30 00:46'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-0
 dependencies: []
 priority: high
-ordinal: 1500
+ordinal: 6000
 ---
 
 ## Description

--- a/backlog/tasks/task-8 - Playback-persistence-resume-last-track-and-position-on-restart.md
+++ b/backlog/tasks/task-8 - Playback-persistence-resume-last-track-and-position-on-restart.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-8
 title: Playback persistence (resume last track and position on restart)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 03:14'
+updated_date: '2026-03-30 01:30'
 labels:
   - feature
   - playback
@@ -12,7 +12,7 @@ labels:
 milestone: m-0
 dependencies: []
 priority: medium
-ordinal: 1750
+ordinal: 8000
 ---
 
 ## Description

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
 import { join, resolve } from 'path'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { spawn, ChildProcess } from 'child_process'
 import * as http from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
@@ -69,13 +69,38 @@ function stopServer(): void {
   }
 }
 
+type WindowBounds = { x: number; y: number; width: number; height: number }
+
+function loadWindowBounds(): WindowBounds {
+  const defaults: WindowBounds = { x: 0, y: 0, width: 900, height: 670 }
+  try {
+    const file = join(app.getPath('userData'), 'window-state.json')
+    return JSON.parse(readFileSync(file, 'utf8')) as WindowBounds
+  } catch {
+    return defaults
+  }
+}
+
+function saveWindowBounds(win: BrowserWindow): void {
+  try {
+    const file = join(app.getPath('userData'), 'window-state.json')
+    writeFileSync(file, JSON.stringify(win.getBounds()))
+  } catch {
+    // Non-critical — ignore write errors.
+  }
+}
+
 function createWindow(): void {
+  const bounds = loadWindowBounds()
+
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 900,
-    height: 670,
+    ...bounds,
     show: false,
     autoHideMenuBar: true,
+    // Match the app's dark background so the native window surface never
+    // shows through as white gutters during resize or repaint.
+    backgroundColor: '#141414',
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
@@ -86,6 +111,10 @@ function createWindow(): void {
   mainWindow.on('ready-to-show', () => {
     mainWindow.show()
   })
+
+  // Persist bounds on every move/resize so the next launch restores them.
+  mainWindow.on('moved', () => saveWindowBounds(mainWindow))
+  mainWindow.on('resized', () => saveWindowBounds(mainWindow))
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -5,6 +5,7 @@ import { spawn, ChildProcess } from 'child_process'
 import * as http from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+import { theme } from '../shared/theme'
 
 // ---------------------------------------------------------------------------
 // Server lifecycle
@@ -100,7 +101,7 @@ function createWindow(): void {
     autoHideMenuBar: true,
     // Match the app's dark background so the native window surface never
     // shows through as white gutters during resize or repaint.
-    backgroundColor: '#141414',
+    backgroundColor: theme.bg,
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -11,7 +11,8 @@
 }
 
 :root {
-  --bg: #141414;
+  /* --bg is set by main.tsx from shared/theme.ts so the main process can use
+     the same value for BrowserWindow.backgroundColor without a magic number. */
   --surface: #1e1e1e;
   --surface-hover: #2a2a2a;
   --border: #2e2e2e;

--- a/kamp_ui/src/renderer/src/main.tsx
+++ b/kamp_ui/src/renderer/src/main.tsx
@@ -3,6 +3,12 @@ import './assets/main.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { theme } from '../../shared/theme'
+
+// Apply shared design tokens as CSS custom properties so the stylesheet can
+// reference var(--bg) etc. while the main process uses the same values for
+// BrowserWindow options (e.g. backgroundColor).
+document.documentElement.style.setProperty('--bg', theme.bg)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/kamp_ui/src/shared/theme.ts
+++ b/kamp_ui/src/shared/theme.ts
@@ -1,0 +1,13 @@
+/**
+ * Design token constants shared between the main process and the renderer.
+ *
+ * The main process needs these at window-creation time (before the renderer
+ * loads), so they can't live in CSS. Defining them here lets both sides stay
+ * in sync: the main process reads them directly; the renderer sets them as
+ * CSS custom properties on <html> so the stylesheet can reference var(--bg) etc.
+ */
+
+export const theme = {
+  /** Primary app background — must match the BrowserWindow backgroundColor. */
+  bg: '#141414'
+} as const

--- a/kamp_ui/tsconfig.node.json
+++ b/kamp_ui/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*", "src/shared/**/*"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"]

--- a/kamp_ui/tsconfig.web.json
+++ b/kamp_ui/tsconfig.web.json
@@ -4,7 +4,8 @@
     "src/renderer/src/env.d.ts",
     "src/renderer/src/**/*",
     "src/renderer/src/**/*.tsx",
-    "src/preload/*.d.ts"
+    "src/preload/*.d.ts",
+    "src/shared/**/*"
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
## Summary

- **TASK-37**: Window position and size are now saved to `window-state.json` in Electron's userData directory on every `moved`/`resized` event, and restored on next launch. Falls back to 900×670 if no file exists.
- **TASK-29**: Added `backgroundColor: '#141414'` to `BrowserWindow` matching the app's CSS `--bg` token. The native Chromium surface previously defaulted to white, which became visible as gutters at the trailing edge while shrinking.

## Test plan

- [x] Resize and reposition the window, quit, relaunch — window opens at the saved size and position
- [x] Resize the window smaller — no white gutters appear on the right or bottom edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)