### PR TITLE
feat: import-time execution probe for backend extensions (TASK-83)

### DIFF
--- a/backlog/tasks/task-17 - Extension-host-and-KampGround-API.md
+++ b/backlog/tasks/task-17 - Extension-host-and-KampGround-API.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-17
 title: Extension host and KampGround API
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-05 21:21'
+updated_date: '2026-04-06 02:46'
 labels:
   - feature
   - architecture
@@ -24,11 +24,11 @@ Per the architecture invariant: the SDK surface must be extracted from two real 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Extension host discovers and loads backend extensions via entry points
-- [ ] #2 KampGround API covers at minimum: library access, playback control, event subscription
-- [ ] #3 API is documented with examples
-- [ ] #4 A crash in an extension worker does not take down the daemon
-- [ ] #5 Backend extensions receive and return structured data objects (TrackMetadata, ArtworkResult, etc.); no file paths are ever passed to extension code
-- [ ] #6 network.external capability is exposed only as KampGround.fetch(url, method, body) — the host makes the request; the extension never calls the network directly; declared network.domains allowlist is enforced per-request
-- [ ] #7 library.write capability is exposed only as named atomic mutations (update_metadata, set_artwork); no raw database access is possible through KampGround
+- [x] #1 Extension host discovers and loads backend extensions via entry points
+- [x] #2 KampGround API covers at minimum: library access, playback control, event subscription
+- [x] #3 API is documented with examples
+- [x] #4 A crash in an extension worker does not take down the daemon
+- [x] #5 Backend extensions receive and return structured data objects (TrackMetadata, ArtworkResult, etc.); no file paths are ever passed to extension code
+- [x] #6 network.external capability is exposed only as KampGround.fetch(url, method, body) — the host makes the request; the extension never calls the network directly; declared network.domains allowlist is enforced per-request
+- [x] #7 library.write capability is exposed only as named atomic mutations (update_metadata, set_artwork); no raw database access is possible through KampGround
 <!-- AC:END -->

--- a/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
+++ b/backlog/tasks/task-17.1 - Entry-point-discovery-and-ABC-conformance-validation.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 19:26'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - architecture
@@ -13,7 +13,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 1000
+ordinal: 2000
 ---
 
 ## Description

--- a/backlog/tasks/task-17.2 - Worker-subprocess-lifecycle-and-crash-isolation.md
+++ b/backlog/tasks/task-17.2 - Worker-subprocess-lifecycle-and-crash-isolation.md
@@ -4,6 +4,7 @@ title: Worker subprocess lifecycle and crash isolation
 status: Done
 assignee: []
 created_date: '2026-04-05 16:36'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - architecture
@@ -11,7 +12,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 1200
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
+++ b/backlog/tasks/task-17.3 - KampContext-structured-data-types.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 21:38'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - architecture
@@ -13,7 +13,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 2200
+ordinal: 4000
 ---
 
 ## Description

--- a/backlog/tasks/task-17.4 - KampContext-library-playback-and-event-API.md
+++ b/backlog/tasks/task-17.4 - KampContext-library-playback-and-event-API.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Claude
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-05 21:41'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - architecture
@@ -13,7 +13,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 3200
+ordinal: 5000
 ---
 
 ## Description

--- a/backlog/tasks/task-17.5 - KampGround.fetch-—-proxied-network-capability.md
+++ b/backlog/tasks/task-17.5 - KampGround.fetch-—-proxied-network-capability.md
@@ -4,7 +4,7 @@ title: KampGround.fetch() — proxied network capability
 status: Done
 assignee: []
 created_date: '2026-04-05 16:36'
-updated_date: '2026-04-06 01:20'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - security
@@ -12,7 +12,7 @@ labels:
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 4200
+ordinal: 6000
 ---
 
 ## Description

--- a/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
+++ b/backlog/tasks/task-17.6 - library.write-—-named-atomic-mutations-on-KampGround.md
@@ -4,14 +4,14 @@ title: library.write — named atomic mutations on KampGround
 status: Done
 assignee: []
 created_date: '2026-04-06 01:26'
-updated_date: '2026-04-06 01:58'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - 'estimate: side'
 milestone: m-2
 dependencies: []
 parent_task_id: TASK-17
