### PR TITLE
feat: add to queue, play next, and queue rearrangement (TASK-41, TASK-54)

### DIFF
--- a/backlog/completed/task-40 - The-Playback-Queue-is-a-panel-that-can-be-shown.md
+++ b/backlog/completed/task-40 - The-Playback-Queue-is-a-panel-that-can-be-shown.md
@@ -1,0 +1,24 @@
+---
+id: TASK-40
+title: The Playback Queue is a panel that can be shown
+status: Done
+assignee: []
+created_date: '2026-03-30 01:49'
+updated_date: '2026-03-31 17:09'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-8
+dependencies: []
+priority: medium
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+By default, this collapsable panel should take up the right 25% of the application real esate.
+
+There will need to be a button to show/hide this panel.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/milestones/m-16 - dumb-playlists.md
+++ b/backlog/milestones/m-16 - dumb-playlists.md
@@ -1,0 +1,8 @@
+---
+id: m-16
+title: "Dumb Playlists"
+---
+
+## Description
+
+Milestone: Dumb Playlists

--- a/backlog/milestones/m-17 - smart-playlists.md
+++ b/backlog/milestones/m-17 - smart-playlists.md
@@ -1,0 +1,8 @@
+---
+id: m-17
+title: "Smart Playlists"
+---
+
+## Description
+
+Milestone: Smart Playlists

--- a/backlog/milestones/m-18 - save-queue-as-playlist.md
+++ b/backlog/milestones/m-18 - save-queue-as-playlist.md
@@ -1,0 +1,8 @@
+---
+id: m-18
+title: "Save Queue as Playlist"
+---
+
+## Description
+
+Milestone: Save Queue as Playlist

--- a/backlog/tasks/task-41 - A-track-can-be-added-to-the-playback-queue.md
+++ b/backlog/tasks/task-41 - A-track-can-be-added-to-the-playback-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-41
 title: A track can be added to the playback queue
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-30 01:49'
-updated_date: '2026-03-31 03:44'
+updated_date: '2026-03-31 17:11'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-41 - A-track-can-be-added-to-the-playback-queue.md
+++ b/backlog/tasks/task-41 - A-track-can-be-added-to-the-playback-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-41
 title: A track can be added to the playback queue
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-30 01:49'
-updated_date: '2026-03-31 17:11'
+updated_date: '2026-03-31 19:32'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: high
-ordinal: 1500
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-54 - the-queue-can-be-rearranged.md
+++ b/backlog/tasks/task-54 - the-queue-can-be-rearranged.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-54
 title: the queue can be rearranged
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-31 03:25'
-updated_date: '2026-03-31 03:44'
+updated_date: '2026-03-31 17:12'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-54 - the-queue-can-be-rearranged.md
+++ b/backlog/tasks/task-54 - the-queue-can-be-rearranged.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-54
 title: the queue can be rearranged
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-31 03:25'
-updated_date: '2026-03-31 17:12'
+updated_date: '2026-03-31 19:32'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: medium
-ordinal: 3500
+ordinal: 4000
 ---
 
 

