### PR TITLE
feat: BaseSyncer ABC, ctx.stage(), and KampBandcampSyncer wrapper (TASK-18.1)

### DIFF
--- a/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
+++ b/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-18.1
 title: Design BaseSyncer ABC and ctx.stage() for Bandcamp extension wrapper
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-06 14:29'
-updated_date: '2026-04-06 18:43'
+updated_date: '2026-04-06 18:57'
 labels:
   - extensions
   - bandcamp

--- a/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
+++ b/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-18.1
 title: Design BaseSyncer ABC and ctx.stage() for Bandcamp extension wrapper
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-06 14:29'
 updated_date: '2026-04-06 19:25'
@@ -12,7 +12,7 @@ milestone: m-2
 dependencies: []
 parent_task_id: TASK-18
 priority: medium
-ordinal: 1000
+ordinal: 12000
 ---
 
 ## Description

--- a/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
+++ b/backlog/tasks/task-18.1 - Design-BaseSyncer-ABC-and-ctx.stage-for-Bandcamp-extension-wrapper.md
@@ -4,7 +4,7 @@ title: Design BaseSyncer ABC and ctx.stage() for Bandcamp extension wrapper
 status: In Progress
 assignee: []
 created_date: '2026-04-06 14:29'
-updated_date: '2026-04-06 18:57'
+updated_date: '2026-04-06 19:25'
 labels:
   - extensions
   - bandcamp
@@ -12,7 +12,7 @@ milestone: m-2
 dependencies: []
 parent_task_id: TASK-18
 priority: medium
-ordinal: 3000
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_daemon/daemon_core.py
+++ b/kamp_daemon/daemon_core.py
@@ -18,7 +18,8 @@ from typing import Literal
 from .config import Config, _state_dir
 from .config_monitor import ConfigMonitor
 from .ext import ExtensionRegistry, discover_extensions
-from .syncer import Syncer
+from .ext.builtin.bandcamp import KampBandcampSyncer
+from .ext.context import KampGround, PlaybackSnapshot
 from .watcher import Watcher
 
 _PID_PATH: Path = _state_dir() / "daemon.pid"
@@ -42,10 +43,12 @@ class DaemonCore:
         self._state: DaemonState = "stopped"
         self._done = threading.Event()
         # Created here so callers can wire callbacks (e.g. status_callback on
-        # Syncer) before start() launches threads — avoids a race where the
+        # the syncer) before start() launches threads — avoids a race where the
         # first automatic sync fires before the menu bar has wired its callback.
         self._watcher: Watcher = Watcher(config)
-        self._syncer: Syncer = Syncer(config)
+        ctx = KampGround(playback=PlaybackSnapshot(), library_tracks=[])
+        self._syncer: KampBandcampSyncer = KampBandcampSyncer(ctx)
+        self._syncer._configure(config)
         self._monitor: ConfigMonitor | None = None
         self._extension_registry: ExtensionRegistry = ExtensionRegistry()
 
@@ -68,8 +71,8 @@ class DaemonCore:
         return self._watcher
 
     @property
-    def syncer(self) -> Syncer:
-        """The Syncer instance (available immediately after construction)."""
+    def syncer(self) -> KampBandcampSyncer:
+        """The syncer instance (available immediately after construction)."""
         return self._syncer
 
     # ------------------------------------------------------------------

--- a/kamp_daemon/ext/abc.py
+++ b/kamp_daemon/ext/abc.py
@@ -7,6 +7,73 @@ from abc import ABC, abstractmethod
 from .types import ArtworkQuery, ArtworkResult, TrackMetadata
 
 
