### PR TITLE
fix: preserve album grid scroll position on back navigation (TASK-61)

### DIFF
--- a/backlog/milestones/m-21 - preferences.md
+++ b/backlog/milestones/m-21 - preferences.md
@@ -1,0 +1,8 @@
+---
+id: m-21
+title: "Preferences"
+---
+
+## Description
+
+Milestone: Preferences

--- a/backlog/milestones/m-22 - last.fm-integration.md
+++ b/backlog/milestones/m-22 - last.fm-integration.md
@@ -1,0 +1,8 @@
+---
+id: m-22
+title: "last.fm integration"
+---
+
+## Description
+
+Milestone: last.fm integration

--- a/backlog/tasks/task-27 - last.fm-scrobble-integration.md
+++ b/backlog/tasks/task-27 - last.fm-scrobble-integration.md
@@ -4,12 +4,12 @@ title: last.fm scrobble integration
 status: To Do
 assignee: []
 created_date: '2026-03-29 17:28'
-updated_date: '2026-03-31 03:21'
+updated_date: '2026-04-02 20:25'
 labels:
   - feature
   - integration
   - 'estimate: lp'
-milestone: m-5
+milestone: m-22
 dependencies: []
 priority: medium
 ordinal: 2000

--- a/backlog/tasks/task-61 - preserve-scroll-range-when-clicking-on-an-album-page-and-then-going-back.md
+++ b/backlog/tasks/task-61 - preserve-scroll-range-when-clicking-on-an-album-page-and-then-going-back.md
@@ -1,13 +1,15 @@
 ---
 id: TASK-61
 title: preserve scroll range when clicking on an album page and then going back
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-02 01:39'
+updated_date: '2026-04-02 21:31'
 labels: []
 milestone: m-5
 dependencies: []
 priority: low
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-64 - Library-scan-progress-UI.md
+++ b/backlog/tasks/task-64 - Library-scan-progress-UI.md
@@ -1,5 +1,5 @@
 ---
-id: DRAFT-6
+id: TASK-64
 title: Library scan progress UI
 status: Draft
 assignee: []

