### PR TITLE
feat: collapsible queue panel (TASK-40)

### DIFF
--- a/backlog/milestones/m-11 - album-page-ui-polish.md
+++ b/backlog/milestones/m-11 - album-page-ui-polish.md
@@ -1,0 +1,8 @@
+---
+id: m-11
+title: "Album Page UI Polish"
+---
+
+## Description
+
+Milestone: Album Page UI Polish

--- a/backlog/milestones/m-12 - artist-page-ui-polish.md
+++ b/backlog/milestones/m-12 - artist-page-ui-polish.md
@@ -1,0 +1,8 @@
+---
+id: m-12
+title: "Artist Page UI Polish"
+---
+
+## Description
+
+Milestone: Artist Page UI Polish

--- a/backlog/milestones/m-13 - shuffle.md
+++ b/backlog/milestones/m-13 - shuffle.md
@@ -1,0 +1,8 @@
+---
+id: m-13
+title: "Shuffle"
+---
+
+## Description
+
+Milestone: Shuffle

--- a/backlog/milestones/m-14 - repeat.md
+++ b/backlog/milestones/m-14 - repeat.md
@@ -1,0 +1,8 @@
+---
+id: m-14
+title: "Repeat"
+---
+
+## Description
+
+Milestone: Repeat

--- a/backlog/milestones/m-15 - security---internal-database-&-repo.md
+++ b/backlog/milestones/m-15 - security---internal-database-&-repo.md
@@ -1,0 +1,8 @@
+---
+id: m-15
+title: "Security - Internal Database & Repo"
+---
+
+## Description
+
+Milestone: Security - Internal Database & Repo

--- a/backlog/tasks/task-40 - The-Playback-Queue-is-a-panel-that-can-be-shown.md
+++ b/backlog/tasks/task-40 - The-Playback-Queue-is-a-panel-that-can-be-shown.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-40
 title: The Playback Queue is a panel that can be shown
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-30 01:49'
-updated_date: '2026-03-31 03:23'
+updated_date: '2026-03-31 17:09'
 labels:
   - feature
   - ui

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -110,6 +110,15 @@ class PlaybackQueue:
     def set_repeat(self, repeat: bool) -> None:
         self._repeat = repeat
 