+class BaseSyncer(ABC):
+    """Polls an external source and deposits new downloads into staging.
+
+    Implementations run in-process within the daemon — the extension host
+    already provides process isolation, so a nested subprocess is not needed.
+    Third-party syncers that cannot write to the filesystem directly should
+    call ``ctx.stage(filename, content)`` to deposit files; the host writes
+    them to the staging directory.
+
+    Lifecycle
+    ---------
+    ``DaemonCore`` calls the following methods in order::
+
+        syncer.start()        # begin background polling
+        syncer.pause()        # temporarily stop polling (e.g. pipeline pause)
+        syncer.resume()       # restart polling after pause
+        syncer.stop()         # final shutdown; join background thread
+
+    The default implementations of ``pause`` and ``resume`` delegate to
+    ``stop`` / ``start`` respectively.  Override them if the implementation
+    can cheaply suspend without fully tearing down (e.g. by setting an event).
+
+    Manual triggers
+    ---------------
+    ``sync_once`` and ``mark_synced`` are optional capabilities.  Override
+    them to support manual sync triggers (e.g. a "Sync now" menu item).
+    """
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start the background polling thread."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop the background polling thread and join it."""
+        raise NotImplementedError
+
+    def pause(self) -> None:
+        """Temporarily pause polling. Default: calls stop()."""
+        self.stop()
+
+    def resume(self) -> None:
+        """Resume polling after pause(). Default: calls start()."""
+        self.start()
+
+    def sync_once(self, *, skip_auto_mark: bool = False) -> None:
+        """Perform a single immediate sync without waiting for the poll interval.
+
+        Override to support manual sync triggers.  The default raises
+        ``NotImplementedError`` so callers can detect unsupported syncers.
+
+        Args:
+            skip_auto_mark: When True, skip the automatic "mark existing
+                collection as synced" step that normally runs on first use.
+        """
+        raise NotImplementedError
+
+    def mark_synced(self) -> None:
+        """Mark the entire collection as already synced without downloading.
+
+        Override to support the "mark synced" operation.  The default raises
+        ``NotImplementedError`` so callers can detect unsupported syncers.
+        """
+        raise NotImplementedError
+
+
 class BaseTagger(ABC):
     """Resolves track metadata.
 

--- a/kamp_daemon/ext/builtin/bandcamp.py
+++ b/kamp_daemon/ext/builtin/bandcamp.py
@@ -1,0 +1,150 @@
+"""First-party syncer: Bandcamp collection downloader.
+
+Wraps kamp_daemon.syncer.Syncer using the public BaseSyncer API so the
+Bandcamp downloader is registered and discovered as an extension like any
+other, rather than being hard-coded into DaemonCore.
+
+Architecture note
+-----------------
+The underlying Syncer already provides its own subprocess isolation via
+_spawn_worker: Playwright and the bandcamp module are loaded only inside a
+child process, which the OS reclaims entirely on exit.  There is therefore
+no reason to nest a second subprocess (via invoke_extension()) inside the
+daemon.  KampBandcampSyncer calls the inner Syncer in-process, mirroring
+the pattern used by KampMusicBrainzTagger and KampCoverArtArchive.
+
+Callbacks
+---------
+DaemonCore and the menu bar wire status_callback and error_callback on the
+syncer *before* start() is called (to avoid a race where the first automatic
+sync fires before the UI has wired its callback).  These attributes are
+delegated transparently to the inner Syncer via properties.
+
+reload() and pause()/resume()
+------------------------------
+reload() is an internal daemon lifecycle method (takes a Config object) that
+is not part of the BaseSyncer ABC.  DaemonCore calls it directly on
+KampBandcampSyncer after type-narrowing.  pause() and resume() override the
+BaseSyncer defaults to use the inner Syncer's richer pause/resume semantics
+(event-based suspension rather than full stop/start).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from kamp_daemon.ext.abc import BaseSyncer
+from kamp_daemon.ext.context import KampGround
+
+logger = logging.getLogger(__name__)
+
+
+class KampBandcampSyncer(BaseSyncer):
+    """Sync Bandcamp purchases to the staging directory.
+
+    Thin extension wrapper around ``kamp_daemon.syncer.Syncer``.  All public
+    methods delegate to the inner syncer; this class exists to register the
+    Bandcamp syncer in the extension registry so it is discovered and pinned
+    alongside third-party extensions.
+    """
+
+    def __init__(self, ctx: KampGround) -> None:
+        # Lazy import: probe runs at module import time; keep the module-level
+        # clean so the probe does not fire on bandcamp/playwright side-effects.
+        from kamp_daemon.config import Config
+        from kamp_daemon.syncer import Syncer
+
+        # KampGround carries no Config reference — the daemon constructs
+        # KampBandcampSyncer directly (in-process) and passes config via
+        # _configure(), which DaemonCore calls immediately after construction.
+        self._ctx = ctx
+        self._inner: Syncer | None = None
+        self._Config = Config
+        self._Syncer = Syncer
+
+    def _configure(self, config: object) -> None:
+        """Initialise the inner Syncer with a Config object.
+
+        Called by DaemonCore immediately after construction, before start().
+        Separated from __init__ because KampGround carries no Config reference
+        — Config is an internal daemon type, not an extension type.
+        """
+        from kamp_daemon.syncer import Syncer
+
+        self._inner = Syncer(config)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # BaseSyncer interface
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start background polling (no-op when poll_interval_minutes is 0)."""
+        assert self._inner is not None, "call _configure() before start()"
+        self._inner.start()
+
+    def stop(self) -> None:
+        """Signal the polling thread to exit and wait for it."""
+        assert self._inner is not None, "call _configure() before stop()"
+        self._inner.stop()
+
+    def pause(self) -> None:
+        """Suspend polling without discarding thread state (event-based)."""
+        assert self._inner is not None, "call _configure() before pause()"
+        self._inner.pause()
+
+    def resume(self) -> None:
+        """Resume polling after pause()."""
+        assert self._inner is not None, "call _configure() before resume()"
+        self._inner.resume()
+
+    def sync_once(self, *, skip_auto_mark: bool = False) -> None:
+        """Download new purchases in an isolated subprocess."""
+        assert self._inner is not None, "call _configure() before sync_once()"
+        self._inner.sync_once(skip_auto_mark=skip_auto_mark)
+
+    def mark_synced(self) -> None:
+        """Mark the entire collection as already synced without downloading."""
+        assert self._inner is not None, "call _configure() before mark_synced()"
+        self._inner.mark_synced()
+
+    # ------------------------------------------------------------------
+    # Internal daemon API (not part of BaseSyncer)
+    # ------------------------------------------------------------------
+
+    def reload(self, config: object) -> None:
+        """Apply a new Config live (called by DaemonCore on config reload)."""
+        assert self._inner is not None, "call _configure() before reload()"
+        self._inner.reload(config)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # Callback delegation
+    # ------------------------------------------------------------------
+
+    @property
+    def status_callback(self) -> Callable[[str], None] | None:
+        """Status string callback wired by the menu bar / DaemonCore."""
+        if self._inner is None:
+            return None
+        return self._inner.status_callback
+
+    @status_callback.setter
+    def status_callback(self, cb: Callable[[str], None] | None) -> None:
+        assert (
+            self._inner is not None
+        ), "call _configure() before setting status_callback"
+        self._inner.status_callback = cb
+
+    @property
+    def error_callback(self) -> Callable[[str, str, str], None] | None:
+        """Error notification callback wired by the menu bar."""
+        if self._inner is None:
+            return None
+        return self._inner.error_callback
+
+    @error_callback.setter
+    def error_callback(self, cb: Callable[[str, str, str], None] | None) -> None:
+        assert (
+            self._inner is not None
+        ), "call _configure() before setting error_callback"
+        self._inner.error_callback = cb

--- a/kamp_daemon/ext/context.py
+++ b/kamp_daemon/ext/context.py
@@ -90,8 +90,26 @@ class SetArtworkMutation:
     artwork: ArtworkResult
 
 
+@dataclass
+class StageMutation:
+    """A queued request to deposit a file in the staging directory.
+
+    Collected during extension execution (typically by a BaseSyncer) and
+    applied by the host after the worker completes.  The host writes
+    ``content`` to ``staging_dir / filename``.  Extensions must not write
+    to the filesystem directly — use ``KampGround.stage()`` instead.
+
+    Args:
+        filename: Base filename (no path separators) for the staged file.
+        content: Raw bytes to write (e.g. a downloaded ZIP archive).
+    """
+
+    filename: str
+    content: bytes
+
+
 # Union type for all mutation variants.
-Mutation = UpdateMetadataMutation | SetArtworkMutation
+Mutation = UpdateMetadataMutation | SetArtworkMutation | StageMutation
 
 
 @dataclass
@@ -256,6 +274,37 @@ class KampGround:
             ctx.set_artwork(track.mbid, ArtworkResult(result.body, "image/jpeg"))
         """
         self._pending_mutations.append(SetArtworkMutation(mbid=mbid, artwork=artwork))
