### PR TITLE
feat: album page glow-up (TASK-69)

### DIFF
--- a/backlog/milestones/m-23 - tag-editor.md
+++ b/backlog/milestones/m-23 - tag-editor.md
@@ -1,0 +1,8 @@
+---
+id: m-23
+title: "Tag Editor"
+---
+
+## Description
+
+Milestone: Tag Editor

--- a/backlog/milestones/m-24 - base-kamp.md
+++ b/backlog/milestones/m-24 - base-kamp.md
@@ -1,0 +1,8 @@
+---
+id: m-24
+title: "Base Kamp"
+---
+
+## Description
+
+Milestone: Base Kamp

--- a/backlog/tasks/task-11 - Windows-taskbar-transport-controls.md
+++ b/backlog/tasks/task-11 - Windows-taskbar-transport-controls.md
@@ -4,12 +4,12 @@ title: Windows taskbar transport controls
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 03:15'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
   - windows
   - os-integration
-  - 'estimate: side'
+  - 'estimate: lp'
 milestone: m-3
 dependencies: []
 ordinal: 9000

--- a/backlog/tasks/task-13 - Bandcamp-sync-status-in-GUI-idle-syncing-manual-trigger-recent-additions.md
+++ b/backlog/tasks/task-13 - Bandcamp-sync-status-in-GUI-idle-syncing-manual-trigger-recent-additions.md
@@ -4,10 +4,11 @@ title: 'Bandcamp sync status in GUI (idle/syncing, manual trigger, recent additi
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:11'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - bandcamp
   - ui
+  - bandcamp
   - 'estimate: side'
 milestone: m-1
 dependencies: []

--- a/backlog/tasks/task-14 - New-purchase-highlight-watcher-→-library-re-scan-→-surfaced-in-UI.md
+++ b/backlog/tasks/task-14 - New-purchase-highlight-watcher-→-library-re-scan-→-surfaced-in-UI.md
@@ -4,10 +4,11 @@ title: New purchase highlight (watcher → library re-scan → surfaced in UI)
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:11'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - bandcamp
   - ui
+  - bandcamp
   - 'estimate: side'
 milestone: m-1
 dependencies: []

--- a/backlog/tasks/task-15 - Bandcamp-storefront-browser-collection-wishlist-followed-artists.md
+++ b/backlog/tasks/task-15 - Bandcamp-storefront-browser-collection-wishlist-followed-artists.md
@@ -4,11 +4,12 @@ title: 'Bandcamp storefront browser (collection, wishlist, followed artists)'
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:11'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - bandcamp
   - ui
-  - 'estimate: lp'
+  - bandcamp
+  - 'estimate: 2xlp'
 milestone: m-1
 dependencies: []
 ---

--- a/backlog/tasks/task-16 - Bandcamp-purchase-flow-Buy-→-checkout-→-daemon-picks-up-download.md
+++ b/backlog/tasks/task-16 - Bandcamp-purchase-flow-Buy-→-checkout-→-daemon-picks-up-download.md
@@ -4,12 +4,11 @@ title: Bandcamp purchase flow (Buy → checkout → daemon picks up download)
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:11'
-updated_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
   - bandcamp
-  - ui
-  - 'estimate: lp'
+  - 'estimate: 2xlp'
 milestone: m-1
 dependencies:
   - TASK-15

--- a/backlog/tasks/task-17 - Extension-host-and-KampContext-API.md
+++ b/backlog/tasks/task-17 - Extension-host-and-KampContext-API.md
@@ -4,10 +4,11 @@ title: Extension host and KampContext API
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - extensions
-  - 'estimate: lp'
+  - architecture
+  - 'estimate: box set'
 milestone: m-2
 dependencies: []
 ---

--- a/backlog/tasks/task-18 - Refactor-built-in-features-as-extensions-validate-KampContext-API.md
+++ b/backlog/tasks/task-18 - Refactor-built-in-features-as-extensions-validate-KampContext-API.md
@@ -4,10 +4,10 @@ title: Refactor built-in features as extensions (validate KampContext API)
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
-  - feature
-  - extensions
-  - refactor
+  - chore
+  - architecture
   - 'estimate: lp'
 milestone: m-2
 dependencies:

--- a/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
+++ b/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
@@ -4,10 +4,10 @@ title: contextBridge API and frontend panel registration system
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - extensions
-  - electron
+  - architecture
   - 'estimate: lp'
 milestone: m-2
 dependencies: []

--- a/backlog/tasks/task-2 - Full-Windows-Support.md
+++ b/backlog/tasks/task-2 - Full-Windows-Support.md
@@ -4,11 +4,11 @@ title: Full Windows Support
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:04'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
+  - feature
   - windows
-  - 'estimate: box set'
+  - 'estimate: discography'
 milestone: m-3
 dependencies: []
 ---

--- a/backlog/tasks/task-2.1 - Windows-tray-app-pystray-full-parity-with-rumps.md
+++ b/backlog/tasks/task-2.1 - Windows-tray-app-pystray-full-parity-with-rumps.md
@@ -4,11 +4,10 @@ title: 'Windows tray app (pystray, full parity with rumps)'
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:05'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
+  - feature
   - windows
