### PR TITLE
feat: library.write audit log (TASK-85)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-poetry run black --check kamp_daemon/ tests/
+poetry run black --check kamp_core/ kamp_daemon/ tests/
 poetry run mypy kamp_daemon/
 
 # Run UI checks only when kamp_ui files are staged — skips on Python-only commits.

--- a/backlog/tasks/task-85 - library.write-audit-log.md
+++ b/backlog/tasks/task-85 - library.write-audit-log.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-85
 title: library.write audit log
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-06 11:55'
+updated_date: '2026-04-06 13:00'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-17
 documentation:
   - project/kampground-ideation.md
-ordinal: 4000
+ordinal: 10000
 ---
 
 ## Description

--- a/backlog/tasks/task-85 - library.write-audit-log.md
+++ b/backlog/tasks/task-85 - library.write-audit-log.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-85
 title: library.write audit log
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-05 21:21'
+updated_date: '2026-04-06 11:55'
 labels:
   - feature
   - security

--- a/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
+++ b/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
@@ -1,0 +1,50 @@
+---
+id: TASK-90
+title: Extension invocation policy — wire tagger/artwork extensions into the pipeline
+status: To Do
+assignee: []
+created_date: '2026-04-06 12:54'
+labels:
+  - feature
+  - design
+  - 'estimate: lp'
+milestone: m-2
+dependencies:
+  - TASK-85
+  - TASK-17
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement the policy that governs when and how the host invokes registered tagger and artwork-source extensions against library tracks.
+
+The current pipeline (extract → tag → artwork → move) uses first-party MusicBrainz and Cover Art Archive code exclusively. `invoke_extension()` and `apply_mutations()` exist but nothing calls them from the pipeline yet. This task decides the invocation model and wires it in.
+
+## Key design constraint: audit log inflation
+
+Every mutation issued by an extension is appended to `extension_audit_log` (TASK-85). The log is append-only and never pruned. Invocation policy therefore directly controls database growth:
+
+- **Correct policy** (invoke each extension once per track at ingest, skip on re-scan): log grows O(library size) — negligible.
+- **Incorrect policy** (invoke on every scan over all existing tracks): log grows O(library × time) — can reach hundreds of MB within a year at 100 new tracks/week.
+
+As a general principle, kamp should be a good citizen in the client's filesystem. Generating unbounded write traffic on a local SQLite database to record mutations that have no effect (re-tagging a track that's already correctly tagged) is not acceptable.
+
+The invocation policy must therefore guarantee that extensions are not offered tracks they have already processed, unless there is a deliberate reason to reprocess (e.g. user-triggered re-tag, new extension version).
+
+## Questions to resolve
+
+1. **Trigger point**: ingest-time only (new tracks entering from staging), on-demand (user action), or both?
+2. **Already-processed detection**: use the audit log to detect "this extension has already run on this track" and skip, or rely on the extension's own skip logic, or filter at the host level by track age/MBID presence?
+3. **Extension version changes**: should a new version of an installed extension cause re-processing of existing tracks? If so, how is that scoped?
+4. **Ordering**: do registered taggers run before or after the first-party MusicBrainz step? Do they replace it or supplement it?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Registered tagger extensions are invoked at ingest time for new tracks entering the library
+- [ ] #2 Each track is offered to each extension at most once per ingest event — no redundant mutations on re-scan
+- [ ] #3 The host uses the audit log or equivalent mechanism to enforce the single-invocation guarantee, not extension skip logic (extension skip logic is unreliable and not under our control)
+- [ ] #4 Registered artwork-source extensions are invoked under the same policy as taggers
+- [ ] #5 The invocation policy is documented in a comment at the call site explaining why re-scan invocation is explicitly excluded
+<!-- AC:END -->

