### PR TITLE
feat: KampContext structured data types and corrected ABC signatures (TASK-17.3)

### DIFF
--- a/backlog/tasks/task-17.2 - Worker-subprocess-lifecycle-and-crash-isolation.md
+++ b/backlog/tasks/task-17.2 - Worker-subprocess-lifecycle-and-crash-isolation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17.2
 title: Worker subprocess lifecycle and crash isolation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-05 16:36'
 labels:

--- a/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
+++ b/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 20:13'
+updated_date: '2026-04-05 20:14'
 labels:
   - feature
   - architecture
@@ -26,10 +26,10 @@ Initial types needed: `TrackMetadata`, `ArtworkQuery`, `ArtworkResult`. Addition
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TrackMetadata, ArtworkQuery, and ArtworkResult are defined as typed dataclasses or similar
-- [ ] #2 All fields use Python primitive types or other KampContext types; no pathlib.Path, no SQLite connections, no internal daemon types
-- [ ] #3 Types are importable from a public kamp.extensions module
-- [ ] #4 Types are serialisable (can round-trip through the worker subprocess IPC boundary)
+- [x] #1 TrackMetadata, ArtworkQuery, and ArtworkResult are defined as typed dataclasses or similar
+- [x] #2 All fields use Python primitive types or other KampContext types; no pathlib.Path, no SQLite connections, no internal daemon types
+- [x] #3 Types are importable from a public kamp.extensions module
+- [x] #4 Types are serialisable (can round-trip through the worker subprocess IPC boundary)
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
+++ b/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 20:12'
+updated_date: '2026-04-05 20:13'
 labels:
   - feature
   - architecture
@@ -31,3 +31,23 @@ Initial types needed: `TrackMetadata`, `ArtworkQuery`, `ArtworkResult`. Addition
 - [ ] #3 Types are importable from a public kamp.extensions module
 - [ ] #4 Types are serialisable (can round-trip through the worker subprocess IPC boundary)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+1. `kamp_daemon/ext/types.py` — three @dataclass definitions:
+   - TrackMetadata: title, artist, album, album_artist, year (str), track_number (int), mbid (str)
+   - ArtworkQuery: mbid, release_group_mbid, album, artist (all str)
+   - ArtworkResult: image_bytes (bytes), mime_type (str)
+
+2. Update ABC signatures in `kamp_daemon/ext/abc.py` to match ideation doc:
+   - BaseTagger.tag(self, track: TrackMetadata) -> TrackMetadata
+   - BaseArtworkSource.fetch(self, query: ArtworkQuery) -> ArtworkResult | None
+   (previous stubs used wrong method names and list[str] args)
+
+3. Export types from `kamp_daemon/ext/__init__.py`
+
+4. `tests/test_extension_types.py` — field/type checks + pickle round-trip for all three types
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
+++ b/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-17.3
 title: KampContext structured data types
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - Claude
 created_date: '2026-04-05 16:36'
+updated_date: '2026-04-05 20:12'
 labels:
   - feature
   - architecture

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -3,12 +3,16 @@
 from .abc import BaseArtworkSource, BaseTagger
 from .discovery import discover_extensions
 from .registry import ExtensionRegistry
+from .types import ArtworkQuery, ArtworkResult, TrackMetadata
 from .worker import invoke_extension
 
 __all__ = [
+    "ArtworkQuery",
+    "ArtworkResult",
     "BaseArtworkSource",
     "BaseTagger",
     "ExtensionRegistry",
+    "TrackMetadata",
     "discover_extensions",
     "invoke_extension",
 ]

--- a/kamp_daemon/ext/abc.py
+++ b/kamp_daemon/ext/abc.py
@@ -1,47 +1,35 @@
-"""Abstract base classes for kamp backend extensions.
-
-These ABCs define the minimum conformance surface for the two extension types
-kamp supports today. Method signatures are intentionally minimal stubs — they
-will be fleshed out as real first-party extensions are built (per the TASK-17
-architecture invariant: extract the surface from working code, don't design it
-in the abstract).
-"""
+"""Abstract base classes for kamp backend extensions."""
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from .types import ArtworkQuery, ArtworkResult, TrackMetadata
+
 
 class BaseTagger(ABC):
-    """Resolves and writes track metadata.
+    """Resolves track metadata.
 