+
+    def stage(self, filename: str, content: bytes) -> None:
+        """Queue a file to be deposited in the staging directory by the host.
+
+        The host writes ``content`` to ``staging_dir / filename`` after the
+        extension completes.  Extensions (particularly ``BaseSyncer``
+        implementations) must use this method rather than writing to the
+        filesystem directly — doing so would couple the extension to a
+        specific path, breaking the extension isolation contract.
+
+        Args:
+            filename: Base filename for the staged file.  Must not contain
+                path separators (``/`` or ``\\``).  The host rejects names
+                that would escape the staging directory.
+            content: Raw bytes to write (e.g. a downloaded ZIP archive).
+
+        Raises:
+            ValueError: If *filename* contains a path separator.
+
+        Example::
+
+            ctx.stage("artist-album.zip", zip_bytes)
+        """
+        if "/" in filename or "\\" in filename:
+            raise ValueError(
+                f"stage() filename must be a base name with no path separators; "
+                f"got {filename!r}"
+            )
+        self._pending_mutations.append(
+            StageMutation(filename=filename, content=content)
+        )
 
     # ------------------------------------------------------------------
     # Events

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ kamp = "kamp_daemon.__main__:main"
 [tool.poetry.plugins."kamp.extensions"]
 kamp-musicbrainz-tagger = "kamp_daemon.ext.builtin.musicbrainz:KampMusicBrainzTagger"
 kamp-coverart-archive   = "kamp_daemon.ext.builtin.coverart:KampCoverArtArchive"
