### PR TITLE
feat: favorite tracks (TASK-39)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -42,7 +42,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     mb_release_id    TEXT    NOT NULL DEFAULT '',
     mb_recording_id  TEXT    NOT NULL DEFAULT '',
     date_added       REAL,    -- file birthtime/ctime at first scan (Unix timestamp)
-    last_played      REAL     -- Unix timestamp of last natural EOF; NULL until played
+    last_played      REAL,    -- Unix timestamp of last natural EOF; NULL until played
+    favorite         INTEGER NOT NULL DEFAULT 0
 );
 
 -- FTS5 virtual table for full-text search across track metadata.
@@ -129,6 +130,7 @@ class Track:
     id: int = field(default=0, compare=False)
     date_added: float | None = field(default=None, compare=False)
     last_played: float | None = field(default=None, compare=False)
+    favorite: bool = field(default=False, compare=False)
 
 
 @dataclass
@@ -227,6 +229,15 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 3")
             self._conn.commit()
+            version = 3
+
+        if version < 4:
+            # v3 → v4: favorite column added.
+            self._conn.execute(
+                "ALTER TABLE tracks ADD COLUMN favorite INTEGER NOT NULL DEFAULT 0"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 4")
+            self._conn.commit()
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -295,6 +306,14 @@ class LibraryIndex:
         self._conn.execute(
             "UPDATE tracks SET last_played = ? WHERE file_path = ?",
             (time.time(), str(file_path)),
+        )
+        self._conn.commit()
+
+    def set_favorite(self, file_path: Path, favorite: bool) -> None:
+        """Set or clear the favorite flag for the track at *file_path*."""
+        self._conn.execute(
+            "UPDATE tracks SET favorite = ? WHERE file_path = ?",
+            (int(favorite), str(file_path)),
         )
         self._conn.commit()
 
@@ -483,6 +502,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         mb_recording_id=row["mb_recording_id"],
         date_added=row["date_added"],
         last_played=row["last_played"],
+        favorite=bool(row["favorite"]),
     )
 
 

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -62,6 +62,16 @@ class PlaybackQueue:
         else:
             self._pos = start_index if tracks else -1
 
+    def update_favorite(self, file_path: Path, favorite: bool) -> None:
+        """Update the favorite flag on any queued tracks matching *file_path*.
+
+        Called after a favorite is toggled so that the next player-state
+        snapshot reflects the new value without requiring a queue reload.
+        """
+        for t in self._tracks:
+            if t.file_path == file_path:
+                t.favorite = favorite
+
     def current(self) -> Track | None:
         if not self._tracks or self._pos < 0:
             return None

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -41,6 +41,7 @@ class TrackOut(BaseModel):
     embedded_art: bool
     mb_release_id: str
     mb_recording_id: str
+    favorite: bool
 
     @classmethod
     def from_track(cls, t: Track) -> "TrackOut":
@@ -57,6 +58,7 @@ class TrackOut(BaseModel):
             embedded_art=t.embedded_art,
             mb_release_id=t.mb_release_id,
             mb_recording_id=t.mb_recording_id,
+            favorite=t.favorite,
         )
 
 
@@ -106,6 +108,11 @@ class ScanResult(BaseModel):
 
 class LibraryPathRequest(BaseModel):
     path: str
+
+
+class FavoriteRequest(BaseModel):
+    file_path: str
+    favorite: bool
 
 
 class SearchOut(BaseModel):
@@ -240,6 +247,17 @@ def create_app(
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
         ]
+
+    @app.post("/api/v1/tracks/favorite")
+    def set_track_favorite(req: FavoriteRequest) -> dict[str, Any]:
+        track = index.get_track_by_path(Path(req.file_path))
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        index.set_favorite(Path(req.file_path), req.favorite)
+        # Keep the in-memory queue in sync so the next player-state snapshot
+        # reflects the new favorite value without requiring a queue reload.
+        queue.update_favorite(Path(req.file_path), req.favorite)
+        return {"ok": True}
 
     @app.get("/api/v1/album-art")
     def get_album_art(album_artist: str, album: str) -> Response:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -19,6 +19,7 @@ export type Track = {
   embedded_art: boolean
   mb_release_id: string
   mb_recording_id: string
+  favorite: boolean
 }
 
 export type Album = {
@@ -167,6 +168,8 @@ export const skipToQueueTrack = (position: number): Promise<unknown> =>
 export const clearQueue = (): Promise<unknown> => post('/api/v1/player/queue/clear', {})
 export const clearRemainingQueue = (position: number): Promise<unknown> =>
   post('/api/v1/player/queue/clear-remaining', { position })
+export const setTrackFavorite = (filePath: string, favorite: boolean): Promise<unknown> =>
+  post('/api/v1/tracks/favorite', { file_path: filePath, favorite })
 
 // ---------------------------------------------------------------------------
 // WebSocket state stream

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1297,6 +1297,27 @@ body,
   color: var(--accent);
 }
 
