### PR TITLE
feat: window bounds, context menu edge detection, queue navigation (TASK-78, TASK-79, TASK-80)

### DIFF
--- a/backlog/tasks/task-77 - auto-scroll-queue-to-show-a-little-history-and-a-lot-of-future.md
+++ b/backlog/tasks/task-77 - auto-scroll-queue-to-show-a-little-history-and-a-lot-of-future.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-77
 title: auto-scroll queue to show a little history and a lot of future
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-03 12:50'
-updated_date: '2026-04-03 13:02'
+updated_date: '2026-04-03 17:33'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
+++ b/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-78
 title: add 'go to track' and 'go to album' context menu items for queue
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-03 12:58'
-updated_date: '2026-04-03 13:02'
+updated_date: '2026-04-03 17:36'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
+++ b/backlog/tasks/task-78 - add-go-to-track-and-go-to-album-context-menu-items-for-queue.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-78
 title: add 'go to track' and 'go to album' context menu items for queue
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-03 12:58'
-updated_date: '2026-04-03 17:36'
+updated_date: '2026-04-03 17:52'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
+++ b/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-79
 title: check window boundaries for context menus
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-03 13:01'
-updated_date: '2026-04-03 13:02'
+updated_date: '2026-04-03 17:33'
 labels:
   - bug
   - ui

--- a/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
+++ b/backlog/tasks/task-79 - check-window-boundaries-for-context-menus.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-79
 title: check window boundaries for context menus
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-03 13:01'
-updated_date: '2026-04-03 17:33'
+updated_date: '2026-04-03 17:52'
 labels:
   - bug
   - ui

--- a/backlog/tasks/task-80 - minimum-boundaries-for-window.md
+++ b/backlog/tasks/task-80 - minimum-boundaries-for-window.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-80
 title: minimum boundaries for window
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-03 15:35'
-updated_date: '2026-04-03 15:39'
+updated_date: '2026-04-03 17:29'
 labels:
   - 'estimate: single'
 milestone: m-20

--- a/backlog/tasks/task-80 - minimum-boundaries-for-window.md
+++ b/backlog/tasks/task-80 - minimum-boundaries-for-window.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-80
 title: minimum boundaries for window
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-03 15:35'
-updated_date: '2026-04-03 17:29'
+updated_date: '2026-04-03 17:52'
 labels:
   - 'estimate: single'
 milestone: m-20

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -101,6 +101,8 @@ function createWindow(): void {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     ...bounds,
+    minWidth: 800,
+    minHeight: 600,
     show: false,
     autoHideMenuBar: true,
     // Match the app's dark background so the native window surface never

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1582,3 +1582,9 @@ body,
   background: var(--surface-hover);
   color: var(--accent);
 }
+
+.track-context-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -94,6 +94,15 @@ export function AlbumGrid(): React.JSX.Element {
     return () => document.removeEventListener('mousedown', handler)
   }, [menu])
 