+kamp-bandcamp-syncer    = "kamp_daemon.ext.builtin.bandcamp:KampBandcampSyncer"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_builtin_bandcamp.py
+++ b/tests/test_builtin_bandcamp.py
@@ -1,0 +1,207 @@
+"""Tests for KampBandcampSyncer and BaseSyncer ABC."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamp_daemon.ext.abc import BaseSyncer
+from kamp_daemon.ext.builtin.bandcamp import KampBandcampSyncer
+from kamp_daemon.ext.context import KampGround, PlaybackSnapshot
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> KampGround:
+    return KampGround(playback=PlaybackSnapshot(), library_tracks=[])
+
+
+def _make_syncer() -> KampBandcampSyncer:
+    """Create a KampBandcampSyncer with a pre-wired mock inner Syncer.
+
+    Bypasses _configure() by directly setting _inner — used for delegation
+    tests that just need to verify method forwarding, not construction.
+    """
+    syncer = KampBandcampSyncer(_ctx())
+    syncer._inner = MagicMock()  # type: ignore[assignment]
+    return syncer
+
+
+# ---------------------------------------------------------------------------
+# BaseSyncer ABC
+# ---------------------------------------------------------------------------
+
+
+class TestBaseSyncerABC:
+    def test_cannot_instantiate_directly(self) -> None:
+        """`BaseSyncer` is abstract and cannot be instantiated without implementing start/stop."""
+        with pytest.raises(TypeError):
+            BaseSyncer()  # type: ignore[abstract]
+
+    def test_pause_default_delegates_to_stop(self) -> None:
+        """Default pause() calls stop() — subclasses that don't override get stop semantics."""
+
+        class MinimalSyncer(BaseSyncer):
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def start(self) -> None:
+                self.calls.append("start")
+
+            def stop(self) -> None:
+                self.calls.append("stop")
+
+        s = MinimalSyncer()
+        s.pause()
+        assert s.calls == ["stop"]
+
+    def test_resume_default_delegates_to_start(self) -> None:
+        """Default resume() calls start()."""
+
+        class MinimalSyncer(BaseSyncer):
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def start(self) -> None:
+                self.calls.append("start")
+
+            def stop(self) -> None:
+                self.calls.append("stop")
+
+        s = MinimalSyncer()
+        s.resume()
+        assert s.calls == ["start"]
+
+    def test_sync_once_default_raises(self) -> None:
+        """Default sync_once() raises NotImplementedError."""
+
+        class MinimalSyncer(BaseSyncer):
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        s = MinimalSyncer()
+        with pytest.raises(NotImplementedError):
+            s.sync_once()
+
+    def test_mark_synced_default_raises(self) -> None:
+        """Default mark_synced() raises NotImplementedError."""
+
+        class MinimalSyncer(BaseSyncer):
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        s = MinimalSyncer()
+        with pytest.raises(NotImplementedError):
+            s.mark_synced()
+
+    def test_kamp_bandcamp_syncer_is_base_syncer(self) -> None:
+        """KampBandcampSyncer is a concrete BaseSyncer implementation."""
+        assert issubclass(KampBandcampSyncer, BaseSyncer)
+
+
+# ---------------------------------------------------------------------------
+# KampBandcampSyncer lifecycle delegation
+# ---------------------------------------------------------------------------
+
+
+class TestKampBandcampSyncer:
+    def test_configure_creates_inner_syncer(self) -> None:
+        """_configure() instantiates the inner Syncer with the given config."""
+        config = MagicMock()
+        syncer = KampBandcampSyncer(_ctx())
+
+        # Patch the Syncer class at its module source so the lazy import picks it up.
+        with patch("kamp_daemon.syncer.Syncer") as MockSyncer:
+            syncer._configure(config)
+
+        MockSyncer.assert_called_once_with(config)
+        assert syncer._inner is MockSyncer.return_value
+
+    def test_start_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.start()
+        syncer._inner.start.assert_called_once()
+
+    def test_stop_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.stop()
+        syncer._inner.stop.assert_called_once()
+
+    def test_pause_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.pause()
+        syncer._inner.pause.assert_called_once()
+
+    def test_resume_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.resume()
+        syncer._inner.resume.assert_called_once()
+
+    def test_sync_once_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.sync_once(skip_auto_mark=True)
+        syncer._inner.sync_once.assert_called_once_with(skip_auto_mark=True)
+
+    def test_mark_synced_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        syncer.mark_synced()
+        syncer._inner.mark_synced.assert_called_once()
+
+    def test_reload_delegates_to_inner(self) -> None:
+        syncer = _make_syncer()
+        new_config = MagicMock()
+        syncer.reload(new_config)
+        syncer._inner.reload.assert_called_once_with(new_config)
+
+    def test_status_callback_getter_delegates(self) -> None:
+        """status_callback getter returns the inner syncer's value."""
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer._inner.status_callback = cb
+        assert syncer.status_callback is cb
+
+    def test_status_callback_setter_delegates(self) -> None:
+        """status_callback setter writes through to the inner syncer."""
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer.status_callback = cb
+        assert syncer._inner.status_callback is cb
+
+    def test_error_callback_getter_delegates(self) -> None:
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer._inner.error_callback = cb
+        assert syncer.error_callback is cb
+
+    def test_error_callback_setter_delegates(self) -> None:
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer.error_callback = cb
+        assert syncer._inner.error_callback is cb
+
+    def test_status_callback_none_before_configure(self) -> None:
+        """status_callback returns None when _inner has not been configured."""
+        syncer = KampBandcampSyncer(_ctx())
+        assert syncer.status_callback is None
+
+    def test_error_callback_none_before_configure(self) -> None:
+        """error_callback returns None when _inner has not been configured."""
+        syncer = KampBandcampSyncer(_ctx())
+        assert syncer.error_callback is None
+
+    def test_methods_assert_before_configure(self) -> None:
+        """Calling lifecycle methods before _configure() raises AssertionError."""
+        syncer = KampBandcampSyncer(_ctx())
+        with pytest.raises(AssertionError):
+            syncer.start()
+        with pytest.raises(AssertionError):
+            syncer.stop()

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -32,7 +32,7 @@ def mock_watcher():
 
 @pytest.fixture
 def mock_syncer():
