### PR TITLE
feat: contextBridge API and frontend panel registration system (TASK-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,38 @@ poetry run black kamp_daemon/ kamp_core/ tests/
 ```
 
 
+### Frontend extensions
+
+The Electron UI supports frontend extensions — npm packages that contribute panels to the nav bar.
+
+**How it works:**
+
+1. The main process scans `kamp_ui/extensions/` (first-party) and `node_modules/` (installed) for packages with `"kamp-extension"` in their `keywords`.
+2. Each extension's entry point is an ES module that exports a `register(api)` function.
+3. `register` receives `window.KampAPI` and calls `api.panels.register(manifest)` to add a tab.
+
+**Writing an extension:**
+
+```js
+// package.json: { "keywords": ["kamp-extension"], "main": "index.js", "type": "module" }
+
+export function register(api) {
+  api.panels.register({
+    id: 'my-extension.my-panel',   // must be globally unique
+    title: 'My Panel',
+    render(container) {
+      container.textContent = 'Hello from my panel'
+      // Return a cleanup function called on unmount:
+      return () => {}
+    }
+  })
+}
+```
+
+Extensions run in the renderer process with `nodeIntegration: false` — they have no access to `ipcRenderer` or Node.js APIs. The only kamp surface is `window.KampAPI`, which exposes `panels`, `extensions`, and `serverUrl` (the HTTP server base URL for calling the REST API).
+
+An example first-party extension lives in `kamp_ui/extensions/kamp-example-panel/`.
+
 ---
 
 *Built by [Claude Sonnet 4.6](https://www.anthropic.com/claude) (claude-sonnet-4-6) — Anthropic's AI assistant.*

--- a/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
+++ b/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
@@ -4,7 +4,7 @@ title: contextBridge API and frontend panel registration system
 status: In Progress
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-06 19:37'
+updated_date: '2026-04-06 20:15'
 labels:
   - feature
   - architecture
@@ -24,8 +24,8 @@ Extensions must never touch `ipcRenderer` or Node.js directly — only `window.K
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 window.KampAPI is injected via contextBridge in the preload script
-- [ ] #2 Frontend extensions are discovered via kamp-extension npm keyword
-- [ ] #3 An example first-party extension registers a panel successfully
-- [ ] #4 Extensions cannot access ipcRenderer or Node.js APIs directly
+- [x] #1 window.KampAPI is injected via contextBridge in the preload script
+- [x] #2 Frontend extensions are discovered via kamp-extension npm keyword
+- [x] #3 An example first-party extension registers a panel successfully
+- [x] #4 Extensions cannot access ipcRenderer or Node.js APIs directly
 <!-- AC:END -->

--- a/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
+++ b/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19
 title: contextBridge API and frontend panel registration system
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-06 19:37'
 labels:
   - feature
   - architecture

--- a/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
+++ b/backlog/tasks/task-19 - contextBridge-API-and-frontend-panel-registration-system.md
@@ -1,17 +1,17 @@
 ---
 id: TASK-19
 title: contextBridge API and frontend panel registration system
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-06 20:15'
+updated_date: '2026-04-06 20:28'
 labels:
   - feature
   - architecture
   - 'estimate: lp'
 milestone: m-2
 dependencies: []
-ordinal: 6000
+ordinal: 13000
 ---
 
 ## Description

--- a/kamp_ui/electron-builder.yml
+++ b/kamp_ui/electron-builder.yml
@@ -9,6 +9,7 @@ files:
   - '!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+  - 'extensions/**'
 asarUnpack:
   - resources/**
 win:

--- a/kamp_ui/eslint.config.mjs
+++ b/kamp_ui/eslint.config.mjs
@@ -6,7 +6,7 @@ import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
 export default defineConfig(
-  { ignores: ['**/node_modules', '**/dist', '**/out'] },
+  { ignores: ['**/node_modules', '**/dist', '**/out', 'extensions/**'] },
   tseslint.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],

