### PR TITLE
feat: context menus in search results (TASK-81)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -392,6 +392,14 @@ body,
   background: var(--surface-hover);
 }
 
+.search-track-fav {
+  width: 12px;
+  flex-shrink: 0;
+  font-size: 9px;
+  color: var(--error);
+  text-align: center;
+}
+
 .search-track-title {
   font-size: 13px;
   white-space: nowrap;

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -1,10 +1,19 @@
-import React, { useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
 
-function SearchAlbumCard({ album }: { album: Album }): React.JSX.Element {
+type AlbumMenu = { x: number; y: number; album: Album }
+type TrackMenu = { x: number; y: number; filePath: string; favorite: boolean }
+
+function SearchAlbumCard({
+  album,
+  onContextMenu
+}: {
+  album: Album
+  onContextMenu: (e: React.MouseEvent, album: Album) => void
+}): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
   const setActiveView = useStore((s) => s.setActiveView)
@@ -22,6 +31,7 @@ function SearchAlbumCard({ album }: { album: Album }): React.JSX.Element {
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+      onContextMenu={(e) => onContextMenu(e, album)}
     >
       <div className={`search-album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
@@ -42,12 +52,18 @@ function SearchAlbumCard({ album }: { album: Album }): React.JSX.Element {
   )
 }
 
-function SearchTrackRow({ track, index }: { track: Track; index: number }): React.JSX.Element {
+function SearchTrackRow({
+  track,
+  onContextMenu
+}: {
+  track: Track
+  onContextMenu: (e: React.MouseEvent, track: Track) => void
+}): React.JSX.Element {
   const playTrack = useStore((s) => s.playTrack)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
 
   const handleClick = (): void => {
-    void playTrack(track.album_artist, track.album, index)
+    void playTrack(track.album_artist, track.album, track.track_number - 1)
     void setSearchQuery('')
   }
 
@@ -57,6 +73,7 @@ function SearchTrackRow({ track, index }: { track: Track; index: number }): Reac
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+      onContextMenu={(e) => onContextMenu(e, track)}
     >
       <span className="search-track-title">{track.title}</span>
       <span className="search-track-meta">
@@ -69,6 +86,57 @@ function SearchTrackRow({ track, index }: { track: Track; index: number }): Reac
 export function SearchView(): React.JSX.Element {
   const results = useStore((s) => s.searchResults)
   const query = useStore((s) => s.searchQuery)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const playNext = useStore((s) => s.playNext)
+  const addToQueue = useStore((s) => s.addToQueue)
+  const setFavorite = useStore((s) => s.setFavorite)
+
+  const [albumMenu, setAlbumMenu] = useState<AlbumMenu | null>(null)
+  const [trackMenu, setTrackMenu] = useState<TrackMenu | null>(null)
+  const albumMenuRef = useRef<HTMLDivElement>(null)
+  const trackMenuRef = useRef<HTMLDivElement>(null)
+
+  // Dismiss album menu on click outside.
+  useEffect(() => {
+    if (!albumMenu) return
+    const handler = (e: MouseEvent): void => {
+      if (albumMenuRef.current && !albumMenuRef.current.contains(e.target as Node)) {
+        setAlbumMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [albumMenu])
+
+  // Dismiss track menu on click outside.
+  useEffect(() => {
+    if (!trackMenu) return
+    const handler = (e: MouseEvent): void => {
+      if (trackMenuRef.current && !trackMenuRef.current.contains(e.target as Node)) {
+        setTrackMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [trackMenu])
+
+  // Flip menus toward the cursor if they would overflow the window edge.
+  useLayoutEffect(() => {
+    if (!albumMenu || !albumMenuRef.current) return
+    const el = albumMenuRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) el.style.left = `${albumMenu.x - rect.width}px`
+    if (rect.bottom > window.innerHeight) el.style.top = `${albumMenu.y - rect.height}px`
+  }, [albumMenu])
+
+  useLayoutEffect(() => {
+    if (!trackMenu || !trackMenuRef.current) return
+    const el = trackMenuRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) el.style.left = `${trackMenu.x - rect.width}px`
+    if (rect.bottom > window.innerHeight) el.style.top = `${trackMenu.y - rect.height}px`
+  }, [trackMenu])
 
   if (!results) {
     return <div className="search-empty">Searching…</div>
@@ -89,7 +157,15 @@ export function SearchView(): React.JSX.Element {
           <h2 className="search-section-title">Albums</h2>
           <div className="search-album-grid">
             {results.albums.map((album) => (
-              <SearchAlbumCard key={`${album.album_artist}\0${album.album}`} album={album} />
+              <SearchAlbumCard
+                key={`${album.album_artist}\0${album.album}`}
+                album={album}
+                onContextMenu={(e, a) => {
+                  e.preventDefault()
+                  setTrackMenu(null)
+                  setAlbumMenu({ x: e.clientX, y: e.clientY, album: a })
+                }}
+              />
             ))}
           </div>
         </section>
@@ -98,11 +174,87 @@ export function SearchView(): React.JSX.Element {
         <section className="search-section">
           <h2 className="search-section-title">Tracks</h2>
           <div className="search-track-list">
-            {results.tracks.map((track, i) => (
-              <SearchTrackRow key={`${track.file_path}`} track={track} index={i} />
+            {results.tracks.map((track) => (
+              <SearchTrackRow
+                key={track.file_path}
+                track={track}
+                onContextMenu={(e, t) => {
+                  e.preventDefault()
+                  setAlbumMenu(null)
+                  setTrackMenu({
+                    x: e.clientX,
+                    y: e.clientY,
+                    filePath: t.file_path,
+                    favorite: t.favorite
+                  })
+                }}
+              />
             ))}
           </div>
         </section>
+      )}
+
+      {albumMenu && (
+        <div
+          ref={albumMenuRef}
+          className="track-context-menu"
+          style={{ top: albumMenu.y, left: albumMenu.x }}
+        >
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void playAlbumNext(albumMenu.album.album_artist, albumMenu.album.album)
+              setAlbumMenu(null)
+            }}
+          >
+            ▶ Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addAlbumToQueue(albumMenu.album.album_artist, albumMenu.album.album)
+              setAlbumMenu(null)
+            }}
+          >
+            + Add to Queue
+          </button>
+        </div>
+      )}
+
+      {trackMenu && (
+        <div
+          ref={trackMenuRef}
+          className="track-context-menu"
+          style={{ top: trackMenu.y, left: trackMenu.x }}
+        >
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void playNext(trackMenu.filePath)
+              setTrackMenu(null)
+            }}
+          >
+            ▶ Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addToQueue(trackMenu.filePath)
+              setTrackMenu(null)
+            }}
+          >
+            + Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void setFavorite(trackMenu.filePath, !trackMenu.favorite)
+              setTrackMenu(null)
+            }}
+          >
+            {trackMenu.favorite ? '♥ Remove from Favorites' : '♡ Add to Favorites'}
+          </button>
+        </div>
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -75,6 +75,9 @@ function SearchTrackRow({
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       onContextMenu={(e) => onContextMenu(e, track)}
     >
+      <span className="search-track-fav" aria-hidden="true">
+        {track.favorite ? '♥' : ''}
+      </span>
       <span className="search-track-title">{track.title}</span>
       <span className="search-track-meta">
         {track.artist} — {track.album}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -358,6 +358,17 @@ export const useStore = create<PlayerStore>((set, get) => ({
           }
         : s.queue
     }))
+    // Patch search results so the favorite glyph updates without a re-search.
+    set((s) => ({
+      searchResults: s.searchResults
+        ? {
+            ...s.searchResults,
+            tracks: s.searchResults.tracks.map((t) =>
+              t.file_path === filePath ? { ...t, favorite } : t
+            )
+          }
+        : s.searchResults
+    }))
     // Reload the open album track list so the heart in track rows updates.
     await get().refreshOpenAlbum()
   },


### PR DESCRIPTION
## Summary

- Right-clicking an album in search results now shows **▶ Play Next** and **+ Add to Queue**, matching `AlbumGrid`
- Right-clicking a track in search results now shows **▶ Play Next**, **+ Add to Queue**, and **♥/♡ Favorites**, matching `TrackList`
- Menu boundary flip logic (from TASK-79) is included for both menus
- Opening one menu dismisses the other

## Test plan

- [x] Search for an album — right-click a result — Play Next and Add to Queue work
- [x] Search for a track — right-click a result — Play Next, Add to Queue, and Favorites toggle work
- [x] Right-click near window edge — menu flips inward
- [x] Click outside an open menu — it dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)