### PR TITLE
feat: splash screen with spinning vinyl record (TASK-53)

### DIFF
--- a/backlog/tasks/task-53 - UI-polish-show-a-splash-screen-while-loading-the-application.md
+++ b/backlog/tasks/task-53 - UI-polish-show-a-splash-screen-while-loading-the-application.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-53
 title: 'UI polish: show a splash screen while loading the application'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-31 03:20'
-updated_date: '2026-04-03 04:35'
+updated_date: '2026-04-03 06:29'
 labels:
   - feature
   - ui
@@ -13,7 +13,7 @@ labels:
 milestone: m-9
 dependencies: []
 priority: medium
-ordinal: 125
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -37,18 +37,25 @@ export default function App(): React.JSX.Element {
   // read a browser-clamped value when the outgoing view's content was taller.
   const viewScrollRef = useRef<Partial<Record<string, number>>>({})
 
-  // Splash: shown while status is 'reconnecting' (initial load), then fades out.
+  // Splash: shown while reconnecting, then lingers 1s after connect so the
+  // library fetch completes before the app is revealed, then fades out.
   const [splashHiding, setSplashHiding] = useState(false)
   const [splashGone, setSplashGone] = useState(false)
   const splashFadeStartedRef = useRef(false)
+  const splashLingerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const splashFadeRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => {
-    let t: ReturnType<typeof setTimeout> | undefined
     if (serverStatus !== 'reconnecting' && !splashFadeStartedRef.current) {
       splashFadeStartedRef.current = true
-      setSplashHiding(true)
-      t = setTimeout(() => setSplashGone(true), 500)
+      splashLingerRef.current = setTimeout(() => {
+        setSplashHiding(true)
+        splashFadeRef.current = setTimeout(() => setSplashGone(true), 500)
+      }, 1000)
     }
-    return () => clearTimeout(t)
+    return () => {
+      clearTimeout(splashLingerRef.current)
+      clearTimeout(splashFadeRef.current)
+    }
   }, [serverStatus])
 
   useEffect(() => {

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -184,13 +184,16 @@ export default function App(): React.JSX.Element {
 
   if (serverStatus === 'disconnected') {
     return (
-      <div className="server-offline">
-        <div className="server-offline-icon">⏻</div>
-        <div className="server-offline-title">kamp server is not running</div>
-        <div className="server-offline-hint">
-          Start it with <code>kamp server</code>
+      <>
+        <div className="server-offline">
+          <div className="server-offline-icon">⏻</div>
+          <div className="server-offline-title">kamp server is not running</div>
+          <div className="server-offline-hint">
+            Start it with <code>kamp server</code>
+          </div>
         </div>
-      </div>
+        {!splashGone && <SplashScreen hiding={splashHiding} />}
+      </>
     )
   }
 

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
@@ -7,6 +7,7 @@ import { NowPlayingView } from './components/NowPlayingView'
 import { SearchBar } from './components/SearchBar'
 import { SearchView } from './components/SearchView'
 import { SetupScreen } from './components/SetupScreen'
+import { SplashScreen } from './components/SplashScreen'
 import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
 import { QueuePanel } from './components/QueuePanel'
@@ -35,6 +36,20 @@ export default function App(): React.JSX.Element {
   // Per-view scroll positions — kept current by a scroll listener so we never
   // read a browser-clamped value when the outgoing view's content was taller.
   const viewScrollRef = useRef<Partial<Record<string, number>>>({})
+
+  // Splash: shown while status is 'reconnecting' (initial load), then fades out.
+  const [splashHiding, setSplashHiding] = useState(false)
+  const [splashGone, setSplashGone] = useState(false)
+  const splashFadeStartedRef = useRef(false)
+  useEffect(() => {
+    let t: ReturnType<typeof setTimeout> | undefined
+    if (serverStatus !== 'reconnecting' && !splashFadeStartedRef.current) {
+      splashFadeStartedRef.current = true
+      setSplashHiding(true)
+      t = setTimeout(() => setSplashGone(true), 500)
+    }
+    return () => clearTimeout(t)
+  }, [serverStatus])
 
   useEffect(() => {
     // Load UI state (sort order, active view) before loading the library so the
@@ -214,6 +229,7 @@ export default function App(): React.JSX.Element {
         {queueVisible && <QueuePanel />}
       </div>
       <TransportBar />
+      {!splashGone && <SplashScreen hiding={splashHiding} />}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -39,14 +39,14 @@ export default function App(): React.JSX.Element {
 
   // Splash: shown while reconnecting, then lingers 1s after connect so the
   // library fetch completes before the app is revealed, then fades out.
+  // No one-shot guard — the cleanup + re-run from React StrictMode is safe
+  // because the cleanup cancels the timer before the re-run restarts it.
   const [splashHiding, setSplashHiding] = useState(false)
   const [splashGone, setSplashGone] = useState(false)
-  const splashFadeStartedRef = useRef(false)
   const splashLingerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const splashFadeRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => {
-    if (serverStatus !== 'reconnecting' && !splashFadeStartedRef.current) {
-      splashFadeStartedRef.current = true
+    if (serverStatus !== 'reconnecting') {
       splashLingerRef.current = setTimeout(() => {
         setSplashHiding(true)
         splashFadeRef.current = setTimeout(() => setSplashGone(true), 500)

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -105,7 +105,7 @@ body,
 }
 
 .splash-svg {
-  width: 260px;
+  width: 520px;
   height: auto;
 }
 

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -79,6 +79,86 @@ body,
   font-family: monospace;
 }
 
+/* -------------------------------------------------------------------------
+   Splash screen — shown on initial load while the server connection is
+   being established. Uses literal #141414 (= --bg) in the SVG because
+   that colour is embedded in the SVG markup.
+   ------------------------------------------------------------------------- */
+
+.splash-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1;
+  transition: opacity 0.5s ease-out;
+  /* Prevent any interaction with the app below */
+  pointer-events: all;
+}
+
+.splash-hiding {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.splash-svg {
+  width: 260px;
+  height: auto;
+}
+
+/* The spinning record group — transform-origin uses SVG coordinates */
+.splash-record-spin {
+  transform-origin: 100px 100px;
+  animation: splash-spin 1.8s linear infinite;
+}
+
+@keyframes splash-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Stars — each twinkles at its own phase */
+.splash-deco {
+  animation: splash-twinkle 2.4s ease-in-out infinite;
+}
+.s1 { animation-delay: 0s; }
+.s2 { animation-delay: 0.8s; }
+.s3 { animation-delay: 1.6s; }
+.s4 { animation-delay: 0.4s; }
+
+@keyframes splash-twinkle {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Music notes — bob gently upward */
+.splash-note {
+  animation: splash-float 3s ease-in-out infinite;
+}
+.n1 { animation-delay: 0s; }
+.n2 { animation-delay: 1.5s; }
+
+@keyframes splash-float {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  50% {
+    transform: translateY(-7px);
+    opacity: 0.85;
+  }
+}
+
 /* Reconnecting banner — shown when connection drops but library is cached */
 .reconnecting-banner {
   background: var(--surface);

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -125,7 +125,7 @@ export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element
           - Headshell continues from bend to stylus at 170° on groove r=74 → (113, 173)
         */}
         <path
-          d="M 218 18 Q 182 153 113 173"
+          d="M 218 18 L 187 134 Q 182 153 113 173"
           fill="none"
           stroke="#c4aa78"
           strokeWidth="2"

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -116,22 +116,25 @@ export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element
         </g>
 
         {/* === Tonearm (static) === */}
-        {/* Pivot post */}
-        <circle cx="216" cy="18" r="6" fill="none" stroke="#c4aa78" strokeWidth="1.5" />
-        <circle cx="216" cy="18" r="2.5" fill="#c4aa78" />
-        {/* Arm — from pivot down to stylus at the record grooves */}
-        <line
-          x1="213"
-          y1="22"
-          x2="158"
-          y2="55"
+        {/* Pivot post — arm connects to its centre */}
+        <circle cx="218" cy="18" r="7" fill="none" stroke="#c4aa78" strokeWidth="1.5" />
+        <circle cx="218" cy="18" r="2.5" fill="#c4aa78" />
+        {/*
+          Arm geometry (angles clockwise from 12 o'clock):
+          - Main tube exits pivot centre at 195° for 140 px → bend at (182, 153)
+          - Headshell continues from bend to stylus at 170° on groove r=74 → (113, 173)
+        */}
+        <path
+          d="M 218 18 L 182 153 L 113 173"
+          fill="none"
           stroke="#c4aa78"
           strokeWidth="2"
           strokeLinecap="round"
+          strokeLinejoin="round"
         />
         {/* Stylus head */}
-        <circle cx="157" cy="56" r="3" fill="none" stroke="#c4aa78" strokeWidth="1.2" />
-        <circle cx="157" cy="56" r="1.5" fill="#c4aa78" />
+        <circle cx="113" cy="173" r="3" fill="none" stroke="#c4aa78" strokeWidth="1.2" />
+        <circle cx="113" cy="173" r="1.5" fill="#c4aa78" />
       </svg>
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+
+export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element {
+  return (
+    <div className={`splash-screen${hiding ? ' splash-hiding' : ''}`}>
+      <svg
+        className="splash-svg"
+        viewBox="0 0 230 200"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        {/* Decorative stars — twinkle independently */}
+        <text
+          className="splash-deco s1"
+          x="22"
+          y="38"
+          textAnchor="middle"
+          fontSize="11"
+          fill="#c4aa78"
+        >
+          ✦
+        </text>
+        <text
+          className="splash-deco s2"
+          x="20"
+          y="162"
+          textAnchor="middle"
+          fontSize="8"
+          fill="#c4aa78"
+        >
+          ✦
+        </text>
+        <text
+          className="splash-deco s3"
+          x="180"
+          y="170"
+          textAnchor="middle"
+          fontSize="7"
+          fill="#c4aa78"
+        >
+          ✧
+        </text>
+        <text
+          className="splash-deco s4"
+          x="162"
+          y="12"
+          textAnchor="middle"
+          fontSize="7"
+          fill="#c4aa78"
+        >
+          ✧
+        </text>
+
+        {/* Music notes — float gently */}
+        <text className="splash-note n1" x="10" y="105" fontSize="15" fill="#c4aa78">
+          ♪
+        </text>
+        <text className="splash-note n2" x="196" y="130" fontSize="12" fill="#c4aa78">
+          ♫
+        </text>
+
+        {/* === Spinning record === */}
+        <g className="splash-record-spin">
+          {/* Record body */}
+          <circle cx="100" cy="100" r="86" fill="#1c1a16" stroke="#c4aa78" strokeWidth="1.5" />
+          {/* Pressed grooves — very subtle concentric rings */}
+          {[78, 70, 62, 54, 46, 38, 32].map((r) => (
+            <circle
+              key={r}
+              cx="100"
+              cy="100"
+              r={r}
+              fill="none"
+              stroke="#2a2620"
+              strokeWidth="0.8"
+            />
+          ))}
+          {/* Center label */}
+          <circle cx="100" cy="100" r="26" fill="#bf7a20" />
+          <circle
+            cx="100"
+            cy="100"
+            r="22.5"
+            fill="none"
+            stroke="#8a5515"
+            strokeWidth="0.6"
+            strokeDasharray="2.5 2"
+          />
+          <circle cx="100" cy="100" r="26" fill="none" stroke="#8a5515" strokeWidth="1" />
+          {/* Label text */}
+          <text
+            x="100"
+            y="97"
+            textAnchor="middle"
+            fill="#1c1a16"
+            fontSize="9"
+            fontWeight="700"
+            letterSpacing="2.5"
+            fontFamily="'DM Sans', sans-serif"
+          >
+            KAMP
+          </text>
+          <text
+            x="100"
+            y="108"
+            textAnchor="middle"
+            fill="#1c1a16"
+            fontSize="4.8"
+            letterSpacing="1.5"
+            fontFamily="'DM Sans', sans-serif"
+          >
+            HI · FI
+          </text>
+          {/* Centre spindle hole */}
+          <circle cx="100" cy="100" r="3.5" fill="#141414" />
+        </g>
+
+        {/* === Tonearm (static) === */}
+        {/* Pivot post */}
+        <circle cx="216" cy="18" r="6" fill="none" stroke="#c4aa78" strokeWidth="1.5" />
+        <circle cx="216" cy="18" r="2.5" fill="#c4aa78" />
+        {/* Arm — from pivot down to stylus at the record grooves */}
+        <line
+          x1="213"
+          y1="22"
+          x2="158"
+          y2="55"
+          stroke="#c4aa78"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        {/* Stylus head */}
+        <circle cx="157" cy="56" r="3" fill="none" stroke="#c4aa78" strokeWidth="1.2" />
+        <circle cx="157" cy="56" r="1.5" fill="#c4aa78" />
+      </svg>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -125,7 +125,7 @@ export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element
           - Headshell continues from bend to stylus at 170° on groove r=74 → (113, 173)
         */}
         <path
-          d="M 218 18 L 182 153 L 113 173"
+          d="M 218 18 Q 182 153 113 173"
           fill="none"
           stroke="#c4aa78"
           strokeWidth="2"


### PR DESCRIPTION
## Summary

- Splash screen overlays the app on startup while the server connection is being established
- Animated vinyl record in a 1950s line-art style: spinning record with grooves and amber label, curved tonearm with stylus in the groove, twinkling stars, floating music notes
- Splash lingers 1 second after the server connects (giving the library fetch time to complete), then fades out over 500ms
- Covers both the initial reconnecting state and the offline error page so neither flashes before the app is ready
- StrictMode-safe: no one-shot guard ref that would be cancelled by React's double-invoke in development

## Test plan

- [x] Launch the app with the server already running — splash appears, spins, then fades into the loaded library
- [x] Launch the app with the server starting up — splash holds until connected, then fades
- [x] Launch the app with the server not running — splash covers the offline screen until the retry sequence gives up, then fades to reveal the error
- [x] Hot-reload / manual reload — splash appears each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)