-  - tray
   - 'estimate: lp'
 milestone: m-3
 dependencies: []

--- a/backlog/tasks/task-2.2 - Windows-CI-GitHub-Actions-windows-latest.md
+++ b/backlog/tasks/task-2.2 - Windows-CI-GitHub-Actions-windows-latest.md
@@ -4,10 +4,9 @@ title: Windows CI (GitHub Actions windows-latest)
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:04'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
-  - windows
+  - chore
   - ci
   - 'estimate: side'
 milestone: m-3

--- a/backlog/tasks/task-2.3 - Playwright-E2E-tests-on-Windows.md
+++ b/backlog/tasks/task-2.3 - Playwright-E2E-tests-on-Windows.md
@@ -4,12 +4,11 @@ title: Playwright E2E tests on Windows
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:04'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
-  - windows
+  - chore
   - testing
-  - 'estimate: side'
+  - 'estimate: lp'
 milestone: m-3
 dependencies: []
 parent_task_id: TASK-2

--- a/backlog/tasks/task-2.4 - Windows-service-install-via-NSSM.md
+++ b/backlog/tasks/task-2.4 - Windows-service-install-via-NSSM.md
@@ -4,11 +4,10 @@ title: Windows service install via NSSM
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:05'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
+  - feature
   - windows
-  - service
   - 'estimate: side'
 milestone: m-3
 dependencies: []

--- a/backlog/tasks/task-2.5 - Chocolatey-packaging.md
+++ b/backlog/tasks/task-2.5 - Chocolatey-packaging.md
@@ -4,9 +4,9 @@ title: Chocolatey packaging
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:05'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
+  - chore
   - windows
   - packaging
   - 'estimate: side'

--- a/backlog/tasks/task-2.6 - Windows-path-config-conventions-APPDATA-audit.md
+++ b/backlog/tasks/task-2.6 - Windows-path-config-conventions-APPDATA-audit.md
@@ -4,11 +4,11 @@ title: Windows path/config conventions (%APPDATA% audit)
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-29 03:05'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
+  - chore
   - windows
-  - 'estimate: single'
+  - 'estimate: side'
 milestone: m-3
 dependencies: []
 parent_task_id: TASK-2

--- a/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
+++ b/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
@@ -4,10 +4,10 @@ title: 'UI slot API: declarative panel manifests rendered by Electron host'
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:37'
 labels:
   - feature
-  - extensions
-  - ui
+  - architecture
   - 'estimate: lp'
 milestone: m-2
 dependencies: []

--- a/backlog/tasks/task-21 - iframe-sandboxing-and-CSP-for-community-extensions.md
+++ b/backlog/tasks/task-21 - iframe-sandboxing-and-CSP-for-community-extensions.md
@@ -4,10 +4,10 @@ title: iframe sandboxing and CSP for community extensions
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:37'
 labels:
   - feature
-  - extensions
-  - security
+  - architecture
   - 'estimate: side'
 milestone: m-2
 dependencies: []

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -4,9 +4,9 @@ title: Extension settings UI
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:37'
 labels:
   - feature
-  - extensions
   - ui
   - 'estimate: side'
 milestone: m-2

--- a/backlog/tasks/task-23 - Extension-developer-documentation.md
+++ b/backlog/tasks/task-23 - Extension-developer-documentation.md
@@ -4,9 +4,9 @@ title: Extension developer documentation
 status: To Do
 assignee: []
 created_date: '2026-03-29 03:12'
+updated_date: '2026-04-03 04:37'
 labels:
   - docs
-  - extensions
   - 'estimate: side'
 milestone: m-2
 dependencies:

--- a/backlog/tasks/task-3 - Cross-platform-service-installation-Linux-systemd-Windows-NSSM.md
+++ b/backlog/tasks/task-3 - Cross-platform-service-installation-Linux-systemd-Windows-NSSM.md
@@ -4,11 +4,12 @@ title: 'Cross-platform service installation (Linux systemd, Windows NSSM)'
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:57'
-updated_date: '2026-03-29 03:13'
+updated_date: '2026-04-03 04:36'
 labels:
-  - platform
-  - infrastructure
-  - 'estimate: side'
+  - feature
+  - linux
+  - windows
+  - 'estimate: lp'
 milestone: m-4
 dependencies: []
 ---

--- a/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
+++ b/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
@@ -4,12 +4,11 @@ title: 'Investigate: main process inflates ~50 MB when Bandcamp sync starts'
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-31 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
   - bug
   - performance
-  - investigation
-  - 'estimate: lp'
+  - 'estimate: side'
 milestone: m-6
 dependencies: []
 ---

--- a/backlog/tasks/task-31 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
+++ b/backlog/tasks/task-31 - Best-Release-prefer-physical-format-LP-CD-over-digital-streaming-when-multiple-MB-results-exist.md
@@ -6,13 +6,14 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-04-02 23:18'
+updated_date: '2026-04-03 05:30'
 labels:
   - feature
