### PR TITLE
chore: rename app to kamp (TASK-51)

### DIFF
--- a/kamp_ui/electron-builder.yml
+++ b/kamp_ui/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.electron.app
-productName: kamp_ui
+appId: com.kamp.app
+productName: kamp
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: kamp_ui
+  executableName: kamp
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/kamp_ui/package.json
+++ b/kamp_ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kamp_ui",
   "version": "1.0.0",
-  "description": "An Electron application with React and TypeScript",
+  "description": "kamp music player",
   "main": "./out/main/index.js",
   "author": "example.com",
   "homepage": "https://electron-vite.org",

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -139,7 +139,7 @@ function createWindow(): void {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
   // Set app user model id for windows
-  electronApp.setAppUserModelId('com.electron')
+  electronApp.setAppUserModelId('com.kamp.app')
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -138,7 +138,9 @@ function createWindow(): void {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
-  // Set app user model id for windows
+  // Override the app name at runtime — in dev the binary is named "Electron";
+  // this sets the macOS menu bar name regardless of how the app was launched.
+  app.setName('kamp')
   electronApp.setAppUserModelId('com.kamp.app')
 
   // Default open or close DevTools by F12 in development

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -7,6 +7,10 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { theme } from '../shared/theme'
 
+// Set the app name before the app is ready so the macOS menu bar and all
+// default menu items ("About kamp", "Quit kamp") reflect the correct name.
+app.setName('kamp')
+
 // ---------------------------------------------------------------------------
 // Server lifecycle
 // ---------------------------------------------------------------------------
@@ -138,9 +142,6 @@ function createWindow(): void {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
-  // Override the app name at runtime — in dev the binary is named "Electron";
-  // this sets the macOS menu bar name regardless of how the app was launched.
-  app.setName('kamp')
   electronApp.setAppUserModelId('com.kamp.app')
 
   // Default open or close DevTools by F12 in development


### PR DESCRIPTION
## Summary

- `productName`: `kamp_ui` → `kamp` (controls the packaged app name on macOS/Windows/Linux)
- `appId`: `com.electron.app` → `com.kamp.app`
- Windows `executableName`: `kamp_ui` → `kamp`
- `app.setName('kamp')` called before `whenReady()` so "About kamp" / "Quit kamp" menu items are correct in dev and in production
- `package.json` description updated

**Note:** The top-level macOS menu bar still shows "Electron" in dev mode — that comes from the binary name, which electron-builder renames to `kamp` when packaging. It's a dev-only cosmetic limitation, not a bug.

## Test plan

- [x] Application menu shows "About kamp" and "Quit kamp" (not kamp_ui)
- [x] Packaged build shows "kamp" in the macOS menu bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)