--- a/backlog/tasks/task-91 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
+++ b/backlog/tasks/task-91 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
@@ -1,0 +1,50 @@
+---
+id: TASK-91
+title: Extension invocation policy — wire tagger/artwork extensions into the pipeline
+status: To Do
+assignee: []
+created_date: '2026-04-06 12:55'
+labels:
+  - feature
+  - design
+  - 'estimate: lp'
+milestone: m-2
+dependencies:
+  - TASK-85
+  - TASK-17
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement the policy that governs when and how the host invokes registered tagger and artwork-source extensions against library tracks.
+
+The current pipeline (extract → tag → artwork → move) uses first-party MusicBrainz and Cover Art Archive code exclusively. `invoke_extension()` and `apply_mutations()` exist but nothing calls them from the pipeline yet. This task decides the invocation model and wires it in.
+
+## Key design constraint: audit log inflation
+
+Every mutation issued by an extension is appended to `extension_audit_log` (TASK-85). The log is append-only and never pruned. Invocation policy therefore directly controls database growth:
+
+- **Correct policy** (invoke each extension once per track at ingest, skip on re-scan): log grows O(library size) — negligible.
+- **Incorrect policy** (invoke on every scan over all existing tracks): log grows O(library x time) — can reach hundreds of MB within a year at 100 new tracks/week.
+
+As a general principle, kamp should be a good citizen in the client's filesystem. Generating unbounded write traffic on a local SQLite database to record mutations that have no effect (re-tagging a track that is already correctly tagged) is not acceptable.
+
+The invocation policy must therefore guarantee that extensions are not offered tracks they have already processed, unless there is a deliberate reason to reprocess (e.g. user-triggered re-tag, new extension version).
+
+## Questions to resolve
+
+1. **Trigger point**: ingest-time only (new tracks entering from staging), on-demand (user action), or both?
+2. **Already-processed detection**: use the audit log to detect this extension has already run on this track and skip, or rely on extension skip logic, or filter at the host level by track age/MBID presence?
+3. **Extension version changes**: should a new version of an installed extension cause re-processing of existing tracks? If so, how is that scoped?
+4. **Ordering**: do registered taggers run before or after the first-party MusicBrainz step? Do they replace it or supplement it?
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Registered tagger extensions are invoked at ingest time for new tracks entering the library
+- [ ] #2 Each track is offered to each extension at most once per ingest event — no redundant mutations on re-scan
+- [ ] #3 The host uses the audit log or equivalent mechanism to enforce the single-invocation guarantee, not extension skip logic (extension skip logic is unreliable and not under our control)
+- [ ] #4 Registered artwork-source extensions are invoked under the same policy as taggers
+- [ ] #5 The invocation policy is documented in a comment at the call site explaining why re-scan invocation is explicitly excluded
+<!-- AC:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -706,16 +706,18 @@ class LibraryIndex:
 # Track fields that extensions are permitted to write via apply_metadata_update.
 # Excludes internal columns (embedded_art, play_count, last_played, etc.) so
 # extensions cannot corrupt playback state or override quality signals.
