### PR TITLE
feat: Preferences dialog (TASK-36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ kamp status            # check if it's running
 kamp uninstall-service # remove it permanently
 ```
 
+### Preferences dialog (UI)
+
+Open the Preferences dialog from **kamp → Preferences** in the macOS menu bar, or with **Cmd+,** (macOS) / **Ctrl+,** (Linux/Windows). Changes take effect immediately — no Apply or OK button. Settings marked **↺ restart** require restarting the kamp server to take effect.
+
 ### View or update config from the command line
 
 ```bash

--- a/backlog/tasks/task-36 - preferences-panel.md
+++ b/backlog/tasks/task-36 - preferences-panel.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-36
 title: Preferences panel
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 14:01'
-updated_date: '2026-04-05 16:45'
+updated_date: '2026-04-05 16:56'
 labels:
   - feature
   - ui
@@ -45,3 +45,68 @@ Consult with UI Designer before implementation.
 - [ ] #10 Dialog background matches the queue panel background
 - [ ] #11 Dialog can be dismissed with the X button or Escape key
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+Estimate: LP (2 sides)
+
+### Backend (Python)
+
+1. **`kamp_core/server.py`** — Add `GET /api/v1/config` and `PATCH /api/v1/config`
+   - Add `config_values: dict[str, Any] | None` parameter (flat pref values, keyed by dot-notation)
+   - Add `on_config_set: Callable[[str, str], None] | None` parameter (raises KeyError/ValueError on bad input)
+   - Track config state in `_state["config"]`
+   - `GET /api/v1/config` → returns current values (paths/library/artwork/musicbrainz/bandcamp; not ui)
+   - `PATCH /api/v1/config` body `{key, value}` → validates via callback, updates `_state["config"]`, returns `{ok: true}` or 422
+   - Add `ConfigPatchRequest` Pydantic model
+
+2. **`kamp_daemon/__main__.py`** — Wire config values and callback
+   - Build `config_values` dict from Config object before calling `create_app()`
+   - Add `_on_config_set(key, value)` callback → calls `config_set(config_path, key, value)`, lets exceptions propagate
+
+3. **`tests/test_server.py`** — Add tests for new endpoints (red/green TDD)
+
+### Frontend (TypeScript/React)
+
+4. **`kamp_ui/src/renderer/src/api/client.ts`**
+   - Add `ConfigValues` type (flat dict)
+   - Add `getConfig()` → `GET /api/v1/config`
+   - Add `patchConfig(key, value)` → `PATCH /api/v1/config`
+
+5. **`kamp_ui/src/renderer/src/store.ts`**
+   - Add `configValues: ConfigValues | null`, `prefsOpen: boolean`
+   - Add `loadConfig()`, `setConfigValue(key, value)`, `openPrefs()`, `closePrefs()` actions
+
+6. **`kamp_ui/src/renderer/src/components/PreferencesDialog.tsx`** (new)
+   - Full dialog following UI Designer design spec
+   - Sections: Paths, Library, Artwork, MusicBrainz, Bandcamp (only if configured)
+   - Folder pickers via `window.api.openDirectory()` IPC
+   - Ephemeral ✓ confirmation per row (1500ms fade)
+   - Restart badges on: paths.staging, paths.library, musicbrainz.contact, bandcamp.poll_interval_minutes
+   - Dismiss with X button or Escape key
+
+7. **`kamp_ui/src/renderer/src/App.tsx`**
+   - Mount `<PreferencesDialog>` (when `prefsOpen`)
+   - Add `Cmd/Ctrl+,` keyboard shortcut → `openPrefs()`
+   - Listen for `open-preferences` IPC from main process
+
+8. **`kamp_ui/src/main/index.ts`**
+   - Set `applicationMenu` with App Name → Preferences (Cmd+,)
+   - On click: send `open-preferences` to focused window via IPC
+
+9. **`kamp_ui/src/preload/index.ts` + `index.d.ts`**
+   - Expose `onOpenPreferences(callback)` using `ipcRenderer.on`
+
+10. **`kamp_ui/src/renderer/src/assets/main.css`**
+    - Add prefs-* CSS from UI Designer
+
+### UI Designer design brief (key decisions)
+- Dialog: 520px wide, `background: var(--surface)`, `border-radius: 8px`
+- Overlay backdrop: `rgba(0,0,0,0.6)`
+- Controls: text/email inputs, number inputs (90px + unit label), textarea (monospace) for path_template, select for bandcamp.format, path-picker rows for folder paths
+- Save confirmation: inline `✓` in `--accent` that fades out after 1500ms
+- Restart badge: `↺ restart` pill next to label for paths.staging, paths.library, musicbrainz.contact, bandcamp.poll_interval_minutes
+<!-- SECTION:PLAN:END -->

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -157,6 +157,11 @@ class SkipToRequest(BaseModel):
     position: int
 
 
+class ConfigPatchRequest(BaseModel):
+    key: str
+    value: str
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -173,6 +178,8 @@ def create_app(
     ui_sort_order: str = "album_artist",
     ui_queue_panel_open: int = 0,
     on_ui_state_set: Callable[[str, str], None] | None = None,
+    config_values: dict[str, Any] | None = None,
+    on_config_set: Callable[[str, str], None] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -193,6 +200,7 @@ def create_app(
         "ui_sort_order": ui_sort_order,
         "ui_queue_panel_open": ui_queue_panel_open,
         "library_version": 0,
+        "config": dict(config_values) if config_values is not None else {},
     }
 
     def _notify_library_changed() -> None:
@@ -380,6 +388,32 @@ def create_app(
         _state["ui_queue_panel_open"] = value
         if on_ui_state_set is not None:
             on_ui_state_set("ui.queue_panel_open", str(value))
+        return {"ok": True}
+
+    # -----------------------------------------------------------------------
+    # Config (preferences)
+    # -----------------------------------------------------------------------
+
+    @app.get("/api/v1/config")
+    def get_config() -> dict[str, Any]:
+        return cast(dict[str, Any], _state["config"])
+
+    # Integer config keys — values are coerced to int when stored so that
+    # GET /api/v1/config returns the correct JSON type (number, not string).
+    _INT_CONFIG_KEYS = frozenset(
+        {"artwork.min_dimension", "artwork.max_bytes", "bandcamp.poll_interval_minutes"}
+    )
+
+    @app.patch("/api/v1/config")
+    def patch_config(req: ConfigPatchRequest) -> dict[str, Any]:
+        if on_config_set is not None:
+            try:
+                on_config_set(req.key, req.value)
+            except (KeyError, ValueError) as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+        # Coerce to the correct Python type before caching in memory.
+        coerced: Any = int(req.value) if req.key in _INT_CONFIG_KEYS else req.value
+        _state["config"][req.key] = coerced
         return {"ok": True}
 
     # -----------------------------------------------------------------------

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -597,6 +597,27 @@ def _cmd_server(
     def _on_ui_state_set(key: str, value: str) -> None:
         _config_set(config_path, key, value)
 
+    def _on_config_set(key: str, value: str) -> None:
+        # Raises KeyError / ValueError on invalid key or value — server
+        # catches these and returns HTTP 422 to the client.
+        _config_set(config_path, key, value)
+
+    # Build the initial preference values dict from the loaded config.
+    # Bandcamp fields are None when the [bandcamp] section is absent.
+    _config_values: dict[str, object] = {
+        "paths.staging": str(config.paths.staging),
+        "paths.library": str(config.paths.library),
+        "musicbrainz.contact": config.musicbrainz.contact,
+        "artwork.min_dimension": config.artwork.min_dimension,
+        "artwork.max_bytes": config.artwork.max_bytes,
+        "library.path_template": config.library.path_template,
+        "bandcamp.username": config.bandcamp.username if config.bandcamp else None,
+        "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
+        "bandcamp.poll_interval_minutes": (
+            config.bandcamp.poll_interval_minutes if config.bandcamp else None
+        ),
+    }
+
     app = create_app(
         index=index,
         engine=engine,
@@ -607,6 +628,8 @@ def _cmd_server(
         ui_sort_order=config.ui.sort_order,
         ui_queue_panel_open=config.ui.queue_panel_open,
         on_ui_state_set=_on_ui_state_set,
+        config_values=_config_values,
+        on_config_set=_on_config_set,
     )
 
     # Watch the library directory and re-scan when audio files are added or

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, dialog, globalShortcut } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, dialog, globalShortcut, Menu } from 'electron'
 import { join, resolve } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { spawn, ChildProcess } from 'child_process'
@@ -95,6 +95,53 @@ function saveWindowBounds(win: BrowserWindow): void {
   }
 }
 
+function buildAppMenu(): void {
+  // Build a minimal application menu that exposes Preferences (Cmd+,) under
+  // the app name menu on macOS, while preserving standard Edit and Window items.
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: app.name,
+      submenu: [
+        {
+          label: 'Preferences…',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => {
+            // Send an IPC message to the focused renderer so it opens the dialog.
+            const win = BrowserWindow.getFocusedWindow()
+            win?.webContents.send('open-preferences')
+          }
+        },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' }
+      ]
+    },
+    {
+      label: 'Window',
+      role: 'window',
+      submenu: [{ role: 'minimize' }, { role: 'zoom' }, { role: 'close' }]
+    }
+  ]
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
 function createWindow(): void {
   const bounds = loadWindowBounds()
 
@@ -145,6 +192,8 @@ function createWindow(): void {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
   electronApp.setAppUserModelId('com.kamp.app')
+
+  buildAppMenu()
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -134,6 +134,20 @@ function buildAppMenu(): void {
       ]
     },
     {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    {
       label: 'Window',
       role: 'window',
       submenu: [{ role: 'minimize' }, { role: 'zoom' }, { role: 'close' }]

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -5,6 +5,7 @@ declare global {
     electron: ElectronAPI
     api: {
       openDirectory: () => Promise<string | null>
+      onOpenPreferences: (callback: () => void) => () => void
     }
   }
 }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -3,7 +3,13 @@ import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
 const api = {
-  openDirectory: (): Promise<string | null> => ipcRenderer.invoke('open-directory')
+  openDirectory: (): Promise<string | null> => ipcRenderer.invoke('open-directory'),
+  onOpenPreferences: (callback: () => void): (() => void) => {
+    const handler = (): void => callback()
+    ipcRenderer.on('open-preferences', handler)
+    // Return a cleanup function so the caller can unsubscribe.
+    return () => ipcRenderer.off('open-preferences', handler)
+  }
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
 import { AlbumGrid } from './components/AlbumGrid'
 import { NowPlayingView } from './components/NowPlayingView'
+import { PreferencesDialog } from './components/PreferencesDialog'
 import { SearchBar } from './components/SearchBar'
 import { SearchView } from './components/SearchView'
 import { SetupScreen } from './components/SetupScreen'
@@ -31,6 +32,7 @@ export default function App(): React.JSX.Element {
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const loadQueue = useStore((s) => s.loadQueue)
+  const openPrefs = useStore((s) => s.openPrefs)
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
   // Per-view scroll positions — kept current by a scroll listener so we never
@@ -114,6 +116,13 @@ export default function App(): React.JSX.Element {
         return
       }
 
+      // Cmd+, (mac) / Ctrl+, (win/linux) opens Preferences.
+      if (e.key === ',' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        openPrefs()
+        return
+      }
+
       // Escape clears search when the search bar is focused.
       if (e.key === 'Escape' && searchQuery) {
         void setSearchQuery('')
@@ -159,8 +168,17 @@ export default function App(): React.JSX.Element {
     activeView,
     searchQuery,
     setSearchQuery,
-    toggleQueuePanel
+    toggleQueuePanel,
+    openPrefs
   ])
+
+  // Listen for "open-preferences" IPC from the main process (sent when the
+  // user clicks App Name → Preferences in the native macOS menu bar).
+  useEffect(() => {
+    if (!window.api.onOpenPreferences) return
+    const cleanup = window.api.onOpenPreferences(openPrefs)
+    return cleanup
+  }, [openPrefs])
 
   // Keep viewScrollRef continuously current so we always have the right value
   // when switching views — reading scrollTop after a DOM update can give a
@@ -193,6 +211,7 @@ export default function App(): React.JSX.Element {
           </div>
         </div>
         {!splashGone && <SplashScreen hiding={splashHiding} />}
+        <PreferencesDialog />
       </>
     )
   }
@@ -240,6 +259,7 @@ export default function App(): React.JSX.Element {
       </div>
       <TransportBar />
       {!splashGone && <SplashScreen hiding={splashHiding} />}
+      <PreferencesDialog />
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -67,6 +67,16 @@ async function get<T>(path: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
+async function patch<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`)
+  return res.json() as Promise<T>
+}
+
 // ---------------------------------------------------------------------------
 // Library
 // ---------------------------------------------------------------------------
@@ -124,6 +134,23 @@ export const setQueuePanelApi = (open: boolean): Promise<{ ok: boolean }> =>
 export type ScanProgress = { active: boolean; current: number; total: number }
 
 export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')
+
+export type ConfigValues = {
+  'paths.staging': string | null
+  'paths.library': string | null
+  'musicbrainz.contact': string | null
+  'artwork.min_dimension': number | null
+  'artwork.max_bytes': number | null
+  'library.path_template': string | null
+  'bandcamp.username': string | null
+  'bandcamp.format': string | null
+  'bandcamp.poll_interval_minutes': number | null
+}
+
+export const getConfig = (): Promise<ConfigValues> => get('/api/v1/config')
+
+export const patchConfig = (key: string, value: string): Promise<{ ok: boolean }> =>
+  patch('/api/v1/config', { key, value })
 
 // ---------------------------------------------------------------------------
 // Player

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -73,7 +73,17 @@ async function patch<T>(path: string, body: unknown): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`)
+  if (!res.ok) {
+    // Prefer the server's detail message over the raw HTTP status text.
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail) message = json.detail
+    } catch {
+      // JSON parse failed — fall back to the HTTP status message.
+    }
+    throw new Error(message)
+  }
   return res.json() as Promise<T>
 }
 

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -628,59 +628,6 @@ body,
   color: var(--accent);
 }
 
-.panel-library-footer {
-  padding: 10px 14px;
-  border-top: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.panel-library-path {
-  font-size: 11px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.panel-library-change-btn,
-.panel-rescan-btn {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 11px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-}
-
-.panel-library-change-btn:hover,
-.panel-rescan-btn:hover {
-  background: var(--surface-hover);
-  color: var(--text);
-}
-
-.panel-rescan-scanning {
-  font-size: 11px;
-  color: var(--text-dim);
-}
-
-.panel-rescan-progress {
-  height: 2px;
-  background: var(--border);
-  border-radius: 1px;
-  overflow: hidden;
-}
-
-.panel-rescan-progress-fill {
-  height: 100%;
-  background: var(--accent);
-  border-radius: 1px;
-  transition: width 0.3s ease;
-}
 
 /* Album grid --------------------------------------------------------------- */
 
@@ -1596,4 +1543,293 @@ body,
   height: 1px;
   background: var(--border);
   margin: 4px 0;
+}
+
+/* Preferences dialog -------------------------------------------------------- */
+
+.prefs-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 900;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes prefs-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.prefs-dialog {
+  width: 520px;
+  max-height: calc(100vh - 80px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: prefs-in 150ms ease;
+}
+
+.prefs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  height: 44px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.prefs-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.prefs-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 3px;
+  line-height: 1;
+}
+
+.prefs-close-btn:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.prefs-close-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.prefs-body {
+  padding: 8px 24px 24px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.prefs-section {
+  margin-top: 24px;
+}
+
+.prefs-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.prefs-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.prefs-row:last-child {
+  border-bottom: none;
+}
+
+.prefs-row-header {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.prefs-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  flex: 1;
+}
+
+.prefs-restart-badge {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin-left: 6px;
+}
+
+.prefs-input,
+.prefs-select,
+.prefs-textarea {
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  transition: border-color 150ms ease;
+  width: 100%;
+}
+
+.prefs-input:focus,
+.prefs-select:focus,
+.prefs-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+
+.prefs-input::placeholder,
+.prefs-textarea::placeholder {
+  color: var(--text-dim);
+}
+
+.prefs-number-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prefs-input--number {
+  width: 90px;
+}
+
+.prefs-unit {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.prefs-textarea {
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-size: 12px;
+  resize: vertical;
+  min-height: 48px;
+  line-height: 1.5;
+}
+
+.prefs-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin-top: 2px;
+}
+
+.prefs-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  cursor: pointer;
+}
+
+.prefs-path-display {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  min-height: 34px;
+}
+
+.prefs-path-text {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, 'SF Mono', monospace;
+}
+
+.prefs-path-text--saved {
+  color: var(--accent);
+  transition: color 600ms ease;
+}
+
+.prefs-choose-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.prefs-choose-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.prefs-choose-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.prefs-saved-check {
+  font-size: 12px;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 100ms ease;
+  margin-left: 8px;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+.prefs-saved-check--visible {
+  opacity: 1;
+  transition: opacity 100ms ease;
+}
+
+.prefs-scan-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.prefs-scan-scanning {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.prefs-scan-progress {
+  height: 2px;
+  background: var(--border);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.prefs-scan-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 200ms ease;
 }

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -5,23 +5,6 @@ export function ArtistPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
   const selected = useStore((s) => s.library.selectedArtist)
   const selectArtist = useStore((s) => s.selectArtist)
-  const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
-  const setLibraryPath = useStore((s) => s.setLibraryPath)
-  const scanLibrary = useStore((s) => s.scanLibrary)
-  const scanStatus = useStore((s) => s.scanStatus)
-  const scanProgress = useStore((s) => s.scanProgress)
-
-  async function handleChangeLibrary(): Promise<void> {
-    const dir = await window.api.openDirectory()
-    if (dir === null) return
-    await setLibraryPath(dir)
-  }
-
-  const scanning = scanStatus === 'scanning'
-  const progressPct =
-    scanProgress && scanProgress.total > 0
-      ? (scanProgress.current / scanProgress.total) * 100
-      : null
 
   return (
     <aside className="artist-panel">
@@ -47,29 +30,6 @@ export function ArtistPanel(): React.JSX.Element {
           </li>
         ))}
       </ul>
-      <div className="panel-library-footer">
-        <span className="panel-library-path" title={configuredLibraryPath ?? undefined}>
-          {configuredLibraryPath ?? '—'}
-        </span>
-        {/* TODO: move re-scan to preferences panel once DRAFT-8 ships */}
-        {scanning ? (
-          <>
-            <span className="panel-rescan-scanning">Scanning…</span>
-            {progressPct !== null && (
-              <div className="panel-rescan-progress">
-                <div className="panel-rescan-progress-fill" style={{ width: `${progressPct}%` }} />
-              </div>
-            )}
-          </>
-        ) : (
-          <button className="panel-rescan-btn" onClick={scanLibrary}>
-            Re-scan Library
-          </button>
-        )}
-        <button className="panel-library-change-btn" onClick={handleChangeLibrary}>
-          Change Library…
-        </button>
-      </div>
     </aside>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -337,7 +337,12 @@ export function PreferencesDialog(): React.JSX.Element | null {
   const handleSave = async (key: string, value: string): Promise<void> => {
     if (INT_KEYS.has(key)) {
       const n = Number(value)
-      if (!Number.isInteger(n) || n < 0) throw new Error('Must be a non-negative integer')
+      if (value.trim() === '' || !Number.isInteger(n) || n < 0)
+        throw new Error('Enter a whole number (0 or greater).')
+    }
+    if (key === 'musicbrainz.contact') {
+      if (!value.includes('@') || value.trim() === '')
+        throw new Error('Enter a valid email address.')
     }
     await setConfigValue(key, value)
   }

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1,0 +1,483 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useStore } from '../store'
+
+// Keys whose values must be integers — sent as strings over the wire but
+// stored as numbers in the config.
+const INT_KEYS = new Set([
+  'artwork.min_dimension',
+  'artwork.max_bytes',
+  'bandcamp.poll_interval_minutes'
+])
+
+// Keys that require a server restart to take effect.
+const RESTART_KEYS = new Set([
+  'paths.staging',
+  'paths.library',
+  'musicbrainz.contact',
+  'bandcamp.poll_interval_minutes'
+])
+
+const BANDCAMP_FORMATS = ['mp3-v0', 'mp3-320', 'flac', 'aac-hi', 'vorbis', 'alac', 'wav']
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function RestartBadge(): React.JSX.Element {
+  return <span className="prefs-restart-badge">↺ restart</span>
+}
+
+function SavedCheck({ visible }: { visible: boolean }): React.JSX.Element {
+  return (
+    <span className={`prefs-saved-check${visible ? ' prefs-saved-check--visible' : ''}`}>✓</span>
+  )
+}
+
+// A single text/email/number input row.
+// Uses an uncontrolled input (defaultValue + ref) to avoid sync effects.
+// The `key` prop on the input remounts it whenever the store value changes,
+// which ensures the field always reflects the latest persisted value.
+function InputRow({
+  label,
+  configKey,
+  type = 'text',
+  unit,
+  hint,
+  initialValue,
+  onSave
+}: {
+  label: string
+  configKey: string
+  type?: 'text' | 'email' | 'number'
+  unit?: string
+  hint?: string
+  initialValue: string
+  onSave: (key: string, value: string) => Promise<void>
+}): React.JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handleBlur = useCallback(async () => {
+    const value = inputRef.current?.value ?? ''
+    if (value === initialValue) return
+    setError(null)
+    try {
+      await onSave(configKey, value)
+      setSaved(true)
+      clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSaved(false), 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    }
+  }, [initialValue, configKey, onSave])
+
+  const isNumber = type === 'number'
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{label}</span>
+        {RESTART_KEYS.has(configKey) && <RestartBadge />}
+        <SavedCheck visible={saved} />
+      </div>
+      <div className={isNumber ? 'prefs-number-row' : undefined}>
+        <input
+          // key remounts the input whenever the persisted value changes, so
+          // the field always reflects what the server has confirmed.
+          key={initialValue}
+          ref={inputRef}
+          className={`prefs-input${isNumber ? ' prefs-input--number' : ''}`}
+          type={type}
+          min={isNumber ? 0 : undefined}
+          defaultValue={initialValue}
+          onBlur={handleBlur}
+        />
+        {unit && <span className="prefs-unit">{unit}</span>}
+      </div>
+      {hint && <p className="prefs-hint">{hint}</p>}
+      {error && (
+        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// A folder-picker row (read-only display + Choose... button).
+function PathRow({
+  label,
+  configKey,
+  initialValue,
+  onSave
+}: {
+  label: string
+  configKey: string
+  initialValue: string
+  onSave: (key: string, value: string) => Promise<void>
+}): React.JSX.Element {
+  const [displayPath, setDisplayPath] = useState(initialValue)
+  const [flashSaved, setFlashSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handleChoose = useCallback(async () => {
+    const chosen = await window.api.openDirectory()
+    if (!chosen) return
+    setError(null)
+    try {
+      await onSave(configKey, chosen)
+      setDisplayPath(chosen)
+      setFlashSaved(true)
+      clearTimeout(flashTimerRef.current)
+      flashTimerRef.current = setTimeout(() => setFlashSaved(false), 600)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    }
+  }, [configKey, onSave])
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{label}</span>
+        <RestartBadge />
+      </div>
+      <div className="prefs-path-display">
+        <span className={`prefs-path-text${flashSaved ? ' prefs-path-text--saved' : ''}`}>
+          {displayPath || '(not set)'}
+        </span>
+        <button className="prefs-choose-btn" onClick={handleChoose}>
+          Choose...
+        </button>
+      </div>
+      {error && (
+        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// A select (dropdown) row.
+function SelectRow({
+  label,
+  configKey,
+  options,
+  initialValue,
+  onSave
+}: {
+  label: string
+  configKey: string
+  options: string[]
+  initialValue: string
+  onSave: (key: string, value: string) => Promise<void>
+}): React.JSX.Element {
+  const [localValue, setLocalValue] = useState(initialValue || options[0])
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handleChange = useCallback(
+    async (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value
+      setLocalValue(value)
+      setError(null)
+      try {
+        await onSave(configKey, value)
+        setSaved(true)
+        clearTimeout(savedTimerRef.current)
+        savedTimerRef.current = setTimeout(() => setSaved(false), 1500)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Save failed')
+      }
+    },
+    [configKey, onSave]
+  )
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{label}</span>
+        {RESTART_KEYS.has(configKey) && <RestartBadge />}
+        <SavedCheck visible={saved} />
+      </div>
+      <select className="prefs-select" value={localValue} onChange={handleChange}>
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+      {error && (
+        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// A textarea row (used for path_template).
+function TextareaRow({
+  label,
+  configKey,
+  hint,
+  initialValue,
+  onSave
+}: {
+  label: string
+  configKey: string
+  hint?: string
+  initialValue: string
+  onSave: (key: string, value: string) => Promise<void>
+}): React.JSX.Element {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handleBlur = useCallback(async () => {
+    const value = textareaRef.current?.value ?? ''
+    if (value === initialValue) return
+    setError(null)
+    try {
+      await onSave(configKey, value)
+      setSaved(true)
+      clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSaved(false), 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    }
+  }, [initialValue, configKey, onSave])
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{label}</span>
+        <SavedCheck visible={saved} />
+      </div>
+      <textarea
+        key={initialValue}
+        ref={textareaRef}
+        className="prefs-textarea"
+        rows={2}
+        defaultValue={initialValue}
+        onBlur={handleBlur}
+      />
+      {hint && <p className="prefs-hint">{hint}</p>}
+      {error && (
+        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main dialog
+// ---------------------------------------------------------------------------
+
+export function PreferencesDialog(): React.JSX.Element | null {
+  const prefsOpen = useStore((s) => s.prefsOpen)
+  const closePrefs = useStore((s) => s.closePrefs)
+  const loadConfig = useStore((s) => s.loadConfig)
+  const configValues = useStore((s) => s.configValues)
+  const setConfigValue = useStore((s) => s.setConfigValue)
+  const scanLibrary = useStore((s) => s.scanLibrary)
+  const scanStatus = useStore((s) => s.scanStatus)
+  const scanProgress = useStore((s) => s.scanProgress)
+
+  // Load config the first time the dialog opens.
+  useEffect(() => {
+    if (prefsOpen && configValues === null) {
+      void loadConfig()
+    }
+  }, [prefsOpen, configValues, loadConfig])
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!prefsOpen) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') closePrefs()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [prefsOpen, closePrefs])
+
+  if (!prefsOpen) return null
+
+  // Show a loading placeholder while config is being fetched.
+  if (configValues === null) {
+    return (
+      <div className="prefs-overlay">
+        <div className="prefs-dialog">
+          <div className="prefs-header">
+            <span className="prefs-title">PREFERENCES</span>
+            <button className="prefs-close-btn" onClick={closePrefs} aria-label="Close preferences">
+              ✕
+            </button>
+          </div>
+          <div className="prefs-body" />
+        </div>
+      </div>
+    )
+  }
+
+  const hasBandcamp = configValues['bandcamp.username'] !== null
+
+  const str = (key: keyof typeof configValues): string => {
+    const v = configValues[key]
+    return v != null ? String(v) : ''
+  }
+
+  const handleSave = async (key: string, value: string): Promise<void> => {
+    if (INT_KEYS.has(key)) {
+      const n = Number(value)
+      if (!Number.isInteger(n) || n < 0) throw new Error('Must be a non-negative integer')
+    }
+    await setConfigValue(key, value)
+  }
+
+  return (
+    <div className="prefs-overlay" onClick={(e) => e.target === e.currentTarget && closePrefs()}>
+      <div className="prefs-dialog" role="dialog" aria-modal="true" aria-label="Preferences">
+        {/* Title bar */}
+        <div className="prefs-header">
+          <span className="prefs-title">PREFERENCES</span>
+          <button className="prefs-close-btn" onClick={closePrefs} aria-label="Close preferences">
+            ✕
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="prefs-body">
+          {/* PATHS */}
+          <div className="prefs-section">
+            <div className="prefs-section-label">Paths</div>
+            <PathRow
+              label="Library folder"
+              configKey="paths.library"
+              initialValue={str('paths.library')}
+              onSave={handleSave}
+            />
+            <PathRow
+              label="Staging folder"
+              configKey="paths.staging"
+              initialValue={str('paths.staging')}
+              onSave={handleSave}
+            />
+            <div className="prefs-row">
+              <div className="prefs-row-header">
+                <span className="prefs-label">Library index</span>
+              </div>
+              {scanStatus === 'scanning' ? (
+                <div className="prefs-scan-status">
+                  <span className="prefs-scan-scanning">Scanning…</span>
+                  {scanProgress && scanProgress.total > 0 && (
+                    <div className="prefs-scan-progress">
+                      <div
+                        className="prefs-scan-progress-fill"
+                        style={{
+                          width: `${(scanProgress.current / scanProgress.total) * 100}%`
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <button className="prefs-choose-btn" onClick={() => void scanLibrary()}>
+                  Re-scan Library
+                </button>
+              )}
+              {scanStatus === 'done' && <p className="prefs-hint">Scan complete.</p>}
+              {scanStatus === 'error' && (
+                <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+                  Scan failed — check server logs.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* LIBRARY */}
+          <div className="prefs-section">
+            <div className="prefs-section-label">Library</div>
+            <TextareaRow
+              label="Path template"
+              configKey="library.path_template"
+              initialValue={str('library.path_template')}
+              hint="{album_artist}  {year}  {album}  {track}  {title}  {ext}"
+              onSave={handleSave}
+            />
+          </div>
+
+          {/* ARTWORK */}
+          <div className="prefs-section">
+            <div className="prefs-section-label">Artwork</div>
+            <InputRow
+              label="Minimum dimension"
+              configKey="artwork.min_dimension"
+              type="number"
+              unit="px"
+              initialValue={str('artwork.min_dimension')}
+              onSave={handleSave}
+            />
+            <InputRow
+              label="Maximum file size"
+              configKey="artwork.max_bytes"
+              type="number"
+              unit="bytes"
+              initialValue={str('artwork.max_bytes')}
+              onSave={handleSave}
+            />
+          </div>
+
+          {/* MUSICBRAINZ */}
+          <div className="prefs-section">
+            <div className="prefs-section-label">MusicBrainz</div>
+            <InputRow
+              label="Contact email"
+              configKey="musicbrainz.contact"
+              type="email"
+              initialValue={str('musicbrainz.contact')}
+              hint="Sent in MusicBrainz User-Agent; required by their policy."
+              onSave={handleSave}
+            />
+          </div>
+
+          {/* BANDCAMP — only when the section is configured */}
+          {hasBandcamp && (
+            <div className="prefs-section">
+              <div className="prefs-section-label">Bandcamp</div>
+              <InputRow
+                label="Username"
+                configKey="bandcamp.username"
+                initialValue={str('bandcamp.username')}
+                onSave={handleSave}
+              />
+              <SelectRow
+                label="Download format"
+                configKey="bandcamp.format"
+                options={BANDCAMP_FORMATS}
+                initialValue={str('bandcamp.format')}
+                onSave={handleSave}
+              />
+              <InputRow
+                label="Poll interval"
+                configKey="bandcamp.poll_interval_minutes"
+                type="number"
+                unit="min"
+                initialValue={str('bandcamp.poll_interval_minutes')}
+                hint="0 = manual only"
+                onSave={handleSave}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -10,6 +10,7 @@ import { create } from 'zustand'
 import * as api from './api/client'
 import type {
   Album,
+  ConfigValues,
   PlayerState,
   QueueState,
   ScanProgress,
@@ -81,6 +82,14 @@ type PlayerStore = {
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
   applyServerState: (state: PlayerState) => void
+
+  // Preferences
+  configValues: ConfigValues | null
+  prefsOpen: boolean
+  loadConfig: () => Promise<void>
+  setConfigValue: (key: string, value: string) => Promise<void>
+  openPrefs: () => void
+  closePrefs: () => void
 }
 
 const initialPlayer: PlayerState = {
@@ -113,6 +122,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   searchResults: null,
   queueVisible: false,
   queue: null,
+  configValues: null,
+  prefsOpen: false,
 
   setServerStatus: (status) => set({ serverStatus: status }),
 
@@ -377,6 +388,25 @@ export const useStore = create<PlayerStore>((set, get) => ({
     await api.setLibraryPath(path)
     set({ configuredLibraryPath: path })
   },
+
+  loadConfig: async () => {
+    try {
+      const configValues = await api.getConfig()
+      set({ configValues })
+    } catch {
+      // Best-effort — preferences dialog will show empty fields.
+    }
+  },
+
+  setConfigValue: async (key, value) => {
+    await api.patchConfig(key, value)
+    set((s) => ({
+      configValues: s.configValues ? { ...s.configValues, [key]: value } : s.configValues
+    }))
+  },
+
+  openPrefs: () => set({ prefsOpen: true }),
+  closePrefs: () => set({ prefsOpen: false }),
 
   scanLibrary: async () => {
     set({ scanStatus: 'scanning', scanError: null, scanProgress: null })

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -985,3 +985,140 @@ class TestFavoriteEndpoint:
         )
         assert "play_count" in track
         assert track["play_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Config endpoints
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CONFIG_VALUES = {
+    "paths.staging": "~/Music/staging",
+    "paths.library": "~/Music",
+    "musicbrainz.contact": "user@example.com",
+    "artwork.min_dimension": 1000,
+    "artwork.max_bytes": 1000000,
+    "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
+    "bandcamp.username": None,
+    "bandcamp.format": None,
+    "bandcamp.poll_interval_minutes": None,
+}
+
+
+class TestConfigEndpoints:
+    def test_get_config_returns_values(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES,
+        )
+        response = TestClient(app).get("/api/v1/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["paths.staging"] == "~/Music/staging"
+        assert data["paths.library"] == "~/Music"
+        assert data["musicbrainz.contact"] == "user@example.com"
+        assert data["artwork.min_dimension"] == 1000
+        assert data["artwork.max_bytes"] == 1000000
+        assert data["library.path_template"].startswith("{album_artist}")
+        assert data["bandcamp.username"] is None
+
+    def test_get_config_returns_empty_dict_when_not_configured(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        response = TestClient(app).get("/api/v1/config")
+        assert response.status_code == 200
+        assert response.json() == {}
+
+    def test_patch_config_calls_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        received: list[tuple[str, str]] = []
+
+        def _on_config_set(key: str, value: str) -> None:
+            received.append((key, value))
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES.copy(),
+            on_config_set=_on_config_set,
+        )
+        response = TestClient(app).patch(
+            "/api/v1/config", json={"key": "artwork.min_dimension", "value": "500"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        assert received == [("artwork.min_dimension", "500")]
+
+    def test_patch_config_updates_in_memory_state(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES.copy(),
+            on_config_set=lambda k, v: None,
+        )
+        c = TestClient(app)
+        c.patch("/api/v1/config", json={"key": "artwork.min_dimension", "value": "500"})
+        data = c.get("/api/v1/config").json()
+        assert data["artwork.min_dimension"] == 500
+
+    def test_patch_config_returns_422_on_invalid_key(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        def _on_config_set(key: str, value: str) -> None:
+            raise KeyError(f"Unknown config key {key!r}")
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES.copy(),
+            on_config_set=_on_config_set,
+        )
+        response = TestClient(app).patch(
+            "/api/v1/config", json={"key": "nonexistent.key", "value": "foo"}
+        )
+        assert response.status_code == 422
+
+    def test_patch_config_returns_422_on_invalid_value(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        def _on_config_set(key: str, value: str) -> None:
+            raise ValueError(f"Invalid value {value!r}")
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES.copy(),
+            on_config_set=_on_config_set,
+        )
+        response = TestClient(app).patch(
+            "/api/v1/config", json={"key": "bandcamp.format", "value": "invalid-fmt"}
+        )
+        assert response.status_code == 422
+
+    def test_patch_config_coerces_int_values_in_state(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Integer config values should be stored as ints after a PATCH."""
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values=_SAMPLE_CONFIG_VALUES.copy(),
+            on_config_set=lambda k, v: None,
+        )
+        c = TestClient(app)
+        c.patch("/api/v1/config", json={"key": "artwork.max_bytes", "value": "500000"})
+        data = c.get("/api/v1/config").json()
+        assert data["artwork.max_bytes"] == 500000
+        assert isinstance(data["artwork.max_bytes"], int)


### PR DESCRIPTION
## Summary

- Adds `GET /PATCH /api/v1/config` endpoints to expose all user-facing config options over the REST API
- New `PreferencesDialog` modal with sections for Paths, Library, Artwork, MusicBrainz, and Bandcamp (conditional)
- Settings save immediately on blur/change; fields show an ephemeral ✓ on save
- Fields requiring a server restart are marked with a `↺ restart` badge
- Re-scan Library moved from the ArtistPanel footer into the Preferences Paths section
- Library path display and "Change Library…" button removed from ArtistPanel
- Dialog opens via **kamp → Preferences** (native macOS menu) or **Cmd+,** keyboard shortcut
- 7 new server tests covering GET, PATCH, validation, and int coercion

## Test plan

- [x] Open Preferences with Cmd+, and via kamp menu — dialog appears
- [x] All config fields show current values from config.toml
- [x] Edit a field, tab away — value persists after server restart
- [x] Edit a field with an invalid value (e.g. non-integer for min_dimension) — error shown, not saved
- [x] Choose a new library/staging folder via Choose… picker — path updates and saves
- [x] Re-scan Library button triggers a scan; progress bar visible in dialog
- [x] Dismiss with X button and Escape key both work
- [x] ArtistPanel no longer shows path display, rescan button, or Change Library button
- [x] `poetry run pytest --no-cov -q` — 677 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)