-    A tagger receives a batch of audio file paths and is expected to look up
-    and write canonical tag data (title, artist, album, year, etc.).
+    Receives a TrackMetadata object, enriches or corrects it, and returns
+    the updated object.  The host writes the result to disk — the tagger
+    never touches audio files directly.
     """
 
     @abstractmethod
-    def tag(self, paths: list[str]) -> None:
-        """Tag the given audio files.
-
-        Args:
-            paths: Absolute paths to audio files that need tagging.
-        """
+    def tag(self, track: TrackMetadata) -> TrackMetadata:
+        """Return an updated copy of *track* with resolved metadata."""
         raise NotImplementedError
 
 
 class BaseArtworkSource(ABC):
-    """Fetches and embeds front cover artwork.
+    """Fetches front cover artwork.
 
-    An artwork source receives an MBID and a list of audio file paths and is
-    expected to embed qualifying cover art into each file.
+    Receives an ArtworkQuery and returns an ArtworkResult, or None if no
+    qualifying art could be found.  The host embeds the result — the source
+    never touches audio files directly.
     """
 
     @abstractmethod
-    def fetch_artwork(self, mbid: str, paths: list[str]) -> None:
-        """Fetch and embed artwork for the release identified by *mbid*.
-
-        Args:
-            mbid: MusicBrainz release ID.
-            paths: Absolute paths to audio files that should receive the art.
-        """
+    def fetch(self, query: ArtworkQuery) -> ArtworkResult | None:
+        """Return artwork for *query*, or None if unavailable."""
         raise NotImplementedError

