### PR TITLE
feat: track play count (TASK-28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,64 @@ The session file (`bandcamp_session.json`) is written with owner-only permission
 
 ## Development
 
+### Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Python | 3.11+ | [python.org](https://www.python.org/downloads/) — check "Add to PATH" on Windows |
+| Poetry | latest | `pip install poetry` or see [python-poetry.org](https://python-poetry.org/docs/#installation) |
+| Node.js | 18+ (LTS) | [nodejs.org](https://nodejs.org/) — includes npm |
+| mpv | latest | [mpv.io](https://mpv.io/) — must be on `PATH` for the player server to run |
+| Git | any | [git-scm.com](https://git-scm.com/) |
+
+### Bootstrap
+
 ```bash
+# 1. Clone
+git clone https://github.com/eightyeighteyes/kamp
+cd kamp
+
+# 2. Enable the pre-commit hook (black + mypy)
+git config core.hooksPath .githooks
+
+# 3. Install Python dependencies (creates a .venv in the project root)
 poetry install
-playwright install chromium
-poetry run pytest      # run tests
-poetry run mypy kamp_daemon/     # type check
-poetry run black kamp_daemon/ tests/  # format
+
+# 4. Install Playwright browser binaries (required for Bandcamp auto-download)
+poetry run playwright install chromium
+
+# 5. Install UI dependencies
+cd kamp_ui
+npm install
+```
+
+### Run in development
+
+```bash
+# Start the Python server (from repo root)
+poetry run kamp server
+
+# In a second terminal, start the Electron UI with hot-reload (from kamp_ui/)
+cd kamp_ui
+npm run dev
+```
+
+`npm run dev` launches Electron and the Vite dev server. The renderer reconnects automatically whenever the Python server starts or restarts.
+
+### Tests and linting
+
+```bash
+# Run all tests (from repo root)
+poetry run pytest
+
+# Run a single test file without the coverage threshold check
+poetry run pytest tests/test_server.py -v --no-cov
+
+# Type check
+poetry run mypy kamp_daemon/ kamp_core/
+
+# Format
+poetry run black kamp_daemon/ kamp_core/ tests/
 ```
 
 

--- a/backlog/tasks/task-28 - track-listening-statistics-are-kept-in-the-Library.md
+++ b/backlog/tasks/task-28 - track-listening-statistics-are-kept-in-the-Library.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-28
 title: track listening statistics are kept in the Library
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 17:29'
-updated_date: '2026-03-31 03:21'
+updated_date: '2026-04-02 16:17'
 labels:
   - feature
   - library
@@ -12,7 +12,7 @@ labels:
 milestone: m-5
 dependencies: []
 priority: medium
-ordinal: 3000
+ordinal: 2000
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 4
+_SCHEMA_VERSION = 5
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     mb_recording_id  TEXT    NOT NULL DEFAULT '',
     date_added       REAL,    -- file birthtime/ctime at first scan (Unix timestamp)
     last_played      REAL,    -- Unix timestamp of last natural EOF; NULL until played
-    favorite         INTEGER NOT NULL DEFAULT 0
+    favorite         INTEGER NOT NULL DEFAULT 0,
+    play_count       INTEGER NOT NULL DEFAULT 0
 );
 
 -- FTS5 virtual table for full-text search across track metadata.
@@ -131,6 +132,7 @@ class Track:
     date_added: float | None = field(default=None, compare=False)
     last_played: float | None = field(default=None, compare=False)
     favorite: bool = field(default=False, compare=False)
+    play_count: int = field(default=0, compare=False)
 
 
 @dataclass
@@ -238,6 +240,15 @@ class LibraryIndex:
             )
             self._conn.execute("UPDATE schema_version SET version = 4")
             self._conn.commit()
+            version = 4
+
+        if version < 5:
+            # v4 → v5: play_count column added.
+            self._conn.execute(
+                "ALTER TABLE tracks ADD COLUMN play_count INTEGER NOT NULL DEFAULT 0"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 5")
+            self._conn.commit()
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -304,7 +315,7 @@ class LibraryIndex:
         import time
 
         self._conn.execute(
-            "UPDATE tracks SET last_played = ? WHERE file_path = ?",
+            "UPDATE tracks SET last_played = ?, play_count = play_count + 1 WHERE file_path = ?",
             (time.time(), str(file_path)),
         )
         self._conn.commit()
@@ -503,6 +514,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         date_added=row["date_added"],
         last_played=row["last_played"],
         favorite=bool(row["favorite"]),
+        play_count=row["play_count"],
     )
 
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -42,6 +42,7 @@ class TrackOut(BaseModel):
     mb_release_id: str
     mb_recording_id: str
     favorite: bool
+    play_count: int
 
     @classmethod
     def from_track(cls, t: Track) -> "TrackOut":
@@ -59,6 +60,7 @@ class TrackOut(BaseModel):
             mb_release_id=t.mb_release_id,
             mb_recording_id=t.mb_recording_id,
             favorite=t.favorite,
+            play_count=t.play_count,
         )
 
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -20,6 +20,7 @@ export type Track = {
   mb_release_id: string
   mb_recording_id: string
   favorite: boolean
+  play_count: number
 }
 
 export type Album = {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 4
+        assert version == 5
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -938,7 +938,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 4
+        assert version == 5
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -995,7 +995,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 4
+        assert version == 5
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1179,6 +1179,119 @@ class TestRecordPlayed:
         index.record_played(tmp_path / "ghost.mp3")  # should not raise
         index.close()
 
+    def test_play_count_defaults_to_zero(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        p = tmp_path / "track.mp3"
+        _make_mp3(p, artist="A", album_artist="A", album="B", title="T")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=p,
+                    title="T",
+                    artist="A",
+                    album_artist="A",
+                    album="B",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                )
+            ]
+        )
+        track = index.get_track_by_path(p)
+        index.close()
+        assert track is not None
+        assert track.play_count == 0
+
+    def test_record_played_increments_play_count(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        p = tmp_path / "track.mp3"
+        _make_mp3(p, artist="A", album_artist="A", album="B", title="T")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=p,
+                    title="T",
+                    artist="A",
+                    album_artist="A",
+                    album="B",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                )
+            ]
+        )
+        index.record_played(p)
+        index.record_played(p)
+        track = index.get_track_by_path(p)
+        index.close()
+        assert track is not None
+        assert track.play_count == 2
+
+    def test_migration_v4_to_v5_adds_play_count_column(self, tmp_path: Path) -> None:
+        """Existing v4 databases gain the play_count column on open."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (4)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL DEFAULT '',
+                artist TEXT NOT NULL DEFAULT '',
+                album_artist TEXT NOT NULL DEFAULT '',
+                album TEXT NOT NULL DEFAULT '',
+                year TEXT NOT NULL DEFAULT '',
+                track_number INTEGER NOT NULL DEFAULT 0,
+                disc_number INTEGER NOT NULL DEFAULT 1,
+                ext TEXT NOT NULL DEFAULT '',
+                embedded_art INTEGER NOT NULL DEFAULT 0,
+                mb_release_id TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added REAL,
+                last_played REAL,
+                favorite INTEGER NOT NULL DEFAULT 0
+            )
+            """)
+        conn.execute(
+            "INSERT INTO tracks VALUES (1, '/d.mp3', 'Song', 'Band', 'Band', "
+            "'Album', '2000', 1, 1, 'mp3', 0, '', '', NULL, NULL, 0)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5("
+            "title, artist, album_artist, album, tokenize='unicode61')"
+        )
+        conn.execute(
+            "CREATE TABLE player_state ("
+            "id INTEGER PRIMARY KEY CHECK (id = 1), "
+            "track_path TEXT NOT NULL, position REAL NOT NULL DEFAULT 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        row = index._conn.execute(
+            "SELECT play_count FROM tracks WHERE id = 1"
+        ).fetchone()
+        index.close()
+
+        assert version == 5
+        assert row is not None
+        assert row[0] == 0
+
 
 # ---------------------------------------------------------------------------
 # Favorite
@@ -1288,6 +1401,6 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 4
+        assert version == 5
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -972,3 +972,16 @@ class TestFavoriteEndpoint:
         )
         assert "favorite" in track
         assert track["favorite"] is False
+
+    def test_track_out_includes_play_count_field(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        track = (
+            TestClient(app)
+            .get("/api/v1/tracks?album_artist=Artist&album=Album")
+            .json()[0]
+        )
+        assert "play_count" in track
+        assert track["play_count"] == 0


### PR DESCRIPTION
## Summary

- DB schema v5: adds `play_count INTEGER NOT NULL DEFAULT 0` with migration from v4
- `record_played()` now increments `play_count` atomically alongside `last_played` (single `UPDATE` statement)
- `last_played` was already fully wired — this task's main addition is `play_count`
- `Track` dataclass, `TrackOut` API model, and frontend `Track` type all include `play_count`

## Test plan

- [x] `poetry run pytest tests/test_library.py tests/test_server.py -v --no-cov`
- [x] Play a track to natural EOF → `play_count` increments in DB; play again → increments again
- [x] Existing DBs (v4) migrate cleanly — all tracks start at `play_count = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)