### PR TITLE
feat: remove native title bar (TASK-52)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -102,6 +102,9 @@ function createWindow(): void {
     // Match the app's dark background so the native window surface never
     // shows through as white gutters during resize or repaint.
     backgroundColor: theme.bg,
+    // Remove the native title bar on macOS — the view-tabs nav takes its place
+    // and acts as the drag region. Traffic lights remain visible at top-left.
+    ...(process.platform === 'darwin' ? { titleBarStyle: 'hidden' as const } : {}),
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -177,8 +177,13 @@ body,
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   padding: 0 8px;
+  /* Left padding reserves space for macOS traffic lights (close/min/max).
+     On non-macOS this is just a little extra breathing room. */
+  padding-left: 76px;
   gap: 2px;
   flex-shrink: 0;
+  /* Make the nav bar the window drag region so the user can move the window. */
+  -webkit-app-region: drag;
 }
 
 .view-tabs button {
@@ -191,6 +196,8 @@ body,
   padding: 8px 12px;
   margin-bottom: -1px;
   transition: color 0.15s, border-color 0.15s;
+  /* Buttons must opt out of the drag region so clicks register. */
+  -webkit-app-region: no-drag;
 }
 
 .view-tabs button:hover {
@@ -215,6 +222,7 @@ body,
   padding: 3px 8px;
   width: 200px;
   transition: border-color 0.15s;
+  -webkit-app-region: no-drag;
 }
 
 .search-bar:focus-within {


### PR DESCRIPTION
## Summary

- Removes the native macOS title bar (`titleBarStyle: 'hidden'`) — traffic lights remain, title chrome is gone
- The view-tabs nav bar takes the title bar's place and becomes the window drag region
- Buttons and search bar opt out of the drag region so clicks register normally
- 76px left padding reserves space for the traffic light cluster

## Test plan

- [x] App launches without a native title bar — traffic lights visible at top-left of the nav bar
- [x] Window can be dragged by clicking and holding on the nav bar (between traffic lights and tabs)
- [x] Library / Now Playing buttons still clickable
- [x] Search bar still clickable and focusable
- [x] Window resize handles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)