### PR TITLE
feat: add album to queue and play next (TASK-42)

### DIFF
--- a/backlog/tasks/task-42 - an-album-can-be-added-to-the-playback-queue.md
+++ b/backlog/tasks/task-42 - an-album-can-be-added-to-the-playback-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-42
 title: an album can be added to the playback queue
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-30 01:49'
-updated_date: '2026-03-31 03:25'
+updated_date: '2026-03-31 20:10'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: high
-ordinal: 1750
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -165,6 +165,34 @@ class PlaybackQueue:
         elif insert_pos <= self._pos:
             self._pos += 1
 
+    def add_album_to_queue(self, tracks: list[Track]) -> None:
+        """Append all *tracks* to the end of the queue in order."""
+        for track in tracks:
+            self.add_to_queue(track)
+
+    def play_album_next(self, tracks: list[Track]) -> None:
+        """Insert all *tracks* immediately after the current position in order.
+
+        Each track is inserted at a successive offset so the album plays in
+        the correct sequence.
+        """
+        for offset, track in enumerate(tracks):
+            insert_at = (self._pos + 1 + offset) if self._pos >= 0 else offset
+            idx = len(self._tracks)
+            self._tracks.append(track)
+            self._order.insert(insert_at, idx)
+        if self._pos < 0 and tracks:
+            self._pos = 0
+
+    def insert_album_at(self, tracks: list[Track], display_idx: int) -> None:
+        """Insert all *tracks* starting at display position *display_idx* in order.
+
+        Adjusts *_pos* for each insertion so the currently playing track does
+        not change.
+        """
+        for offset, track in enumerate(tracks):
+            self.insert_at(track, display_idx + offset)
+
     def play_next(self, track: Track) -> None:
         """Insert *track* immediately after the current position.
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -132,6 +132,17 @@ class InsertQueueRequest(BaseModel):
     index: int
 
 
+class AlbumQueueRequest(BaseModel):
+    album_artist: str
+    album: str
+
+
+class InsertAlbumQueueRequest(BaseModel):
+    album_artist: str
+    album: str
+    index: int
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -399,6 +410,30 @@ def create_app(
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.insert_at(track, req.index)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/add-album")
+    def queue_add_album(req: AlbumQueueRequest) -> dict[str, Any]:
+        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if not tracks:
+            raise HTTPException(status_code=404, detail="Album not found")
+        queue.add_album_to_queue(tracks)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/play-album-next")
+    def queue_play_album_next(req: AlbumQueueRequest) -> dict[str, Any]:
+        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if not tracks:
+            raise HTTPException(status_code=404, detail="Album not found")
+        queue.play_album_next(tracks)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/insert-album")
+    def queue_insert_album(req: InsertAlbumQueueRequest) -> dict[str, Any]:
+        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if not tracks:
+            raise HTTPException(status_code=404, detail="Album not found")
+        queue.insert_album_at(tracks, req.index)
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/move")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -135,6 +135,16 @@ export const setShuffle = (shuffle: boolean): Promise<unknown> =>
   post('/api/v1/player/shuffle', { shuffle })
 export const setRepeat = (repeat: boolean): Promise<unknown> =>
   post('/api/v1/player/repeat', { repeat })
+export const addAlbumToQueue = (albumArtist: string, album: string): Promise<unknown> =>
+  post('/api/v1/player/queue/add-album', { album_artist: albumArtist, album })
+export const playAlbumNext = (albumArtist: string, album: string): Promise<unknown> =>
+  post('/api/v1/player/queue/play-album-next', { album_artist: albumArtist, album })
+export const insertAlbumAt = (
+  albumArtist: string,
+  album: string,
+  index: number
+): Promise<unknown> =>
+  post('/api/v1/player/queue/insert-album', { album_artist: albumArtist, album, index })
 export const addToQueue = (filePath: string): Promise<unknown> =>
   post('/api/v1/player/queue/add', { file_path: filePath })
 export const insertIntoQueue = (filePath: string, index: number): Promise<unknown> =>

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -1,10 +1,18 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
 import { SortControl } from './SortControl'
 
-function AlbumCard({ album }: { album: Album }): React.JSX.Element {
+type ContextMenu = { x: number; y: number; album: Album }
+
+function AlbumCard({
+  album,
+  onContextMenu
+}: {
+  album: Album
+  onContextMenu: (e: React.MouseEvent, album: Album) => void
+}): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
@@ -17,8 +25,17 @@ function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     <div
       className={`album-card${isActive ? ' playing' : ''}`}
       tabIndex={0}
+      draggable
       onClick={() => selectAlbum(album)}
       onKeyDown={(e) => e.key === 'Enter' && selectAlbum(album)}
+      onContextMenu={(e) => onContextMenu(e, album)}
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'text/kamp-album',
+          JSON.stringify({ album_artist: album.album_artist, album: album.album })
+        )
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
     >
       <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
@@ -44,6 +61,22 @@ function AlbumCard({ album }: { album: Album }): React.JSX.Element {
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
+
+  const [menu, setMenu] = useState<ContextMenu | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menu) return
+    const handler = (e: MouseEvent): void => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
 
   const visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
 
@@ -57,8 +90,38 @@ export function AlbumGrid(): React.JSX.Element {
       ) : (
         <div className="album-grid">
           {visible.map((album) => (
-            <AlbumCard key={`${album.album_artist}\0${album.album}`} album={album} />
+            <AlbumCard
+              key={`${album.album_artist}\0${album.album}`}
+              album={album}
+              onContextMenu={(e, a) => {
+                e.preventDefault()
+                setMenu({ x: e.clientX, y: e.clientY, album: a })
+              }}
+            />
           ))}
+        </div>
+      )}
+
+      {menu && (
+        <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void playAlbumNext(menu.album.album_artist, menu.album.album)
+              setMenu(null)
+            }}
+          >
+            ▶ Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addAlbumToQueue(menu.album.album_artist, menu.album.album)
+              setMenu(null)
+            }}
+          >
+            + Add to Queue
+          </button>
         </div>
       )}
     </div>

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -7,6 +7,8 @@ export function QueuePanel(): React.JSX.Element {
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
   const addToQueue = useStore((s) => s.addToQueue)
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
+  const insertAlbumAt = useStore((s) => s.insertAlbumAt)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
   const activeRef = useRef<HTMLLIElement>(null)
 
   const tracks = queue?.tracks ?? []
@@ -21,11 +23,22 @@ export function QueuePanel(): React.JSX.Element {
     e.currentTarget.classList.remove('drag-over')
     const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
     const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+    const albumJson = e.dataTransfer.getData('text/kamp-album')
     if (queueIdx !== '') {
       const from = Number(queueIdx)
       if (from !== dropIdx) void moveQueueTrack(from, dropIdx)
     } else if (trackPath) {
       void insertIntoQueue(trackPath, dropIdx)
+    } else if (albumJson) {
+      try {
+        const { album_artist, album } = JSON.parse(albumJson) as {
+          album_artist: string
+          album: string
+        }
+        void insertAlbumAt(album_artist, album, dropIdx)
+      } catch {
+        // malformed drag data — ignore
+      }
     }
   }
 
@@ -43,7 +56,20 @@ export function QueuePanel(): React.JSX.Element {
           onDragOver={(e) => e.preventDefault()}
           onDrop={(e) => {
             const trackPath = e.dataTransfer.getData('text/kamp-track-path')
-            if (trackPath) void addToQueue(trackPath)
+            const albumJson = e.dataTransfer.getData('text/kamp-album')
+            if (trackPath) {
+              void addToQueue(trackPath)
+            } else if (albumJson) {
+              try {
+                const { album_artist, album } = JSON.parse(albumJson) as {
+                  album_artist: string
+                  album: string
+                }
+                void addAlbumToQueue(album_artist, album)
+              } catch {
+                // malformed drag data — ignore
+              }
+            }
           }}
         >
           No tracks in queue.

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -66,6 +66,9 @@ type PlayerStore = {
   setVolume: (volume: number) => Promise<void>
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
+  addAlbumToQueue: (albumArtist: string, album: string) => Promise<void>
+  playAlbumNext: (albumArtist: string, album: string) => Promise<void>
+  insertAlbumAt: (albumArtist: string, album: string, index: number) => Promise<void>
   addToQueue: (filePath: string) => Promise<void>
   insertIntoQueue: (filePath: string, index: number) => Promise<void>
   playNext: (filePath: string) => Promise<void>
@@ -266,6 +269,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setRepeat: async (repeat) => {
     await api.setRepeat(repeat)
+  },
+
+  addAlbumToQueue: async (albumArtist, album) => {
+    await api.addAlbumToQueue(albumArtist, album)
+    void get().loadQueue()
+  },
+
+  playAlbumNext: async (albumArtist, album) => {
+    await api.playAlbumNext(albumArtist, album)
+    void get().loadQueue()
+  },
+
+  insertAlbumAt: async (albumArtist, album, index) => {
+    await api.insertAlbumAt(albumArtist, album, index)
+    void get().loadQueue()
   },
 
   addToQueue: async (filePath) => {

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -415,6 +415,75 @@ class TestPlaybackQueue:
         tracks, _ = q.queue_tracks()
         assert tracks[-1] == extra
 
+    # ------------------------------------------------------------------
+    # add_album_to_queue
+    # ------------------------------------------------------------------
+
+    def test_add_album_to_queue_appends_tracks_in_order(self) -> None:
+        q = PlaybackQueue()
+        album = [_track(i) for i in range(3)]
+        q.add_album_to_queue(album)
+        tracks, pos = q.queue_tracks()
+        assert tracks == album
+        assert pos == 0
+
+    def test_add_album_to_queue_onto_existing_queue(self) -> None:
+        q = PlaybackQueue()
+        existing = [_track(i) for i in range(2)]
+        album = [_track(10 + i) for i in range(3)]
+        q.load(existing)
+        q.add_album_to_queue(album)
+        tracks, _ = q.queue_tracks()
+        assert tracks[2:] == album
+
+    # ------------------------------------------------------------------
+    # play_album_next
+    # ------------------------------------------------------------------
+
+    def test_play_album_next_inserts_after_current_in_order(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(3)]
+        q.load(ts)  # pos=0
+        album = [_track(10 + i) for i in range(3)]
+        q.play_album_next(album)
+        tracks, pos = q.queue_tracks()
+        assert pos == 0
+        assert tracks[1:4] == album  # album occupies positions 1-3
+        assert len(tracks) == 6
+
+    def test_play_album_next_on_empty_queue(self) -> None:
+        q = PlaybackQueue()
+        album = [_track(i) for i in range(3)]
+        q.play_album_next(album)
+        tracks, pos = q.queue_tracks()
+        assert tracks == album
+        assert pos == 0
+
+    # ------------------------------------------------------------------
+    # insert_album_at
+    # ------------------------------------------------------------------
+
+    def test_insert_album_at_places_tracks_at_position(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        album = [_track(10 + i) for i in range(3)]
+        q.insert_album_at(album, 2)
+        tracks, _ = q.queue_tracks()
+        assert tracks[2:5] == album
+        assert len(tracks) == 7
+
+    def test_insert_album_at_adjusts_pos_when_inserted_before_current(self) -> None:
+        q = PlaybackQueue()
+        ts = [_track(i) for i in range(4)]
+        q.load(ts)
+        q.next()
+        q.next()  # pos=2
+        album = [_track(10 + i) for i in range(2)]
+        q.insert_album_at(album, 0)  # insert 2 tracks before current
+        _, pos = q.queue_tracks()
+        assert pos == 4  # shifted forward by 2
+
 
 # ---------------------------------------------------------------------------
 # MpvPlaybackEngine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -536,6 +536,74 @@ class TestQueueMutationEndpoints:
         assert resp.status_code == 400
 
 
+class TestAlbumQueueEndpoints:
+    def test_add_album_to_queue_calls_queue_method(
+        self, client: TestClient, mock_index: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        ts = [_track(i) for i in range(3)]
+        mock_index.tracks_for_album.return_value = ts
+        resp = client.post(
+            "/api/v1/player/queue/add-album",
+            json={"album_artist": "Artist", "album": "Album"},
+        )
+        assert resp.status_code == 200
+        mock_queue.add_album_to_queue.assert_called_once_with(ts)
+
+    def test_add_album_to_queue_404_for_unknown_album(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = []
+        resp = client.post(
+            "/api/v1/player/queue/add-album",
+            json={"album_artist": "X", "album": "Y"},
+        )
+        assert resp.status_code == 404
+
+    def test_play_album_next_calls_queue_method(
+        self, client: TestClient, mock_index: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        ts = [_track(i) for i in range(3)]
+        mock_index.tracks_for_album.return_value = ts
+        resp = client.post(
+            "/api/v1/player/queue/play-album-next",
+            json={"album_artist": "Artist", "album": "Album"},
+        )
+        assert resp.status_code == 200
+        mock_queue.play_album_next.assert_called_once_with(ts)
+
+    def test_play_album_next_404_for_unknown_album(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = []
+        resp = client.post(
+            "/api/v1/player/queue/play-album-next",
+            json={"album_artist": "X", "album": "Y"},
+        )
+        assert resp.status_code == 404
+
+    def test_insert_album_calls_queue_method(
+        self, client: TestClient, mock_index: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        ts = [_track(i) for i in range(3)]
+        mock_index.tracks_for_album.return_value = ts
+        resp = client.post(
+            "/api/v1/player/queue/insert-album",
+            json={"album_artist": "Artist", "album": "Album", "index": 2},
+        )
+        assert resp.status_code == 200
+        mock_queue.insert_album_at.assert_called_once_with(ts, 2)
+
+    def test_insert_album_404_for_unknown_album(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = []
+        resp = client.post(
+            "/api/v1/player/queue/insert-album",
+            json={"album_artist": "X", "album": "Y", "index": 0},
+        )
+        assert resp.status_code == 404
+
+
 class TestPlayerWebSocket:
     def test_websocket_sends_initial_state(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Right-click any album card for **Play Next** and **Add to Queue** context menu actions
- Albums can be **dragged from the album grid into the queue panel**, inserting all tracks at the drop position (or appending if dropped on the empty-queue placeholder)
- Adds three bulk `PlaybackQueue` methods: `add_album_to_queue`, `play_album_next`, `insert_album_at`
- Three new server endpoints: `POST /api/v1/player/queue/add-album`, `/play-album-next`, `/insert-album`

## Test plan

- [x] Right-click album → "Play Next" → all tracks appear after current track in queue, in order
- [x] Right-click album → "Add to Queue" → all tracks appended to queue in order
- [x] Drag album onto a queue row → tracks inserted at that position
- [x] Drag album onto empty queue → tracks fill the queue
- [x] `poetry run pytest tests/ --no-cov -q` → 628 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)