+.favorite-btn {
+  color: var(--text-dim);
+}
+
+.favorite-btn:hover {
+  color: #e06c75;
+}
+
+.favorite-btn.active {
+  color: #e06c75;
+}
+
+.favorite-btn.active:hover {
+  color: var(--text);
+}
+
+.favorite-btn:disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
 /* Drag-to-reorder: grab cursor for draggable rows, locked cursor for current */
 .queue-track-row[draggable='true'] {
   cursor: grab;

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 
-type ContextMenu = { x: number; y: number; filePath: string }
+type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
 export function TrackList(): React.JSX.Element | null {
   const album = useStore((s) => s.library.selectedAlbum)
@@ -14,6 +14,7 @@ export function TrackList(): React.JSX.Element | null {
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const addToQueue = useStore((s) => s.addToQueue)
   const playNext = useStore((s) => s.playNext)
+  const setFavorite = useStore((s) => s.setFavorite)
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -90,7 +91,12 @@ export function TrackList(): React.JSX.Element | null {
               }}
               onContextMenu={(e) => {
                 e.preventDefault()
-                setMenu({ x: e.clientX, y: e.clientY, filePath: track.file_path })
+                setMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  filePath: track.file_path,
+                  favorite: track.favorite
+                })
               }}
             >
               <span className="track-row-num">
@@ -122,6 +128,15 @@ export function TrackList(): React.JSX.Element | null {
             }}
           >
             + Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void setFavorite(menu.filePath, !menu.favorite)