-  - musicbrainz
+  - backend
   - 'estimate: side'
 milestone: m-19
 dependencies: []
+ordinal: 7000
 ---
 
 ## Description

--- a/backlog/tasks/task-32 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
+++ b/backlog/tasks/task-32 - Nested-folders-recurse-into-subdirectories-in-staging-and-treat-each-leaf-folder-as-an-album.md
@@ -6,11 +6,11 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-31 03:12'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - ingest
-  - 'estimate: side'
+  - backend
+  - 'estimate: single'
 milestone: m-6
 dependencies: []
 ---

--- a/backlog/tasks/task-33 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
+++ b/backlog/tasks/task-33 - Configurable-album-art-search-Bandcamp-Apple-Spotify-Qobuz.md
@@ -4,11 +4,11 @@ title: 'Configurable album art search (Bandcamp, Apple, Spotify, Qobuz)'
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-31 03:22'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - artwork
-  - 'estimate: 2xlp'
+  - backend
+  - 'estimate: lp'
 milestone: m-7
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-34 - Allow-user-to-verify-tags-before-they-are-written.md
+++ b/backlog/tasks/task-34 - Allow-user-to-verify-tags-before-they-are-written.md
@@ -4,10 +4,10 @@ title: Allow user to verify tags before they are written
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-31 03:22'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
-  - ux
+  - ui
   - 'estimate: lp'
 milestone: m-7
 dependencies: []

--- a/backlog/tasks/task-35 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
+++ b/backlog/tasks/task-35 - bug-MusicBrainz-Release-Id-tag-casing-inconsistency.md
@@ -4,11 +4,9 @@ title: 'bug: MusicBrainz Release Id tag casing inconsistency'
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-03-31 03:22'
+updated_date: '2026-04-03 04:36'
 labels:
   - bug
-  - musicbrainz
-  - tagging
   - 'estimate: single'
 milestone: m-7
 dependencies: []

--- a/backlog/tasks/task-46 - Cover-art-in-macOS-Control-Center.md
+++ b/backlog/tasks/task-46 - Cover-art-in-macOS-Control-Center.md
@@ -4,10 +4,12 @@ title: Cover art in macOS Control Center
 status: To Do
 assignee: []
 created_date: '2026-03-30 23:14'
-updated_date: '2026-03-31 03:27'
+updated_date: '2026-04-03 04:36'
 labels:
+  - feature
   - macos
-  - now-playing
+  - os-integration
+  - 'estimate: side'
 milestone: m-9
 dependencies: []
 priority: low

--- a/backlog/tasks/task-48 - Media-keys-next-prev-track.md
+++ b/backlog/tasks/task-48 - Media-keys-next-prev-track.md
@@ -4,11 +4,12 @@ title: 'Media keys: next/prev track'
 status: To Do
 assignee: []
 created_date: '2026-03-30 23:47'
-updated_date: '2026-03-31 03:27'
+updated_date: '2026-04-03 04:36'
 labels:
+  - feature
   - macos
-  - media-keys
-  - architecture
+  - os-integration
+  - 'estimate: 2xlp'
 milestone: m-9
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-49 - Self-contained-macOS-.app-bundle-kamp-server-mpv.md
+++ b/backlog/tasks/task-49 - Self-contained-macOS-.app-bundle-kamp-server-mpv.md
@@ -4,11 +4,12 @@ title: Self-contained macOS .app bundle (kamp server + mpv)
 status: To Do
 assignee: []
 created_date: '2026-03-31 02:40'
-updated_date: '2026-03-31 03:27'
+updated_date: '2026-04-03 04:36'
 labels:
   - packaging
   - distribution
   - macos
+  - 'estimate: box set'
 milestone: m-9
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-50 - Spike-Bandcamp-download-link-scraping-without-full-Playwright-bundle.md
+++ b/backlog/tasks/task-50 - Spike-Bandcamp-download-link-scraping-without-full-Playwright-bundle.md
@@ -4,12 +4,11 @@ title: 'Spike: Bandcamp download link scraping without full Playwright bundle'
 status: To Do
 assignee: []
 created_date: '2026-03-31 02:46'
-updated_date: '2026-03-31 03:10'
+updated_date: '2026-04-03 04:36'
 labels:
   - spike
-  - packaging
   - bandcamp
-  - distribution
+  - 'estimate: side'
 milestone: m-1
 dependencies: []
 priority: low

--- a/backlog/tasks/task-51 - change-application-name-to-kamp.md
+++ b/backlog/tasks/task-51 - change-application-name-to-kamp.md
@@ -4,8 +4,10 @@ title: change application name to kamp
 status: To Do
 assignee: []
 created_date: '2026-03-31 03:15'
-updated_date: '2026-03-31 03:27'
-labels: []
+updated_date: '2026-04-03 04:35'
+labels:
+  - chore
+  - 'estimate: single'
 milestone: m-9
 dependencies: []
 priority: low

