### PR TITLE
feat: extension worker subprocess lifecycle and crash isolation (TASK-17.2)

### DIFF
--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -3,10 +3,12 @@
 from .abc import BaseArtworkSource, BaseTagger
 from .discovery import discover_extensions
 from .registry import ExtensionRegistry
+from .worker import invoke_extension
 
 __all__ = [
     "BaseArtworkSource",
     "BaseTagger",
     "ExtensionRegistry",
     "discover_extensions",
+    "invoke_extension",
 ]

--- a/kamp_daemon/ext/worker.py
+++ b/kamp_daemon/ext/worker.py
@@ -1,0 +1,142 @@
+"""Subprocess worker for extension method invocations.
+
+Each call to invoke_extension() runs the extension method inside a fresh
+spawn-context subprocess. A crash (unhandled exception or segfault) is caught
+here: the failure is logged and False is returned — the daemon never raises and
+continues processing other items.
+
+The pattern mirrors pipeline.py; see that module for the rationale behind the
+spawn context and the QueueHandler cleanup in the worker's finally block.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import multiprocessing
+import queue
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Worker entry point (runs inside the subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _extension_worker(
+    cls: type,
+    method_name: str,
+    args: tuple[Any, ...],
+    log_q: Any,
+    result_q: Any,
+) -> None:
+    """Subprocess entry point: instantiate *cls* and call *method_name*(*args).
+
+    Logging is forwarded to the parent via log_q.  The QueueHandler is removed
+    in the finally block so that _replay_log_queue re-emission in tests does not
+    loop back through the root logger's handler (same invariant as pipeline.py).
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    queue_handler = logging.handlers.QueueHandler(log_q)
+    root.addHandler(queue_handler)
+    try:
+        instance = cls()
+        getattr(instance, method_name)(*args)
+        result_q.put(("ok", None))
+    except Exception as exc:  # noqa: BLE001
+        result_q.put(("error", str(exc)))
+    finally:
+        root.removeHandler(queue_handler)
+
+
+# ---------------------------------------------------------------------------
+# Spawn helper (pragma: no cover — real subprocess, not run in unit tests)
+# ---------------------------------------------------------------------------
+
+
+def _spawn_extension_worker(
+    cls: type,
+    method_name: str,
+    args: tuple[Any, ...],
+) -> tuple[Any, Any, Any]:
+    """Spawn an isolated subprocess running _extension_worker.
+
+    Uses 'spawn' so the child starts with a clean interpreter.
+    Returns (proc, log_q, result_q).
+    """  # pragma: no cover
+    ctx = multiprocessing.get_context("spawn")
+    log_q: Any = ctx.Queue()
+    result_q: Any = ctx.Queue()
+    proc = ctx.Process(
+        target=_extension_worker,
+        args=(cls, method_name, args, log_q, result_q),
+    )
+    proc.start()
+    return proc, log_q, result_q
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def invoke_extension(cls: type, method_name: str, *args: Any) -> bool:
+    """Invoke cls().method_name(*args) in an isolated subprocess.
+
+    Returns True on success, False on any failure (exception or crash).  Never
+    raises — callers can unconditionally continue after a False return.
+    """
+    proc, log_q, result_q = _spawn_extension_worker(cls, method_name, args)
+
+    # Drain log_q while the subprocess runs to prevent the OS pipe from
+    # filling and blocking the child (same pattern as pipeline.py).
+    while proc.is_alive():  # pragma: no cover
+        _drain_log_queue(log_q)
+
+    proc.join()
+    _drain_log_queue(log_q)
+
+    # Non-zero exit code indicates a hard crash (e.g. segfault) — the worker
+    # never got to put a result on result_q.
+    if proc.exitcode != 0:
+        _logger.error(
+            "Extension worker for %s.%s exited with code %d (crash)",
+            cls.__qualname__,
+            method_name,
+            proc.exitcode,
+        )
+        return False
+
+    try:
+        status, value = result_q.get_nowait()
+    except queue.Empty:  # pragma: no cover
+        _logger.error(
+            "Extension worker for %s.%s exited without a result",
+            cls.__qualname__,
+            method_name,
+        )
+        return False
+
+    if status == "error":
+        _logger.error(
+            "Extension %s.%s failed: %s",
+            cls.__qualname__,
+            method_name,
+            value,
+        )
+        return False
+
+    return True
+
+
+def _drain_log_queue(log_q: Any) -> None:
+    """Re-emit log records from the subprocess into the parent's log handlers."""
+    while True:
+        try:
+            record = log_q.get_nowait()
+            logging.getLogger(record.name).handle(record)
+        except queue.Empty:
+            break

