### PR TITLE
feat: no text selection, now playing links (TASK-60, TASK-76)

### DIFF
--- a/backlog/tasks/task-51 - change-application-name-to-kamp.md
+++ b/backlog/tasks/task-51 - change-application-name-to-kamp.md
@@ -1,17 +1,17 @@
 ---
 id: TASK-51
 title: change application name to kamp
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-31 03:15'
-updated_date: '2026-04-03 04:35'
+updated_date: '2026-04-03 11:57'
 labels:
   - chore
   - 'estimate: single'
 milestone: m-9
 dependencies: []
 priority: low
-ordinal: 4000
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-52 - UI-polish-remove-title-bar.md
+++ b/backlog/tasks/task-52 - UI-polish-remove-title-bar.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-52
 title: 'UI polish: remove title bar'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-31 03:17'
-updated_date: '2026-04-03 04:35'
+updated_date: '2026-04-03 11:57'
 labels:
   - feature
   - ui
@@ -13,7 +13,7 @@ labels:
 milestone: m-9
 dependencies: []
 priority: medium
-ordinal: 250
+ordinal: 2000
 ---
 
 ## Description

--- a/backlog/tasks/task-60 - text-shouldnt-be-selectable.md
+++ b/backlog/tasks/task-60 - text-shouldnt-be-selectable.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-60
 title: text shouldn't be selectable
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-01 02:23'
-updated_date: '2026-04-03 04:35'
+updated_date: '2026-04-03 12:58'
 labels:
   - polish
   - ui

--- a/backlog/tasks/task-76 - links-back-to-library-on-now-playing-screen.md
+++ b/backlog/tasks/task-76 - links-back-to-library-on-now-playing-screen.md
@@ -1,0 +1,22 @@
+---
+id: TASK-76
+title: links back to library on now playing screen
+status: Done
+assignee: []
+created_date: '2026-04-03 11:59'
+updated_date: '2026-04-03 12:45'
+labels:
+  - feature
+  - ui
+  - 'estimate: single'
+milestone: m-20
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+on now playing screen:
+the album title should link back to the album page
+the artist name should link back to the artist page
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-77 - auto-scroll-queue-to-show-a-little-history-and-a-lot-of-future.md
+++ b/backlog/tasks/task-77 - auto-scroll-queue-to-show-a-little-history-and-a-lot-of-future.md
@@ -1,0 +1,25 @@
+---
+id: TASK-77
+title: auto-scroll queue to show a little history and a lot of future
+status: To Do
+assignee: []
+created_date: '2026-04-03 12:50'
+updated_date: '2026-04-03 13:02'
+labels:
+  - feature
+  - ui
+  - 'estimate: single'
+milestone: m-20
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When a track is advanced, either by playthrough or next button, quickly scroll the queue.
+
+the last five tracks played should be visible, then the current playing track, then the rest of the queue.
+
+when there are fewer than five tracks in the history, no scrolling is necessary.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
+++ b/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
@@ -1,0 +1,26 @@
+---
+id: TASK-78
+title: add 'go to track' and 'go to album' context menu items for queue
+status: To Do
+assignee: []
+created_date: '2026-04-03 12:58'
+updated_date: '2026-04-03 13:02'
+labels:
+  - feature
+  - ui
+  - 'estimate: single'
+milestone: m-20
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+context menu for all items in queue should be:
+
+⌾ Go to Album
+♫ Go to Artist
+----
+queue management options
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
+++ b/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
@@ -1,0 +1,25 @@
+---
+id: TASK-79
+title: check window boundaries for context menus
+status: To Do
+assignee: []
+created_date: '2026-04-03 13:01'
+updated_date: '2026-04-03 13:02'
+labels:
+  - bug
+  - ui
+  - 'estimate: single'
+milestone: m-20
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+when a context menu is opened close to the right border of the screen, it gets clipped by the edge of the window
+
+if the context menu size will go off the edge of the window's x-axis boundary, it should open with an inverted x-axis (to the left of the cursor instead of the right).
+
+if the context menu size will go off the edge of the window's y-axis boundary, it should open with an inverted y-axis (above the cursor instead of below it).
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1300,6 +1300,7 @@ body,
   font-size: 18px;
   font-weight: 600;
   color: var(--text);
+  text-align: right;
 }
 
 .now-playing-artist {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -8,6 +8,16 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  /* Prevent text selection app-wide — this is a music player, not a document. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* Restore text selection for actual input fields. */
+input,
+textarea {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 :root {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1313,6 +1313,19 @@ body,
   opacity: 0.7;
 }
 
+.now-playing-link {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.now-playing-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .now-playing-empty {
   display: flex;
   flex-direction: column;

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1300,7 +1300,6 @@ body,
   font-size: 18px;
   font-weight: 600;
   color: var(--text);
-  text-align: right;
 }
 
 .now-playing-artist {

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -6,6 +6,10 @@ export function NowPlayingView(): React.JSX.Element {
   const player = useStore((s) => s.player)
   const { current_track } = player
   const [artLoaded, setArtLoaded] = useState(false)
+  const albums = useStore((s) => s.library.albums)
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
 
   if (!current_track) {
     return (
@@ -14,6 +18,22 @@ export function NowPlayingView(): React.JSX.Element {
         <div className="now-playing-empty-hint">Nothing playing</div>
       </div>
     )
+  }
+
+  function goToAlbum(): void {
+    if (!current_track) return
+    const album = albums.find(
+      (a) => a.album === current_track.album && a.album_artist === current_track.album_artist
+    )
+    if (!album) return
+    void setActiveView('library')
+    void selectAlbum(album)
+  }
+
+  function goToArtist(): void {
+    if (!current_track) return
+    void setActiveView('library')
+    selectArtist(current_track.album_artist)
   }
 
   return (
@@ -28,11 +48,13 @@ export function NowPlayingView(): React.JSX.Element {
       </div>
       <div className="now-playing-meta">
         <div className="now-playing-title">{current_track.title}</div>
-        <div className="now-playing-artist">{current_track.artist}</div>
-        <div className="now-playing-album">
+        <button className="now-playing-artist now-playing-link" onClick={goToArtist}>
+          {current_track.artist}
+        </button>
+        <button className="now-playing-album now-playing-link" onClick={goToAlbum}>
           {current_track.album}
           {current_track.year ? ` · ${current_track.year}` : ''}
-        </div>
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

**TASK-60 — text shouldn't be selectable**
- `user-select: none` applied globally — no I-beam cursors, Cmd-A highlights nothing
- `input` and `textarea` elements opted back in so the search bar still works normally

**TASK-76 — links back to library on now playing screen**
- Artist name is now a button that navigates to the artist filter in the library
- Album title is now a button that navigates to the album track list
- Both switch the active view to library first

## Test plan

- [x] Click and drag over any text in the app — nothing highlights
- [x] Cmd-A anywhere — nothing highlights
- [x] Search bar still accepts typed input and can be selected normally
- [x] On the Now Playing screen, click the artist name — switches to library, filters to that artist
- [x] On the Now Playing screen, click the album title — switches to library, opens that album's track list
- [x] Both links show underline on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)