-    with patch("kamp_daemon.daemon_core.Syncer") as cls:
+    with patch("kamp_daemon.daemon_core.KampBandcampSyncer") as cls:
         yield cls
 
 

--- a/tests/test_extension_context.py
+++ b/tests/test_extension_context.py
@@ -377,3 +377,53 @@ def test_mutations_pickle_cleanly() -> None:
     for m in (m1, m2):
         restored = pickle.loads(pickle.dumps(m))
         assert restored.mbid == m.mbid
+
+
+# ---------------------------------------------------------------------------
+# ctx.stage() / StageMutation
+# ---------------------------------------------------------------------------
+
+
+def test_stage_queues_stage_mutation() -> None:
+    """ctx.stage() queues a StageMutation with the given filename and content."""
+    from kamp_daemon.ext.context import StageMutation
+
+    ctx = KampGround()
+    ctx.stage("artist-album.zip", b"\x50\x4b\x03\x04")  # minimal ZIP magic
+
+    mutations = ctx.pending_mutations
+    assert len(mutations) == 1
+    assert isinstance(mutations[0], StageMutation)
+    assert mutations[0].filename == "artist-album.zip"
+    assert mutations[0].content == b"\x50\x4b\x03\x04"
+
+
+def test_stage_rejects_path_separators() -> None:
+    """ctx.stage() raises ValueError if the filename contains a path separator."""
+    ctx = KampGround()
+    with pytest.raises(ValueError, match="path separator"):
+        ctx.stage("subdir/evil.zip", b"")
+    with pytest.raises(ValueError, match="path separator"):
+        ctx.stage("subdir\\evil.zip", b"")
+
+
+def test_stage_mutation_pickles_cleanly() -> None:
+    """StageMutation is picklable so it can cross the subprocess boundary."""
+    from kamp_daemon.ext.context import StageMutation
+
+    m = StageMutation(filename="album.zip", content=b"\x00\x01\x02")
+    restored = pickle.loads(pickle.dumps(m))
+    assert restored.filename == m.filename
+    assert restored.content == m.content
+
+
+def test_stage_and_update_metadata_coexist() -> None:
+    """Multiple mutation types can be queued in the same ctx."""
+    from kamp_daemon.ext.context import StageMutation
+
+    ctx = KampGround()
+    ctx.update_metadata("rec-1", {"title": "New Title"})
+    ctx.stage("download.zip", b"zip-bytes")
+
+    assert len(ctx.pending_mutations) == 2
+    assert isinstance(ctx.pending_mutations[1], StageMutation)


