### PR TITLE
feat: re-index tracks when file mtime changes (TASK-66)

### DIFF
--- a/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
+++ b/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-66
 title: re-index tracks whose file mtime has changed since last scan
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-02 21:45'
-updated_date: '2026-04-02 21:46'
+updated_date: '2026-04-02 22:23'
 labels:
   - feature
   - library
@@ -12,6 +12,7 @@ labels:
 milestone: m-5
 dependencies: []
 priority: medium
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
+++ b/backlog/tasks/task-66 - re-index-tracks-whose-file-mtime-has-changed-since-last-scan.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-66
 title: re-index tracks whose file mtime has changed since last scan
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-02 21:45'
-updated_date: '2026-04-02 22:23'
+updated_date: '2026-04-02 22:51'
 labels:
   - feature
   - library
@@ -12,7 +12,7 @@ labels:
 milestone: m-5
 dependencies: []
 priority: medium
-ordinal: 1000
+ordinal: 4000
 ---
 
 ## Description

--- a/backlog/tasks/task-67 - check-album-paths-for-album-art.md
+++ b/backlog/tasks/task-67 - check-album-paths-for-album-art.md
@@ -1,0 +1,18 @@
+---
+id: TASK-67
+title: check album paths for album art
+status: To Do
+assignee: []
+created_date: '2026-04-02 22:48'
+labels: []
+milestone: m-11
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+if a supported image file is in the album folder, use that as album art
+
+prefer embedded album art to path album art
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -506,7 +506,22 @@ class LibraryIndex:
 
 def _track_to_params(
     t: Track,
-) -> tuple[str, str, str, str, str, str, int, int, str, int, str, str, float | None, float | None]:
+) -> tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    int,
+    int,
+    str,
+    int,
+    str,
+    str,
+    float | None,
+    float | None,
+]:
     return (
         str(t.file_path),
         t.title,
@@ -806,4 +821,6 @@ class LibraryScanner:
 
         unchanged = len(on_disk & in_index) - len(to_update)
 
-        return ScanResult(added=added, removed=removed, unchanged=unchanged, updated=updated)
+        return ScanResult(
+            added=added, removed=removed, unchanged=unchanged, updated=updated
+        )

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 5
+_SCHEMA_VERSION = 6
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     date_added       REAL,    -- file birthtime/ctime at first scan (Unix timestamp)
     last_played      REAL,    -- Unix timestamp of last natural EOF; NULL until played
     favorite         INTEGER NOT NULL DEFAULT 0,
-    play_count       INTEGER NOT NULL DEFAULT 0
+    play_count       INTEGER NOT NULL DEFAULT 0,
+    file_mtime       REAL     -- st_mtime at last scan; NULL until v6 migration backfill
 );
 
 -- FTS5 virtual table for full-text search across track metadata.
