### PR TITLE
feat: library.write — named atomic mutations on KampGround (TASK-17.6)

### DIFF
--- a/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
+++ b/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
@@ -4,6 +4,7 @@ title: library.write — named atomic mutations on KampGround
 status: In Progress
 assignee: []
 created_date: '2026-04-06 01:26'
+updated_date: '2026-04-06 01:41'
 labels:
   - feature
   - 'estimate: side'
@@ -21,8 +22,8 @@ Expose `library.write` capability on KampGround as named atomic mutations (`upda
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 KampGround.update_metadata(mbid, fields) queues a metadata update to be applied by the host after the worker completes
-- [ ] #2 KampGround.set_artwork(mbid, artwork_result) queues an artwork write to be applied by the host after the worker completes
-- [ ] #3 Mutations are collected as a list on KampGround and returned to the host via the result queue; the host applies them — no direct DB access from the worker subprocess
-- [ ] #4 Extensions cannot access the database directly through KampGround
+- [x] #1 KampGround.update_metadata(mbid, fields) queues a metadata update to be applied by the host after the worker completes
+- [x] #2 KampGround.set_artwork(mbid, artwork_result) queues an artwork write to be applied by the host after the worker completes
+- [x] #3 Mutations are collected as a list on KampGround and returned to the host via the result queue; the host applies them — no direct DB access from the worker subprocess
+- [x] #4 Extensions cannot access the database directly through KampGround
 <!-- AC:END -->

--- a/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
+++ b/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
@@ -1,0 +1,28 @@
+---
+id: TASK-17.6
+title: library.write — named atomic mutations on KampGround
+status: In Progress
+assignee: []
+created_date: '2026-04-06 01:26'
+labels:
+  - feature
+  - 'estimate: side'
+milestone: m-2
+dependencies: []
+parent_task_id: TASK-17
+ordinal: 1600
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose `library.write` capability on KampGround as named atomic mutations (`update_metadata`, `set_artwork`). Extensions must never have raw database access — all writes go through these methods, which the host executes on behalf of the extension after the worker returns.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 KampGround.update_metadata(mbid, fields) queues a metadata update to be applied by the host after the worker completes
+- [ ] #2 KampGround.set_artwork(mbid, artwork_result) queues an artwork write to be applied by the host after the worker completes
+- [ ] #3 Mutations are collected as a list on KampGround and returned to the host via the result queue; the host applies them — no direct DB access from the worker subprocess
+- [ ] #4 Extensions cannot access the database directly through KampGround
+<!-- AC:END -->

--- a/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
+++ b/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
@@ -1,17 +1,17 @@
 ---
 id: TASK-17.6
 title: library.write — named atomic mutations on KampGround
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-06 01:26'
-updated_date: '2026-04-06 01:41'
+updated_date: '2026-04-06 01:58'
 labels:
   - feature
   - 'estimate: side'
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 1600
+ordinal: 5200
 ---
 
 ## Description

--- a/backlog/tasks/task-88 - auto-tagging-should-fall-back-to-existing-artist-album-tags.md
+++ b/backlog/tasks/task-88 - auto-tagging-should-fall-back-to-existing-artist-album-tags.md
@@ -1,0 +1,24 @@
+---
+id: TASK-88
+title: auto-tagging should fall back to existing artist/album tags
+status: To Do
+assignee: []
+created_date: '2026-04-06 02:33'
+labels: []
+milestone: m-6
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+occasionally, a musicbrainz lookup will mis-tag files, especially newer releases from indies that may not be in the database yet.
+
+If the MusicBrainz lookup doesn't agree with the existing Artist and Album Title tags, log a warning and don't trust the MusicBrainz tag: skip ID3 tags, and move to the album art tagging so the file ends up in the library with the correct tags.
+
+Make this behavior configurable:
+[musicbrainz]
+trust-musicbrainz-when-tags-conflict = false
+
+Expose this behavior in Preferences.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-89 - cover.jpg-.png-should-be-preferred-in-local-artwork-files.md
+++ b/backlog/tasks/task-89 - cover.jpg-.png-should-be-preferred-in-local-artwork-files.md
@@ -1,0 +1,19 @@
+---
+id: TASK-89
+title: cover.jpg/.png should be preferred in local artwork files
+status: To Do
+assignee: []
+created_date: '2026-04-06 02:38'
+labels: []
+milestone: m-6
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+if more than one image file is included in a bandcamp zip, prefer the one called 'cover'.
+
+example: 
+TAKAAT - Is Noise, Vol 2 had a cover.jpg and "TAKAAT - TAKAAT - Is Noise, Vol. 2 - _Back-Cover.jpg". kamp daemon chose the "back cover" as the album art.
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -1,7 +1,14 @@
 """kamp extension host — public symbols."""
 
 from .abc import BaseArtworkSource, BaseTagger
-from .context import FetchResponse, KampGround, PlaybackSnapshot
+from .context import (
+    FetchResponse,
+    KampGround,
+    Mutation,
+    PlaybackSnapshot,
+    SetArtworkMutation,
+    UpdateMetadataMutation,
+)
 from .discovery import discover_extensions
 from .registry import ExtensionRegistry
 from .types import ArtworkQuery, ArtworkResult, TrackMetadata
@@ -15,8 +22,11 @@ __all__ = [
     "ExtensionRegistry",
     "FetchResponse",
     "KampGround",
+    "Mutation",
     "PlaybackSnapshot",
+    "SetArtworkMutation",
     "TrackMetadata",
+    "UpdateMetadataMutation",
     "discover_extensions",
     "invoke_extension",
 ]

--- a/kamp_daemon/ext/context.py
+++ b/kamp_daemon/ext/context.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
-from .types import TrackMetadata
+from .types import ArtworkResult, TrackMetadata
 
 
 @dataclass(frozen=True)
@@ -59,6 +59,42 @@ class FetchResponse:
 
 
 @dataclass
+class UpdateMetadataMutation:
+    """A queued request to update track metadata fields in the library.
+
+    Collected during extension execution and applied by the host after the
+    worker completes — the worker subprocess never writes to the database.
+
+    Args:
+        mbid: MusicBrainz recording ID identifying the track to update.
+        fields: Mapping of field names to new values (str or int).
+    """
+
+    mbid: str
+    fields: dict[str, str | int]
+
+
+@dataclass
+class SetArtworkMutation:
+    """A queued request to write artwork for a track in the library.
+
+    Collected during extension execution and applied by the host after the
+    worker completes — the worker subprocess never writes to the database.
+
+    Args:
+        mbid: MusicBrainz recording ID identifying the track to update.
+        artwork: ArtworkResult containing image bytes and MIME type.
+    """
+
+    mbid: str
+    artwork: ArtworkResult
+
+
+# Union type for all mutation variants.
+Mutation = UpdateMetadataMutation | SetArtworkMutation
+
+
+@dataclass
 class KampGround:
     """Host API surface passed to backend extension constructors.
 
@@ -82,6 +118,12 @@ class KampGround:
     # Not exposed directly — use subscribe() instead.
     _callbacks: dict[str, list[Callable[[], None]]] = field(
         default_factory=dict, repr=False, compare=False
+    )
+    # Mutations queued by the extension during its run; applied by the host
+    # after the worker completes. Not exposed directly — use update_metadata()
+    # and set_artwork() instead.
+    _pending_mutations: list[Mutation] = field(
+        default_factory=list, repr=False, compare=False
     )
 
     # ------------------------------------------------------------------
@@ -165,6 +207,55 @@ class KampGround:
                 headers=dict(resp.headers),
                 body=resp.read(),
             )
+
+    # ------------------------------------------------------------------
+    # Library writes
+    # ------------------------------------------------------------------
+
+    @property
+    def pending_mutations(self) -> list[Mutation]:
+        """Read-only view of mutations queued so far.
+
+        Consumed by the host after the worker exits — extension code should
+        not call this directly.
+        """
+        return list(self._pending_mutations)
+
+    def update_metadata(self, mbid: str, fields: dict[str, str | int]) -> None:
+        """Queue a metadata update to be applied by the host.
+
+        The host applies this mutation to the library database after the
+        worker subprocess exits. Extensions must not write to the database
+        directly — all library writes go through this method.
+
+        Args:
+            mbid: MusicBrainz recording ID of the track to update.
+            fields: Mapping of field names to new values. Allowed keys match
+                TrackMetadata field names (e.g. ``"title"``, ``"artist"``).
+
+        Example::
+
+            ctx.update_metadata(track.mbid, {"title": "Alright", "year": "2015"})
+        """
+        self._pending_mutations.append(UpdateMetadataMutation(mbid=mbid, fields=fields))
+
+    def set_artwork(self, mbid: str, artwork: ArtworkResult) -> None:
+        """Queue an artwork write to be applied by the host.
+
+        The host applies this mutation to the library database after the
+        worker subprocess exits. Extensions must not write to the database
+        directly — all library writes go through this method.
+
+        Args:
+            mbid: MusicBrainz recording ID of the track to update.
+            artwork: ArtworkResult containing image bytes and MIME type.
+
+        Example::
+
+            result = ctx.fetch("https://coverartarchive.org/...")
+            ctx.set_artwork(track.mbid, ArtworkResult(result.body, "image/jpeg"))
+        """
+        self._pending_mutations.append(SetArtworkMutation(mbid=mbid, artwork=artwork))
 
     # ------------------------------------------------------------------
     # Events

--- a/kamp_daemon/ext/worker.py
+++ b/kamp_daemon/ext/worker.py
@@ -15,9 +15,9 @@ import logging
 import logging.handlers
 import multiprocessing
 import queue
-from typing import Any
+from typing import Any, Literal, cast
 
-from .context import KampGround
+from .context import KampGround, Mutation
 
 _logger = logging.getLogger(__name__)
 
@@ -51,7 +51,9 @@ def _extension_worker(
     try:
         instance = cls(ctx)
         getattr(instance, method_name)(*args)
-        result_q.put(("ok", None))
+        # Include pending mutations so the host can apply library writes
+        # after the worker exits — the subprocess never touches the DB.
+        result_q.put(("ok", ctx.pending_mutations))
     except Exception as exc:  # noqa: BLE001
         result_q.put(("error", str(exc)))
     finally:
@@ -95,7 +97,7 @@ def invoke_extension(
     method_name: str,
     *args: Any,
     ctx: KampGround | None = None,
-) -> bool:
+) -> list[Mutation] | Literal[False]:
     """Invoke cls(ctx).method_name(*args) in an isolated subprocess.
 
     Args:
@@ -107,8 +109,12 @@ def invoke_extension(
             empty context is used if omitted.
 
     Returns:
-        True on success, False on any failure (exception or crash). Never
-        raises — callers can unconditionally continue after a False return.
+        List of Mutation objects queued by the extension (may be empty) on
+        success. False on any failure (exception or crash). Never raises —
+        callers can unconditionally continue after a False return.
+
+        Check for failure with ``result is False``; an empty list means
+        success with no library writes queued.
     """
     if ctx is None:
         ctx = KampGround()
@@ -153,7 +159,8 @@ def invoke_extension(
         )
         return False
 
-    return True
+    # value is list[Mutation] from the worker's result_q payload
+    return cast(list[Mutation], value)
 
 
 def _drain_log_queue(log_q: Any) -> None:

--- a/tests/test_extension_context.py
+++ b/tests/test_extension_context.py
@@ -10,8 +10,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kamp_daemon.ext.context import FetchResponse, KampGround, PlaybackSnapshot
-from kamp_daemon.ext.types import ArtworkQuery, TrackMetadata
+from kamp_daemon.ext.context import (
+    FetchResponse,
+    KampGround,
+    PlaybackSnapshot,
+    SetArtworkMutation,
+    UpdateMetadataMutation,
+)
+from kamp_daemon.ext.types import ArtworkQuery, ArtworkResult, TrackMetadata
 from kamp_daemon.ext.worker import invoke_extension
 
 # ---------------------------------------------------------------------------
@@ -222,7 +228,7 @@ def test_default_context_used_when_omitted() -> None:
 
     with patch("kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline):
         result = invoke_extension(_NullExt, "run")  # no ctx kwarg
-    assert result is True
+    assert result is not False
 
 
 # ---------------------------------------------------------------------------
@@ -307,3 +313,67 @@ def test_fetch_response_pickles() -> None:
     restored = pickle.loads(pickle.dumps(resp))
     assert restored.status_code == 200
     assert restored.body == b"data"
+
+
+# ---------------------------------------------------------------------------
+# AC #1 / AC #2 / AC #3 / AC #4 — library.write mutations
+# ---------------------------------------------------------------------------
+
+
+def _make_artwork() -> ArtworkResult:
+    return ArtworkResult(image_bytes=b"\xff\xd8\xff", mime_type="image/jpeg")
+
+
+def test_pending_mutations_empty_by_default() -> None:
+    ctx = KampGround()
+    assert ctx.pending_mutations == []
+
+
+def test_update_metadata_queues_mutation() -> None:
+    ctx = KampGround()
+    ctx.update_metadata("mbid-1", {"title": "Alright", "year": 2015})
+    muts = ctx.pending_mutations
+    assert len(muts) == 1
+    assert isinstance(muts[0], UpdateMetadataMutation)
+    assert muts[0].mbid == "mbid-1"
+    assert muts[0].fields == {"title": "Alright", "year": 2015}
+
+
+def test_set_artwork_queues_mutation() -> None:
+    ctx = KampGround()
+    art = _make_artwork()
+    ctx.set_artwork("mbid-2", art)
+    muts = ctx.pending_mutations
+    assert len(muts) == 1
+    assert isinstance(muts[0], SetArtworkMutation)
+    assert muts[0].mbid == "mbid-2"
+    assert muts[0].artwork is art
+
+
+def test_multiple_mutations_queued_in_order() -> None:
+    ctx = KampGround()
+    ctx.update_metadata("mbid-1", {"title": "A"})
+    ctx.set_artwork("mbid-2", _make_artwork())
+    ctx.update_metadata("mbid-3", {"year": 2020})
+    muts = ctx.pending_mutations
+    assert len(muts) == 3
+    assert isinstance(muts[0], UpdateMetadataMutation)
+    assert isinstance(muts[1], SetArtworkMutation)
+    assert isinstance(muts[2], UpdateMetadataMutation)
+
+
+def test_pending_mutations_returns_copy() -> None:
+    """Mutating the returned list must not affect the internal queue."""
+    ctx = KampGround()
+    ctx.update_metadata("mbid-1", {"title": "A"})
+    copy = ctx.pending_mutations
+    copy.clear()
+    assert len(ctx.pending_mutations) == 1
+
+
+def test_mutations_pickle_cleanly() -> None:
+    m1 = UpdateMetadataMutation(mbid="mbid-1", fields={"title": "Alright"})
+    m2 = SetArtworkMutation(mbid="mbid-2", artwork=_make_artwork())
+    for m in (m1, m2):
+        restored = pickle.loads(pickle.dumps(m))
+        assert restored.mbid == m.mbid

--- a/tests/test_extension_worker.py
+++ b/tests/test_extension_worker.py
@@ -8,7 +8,7 @@ import queue as _queue_module
 from typing import Any
 from unittest.mock import patch
 
-from kamp_daemon.ext.context import KampGround
+from kamp_daemon.ext.context import KampGround, UpdateMetadataMutation
 from kamp_daemon.ext.worker import _drain_log_queue, _extension_worker, invoke_extension
 
 # ---------------------------------------------------------------------------
@@ -71,13 +71,14 @@ def _crash_worker(
 # ---------------------------------------------------------------------------
 
 
-def test_success_returns_true() -> None:
+def test_success_returns_mutations_list() -> None:
     _Recorder.calls = []
     with patch(
         "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
     ):
         result = invoke_extension(_Recorder, "run", "a", "b")
-    assert result is True
+    assert result is not False
+    assert isinstance(result, list)
     assert _Recorder.calls == [("a", "b")]
 
 
@@ -179,3 +180,32 @@ def test_log_records_replayed_in_parent() -> None:
         target.removeHandler(handler)
 
     assert any("hello from worker" in r.getMessage() for r in records)
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — mutations returned to host via result queue
+# ---------------------------------------------------------------------------
+
+
+def test_mutations_returned_by_invoke_extension() -> None:
+    """Mutations queued during the worker run are returned to the caller."""
+
+    class _MutatingExt:
+        def __init__(self, ctx: KampGround) -> None:
+            self._ctx = ctx
+
+        def run(self) -> None:
+            self._ctx.update_metadata("mbid-1", {"title": "Alright"})
+            self._ctx.update_metadata("mbid-2", {"year": 2015})
+
+    with patch(
+        "kamp_daemon.ext.worker._spawn_extension_worker", side_effect=_inline_worker
+    ):
+        result = invoke_extension(_MutatingExt, "run")
+
+    assert result is not False
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(m, UpdateMetadataMutation) for m in result)
+    assert result[0].mbid == "mbid-1"
+    assert result[1].mbid == "mbid-2"


### PR DESCRIPTION
## Summary

- Adds `UpdateMetadataMutation` and `SetArtworkMutation` dataclasses (picklable, all primitives)
- Adds `KampGround.update_metadata(mbid, fields)` and `KampGround.set_artwork(mbid, artwork)` — queue mutations during extension run; host applies them after worker exits
- Adds `KampGround.pending_mutations` read-only property (returns a copy)
- Updates `_extension_worker` to include `ctx.pending_mutations` in result queue payload
- Changes `invoke_extension` return type: `list[Mutation] | Literal[False]` — success returns mutations list, failure returns `False`; check with `result is not False`
- Exports `Mutation`, `UpdateMetadataMutation`, `SetArtworkMutation` from `kamp_daemon/ext`

## Test plan

- [x] `pending_mutations` empty by default
- [x] `update_metadata()` queues `UpdateMetadataMutation` with correct fields
- [x] `set_artwork()` queues `SetArtworkMutation` with correct artwork
- [x] Multiple mutations queued in order
- [x] `pending_mutations` returns a copy (mutating it doesn't affect internal queue)
- [x] Both mutation types pickle cleanly
- [x] Mutations flow through `invoke_extension` to caller (end-to-end)
- [x] 35 tests total, all green; black + mypy clean

Closes TASK-17.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)