### PR TITLE
feat: double-click queue track to skip to it (TASK-56)

### DIFF
--- a/backlog/tasks/task-42 - an-album-can-be-added-to-the-playback-queue.md
+++ b/backlog/tasks/task-42 - an-album-can-be-added-to-the-playback-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-42
 title: an album can be added to the playback queue
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-30 01:49'
-updated_date: '2026-03-31 20:10'
+updated_date: '2026-03-31 21:31'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: high
-ordinal: 1000
+ordinal: 5000
 ---
 
 ## Description

--- a/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
+++ b/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-56
 title: double-clicking on a track in the queue advances the queue to that track
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-31 17:39'
-updated_date: '2026-03-31 19:44'
+updated_date: '2026-03-31 21:32'
 labels:
   - feature
   - ui
@@ -12,6 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: medium
+ordinal: 1000
 ---
 
 ## Implementation Notes

--- a/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
+++ b/backlog/tasks/task-56 - double-clicking-on-a-track-in-the-queue-advances-the-queue-to-that-track.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-56
 title: double-clicking on a track in the queue advances the queue to that track
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-31 17:39'
-updated_date: '2026-03-31 21:32'
+updated_date: '2026-03-31 22:13'
 labels:
   - feature
   - ui
@@ -12,7 +12,7 @@ labels:
 milestone: m-8
 dependencies: []
 priority: medium
-ordinal: 1000
+ordinal: 6000
 ---
 
 ## Implementation Notes

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -92,6 +92,13 @@ class PlaybackQueue:
         self._pos = prev_pos
         return self.current()
 
+    def skip_to(self, position: int) -> Track | None:
+        """Jump directly to *position* in the queue. Returns the track, or None if invalid."""
+        if not self._order or position < 0 or position >= len(self._order):
+            return None
+        self._pos = position
+        return self.current()
+
     def set_shuffle(self, shuffle: bool) -> None:
         if shuffle == self._shuffle:
             return

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -143,6 +143,10 @@ class InsertAlbumQueueRequest(BaseModel):
     index: int
 
 
+class SkipToRequest(BaseModel):
+    position: int
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -384,6 +388,13 @@ def create_app(
     @app.post("/api/v1/player/prev")
     def prev_track() -> dict[str, Any]:
         track = queue.prev()
+        if track:
+            engine.play(track.file_path)
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/skip-to")
+    def skip_to_position(req: SkipToRequest) -> dict[str, Any]:
+        track = queue.skip_to(req.position)
         if track:
             engine.play(track.file_path)
         return {"ok": True}

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -153,6 +153,8 @@ export const playNext = (filePath: string): Promise<unknown> =>
   post('/api/v1/player/queue/play-next', { file_path: filePath })
 export const moveQueueTrack = (fromIndex: number, toIndex: number): Promise<unknown> =>
   post('/api/v1/player/queue/move', { from_index: fromIndex, to_index: toIndex })
+export const skipToQueueTrack = (position: number): Promise<unknown> =>
+  post('/api/v1/player/queue/skip-to', { position })
 
 // ---------------------------------------------------------------------------
 // WebSocket state stream

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -5,6 +5,7 @@ export function QueuePanel(): React.JSX.Element {
   const queue = useStore((s) => s.queue)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
+  const skipToQueueTrack = useStore((s) => s.skipToQueueTrack)
   const addToQueue = useStore((s) => s.addToQueue)
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const insertAlbumAt = useStore((s) => s.insertAlbumAt)
@@ -97,6 +98,7 @@ export function QueuePanel(): React.JSX.Element {
                   e.currentTarget.classList.remove('drag-over')
                 }}
                 onDrop={(e) => handleDrop(e, idx)}
+                onDoubleClick={() => void skipToQueueTrack(idx)}
               >
                 <span className="queue-track-num">{idx + 1}</span>
                 <span className="queue-track-title">{track.title}</span>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -73,6 +73,7 @@ type PlayerStore = {
   insertIntoQueue: (filePath: string, index: number) => Promise<void>
   playNext: (filePath: string) => Promise<void>
   moveQueueTrack: (fromIndex: number, toIndex: number) => Promise<void>
+  skipToQueueTrack: (position: number) => Promise<void>
   refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
@@ -303,6 +304,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   moveQueueTrack: async (fromIndex, toIndex) => {
     await api.moveQueueTrack(fromIndex, toIndex)
+    void get().loadQueue()
+  },
+
+  skipToQueueTrack: async (position) => {
+    await api.skipToQueueTrack(position)
     void get().loadQueue()
   },
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -100,6 +100,30 @@ class TestPlaybackQueue:
         q.set_repeat(True)
         assert q.prev() == tracks[2]
 
+    def test_skip_to_valid_position(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(5)]
+        q.load(tracks)
+        assert q.skip_to(3) == tracks[3]
+        assert q.current() == tracks[3]
+
+    def test_skip_to_out_of_bounds_returns_none(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        assert q.skip_to(5) is None
+        assert q.current() == tracks[0]  # _pos unchanged
+
+    def test_skip_to_negative_returns_none(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        assert q.skip_to(-1) is None
+
+    def test_skip_to_empty_queue_returns_none(self) -> None:
+        q = PlaybackQueue()
+        assert q.skip_to(0) is None
+
     def test_shuffle_randomises_order(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(20)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -535,6 +535,24 @@ class TestQueueMutationEndpoints:
         )
         assert resp.status_code == 400
 
+    def test_skip_to_calls_engine_play(
+        self, client: TestClient, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(3)
+        mock_queue.skip_to.return_value = t
+        resp = client.post("/api/v1/player/queue/skip-to", json={"position": 3})
+        assert resp.status_code == 200
+        mock_queue.skip_to.assert_called_once_with(3)
+        mock_engine.play.assert_called_once_with(t.file_path)
+
+    def test_skip_to_invalid_position_does_not_play(
+        self, client: TestClient, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_queue.skip_to.return_value = None
+        resp = client.post("/api/v1/player/queue/skip-to", json={"position": 99})
+        assert resp.status_code == 200
+        mock_engine.play.assert_not_called()
+
 
 class TestAlbumQueueEndpoints:
     def test_add_album_to_queue_calls_queue_method(


### PR DESCRIPTION
## Summary

- Adds `skip_to(position)` method to `PlaybackQueue` — sets `_pos` directly, returns `None` if out of bounds
- New `POST /api/v1/player/queue/skip-to` endpoint calls `skip_to` then `engine.play()`
- `onDoubleClick` on queue rows calls `skipToQueueTrack(idx)` via the store

## Test plan

- [x] `poetry run pytest tests/test_playback.py tests/test_server.py -v --no-cov` — all 145 tests pass
- [x] Manually: open queue panel with multiple tracks, double-click a track mid-queue → playback jumps to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)