--- a/kamp_ui/extensions/kamp-example-panel/index.js
+++ b/kamp_ui/extensions/kamp-example-panel/index.js
@@ -1,0 +1,68 @@
+/**
+ * kamp-example-panel
+ *
+ * A first-party extension demonstrating the KampAPI panel registration system.
+ * This module is a plain ES module — it has no access to Node.js, Electron, or
+ * ipcRenderer. All interaction with the app happens through the `api` argument.
+ */
+
+/**
+ * Called by the host once KampAPI is ready.
+ * @param {import('../../src/shared/kampAPI').KampAPI} api
+ */
+export function register(api) {
+  api.panels.register({
+    id: 'kamp-example-panel.stats',
+    title: 'Stats',
+
+    render(container) {
+      container.style.cssText = 'padding: 20px; font-family: monospace; font-size: 13px;'
+
+      async function refresh() {
+        try {
+          const res = await fetch(`${api.serverUrl}/api/v1/player/state`)
+          /** @type {{ playing: boolean, position: number, duration: number, volume: number, current_track: object | null }} */
+          const state = await res.json()
+
+          const track = state.current_track
+          container.innerHTML = track
+            ? `<div style="color:#fff;font-size:14px;font-weight:bold;margin-bottom:12px">Now Playing</div>
+               <table style="color:#ccc;border-collapse:collapse;width:100%">
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Title</td><td>${esc(track.title)}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Artist</td><td>${esc(track.artist)}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Album</td><td>${esc(track.album)}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Year</td><td>${esc(track.year)}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Plays</td><td>${track.play_count}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Position</td><td>${fmt(state.position)} / ${fmt(state.duration)}</td></tr>
+                 <tr><td style="padding:3px 12px 3px 0;color:#888">Volume</td><td>${Math.round(state.volume * 100)}%</td></tr>
+               </table>`
+            : `<div style="color:#888">Nothing playing</div>`
+        } catch {
+          container.innerHTML = `<div style="color:#666">Server unavailable</div>`
+        }
+      }
+
+      void refresh()
+      const interval = setInterval(() => void refresh(), 2000)
+
+      // Return cleanup so the host can stop polling when the panel unmounts.
+      return () => clearInterval(interval)
+    }
+  })
+}
+
+/** Escape HTML special characters to prevent XSS from track metadata. */
+function esc(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** Format seconds as m:ss. */
+function fmt(secs) {
+  const m = Math.floor(secs / 60)
+  const s = Math.floor(secs % 60)
+  return `${m}:${String(s).padStart(2, '0')}`
+}

--- a/kamp_ui/extensions/kamp-example-panel/package.json
+++ b/kamp_ui/extensions/kamp-example-panel/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "kamp-example-panel",
+  "version": "1.0.0",
+  "description": "Example first-party kamp extension — demonstrates panel registration via window.KampAPI.",
+  "keywords": ["kamp-extension"],
+  "displayName": "Stats",
+  "main": "index.js",
+  "type": "module"
+}

--- a/kamp_ui/src/main/extensions.ts
+++ b/kamp_ui/src/main/extensions.ts
@@ -1,0 +1,67 @@
+/**
+ * Extension discovery.
+ *
+ * Scans two locations for packages that declare the "kamp-extension" keyword:
+ *   1. <appPath>/extensions/  — first-party extensions bundled with the app
+ *   2. <appPath>/node_modules/ — installed npm extensions
+ *
+ * A package qualifies when its package.json has "kamp-extension" in `keywords`
+ * and its declared entry point (`main`) exists on disk.
+ */
+
+import { app } from 'electron'
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import { join, resolve } from 'path'
+import type { ExtensionInfo } from '../shared/kampAPI'
+
+function scanDir(dir: string): ExtensionInfo[] {
+  if (!existsSync(dir)) return []
+
+  const results: ExtensionInfo[] = []
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+
+    const pkgPath = join(dir, entry.name, 'package.json')
+    if (!existsSync(pkgPath)) continue
+
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+        name?: string
+        displayName?: string
+        keywords?: string[]
+        main?: string
+      }
+
+      if (!Array.isArray(pkg.keywords) || !pkg.keywords.includes('kamp-extension')) continue
+
+      const mainFile = pkg.main ?? 'index.js'
+      const entryPath = resolve(dir, entry.name, mainFile)
+      if (!existsSync(entryPath)) continue
+
+      // Read code here in the main process (which has fs access) so the
+      // renderer never needs a file:// import — it loads via a Blob URL instead.
+      const code = readFileSync(entryPath, 'utf8')
+
+      results.push({
+        id: pkg.name ?? entry.name,
+        name: pkg.displayName ?? pkg.name ?? entry.name,
+        code
+      })
+    } catch {
+      // Skip packages with malformed package.json.
+    }
+  }
+
+  return results
+}
+
+export function discoverExtensions(): ExtensionInfo[] {
+  const appPath = app.getAppPath()
+  // First-party extensions ship alongside the app.
+  const builtinDir = join(appPath, 'extensions')
+  // Installed npm extensions live in node_modules.
+  const nodeModulesDir = join(appPath, 'node_modules')
+
+  return [...scanDir(builtinDir), ...scanDir(nodeModulesDir)]
+}

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -6,6 +6,7 @@ import * as http from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { theme } from '../shared/theme'
+import { discoverExtensions } from './extensions'
 
 // Set the app name before the app is ready so the macOS menu bar and all
 // default menu items ("About kamp", "Quit kamp") reflect the correct name.