@@ -72,6 +73,14 @@ CREATE TABLE IF NOT EXISTS queue_state (
 
 # Characters that have special meaning in FTS5 MATCH expressions.
 _FTS_SPECIAL = re.compile(r'["*^()]')
+
+
+def _get_mtime(path: Path) -> float | None:
+    """Return st_mtime for *path*, or None on OS error."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
 
 
 def _get_date_added(path: Path) -> float | None:
@@ -133,6 +142,7 @@ class Track:
     last_played: float | None = field(default=None, compare=False)
     favorite: bool = field(default=False, compare=False)
     play_count: int = field(default=0, compare=False)
+    file_mtime: float | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -153,6 +163,7 @@ class ScanResult:
     added: int
     removed: int
     unchanged: int
+    updated: int = 0
 
 
 class LibraryIndex:
@@ -249,6 +260,17 @@ class LibraryIndex:
             )
             self._conn.execute("UPDATE schema_version SET version = 5")
             self._conn.commit()
+            version = 5
+
+        if version < 6:
+            # v5 → v6: file_mtime column added.
+            # Intentionally left NULL for all existing rows so that the next
+            # scan treats every track as "changed" and re-reads its tags.
+            # This ensures tag edits made before the upgrade (e.g. adding cover
+            # art) are picked up on the first scan after migration.
+            self._conn.execute("ALTER TABLE tracks ADD COLUMN file_mtime REAL")
+            self._conn.execute("UPDATE schema_version SET version = 6")
+            self._conn.commit()
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -271,8 +293,8 @@ class LibraryIndex:
             INSERT INTO tracks
                 (file_path, title, artist, album_artist, album, year,
                  track_number, disc_number, ext, embedded_art,
-                 mb_release_id, mb_recording_id, date_added)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 mb_release_id, mb_recording_id, date_added, file_mtime)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 title           = excluded.title,
                 artist          = excluded.artist,
@@ -284,7 +306,8 @@ class LibraryIndex:
                 ext             = excluded.ext,
                 embedded_art    = excluded.embedded_art,
                 mb_release_id   = excluded.mb_release_id,
-                mb_recording_id = excluded.mb_recording_id
+                mb_recording_id = excluded.mb_recording_id,
+                file_mtime      = excluded.file_mtime
                 -- date_added intentionally omitted: preserve original scan date on re-scan
                 -- last_played intentionally omitted: managed exclusively by record_played()
             """,
@@ -377,6 +400,11 @@ class LibraryIndex:
         """Return the set of all file paths currently in the index."""
         rows = self._conn.execute("SELECT file_path FROM tracks").fetchall()
         return {Path(r["file_path"]) for r in rows}
+
+    def indexed_paths_with_mtime(self) -> dict[Path, float | None]:
+        """Return a mapping of indexed file paths to their stored file_mtime."""
+        rows = self._conn.execute("SELECT file_path, file_mtime FROM tracks").fetchall()
+        return {Path(r["file_path"]): r["file_mtime"] for r in rows}
 
     def get_track_by_path(self, path: Path) -> "Track | None":
         """Return the track for *path*, or None if not indexed."""
@@ -478,7 +506,7 @@ class LibraryIndex:
 
 def _track_to_params(
     t: Track,
-) -> tuple[str, str, str, str, str, str, int, int, str, int, str, str, float | None]:
+) -> tuple[str, str, str, str, str, str, int, int, str, int, str, str, float | None, float | None]:
     return (
         str(t.file_path),
         t.title,
@@ -493,6 +521,7 @@ def _track_to_params(
         t.mb_release_id,
         t.mb_recording_id,
         t.date_added,
+        t.file_mtime,
     )
 
 
@@ -515,6 +544,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         last_played=row["last_played"],
         favorite=bool(row["favorite"]),
         play_count=row["play_count"],
+        file_mtime=row["file_mtime"],
     )
 
 
@@ -695,6 +725,7 @@ def _read_tags(path: Path) -> Track | None:
         else:
             return None
         track.date_added = _get_date_added(path)
+        track.file_mtime = _get_mtime(path)
         return track
     except Exception:
         logger.warning("Could not read tags from %s", path, exc_info=True)
@@ -719,12 +750,14 @@ class LibraryScanner:
     ) -> ScanResult:
         """Scan *library_path* recursively and update the index.
 
-        Files already in the index are left untouched (unchanged).
-        New files are read and added. Index entries whose files no longer
-        exist on disk are removed.
+        New files are read and added. Files whose mtime has changed since the
+        last scan are re-read so tag edits (e.g. adding cover art) are picked
+        up automatically. Index entries whose files no longer exist on disk are
+        removed.
 
-        *on_progress*, if provided, is called after each new file's tags are
-        read with (current, total) where total = number of new files to index.
+        *on_progress*, if provided, is called after each processed file's tags
+        are read with (current, total) where total = number of files to index
+        (new + updated).
         """
         if not library_path.exists():
             return ScanResult(added=0, removed=0, unchanged=0)
@@ -734,28 +767,43 @@ class LibraryScanner:
             for p in library_path.rglob("*")
             if p.is_file() and p.suffix.lower() in _AUDIO_SUFFIXES
         }
-        in_index = self._index.indexed_paths()
+        indexed = self._index.indexed_paths_with_mtime()
+        in_index = set(indexed.keys())
 
-        # Read tags for all new files, then commit in one transaction.
         to_add = on_disk - in_index
-        total = len(to_add)
-        new_tracks: list[Track] = []
-        for current, path in enumerate(to_add, start=1):
+
+        # Re-read any existing file whose mtime differs from what was stored.
+        # A None stored mtime (pre-v6 rows) is treated as changed so they get
+        # backfilled on the first scan after the migration.
+        to_update: set[Path] = set()
+        for path in on_disk & in_index:
+            current_mtime = _get_mtime(path)
+            if current_mtime is None:
+                continue  # can't stat — leave it alone
+            if indexed[path] != current_mtime:
+                to_update.add(path)
+
+        to_process = to_add | to_update
+        total = len(to_process)
+        tracks_to_upsert: list[Track] = []
+        for current, path in enumerate(to_process, start=1):
             track = _read_tags(path)
             if track is not None:
-                new_tracks.append(track)
+                tracks_to_upsert.append(track)
             else:
                 logger.warning("Skipped unreadable file: %s", path)
             if on_progress is not None:
                 on_progress(current, total)
-        self._index.upsert_many(new_tracks)
-        added = len(new_tracks)
+        self._index.upsert_many(tracks_to_upsert)
+
+        added = len([t for t in tracks_to_upsert if t.file_path in to_add])
+        updated = len([t for t in tracks_to_upsert if t.file_path in to_update])
 
         removed = 0
         for path in in_index - on_disk:
             self._index.remove_track(path)
             removed += 1
 
-        unchanged = len(on_disk & in_index)
+        unchanged = len(on_disk & in_index) - len(to_update)
 
-        return ScanResult(added=added, removed=removed, unchanged=unchanged)
+        return ScanResult(added=added, removed=removed, unchanged=unchanged, updated=updated)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -106,6 +106,7 @@ class ScanResult(BaseModel):
     added: int
     removed: int
     unchanged: int
+    updated: int
 
 
 class LibraryPathRequest(BaseModel):
@@ -314,7 +315,10 @@ def create_app(
             _state["scan_progress"] = {"active": False, "current": 0, "total": 0}
 
         return ScanResult(
-            added=result.added, removed=result.removed, unchanged=result.unchanged
+            added=result.added,
+            removed=result.removed,
+            unchanged=result.unchanged,
+            updated=result.updated,
         )
 
     @app.get("/api/v1/library/scan/progress")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -43,6 +43,7 @@ export type ScanResult = {
   added: number
   removed: number
   unchanged: number
+  updated: number
 }
 
 // Configurable base URL: defaults to localhost but can be overridden via

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 5
+        assert version == 6
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -938,7 +938,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 5
+        assert version == 6
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -995,7 +995,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 5
+        assert version == 6
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1288,7 +1288,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 5
+        assert version == 6
         assert row is not None
         assert row[0] == 0
 
@@ -1401,6 +1401,189 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 5
+        assert version == 6
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
+
+
+# ---------------------------------------------------------------------------
+# Mtime-based re-indexing (TASK-66)
+# ---------------------------------------------------------------------------
+
+
+class TestMtimeReindex:
+    """Tests for LibraryScanner mtime change detection."""
+
+    def test_scan_stores_file_mtime_on_first_index(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        p = lib / "01.mp3"
+        _make_mp3(p, title="T")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        LibraryScanner(index).scan(lib)
+        tracks = index.all_tracks()
+        index.close()
+
+        assert tracks[0].file_mtime == pytest.approx(p.stat().st_mtime, abs=1.0)
+
+    def test_scan_reindexes_file_when_mtime_changes(self, tmp_path: Path) -> None:
+        """Updating a file's mtime causes re-read on next scan."""
+        lib = tmp_path / "music"
+        lib.mkdir()
+        p = lib / "01.mp3"
+        _make_mp3(p, title="Original")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+
+        # Rewrite the file with a new title and bump mtime.
+        _make_mp3(p, title="Updated")
+        import os
+
+        os.utime(p, (p.stat().st_atime, p.stat().st_mtime + 1))
+
+        result = scanner.scan(lib)
+        tracks = index.all_tracks()
+        index.close()
+
+        assert result.updated == 1
+        assert result.added == 0
+        assert result.unchanged == 0
+        assert tracks[0].title == "Updated"
+
+    def test_scan_unchanged_count_excludes_updated_files(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        p1 = lib / "01.mp3"
+        p2 = lib / "02.mp3"
+        _make_mp3(p1, title="T1")
+        _make_mp3(p2, title="T2")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+
+        # Bump mtime on one file.
+        import os
+
+        os.utime(p1, (p1.stat().st_atime, p1.stat().st_mtime + 1))
+
+        result = scanner.scan(lib)
+        index.close()
+
+        assert result.updated == 1
+        assert result.unchanged == 1
+
+    def test_scan_updates_stored_mtime_after_reindex(self, tmp_path: Path) -> None:
+        """After re-indexing a changed file, its stored mtime matches the new value."""
+        lib = tmp_path / "music"
+        lib.mkdir()
+        p = lib / "01.mp3"
+        _make_mp3(p, title="T")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+
+        import os
+
+        new_mtime = p.stat().st_mtime + 1
+        os.utime(p, (p.stat().st_atime, new_mtime))
+        scanner.scan(lib)
+
+        tracks = index.all_tracks()
+        index.close()
+
+        assert tracks[0].file_mtime == pytest.approx(new_mtime, abs=0.001)
+
+    def test_null_mtime_in_db_causes_reindex_on_scan(self, tmp_path: Path) -> None:
+        """Tracks with NULL file_mtime (e.g. after v5→v6 migration) are always
+        re-read on the next scan so tag changes made before the upgrade are
+        picked up automatically."""
+        lib = tmp_path / "music"
+        lib.mkdir()
+        p = lib / "01.mp3"
+        _make_mp3(p, title="Original")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+
+        # Simulate the state right after a v5→v6 migration: file_mtime is NULL.
+        index._conn.execute(
+            "UPDATE tracks SET file_mtime = NULL WHERE file_path = ?", (str(p),)
+        )
+        index._conn.commit()
+
+        # Also update the file tags to simulate an edit made before the migration.
+        _make_mp3(p, title="Updated")
+
+        result = scanner.scan(lib)
+        tracks = index.all_tracks()
+        index.close()
+
+        assert result.updated == 1
+        assert tracks[0].title == "Updated"
+        assert tracks[0].file_mtime is not None  # mtime stored after re-read
+
+    def test_migration_v5_to_v6_adds_file_mtime_column(self, tmp_path: Path) -> None:
+        """Existing v5 databases gain the file_mtime column on open."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (5)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL DEFAULT '',
+                artist TEXT NOT NULL DEFAULT '',
+                album_artist TEXT NOT NULL DEFAULT '',
+                album TEXT NOT NULL DEFAULT '',
+                year TEXT NOT NULL DEFAULT '',
+                track_number INTEGER NOT NULL DEFAULT 0,
+                disc_number INTEGER NOT NULL DEFAULT 1,
+                ext TEXT NOT NULL DEFAULT '',
+                embedded_art INTEGER NOT NULL DEFAULT 0,
+                mb_release_id TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added REAL,
+                last_played REAL,
+                favorite INTEGER NOT NULL DEFAULT 0,
+                play_count INTEGER NOT NULL DEFAULT 0
+            )
+            """)
+        conn.execute(
+            "INSERT INTO tracks VALUES (1, '/e.mp3', 'Song', 'Band', 'Band', "
+            "'Album', '2000', 1, 1, 'mp3', 0, '', '', NULL, NULL, 0, 0)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5("
+            "title, artist, album_artist, album, tokenize='unicode61')"
+        )
+        conn.execute(
+            "CREATE TABLE player_state ("
+            "id INTEGER PRIMARY KEY CHECK (id = 1), "
+            "track_path TEXT NOT NULL, position REAL NOT NULL DEFAULT 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        row = index._conn.execute(
+            "SELECT file_mtime FROM tracks WHERE id = 1"
+        ).fetchone()
+        index.close()
+
+        assert version == 6
+        assert row is not None
+        # file_mtime is intentionally left NULL on migration so the next scan
+        # treats all existing tracks as changed and re-reads their tags.
+        assert row[0] is None


### PR DESCRIPTION
## Summary

- Adds `file_mtime REAL` column (schema v6) tracking each track's filesystem mtime at last scan
- `LibraryScanner.scan()` now compares stored vs current mtime for existing files; changed files are re-read and re-indexed
- The v5→v6 migration intentionally leaves `file_mtime = NULL` so the first scan after upgrade re-reads all existing tracks, picking up any tag edits (e.g. cover art) made before the upgrade
- `ScanResult` gains an `updated` count for re-indexed files (surfaced in server API and frontend type)

## Test plan

- [x] All existing tests pass (`poetry run pytest tests/test_library.py tests/test_server.py -v --no-cov`)
- [x] New `TestMtimeReindex` class covers: mtime stored on first index, re-index on mtime change, unchanged count excludes updated files, stored mtime updated after re-index, NULL mtime triggers re-read, v5→v6 migration adds column with NULL values
- [x] Manual: add cover art to an audio file, rescan → art appears in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)