+    def queue_tracks(self) -> tuple[list[Track], int]:
+        """Return (tracks_in_playback_order, pos) for API serialisation.
+
+        Mirrors get_state() but returns Track objects rather than Paths so
+        the server can call TrackOut.from_track() without an extra lookup.
+        Returns ([], -1) when the queue is empty.
+        """
+        return [self._tracks[i] for i in self._order], self._pos
+
     def get_state(self) -> tuple[list[Path], int, bool, bool]:
         """Return (tracks_in_playback_order, pos, shuffle, repeat) for persistence.
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -113,6 +113,11 @@ class SearchOut(BaseModel):
     tracks: list[TrackOut]
 
 
+class QueueOut(BaseModel):
+    tracks: list[TrackOut]
+    position: int  # index of the currently playing track; -1 if empty
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -300,6 +305,11 @@ def create_app(
     @app.get("/api/v1/player/state", response_model=PlayerStateOut)
     def get_player_state() -> PlayerStateOut:
         return _state_snapshot()
+
+    @app.get("/api/v1/player/queue", response_model=QueueOut)
+    def get_queue() -> QueueOut:
+        tracks, pos = queue.queue_tracks()
+        return QueueOut(tracks=[TrackOut.from_track(t) for t in tracks], position=pos)
 
     @app.post("/api/v1/player/play")
     def play(req: PlayRequest) -> dict[str, Any]:

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { SearchView } from './components/SearchView'
 import { SetupScreen } from './components/SetupScreen'
 import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
+import { QueuePanel } from './components/QueuePanel'
 
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
@@ -26,6 +27,9 @@ export default function App(): React.JSX.Element {
   const prev = useStore((s) => s.prev)
   const searchQuery = useStore((s) => s.searchQuery)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
+  const queueVisible = useStore((s) => s.queueVisible)
+  const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const loadQueue = useStore((s) => s.loadQueue)
   const searchBarRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -57,6 +61,7 @@ export default function App(): React.JSX.Element {
           setServerStatus('connected')
           loadLibrary()
           loadUiState()
+          void loadQueue()
         },
         () => {
           // Background scan completed — refresh album list then open track list.
@@ -110,11 +115,24 @@ export default function App(): React.JSX.Element {
         case 'L':
           void setActiveView(activeView === 'library' ? 'now-playing' : 'library')
           break
+        case 'q':
+        case 'Q':
+          toggleQueuePanel()
+          break
       }
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [togglePlayPause, next, prev, setActiveView, activeView, searchQuery, setSearchQuery])
+  }, [
+    togglePlayPause,
+    next,
+    prev,
+    setActiveView,
+    activeView,
+    searchQuery,
+    setSearchQuery,
+    toggleQueuePanel
+  ])
 
   if (serverStatus === 'disconnected') {
     return (
@@ -167,6 +185,7 @@ export default function App(): React.JSX.Element {
             <AlbumGrid />
           )}
         </main>
+        {queueVisible && <QueuePanel />}
       </div>
       <TransportBar />
     </div>

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -91,6 +91,13 @@ export type SearchResult = {
 export const search = (q: string, sort = 'album_artist'): Promise<SearchResult> =>
   get(`/api/v1/search?q=${encodeURIComponent(q)}&sort=${encodeURIComponent(sort)}`)
 
+export type QueueState = {
+  tracks: Track[]
+  position: number
+}
+
+export const getQueue = (): Promise<QueueState> => get('/api/v1/player/queue')
+
 export const scanLibrary = (): Promise<ScanResult> => post('/api/v1/library/scan')
 
 export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1165,3 +1165,134 @@ body,
 .artist-list li:active {
   opacity: 0.7;
 }
+
+/* Queue panel -------------------------------------------------------------- */
+
+.queue-panel {
+  width: 280px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.queue-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  height: 44px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.queue-panel-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.queue-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 3px;
+  line-height: 1;
+}
+
+.queue-close-btn:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.queue-track-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.queue-track-row {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 8px;
+  padding: 6px 10px;
+  border-radius: 3px;
+  margin: 0 4px;
+  border-left: 3px solid transparent;
+  cursor: default;
+}
+
+.queue-track-row:hover {
+  background: var(--surface-hover);
+}
+
+.queue-track-row.current {
+  border-left-color: var(--accent);
+}
+
+.queue-track-row.played {
+  opacity: 0.4;
+}
+
+.queue-track-num {
+  grid-row: 1 / 3;
+  align-self: center;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.queue-track-row.current .queue-track-num {
+  color: var(--accent);
+}
+
+.queue-track-title {
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+}
+
+.queue-track-row.current .queue-track-title {
+  color: var(--accent);
+}
+
+.queue-track-artist {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.queue-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+/* Queue toggle button in transport bar */
+.queue-toggle-btn {
+  font-size: 15px;
+}
+
+.queue-toggle-btn.active {
+  color: var(--accent);
+}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react'
+import { useStore } from '../store'
+
+export function QueuePanel(): React.JSX.Element {
+  const queue = useStore((s) => s.queue)
+  const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const activeRef = useRef<HTMLLIElement>(null)
+
+  const tracks = queue?.tracks ?? []
+  const position = queue?.position ?? -1
+
+  // Scroll the active track into view whenever it changes.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [position])
+
+  return (
+    <aside className="queue-panel">
+      <div className="queue-panel-header">
+        <span className="queue-panel-label">QUEUE</span>
+        <button className="queue-close-btn" onClick={toggleQueuePanel} title="Close queue">
+          ✕
+        </button>
+      </div>
+      {tracks.length === 0 ? (
+        <div className="queue-empty">No tracks in queue.</div>
+      ) : (
+        <ol className="queue-track-list">
+          {tracks.map((track, idx) => {
+            const isCurrent = idx === position
+            const isPlayed = position >= 0 && idx < position
+            return (
+              <li
+                key={track.file_path}
+                ref={isCurrent ? activeRef : null}
+                className={`queue-track-row${isCurrent ? ' current' : ''}${isPlayed ? ' played' : ''}`}
+              >
+                <span className="queue-track-num">{idx + 1}</span>
+                <span className="queue-track-title">{track.title}</span>
+                <span className="queue-track-artist">{track.artist}</span>
+              </li>
+            )
+          })}
+        </ol>
+      )}
+    </aside>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -15,6 +15,8 @@ export function TransportBar(): React.JSX.Element {
   const prev = useStore((s) => s.prev)
   const seek = useStore((s) => s.seek)
   const setVolume = useStore((s) => s.setVolume)
+  const queueVisible = useStore((s) => s.queueVisible)
+  const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
 
   const { playing, position, duration, volume, current_track } = player
   return (
@@ -80,6 +82,14 @@ export function TransportBar(): React.JSX.Element {
         />
         <span className="volume-label">{volume}</span>
       </div>
+
+      <button
+        className={`transport-btn queue-toggle-btn${queueVisible ? ' active' : ''}`}
+        onClick={toggleQueuePanel}
+        title="Queue (Q)"
+      >
+        ☰
+      </button>
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -11,6 +11,7 @@ import * as api from './api/client'
 import type {
   Album,
   PlayerState,
+  QueueState,
   ScanProgress,
   ScanResult,
   SearchResult,
@@ -40,9 +41,13 @@ type PlayerStore = {
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
   searchQuery: string
   searchResults: SearchResult | null
+  queueVisible: boolean
+  queue: QueueState | null
 
   // Actions
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
+  toggleQueuePanel: () => void
+  loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (sort: 'album_artist' | 'album' | 'date_added' | 'last_played') => Promise<void>
   setActiveView: (view: 'library' | 'now-playing') => Promise<void>
@@ -95,8 +100,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
   sortOrder: 'album_artist',
   searchQuery: '',
   searchResults: null,
+  queueVisible: false,
+  queue: null,
 
   setServerStatus: (status) => set({ serverStatus: status }),
+
+  toggleQueuePanel: () => set((s) => ({ queueVisible: !s.queueVisible })),
+
+  loadQueue: async () => {
+    try {
+      const queue = await api.getQueue()
+      set({ queue })
+    } catch {
+      // Best-effort — stale or empty queue is fine.
+    }
+  },
 
   setSortOrder: async (sort) => {
     set({ sortOrder: sort })
@@ -189,10 +207,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   playAlbum: async (albumArtist, album, trackIndex = 0) => {
     await api.playAlbum(albumArtist, album, trackIndex)
+    void get().loadQueue()
   },
 
   playTrack: async (albumArtist, album, trackIndex) => {
     await api.playAlbum(albumArtist, album, trackIndex)
+    void get().loadQueue()
   },
 
   togglePlayPause: async () => {
@@ -210,10 +230,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   next: async () => {
     await api.nextTrack()
+    void get().loadQueue()
   },
 
   prev: async () => {
     await api.prevTrack()
+    void get().loadQueue()
   },
 
   seek: async (position) => {
@@ -227,6 +249,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setShuffle: async (shuffle) => {
     await api.setShuffle(shuffle)
+    void get().loadQueue()
   },
 
   setRepeat: async (repeat) => {

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -162,6 +162,45 @@ class TestPlaybackQueue:
         q.set_shuffle(True)  # no tracks loaded — should not raise
         assert q.current() is None
 
+    def test_queue_tracks_empty(self) -> None:
+        tracks, pos = PlaybackQueue().queue_tracks()
+        assert tracks == []
+        assert pos == -1
+
+    def test_queue_tracks_returns_tracks_in_playback_order(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        tracks, pos = q.queue_tracks()
+        assert tracks == ts
+        assert pos == 0
+
+    def test_queue_tracks_reflects_position_after_next(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        q.next()
+        tracks, pos = q.queue_tracks()
+        assert tracks == ts
+        assert pos == 1
+
+    def test_queue_tracks_returns_shuffled_order(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(10)]
+        q.load(ts)
+        q.set_shuffle(True)
+        tracks, pos = q.queue_tracks()
+        assert set(t.file_path for t in tracks) == {t.file_path for t in ts}
+        assert pos == 0
+
+    def test_queue_tracks_after_empty_load(self) -> None:
+        q = PlaybackQueue()
+        q.load([_track(1)])
+        q.load([])
+        tracks, pos = q.queue_tracks()
+        assert tracks == []
+        assert pos == -1
+
     def test_get_state_returns_paths_in_playback_order(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(3)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,6 +63,7 @@ def mock_engine() -> MagicMock:
 def mock_queue() -> MagicMock:
     queue = MagicMock()
     queue.current.return_value = None
+    queue.queue_tracks.return_value = ([], -1)
     return queue
 
 
@@ -436,6 +437,43 @@ class TestPlayerControlEndpoints:
 # ---------------------------------------------------------------------------
 # WebSocket
 # ---------------------------------------------------------------------------
+
+
+class TestQueueEndpoint:
+    def test_empty_queue(self, client: TestClient) -> None:
+        response = client.get("/api/v1/player/queue")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["tracks"] == []
+        assert data["position"] == -1
+
+    def test_returns_tracks_with_position(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        ts = [_track(1), _track(2), _track(3)]
+        mock_queue.queue_tracks.return_value = (ts, 1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/player/queue").json()
+        assert len(data["tracks"]) == 3
+        assert data["position"] == 1
+        assert data["tracks"][1]["title"] == "Track 2"
+
+    def test_track_has_required_fields(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_queue.queue_tracks.return_value = ([_track(1)], 0)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        track = c.get("/api/v1/player/queue").json()["tracks"][0]
+        assert set(track.keys()) >= {
+            "title",
+            "artist",
+            "album_artist",
+            "album",
+            "file_path",
+            "ext",
+        }
 
 
 class TestPlayerWebSocket:


### PR DESCRIPTION
## Summary

- `PlaybackQueue.queue_tracks()` — returns tracks in playback order + current position for API serialisation
- `GET /api/v1/player/queue` — new endpoint returning `{tracks, position}`
- `QueuePanel` component — 280px right-side panel showing tracks in playback order; current track has accent left border; played tracks are dimmed
- ☰ toggle button at far right of transport bar; `Q` keyboard shortcut
- Queue auto-loads on WS connect and refreshes after play, next, prev, shuffle

## Design

- Fixed 280px width, `border-left: 1px solid var(--border)`, sits in the existing `app-body` flex row
- Current track: `border-left: 3px solid var(--accent)`, title in accent colour
- Played tracks: `opacity: 0.4`
- Auto-scrolls current track into view on open and on track change
- No DnD yet — display only (TASK-41/42 will add drag-to-queue)

## Test plan

- [x] `pytest tests/test_playback.py -k queue_tracks` — 5 new tests pass
- [x] `pytest tests/test_server.py -k TestQueueEndpoint` — 3 new tests pass
- [x] Full suite: 595 tests pass
- [x] Manual: play an album, press Q — panel opens showing queue with current track highlighted; pressing Q again closes it; next/prev updates the highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)