@@ -218,6 +219,8 @@ app.whenReady().then(async () => {
 
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
+
+  ipcMain.handle('kamp:get-extensions', () => discoverExtensions())
 
   ipcMain.handle('open-directory', async () => {
     const result = await dialog.showOpenDialog({

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -1,4 +1,5 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
+import type { KampAPI } from '../shared/kampAPI'
 
 declare global {
   interface Window {
@@ -7,5 +8,6 @@ declare global {
       openDirectory: () => Promise<string | null>
       onOpenPreferences: (callback: () => void) => () => void
     }
+    KampAPI: KampAPI
   }
 }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import { buildKampAPI } from './kampAPI'
 
 // Custom APIs for renderer
 const api = {
@@ -12,6 +13,8 @@ const api = {
   }
 }
 
+const kampAPI = buildKampAPI()
+
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise
 // just add to the DOM global.
@@ -19,6 +22,7 @@ if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('api', api)
+    contextBridge.exposeInMainWorld('KampAPI', kampAPI)
   } catch (error) {
     console.error(error)
   }
@@ -27,4 +31,6 @@ if (process.contextIsolated) {
   window.electron = electronAPI
   // @ts-ignore (define in dts)
   window.api = api
+  // @ts-ignore (define in dts)
+  window.KampAPI = kampAPI
 }

--- a/kamp_ui/src/preload/kampAPI.ts
+++ b/kamp_ui/src/preload/kampAPI.ts
@@ -1,0 +1,44 @@
+/**
+ * Builds the window.KampAPI object that is exposed to the renderer via contextBridge.
+ *
+ * This module runs in the preload context (has Node.js / Electron APIs) but the
+ * returned object contains only plain values and functions — no Node.js objects
+ * leak into the renderer.
+ */
+
+import { ipcRenderer } from 'electron'
+import type { KampAPI, PanelManifest } from '../shared/kampAPI'
+
+const panelRegistry: PanelManifest[] = []
+// Callbacks registered by the renderer via panels.onRegister().
+// contextBridge wraps renderer functions so they can be called from the preload.
+const registerCallbacks = new Set<(manifest: PanelManifest) => void>()
+
+export function buildKampAPI(): KampAPI {
+  return {
+    serverUrl: 'http://127.0.0.1:8000',
+
+    panels: {
+      register(manifest: PanelManifest): void {
+        // Idempotent: skip duplicate registrations (e.g. React StrictMode re-runs).
+        if (panelRegistry.some((p) => p.id === manifest.id)) return
+        panelRegistry.push(manifest)
+        // Notify all renderer-side subscribers via their contextBridge-proxied callbacks.
+        registerCallbacks.forEach((cb) => cb(manifest))
+      },
+      getAll(): PanelManifest[] {
+        return [...panelRegistry]
+      },
+      onRegister(callback): () => void {
+        registerCallbacks.add(callback)
+        return () => registerCallbacks.delete(callback)
+      }
+    },
+
+    extensions: {
+      getAll() {
+        return ipcRenderer.invoke('kamp:get-extensions')
+      }
+    }
+  }
+}

--- a/kamp_ui/src/renderer/index.html
+++ b/kamp_ui/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
     />
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
 import { AlbumGrid } from './components/AlbumGrid'
+import { ExtensionPanel } from './components/ExtensionPanel'
 import { NowPlayingView } from './components/NowPlayingView'
 import { PreferencesDialog } from './components/PreferencesDialog'
 import { SearchBar } from './components/SearchBar'
@@ -12,6 +13,7 @@ import { SplashScreen } from './components/SplashScreen'
 import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
 import { QueuePanel } from './components/QueuePanel'
+import { useRegisteredPanels } from './hooks/useRegisteredPanels'
 
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
@@ -33,6 +35,9 @@ export default function App(): React.JSX.Element {
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const loadQueue = useStore((s) => s.loadQueue)
   const openPrefs = useStore((s) => s.openPrefs)
+  const extensionPanels = useRegisteredPanels()
+  // Active extension panel id, or null when a built-in view is showing.
+  const [activeExtPanel, setActiveExtPanel] = useState<string | null>(null)
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
   // Per-view scroll positions — kept current by a scroll listener so we never
@@ -180,6 +185,38 @@ export default function App(): React.JSX.Element {
     return cleanup
   }, [openPrefs])
 
+  // Discover and load frontend extensions. Each extension entry point is a
+  // plain ES module that exports a `register(api)` function. Extensions call
+  // window.KampAPI.panels.register() to contribute panels; the
+  // useRegisteredPanels hook above picks up the resulting CustomEvents.
+  useEffect(() => {
+    async function loadExtensions(): Promise<void> {
+      try {
+        const extensions = await window.KampAPI.extensions.getAll()
+        for (const ext of extensions) {
+          // Create a Blob URL so the renderer can import ES module code
+          // supplied by the main process — file:// imports are blocked by
+          // Chromium when the page is served from an http:// origin (dev mode).
+          const blob = new Blob([ext.code], { type: 'text/javascript' })
+          const blobUrl = URL.createObjectURL(blob)
+          try {
+            const mod = await import(/* @vite-ignore */ blobUrl)
+            if (typeof mod.register === 'function') {
+              mod.register(window.KampAPI)
+            }
+          } catch (err) {
+            console.error(`[kamp] failed to load extension "${ext.id}":`, err)
+          } finally {
+            URL.revokeObjectURL(blobUrl)
+          }
+        }
+      } catch (err) {
+        console.error('[kamp] extension discovery failed:', err)
+      }
+    }
+    void loadExtensions()
+  }, [])
+
   // Keep viewScrollRef continuously current so we always have the right value
   // when switching views — reading scrollTop after a DOM update can give a
   // browser-clamped value if the new content is shorter than the old.
@@ -226,25 +263,44 @@ export default function App(): React.JSX.Element {
       {!showSetup && (
         <nav className="view-tabs">
           <button
-            className={activeView === 'library' ? 'active' : ''}
-            onClick={() => setActiveView('library')}
+            className={activeView === 'library' && !activeExtPanel ? 'active' : ''}
+            onClick={() => {
+              void setActiveView('library')
+              setActiveExtPanel(null)
+            }}
           >
             Library
           </button>
           <button
-            className={activeView === 'now-playing' ? 'active' : ''}
-            onClick={() => setActiveView('now-playing')}
+            className={activeView === 'now-playing' && !activeExtPanel ? 'active' : ''}
+            onClick={() => {
+              void setActiveView('now-playing')
+              setActiveExtPanel(null)
+            }}
           >
             Now Playing
           </button>
+          {extensionPanels.map((panel) => (
+            <button
+              key={panel.id}
+              className={activeExtPanel === panel.id ? 'active' : ''}
+              onClick={() => setActiveExtPanel(panel.id)}
+            >
+              {panel.title}
+            </button>
+          ))}
           <SearchBar ref={searchBarRef} />
         </nav>
       )}
       <div className="app-body">
-        {!showSetup && activeView === 'library' && !searchQuery && <ArtistPanel />}
+        {!showSetup && activeView === 'library' && !searchQuery && !activeExtPanel && (
+          <ArtistPanel />
+        )}
         <main className="main-content" ref={mainContentRef}>
           {showSetup ? (
             <SetupScreen />
+          ) : activeExtPanel ? (
+            <ExtensionPanel panel={extensionPanels.find((p) => p.id === activeExtPanel)!} />
           ) : searchQuery ? (
             <SearchView />
           ) : activeView === 'now-playing' ? (

--- a/kamp_ui/src/renderer/src/components/ExtensionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ExtensionPanel.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useRef } from 'react'
+import type { PanelManifest } from '../hooks/useRegisteredPanels'
+
+/**
+ * Mounts an extension panel's DOM renderer into a container div.
+ *
+ * The panel's `render(container)` is called once on mount and its returned
+ * cleanup function is called on unmount — matching the React useEffect contract.
+ * Extensions render plain DOM; they never touch React internals.
+ */
+export function ExtensionPanel({ panel }: { panel: PanelManifest }): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    return panel.render(el)
+  }, [panel])
+
+  return <div className="extension-panel" ref={containerRef} />
+}

--- a/kamp_ui/src/renderer/src/hooks/useRegisteredPanels.ts
+++ b/kamp_ui/src/renderer/src/hooks/useRegisteredPanels.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import type { PanelManifest } from '../../../shared/kampAPI'
+
+export type { PanelManifest }
+
+/**
+ * Returns the live list of panels registered by loaded extensions.
+ *
+ * Seeds from the current KampAPI registry (panels registered before React
+ * mounted) and subscribes to the "kamp:panel-registered" CustomEvent for
+ * any panels registered afterward.
+ */
+export function useRegisteredPanels(): PanelManifest[] {
+  const [panels, setPanels] = useState<PanelManifest[]>(() => window.KampAPI?.panels.getAll() ?? [])
+
+  useEffect(() => {
+    // onRegister() goes through contextBridge — the preload calls our callback
+    // directly, bypassing the context-isolation boundary that blocks CustomEvents.
+    return window.KampAPI.panels.onRegister((manifest) => {
+      setPanels((prev) => [...prev, manifest])
+    })
+  }, [])
+
+  return panels
+}

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared KampAPI types.
+ *
+ * Imported by the preload (builds the object) and by the renderer (consumes it).
+ * Must contain only pure TypeScript — no Node.js or Electron imports.
+ */
+
+/** A panel contributed by a frontend extension. */
+export type PanelManifest = {
+  /** Unique identifier for the panel (e.g. "kamp-example-panel.stats"). */
+  id: string
+  /** Human-readable title shown in the nav tab. */
+  title: string
+  /**
+   * Mount the panel into `container` and return a cleanup function.
+   * Called once when the panel tab is first shown; cleanup is called on unmount.
+   */
+  render: (container: HTMLElement) => () => void
+}
+
+/** Descriptor returned by the main process for each discovered extension. */
+export type ExtensionInfo = {
+  id: string
+  name: string
+  /** Source code of the extension's entry point, read by the main process. */
+  code: string
+}
+
+/** The full shape of window.KampAPI. */
+export type KampAPI = {
+  /**
+   * Base URL of the kamp HTTP server.
+   * Extensions should use this rather than hard-coding localhost:8000.
+   */
+  serverUrl: string
+
+  panels: {
+    /** Register a panel contributed by an extension. */
+    register: (manifest: PanelManifest) => void
+    /** Return a snapshot of all currently registered panels. */
+    getAll: () => PanelManifest[]
+    /**
+     * Subscribe to panel registrations. The callback is invoked each time a
+     * panel is registered. Returns an unsubscribe function.
+     */
+    onRegister: (callback: (manifest: PanelManifest) => void) => () => void
+  }
+
+  extensions: {
+    /** Ask the main process to discover installed kamp-extension packages. */
+    getAll: () => Promise<ExtensionInfo[]>
+  }
+}


### PR DESCRIPTION
## Summary

- Exposes `window.KampAPI` via Electron `contextBridge` as the sole API surface for frontend extensions
- Main process scans `kamp_ui/extensions/` and `node_modules/` for packages with `kamp-extension` keyword; reads their entry point code and returns it to the renderer
- Renderer loads extensions as Blob URL ES modules (file:// is blocked by Chromium from http:// origins in dev mode) and calls their exported `register(api)` function
- Panel subscriptions use a contextBridge-proxied callback (`panels.onRegister`) — CustomEvents don't cross context-isolation boundaries
- Includes `kamp-example-panel` first-party extension: a "Stats" panel showing live player state via the HTTP API
- Extensions have no access to `ipcRenderer` or Node.js (`nodeIntegration: false` by default)

## Key files

- `src/shared/kampAPI.ts` — shared `KampAPI`, `PanelManifest`, `ExtensionInfo` types
- `src/preload/kampAPI.ts` — builds the `window.KampAPI` object
- `src/main/extensions.ts` — extension discovery + file reading
- `src/renderer/src/hooks/useRegisteredPanels.ts` — subscribes to panel registrations
- `src/renderer/src/components/ExtensionPanel.tsx` — mounts panel DOM renderers into React
- `extensions/kamp-example-panel/` — first-party example

## Test plan

- [x] `npm run dev` in `kamp_ui/` — a "Stats" tab appears in the nav bar
- [x] Clicking "Stats" shows a live player state table (updates every 2s)
- [x] No `[kamp]` errors in DevTools console
- [x] An extension with duplicate `id` only registers once (StrictMode safety)
- [x] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)