--- a/kamp_daemon/ext/types.py
+++ b/kamp_daemon/ext/types.py
@@ -1,0 +1,54 @@
+"""Structured data types for the kamp extension host.
+
+Extensions receive and return these types exclusively — no file paths, no
+database handles, no internal daemon objects.  All fields are Python primitives
+so instances are picklable across the worker subprocess IPC boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TrackMetadata:
+    """Canonical metadata for a single track.
+
+    Passed to BaseTagger.tag(); the tagger returns an updated instance.
+    Fields that the tagger cannot resolve should be returned unchanged.
+    """
+
+    title: str
+    artist: str
+    album: str
+    album_artist: str
+    year: str
+    track_number: int
+    mbid: str  # MusicBrainz release MBID
+
+
+@dataclass
+class ArtworkQuery:
+    """Parameters passed to BaseArtworkSource.fetch().
+
+    Provides enough context for an artwork source to locate the correct
+    image without receiving any file path or internal database handle.
+    """
+
+    mbid: str  # MusicBrainz release MBID
+    release_group_mbid: str
+    album: str
+    artist: str
+
+
+@dataclass
+class ArtworkResult:
+    """Artwork returned by BaseArtworkSource.fetch().
+
+    image_bytes is the raw image data; mime_type is "image/jpeg" or
+    "image/png".  The host is responsible for embedding the bytes into
+    audio files — the extension never touches the filesystem.
+    """
+
+    image_bytes: bytes
+    mime_type: str

--- a/project/kampground-ideation.md
+++ b/project/kampground-ideation.md
@@ -2,7 +2,7 @@
 
 ## What is possible with kampground?
 
-Ideally, anything that's supported by the database and the renderer — and that includes everything the built-in features do. Bandcamp sync, MusicBrainz tagging, and artwork fetching must all be buildable using the public `KampContext` API. This invariant keeps the SDK honest: the API surface is extracted from two real working extensions, not designed in the abstract first.
+Ideally, anything that's supported by the database and the renderer — and that includes everything the built-in features do. Bandcamp sync, MusicBrainz tagging, and artwork fetching must all be buildable using the public `KampGround` API. This invariant keeps the SDK honest: the API surface is extracted from two real working extensions, not designed in the abstract first.
 
 The extensions directory is watched; extensions reload on file change.
 
@@ -22,7 +22,7 @@ Every extension — frontend and backend — declares the permissions it needs i
 - `settings` — read and write the extension's own settings namespace
 
 **Backend permissions:**
-- `network.external` — make HTTP/HTTPS requests via `KampContext.fetch(url, method, body)`. The host makes the request; the extension never calls the network directly. The manifest must also declare an allowlist of permitted domains (`network.domains = ["api.discogs.com"]`); requests to unlisted domains are rejected.
+- `network.external` — make HTTP/HTTPS requests via `KampGround.fetch(url, method, body)`. The host makes the request; the extension never calls the network directly. The manifest must also declare an allowlist of permitted domains (`network.domains = ["api.discogs.com"]`); requests to unlisted domains are rejected.
 - `audio.read` — receive raw audio data for the track being processed (e.g. for fingerprinting); the host mediates the read, the extension never receives a file path
 - `library.write` — modify library metadata via a set of named atomic operations: `update_metadata(track_id, fields)`, `set_artwork(track_id, bytes)`. No bulk deletes, no raw SQL. Every write is logged to an append-only audit table (`extension_id`, `operation`, `old_value`, `new_value`, `timestamp`) enabling rollback of any extension's changes.
 

--- a/tests/test_extension_discovery.py
+++ b/tests/test_extension_discovery.py
@@ -8,9 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kamp_daemon.ext import (
+    ArtworkQuery,
+    ArtworkResult,
     BaseArtworkSource,
     BaseTagger,
     ExtensionRegistry,
+    TrackMetadata,
     discover_extensions,
 )
 from kamp_daemon.ext.discovery import _ENTRY_POINT_GROUP
@@ -21,13 +24,13 @@ from kamp_daemon.ext.discovery import _ENTRY_POINT_GROUP
 
 
 class GoodTagger(BaseTagger):
-    def tag(self, paths: list[str]) -> None:
-        pass
+    def tag(self, track: TrackMetadata) -> TrackMetadata:
+        return track
 
 
 class GoodArtworkSource(BaseArtworkSource):
-    def fetch_artwork(self, mbid: str, paths: list[str]) -> None:
-        pass
+    def fetch(self, query: ArtworkQuery) -> ArtworkResult | None:
+        return None
 
 
 class BadExtension:

--- a/tests/test_extension_types.py
+++ b/tests/test_extension_types.py
@@ -1,0 +1,82 @@
+"""Tests for KampContext structured data types."""
+
+from __future__ import annotations
+
+import pickle
+
+from kamp_daemon.ext import ArtworkQuery, ArtworkResult, TrackMetadata
+
+# ---------------------------------------------------------------------------
+# AC #1 / AC #2 — types exist with correct primitive fields
+# ---------------------------------------------------------------------------
+
+
+def test_track_metadata_fields() -> None:
+    t = TrackMetadata(
+        title="Tha Carter III",
+        artist="Lil Wayne",
+        album="Tha Carter III",
+        album_artist="Lil Wayne",
+        year="2008",
+        track_number=1,
+        mbid="abc-123",
+    )
+    assert t.title == "Tha Carter III"
+    assert t.artist == "Lil Wayne"
+    assert t.album == "Tha Carter III"
+    assert t.album_artist == "Lil Wayne"
+    assert t.year == "2008"
+    assert t.track_number == 1
+    assert t.mbid == "abc-123"
+
+
+def test_artwork_query_fields() -> None:
+    q = ArtworkQuery(
+        mbid="rel-456",
+        release_group_mbid="rg-789",
+        album="Madvillainy",
+        artist="Madvillain",
+    )
+    assert q.mbid == "rel-456"
+    assert q.release_group_mbid == "rg-789"
+    assert q.album == "Madvillainy"
+    assert q.artist == "Madvillain"
+
+
+def test_artwork_result_fields() -> None:
+    r = ArtworkResult(image_bytes=b"\xff\xd8\xff", mime_type="image/jpeg")
+    assert r.image_bytes == b"\xff\xd8\xff"
+    assert r.mime_type == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — picklable across subprocess IPC boundary
+# ---------------------------------------------------------------------------
+
+
+def test_track_metadata_pickle_roundtrip() -> None:
+    original = TrackMetadata(
+        title="Alright",
+        artist="Kendrick Lamar",
+        album="To Pimp a Butterfly",
+        album_artist="Kendrick Lamar",
+        year="2015",
+        track_number=7,
+        mbid="deadbeef",
+    )
+    assert pickle.loads(pickle.dumps(original)) == original
+
+
+def test_artwork_query_pickle_roundtrip() -> None:
+    original = ArtworkQuery(
+        mbid="m1",
+        release_group_mbid="rg1",
+        album="Illmatic",
+        artist="Nas",
+    )
+    assert pickle.loads(pickle.dumps(original)) == original
+
+
+def test_artwork_result_pickle_roundtrip() -> None:
+    original = ArtworkResult(image_bytes=b"\x89PNG", mime_type="image/png")
+    assert pickle.loads(pickle.dumps(original)) == original


### PR DESCRIPTION
## Summary

- Adds `kamp_daemon/ext/types.py` with `TrackMetadata`, `ArtworkQuery`, and `ArtworkResult` dataclasses
- All fields are Python primitives — no `pathlib.Path`, no internal daemon types, fully picklable across the worker subprocess IPC boundary
- Corrects `BaseTagger.tag()` and `BaseArtworkSource.fetch()` signatures to match the kampground ideation spec (typed objects in/out, not `list[str]`)
- All three types exported from `kamp_daemon/ext/__init__.py`

## Test plan

- [ ] 6 new tests in `tests/test_extension_types.py` (field checks + pickle round-trips) — all passing
- [ ] Updated `test_extension_discovery.py` fixtures to use correct signatures — all passing
- [ ] mypy + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)