--- a/backlog/tasks/task-65 - A-modal-dialog-is-available-for-setting-preferences.md
+++ b/backlog/tasks/task-65 - A-modal-dialog-is-available-for-setting-preferences.md
@@ -1,0 +1,30 @@
+---
+id: TASK-65
+title: A modal dialog is available for setting preferences
+status: To Do
+assignee: []
+created_date: '2026-04-02 20:24'
+labels: []
+milestone: m-21
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A preferences modal dialog can be opened from macOS menu bar App Name -> Preferences.
+
+Cmd/ctrl + , opens the preferences dialog.
+
+When a preference is set, it is immediately set (the user doesn't need to click Apply or OK or any of that nonsense).
+
+An ephemeral dialog shows that the preference was saved.
+
+Library path options are moved to preferences dialog.
+
+Background color of dialog matches queue panel background.
+
+Dialog can be dismissed with an X in the upper right corner or Escape key.
+
+Consult with UI Designer on all of this.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
+++ b/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
@@ -1,0 +1,46 @@
+---
+id: TASK-66
+title: re-index tracks whose file mtime has changed since last scan
+status: To Do
+assignee: []
+created_date: '2026-04-02 21:45'
+updated_date: '2026-04-02 21:46'
+labels:
+  - feature
+  - library
+  - 'estimate: side'
+milestone: m-5
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The scanner currently only reads tags for files not yet in the index (`to_add = on_disk - in_index`). Files already indexed are never re-read, so tag changes made outside of kamp (e.g. adding cover art, fixing metadata with an external editor) are invisible until the database is deleted and a full rescan is done.
+
+## Root cause
+
+`LibraryScanner.scan()` in `kamp_core/library.py` computes `to_add = on_disk - in_index` and only reads tags for new files. There is no mechanism to detect that an existing file's tags have changed.
+
+## Solution
+
+Add a `file_mtime` column (REAL, Unix timestamp) to the `tracks` table. On each scan:
+
+1. Record `path.stat().st_mtime` when a track is first indexed.
+2. For files already in the index, compare the current `st_mtime` against the stored value.
+3. Re-read tags (and update `file_mtime`) for any file whose mtime has changed.
+
+This catches cover art additions, tag corrections, and any other metadata edits made by external tools without requiring a full re-index.
+
+## Known trigger
+
+Adding cover art to an M4A file with an external editor leaves `embedded_art=0` in the DB and the art never appears in the UI, even after repeated rescans.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After adding or changing embedded art in an audio file outside of kamp, a library rescan detects the changed mtime and updates the track's tags (including embedded_art) in the index
+- [ ] #2 Unchanged files (same mtime) are still skipped — scan performance is not degraded for unmodified libraries
+- [ ] #3 file_mtime column is added with a v→v+1 migration; existing tracks get their mtime backfilled from the filesystem on first migration
+<!-- AC:END -->

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -32,7 +32,8 @@ export default function App(): React.JSX.Element {
   const loadQueue = useStore((s) => s.loadQueue)
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
-  // Per-view scroll positions so switching library ↔ now-playing doesn't reset scroll.
+  // Per-view scroll positions — kept current by a scroll listener so we never
+  // read a browser-clamped value when the outgoing view's content was taller.
   const viewScrollRef = useRef<Partial<Record<string, number>>>({})
 
   useEffect(() => {
@@ -139,17 +140,24 @@ export default function App(): React.JSX.Element {
     toggleQueuePanel
   ])
 
-  // Save the outgoing view's scroll position and restore the incoming view's,
-  // synchronously before paint so there's no visible jump.
-  const prevViewRef = useRef(activeView)
+  // Keep viewScrollRef continuously current so we always have the right value
+  // when switching views — reading scrollTop after a DOM update can give a
+  // browser-clamped value if the new content is shorter than the old.
+  useEffect(() => {
+    const el = mainContentRef.current
+    if (!el) return
+    const onScroll = (): void => {
+      viewScrollRef.current[activeView] = el.scrollTop
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [activeView])
+
+  // Restore the incoming view's scroll position synchronously before paint.
   useLayoutEffect(() => {
     const el = mainContentRef.current
     if (!el) return
-    if (prevViewRef.current !== activeView) {
-      viewScrollRef.current[prevViewRef.current] = el.scrollTop
-      el.scrollTop = viewScrollRef.current[activeView] ?? 0
-      prevViewRef.current = activeView
-    }
+    el.scrollTop = viewScrollRef.current[activeView] ?? 0
   }, [activeView])
 
   if (serverStatus === 'disconnected') {

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useLayoutEffect, useRef } from 'react'
 import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
@@ -31,6 +31,9 @@ export default function App(): React.JSX.Element {
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const loadQueue = useStore((s) => s.loadQueue)
   const searchBarRef = useRef<HTMLInputElement>(null)
+  const mainContentRef = useRef<HTMLElement>(null)
+  // Per-view scroll positions so switching library ↔ now-playing doesn't reset scroll.
+  const viewScrollRef = useRef<Partial<Record<string, number>>>({})
 
   useEffect(() => {
     // Load UI state (sort order, active view) before loading the library so the
@@ -136,6 +139,19 @@ export default function App(): React.JSX.Element {
     toggleQueuePanel
   ])
 
+  // Save the outgoing view's scroll position and restore the incoming view's,
+  // synchronously before paint so there's no visible jump.
+  const prevViewRef = useRef(activeView)
+  useLayoutEffect(() => {
+    const el = mainContentRef.current
+    if (!el) return
+    if (prevViewRef.current !== activeView) {
+      viewScrollRef.current[prevViewRef.current] = el.scrollTop
+      el.scrollTop = viewScrollRef.current[activeView] ?? 0
+      prevViewRef.current = activeView
+    }
+  }, [activeView])
+
   if (serverStatus === 'disconnected') {
     return (
       <div className="server-offline">
@@ -174,7 +190,7 @@ export default function App(): React.JSX.Element {
       )}
       <div className="app-body">
         {!showSetup && activeView === 'library' && !searchQuery && <ArtistPanel />}
-        <main className="main-content">
+        <main className="main-content" ref={mainContentRef}>
           {showSetup ? (
             <SetupScreen />
           ) : searchQuery ? (

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -1,4 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
+
+// Persists scroll position across AlbumGrid mount/unmount cycles (e.g. open
+// album → back). Module-level so it survives React unmounting the component.
+let savedScrollTop = 0
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
@@ -66,6 +70,17 @@ export function AlbumGrid(): React.JSX.Element {
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const scroller = containerRef.current?.closest<HTMLElement>('.main-content')
+    // Restore scroll position from before the album was opened.
+    if (scroller) scroller.scrollTop = savedScrollTop
+    return () => {
+      // Save scroll position when navigating into an album.
+      if (scroller) savedScrollTop = scroller.scrollTop
+    }
+  }, [])
 
   useEffect(() => {
     if (!menu) return
@@ -81,7 +96,7 @@ export function AlbumGrid(): React.JSX.Element {
   const visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
 
   return (
-    <div className="album-grid-container">
+    <div className="album-grid-container" ref={containerRef}>
       <SortControl />
       {visible.length === 0 ? (
         <div className="album-grid-empty">

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 // Persists scroll position across AlbumGrid mount/unmount cycles (e.g. open
 // album → back). Module-level so it survives React unmounting the component.
@@ -72,9 +72,10 @@ export function AlbumGrid(): React.JSX.Element {
   const menuRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const scroller = containerRef.current?.closest<HTMLElement>('.main-content')
-    // Restore scroll position from before the album was opened.
+    // Restore scroll position synchronously before paint to avoid a visible
+    // jump to the top when navigating back from a track list.
     if (scroller) scroller.scrollTop = savedScrollTop
     return () => {
       // Save scroll position when navigating into an album.


### PR DESCRIPTION
## Summary

- Scroll position in the album grid is now restored when pressing "← Albums" after viewing a track list
- `AlbumGrid` saves `scrollTop` of its `.main-content` ancestor on unmount and restores it on remount
- State lives in a module-level variable — no store changes, no prop drilling

## Test plan

- [x] Scroll partway down the album grid, open an album, press "← Albums" — grid returns to same scroll position
- [x] Opening a different album from a scrolled position also restores correctly on back
- [x] Initial load (no prior scroll) still starts at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)