--- a/backlog/tasks/task-52 - UI-polish-remove-title-bar.md
+++ b/backlog/tasks/task-52 - UI-polish-remove-title-bar.md
@@ -4,8 +4,12 @@ title: 'UI polish: remove title bar'
 status: To Do
 assignee: []
 created_date: '2026-03-31 03:17'
-updated_date: '2026-03-31 03:27'
-labels: []
+updated_date: '2026-04-03 04:35'
+labels:
+  - feature
+  - ui
+  - electron
+  - 'estimate: single'
 milestone: m-9
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-53 - UI-polish-show-a-splash-screen-while-loading-the-application.md
+++ b/backlog/tasks/task-53 - UI-polish-show-a-splash-screen-while-loading-the-application.md
@@ -4,8 +4,12 @@ title: 'UI polish: show a splash screen while loading the application'
 status: To Do
 assignee: []
 created_date: '2026-03-31 03:20'
-updated_date: '2026-03-31 03:27'
-labels: []
+updated_date: '2026-04-03 04:35'
+labels:
+  - feature
+  - ui
+  - electron
+  - 'estimate: single'
 milestone: m-9
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-60 - text-shouldnt-be-selectable.md
+++ b/backlog/tasks/task-60 - text-shouldnt-be-selectable.md
@@ -4,7 +4,11 @@ title: text shouldn't be selectable
 status: To Do
 assignee: []
 created_date: '2026-04-01 02:23'
-labels: []
+updated_date: '2026-04-03 04:35'
+labels:
+  - polish
+  - ui
+  - 'estimate: single'
 milestone: m-20
 dependencies: []
 ---

--- a/backlog/tasks/task-64 - Library-scan-progress-UI.md
+++ b/backlog/tasks/task-64 - Library-scan-progress-UI.md
@@ -4,11 +4,12 @@ title: Library scan progress UI
 status: To Do
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-04-02 23:19'
+updated_date: '2026-04-03 04:36'
 labels:
   - feature
   - ux
   - library
+  - 'estimate: lp'
 milestone: m-20
 dependencies: []
 ---

--- a/backlog/tasks/task-65 - A-modal-dialog-is-available-for-setting-preferences.md
+++ b/backlog/tasks/task-65 - A-modal-dialog-is-available-for-setting-preferences.md
@@ -4,7 +4,12 @@ title: A modal dialog is available for setting preferences
 status: To Do
 assignee: []
 created_date: '2026-04-02 20:24'
-labels: []
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - electron
+  - 'estimate: lp'
 milestone: m-21
 dependencies: []
 ---

--- a/backlog/tasks/task-67 - check-album-paths-for-album-art.md
+++ b/backlog/tasks/task-67 - check-album-paths-for-album-art.md
@@ -4,9 +4,14 @@ title: check album paths for album art
 status: To Do
 assignee: []
 created_date: '2026-04-02 22:48'
-labels: []
-milestone: m-11
+updated_date: '2026-04-03 05:30'
+labels:
+  - feature
+  - backend
+  - 'estimate: lp'
+milestone: m-19
 dependencies: []
+ordinal: 8000
 ---
 
 ## Description

--- a/backlog/tasks/task-68 - replace-favorite-glyph.md
+++ b/backlog/tasks/task-68 - replace-favorite-glyph.md
@@ -1,0 +1,22 @@
+---
+id: TASK-68
+title: replace favorite glyph
+status: To Do
+assignee: []
+created_date: '2026-04-03 03:36'
+updated_date: '2026-04-03 04:35'
+labels:
+  - polish
+  - ui
+  - 'estimate: single'
+milestone: m-20
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+i want a nicer looking heart than the unicode heart, and i want unfilled/filled states (instead of dim/colored).
+
+color should match theme color, not be pink/red.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-69 - album-page-glow-up.md
+++ b/backlog/tasks/task-69 - album-page-glow-up.md
@@ -1,0 +1,38 @@
+---
+id: TASK-69
+title: album page glow up
+status: Done
+assignee: []
+created_date: '2026-04-03 03:49'
+updated_date: '2026-04-03 05:30'
+labels:
+  - feature
+  - ui
+  - 'estimate: lp'
+milestone: m-11
+dependencies: []
+priority: high
+ordinal: 1000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+album art takes up the top 25% of the page
+
+album art fades into background color over the next 50% of page
+
+track list starts halfway down page
+
+track list is scrollable, but album art is static background
+
+album title is prominent h1 above track list div
+
+artist name is prominent h2 below album title, above track list div
+
+artist name is link to artist page
+
+back to library button is back arrow in upper left corner of page
+
+consult with UI Designer on how to make this look good
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-70 - a-Base-Kamp-view-exists-to-serve-as-the-first-open-experience-for-the-application.md
+++ b/backlog/tasks/task-70 - a-Base-Kamp-view-exists-to-serve-as-the-first-open-experience-for-the-application.md
@@ -1,0 +1,26 @@
+---
+id: TASK-70
+title: >-
+  a Base Kamp view exists to serve as the first open experience for the
+  application
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:23'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: 2xlp'
+milestone: m-24
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Base Kamp is the center of Kamp: it offers enticing glimpses into the user's collection, with nudges about what is available for them to listen to without putting their whole library in front of them.
+
+Base Kamp a page with configurable, rearrangeable modules.
+
+This task is just to create the landing page and provide an architecture for the extensible pieces.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-71 - New-Arrivals-module.md
+++ b/backlog/tasks/task-71 - New-Arrivals-module.md
@@ -1,0 +1,16 @@
+---
+id: TASK-71
+title: New Arrivals module
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:24'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-24
+dependencies: []
+---
+
+