-_WRITABLE_TRACK_FIELDS: frozenset[str] = frozenset({
-    "title",
-    "artist",
-    "album_artist",
-    "album",
-    "year",
-    "track_number",
-    "disc_number",
-    "mb_release_id",
-})
+_WRITABLE_TRACK_FIELDS: frozenset[str] = frozenset(
+    {
+        "title",
+        "artist",
+        "album_artist",
+        "album",
+        "year",
+        "track_number",
+        "disc_number",
+        "mb_release_id",
+    }
+)
 
 
 def _track_to_params(

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import sqlite3
 import threading
+import time as _time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -20,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 6
+_SCHEMA_VERSION = 7
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -69,6 +71,34 @@ CREATE TABLE IF NOT EXISTS queue_state (
     shuffle INTEGER NOT NULL DEFAULT 0,
     repeat  INTEGER NOT NULL DEFAULT 0
 );
+
+-- Append-only audit trail for all library.write mutations issued by extensions.
+-- track_mbid is the MusicBrainz recording ID of the affected track.
+-- old_value / new_value are JSON-encoded field dicts so arbitrary mutation
+-- payloads can be captured without schema changes.
+CREATE TABLE IF NOT EXISTS extension_audit_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    extension_id TEXT    NOT NULL,
+    track_mbid   TEXT    NOT NULL DEFAULT '',
+    operation    TEXT    NOT NULL,
+    old_value    TEXT    NOT NULL DEFAULT '',
+    new_value    TEXT    NOT NULL DEFAULT '',
+    timestamp    REAL    NOT NULL
+);
+
+-- Enforce append-only invariant at the DB level so no code path can silently
+-- erase the audit trail.
+CREATE TRIGGER IF NOT EXISTS _audit_log_no_delete
+BEFORE DELETE ON extension_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'extension_audit_log is append-only: DELETE is not permitted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS _audit_log_no_update
+BEFORE UPDATE ON extension_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'extension_audit_log is append-only: UPDATE is not permitted');
+END;
 """
 
 # Characters that have special meaning in FTS5 MATCH expressions.
@@ -270,6 +300,14 @@ class LibraryIndex:
             # art) are picked up on the first scan after migration.
             self._conn.execute("ALTER TABLE tracks ADD COLUMN file_mtime REAL")
             self._conn.execute("UPDATE schema_version SET version = 6")
+            self._conn.commit()
+            version = 6
+
+        if version < 7:
+            # v6 → v7: extension_audit_log table and append-only triggers added.
+            # The table and triggers are created by _DDL via executescript at the
+            # top of _migrate, so we only need to bump the version here.
+            self._conn.execute("UPDATE schema_version SET version = 7")
             self._conn.commit()
 
     def _rebuild_fts(self) -> None:
@@ -502,6 +540,182 @@ class LibraryIndex:
             for conn in self._all_conns:
                 conn.close()
             self._all_conns.clear()
+
+    # ------------------------------------------------------------------
+    # Extension library writes + audit log
+    # ------------------------------------------------------------------
+
+    def apply_metadata_update(
+        self,
+        extension_id: str,
+        mbid: str,
+        fields: dict[str, str | int],
+    ) -> None:
+        """Log and apply a metadata update mutation from an extension.
+
+        Reads the current field values before writing so the audit log
+        captures a meaningful old_value. Only fields in
+        _WRITABLE_TRACK_FIELDS are applied; others are silently discarded
+        so extensions cannot touch internal columns (e.g. embedded_art,
+        play_count).
+
+        The audit entry is written in the same transaction as the UPDATE
+        so the log is always consistent with the applied state (AC #2).
+        """
+        row = self._conn.execute(
+            "SELECT * FROM tracks WHERE mb_recording_id = ?", (mbid,)
+        ).fetchone()
+        old_fields: dict[str, Any] = {}
+        if row:
+            for k in fields:
+                if k in row.keys():
+                    old_fields[k] = row[k]
+
+        # Write audit entry before the mutation (AC #2).
+        self._conn.execute(
+            """
+            INSERT INTO extension_audit_log
+                (extension_id, track_mbid, operation, old_value, new_value, timestamp)
+            VALUES (?, ?, 'update_metadata', ?, ?, ?)
+            """,
+            (
+                extension_id,
+                mbid,
+                json.dumps(old_fields),
+                json.dumps(dict(fields)),
+                _time.time(),
+            ),
+        )
+
+        # Apply only the safe, known-writable fields.
+        safe = {k: v for k, v in fields.items() if k in _WRITABLE_TRACK_FIELDS}
+        if row and safe:
+            set_clause = ", ".join(f"{k} = ?" for k in safe)
+            params: list[Any] = [*safe.values(), mbid]
+            self._conn.execute(
+                f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",  # noqa: S608
+                params,
+            )
+        self._conn.commit()
+
+    def apply_set_artwork(
+        self,
+        extension_id: str,
+        mbid: str,
+        mime_type: str,
+    ) -> None:
+        """Log and apply a set_artwork mutation from an extension.
+
+        Records the old embedded_art flag in the audit log, then marks
+        the track as having embedded art. The mime_type is stored in
+        new_value for informational purposes.
+
+        The audit entry is written in the same transaction as the UPDATE
+        (AC #2).
+        """
+        row = self._conn.execute(
+            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", (mbid,)
+        ).fetchone()
+        old_embedded_art: bool | None = bool(row["embedded_art"]) if row else None
+
+        self._conn.execute(
+            """
+            INSERT INTO extension_audit_log
+                (extension_id, track_mbid, operation, old_value, new_value, timestamp)
+            VALUES (?, ?, 'set_artwork', ?, ?, ?)
+            """,
+            (
+                extension_id,
+                mbid,
+                json.dumps({"embedded_art": old_embedded_art}),
+                json.dumps({"mime_type": mime_type}),
+                _time.time(),
+            ),
+        )
+        if row:
+            self._conn.execute(
+                "UPDATE tracks SET embedded_art = 1 WHERE mb_recording_id = ?",
+                (mbid,),
+            )
+        self._conn.commit()
+
+    def rollback_extension(self, extension_id: str) -> int:
+        """Revert all library writes performed by *extension_id*.
+
+        Reads the audit log for the given extension and reverses each
+        entry in reverse-chronological order (newest write undone first)
+        so the final state matches the pre-extension library state.
+
+        Returns the number of mutations reverted.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT track_mbid, operation, old_value
+            FROM extension_audit_log
+            WHERE extension_id = ?
+            ORDER BY timestamp DESC, id DESC
+            """,
+            (extension_id,),
+        ).fetchall()
+
+        reverted = 0
+        for row in rows:
+            op = row["operation"]
+            mbid = row["track_mbid"]
+            old: dict[str, Any] = json.loads(row["old_value"])
+
+            if op == "update_metadata":
+                safe = {k: v for k, v in old.items() if k in _WRITABLE_TRACK_FIELDS}
+                if safe:
+                    set_clause = ", ".join(f"{k} = ?" for k in safe)
+                    params = [*safe.values(), mbid]
+                    self._conn.execute(
+                        f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",  # noqa: S608
+                        params,
+                    )
+            elif op == "set_artwork":
+                embedded_art = old.get("embedded_art")
+                if embedded_art is not None:
+                    self._conn.execute(
+                        "UPDATE tracks SET embedded_art = ? WHERE mb_recording_id = ?",
+                        (int(embedded_art), mbid),
+                    )
+            reverted += 1
+
+        self._conn.commit()
+        return reverted
+
+    def audit_log_for(self, extension_id: str) -> list[dict[str, Any]]:
+        """Return all audit log rows for *extension_id* in ascending order.
+
+        Primarily useful for inspection and testing.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT id, extension_id, track_mbid, operation,
+                   old_value, new_value, timestamp
+            FROM extension_audit_log
+            WHERE extension_id = ?
+            ORDER BY timestamp ASC, id ASC
+            """,
+            (extension_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+# Track fields that extensions are permitted to write via apply_metadata_update.
+# Excludes internal columns (embedded_art, play_count, last_played, etc.) so
+# extensions cannot corrupt playback state or override quality signals.
+_WRITABLE_TRACK_FIELDS: frozenset[str] = frozenset({
+    "title",
+    "artist",
+    "album_artist",
+    "album",
+    "year",
+    "track_number",
+    "disc_number",
+    "mb_release_id",
+})
 
 
 def _track_to_params(

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -191,6 +191,16 @@ def main() -> None:
         help="Which error type to simulate.",
     )
 
+    # rollback subcommand
+    rollback_parser = subparsers.add_parser(
+        "rollback",
+        help="Revert all library writes performed by a given extension.",
+    )
+    rollback_parser.add_argument(
+        "extension_id",
+        help="Extension package name whose writes should be reverted.",
+    )
+
     # config subcommand
     config_parser = subparsers.add_parser(
         "config",
@@ -243,6 +253,11 @@ def main() -> None:
         return
     if command == "status":
         _cmd_status()
+        return
+
+    # rollback bypasses the daemon lifecycle — it only needs the library DB.
+    if command == "rollback":
+        _cmd_rollback(args.extension_id)
         return
 
     # Config commands bypass daemon lifecycle (no musicbrainzngs setup needed).
@@ -335,6 +350,18 @@ def _cmd_config(
             sys.exit(1)
     else:
         config_parser.print_help()
+
+
+def _cmd_rollback(extension_id: str) -> None:
+    from kamp_core.library import LibraryIndex
+
+    db_path = _state_dir() / "library.db"
+    library = LibraryIndex(db_path)
+    try:
+        count = library.rollback_extension(extension_id)
+    finally:
+        library.close()
+    print(f"Reverted {count} mutation(s) for extension '{extension_id}'.")
 
 
 def _cmd_logout() -> None:

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -14,6 +14,7 @@ from .probe import probe_extension
 from .registry import ExtensionRegistry
 from .types import ArtworkQuery, ArtworkResult, TrackMetadata
 from .worker import invoke_extension
+from .write_log import apply_mutations
 
 __all__ = [
     "ArtworkQuery",
@@ -29,6 +30,7 @@ __all__ = [
     "TrackMetadata",
     "UpdateMetadataMutation",
     "discover_extensions",
+    "apply_mutations",
     "invoke_extension",
     "probe_extension",
 ]

--- a/kamp_daemon/ext/write_log.py
+++ b/kamp_daemon/ext/write_log.py
@@ -1,0 +1,55 @@
+"""Host-side application of extension library.write mutations.
+
+After invoke_extension() returns a list of Mutation objects, the host calls
+apply_mutations() to log and apply each one to the library database.  This
+module is the only code path through which extension mutations reach the DB
+— the worker subprocess never writes directly.
+
+Only UpdateMetadataMutation and SetArtworkMutation are permitted; any other
+Mutation subtype raises ValueError so unlisted operations are rejected at
+the point of application (AC #5).
+"""
+
+from __future__ import annotations
+
+from kamp_core.library import LibraryIndex
+
+from .context import Mutation, SetArtworkMutation, UpdateMetadataMutation
+
+
+def apply_mutations(
+    extension_id: str,
+    mutations: list[Mutation],
+    library: LibraryIndex,
+) -> None:
+    """Log and apply a list of mutations from an extension to *library*.
+
+    Each mutation is dispatched to the appropriate LibraryIndex method,
+    which logs the old and new values to extension_audit_log before
+    applying the change.  Processing stops and raises ValueError if an
+    unknown mutation type is encountered so callers can decide whether
+    to abort or log and continue.
+
+    Args:
+        extension_id: Identifier for the extension that produced the
+            mutations (used as the audit log's extension_id column).
+        mutations: Ordered list of mutations returned by invoke_extension.
+        library: LibraryIndex instance to write to.
+
+    Raises:
+        ValueError: If a mutation of an unrecognised type is encountered.
+            Only UpdateMetadataMutation and SetArtworkMutation are valid.
+    """
+    for mutation in mutations:
+        if isinstance(mutation, UpdateMetadataMutation):
+            library.apply_metadata_update(extension_id, mutation.mbid, mutation.fields)
+        elif isinstance(mutation, SetArtworkMutation):
+            library.apply_set_artwork(
+                extension_id, mutation.mbid, mutation.artwork.mime_type
+            )
+        else:
+            raise ValueError(
+                f"Unknown mutation type {type(mutation).__qualname__!r} from "
+                f"extension {extension_id!r} — only UpdateMetadataMutation and "
+                f"SetArtworkMutation are permitted"
+            )

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 6
+        assert version == 7
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -938,7 +938,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 6
+        assert version == 7
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -995,7 +995,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 6
+        assert version == 7
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1288,7 +1288,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 6
+        assert version == 7
         assert row is not None
         assert row[0] == 0
 
@@ -1401,7 +1401,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 6
+        assert version == 7
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -1582,7 +1582,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 6
+        assert version == 7
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.

--- a/tests/test_library_write_log.py
+++ b/tests/test_library_write_log.py
@@ -1,0 +1,351 @@
+"""Tests for TASK-85: library.write audit log.
+
+Covers all five acceptance criteria:
+
+AC #1 — extension_audit_log table has required columns.
+AC #2 — every update_metadata / set_artwork call is logged before the write.
+AC #3 — audit log is append-only (DELETE and UPDATE raise).
+AC #4 — rollback_extension() reverts all writes by a given extension_id.
+AC #5 — apply_mutations() rejects unknown mutation types; only
+         UpdateMetadataMutation and SetArtworkMutation are permitted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kamp_core.library import LibraryIndex, Track
+from kamp_daemon.ext.context import (
+    SetArtworkMutation,
+    UpdateMetadataMutation,
+)
+from kamp_daemon.ext.types import ArtworkResult
+from kamp_daemon.ext.write_log import apply_mutations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_track(
+    path: Path,
+    *,
+    mbid: str = "rec-1",
+    title: str = "Original Title",
+    artist: str = "Original Artist",
+    embedded_art: bool = False,
+) -> Track:
+    return Track(
+        file_path=path,
+        title=title,
+        artist=artist,
+        album_artist=artist,
+        album="Some Album",
+        year="2020",
+        track_number=1,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=embedded_art,
+        mb_release_id="rel-1",
+        mb_recording_id=mbid,
+    )
+
+
+def _make_library(tmp_path: Path) -> LibraryIndex:
+    return LibraryIndex(tmp_path / "library.db")
+
+
+def _make_artwork() -> ArtworkResult:
+    return ArtworkResult(image_bytes=b"\xff\xd8\xff", mime_type="image/jpeg")
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — audit_log table has required columns
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogTableSchema:
+    def test_audit_log_table_exists(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        row = lib._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='extension_audit_log'"
+        ).fetchone()
+        lib.close()
+        assert row is not None, "extension_audit_log table must exist"
+
+    def test_audit_log_has_required_columns(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cols = {
+            row["name"]
+            for row in lib._conn.execute(
+                "PRAGMA table_info(extension_audit_log)"
+            ).fetchall()
+        }
+        lib.close()
+        assert {
+            "extension_id",
+            "operation",
+            "old_value",
+            "new_value",
+            "timestamp",
+        } <= cols
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — mutations are logged before the write is applied
+# ---------------------------------------------------------------------------
+
+
+class TestMutationLogging:
+    def test_update_metadata_logged(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1", title="Old"))
+
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "New Title"})
+
+        rows = lib.audit_log_for("ext-a")
+        lib.close()
+
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "update_metadata"
+        assert rows[0]["extension_id"] == "ext-a"
+        assert rows[0]["track_mbid"] == "rec-1"
+        assert json.loads(rows[0]["old_value"])["title"] == "Old"
+        assert json.loads(rows[0]["new_value"])["title"] == "New Title"
+
+    def test_update_metadata_actually_applied(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1", title="Old"))
+
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "New Title"})
+
+        row = lib._conn.execute(
+            "SELECT title FROM tracks WHERE mb_recording_id = ?", ("rec-1",)
+        ).fetchone()
+        lib.close()
+        assert row["title"] == "New Title"
+
+    def test_set_artwork_logged(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(
+            _make_track(tmp_path / "a.mp3", mbid="rec-2", embedded_art=False)
+        )
+
+        lib.apply_set_artwork("ext-b", "rec-2", "image/jpeg")
+
+        rows = lib.audit_log_for("ext-b")
+        lib.close()
+
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "set_artwork"
+        old = json.loads(rows[0]["old_value"])
+        new = json.loads(rows[0]["new_value"])
+        assert old["embedded_art"] is False
+        assert new["mime_type"] == "image/jpeg"
+
+    def test_set_artwork_actually_applied(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(
+            _make_track(tmp_path / "a.mp3", mbid="rec-2", embedded_art=False)
+        )
+
+        lib.apply_set_artwork("ext-b", "rec-2", "image/jpeg")
+
+        row = lib._conn.execute(
+            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", ("rec-2",)
+        ).fetchone()
+        lib.close()
+        assert bool(row["embedded_art"]) is True
+
+    def test_log_entry_written_even_when_track_not_found(self, tmp_path: Path) -> None:
+        """Audit log must record the attempt even if no matching track exists."""
+        lib = _make_library(tmp_path)
+
+        lib.apply_metadata_update("ext-a", "nonexistent-mbid", {"title": "X"})
+
+        rows = lib.audit_log_for("ext-a")
+        lib.close()
+        assert len(rows) == 1
+        assert rows[0]["track_mbid"] == "nonexistent-mbid"
+
+    def test_multiple_mutations_all_logged_in_order(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.upsert_track(_make_track(tmp_path / "b.mp3", mbid="rec-2"))
+
+        lib.apply_metadata_update("ext-x", "rec-1", {"title": "T1"})
+        lib.apply_set_artwork("ext-x", "rec-2", "image/png")
+        lib.apply_metadata_update("ext-x", "rec-1", {"artist": "New Artist"})
+
+        rows = lib.audit_log_for("ext-x")
+        lib.close()
+        assert len(rows) == 3
+        assert rows[0]["operation"] == "update_metadata"
+        assert rows[1]["operation"] == "set_artwork"
+        assert rows[2]["operation"] == "update_metadata"
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — audit log is append-only
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogAppendOnly:
+    def test_delete_from_audit_log_raises(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "X"})
+
+        with pytest.raises(Exception):
+            lib._conn.execute("DELETE FROM extension_audit_log")
+
+        lib.close()
+
+    def test_update_audit_log_raises(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "X"})
+
+        with pytest.raises(Exception):
+            lib._conn.execute("UPDATE extension_audit_log SET operation = 'tampered'")
+
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — rollback_extension() reverts all writes by a given extension_id
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackExtension:
+    def test_rollback_metadata_restores_old_title(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1", title="Before"))
+
+        lib.apply_metadata_update("ext-bad", "rec-1", {"title": "After"})
+        lib.rollback_extension("ext-bad")
+
+        row = lib._conn.execute(
+            "SELECT title FROM tracks WHERE mb_recording_id = ?", ("rec-1",)
+        ).fetchone()
+        lib.close()
+        assert row["title"] == "Before"
+
+    def test_rollback_set_artwork_restores_embedded_art_flag(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(
+            _make_track(tmp_path / "a.mp3", mbid="rec-2", embedded_art=False)
+        )
+
+        lib.apply_set_artwork("ext-bad", "rec-2", "image/jpeg")
+        lib.rollback_extension("ext-bad")
+
+        row = lib._conn.execute(
+            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", ("rec-2",)
+        ).fetchone()
+        lib.close()
+        assert bool(row["embedded_art"]) is False
+
+    def test_rollback_multiple_writes_in_reverse_order(self, tmp_path: Path) -> None:
+        """Sequential writes on the same field must roll back to the pre-first-write value."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(
+            _make_track(tmp_path / "a.mp3", mbid="rec-1", title="Original")
+        )
+
+        lib.apply_metadata_update("ext-bad", "rec-1", {"title": "First"})
+        lib.apply_metadata_update("ext-bad", "rec-1", {"title": "Second"})
+        lib.rollback_extension("ext-bad")
+
+        row = lib._conn.execute(
+            "SELECT title FROM tracks WHERE mb_recording_id = ?", ("rec-1",)
+        ).fetchone()
+        lib.close()
+        assert row["title"] == "Original"
+
+    def test_rollback_returns_count_of_reverted_mutations(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.upsert_track(_make_track(tmp_path / "b.mp3", mbid="rec-2"))
+
+        lib.apply_metadata_update("ext-bad", "rec-1", {"title": "X"})
+        lib.apply_set_artwork("ext-bad", "rec-2", "image/jpeg")
+
+        count = lib.rollback_extension("ext-bad")
+        lib.close()
+        assert count == 2
+
+    def test_rollback_only_affects_given_extension(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1", title="Base"))
+
+        lib.apply_metadata_update("ext-good", "rec-1", {"title": "GoodWrite"})
+        lib.apply_metadata_update("ext-bad", "rec-1", {"title": "BadWrite"})
+        lib.rollback_extension("ext-bad")
+
+        row = lib._conn.execute(
+            "SELECT title FROM tracks WHERE mb_recording_id = ?", ("rec-1",)
+        ).fetchone()
+        lib.close()
+        # ext-good's write is still in place; only ext-bad's is reversed
+        assert row["title"] == "GoodWrite"
+
+    def test_rollback_returns_zero_when_no_mutations(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        count = lib.rollback_extension("nonexistent-ext")
+        lib.close()
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# AC #5 — apply_mutations() rejects unknown mutation types
+# ---------------------------------------------------------------------------
+
+
+class TestApplyMutationsDispatch:
+    def test_apply_update_metadata_mutation(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1", title="Old"))
+
+        mutations = [UpdateMetadataMutation(mbid="rec-1", fields={"title": "New"})]
+        apply_mutations("ext-a", mutations, lib)
+
+        rows = lib.audit_log_for("ext-a")
+        lib.close()
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "update_metadata"
+
+    def test_apply_set_artwork_mutation(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-2"))
+
+        mutations = [SetArtworkMutation(mbid="rec-2", artwork=_make_artwork())]
+        apply_mutations("ext-b", mutations, lib)
+
+        rows = lib.audit_log_for("ext-b")
+        lib.close()
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "set_artwork"
+
+    def test_unknown_mutation_type_raises_value_error(self, tmp_path: Path) -> None:
+        """Any mutation type beyond the two permitted ones must be rejected."""
+        lib = _make_library(tmp_path)
+
+        class _UnknownMutation:
+            mbid = "rec-1"
+
+        with pytest.raises(ValueError, match="Unknown mutation type"):
+            apply_mutations("ext-c", [_UnknownMutation()], lib)  # type: ignore[list-item]
+
+        lib.close()
+
+    def test_apply_mutations_empty_list_is_noop(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        apply_mutations("ext-a", [], lib)  # must not raise
+        assert lib.audit_log_for("ext-a") == []
+        lib.close()


### PR DESCRIPTION
## Summary

- Adds an append-only `extension_audit_log` SQLite table (schema v7) with triggers that prevent DELETE/UPDATE at the DB level
- Adds `apply_metadata_update()`, `apply_set_artwork()`, `rollback_extension()` to `LibraryIndex`
- Adds `kamp_daemon/ext/write_log.py` — `apply_mutations()` adapter that type-checks mutations and rejects unlisted operation types
- Adds `kamp rollback <extension_id>` CLI subcommand to revert all writes by a given extension
- 20 tests covering all 5 acceptance criteria

## Test plan

- [ ] `poetry run pytest tests/test_library_write_log.py -v --no-cov` — all 20 pass
- [ ] `poetry run pytest --no-cov -q` — full suite (774 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)