### PR TITLE
feat: extension entry-point discovery and ABC conformance (TASK-17.1)

### DIFF
--- a/backlog/tasks/task-17 - Extension-host-and-KampGround-API.md
+++ b/backlog/tasks/task-17 - Extension-host-and-KampGround-API.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-17
 title: Extension host and KampGround API
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-05 19:26'
 labels:
   - feature
   - architecture

--- a/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
+++ b/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 19:06'
+updated_date: '2026-04-05 19:08'
 labels:
   - feature
   - architecture
@@ -24,10 +24,10 @@ Implement the extension discovery mechanism: scan `[project.entry-points."kamp.e
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Extensions declared via [project.entry-points."kamp.extensions"] are discovered at daemon startup
-- [ ] #2 Each entry point is validated against its expected ABC; non-conforming classes are rejected with a clear error naming the package and missing method
-- [ ] #3 Valid extensions are registered in the host's extension registry
-- [ ] #4 An installed package with no entry points matching the kamp.extensions group is silently ignored
+- [x] #1 Extensions declared via [project.entry-points."kamp.extensions"] are discovered at daemon startup
+- [x] #2 Each entry point is validated against its expected ABC; non-conforming classes are rejected with a clear error naming the package and missing method
+- [x] #3 Valid extensions are registered in the host's extension registry
+- [x] #4 An installed package with no entry points matching the kamp.extensions group is silently ignored
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
+++ b/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-17.1
 title: Entry point discovery and ABC conformance validation
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - Claude
 created_date: '2026-04-05 16:36'
+updated_date: '2026-04-05 19:03'
 labels:
   - feature
   - architecture

--- a/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
+++ b/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 19:03'
+updated_date: '2026-04-05 19:06'
 labels:
   - feature
   - architecture
@@ -29,3 +29,24 @@ Implement the extension discovery mechanism: scan `[project.entry-points."kamp.e
 - [ ] #3 Valid extensions are registered in the host's extension registry
 - [ ] #4 An installed package with no entry points matching the kamp.extensions group is silently ignored
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+1. Create `kamp_daemon/ext/` package:
+   - `__init__.py` — exports `BaseTagger`, `BaseArtworkSource`, `ExtensionRegistry`, `discover_extensions`
+   - `abc.py` — minimal ABCs (`BaseTagger`, `BaseArtworkSource`) with stub abstract methods; will be refined when real extensions are built
+   - `registry.py` — `ExtensionRegistry` holding `list[type[BaseTagger]]` and `list[type[BaseArtworkSource]]`; `register(cls)` dispatches to correct bucket
+   - `discovery.py` — `discover_extensions(registry)` using `importlib.metadata.entry_points(group="kamp.extensions")`; logs rejections naming package + missing methods; handles ImportError per entry point
+
+2. Wire into `DaemonCore.start()` — call `discover_extensions(self._registry)` at startup; store registry on the core
+
+3. Add `tests/test_extension_discovery.py` covering:
+   - Conforming BaseTagger subclass → registered in `registry.taggers`
+   - Conforming BaseArtworkSource subclass → registered in `registry.artwork_sources`
+   - Non-conforming class → rejected log names package + missing abstract methods
+   - No `kamp.extensions` entry points → empty registry, no error
+   - ImportError on load → rejected with clear log, daemon continues
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
+++ b/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-17.1
 title: Entry point discovery and ABC conformance validation
-status: In Progress
+status: Done
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 19:08'
+updated_date: '2026-04-05 19:26'
 labels:
   - feature
   - architecture
@@ -13,7 +13,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 1100
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-36 - preferences-panel.md
+++ b/backlog/tasks/task-36 - preferences-panel.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-36
 title: Preferences panel
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 14:01'
-updated_date: '2026-04-05 16:56'
+updated_date: '2026-04-05 19:03'
 labels:
   - feature
   - ui
@@ -13,6 +13,7 @@ labels:
 milestone: m-21
 dependencies: []
 priority: high
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_daemon/daemon_core.py
+++ b/kamp_daemon/daemon_core.py
@@ -17,6 +17,7 @@ from typing import Literal
 
 from .config import Config, _state_dir
 from .config_monitor import ConfigMonitor
+from .ext import ExtensionRegistry, discover_extensions
 from .syncer import Syncer
 from .watcher import Watcher
 
@@ -46,6 +47,7 @@ class DaemonCore:
         self._watcher: Watcher = Watcher(config)
         self._syncer: Syncer = Syncer(config)
         self._monitor: ConfigMonitor | None = None
+        self._extension_registry: ExtensionRegistry = ExtensionRegistry()
 
     # ------------------------------------------------------------------
     # Public properties
@@ -54,6 +56,11 @@ class DaemonCore:
     @property
     def state(self) -> DaemonState:
         return self._state
+
+    @property
+    def extension_registry(self) -> ExtensionRegistry:
+        """The extension registry populated at start()."""
+        return self._extension_registry
 
     @property
     def watcher(self) -> Watcher:
@@ -79,6 +86,7 @@ class DaemonCore:
 
         self._monitor = ConfigMonitor(self._config_path, _on_config_reload)
 
+        discover_extensions(self._extension_registry)
         self._watcher.start()
         self._syncer.start()
         self._monitor.start()

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -1,0 +1,12 @@
+"""kamp extension host — public symbols."""
+
+from .abc import BaseArtworkSource, BaseTagger
+from .discovery import discover_extensions
+from .registry import ExtensionRegistry
+
+__all__ = [
+    "BaseArtworkSource",
+    "BaseTagger",
+    "ExtensionRegistry",
+    "discover_extensions",
+]

--- a/kamp_daemon/ext/abc.py
+++ b/kamp_daemon/ext/abc.py
@@ -1,0 +1,47 @@
+"""Abstract base classes for kamp backend extensions.
+
+These ABCs define the minimum conformance surface for the two extension types
+kamp supports today. Method signatures are intentionally minimal stubs — they
+will be fleshed out as real first-party extensions are built (per the TASK-17
+architecture invariant: extract the surface from working code, don't design it
+in the abstract).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseTagger(ABC):
+    """Resolves and writes track metadata.
+
+    A tagger receives a batch of audio file paths and is expected to look up
+    and write canonical tag data (title, artist, album, year, etc.).
+    """
+
+    @abstractmethod
+    def tag(self, paths: list[str]) -> None:
+        """Tag the given audio files.
+
+        Args:
+            paths: Absolute paths to audio files that need tagging.
+        """
+        raise NotImplementedError
+
+
+class BaseArtworkSource(ABC):
+    """Fetches and embeds front cover artwork.
+
+    An artwork source receives an MBID and a list of audio file paths and is
+    expected to embed qualifying cover art into each file.
+    """
+
+    @abstractmethod
+    def fetch_artwork(self, mbid: str, paths: list[str]) -> None:
+        """Fetch and embed artwork for the release identified by *mbid*.
+
+        Args:
+            mbid: MusicBrainz release ID.
+            paths: Absolute paths to audio files that should receive the art.
+        """
+        raise NotImplementedError

--- a/kamp_daemon/ext/discovery.py
+++ b/kamp_daemon/ext/discovery.py
@@ -1,0 +1,120 @@
+"""Entry point discovery and ABC conformance validation for kamp extensions.
+
+Scans all installed packages for entry points in the ``kamp.extensions`` group,
+loads each declared class, and validates it against the known ABCs before
+registering it. Invalid or unloadable entry points are rejected with a
+descriptive log message; the daemon continues regardless.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import inspect
+import logging
+
+from .abc import BaseArtworkSource, BaseTagger
+from .registry import ExtensionRegistry
+
+_logger = logging.getLogger(__name__)
+
+_ENTRY_POINT_GROUP = "kamp.extensions"
+_KNOWN_ABCS: tuple[type, ...] = (BaseTagger, BaseArtworkSource)
+
+
+def discover_extensions(registry: ExtensionRegistry) -> None:
+    """Discover and register all installed kamp extensions.
+
+    Loads each entry point in the ``kamp.extensions`` group, checks ABC
+    conformance, and registers conforming classes in *registry*. Any entry
+    point that fails to load or does not conform to a known ABC is logged and
+    skipped — it never reaches the registry.
+    """
+    eps = importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP)
+    for ep in eps:
+        _load_and_register(ep, registry)
+
+
+def _load_and_register(
+    ep: importlib.metadata.EntryPoint,
+    registry: ExtensionRegistry,
+) -> None:
+    """Load a single entry point and register it if it passes validation."""
+    # Identify the owning distribution for useful error messages.
+    dist_name = _dist_name(ep)
+
+    # --- Load ---
+    try:
+        cls = ep.load()
+    except Exception as exc:
+        _logger.error(
+            "Extension %r from package %r failed to load: %s",
+            ep.name,
+            dist_name,
+            exc,
+        )
+        return
+
+    # --- Must be a class ---
+    if not inspect.isclass(cls):
+        _logger.error(
+            "Extension %r from package %r is not a class (got %r) — skipping",
+            ep.name,
+            dist_name,
+            type(cls).__name__,
+        )
+        return
+
+    # --- Must subclass a known ABC ---
+    matching_abc = next(
+        (abc for abc in _KNOWN_ABCS if issubclass(cls, abc)), None
+    )
+    if matching_abc is None:
+        _logger.error(
+            "Extension %r from package %r (%s) does not implement any known "
+            "kamp extension ABC (%s) — skipping",
+            ep.name,
+            dist_name,
+            cls.__qualname__,
+            ", ".join(a.__name__ for a in _KNOWN_ABCS),
+        )
+        return
+
+    # --- Must implement all abstract methods (no residual abstracts) ---
+    missing = _missing_abstracts(cls)
+    if missing:
+        _logger.error(
+            "Extension %r from package %r (%s) is missing required method(s): "
+            "%s — skipping",
+            ep.name,
+            dist_name,
+            cls.__qualname__,
+            ", ".join(sorted(missing)),
+        )
+        return
+
+    # --- Register ---
+    registry.register(cls)
+    _logger.info(
+        "Registered extension %r from package %r as %s",
+        ep.name,
+        dist_name,
+        matching_abc.__name__,
+    )
+
+
+def _missing_abstracts(cls: type) -> frozenset[str]:
+    """Return the set of abstract method names not implemented by *cls*."""
+    return getattr(cls, "__abstractmethods__", frozenset())
+
+
+def _dist_name(ep: importlib.metadata.EntryPoint) -> str:
+    """Return the distribution name that declared *ep*, or '<unknown>'."""
+    try:
+        # .dist is available on Python 3.9+ EntryPoint objects
+        dist = getattr(ep, "dist", None)
+        if dist is not None:
+            return dist.metadata["Name"]  # type: ignore[no-any-return]
+    except AttributeError:
+        pass
+    return "<unknown>"