--- a/backlog/tasks/task-72 - Last-Played-module.md
+++ b/backlog/tasks/task-72 - Last-Played-module.md
@@ -1,0 +1,16 @@
+---
+id: TASK-72
+title: Last Played module
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:24'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-24
+dependencies: []
+---
+
+

--- a/backlog/tasks/task-73 - Carousel-Base-Kamp-module-view.md
+++ b/backlog/tasks/task-73 - Carousel-Base-Kamp-module-view.md
@@ -1,0 +1,16 @@
+---
+id: TASK-73
+title: Carousel Base Kamp module view
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:24'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-24
+dependencies: []
+---
+
+

--- a/backlog/tasks/task-74 - Grid-Base-Kamp-module-view.md
+++ b/backlog/tasks/task-74 - Grid-Base-Kamp-module-view.md
@@ -1,0 +1,16 @@
+---
+id: TASK-74
+title: Grid Base Kamp module view
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:25'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-24
+dependencies: []
+---
+
+

--- a/backlog/tasks/task-75 - List-Base-Kamp-module-view.md
+++ b/backlog/tasks/task-75 - List-Base-Kamp-module-view.md
@@ -1,0 +1,16 @@
+---
+id: TASK-75
+title: List Base Kamp module view
+status: To Do
+assignee: []
+created_date: '2026-04-03 04:25'
+updated_date: '2026-04-03 04:36'
+labels:
+  - feature
+  - ui
+  - 'estimate: side'
+milestone: m-24
+dependencies: []
+---
+
+

--- a/kamp_ui/src/renderer/index.html
+++ b/kamp_ui/src/renderer/index.html
@@ -6,7 +6,12 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+    />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link
+      href="https://fonts.bunny.net/css?family=dm-sans:400,500,600,700&display=swap"
+      rel="stylesheet"
     />
   </head>
 

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -896,103 +896,178 @@ body,
 
 /* Track list view ---------------------------------------------------------- */
 
+/* Opt out of main-content padding/scroll — this view manages its own layout */
+.main-content:has(.track-list-view) {
+  padding: 0;
+  overflow: hidden;
+}
+
 .track-list-view {
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
+  overflow: hidden;
 }
 
-.track-list-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--border);
-}
-
-.back-btn {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  padding: 5px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
-  white-space: nowrap;
+/* Hero: full-width art with gradient fade */
+.track-list-hero {
+  position: relative;
   flex-shrink: 0;
+  height: 45vh;
+  overflow: hidden;
+  background: linear-gradient(160deg, var(--surface) 0%, var(--bg) 100%);
+}
+
+.track-list-hero-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  display: block;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.track-list-hero-img.loaded {
+  opacity: 1;
+}
+
+/* Three-stop fade: transparent → partial → solid bg.
+   Uses literal #121212 (--bg value) because CSS gradient can't interpolate
+   a custom property against `transparent` without a gray-band artifact. */
+.track-list-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 20%,
+    rgba(18, 18, 18, 0.6) 55%,
+    rgba(18, 18, 18, 0.92) 75%,
+    #121212 100%
+  );
+}
+
+/* Back button floats over the hero */
+.back-btn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 10;
+  background: rgba(18, 18, 18, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 5px 12px 5px 9px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
 }
 
 .back-btn:hover {
-  color: var(--text);
-  border-color: var(--text-dim);
+  background: rgba(18, 18, 18, 0.75);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
-.track-list-album-info {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 12px;
+/* Scrollable body — sits below the hero, holds identity + track rows */
+.track-list-body {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+  margin-top: -48px;
 }
 
-.track-list-album-art {
-  width: 56px;
-  height: 56px;
-  object-fit: cover;
-  border-radius: 4px;
-  flex-shrink: 0;
-}
-
-.track-list-album-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  overflow: hidden;
+.track-list-identity {
+  padding: 20px 28px 20px 28px;
 }
 
 .track-list-album-title {
-  font-size: 16px;
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-size: 26px;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.6);
+  margin: 0 0 6px 0;
 }
 
 .track-list-album-artist {
-  font-size: 12px;
-  color: var(--text-dim);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  margin: 0 0 4px 0;
+}
+
+.track-list-artist-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--accent);
+  font-size: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+}
+
+.track-list-artist-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.track-list-artist-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 3px;
 }
 
 .track-list-album-year {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-dim);
+  margin-bottom: 16px;
 }
 
 .play-all-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   background: var(--accent);
   border: none;
   color: var(--text-on-accent);