--- a/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
+++ b/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
@@ -1,0 +1,21 @@
+---
+id: TASK-56
+title: double-clicking on a track in the queue advances the queue to that track
+status: To Do
+assignee: []
+created_date: '2026-03-31 17:39'
+updated_date: '2026-03-31 19:44'
+labels:
+  - feature
+  - ui
+  - 'estimate: single'
+milestone: m-8
+dependencies: []
+priority: medium
+---
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Single: `onDoubleClick` on queue rows + a new `skip_to` endpoint that sets `_pos` directly; no new UI chrome needed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-57 - the-queue-can-be-cleared-with-a-context-menu-action.md
+++ b/backlog/tasks/task-57 - the-queue-can-be-cleared-with-a-context-menu-action.md
@@ -1,0 +1,31 @@
+---
+id: TASK-57
+title: the queue can be cleared with a context menu action
+status: To Do
+assignee: []
+created_date: '2026-03-31 17:44'
+updated_date: '2026-03-31 19:44'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-8
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+right click on queue: "clear queue" removes all songs from queue except for currently playing song.
+
+if no song is playing, "clear queue" removes all songs from queue.
+
+right click on unplayed song in queue: "clear remaining" clears all unplayed songs from queue.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Side: two distinct backend operations ("clear queue" keeps current track, "clear remaining" drops all unplayed), right-click context menu on the queue panel itself (separate from the track row menu), plus backend methods for each case.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
+++ b/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
@@ -1,0 +1,36 @@
+---
+id: TASK-58
+title: filter state does not survive app restart
+status: To Do
+assignee: []
+created_date: '2026-03-31 17:51'
+updated_date: '2026-03-31 19:44'
+labels:
+  - bug
+  - 'estimate: single'
+milestone: m-8
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+to repro:
+open kamp ui: app opens in Sort By Artist
+sort by Last Played
+close kamp ui
+open kamp ui
+
+expected:
+app opens in Sort Last Played
+
+actual:
+app opens in Sort By Artist
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Single: sort order already flows through the store but is never persisted. Needs the same DB treatment as `ui_active_view` — save on change, restore in `loadUiState`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-59 - the-currently-playing-item-is-static-read-only-in-the-queue.md
+++ b/backlog/tasks/task-59 - the-currently-playing-item-is-static-read-only-in-the-queue.md
@@ -1,0 +1,28 @@
+---
+id: TASK-59
+title: the currently playing item is static / read-only in the queue
+status: To Do
+assignee: []
+created_date: '2026-03-31 19:29'
+updated_date: '2026-03-31 19:44'
+labels:
+  - feature
+  - ui
+  - 'estimate: single'
+milestone: m-8
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+the currently playing item can't be dragged around in the queue
+other items in the queue can be reordered around it, but it can't be moved by clicking and dragging
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Single: remove `draggable` from the current-track row in QueuePanel so the browser doesn't initiate a drag. Other rows can already be reordered around it. Add a visual cue (cursor or opacity) to signal the row is locked.
+<!-- SECTION:NOTES:END -->

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -150,6 +150,21 @@ class PlaybackQueue:
         if self._pos < 0:
             self._pos = 0
 