+  // Flip the menu toward the cursor if it would overflow the window edge.
+  useLayoutEffect(() => {
+    if (!menu || !menuRef.current) return
+    const el = menuRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) el.style.left = `${menu.x - rect.width}px`
+    if (rect.bottom > window.innerHeight) el.style.top = `${menu.y - rect.height}px`
+  }, [menu])
+
   const visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
 
   return (

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -1,7 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 
-type ContextMenu = { x: number; y: number; trackIdx: number | null }
+type ContextMenu = {
+  x: number
+  y: number
+  trackIdx: number | null
+  albumArtist?: string
+  album?: string
+}
 
 export function QueuePanel(): React.JSX.Element {
   const queue = useStore((s) => s.queue)
@@ -14,6 +20,10 @@ export function QueuePanel(): React.JSX.Element {
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const insertAlbumAt = useStore((s) => s.insertAlbumAt)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const albums = useStore((s) => s.library.albums)
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
   const activeRef = useRef<HTMLLIElement>(null)
   const listRef = useRef<HTMLOListElement>(null)
   const [menu, setMenu] = useState<ContextMenu | null>(null)
@@ -46,6 +56,15 @@ export function QueuePanel(): React.JSX.Element {
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
+
+  // Flip the menu toward the cursor if it would overflow the window edge.
+  useLayoutEffect(() => {
+    if (!menu || !menuRef.current) return
+    const el = menuRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) el.style.left = `${menu.x - rect.width}px`
+    if (rect.bottom > window.innerHeight) el.style.top = `${menu.y - rect.height}px`
   }, [menu])
 
   function handleDrop(e: React.DragEvent, dropIdx: number): void {
@@ -139,7 +158,13 @@ export function QueuePanel(): React.JSX.Element {
                 onContextMenu={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
-                  setMenu({ x: e.clientX, y: e.clientY, trackIdx: isUnplayed ? idx : null })
+                  setMenu({
+                    x: e.clientX,
+                    y: e.clientY,
+                    trackIdx: isUnplayed ? idx : null,
+                    albumArtist: track.album_artist,
+                    album: track.album
+                  })
                 }}
               >
                 <span className="queue-track-fav" aria-hidden="true">
@@ -155,6 +180,41 @@ export function QueuePanel(): React.JSX.Element {
       )}
       {menu && (
         <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
+          {menu.albumArtist && menu.album && (
+            <>
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  const found =
+                    albums.find(
+                      (a) => a.album_artist === menu.albumArtist && a.album === menu.album
+                    ) ?? {
+                      album_artist: menu.albumArtist!,
+                      album: menu.album!,
+                      year: '',
+                      track_count: 0,
+                      has_art: false
+                    }
+                  void setActiveView('library')
+                  void selectAlbum(found)
+                  setMenu(null)
+                }}
+              >
+                ⌾ Go to Album
+              </button>
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  void setActiveView('library')
+                  selectArtist(menu.albumArtist!)
+                  setMenu(null)
+                }}
+              >
+                ♫ Go to Artist
+              </button>
+              <div className="track-context-menu-divider" />
+            </>
+          )}
           <button
             className="track-context-menu-item"
             onClick={() => {

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -185,16 +185,15 @@ export function QueuePanel(): React.JSX.Element {
               <button
                 className="track-context-menu-item"
                 onClick={() => {
-                  const found =
-                    albums.find(
-                      (a) => a.album_artist === menu.albumArtist && a.album === menu.album
-                    ) ?? {
-                      album_artist: menu.albumArtist!,
-                      album: menu.album!,
-                      year: '',
-                      track_count: 0,
-                      has_art: false
-                    }
+                  const found = albums.find(
+                    (a) => a.album_artist === menu.albumArtist && a.album === menu.album
+                  ) ?? {
+                    album_artist: menu.albumArtist!,
+                    album: menu.album!,
+                    year: '',
+                    track_count: 0,
+                    has_art: false
+                  }
                   void setActiveView('library')
                   void selectAlbum(found)
                   setMenu(null)

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 
@@ -43,6 +43,15 @@ export function TrackList(): React.JSX.Element | null {
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
+
+  // Flip the menu toward the cursor if it would overflow the window edge.
+  useLayoutEffect(() => {
+    if (!menu || !menuRef.current) return
+    const el = menuRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) el.style.left = `${menu.x - rect.width}px`
+    if (rect.bottom > window.innerHeight) el.style.top = `${menu.y - rect.height}px`
   }, [menu])
 
   if (!album) return null


### PR DESCRIPTION
## Summary

- **TASK-80**: Set `minWidth: 800` / `minHeight: 600` on `BrowserWindow` to prevent draw artifacts when resizing below these dimensions
- **TASK-79**: Context menus now flip left/up when they would overflow the window's right or bottom edge — applied to `AlbumGrid`, `TrackList`, and `QueuePanel` via `useLayoutEffect` bounds check (no extra re-render)
- **TASK-78**: Queue track context menus now show **⌾ Go to Album** and **♫ Go to Artist** above a divider, switching to library view and navigating accordingly

## Test plan

- [x] Resize window to near minimum — confirm it stops at 800×600
- [x] Right-click an album near the right/bottom edge of the window — confirm menu flips inward
- [x] Right-click a track near the right/bottom edge — same
- [x] Right-click a queue track — confirm Go to Album / Go to Artist appear at the top; clicking each navigates correctly
- [x] Right-click the queue background (not a track row) — confirm no navigation items appear, only Clear Queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)