### PR TITLE
feat: hash-pinning for installed extensions (TASK-84)

### DIFF
--- a/backlog/tasks/task-84 - Hash-pinning-for-installed-extensions.md
+++ b/backlog/tasks/task-84 - Hash-pinning-for-installed-extensions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-84
 title: Hash-pinning for installed extensions
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-06 11:37'
+updated_date: '2026-04-06 11:51'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-17
 documentation:
   - project/kampground-ideation.md
-ordinal: 3000
+ordinal: 9000
 ---
 
 ## Description

--- a/backlog/tasks/task-84 - Hash-pinning-for-installed-extensions.md
+++ b/backlog/tasks/task-84 - Hash-pinning-for-installed-extensions.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-84
 title: Hash-pinning for installed extensions
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-06 11:37'
 labels:
   - feature
   - security

--- a/kamp_daemon/ext/discovery.py
+++ b/kamp_daemon/ext/discovery.py
@@ -14,6 +14,7 @@ import inspect
 import logging
 
 from .abc import BaseArtworkSource, BaseTagger
+from .pins import verify_or_pin
 from .probe import probe_extension
 from .registry import ExtensionRegistry
 
@@ -50,6 +51,15 @@ def _load_and_register(
     module_name = ep.value.split(":")[0]
     if not probe_extension(module_name, package_name=dist_name):
         return
+
+    # --- Hash verification ---
+    # Verify (or pin on first encounter) the distribution's installed files.
+    # Skipped when the distribution is unknown — probe already ran, and we
+    # cannot enumerate files without a Distribution object.
+    dist = getattr(ep, "dist", None)
+    if dist is not None:
+        if not verify_or_pin(dist_name, dist):
+            return
 
     # --- Load ---
     try:

--- a/kamp_daemon/ext/pins.py
+++ b/kamp_daemon/ext/pins.py
@@ -1,0 +1,189 @@
+"""Extension hash pinning — record and verify SHA-256 hashes of installed files.
+
+At first discovery, each extension distribution's files are hashed and the
+results written to a JSON file outside the extensions directory.  On every
+subsequent load the recorded hashes are compared against the current on-disk
+content.  A mismatch (same version, different bytes) means the files were
+tampered with after install and the extension is blocked.
+
+If the installed version has changed (legitimate upgrade via pip), the hashes
+are refreshed automatically so the user is not interrupted by a false positive.
+
+The pins file is stored in the same directory as the kamp config file
+(~/.config/kamp/ on macOS/Linux) so extension code — which runs inside an
+isolated subprocess — cannot modify it by writing to the extension package
+directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import importlib.metadata
+
+_logger = logging.getLogger(__name__)
+
+_PINS_FILENAME = "extension-pins.json"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def _pins_path() -> Path:
+    """Return the platform-appropriate path for the extension pins file."""
+    if sys.platform == "win32":  # pragma: no cover
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        return base / "kamp" / _PINS_FILENAME
+    return Path("~/.config/kamp").expanduser() / _PINS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Hashing utilities
+# ---------------------------------------------------------------------------
+
+
+def _hash_file(path: Path) -> str:
+    """Return the SHA-256 hex digest of the file at *path*."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _should_hash(rel_str: str) -> bool:
+    """Return True if *rel_str* should be included in the pin record.
+
+    Excludes compiled bytecode caches (__pycache__ / .pyc) because they are
+    deterministically generated from the .py files that are already hashed.
+    """
+    return "__pycache__" not in rel_str and not rel_str.endswith(".pyc")
+
+
+def _compute_dist_hashes(dist: "importlib.metadata.Distribution") -> dict[str, str]:
+    """Return ``{relative_path: sha256hex}`` for all hashable files in *dist*."""
+    result: dict[str, str] = {}
+    files = dist.files or []
+    for pkg_path in files:
+        rel_str = str(pkg_path)
+        if not _should_hash(rel_str):
+            continue
+        abs_path = Path(str(dist.locate_file(pkg_path)))
+        if abs_path.is_file():
+            result[rel_str] = _hash_file(abs_path)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Pins file I/O
+# ---------------------------------------------------------------------------
+
+
+def _load_pins(pins_path: Path) -> dict[str, dict]:  # type: ignore[type-arg]
+    if not pins_path.exists():
+        return {}
+    with open(pins_path) as f:
+        return json.load(f)  # type: ignore[no-any-return]
+
+
+def _save_pins(pins: dict[str, dict], pins_path: Path) -> None:  # type: ignore[type-arg]
+    pins_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(pins_path, "w") as f:
+        json.dump(pins, f, indent=2)
+        f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def verify_or_pin(
+    dist_name: str,
+    dist: "importlib.metadata.Distribution",
+    pins_path: Path | None = None,
+) -> bool:
+    """Verify the installed files of *dist* against stored hashes, or pin on first use.
+
+    Behaviour:
+    - ``dist.files`` is None (e.g. editable install): warn and allow through.
+    - Extension not yet pinned: hash all files, record them, return True.
+    - Pinned version differs from installed version: re-pin (legitimate upgrade), return True.
+    - Pinned version matches, all hashes match: return True.
+    - Pinned version matches, any hash differs: log an error identifying each
+      mismatched file and return False (caller must block the load).
+
+    Args:
+        dist_name: Human-readable distribution name (used in log messages).
+        dist: The ``importlib.metadata.Distribution`` for the extension package.
+        pins_path: Path to the pins JSON file.  Defaults to ``_pins_path()``.
+
+    Returns:
+        True if the extension is safe to load, False if it must be blocked.
+    """
+    if pins_path is None:
+        pins_path = _pins_path()
+
+    if dist.files is None:
+        # Can't enumerate files — editable install or unusual packaging.
+        # Warn but allow: blocking here would prevent all editable-install
+        # development workflows with no security benefit (the RECORD is absent,
+        # so there is nothing to verify against).
+        _logger.warning(
+            "Extension %r has no RECORD file — hash verification skipped "
+            "(editable install or unusual packaging)",
+            dist_name,
+        )
+        return True
+
+    pins = _load_pins(pins_path)
+    try:
+        installed_version: str = dist.metadata["Version"] or "unknown"
+    except KeyError:
+        installed_version = "unknown"
+
+    # --- First discovery or version upgrade: pin (or re-pin) ---
+    if dist_name not in pins or pins[dist_name]["version"] != installed_version:
+        hashes = _compute_dist_hashes(dist)
+        pins[dist_name] = {"version": installed_version, "files": hashes}
+        _save_pins(pins, pins_path)
+        _logger.info(
+            "Pinned extension %r at version %s (%d file(s))",
+            dist_name,
+            installed_version,
+            len(hashes),
+        )
+        return True
+
+    # --- Same version: verify hashes ---
+    stored_files: dict[str, str] = pins[dist_name]["files"]
+    current_hashes = _compute_dist_hashes(dist)
+
+    mismatches: list[str] = []
+    for rel_str, expected in stored_files.items():
+        actual = current_hashes.get(rel_str)
+        if actual is None:
+            mismatches.append(f"{rel_str} (missing)")
+        elif actual != expected:
+            mismatches.append(f"{rel_str} (hash mismatch)")
+
+    if mismatches:
+        _logger.error(
+            "Extension %r blocked — files were modified after pinning:\n  %s\n"
+            "If this is a legitimate update, reinstall the package to refresh the pin.",
+            dist_name,
+            "\n  ".join(mismatches),
+        )
+        return False
+
+    return True

--- a/tests/test_extension_discovery.py
+++ b/tests/test_extension_discovery.py
@@ -205,6 +205,55 @@ def test_probe_rejection_prevents_registration(caplog):
     assert registry.taggers == []
 
 
+def _patch_pins(passes: bool = True):
+    """Patch verify_or_pin to return *passes* without touching the filesystem."""
+    return patch(
+        "kamp_daemon.ext.discovery.verify_or_pin",
+        return_value=passes,
+    )
+
+
+def test_hash_verification_failure_prevents_registration(caplog):
+    """An extension whose files fail hash verification is never registered."""
+    ep = _make_ep("tampered", GoodTagger, dist_name="tampered-pkg")
+    registry = ExtensionRegistry()
+    with _patch_eps(ep), _patch_probe(), _patch_pins(passes=False):
+        discover_extensions(registry)
+    assert registry.taggers == []
+
+
+def test_hash_verification_called_when_dist_present():
+    """verify_or_pin is invoked when the entry point has a dist attribute."""
+    ep = _make_ep("ext", GoodTagger, dist_name="ext-pkg")
+    registry = ExtensionRegistry()
+    with _patch_eps(ep), _patch_probe():
+        with patch(
+            "kamp_daemon.ext.discovery.verify_or_pin", return_value=True
+        ) as mock_verify:
+            discover_extensions(registry)
+    mock_verify.assert_called_once()
+    call_args = mock_verify.call_args
+    assert call_args[0][0] == "ext-pkg"  # dist_name passed correctly
+
+
+def test_hash_verification_skipped_when_no_dist():
+    """verify_or_pin is not called when ep.dist is absent (unknown distribution)."""
+    ep = MagicMock(spec=importlib.metadata.EntryPoint)
+    ep.name = "nodist"
+    ep.value = "test_module:GoodTagger"
+    ep.load.return_value = GoodTagger
+    # No dist attribute — _dist_name returns '<unknown>', dist is None
+    del ep.dist
+
+    registry = ExtensionRegistry()
+    with _patch_eps(ep), _patch_probe():
+        with patch(
+            "kamp_daemon.ext.discovery.verify_or_pin", return_value=True
+        ) as mock_verify:
+            discover_extensions(registry)
+    mock_verify.assert_not_called()
+
+
 def test_dist_name_falls_back_to_unknown_on_attribute_error():
     """_dist_name returns '<unknown>' when dist.metadata raises AttributeError."""
     from kamp_daemon.ext.discovery import _dist_name

--- a/tests/test_extension_pins.py
+++ b/tests/test_extension_pins.py
@@ -1,0 +1,311 @@
+"""Tests for extension hash pinning (TASK-84)."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamp_daemon.ext.pins import _hash_file, _pins_path, verify_or_pin
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dist(name: str, version: str, files: dict[str, bytes]) -> MagicMock:
+    """Build a mock Distribution with the given file contents.
+
+    *files* maps relative path strings to raw bytes.  The mock's locate_file()
+    returns a real tmp Path so _hash_file can open it.
+    """
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": name, "Version": version}
+
+    pkg_paths = []
+    for rel_str in files:
+        pp = MagicMock()
+        pp.__str__ = lambda self, r=rel_str: r
+        pkg_paths.append(pp)
+
+    dist.files = pkg_paths
+    return dist
+
+
+def _write_dist_files(tmp_path: Path, files: dict[str, bytes]) -> dict[str, Path]:
+    """Write *files* under *tmp_path* and return {rel_str: abs_path}."""
+    abs_paths: dict[str, Path] = {}
+    for rel_str, content in files.items():
+        abs_p = tmp_path / rel_str
+        abs_p.parent.mkdir(parents=True, exist_ok=True)
+        abs_p.write_bytes(content)
+        abs_paths[rel_str] = abs_p
+    return abs_paths
+
+
+def _dist_with_real_files(
+    tmp_path: Path, name: str, version: str, files: dict[str, bytes]
+) -> tuple[MagicMock, dict[str, Path]]:
+    """Return (mock dist, abs_paths) where locate_file resolves into tmp_path."""
+    abs_paths = _write_dist_files(tmp_path, files)
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": name, "Version": version}
+
+    pkg_paths = []
+    for rel_str in files:
+        pp = MagicMock()
+        pp.__str__ = lambda self, r=rel_str: r
+        # locate_file(pp) returns the real abs path
+        pkg_paths.append(pp)
+
+    dist.files = pkg_paths
+    dist.locate_file = lambda pp: abs_paths[str(pp)]
+    return dist, abs_paths
+
+
+# ---------------------------------------------------------------------------
+# _hash_file
+# ---------------------------------------------------------------------------
+
+
+def test_hash_file_returns_sha256_hex(tmp_path: Path) -> None:
+    p = tmp_path / "test.py"
+    content = b"print('hello')"
+    p.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert _hash_file(p) == expected
+
+
+def test_hash_file_differs_for_different_content(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_bytes(b"x = 1")
+    b.write_bytes(b"x = 2")
+    assert _hash_file(a) != _hash_file(b)
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — first discovery auto-pins
+# ---------------------------------------------------------------------------
+
+
+def test_first_discovery_pins_and_returns_true(tmp_path: Path) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    dist, _ = _dist_with_real_files(
+        tmp_path, "my-ext", "1.0.0", {"my_ext/__init__.py": b"# init"}
+    )
+
+    result = verify_or_pin("my-ext", dist, pins_path)
+
+    assert result is True
+    pins = json.loads(pins_path.read_text())
+    assert "my-ext" in pins
+    assert pins["my-ext"]["version"] == "1.0.0"
+    assert "my_ext/__init__.py" in pins["my-ext"]["files"]
+
+
+def test_first_discovery_creates_parent_dirs(tmp_path: Path) -> None:
+    pins_path = tmp_path / "sub" / "dir" / "extension-pins.json"
+    dist, _ = _dist_with_real_files(tmp_path, "ext", "1.0", {"ext.py": b""})
+    verify_or_pin("ext", dist, pins_path)
+    assert pins_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — matching hashes pass
+# ---------------------------------------------------------------------------
+
+
+def test_matching_hashes_return_true(tmp_path: Path) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    dist, _ = _dist_with_real_files(
+        tmp_path, "my-ext", "1.0.0", {"my_ext/tagger.py": b"class T: pass"}
+    )
+    # First call pins
+    verify_or_pin("my-ext", dist, pins_path)
+    # Second call verifies — same files, should pass
+    assert verify_or_pin("my-ext", dist, pins_path) is True
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — hash mismatch blocks load
+# ---------------------------------------------------------------------------
+
+
+def test_hash_mismatch_returns_false(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    file_path = tmp_path / "my_ext" / "tagger.py"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_bytes(b"class T: pass")
+
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": "my-ext", "Version": "1.0.0"}
+    pp = MagicMock()
+    pp.__str__ = lambda self: "my_ext/tagger.py"
+    dist.files = [pp]
+    dist.locate_file = lambda _: file_path
+
+    # Pin with original content
+    verify_or_pin("my-ext", dist, pins_path)
+
+    # Tamper with the file
+    file_path.write_bytes(b"import os; os.system('evil')")
+
+    import logging
+
+    with caplog.at_level(logging.ERROR, logger="kamp_daemon.ext.pins"):
+        result = verify_or_pin("my-ext", dist, pins_path)
+
+    assert result is False
+    assert "my-ext" in caplog.text
+    assert "my_ext/tagger.py" in caplog.text
+
+
+def test_hash_mismatch_message_names_extension(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    file_path = tmp_path / "evil_ext.py"
+    file_path.write_bytes(b"original")
+
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": "evil-ext", "Version": "2.3.4"}
+    pp = MagicMock()
+    pp.__str__ = lambda self: "evil_ext.py"
+    dist.files = [pp]
+    dist.locate_file = lambda _: file_path
+
+    verify_or_pin("evil-ext", dist, pins_path)
+    file_path.write_bytes(b"tampered")
+
+    import logging
+
+    with caplog.at_level(logging.ERROR, logger="kamp_daemon.ext.pins"):
+        verify_or_pin("evil-ext", dist, pins_path)
+
+    assert "evil-ext" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — version change re-pins (legitimate upgrade)
+# ---------------------------------------------------------------------------
+
+
+def test_version_change_repins_and_returns_true(tmp_path: Path) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    file_path = tmp_path / "ext.py"
+    file_path.write_bytes(b"v1")
+
+    def _make_dist_v(version: str) -> MagicMock:
+        dist = MagicMock(spec=importlib.metadata.Distribution)
+        dist.metadata = {"Name": "my-ext", "Version": version}
+        pp = MagicMock()
+        pp.__str__ = lambda self: "ext.py"
+        dist.files = [pp]
+        dist.locate_file = lambda _: file_path
+        return dist
+
+    # Pin v1
+    verify_or_pin("my-ext", _make_dist_v("1.0.0"), pins_path)
+
+    # Upgrade: new content, new version
+    file_path.write_bytes(b"v2 new content")
+    result = verify_or_pin("my-ext", _make_dist_v("2.0.0"), pins_path)
+
+    assert result is True
+    pins = json.loads(pins_path.read_text())
+    assert pins["my-ext"]["version"] == "2.0.0"
+    # New hash recorded
+    assert (
+        pins["my-ext"]["files"]["ext.py"]
+        == hashlib.sha256(b"v2 new content").hexdigest()
+    )
+
+
+def test_same_version_tampered_content_blocked(tmp_path: Path) -> None:
+    """Same version string + different bytes = block (not a legitimate upgrade)."""
+    pins_path = tmp_path / "extension-pins.json"
+    file_path = tmp_path / "ext.py"
+    file_path.write_bytes(b"original")
+
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": "my-ext", "Version": "1.0.0"}
+    pp = MagicMock()
+    pp.__str__ = lambda self: "ext.py"
+    dist.files = [pp]
+    dist.locate_file = lambda _: file_path
+
+    verify_or_pin("my-ext", dist, pins_path)
+    file_path.write_bytes(b"tampered, same version")
+
+    assert verify_or_pin("my-ext", dist, pins_path) is False
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — dist.files is None (editable install / unusual package)
+# ---------------------------------------------------------------------------
+
+
+def test_no_record_warns_and_allows(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": "weird-ext", "Version": "1.0.0"}
+    dist.files = None  # no RECORD
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="kamp_daemon.ext.pins"):
+        result = verify_or_pin("weird-ext", dist, pins_path)
+
+    assert result is True
+    assert "weird-ext" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# verify_or_pin — pyc / __pycache__ files are excluded from hashing
+# ---------------------------------------------------------------------------
+
+
+def test_pycache_files_excluded(tmp_path: Path) -> None:
+    pins_path = tmp_path / "extension-pins.json"
+
+    py_file = tmp_path / "ext.py"
+    pyc_file = tmp_path / "__pycache__" / "ext.cpython-313.pyc"
+    py_file.write_bytes(b"code")
+    pyc_file.parent.mkdir()
+    pyc_file.write_bytes(b"compiled")
+
+    dist = MagicMock(spec=importlib.metadata.Distribution)
+    dist.metadata = {"Name": "ext", "Version": "1.0"}
+    pp_py = MagicMock()
+    pp_py.__str__ = lambda self: "ext.py"
+    pp_pyc = MagicMock()
+    pp_pyc.__str__ = lambda self: "__pycache__/ext.cpython-313.pyc"
+    dist.files = [pp_py, pp_pyc]
+
+    paths = {"ext.py": py_file, "__pycache__/ext.cpython-313.pyc": pyc_file}
+    dist.locate_file = lambda pp: paths[str(pp)]
+
+    verify_or_pin("ext", dist, pins_path)
+    pins = json.loads(pins_path.read_text())
+    assert "__pycache__/ext.cpython-313.pyc" not in pins["ext"]["files"]
+    assert "ext.py" in pins["ext"]["files"]
+
+
+# ---------------------------------------------------------------------------
+# _pins_path
+# ---------------------------------------------------------------------------
+
+
+def test_pins_path_is_outside_site_packages() -> None:
+    """The pins file must not live inside any site-packages directory."""
+    p = _pins_path()
+    assert "site-packages" not in str(p)


### PR DESCRIPTION
## Summary

- Adds `kamp_daemon/ext/pins.py` — records SHA-256 hashes of all installed extension files on first discovery and verifies them on every subsequent load
- Wires hash verification into `discovery.py` after the import-time probe and before `ep.load()`, so tampered extensions are blocked before any code runs in the host process
- Hash mismatch logs a clear error naming the specific files that changed; version changes re-pin automatically (legitimate upgrade path)
- Pins file stored at `~/.config/kamp/extension-pins.json` — outside any extension directory, not writable by extension code

## Test plan

- [x] 12 new unit tests in `tests/test_extension_pins.py` covering: first-discovery pinning, matching hashes, hash mismatch blocking, version-change re-pinning, missing RECORD handling, `__pycache__` exclusion
- [x] 3 new integration tests in `tests/test_extension_discovery.py` verifying the gate is in the right place in the load pipeline
- [x] 754/754 passing, mypy clean, black clean

Closes TASK-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)