-  padding: 6px 14px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  white-space: nowrap;
-  flex-shrink: 0;
+  padding: 7px 16px;
+  border-radius: 20px;
+  cursor: pointer;
+  margin-bottom: 0;
+  transition: filter 0.15s;
 }
 
 .play-all-btn:hover {
-  filter: brightness(1.1);
+  filter: brightness(1.12);
+}
+
+.play-all-icon {
+  font-size: 10px;
+}
+
+.track-list-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 16px 28px 4px 28px;
 }
 
 .track-rows {
   list-style: none;
-  overflow-y: auto;
-  flex: 1;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  padding: 0 20px 80px 20px;
 }
 
 .track-row {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -910,20 +910,24 @@ body,
   overflow: hidden;
 }
 
-/* Hero: full-width art with gradient fade */
+/* Hero: full-width art. No overflow clipping — the image intentionally
+   bleeds past the hero boundary into the track list zone. */
 .track-list-hero {
   position: relative;
   flex-shrink: 0;
   height: 45vh;
-  overflow: hidden;
   background: linear-gradient(160deg, var(--surface) 0%, var(--bg) 100%);
 }
 
+/* Image is taller than its container so it bleeds into the track list.
+   Clipped by .track-list-view's overflow: hidden. */
 .track-list-hero-img {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
   width: 100%;
-  height: 100%;
+  height: 150%;
   object-fit: cover;
   object-position: center top;
   display: block;
@@ -935,19 +939,26 @@ body,
   opacity: 1;
 }
 
-/* Three-stop fade: transparent → partial → solid bg.
-   Uses literal #121212 (--bg value) because CSS gradient can't interpolate
-   a custom property against `transparent` without a gray-band artifact. */
+/* Overlay is a sibling of the hero (not inside it) so the gradient spans
+   the hero + part of the track list. Uses literal #141414 (= --bg) because
+   CSS gradient interpolates custom properties through transparent-black,
+   causing a gray band artifact. */
 .track-list-hero-overlay {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 85%;
+  z-index: 1;
+  pointer-events: none;
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    transparent 20%,
-    rgba(18, 18, 18, 0.6) 55%,
-    rgba(18, 18, 18, 0.92) 75%,
-    #121212 100%
+    transparent 15%,
+    rgba(20, 20, 20, 0.45) 45%,
+    rgba(20, 20, 20, 0.8) 63%,
+    rgba(20, 20, 20, 0.95) 75%,
+    #141414 85%
   );
 }
 
@@ -957,7 +968,7 @@ body,
   top: 12px;
   left: 12px;
   z-index: 10;