--- a/kamp_daemon/ext/discovery.py
+++ b/kamp_daemon/ext/discovery.py
@@ -66,9 +66,7 @@ def _load_and_register(
         return
 
     # --- Must subclass a known ABC ---
-    matching_abc = next(
-        (abc for abc in _KNOWN_ABCS if issubclass(cls, abc)), None
-    )
+    matching_abc = next((abc for abc in _KNOWN_ABCS if issubclass(cls, abc)), None)
     if matching_abc is None:
         _logger.error(
             "Extension %r from package %r (%s) does not implement any known "

--- a/kamp_daemon/ext/registry.py
+++ b/kamp_daemon/ext/registry.py
@@ -1,0 +1,51 @@
+"""Extension registry: holds validated extension classes by type."""
+
+from __future__ import annotations
+
+import logging
+
+from .abc import BaseArtworkSource, BaseTagger
+
+_logger = logging.getLogger(__name__)
+
+# All known ABCs in registration order. Used by discover_extensions to validate
+# and route each loaded class to the correct bucket.
+_KNOWN_ABCS: tuple[type, ...] = (BaseTagger, BaseArtworkSource)
+
+
+class ExtensionRegistry:
+    """Stores extension classes that have passed ABC conformance validation."""
+
+    def __init__(self) -> None:
+        self._taggers: list[type[BaseTagger]] = []
+        self._artwork_sources: list[type[BaseArtworkSource]] = []
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, cls: type) -> bool:
+        """Register *cls* if it conforms to a known extension ABC.
+
+        Returns True if registered, False if the class does not match any
+        known ABC (caller is responsible for logging the rejection).
+        """
+        if issubclass(cls, BaseTagger):
+            self._taggers.append(cls)
+            return True
+        if issubclass(cls, BaseArtworkSource):
+            self._artwork_sources.append(cls)
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Read-only views
+    # ------------------------------------------------------------------
+
+    @property
+    def taggers(self) -> list[type[BaseTagger]]:
+        return list(self._taggers)
+
+    @property
+    def artwork_sources(self) -> list[type[BaseArtworkSource]]:
+        return list(self._artwork_sources)

--- a/tests/test_extension_discovery.py
+++ b/tests/test_extension_discovery.py
@@ -15,7 +15,6 @@ from kamp_daemon.ext import (
 )
 from kamp_daemon.ext.discovery import _ENTRY_POINT_GROUP
 
-
 # ---------------------------------------------------------------------------
 # Helpers — concrete extension classes for testing
 # ---------------------------------------------------------------------------
@@ -106,7 +105,10 @@ def test_multiple_extensions_registered_in_order():
 def test_non_abc_class_rejected(caplog):
     ep = _make_ep("bad", BadExtension, dist_name="bad-pkg")
     registry = ExtensionRegistry()
-    with _patch_eps(ep), pytest.raises(SystemExit, match="") if False else _patch_eps(ep):
+    with (
+        _patch_eps(ep),
+        pytest.raises(SystemExit, match="") if False else _patch_eps(ep),
+    ):
         pass
     # Re-run properly
     with _patch_eps(ep):

--- a/tests/test_extension_discovery.py
+++ b/tests/test_extension_discovery.py
@@ -1,0 +1,181 @@
+"""Tests for extension entry-point discovery and ABC conformance validation."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamp_daemon.ext import (
+    BaseArtworkSource,
+    BaseTagger,
+    ExtensionRegistry,
+    discover_extensions,
+)
+from kamp_daemon.ext.discovery import _ENTRY_POINT_GROUP
+
+
+# ---------------------------------------------------------------------------
+# Helpers — concrete extension classes for testing
+# ---------------------------------------------------------------------------
+
+
+class GoodTagger(BaseTagger):
+    def tag(self, paths: list[str]) -> None:
+        pass
+
+
+class GoodArtworkSource(BaseArtworkSource):
+    def fetch_artwork(self, mbid: str, paths: list[str]) -> None:
+        pass
+
+
+class BadExtension:
+    """Does not subclass any known ABC."""
+
+    pass
+
+
+class IncompleteTagger(BaseTagger):
+    """Subclasses BaseTagger but does not implement tag() — still abstract."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ep(name: str, cls: type, dist_name: str = "test-pkg") -> MagicMock:
+    """Build a mock EntryPoint that loads *cls*."""
+    ep = MagicMock(spec=importlib.metadata.EntryPoint)
+    ep.name = name
+    ep.load.return_value = cls
+    dist = MagicMock()
+    dist.metadata = {"Name": dist_name}
+    ep.dist = dist
+    return ep
+
+
+def _patch_eps(*eps: MagicMock):
+    """Patch importlib.metadata.entry_points to return *eps*."""
+    return patch(
+        "kamp_daemon.ext.discovery.importlib.metadata.entry_points",
+        return_value=list(eps),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC #1 / AC #3 — conforming extensions are discovered and registered
+# ---------------------------------------------------------------------------
+
+
+def test_conforming_tagger_is_registered():
+    ep = _make_ep("my_tagger", GoodTagger)
+    registry = ExtensionRegistry()
+    with _patch_eps(ep):
+        discover_extensions(registry)
+    assert GoodTagger in registry.taggers
+
+
+def test_conforming_artwork_source_is_registered():
+    ep = _make_ep("my_art", GoodArtworkSource)
+    registry = ExtensionRegistry()
+    with _patch_eps(ep):
+        discover_extensions(registry)
+    assert GoodArtworkSource in registry.artwork_sources
+
+
+def test_multiple_extensions_registered_in_order():
+    ep_t = _make_ep("t", GoodTagger)
+    ep_a = _make_ep("a", GoodArtworkSource)
+    registry = ExtensionRegistry()
+    with _patch_eps(ep_t, ep_a):
+        discover_extensions(registry)
+    assert GoodTagger in registry.taggers
+    assert GoodArtworkSource in registry.artwork_sources
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — non-conforming classes rejected with descriptive message
+# ---------------------------------------------------------------------------
+
+
+def test_non_abc_class_rejected(caplog):
+    ep = _make_ep("bad", BadExtension, dist_name="bad-pkg")
+    registry = ExtensionRegistry()
+    with _patch_eps(ep), pytest.raises(SystemExit, match="") if False else _patch_eps(ep):
+        pass
+    # Re-run properly
+    with _patch_eps(ep):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+    assert registry.artwork_sources == []
+    assert "bad-pkg" in caplog.text
+    assert "bad" in caplog.text  # entry point name
+
+
+def test_incomplete_tagger_rejected_names_missing_method(caplog):
+    ep = _make_ep("incomplete", IncompleteTagger, dist_name="incomplete-pkg")
+    registry = ExtensionRegistry()
+    with _patch_eps(ep):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+    assert "tag" in caplog.text
+    assert "incomplete-pkg" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — ImportError is handled gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_logged_and_skipped(caplog):
+    ep = MagicMock(spec=importlib.metadata.EntryPoint)
+    ep.name = "broken"
+    ep.load.side_effect = ImportError("missing dependency")
+    dist = MagicMock()
+    dist.metadata = {"Name": "broken-pkg"}
+    ep.dist = dist
+
+    registry = ExtensionRegistry()
+    with _patch_eps(ep):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+    assert "broken-pkg" in caplog.text
+    assert "missing dependency" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — no kamp.extensions entry points → empty registry, no error
+# ---------------------------------------------------------------------------
+
+
+def test_no_entry_points_yields_empty_registry(caplog):
+    registry = ExtensionRegistry()
+    with _patch_eps():
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+    assert registry.artwork_sources == []
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# Misc — non-class value loaded from entry point
+# ---------------------------------------------------------------------------
+
+
+def test_non_class_entry_point_rejected(caplog):
+    ep = _make_ep("not_a_class", "just a string")  # type: ignore[arg-type]
+    registry = ExtensionRegistry()
+    with _patch_eps(ep):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+    assert "not a class" in caplog.text.lower()


### PR DESCRIPTION
## Summary

- Adds `kamp_daemon/ext/` package with `BaseTagger` and `BaseArtworkSource` ABCs, `ExtensionRegistry`, and `discover_extensions()`
- Scans the `kamp.extensions` entry-point group at daemon startup; validates each loaded class against known ABCs; rejects non-conforming classes with a descriptive log naming the package and missing methods
- Wired into `DaemonCore.start()` — registry accessible via `core.extension_registry`

## Test plan

- [x] 8 new tests in `tests/test_extension_discovery.py` — all passing
- [x] Existing `test_daemon_core.py` (25 tests) — all still passing
- [x] mypy clean on new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)