### PR TITLE
fix: persist sort order across app restarts (TASK-58)

### DIFF
--- a/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
+++ b/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
@@ -1,16 +1,17 @@
 ---
 id: TASK-58
 title: filter state does not survive app restart
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-31 17:51'
-updated_date: '2026-03-31 19:44'
+updated_date: '2026-03-31 23:05'
 labels:
   - bug
   - 'estimate: single'
 milestone: m-8
 dependencies: []
 priority: low
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
+++ b/backlog/tasks/task-58 - filter-state-does-not-survive-app-restart.md
@@ -1,17 +1,17 @@
 ---
 id: TASK-58
 title: filter state does not survive app restart
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-31 17:51'
-updated_date: '2026-03-31 23:05'
+updated_date: '2026-03-31 23:50'
 labels:
   - bug
   - 'estimate: single'
 milestone: m-8
 dependencies: []
 priority: low
-ordinal: 1000
+ordinal: 7000
 ---
 
 ## Description

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -160,6 +160,7 @@ def create_app(
     library_path: Path | None = None,
     on_library_path_set: Callable[[Path], None] | None = None,
     ui_active_view: str = "library",
+    ui_sort_order: str = "album_artist",
     on_ui_state_set: Callable[[str, str], None] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
@@ -178,6 +179,7 @@ def create_app(
         "library_path": library_path,
         "scan_progress": {"active": False, "current": 0, "total": 0},
         "ui_active_view": ui_active_view,
+        "ui_sort_order": ui_sort_order,
         "library_version": 0,
     }
 
@@ -315,7 +317,10 @@ def create_app(
 
     @app.get("/api/v1/ui")
     def get_ui_state() -> dict[str, Any]:
-        return {"active_view": _state["ui_active_view"]}
+        return {
+            "active_view": _state["ui_active_view"],
+            "sort_order": _state["ui_sort_order"],
+        }
 
     @app.post("/api/v1/ui/active-view")
     def set_active_view(req: dict[str, Any]) -> dict[str, Any]:
@@ -325,6 +330,20 @@ def create_app(
         _state["ui_active_view"] = view
         if on_ui_state_set is not None:
             on_ui_state_set("ui.active_view", view)
+        return {"ok": True}
+
+    _VALID_SORT_ORDERS = frozenset(
+        {"album_artist", "album", "date_added", "last_played"}
+    )
+
+    @app.post("/api/v1/ui/sort-order")
+    def set_sort_order(req: dict[str, Any]) -> dict[str, Any]:
+        sort = req.get("sort_order", "album_artist")
+        if sort not in _VALID_SORT_ORDERS:
+            raise HTTPException(status_code=422, detail="Invalid sort order")
+        _state["ui_sort_order"] = sort
+        if on_ui_state_set is not None:
+            on_ui_state_set("ui.sort_order", sort)
         return {"ok": True}
 
     # -----------------------------------------------------------------------

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -604,6 +604,7 @@ def _cmd_server(
         library_path=lib_path,
         on_library_path_set=_on_library_path_set,
         ui_active_view=config.ui.active_view,
+        ui_sort_order=config.ui.sort_order,
         on_ui_state_set=_on_ui_state_set,
     )
 

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -76,6 +76,9 @@ class LibraryConfig:
 @dataclass
 class UiConfig:
     active_view: str = "library"  # "library" | "now-playing"
+    sort_order: str = (
+        "album_artist"  # "album_artist" | "album" | "date_added" | "last_played"
+    )
 
 
 @dataclass
@@ -229,7 +232,10 @@ class Config:
             )
 
         ui_raw = raw.get("ui", {})
-        ui = UiConfig(active_view=ui_raw.get("active_view", "library"))
+        ui = UiConfig(
+            active_view=ui_raw.get("active_view", "library"),
+            sort_order=ui_raw.get("sort_order", "album_artist"),
+        )
 
         return cls(
             paths=PathsConfig(
@@ -267,6 +273,7 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "bandcamp.format": str,
     "bandcamp.poll_interval_minutes": int,
     "ui.active_view": str,
+    "ui.sort_order": str,
 }
 
 # Keys whose values must come from a fixed set of choices.
@@ -275,6 +282,7 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
         {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
     ),
     "ui.active_view": frozenset({"library", "now-playing"}),
+    "ui.sort_order": frozenset({"album_artist", "album", "date_added", "last_played"}),
 }
 
 # Sections that must be explicitly added by the user (e.g. via 'kamp sync').
@@ -334,11 +342,18 @@ def config_set(path: Path, key: str, value: str) -> None:
     try:
         new_text = _replace_in_section(text, section, field, toml_value)
     except KeyError as exc:
-        if "not found in config" in str(exc) and section not in _OPTIONAL_SECTIONS:
+        msg = str(exc)
+        if "not found in config" in msg and section not in _OPTIONAL_SECTIONS:
             # Section is standard but absent (e.g. existing config predates this
             # section). Append it so the value is persisted now and replaced on
             # future writes once the section exists.
             path.write_text(text + f"\n[{section}]\n{field} = {toml_value}\n")
+            return
+        if "not found in" in msg and section not in _OPTIONAL_SECTIONS:
+            # Section exists but key is absent (e.g. config predates this field).
+            # Append the key inside the existing section.
+            new_text = _append_to_section(text, section, field, toml_value)
+            path.write_text(new_text)
             return
         raise
     path.write_text(new_text)
@@ -347,6 +362,20 @@ def config_set(path: Path, key: str, value: str) -> None:
 def _toml_escape(s: str) -> str:
     """Escape a string for embedding in a TOML double-quoted string."""
     return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _append_to_section(text: str, section: str, field: str, toml_value: str) -> str:
+    """Append *field = toml_value* at the end of *section* in raw TOML text."""
+    section_re = re.compile(r"^\[" + re.escape(section) + r"\]", re.MULTILINE)
+    section_match = section_re.search(text)
+    assert section_match  # caller guarantees the section exists
+    next_section_re = re.compile(r"^\[[\w-]+\]", re.MULTILINE)
+    next_match = next_section_re.search(text, section_match.end())
+    insert_pos = next_match.start() if next_match else len(text)
+    # Ensure there's a trailing newline before the new key
+    prefix = text[:insert_pos].rstrip("\n") + "\n"
+    suffix = text[insert_pos:]
+    return prefix + f"{field} = {toml_value}\n" + suffix
 
 
 def _replace_in_section(text: str, section: str, field: str, toml_value: str) -> str:

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -33,8 +33,9 @@ export default function App(): React.JSX.Element {
   const searchBarRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    loadLibrary()
-    loadUiState()
+    // Load UI state (sort order, active view) before loading the library so the
+    // library is fetched with the correct persisted sort order, not the default.
+    loadUiState().then(() => loadLibrary())
 
     // Connect WebSocket state stream. On close, retry with exponential backoff
     // (1 s, 2 s, 4 s … capped at 30 s). After 8 failed attempts we give up and
@@ -59,8 +60,7 @@ export default function App(): React.JSX.Element {
         () => {
           attempts = 0
           setServerStatus('connected')
-          loadLibrary()
-          loadUiState()
+          void loadUiState().then(() => loadLibrary())
           void loadQueue()
         },
         () => {

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -103,11 +103,17 @@ export const scanLibrary = (): Promise<ScanResult> => post('/api/v1/library/scan
 export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
   post('/api/v1/config/library-path', { path })
 
-export type UiState = { active_view: 'library' | 'now-playing' }
+export type UiState = {
+  active_view: 'library' | 'now-playing'
+  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played'
+}
 
 export const getUiState = (): Promise<UiState> => get('/api/v1/ui')
 export const setActiveViewApi = (view: 'library' | 'now-playing'): Promise<{ ok: boolean }> =>
   post('/api/v1/ui/active-view', { view })
+export const setSortOrderApi = (
+  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
+): Promise<{ ok: boolean }> => post('/api/v1/ui/sort-order', { sort_order: sortOrder })
 
 export type ScanProgress = { active: boolean; current: number; total: number }
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -129,6 +129,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
     await get().loadLibrary()
     const q = get().searchQuery
     if (q.trim()) await get().setSearchQuery(q)
+    try {
+      await api.setSortOrderApi(sort)
+    } catch {
+      // Best-effort — preference is already applied locally.
+    }
   },
 
   setSearchQuery: async (q) => {
@@ -160,7 +165,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   loadUiState: async () => {
     try {
       const ui = await api.getUiState()
-      set({ activeView: ui.active_view })
+      set({ activeView: ui.active_view, sortOrder: ui.sort_order })
     } catch {
       // Server unreachable — keep default.
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,15 +256,27 @@ class TestConfigSet:
         loaded = Config.load(path)
         assert "new/staging" in str(loaded.paths.staging)
 
-    def test_set_field_missing_from_section_raises_key_error(
-        self, tmp_path: Path
-    ) -> None:
-        """config_set raises KeyError when the field isn't present in the section."""
-        # Craft a TOML where [artwork] exists but min_dimension is missing
+    def test_set_field_missing_from_section_appends_key(self, tmp_path: Path) -> None:
+        """config_set appends a missing key into an existing non-optional section.
+
+        This handles configs that predate a new field (e.g. ui.sort_order added
+        after the user's config was created).
+        """
         path = tmp_path / "config.toml"
         path.write_text("[artwork]\nmax_bytes = 1000000\n")
-        with pytest.raises(KeyError, match="min_dimension"):
-            config_set(path, "artwork.min_dimension", "500")
+        config_set(path, "artwork.min_dimension", "500")
+        assert "min_dimension = 500" in path.read_text()
+
+    def test_set_ui_sort_order_on_config_missing_the_key(self, tmp_path: Path) -> None:
+        """config_set appends ui.sort_order when [ui] exists but lacks the key."""
+        path = tmp_path / "config.toml"
+        # Simulate a config that has [ui] with only active_view (pre-TASK-58)
+        path.write_text('[ui]\nactive_view = "library"\n')
+        config_set(path, "ui.sort_order", "last_played")
+        loaded_text = path.read_text()
+        assert 'sort_order = "last_played"' in loaded_text
+        # active_view must be untouched
+        assert 'active_view = "library"' in loaded_text
 
     def test_set_does_not_clobber_same_fieldname_in_other_section(
         self, tmp_path: Path

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -840,3 +840,54 @@ class TestSearchEndpoint:
         data = res.json()
         assert [a["album"] for a in data["albums"]] == ["Amnesiac", "Kid A"]
         mock_index.albums.assert_called_once_with(sort="album")
+
+
+# ---------------------------------------------------------------------------
+# UI state endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestUiStateEndpoints:
+    def test_get_ui_state_defaults(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/ui")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["active_view"] == "library"
+        assert data["sort_order"] == "album_artist"
+
+    def test_get_ui_state_reflects_init_values(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            ui_active_view="now-playing",
+            ui_sort_order="last_played",
+        )
+        resp = TestClient(app).get("/api/v1/ui")
+        data = resp.json()
+        assert data["active_view"] == "now-playing"
+        assert data["sort_order"] == "last_played"
+
+    def test_set_sort_order_persists(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/ui/sort-order", json={"sort_order": "last_played"})
+        assert resp.status_code == 200
+        assert client.get("/api/v1/ui").json()["sort_order"] == "last_played"
+
+    def test_set_sort_order_invalid_returns_422(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/ui/sort-order", json={"sort_order": "bogus"})
+        assert resp.status_code == 422
+
+    def test_set_sort_order_calls_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        callback = MagicMock()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_ui_state_set=callback,
+        )
+        TestClient(app).post("/api/v1/ui/sort-order", json={"sort_order": "date_added"})
+        callback.assert_called_once_with("ui.sort_order", "date_added")


### PR DESCRIPTION
## Summary

- `sortOrder` was frontend-only state, defaulting to `album_artist` on every restart
- Added `ui.sort_order` to `UiConfig` in `config.py` (loaded from `config.toml`, allowlisted for `config_set`)
- `POST /api/v1/ui/sort-order` saves via the existing `on_ui_state_set` → `config.toml` callback
- `GET /api/v1/ui` now returns `sort_order` alongside `active_view`
- `setSortOrder` in the store persists after applying; `loadUiState` restores it on startup

## Test plan

- [x] `poetry run pytest tests/test_server.py -v --no-cov` — all 69 tests pass
- [x] Manually: set sort to Last Played, quit, reopen — sort preference survives restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)