-  background: rgba(18, 18, 18, 0.55);
+  background: rgba(20, 20, 20, 0.55);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -972,24 +983,36 @@ body,
 }
 
 .back-btn:hover {
-  background: rgba(18, 18, 18, 0.75);
+  background: rgba(20, 20, 20, 0.75);
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-/* Scrollable body — sits below the hero, holds identity + track rows.
-   position + z-index needed to render above the hero's stacking context. */
+/* Scrollable body — transparent so the art can bleed through the top rows. */
 .track-list-body {
   flex: 1;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
-  margin-top: -48px;
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  background: transparent;
 }
 
 .track-list-identity {
-  padding: 20px 28px 20px 28px;
+  /* Pulled up into the hero gradient so the text floats above the fade */
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 28px 10px 28px;
+  margin-top: -48px;
+  position: relative;
+  z-index: 2;
+  flex-shrink: 0;
+}
+
+.track-list-identity-text {
+  min-width: 0;
 }
 
 .track-list-album-title {
@@ -1035,21 +1058,22 @@ body,
 .track-list-album-year {
   font-size: 12px;
   color: var(--text-dim);
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 
 .play-all-btn {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  justify-content: center;
   background: var(--accent);
   border: none;
   color: var(--text-on-accent);
-  font-size: 13px;
-  font-weight: 600;
-  padding: 7px 16px;
-  border-radius: 20px;
+  font-size: 11px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
   cursor: pointer;
+  flex-shrink: 0;
   transition: filter 0.15s;
 }
 
@@ -1057,17 +1081,11 @@ body,
   filter: brightness(1.12);
 }
 
-.play-all-icon {
-  font-size: 10px;
-}
-
 .track-list-divider {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  border-top: 1px solid var(--border);
-  margin: 16px 28px 4px 28px;
-  padding-top: 10px;
+  margin: 8px 0 0 0;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 2;
 }
 
 .track-rows {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -24,7 +24,7 @@
   --text-on-accent: #000;
   --transport-h: 88px;
   --panel-w: 200px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 13px;
   color: var(--text);
   background: var(--bg);

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1050,7 +1050,6 @@ body,
   padding: 7px 16px;
   border-radius: 20px;
   cursor: pointer;
-  margin-bottom: 0;
   transition: filter 0.15s;
 }
 
@@ -1063,9 +1062,12 @@ body,
 }
 
 .track-list-divider {
-  height: 1px;
-  background: var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
   margin: 16px 28px 4px 28px;
+  padding-top: 10px;
 }
 
 .track-rows {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -976,13 +976,16 @@ body,
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-/* Scrollable body — sits below the hero, holds identity + track rows */
+/* Scrollable body — sits below the hero, holds identity + track rows.
+   position + z-index needed to render above the hero's stacking context. */
 .track-list-body {
   flex: 1;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
   margin-top: -48px;
+  position: relative;
+  z-index: 1;
 }
 
 .track-list-identity {

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -52,20 +52,21 @@ export function TrackList(): React.JSX.Element | null {
 
   return (
     <div className="track-list-view">
-      {/* Hero: full-width art with gradient fade */}
+      {/* Hero: full-width art — image intentionally taller than hero to bleed into track list */}
       <div className={`track-list-hero${album.has_art ? ' has-art' : ''}`}>
         {album.has_art && <HeroImage src={artUrl(album.album_artist, album.album)} />}
-        <div className="track-list-hero-overlay" />
       </div>
+      {/* Overlay spans the full view so the gradient covers both hero and the top of the track list */}
+      <div className="track-list-hero-overlay" />
 
       {/* Back button floats over the hero */}
       <button className="back-btn" onClick={() => selectAlbum(null)} aria-label="Back to albums">
         ←
       </button>
 
-      {/* Scrollable body */}
-      <div className="track-list-body">
-        <div className="track-list-identity">
+      {/* Static identity block — does not scroll */}
+      <div className="track-list-identity">
+        <div className="track-list-identity-text">
           <h1 className="track-list-album-title">{album.album}</h1>
           <h2 className="track-list-album-artist">
             <button
@@ -80,17 +81,19 @@ export function TrackList(): React.JSX.Element | null {
           </h2>
           {album.year && <div className="track-list-album-year">{album.year}</div>}
         </div>
+        <button
+          className="play-all-btn"
+          aria-label="Play all"
+          onClick={() => playTrack(album.album_artist, album.album, 0)}
+        >
+          ▶
+        </button>
+      </div>
 
-        <div className="track-list-divider">
-          <button
-            className="play-all-btn"
-            onClick={() => playTrack(album.album_artist, album.album, 0)}
-          >
-            <span className="play-all-icon">▶</span>
-            Play All
-          </button>
-        </div>
+      <div className="track-list-divider" />
 
+      {/* Scrollable body */}
+      <div className="track-list-body">
         <ol className="track-rows">
           {tracks.map((track, i) => {
             const isCurrent = isCurrentAlbum && currentTrack?.track_number === track.track_number

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -4,12 +4,26 @@ import { artUrl } from '../api/client'
 
 type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
+function HeroImage({ src }: { src: string }): React.JSX.Element {
+  const [loaded, setLoaded] = useState(false)
+  return (
+    <img
+      className={`track-list-hero-img${loaded ? ' loaded' : ''}`}
+      src={src}
+      alt=""
+      onLoad={() => setLoaded(true)}
+      onError={() => setLoaded(false)}
+    />
+  )
+}
+
 export function TrackList(): React.JSX.Element | null {
   const album = useStore((s) => s.library.selectedAlbum)
   const tracks = useStore((s) => s.library.tracks)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
   const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
   const playTrack = useStore((s) => s.playTrack)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const addToQueue = useStore((s) => s.addToQueue)
@@ -38,79 +52,92 @@ export function TrackList(): React.JSX.Element | null {
 
   return (
     <div className="track-list-view">
-      <div className="track-list-header">
-        <button className="back-btn" onClick={() => selectAlbum(null)}>
-          ← Albums
-        </button>
-        <div className="track-list-album-info">
-          {album.has_art && (
-            <img
-              className="track-list-album-art"
-              src={artUrl(album.album_artist, album.album)}
-              alt=""
-            />
-          )}
-          <div className="track-list-album-text">
-            <span className="track-list-album-title">{album.album}</span>
-            <span className="track-list-album-artist">{album.album_artist}</span>
-            <span className="track-list-album-year">{album.year}</span>
-          </div>
-        </div>
-        <button
-          className="play-all-btn"
-          onClick={() => playTrack(album.album_artist, album.album, 0)}
-        >
-          ▶ Play All
-        </button>
+      {/* Hero: full-width art with gradient fade */}
+      <div className={`track-list-hero${album.has_art ? ' has-art' : ''}`}>
+        {album.has_art && <HeroImage src={artUrl(album.album_artist, album.album)} />}
+        <div className="track-list-hero-overlay" />
       </div>
 
-      <ol className="track-rows">
-        {tracks.map((track, i) => {
-          const isCurrent = isCurrentAlbum && currentTrack?.track_number === track.track_number
-          return (
-            <li
-              key={`${track.disc_number}-${track.track_number}`}
-              className={`track-row${isCurrent ? ' current' : ''}`}
-              tabIndex={0}
+      {/* Back button floats over the hero */}
+      <button className="back-btn" onClick={() => selectAlbum(null)} aria-label="Back to albums">
+        ←
+      </button>
+
+      {/* Scrollable body */}
+      <div className="track-list-body">
+        <div className="track-list-identity">
+          <h1 className="track-list-album-title">{album.album}</h1>
+          <h2 className="track-list-album-artist">
+            <button
+              className="track-list-artist-link"
               onClick={() => {
-                if (isCurrent) {
-                  togglePlayPause()
-                } else {
-                  playTrack(album.album_artist, album.album, i)
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key !== 'Enter') return
-                if (isCurrent) togglePlayPause()
-                else playTrack(album.album_artist, album.album, i)
-              }}
-              draggable
-              onDragStart={(e) => {
-                e.dataTransfer.setData('text/kamp-track-path', track.file_path)
-                e.dataTransfer.effectAllowed = 'copy'
-              }}
-              onContextMenu={(e) => {
-                e.preventDefault()
-                setMenu({
-                  x: e.clientX,
-                  y: e.clientY,
-                  filePath: track.file_path,
-                  favorite: track.favorite
-                })
+                selectAlbum(null)
+                selectArtist(album.album_artist)
               }}
             >
-              <span className="track-row-fav" aria-hidden="true">
-                {track.favorite ? '♥' : ''}
-              </span>
-              <span className="track-row-num">
-                {isCurrent ? (playing ? '▶' : '▐▐') : track.track_number}
-              </span>
-              <span className="track-row-title">{track.title}</span>
-              <span className="track-row-artist">{track.artist}</span>
-            </li>
-          )
-        })}
-      </ol>
+              {album.album_artist}
+            </button>
+          </h2>
+          {album.year && <div className="track-list-album-year">{album.year}</div>}
+          <button
+            className="play-all-btn"
+            onClick={() => playTrack(album.album_artist, album.album, 0)}
+          >
+            <span className="play-all-icon">▶</span>
+            Play All
+          </button>
+        </div>
+
+        <div className="track-list-divider" />
+
+        <ol className="track-rows">
+          {tracks.map((track, i) => {
+            const isCurrent = isCurrentAlbum && currentTrack?.track_number === track.track_number
+            return (
+              <li
+                key={`${track.disc_number}-${track.track_number}`}
+                className={`track-row${isCurrent ? ' current' : ''}`}
+                tabIndex={0}
+                onClick={() => {
+                  if (isCurrent) {
+                    togglePlayPause()
+                  } else {
+                    playTrack(album.album_artist, album.album, i)
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key !== 'Enter') return
+                  if (isCurrent) togglePlayPause()
+                  else playTrack(album.album_artist, album.album, i)
+                }}
+                draggable
+                onDragStart={(e) => {
+                  e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+                  e.dataTransfer.effectAllowed = 'copy'
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  setMenu({
+                    x: e.clientX,
+                    y: e.clientY,
+                    filePath: track.file_path,
+                    favorite: track.favorite
+                  })
+                }}
+              >
+                <span className="track-row-fav" aria-hidden="true">
+                  {track.favorite ? '♥' : ''}
+                </span>
+                <span className="track-row-num">
+                  {isCurrent ? (playing ? '▶' : '▐▐') : track.track_number}
+                </span>
+                <span className="track-row-title">{track.title}</span>
+                <span className="track-row-artist">{track.artist}</span>
+              </li>
+            )
+          })}
+        </ol>
+      </div>
 
       {menu && (
         <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -79,6 +79,9 @@ export function TrackList(): React.JSX.Element | null {
             </button>
           </h2>
           {album.year && <div className="track-list-album-year">{album.year}</div>}
+        </div>
+
+        <div className="track-list-divider">
           <button
             className="play-all-btn"
             onClick={() => playTrack(album.album_artist, album.album, 0)}
@@ -87,8 +90,6 @@ export function TrackList(): React.JSX.Element | null {
             Play All
           </button>
         </div>
-
-        <div className="track-list-divider" />
 
         <ol className="track-rows">
           {tracks.map((track, i) => {


### PR DESCRIPTION
## Summary

- Full-width hero: album art fills the top 45vh with `object-fit: cover` biased to the top of the image
- Three-stop gradient fades the art into `--bg` (`#121212`) — avoids the gray-band artifact that a two-stop transparent→solid produces
- Back button floats over the hero as a glass-morphism pill (dark fill + `backdrop-filter: blur`)
- Identity block below the fade: h1 album title, h2 artist name (accent-colored, links to artist filter in library), year, and a pill-shaped Play All button
- Track list scrolls independently inside `.track-list-body`; hero art stays static
- Albums without embedded art show a subtle surface→bg diagonal gradient instead
- Hero image fades in on load (`opacity: 0 → 1`) via a small `HeroImage` sub-component that owns its own loaded state (avoids `setState-in-effect` lint rule)
- Artist name click navigates back to the library view filtered to that artist

## Test plan

- [x] Open an album with art — hero fills the top, gradient fades into background, track list scrolls below
- [x] Open an album without art — diagonal gradient fallback, no broken layout
- [x] Click artist name — navigates back to library with artist filtered
- [x] Click ← back button — returns to full album grid
- [x] Play All and per-track interactions work as before
- [x] Context menu (right-click) still appears on tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)