+    def insert_at(self, track: Track, display_idx: int) -> None:
+        """Insert *track* at display position *display_idx* in the queue.
+
+        *display_idx* is clamped to [0, len(_order)] so out-of-range values
+        are safe.  Adjusts _pos if the insertion falls before it.
+        """
+        idx = len(self._tracks)
+        self._tracks.append(track)
+        insert_pos = max(0, min(display_idx, len(self._order)))
+        self._order.insert(insert_pos, idx)
+        if self._pos < 0:
+            self._pos = 0
+        elif insert_pos <= self._pos:
+            self._pos += 1
+
     def play_next(self, track: Track) -> None:
         """Insert *track* immediately after the current position.
 

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -142,6 +142,69 @@ class PlaybackQueue:
         self._shuffle = shuffle
         self._repeat = repeat
 
+    def add_to_queue(self, track: Track) -> None:
+        """Append *track* to the end of the queue."""
+        idx = len(self._tracks)
+        self._tracks.append(track)
+        self._order.append(idx)
+        if self._pos < 0:
+            self._pos = 0
+
+    def play_next(self, track: Track) -> None:
+        """Insert *track* immediately after the current position.
+
+        If the queue is empty the track becomes the first (and current) item.
+        Any existing (non-current) occurrence of the same track is removed
+        first so the track never appears twice in the queue.
+        """
+        # Remove any existing non-current occurrence to avoid duplicates.
+        existing = next(
+            (
+                i
+                for i, ti in enumerate(self._order)
+                if i != self._pos and self._tracks[ti].file_path == track.file_path
+            ),
+            None,
+        )
+        if existing is not None:
+            self._order.pop(existing)
+            # Keep _pos consistent if we removed an entry before it.
+            if self._pos >= 0 and existing < self._pos:
+                self._pos -= 1
+
+        idx = len(self._tracks)
+        self._tracks.append(track)
+        insert_at = self._pos + 1 if self._pos >= 0 else 0
+        self._order.insert(insert_at, idx)
+        if self._pos < 0:
+            self._pos = 0
+
+    def move(self, from_idx: int, to_idx: int) -> None:
+        """Move the track at display position *from_idx* to *to_idx*.
+
+        Both indices are positions in the current playback order (i.e. into
+        ``_order``).  ``_pos`` is updated so the currently playing track does
+        not change.
+        """
+        if from_idx == to_idx:
+            return
+        n = len(self._order)
+        if not (0 <= from_idx < n and 0 <= to_idx < n):
+            raise IndexError(f"Queue index out of range: {from_idx}, {to_idx}")
+
+        item = self._order.pop(from_idx)
+        self._order.insert(to_idx, item)
+
+        # Adjust _pos so the same track remains current.
+        if self._pos < 0:
+            return
+        if from_idx == self._pos:
+            self._pos = to_idx
+        elif from_idx < self._pos <= to_idx:
+            self._pos -= 1
+        elif to_idx <= self._pos < from_idx:
+            self._pos += 1
+
     def _shuffled_order(self, anchor_idx: int) -> None:
         """Shuffle _order so anchor_idx appears first."""
         rest = [i for i in range(len(self._tracks)) if i != anchor_idx]

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -118,6 +118,15 @@ class QueueOut(BaseModel):
     position: int  # index of the currently playing track; -1 if empty
 
 
+class AddToQueueRequest(BaseModel):
+    file_path: str
+
+
+class MoveQueueRequest(BaseModel):
+    from_index: int
+    to_index: int
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -361,6 +370,30 @@ def create_app(
         track = queue.prev()
         if track:
             engine.play(track.file_path)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/add")
+    def queue_add(req: AddToQueueRequest) -> dict[str, Any]:
+        track = index.get_track_by_path(Path(req.file_path))
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        queue.add_to_queue(track)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/play-next")
+    def queue_play_next(req: AddToQueueRequest) -> dict[str, Any]:
+        track = index.get_track_by_path(Path(req.file_path))
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        queue.play_next(track)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/move")
+    def queue_move(req: MoveQueueRequest) -> dict[str, Any]:
+        try:
+            queue.move(req.from_index, req.to_index)
+        except IndexError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"ok": True}
 
     @app.post("/api/v1/player/shuffle")

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -127,6 +127,11 @@ class MoveQueueRequest(BaseModel):
     to_index: int
 
 
+class InsertQueueRequest(BaseModel):
+    file_path: str
+    index: int
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -386,6 +391,14 @@ def create_app(
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.play_next(track)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/insert")
+    def queue_insert(req: InsertQueueRequest) -> dict[str, Any]:
+        track = index.get_track_by_path(Path(req.file_path))
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        queue.insert_at(track, req.index)
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/move")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -135,6 +135,12 @@ export const setShuffle = (shuffle: boolean): Promise<unknown> =>
   post('/api/v1/player/shuffle', { shuffle })
 export const setRepeat = (repeat: boolean): Promise<unknown> =>
   post('/api/v1/player/repeat', { repeat })
+export const addToQueue = (filePath: string): Promise<unknown> =>
+  post('/api/v1/player/queue/add', { file_path: filePath })
+export const playNext = (filePath: string): Promise<unknown> =>
+  post('/api/v1/player/queue/play-next', { file_path: filePath })
+export const moveQueueTrack = (fromIndex: number, toIndex: number): Promise<unknown> =>
+  post('/api/v1/player/queue/move', { from_index: fromIndex, to_index: toIndex })
 
 // ---------------------------------------------------------------------------
 // WebSocket state stream

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -137,6 +137,8 @@ export const setRepeat = (repeat: boolean): Promise<unknown> =>
   post('/api/v1/player/repeat', { repeat })
 export const addToQueue = (filePath: string): Promise<unknown> =>
   post('/api/v1/player/queue/add', { file_path: filePath })
+export const insertIntoQueue = (filePath: string, index: number): Promise<unknown> =>
+  post('/api/v1/player/queue/insert', { file_path: filePath, index })
 export const playNext = (filePath: string): Promise<unknown> =>
   post('/api/v1/player/queue/play-next', { file_path: filePath })
 export const moveQueueTrack = (fromIndex: number, toIndex: number): Promise<unknown> =>

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1296,3 +1296,41 @@ body,
 .queue-toggle-btn.active {
   color: var(--accent);
 }
+
+/* Drag-to-reorder drop target indicator */
+.queue-track-row[draggable] {
+  cursor: grab;
+}
+
+.queue-track-row.drag-over {
+  border-top: 2px solid var(--accent);
+}
+
+/* Right-click context menu on track rows */
+.track-context-menu {
+  position: fixed;
+  z-index: 1000;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 0;
+  min-width: 160px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.track-context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.track-context-menu-item:hover {
+  background: var(--surface-hover);
+  color: var(--accent);
+}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -6,6 +6,7 @@ export function QueuePanel(): React.JSX.Element {
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
   const addToQueue = useStore((s) => s.addToQueue)
+  const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const activeRef = useRef<HTMLLIElement>(null)
 
   const tracks = queue?.tracks ?? []
@@ -24,7 +25,7 @@ export function QueuePanel(): React.JSX.Element {
       const from = Number(queueIdx)
       if (from !== dropIdx) void moveQueueTrack(from, dropIdx)
     } else if (trackPath) {
-      void addToQueue(trackPath)
+      void insertIntoQueue(trackPath, dropIdx)
     }
   }
 

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -4,6 +4,8 @@ import { useStore } from '../store'
 export function QueuePanel(): React.JSX.Element {
   const queue = useStore((s) => s.queue)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const moveQueueTrack = useStore((s) => s.moveQueueTrack)
+  const addToQueue = useStore((s) => s.addToQueue)
   const activeRef = useRef<HTMLLIElement>(null)
 
   const tracks = queue?.tracks ?? []
@@ -14,6 +16,18 @@ export function QueuePanel(): React.JSX.Element {
     activeRef.current?.scrollIntoView({ block: 'nearest' })
   }, [position])
 
+  function handleDrop(e: React.DragEvent, dropIdx: number): void {
+    e.currentTarget.classList.remove('drag-over')
+    const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
+    const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+    if (queueIdx !== '') {
+      const from = Number(queueIdx)
+      if (from !== dropIdx) void moveQueueTrack(from, dropIdx)
+    } else if (trackPath) {
+      void addToQueue(trackPath)
+    }
+  }
+
   return (
     <aside className="queue-panel">
       <div className="queue-panel-header">
@@ -23,7 +37,16 @@ export function QueuePanel(): React.JSX.Element {
         </button>
       </div>
       {tracks.length === 0 ? (
-        <div className="queue-empty">No tracks in queue.</div>
+        <div
+          className="queue-empty"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+            if (trackPath) void addToQueue(trackPath)
+          }}
+        >
+          No tracks in queue.
+        </div>
       ) : (
         <ol className="queue-track-list">
           {tracks.map((track, idx) => {
@@ -34,6 +57,19 @@ export function QueuePanel(): React.JSX.Element {
                 key={track.file_path}
                 ref={isCurrent ? activeRef : null}
                 className={`queue-track-row${isCurrent ? ' current' : ''}${isPlayed ? ' played' : ''}`}
+                draggable
+                onDragStart={(e) => {
+                  e.dataTransfer.setData('text/kamp-queue-idx', String(idx))
+                  e.dataTransfer.effectAllowed = 'move'
+                }}
+                onDragOver={(e) => {
+                  e.preventDefault()
+                  e.currentTarget.classList.add('drag-over')
+                }}
+                onDragLeave={(e) => {
+                  e.currentTarget.classList.remove('drag-over')
+                }}
+                onDrop={(e) => handleDrop(e, idx)}
               >
                 <span className="queue-track-num">{idx + 1}</span>
                 <span className="queue-track-title">{track.title}</span>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
+
+type ContextMenu = { x: number; y: number; filePath: string }
 
 export function TrackList(): React.JSX.Element | null {
   const album = useStore((s) => s.library.selectedAlbum)
@@ -10,6 +12,23 @@ export function TrackList(): React.JSX.Element | null {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const playTrack = useStore((s) => s.playTrack)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
+  const addToQueue = useStore((s) => s.addToQueue)
+  const playNext = useStore((s) => s.playNext)
+
+  const [menu, setMenu] = useState<ContextMenu | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Dismiss the context menu on any click outside it.
+  useEffect(() => {
+    if (!menu) return
+    const handler = (e: MouseEvent): void => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
 
   if (!album) return null
 
@@ -64,6 +83,15 @@ export function TrackList(): React.JSX.Element | null {
                 if (isCurrent) togglePlayPause()
                 else playTrack(album.album_artist, album.album, i)
               }}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+                e.dataTransfer.effectAllowed = 'copy'
+              }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                setMenu({ x: e.clientX, y: e.clientY, filePath: track.file_path })
+              }}
             >
               <span className="track-row-num">
                 {isCurrent ? (playing ? '▶' : '▐▐') : track.track_number}
@@ -74,6 +102,29 @@ export function TrackList(): React.JSX.Element | null {
           )
         })}
       </ol>
+
+      {menu && (
+        <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void playNext(menu.filePath)
+              setMenu(null)
+            }}
+          >
+            ▶ Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addToQueue(menu.filePath)
+              setMenu(null)
+            }}
+          >
+            + Add to Queue
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -67,6 +67,7 @@ type PlayerStore = {
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
   addToQueue: (filePath: string) => Promise<void>
+  insertIntoQueue: (filePath: string, index: number) => Promise<void>
   playNext: (filePath: string) => Promise<void>
   moveQueueTrack: (fromIndex: number, toIndex: number) => Promise<void>
   refreshOpenAlbum: () => Promise<void>
@@ -269,6 +270,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   addToQueue: async (filePath) => {
     await api.addToQueue(filePath)
+    void get().loadQueue()
+  },
+
+  insertIntoQueue: async (filePath, index) => {
+    await api.insertIntoQueue(filePath, index)
     void get().loadQueue()
   },
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -66,6 +66,9 @@ type PlayerStore = {
   setVolume: (volume: number) => Promise<void>
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
+  addToQueue: (filePath: string) => Promise<void>
+  playNext: (filePath: string) => Promise<void>
+  moveQueueTrack: (fromIndex: number, toIndex: number) => Promise<void>
   refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
@@ -158,7 +161,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }
   },
 
-  applyServerState: (state) => set({ player: state }),
+  applyServerState: (state) => {
+    const prevTrack = get().player.current_track
+    set({ player: state })
+    // When the track changes (e.g. auto-advance at end-of-track), the queue
+    // position has moved server-side — reload so the panel stays in sync.
+    if (state.current_track?.file_path !== prevTrack?.file_path) {
+      void get().loadQueue()
+    }
+  },
 
   loadLibrary: async () => {
     try {
@@ -254,6 +265,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setRepeat: async (repeat) => {
     await api.setRepeat(repeat)
+  },
+
+  addToQueue: async (filePath) => {
+    await api.addToQueue(filePath)
+    void get().loadQueue()
+  },
+
+  playNext: async (filePath) => {
+    await api.playNext(filePath)
+    void get().loadQueue()
+  },
+
+  moveQueueTrack: async (fromIndex, toIndex) => {
+    await api.moveQueueTrack(fromIndex, toIndex)
+    void get().loadQueue()
   },
 
   setLibraryPath: async (path) => {

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -254,6 +254,133 @@ class TestPlaybackQueue:
         nxt = q.next()
         assert nxt == tracks[1]
 
+    # ------------------------------------------------------------------
+    # add_to_queue
+    # ------------------------------------------------------------------
+
+    def test_add_to_queue_appends_track(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(2)]
+        q.load(ts)
+        extra = _track(99)
+        q.add_to_queue(extra)
+        tracks, pos = q.queue_tracks()
+        assert tracks[-1] == extra
+        assert len(tracks) == 3
+        assert pos == 0  # current position unchanged
+
+    def test_add_to_queue_on_empty_queue_sets_pos_to_zero(self) -> None:
+        q = PlaybackQueue()
+        extra = _track(1)
+        q.add_to_queue(extra)
+        tracks, pos = q.queue_tracks()
+        assert tracks == [extra]
+        assert pos == 0
+
+    # ------------------------------------------------------------------
+    # play_next
+    # ------------------------------------------------------------------
+
+    def test_play_next_inserts_after_current(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)  # pos=0
+        extra = _track(99)
+        q.play_next(extra)
+        tracks, pos = q.queue_tracks()
+        assert tracks[1] == extra
+        assert pos == 0  # still on first track
+
+    def test_play_next_on_empty_queue_sets_pos_to_zero(self) -> None:
+        q = PlaybackQueue()
+        extra = _track(1)
+        q.play_next(extra)
+        tracks, pos = q.queue_tracks()
+        assert tracks == [extra]
+        assert pos == 0
+
+    def test_play_next_removes_existing_occurrence_to_avoid_ghost(self) -> None:
+        # Reproduces the bug: album loaded, play_next on a track already in queue
+        # should not leave the original occurrence ("ghost") behind.
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)  # _order=[0,1,2,3], pos=0
+        q.play_next(ts[3])
+        tracks, _ = q.queue_tracks()
+        paths = [t.file_path for t in tracks]
+        assert paths.count(ts[3].file_path) == 1, "track should appear exactly once"
+
+    def test_play_next_sequential_calls_produce_correct_order(self) -> None:
+        # play_next(last) then play_next(second-to-last): expected order is
+        # [current, second-to-last, last] with no ghost duplicates.
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)  # pos=0, playing ts[0]
+        q.play_next(ts[3])
+        q.play_next(ts[2])
+        tracks, pos = q.queue_tracks()
+        assert pos == 0
+        assert tracks[1].file_path == ts[2].file_path
+        assert tracks[2].file_path == ts[3].file_path
+        assert len(tracks) == 4  # no ghost — same count as loaded
+
+    def test_play_next_from_middle_inserts_at_correct_position(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        q.next()  # pos=1
+        extra = _track(99)
+        q.play_next(extra)
+        tracks, _ = q.queue_tracks()
+        assert tracks[2] == extra
+
+    # ------------------------------------------------------------------
+    # move
+    # ------------------------------------------------------------------
+
+    def test_move_shifts_order(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        q.move(3, 1)  # move last to position 1
+        tracks, _ = q.queue_tracks()
+        assert tracks[1] == ts[3]
+
+    def test_move_noop_when_same_index(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        q.move(1, 1)
+        tracks, pos = q.queue_tracks()
+        assert tracks == ts
+        assert pos == 0
+
+    def test_move_adjusts_pos_when_current_moves_forward(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        q.next()  # pos=1
+        q.move(1, 3)  # move current track to end
+        _, pos = q.queue_tracks()
+        assert pos == 3
+
+    def test_move_adjusts_pos_when_item_moves_over_current(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        q.next()
+        q.next()  # pos=2
+        q.move(0, 2)  # move item before current to current's position
+        _, pos = q.queue_tracks()
+        assert pos == 1  # current shifted back by one
+
+    def test_move_raises_on_out_of_range_index(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        with pytest.raises(IndexError):
+            q.move(0, 10)
+
 
 # ---------------------------------------------------------------------------
 # MpvPlaybackEngine

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -381,6 +381,40 @@ class TestPlaybackQueue:
         with pytest.raises(IndexError):
             q.move(0, 10)
 
+    # ------------------------------------------------------------------
+    # insert_at
+    # ------------------------------------------------------------------
+
+    def test_insert_at_places_track_at_given_position(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        extra = _track(99)
+        q.insert_at(extra, 1)
+        tracks, pos = q.queue_tracks()
+        assert tracks[1] == extra
+        assert len(tracks) == 4
+        assert pos == 0  # current position unchanged
+
+    def test_insert_at_before_current_shifts_pos(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        q.next()  # pos=1
+        extra = _track(99)
+        q.insert_at(extra, 0)  # insert before current
+        _, pos = q.queue_tracks()
+        assert pos == 2  # current shifted forward by one
+
+    def test_insert_at_clamps_large_index(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)
+        extra = _track(99)
+        q.insert_at(extra, 100)  # beyond end — should append
+        tracks, _ = q.queue_tracks()
+        assert tracks[-1] == extra
+
 
 # ---------------------------------------------------------------------------
 # MpvPlaybackEngine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -476,6 +476,66 @@ class TestQueueEndpoint:
         }
 
 
+class TestQueueMutationEndpoints:
+    def test_add_to_queue_calls_queue_method(
+        self, client: TestClient, mock_index: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(1)
+        mock_index.get_track_by_path.return_value = t
+        resp = client.post(
+            "/api/v1/player/queue/add", json={"file_path": str(t.file_path)}
+        )
+        assert resp.status_code == 200
+        mock_queue.add_to_queue.assert_called_once_with(t)
+
+    def test_add_to_queue_404_for_unknown_path(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = None
+        resp = client.post(
+            "/api/v1/player/queue/add", json={"file_path": "/no/such/file.mp3"}
+        )
+        assert resp.status_code == 404
+
+    def test_play_next_calls_queue_method(
+        self, client: TestClient, mock_index: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(2)
+        mock_index.get_track_by_path.return_value = t
+        resp = client.post(
+            "/api/v1/player/queue/play-next", json={"file_path": str(t.file_path)}
+        )
+        assert resp.status_code == 200
+        mock_queue.play_next.assert_called_once_with(t)
+
+    def test_play_next_404_for_unknown_path(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = None
+        resp = client.post(
+            "/api/v1/player/queue/play-next", json={"file_path": "/no/such/file.mp3"}
+        )
+        assert resp.status_code == 404
+
+    def test_move_queue_calls_queue_method(
+        self, client: TestClient, mock_queue: MagicMock
+    ) -> None:
+        resp = client.post(
+            "/api/v1/player/queue/move", json={"from_index": 0, "to_index": 2}
+        )
+        assert resp.status_code == 200
+        mock_queue.move.assert_called_once_with(0, 2)
+
+    def test_move_queue_400_on_index_error(
+        self, client: TestClient, mock_queue: MagicMock
+    ) -> None:
+        mock_queue.move.side_effect = IndexError("Queue index out of range: 0, 99")
+        resp = client.post(
+            "/api/v1/player/queue/move", json={"from_index": 0, "to_index": 99}
+        )
+        assert resp.status_code == 400
+
+
 class TestPlayerWebSocket:
     def test_websocket_sends_initial_state(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Right-click any track to expose **Play Next** and **Add to Queue** context menu actions
- Tracks can be **dragged from the track list into the queue panel** (drops onto any row or the empty-queue placeholder)
- Queue rows are **draggable to reorder** within the panel
- Queue panel position now syncs when a track auto-advances at end-of-file
- `play_next` deduplicates: queuing a track already in the queue moves it rather than creating a ghost duplicate

## Test plan

- [x] Right-click a track → "Play Next" → appears after current track in queue
- [x] Right-click a track → "Add to Queue" → appended to end of queue
- [x] Right-click last track, then second-to-last → no duplicates in queue
- [x] Drag a track from the track list onto the queue panel → added to queue
- [x] Drag a queue row to a new position → order updates correctly
- [x] Let a track play to the end → queue panel position advances automatically
- [x] `poetry run pytest tests/ --no-cov -q` → 613 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)