### PR DESCRIPTION
## Summary

- Defines `BaseSyncer` ABC in `ext/abc.py`: `start()`/`stop()` are abstract; `pause()`, `resume()`, `sync_once()`, `mark_synced()` have sensible defaults. Documents the lifecycle contract for long-running extension syncers.
- Adds `StageMutation` and `ctx.stage(filename, content)` to `KampGround` so third-party syncers can deposit downloaded files into staging without receiving a raw filesystem path. Validates that filename contains no path separators.
- Creates `KampBandcampSyncer` in `ext/builtin/bandcamp.py`: thin wrapper around the internal `Syncer`, running in-process (the outer daemon process already provides isolation — same rationale as `KampMusicBrainzTagger`). Transparently proxies `status_callback`/`error_callback` properties and all lifecycle methods.
- Updates `DaemonCore` to instantiate `KampBandcampSyncer` instead of `Syncer` directly; registers it as a `kamp.extensions` entry point.

## Test plan

- [x] 834 tests pass (`poetry run pytest`)
- [x] Coverage ≥ 95% (95.27% achieved)
- [x] `poetry run mypy kamp_daemon kamp_core` — no issues
- [x] `poetry run black --check kamp_daemon kamp_core tests/` — no changes needed
- [x] New `tests/test_builtin_bandcamp.py`: covers `BaseSyncer` ABC contract, `KampBandcampSyncer` delegation for all lifecycle methods and callbacks, configure/pre-configure guard behaviour
- [ ] New tests in `tests/test_extension_context.py`: covers `ctx.stage()`, `StageMutation` pickling, path separator rejection, coexistence with other mutation types

🤖 Generated with [Claude Code](https://claude.com/claude-code)