-ordinal: 5200
+ordinal: 7000
 ---
 
 ## Description

--- a/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
+++ b/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-83
 title: Import-time execution probe for backend extensions
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-06 02:46'
 labels:
   - feature
   - security

--- a/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
+++ b/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-83
 title: Import-time execution probe for backend extensions
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-06 11:08'
+updated_date: '2026-04-06 11:26'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-17
 documentation:
   - project/kampground-ideation.md
-ordinal: 2000
+ordinal: 8000
 ---
 
 ## Description

--- a/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
+++ b/backlog/tasks/task-83 - Import-time-execution-probe-for-backend-extensions.md
@@ -4,7 +4,7 @@ title: Import-time execution probe for backend extensions
 status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-06 02:46'
+updated_date: '2026-04-06 11:08'
 labels:
   - feature
   - security
@@ -31,8 +31,8 @@ Depends on: TASK-17 (extension host, which is where this probe hooks in at load 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A backend extension whose module-level code calls open(), socket, subprocess, or os.system is rejected at load time with a clear error
-- [ ] #2 A legitimate extension that only defines classes and reads package metadata loads without error
-- [ ] #3 The probe runs in an isolated subprocess — the daemon process is unaffected by any module-level side effects during probing
-- [ ] #4 Rejection error includes the extension package name and the stubbed symbol that was called
+- [x] #1 A backend extension whose module-level code calls open(), socket, subprocess, or os.system is rejected at load time with a clear error
+- [x] #2 A legitimate extension that only defines classes and reads package metadata loads without error
+- [x] #3 The probe runs in an isolated subprocess — the daemon process is unaffected by any module-level side effects during probing
+- [x] #4 Rejection error includes the extension package name and the stubbed symbol that was called
 <!-- AC:END -->

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -10,6 +10,7 @@ from .context import (
     UpdateMetadataMutation,
 )
 from .discovery import discover_extensions
+from .probe import probe_extension
 from .registry import ExtensionRegistry
 from .types import ArtworkQuery, ArtworkResult, TrackMetadata
 from .worker import invoke_extension
@@ -29,4 +30,5 @@ __all__ = [
     "UpdateMetadataMutation",
     "discover_extensions",
     "invoke_extension",
+    "probe_extension",
 ]

--- a/kamp_daemon/ext/discovery.py
+++ b/kamp_daemon/ext/discovery.py
@@ -14,6 +14,7 @@ import inspect
 import logging
 
 from .abc import BaseArtworkSource, BaseTagger
+from .probe import probe_extension
 from .registry import ExtensionRegistry
 
 _logger = logging.getLogger(__name__)
@@ -42,6 +43,13 @@ def _load_and_register(
     """Load a single entry point and register it if it passes validation."""
     # Identify the owning distribution for useful error messages.
     dist_name = _dist_name(ep)
+
+    # --- Import-time execution probe ---
+    # Derive the module name from the entry point value (e.g. "my_ext.tagger:MyTagger"
+    # → "my_ext.tagger") and probe it before loading the class into this process.
+    module_name = ep.value.split(":")[0]
+    if not probe_extension(module_name, package_name=dist_name):
+        return
 
     # --- Load ---
     try:

--- a/kamp_daemon/ext/probe.py
+++ b/kamp_daemon/ext/probe.py
@@ -1,0 +1,157 @@
+"""Import-time execution probe for backend extensions.
+
+Python entry points execute module-level code at import time — before any ABC
+conformance check or permission gate. A malicious ``__init__.py`` can open
+files, make network connections, or spawn subprocesses before ``tag()`` is
+ever called.
+
+``probe_extension`` loads the extension module once inside a fresh spawn-
+context subprocess with dangerous builtins and stdlib symbols stubbed out.
+Any call to a stubbed symbol during import raises immediately; the subprocess
+reports the violation and the extension is rejected before it is added to the
+active registry.
+
+This is a heuristic, not a complete sandbox — it catches the obvious module-
+level exfiltration pattern. OS-level sandboxing (TASK-87) is the complete
+solution. Legitimate extensions that only define classes and read package
+metadata will pass without issue.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import multiprocessing
+import os
+import queue
+import socket
+import subprocess as _subprocess_module
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Worker (runs inside the isolated subprocess)
+# ---------------------------------------------------------------------------
+
+# Symbols to stub during the probe.  Each entry is (module_object, attr_name).
+# We patch at the object level so sub-imports that already hold a reference to
+# e.g. ``open`` still hit the stub.
+_STUB_TARGETS: list[tuple[Any, str]] = [
+    (builtins, "open"),
+    (socket, "socket"),
+    (_subprocess_module, "Popen"),
+    (_subprocess_module, "run"),
+    (_subprocess_module, "call"),
+    (os, "system"),
+]
+
+
+def _make_stub(symbol_name: str, result_q: Any) -> Any:
+    """Return a callable that reports *symbol_name* as a violation."""
+
+    def _stub(*args: Any, **kwargs: Any) -> None:
+        result_q.put(("violation", symbol_name))
+        raise RuntimeError(
+            f"Extension probe: call to restricted symbol '{symbol_name}' "
+            f"detected at import time"
+        )
+
+    return _stub
+
+
+def _probe_worker(module_name: str, result_q: Any) -> None:
+    """Subprocess entry point: import *module_name* with dangerous symbols stubbed.
+
+    Puts one of:
+    - ``("ok", None)`` — import succeeded with no violations
+    - ``("violation", symbol_name)`` — a stubbed symbol was called during import
+    - ``("error", detail)`` — the module failed to import for another reason
+    """
+    # Install stubs before importing anything from the extension.
+    originals: list[tuple[Any, str, Any]] = []
+    for obj, attr in _STUB_TARGETS:
+        originals.append((obj, attr, getattr(obj, attr)))
+        setattr(obj, attr, _make_stub(attr, result_q))
+
+    try:
+        importlib.import_module(module_name)
+        result_q.put(("ok", None))
+    except RuntimeError:
+        # Violation already placed on result_q by the stub — no second put needed.
+        pass
+    except Exception as exc:  # noqa: BLE001
+        result_q.put(("error", str(exc)))
+    finally:
+        # Restore originals so the subprocess exits cleanly.
+        for obj, attr, original in originals:
+            setattr(obj, attr, original)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def probe_extension(module_name: str, package_name: str = "") -> bool:
+    """Probe *module_name* for import-time execution of restricted symbols.
+
+    Spawns an isolated subprocess, imports the module with dangerous builtins
+    stubbed, and returns True if the import is clean. Returns False (and logs
+    an error) if any stubbed symbol is called or the import fails unexpectedly.
+
+    Args:
+        module_name: Dotted module name to import (e.g. ``"my_ext.tagger"``).
+        package_name: Human-readable package name for log messages. Defaults
+            to *module_name* if omitted.
+
+    Returns:
+        True if the extension passed the probe, False if it was rejected.
+    """
+    label = package_name or module_name
+    mp_ctx = multiprocessing.get_context("spawn")
+    result_q: Any = mp_ctx.Queue()
+    proc = mp_ctx.Process(target=_probe_worker, args=(module_name, result_q))
+    proc.start()
+    proc.join()
+
+    # Non-zero exit without a result_q entry — subprocess crashed during probe.
+    if proc.exitcode != 0:
+        try:
+            status, value = result_q.get_nowait()
+        except queue.Empty:
+            _logger.error(
+                "Extension probe for %r crashed (exit code %d)",
+                label,
+                proc.exitcode,
+            )
+            return False
+    else:
+        try:
+            status, value = result_q.get_nowait()
+        except queue.Empty:
+            _logger.error(
+                "Extension probe for %r exited without a result",
+                label,
+            )
+            return False
+
+    if status == "violation":
+        _logger.error(
+            "Extension %r rejected: module-level call to restricted symbol %r",
+            label,
+            value,
+        )
+        return False
+
+    if status == "error":
+        _logger.error(
+            "Extension %r probe import failed: %s",
+            label,
+            value,
+        )
+        return False
+
+    return True

--- a/tests/test_extension_discovery.py
+++ b/tests/test_extension_discovery.py
@@ -54,6 +54,9 @@ def _make_ep(name: str, cls: type, dist_name: str = "test-pkg") -> MagicMock:
     """Build a mock EntryPoint that loads *cls*."""
     ep = MagicMock(spec=importlib.metadata.EntryPoint)
     ep.name = name
+    ep.value = (
+        f"test_module:{cls.__name__}" if isinstance(cls, type) else "test_module:obj"
+    )
     ep.load.return_value = cls
     dist = MagicMock()
     dist.metadata = {"Name": dist_name}
@@ -69,6 +72,14 @@ def _patch_eps(*eps: MagicMock):
     )
 
 
+def _patch_probe(passes: bool = True):
+    """Patch probe_extension to return *passes* without spawning a subprocess."""
+    return patch(
+        "kamp_daemon.ext.discovery.probe_extension",
+        return_value=passes,
+    )
+
+
 # ---------------------------------------------------------------------------
 # AC #1 / AC #3 — conforming extensions are discovered and registered
 # ---------------------------------------------------------------------------
@@ -77,7 +88,7 @@ def _patch_eps(*eps: MagicMock):
 def test_conforming_tagger_is_registered():
     ep = _make_ep("my_tagger", GoodTagger)
     registry = ExtensionRegistry()
-    with _patch_eps(ep):
+    with _patch_eps(ep), _patch_probe():
         discover_extensions(registry)
     assert GoodTagger in registry.taggers
 
@@ -85,7 +96,7 @@ def test_conforming_tagger_is_registered():
 def test_conforming_artwork_source_is_registered():
     ep = _make_ep("my_art", GoodArtworkSource)
     registry = ExtensionRegistry()
-    with _patch_eps(ep):
+    with _patch_eps(ep), _patch_probe():
         discover_extensions(registry)
     assert GoodArtworkSource in registry.artwork_sources
 
@@ -94,7 +105,7 @@ def test_multiple_extensions_registered_in_order():
     ep_t = _make_ep("t", GoodTagger)
     ep_a = _make_ep("a", GoodArtworkSource)
     registry = ExtensionRegistry()
-    with _patch_eps(ep_t, ep_a):
+    with _patch_eps(ep_t, ep_a), _patch_probe():
         discover_extensions(registry)
     assert GoodTagger in registry.taggers
     assert GoodArtworkSource in registry.artwork_sources
@@ -110,13 +121,10 @@ def test_non_abc_class_rejected(caplog):
     registry = ExtensionRegistry()
     with (
         _patch_eps(ep),
-        pytest.raises(SystemExit, match="") if False else _patch_eps(ep),
+        _patch_probe(),
+        caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"),
     ):
-        pass
-    # Re-run properly
-    with _patch_eps(ep):
-        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
-            discover_extensions(registry)
+        discover_extensions(registry)
     assert registry.taggers == []
     assert registry.artwork_sources == []
     assert "bad-pkg" in caplog.text
@@ -126,7 +134,7 @@ def test_non_abc_class_rejected(caplog):
 def test_incomplete_tagger_rejected_names_missing_method(caplog):
     ep = _make_ep("incomplete", IncompleteTagger, dist_name="incomplete-pkg")
     registry = ExtensionRegistry()
-    with _patch_eps(ep):
+    with _patch_eps(ep), _patch_probe():
         with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
             discover_extensions(registry)
     assert registry.taggers == []
@@ -142,13 +150,14 @@ def test_incomplete_tagger_rejected_names_missing_method(caplog):
 def test_import_error_logged_and_skipped(caplog):
     ep = MagicMock(spec=importlib.metadata.EntryPoint)
     ep.name = "broken"
+    ep.value = "broken_mod:BrokenClass"
     ep.load.side_effect = ImportError("missing dependency")
     dist = MagicMock()
     dist.metadata = {"Name": "broken-pkg"}
     ep.dist = dist
 
     registry = ExtensionRegistry()
-    with _patch_eps(ep):
+    with _patch_eps(ep), _patch_probe():
         with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
             discover_extensions(registry)
     assert registry.taggers == []
@@ -179,8 +188,30 @@ def test_no_entry_points_yields_empty_registry(caplog):
 def test_non_class_entry_point_rejected(caplog):
     ep = _make_ep("not_a_class", "just a string")  # type: ignore[arg-type]
     registry = ExtensionRegistry()
-    with _patch_eps(ep):
+    with _patch_eps(ep), _patch_probe():
         with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
             discover_extensions(registry)
     assert registry.taggers == []
     assert "not a class" in caplog.text.lower()
+
+
+def test_probe_rejection_prevents_registration(caplog):
+    """An extension rejected by the import-time probe is never registered."""
+    ep = _make_ep("evil", GoodTagger, dist_name="evil-pkg")
+    registry = ExtensionRegistry()
+    with _patch_eps(ep), _patch_probe(passes=False):
+        with caplog.at_level("ERROR", logger="kamp_daemon.ext.discovery"):
+            discover_extensions(registry)
+    assert registry.taggers == []
+
+
+def test_dist_name_falls_back_to_unknown_on_attribute_error():
+    """_dist_name returns '<unknown>' when dist.metadata raises AttributeError."""
+    from kamp_daemon.ext.discovery import _dist_name
+
+    ep = MagicMock(spec=importlib.metadata.EntryPoint)
+    dist = MagicMock()
+    dist.metadata = MagicMock()
+    dist.metadata.__getitem__ = MagicMock(side_effect=AttributeError)
+    ep.dist = dist
+    assert _dist_name(ep) == "<unknown>"

--- a/tests/test_extension_probe.py
+++ b/tests/test_extension_probe.py
@@ -1,0 +1,258 @@
+"""Tests for the import-time execution probe (probe.py)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kamp_daemon.ext.probe import _probe_worker, probe_extension
+
+# ---------------------------------------------------------------------------
+# Helpers — write tiny modules into tmp_path and inject into sys.path
+# ---------------------------------------------------------------------------
+
+
+def _write_module(tmp_path: Path, name: str, source: str) -> Path:
+    mod = tmp_path / f"{name}.py"
+    mod.write_text(source)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _probe_worker tests (inline, no subprocess spawned)
+# ---------------------------------------------------------------------------
+
+
+class _FakeQ:
+    """Minimal queue substitute for in-process worker tests."""
+
+    def __init__(self) -> None:
+        self._items: list[Any] = []
+
+    def put(self, item: Any) -> None:
+        self._items.append(item)
+
+    def get_nowait(self) -> Any:
+        if not self._items:
+            raise Exception("empty")
+        return self._items.pop(0)
+
+    @property
+    def first(self) -> Any:
+        return self._items[0] if self._items else None
+
+
+def test_probe_worker_clean_module_puts_ok(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        "_probe_clean",
+        "class MyClass:\n    pass\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_clean", q)
+        status, _ = q.get_nowait()
+        assert status == "ok"
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_clean", None)
+
+
+def test_probe_worker_open_call_puts_violation(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        "_probe_open",
+        "f = open('/dev/null', 'r')\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_open", q)
+        status, symbol = q.get_nowait()
+        assert status == "violation"
+        assert symbol == "open"
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_open", None)
+
+
+def test_probe_worker_socket_call_puts_violation(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        "_probe_socket",
+        "import socket as _s\n_s.socket()\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_socket", q)
+        status, symbol = q.get_nowait()
+        assert status == "violation"
+        assert symbol == "socket"
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_socket", None)
+
+
+def test_probe_worker_subprocess_run_puts_violation(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        "_probe_subprocess",
+        "import subprocess\nsubprocess.run(['true'])\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_subprocess", q)
+        status, symbol = q.get_nowait()
+        assert status == "violation"
+        assert symbol == "run"
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_subprocess", None)
+
+
+def test_probe_worker_os_system_puts_violation(tmp_path: Path) -> None:
+    _write_module(
+        tmp_path,
+        "_probe_os_system",
+        "import os\nos.system('true')\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_os_system", q)
+        status, symbol = q.get_nowait()
+        assert status == "violation"
+        assert symbol == "system"
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_os_system", None)
+
+
+def test_probe_worker_import_error_puts_error(tmp_path: Path) -> None:
+    # Module that raises a non-RuntimeError at import time
+    _write_module(
+        tmp_path,
+        "_probe_import_err",
+        "raise ValueError('bad module')\n",
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        q: _FakeQ = _FakeQ()
+        _probe_worker("_probe_import_err", q)
+        status, detail = q.get_nowait()
+        assert status == "error"
+        assert "bad module" in detail
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("_probe_import_err", None)
+
+
+# ---------------------------------------------------------------------------
+# probe_extension public API — inline worker, no real subprocess
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, exitcode: int = 0) -> None:
+        self.exitcode = exitcode
+
+    def start(self) -> None:
+        pass
+
+    def join(self) -> None:
+        pass
+
+
+def _make_inline_probe(tmp_path: Path, module_name: str) -> Any:
+    """Return a side_effect for mp_ctx.Process that runs the worker inline."""
+    import queue as _queue_module
+
+    class _InlineProcess:
+        def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+            self._target = target
+            self._args = args
+            self.exitcode = 0
+
+        def start(self) -> None:
+            sys.path.insert(0, str(tmp_path))
+            try:
+                self._target(*self._args)
+            finally:
+                sys.path.remove(str(tmp_path))
+                sys.modules.pop(module_name, None)
+
+        def join(self) -> None:
+            pass
+
+    return _InlineProcess
+
+
+def _make_inline_ctx(tmp_path: Path, module_name: str) -> Any:
+    """Return a fake mp_ctx that runs the worker inline with a stdlib Queue.
+
+    The spawn-context Queue uses OS pipes + a feeder thread; get_nowait() can
+    miss items when the worker runs inline (no real subprocess). A stdlib Queue
+    is synchronous and avoids the race entirely.
+    """
+    import queue as _stdlib_queue
+
+    inline_q: Any = _stdlib_queue.Queue()
+
+    class _FakeProcess:
+        def __init__(self, target: Any, args: tuple[Any, ...], **kw: Any) -> None:
+            self._target = target
+            self._args = args
+            self.exitcode = 0
+
+        def start(self) -> None:
+            sys.path.insert(0, str(tmp_path))
+            try:
+                self._target(*self._args)
+            finally:
+                sys.path.remove(str(tmp_path))
+                sys.modules.pop(module_name, None)
+
+        def join(self) -> None:
+            pass
+
+    class _FakeCtx:
+        def Queue(self) -> Any:
+            return inline_q
+
+        def Process(self, **kw: Any) -> _FakeProcess:
+            return _FakeProcess(**kw)
+
+    return _FakeCtx()
+
+
+def test_probe_extension_clean_returns_true(tmp_path: Path) -> None:
+    _write_module(tmp_path, "_pext_clean", "class Good:\n    pass\n")
+    fake_ctx = _make_inline_ctx(tmp_path, "_pext_clean")
+    with patch(
+        "kamp_daemon.ext.probe.multiprocessing.get_context", return_value=fake_ctx
+    ):
+        result = probe_extension("_pext_clean", package_name="test-pkg")
+    assert result is True
+
+
+def test_probe_extension_violation_returns_false(tmp_path: Path, caplog: Any) -> None:
+    _write_module(tmp_path, "_pext_bad", "open('/dev/null')\n")
+    fake_ctx = _make_inline_ctx(tmp_path, "_pext_bad")
+    with (
+        patch(
+            "kamp_daemon.ext.probe.multiprocessing.get_context", return_value=fake_ctx
+        ),
+        caplog.at_level("ERROR", logger="kamp_daemon.ext.probe"),
+    ):
+        result = probe_extension("_pext_bad", package_name="evil-pkg")
+    assert result is False
+    # AC #4 — error includes package name and stubbed symbol
+    assert "evil-pkg" in caplog.text
+    assert "open" in caplog.text

--- a/tests/test_extension_probe.py
+++ b/tests/test_extension_probe.py
@@ -256,3 +256,116 @@ def test_probe_extension_violation_returns_false(tmp_path: Path, caplog: Any) ->
     # AC #4 — error includes package name and stubbed symbol
     assert "evil-pkg" in caplog.text
     assert "open" in caplog.text
+
+
+def test_probe_extension_error_status_returns_false(caplog: Any) -> None:
+    """An ("error", detail) result from the worker returns False."""
+    import queue as _stdlib_queue
+
+    q: Any = _stdlib_queue.Queue()
+    q.put(("error", "bad module"))
+
+    class _FakeProcess:
+        exitcode = 0
+
+        def __init__(self, **kw: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _FakeCtx:
+        def Queue(self) -> Any:
+            return q
+
+        def Process(self, **kw: Any) -> _FakeProcess:
+            return _FakeProcess(**kw)
+
+    with (
+        patch(
+            "kamp_daemon.ext.probe.multiprocessing.get_context", return_value=_FakeCtx()
+        ),
+        caplog.at_level("ERROR", logger="kamp_daemon.ext.probe"),
+    ):
+        result = probe_extension("some_module", package_name="some-pkg")
+    assert result is False
+    assert "some-pkg" in caplog.text
+    assert "bad module" in caplog.text
+
+
+def test_probe_extension_crash_empty_queue_returns_false(caplog: Any) -> None:
+    """Non-zero exit code with empty queue (hard crash) returns False."""
+    import queue as _stdlib_queue
+
+    q: Any = _stdlib_queue.Queue()  # empty — worker never put anything
+
+    class _CrashProcess:
+        exitcode = 139  # SIGSEGV
+
+        def __init__(self, **kw: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _FakeCtx:
+        def Queue(self) -> Any:
+            return q
+
+        def Process(self, **kw: Any) -> _CrashProcess:
+            return _CrashProcess(**kw)
+
+    with (
+        patch(
+            "kamp_daemon.ext.probe.multiprocessing.get_context", return_value=_FakeCtx()
+        ),
+        caplog.at_level("ERROR", logger="kamp_daemon.ext.probe"),
+    ):
+        result = probe_extension("crash_module", package_name="crash-pkg")
+    assert result is False
+    assert "crash-pkg" in caplog.text
+    assert "139" in caplog.text
+
+
+def test_probe_extension_empty_queue_on_success_exit_returns_false(
+    caplog: Any,
+) -> None:
+    """Exit code 0 but empty queue (worker exited without result) returns False."""
+    import queue as _stdlib_queue
+
+    q: Any = _stdlib_queue.Queue()  # empty
+
+    class _FakeProcess:
+        exitcode = 0
+
+        def __init__(self, **kw: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self) -> None:
+            pass
+
+    class _FakeCtx:
+        def Queue(self) -> Any:
+            return q
+
+        def Process(self, **kw: Any) -> _FakeProcess:
+            return _FakeProcess(**kw)
+
+    with (
+        patch(
+            "kamp_daemon.ext.probe.multiprocessing.get_context", return_value=_FakeCtx()
+        ),
+        caplog.at_level("ERROR", logger="kamp_daemon.ext.probe"),
+    ):
+        result = probe_extension("no_result_module", package_name="no-result-pkg")
+    assert result is False
+    assert "no-result-pkg" in caplog.text


### PR DESCRIPTION
## Summary

- Adds `kamp_daemon/ext/probe.py` with `_probe_worker()` and `probe_extension()`
- `_probe_worker` installs stubs over `builtins.open`, `socket.socket`, `subprocess.Popen/run/call`, and `os.system` before importing the extension module; any call to a stubbed symbol puts a `("violation", symbol_name)` onto the result queue and raises, aborting the import
- `probe_extension` spawns the worker in an isolated spawn-context subprocess, reads the result, and returns True (clean) or False (rejected). Rejection log includes the package name and the stubbed symbol (AC #4)
- `discover_extensions` now calls `probe_extension` before loading a class into this process — a probed module that calls restricted symbols never reaches the registry (AC #1)
- Legitimate extensions that only define classes and read package metadata pass cleanly (AC #2)
- Daemon process is unaffected — probe runs in an isolated subprocess (AC #3)

## Test plan

- [x] Clean module → `_probe_worker` puts `("ok", None)`
- [x] `open()` at import time → violation, symbol "open"
- [x] `socket.socket()` at import time → violation, symbol "socket"
- [x] `subprocess.run()` at import time → violation, symbol "run"
- [x] `os.system()` at import time → violation, symbol "system"
- [x] Non-RuntimeError import failure → `("error", detail)`
- [x] `probe_extension` clean → returns True
- [x] `probe_extension` violation → returns False, log contains package name + "open" (AC #4)
- [x] 8 tests, all green; black + mypy clean

Closes TASK-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)