--- a/tests/test_extension_worker.py
+++ b/tests/test_extension_worker.py
@@ -1,0 +1,175 @@
+"""Tests for the extension worker subprocess (worker.py)."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue as _queue_module
+from typing import Any
+from unittest.mock import patch
+
+from kamp_daemon.ext.worker import _extension_worker, _drain_log_queue, invoke_extension
+
+# ---------------------------------------------------------------------------
+# Concrete extension class used across tests
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Records calls so tests can assert the method was invoked."""
+
+    calls: list[tuple[Any, ...]] = []
+
+    def run(self, *args: Any) -> None:
+        _Recorder.calls.append(args)
+
+    def explode(self, *args: Any) -> None:
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Inline worker helper (mirrors test_pipeline_subprocess.py pattern)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, exitcode: int = 0) -> None:
+        self.exitcode = exitcode
+
+    def join(self, timeout: object = None) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return False
+
+
+def _inline_worker(
+    cls: type, method_name: str, args: tuple[Any, ...]
+) -> tuple[Any, Any, Any]:
+    """Run _extension_worker synchronously in-process."""
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    _extension_worker(cls, method_name, args, log_q, result_q)
+    return _FakeProc(), log_q, result_q
+
+
+def _crash_worker(
+    cls: type, method_name: str, args: tuple[Any, ...]
+) -> tuple[Any, Any, Any]:
+    """Simulate a hard crash (non-zero exitcode, empty result_q)."""
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    return _FakeProc(exitcode=139), log_q, result_q  # 139 = SIGSEGV
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — extension methods run inside a subprocess
+# ---------------------------------------------------------------------------
+
+
+def test_success_returns_true() -> None:
+    _Recorder.calls = []
+    with patch(
+        "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
+    ):
+        result = invoke_extension(_Recorder, "run", "a", "b")
+    assert result is True
+    assert _Recorder.calls == [("a", "b")]
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — crash / exception quarantines item, daemon continues
+# ---------------------------------------------------------------------------
+
+
+def test_exception_in_worker_returns_false(caplog: Any) -> None:
+    with patch(
+        "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
+    ):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.worker"):
+            result = invoke_extension(_Recorder, "explode")
+    assert result is False
+    assert "boom" in caplog.text
+
+
+def test_exception_does_not_raise() -> None:
+    """invoke_extension must never propagate the worker's exception."""
+    with patch(
+        "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
+    ):
+        result = invoke_extension(_Recorder, "explode")
+    assert result is False  # no exception raised
+
+
+def test_non_zero_exitcode_returns_false(caplog: Any) -> None:
+    """A segfault (non-zero exitcode, empty result_q) is handled gracefully."""
+    with patch(
+        "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_crash_worker
+    ):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.worker"):
+            result = invoke_extension(_Recorder, "run")
+    assert result is False
+    assert "139" in caplog.text or "crash" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — worker cleans up QueueHandler; no re-emission loop
+# ---------------------------------------------------------------------------
+
+
+def test_queue_handler_removed_after_worker() -> None:
+    """Root logger must not retain the QueueHandler after the worker exits."""
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    _extension_worker(_Recorder, "run", (), log_q, result_q)
+
+    assert root.handlers == handlers_before
+
+
+def test_no_reemission_loop_on_second_drain() -> None:
+    """Draining log_q twice must not produce duplicate records.
+
+    If the QueueHandler is left on the root logger, _drain_log_queue re-emits
+    records via the logger hierarchy which loops back into the queue.  This test
+    verifies the queue is empty after the first drain.
+    """
+    log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+    result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+
+    # Worker emits one log record internally during instantiation/call
+    _extension_worker(_Recorder, "run", ("x",), log_q, result_q)
+
+    _drain_log_queue(log_q)  # first drain — clears the queue
+    assert log_q.empty(), "Queue should be empty after first drain"
+
+
+# ---------------------------------------------------------------------------
+# AC #3 / AC #4 — log records replayed in parent; subprocess exits cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_log_records_replayed_in_parent() -> None:
+    """Log records emitted by the worker are forwarded to the parent's handlers."""
+
+    class _LoggingExtension:
+        def run(self) -> None:
+            logging.getLogger("kamp_daemon.ext.worker").info("hello from worker")
+
+    records: list[logging.LogRecord] = []
+    handler = logging.handlers.MemoryHandler(capacity=100, flushLevel=logging.CRITICAL)
+    target = logging.getLogger("kamp_daemon.ext.worker")
+    target.addHandler(handler)
+    target.setLevel(logging.DEBUG)
+    try:
+        with patch(
+            "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
+        ):
+            invoke_extension(_LoggingExtension, "run")
+        records = list(handler.buffer)
+    finally:
+        target.removeHandler(handler)
+
+    assert any("hello from worker" in r.getMessage() for r in records)


### PR DESCRIPTION
## Summary

- Adds `kamp_daemon/ext/worker.py` with `invoke_extension(cls, method_name, *args) -> bool`
- Each extension call runs in a fresh spawn-context subprocess — crashes are fully isolated from the daemon
- Exceptions and hard crashes (non-zero exitcode / segfault) are caught, logged, and return `False`; the daemon never raises
- Worker removes its `QueueHandler` in `finally` to prevent log re-emission loops when running inline in tests (same invariant as `pipeline.py`)
- `invoke_extension` exported from `kamp_daemon/ext/__init__.py`

## Test plan

- [x] 7 new tests in `tests/test_extension_worker.py` — all passing
- [x] mypy + black clean
- [x] Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)