+              setMenu(null)
+            }}
+          >
+            {menu.favorite ? '♥ Remove from Favorites' : '♡ Add to Favorites'}
           </button>
         </div>
       )}

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -17,6 +17,7 @@ export function TransportBar(): React.JSX.Element {
   const setVolume = useStore((s) => s.setVolume)
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const setFavorite = useStore((s) => s.setFavorite)
 
   const { playing, position, duration, volume, current_track } = player
   return (
@@ -32,6 +33,18 @@ export function TransportBar(): React.JSX.Element {
           <span className="track-idle">No track loaded</span>
         )}
       </div>
+
+      <button
+        className={`transport-btn favorite-btn${current_track?.favorite ? ' active' : ''}`}
+        onClick={() =>
+          current_track && void setFavorite(current_track.file_path, !current_track.favorite)
+        }
+        disabled={!current_track}
+        title={current_track?.favorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-pressed={current_track?.favorite ?? false}
+      >
+        ♥
+      </button>
 
       <div className="transport-controls">
         <button className="transport-btn" onClick={prev} title="Previous (←)">

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -76,6 +76,7 @@ type PlayerStore = {
   skipToQueueTrack: (position: number) => Promise<void>
   clearQueue: () => Promise<void>
   clearRemainingQueue: (position: number) => Promise<void>
+  setFavorite: (filePath: string, favorite: boolean) => Promise<void>
   refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
@@ -335,6 +336,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
   clearRemainingQueue: async (position) => {
     await api.clearRemainingQueue(position)
     void get().loadQueue()
+  },
+
+  setFavorite: async (filePath, favorite) => {
+    await api.setTrackFavorite(filePath, favorite)
+    // Keep the player state in sync if the favorited track is currently playing.
+    if (get().player.current_track?.file_path === filePath) {
+      set((s) => ({
+        player: {
+          ...s.player,
+          current_track: s.player.current_track ? { ...s.player.current_track, favorite } : null
+        }
+      }))
+    }
+    // Reload the open album track list so the heart in track rows updates.
+    await get().refreshOpenAlbum()
   },
 
   setLibraryPath: async (path) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 3
+        assert version == 4
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -938,7 +938,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 3
+        assert version == 4
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -984,7 +984,7 @@ class TestSearch:
         conn.commit()
         conn.close()
 
-        # Opening with LibraryIndex should migrate v2 → v3.
+        # Opening with LibraryIndex should migrate v2 → v4.
         index = LibraryIndex(db_path)
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
@@ -995,7 +995,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 3
+        assert version == 4
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1178,3 +1178,116 @@ class TestRecordPlayed:
         index = LibraryIndex(tmp_path / "library.db")
         index.record_played(tmp_path / "ghost.mp3")  # should not raise
         index.close()
+
+
+# ---------------------------------------------------------------------------
+# Favorite
+# ---------------------------------------------------------------------------
+
+
+class TestFavorite:
+    """Tests for LibraryIndex.set_favorite() and Track.favorite persistence."""
+
+    def _make_index_with_track(self, tmp_path: Path) -> tuple[LibraryIndex, Path]:
+        index = LibraryIndex(tmp_path / "library.db")
+        p = tmp_path / "track.mp3"
+        _make_mp3(p, artist="A", album_artist="A", album="B", title="T")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=p,
+                    title="T",
+                    artist="A",
+                    album_artist="A",
+                    album="B",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                )
+            ]
+        )
+        return index, p
+
+    def test_favorite_defaults_to_false(self, tmp_path: Path) -> None:
+        index, p = self._make_index_with_track(tmp_path)
+        track = index.get_track_by_path(p)
+        index.close()
+        assert track is not None
+        assert track.favorite is False
+
+    def test_set_favorite_marks_track(self, tmp_path: Path) -> None:
+        index, p = self._make_index_with_track(tmp_path)
+        index.set_favorite(p, True)
+        track = index.get_track_by_path(p)
+        index.close()
+        assert track is not None
+        assert track.favorite is True
+
+    def test_set_favorite_clears_flag(self, tmp_path: Path) -> None:
+        index, p = self._make_index_with_track(tmp_path)
+        index.set_favorite(p, True)
+        index.set_favorite(p, False)
+        track = index.get_track_by_path(p)
+        index.close()
+        assert track is not None
+        assert track.favorite is False
+
+    def test_migration_v3_to_v4_adds_favorite_column(self, tmp_path: Path) -> None:
+        """Existing v3 databases gain the favorite column on open."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        # Build a v3-style database (has date columns but no favorite).
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (3)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL DEFAULT '',
+                artist TEXT NOT NULL DEFAULT '',
+                album_artist TEXT NOT NULL DEFAULT '',
+                album TEXT NOT NULL DEFAULT '',
+                year TEXT NOT NULL DEFAULT '',
+                track_number INTEGER NOT NULL DEFAULT 0,
+                disc_number INTEGER NOT NULL DEFAULT 1,
+                ext TEXT NOT NULL DEFAULT '',
+                embedded_art INTEGER NOT NULL DEFAULT 0,
+                mb_release_id TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added REAL,
+                last_played REAL
+            )
+            """)
+        conn.execute(
+            "INSERT INTO tracks VALUES (1, '/c.mp3', 'Song', 'Band', 'Band', "
+            "'Album', '2000', 1, 1, 'mp3', 0, '', '', NULL, NULL)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5("
+            "title, artist, album_artist, album, tokenize='unicode61')"
+        )
+        conn.execute(
+            "CREATE TABLE player_state ("
+            "id INTEGER PRIMARY KEY CHECK (id = 1), "
+            "track_path TEXT NOT NULL, position REAL NOT NULL DEFAULT 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        # Opening with LibraryIndex should migrate v3 → v4.
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
+        index.close()
+
+        assert version == 4
+        assert row is not None
+        assert row[0] == 0  # existing tracks default to not-favorited

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -189,6 +189,22 @@ class TestPlaybackQueue:
         q.clear_remaining(from_position=0)
         assert q.current() is None
 
+    def test_update_favorite_patches_matching_tracks(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        q.update_favorite(tracks[1].file_path, True)
+        assert q._tracks[0].favorite is False
+        assert q._tracks[1].favorite is True
+        assert q._tracks[2].favorite is False
+
+    def test_update_favorite_no_match_is_noop(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(2)]
+        q.load(tracks)
+        q.update_favorite(Path("/nonexistent.mp3"), True)  # should not raise
+        assert all(not t.favorite for t in q._tracks)
+
     def test_shuffle_randomises_order(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(20)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -926,3 +926,49 @@ class TestUiStateEndpoints:
         )
         TestClient(app).post("/api/v1/ui/sort-order", json={"sort_order": "date_added"})
         callback.assert_called_once_with("ui.sort_order", "date_added")
+
+
+# ---------------------------------------------------------------------------
+# Favorite endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestFavoriteEndpoint:
+    def test_set_favorite_endpoint(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = _track(1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite",
+            json={"file_path": "/music/01.mp3", "favorite": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        mock_index.set_favorite.assert_called_once_with(Path("/music/01.mp3"), True)
+        # Queue must also be updated so the next player-state snapshot is correct.
+        mock_queue.update_favorite.assert_called_once_with(Path("/music/01.mp3"), True)
+
+    def test_set_favorite_returns_404_for_unknown_track(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = None
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite",
+            json={"file_path": "/music/ghost.mp3", "favorite": True},
+        )
+        assert resp.status_code == 404
+
+    def test_track_out_includes_favorite_field(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        track = (
+            TestClient(app)
+            .get("/api/v1/tracks?album_artist=Artist&album=Album")
+            .json()[0]
+        )
+        assert "favorite" in track
+        assert track["favorite"] is False


### PR DESCRIPTION
## Summary

- DB schema v4: adds `favorite` column to tracks with migration from v3
- `POST /api/v1/tracks/favorite` toggles favorite state; also patches the in-memory `PlaybackQueue` so the next WebSocket snapshot reflects the new value without a queue reload
- Transport bar: ♥ heart button, dim when unfavorited, red (`#e06c75`) when favorited — disabled when nothing is playing
- Track list right-click context menu: "♡ Add to Favorites" / "♥ Remove from Favorites"
- Favorite state persists in the library DB and survives restarts

## Test plan

- [x] Play a track → dim ♥ appears in transport bar; click → turns red; restart app → still red
- [x] Click again → reverts to dim; persists across restart
- [x] Right-click a track in the track list → "♡ Add to Favorites" toggles it; if that track is playing the transport heart updates immediately
- [x] Heart is dim and non-interactive when no track is loaded
- [x] `poetry run pytest tests/test_library.py tests/test_playback.py tests/test_server.py -v --no-cov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)