### PR TITLE
feat: UI slot API — declarative panel manifests (TASK-20)

### DIFF
--- a/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
+++ b/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-20
 title: 'UI slot API: declarative panel manifests rendered by Electron host'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-06 21:02'
 labels:
   - feature
   - architecture

--- a/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
+++ b/backlog/tasks/task-20 - UI-slot-API-declarative-panel-manifests-rendered-by-Electron-host.md
@@ -1,17 +1,17 @@
 ---
 id: TASK-20
 title: 'UI slot API: declarative panel manifests rendered by Electron host'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-06 21:02'
+updated_date: '2026-04-07 02:38'
 labels:
   - feature
   - architecture
   - 'estimate: lp'
 milestone: m-2
 dependencies: []
-ordinal: 7000
+ordinal: 14000
 ---
 
 ## Description

--- a/kamp_ui/extensions/kamp-example-panel/index.js
+++ b/kamp_ui/extensions/kamp-example-panel/index.js
@@ -14,6 +14,7 @@ export function register(api) {
   api.panels.register({
     id: 'kamp-example-panel.stats',
     title: 'Stats',
+    defaultSlot: 'main',
 
     render(container) {
       container.style.cssText = 'padding: 20px; font-family: monospace; font-size: 13px;'

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -2,18 +2,70 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
-import { AlbumGrid } from './components/AlbumGrid'
 import { ExtensionPanel } from './components/ExtensionPanel'
+import { LibraryView } from './components/LibraryView'
 import { NowPlayingView } from './components/NowPlayingView'
+import { PanelPicker } from './components/PanelPicker'
 import { PreferencesDialog } from './components/PreferencesDialog'
+import { QueuePanel } from './components/QueuePanel'
 import { SearchBar } from './components/SearchBar'
 import { SearchView } from './components/SearchView'
 import { SetupScreen } from './components/SetupScreen'
 import { SplashScreen } from './components/SplashScreen'
-import { TrackList } from './components/TrackList'
 import { TransportBar } from './components/TransportBar'
-import { QueuePanel } from './components/QueuePanel'
-import { useRegisteredPanels } from './hooks/useRegisteredPanels'
+import { registerBuiltInPanel, usePanelLayout } from './hooks/usePanelLayout'
+import type { UnifiedPanel } from './hooks/usePanelLayout'
+
+// ---------------------------------------------------------------------------
+// Register built-in panels before the component mounts.
+// Each call is idempotent — safe across HMR and React StrictMode re-runs.
+// ---------------------------------------------------------------------------
+registerBuiltInPanel({
+  id: 'kamp.library',
+  title: 'Library',
+  defaultSlot: 'main',
+  compatibleSlots: ['main'],
+  component: LibraryView
+})
+registerBuiltInPanel({
+  id: 'kamp.now-playing',
+  title: 'Now Playing',
+  defaultSlot: 'main',
+  compatibleSlots: ['main'],
+  component: NowPlayingView
+})
+registerBuiltInPanel({
+  id: 'kamp.artist-list',
+  title: 'Artists',
+  defaultSlot: 'left',
+  compatibleSlots: ['left', 'right'],
+  component: ArtistPanel
+})
+registerBuiltInPanel({
+  id: 'kamp.queue',
+  title: 'Queue',
+  defaultSlot: 'right',
+  compatibleSlots: ['left', 'right'],
+  component: QueuePanel
+})
+registerBuiltInPanel({
+  id: 'kamp.transport',
+  title: 'Transport',
+  defaultSlot: 'bottom',
+  compatibleSlots: ['bottom'],
+  component: TransportBar
+})
+
+// ---------------------------------------------------------------------------
+// SlotPanel: renders a single panel regardless of whether it is a built-in
+// React component or an extension DOM renderer.
+// ---------------------------------------------------------------------------
+function SlotPanel({ panel }: { panel: UnifiedPanel }): React.JSX.Element {
+  if (panel.kind === 'builtin') {
+    return <panel.component />
+  }
+  return <ExtensionPanel panel={panel} />
+}
 
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
@@ -23,7 +75,6 @@ export default function App(): React.JSX.Element {
   const setServerStatus = useStore((s) => s.setServerStatus)
   const serverStatus = useStore((s) => s.serverStatus)
   const hasAlbums = useStore((s) => s.library.albums.length > 0)
-  const selectedAlbum = useStore((s) => s.library.selectedAlbum)
   const activeView = useStore((s) => s.activeView)
   const setActiveView = useStore((s) => s.setActiveView)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
@@ -31,23 +82,28 @@ export default function App(): React.JSX.Element {
   const prev = useStore((s) => s.prev)
   const searchQuery = useStore((s) => s.searchQuery)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
+  const loadQueue = useStore((s) => s.loadQueue)
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
-  const loadQueue = useStore((s) => s.loadQueue)
+  const artistPanelVisible = useStore((s) => s.artistPanelVisible)
+  const toggleArtistPanel = useStore((s) => s.toggleArtistPanel)
   const openPrefs = useStore((s) => s.openPrefs)
-  const extensionPanels = useRegisteredPanels()
+
+  const layout = usePanelLayout()
+
   // Active extension panel id, or null when a built-in view is showing.
   const [activeExtPanel, setActiveExtPanel] = useState<string | null>(null)
+
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
+
   // Per-view scroll positions — kept current by a scroll listener so we never
   // read a browser-clamped value when the outgoing view's content was taller.
+  // Key: active main panel id (built-in view name or extension panel id).
   const viewScrollRef = useRef<Partial<Record<string, number>>>({})
 
   // Splash: shown while reconnecting, then lingers 1s after connect so the
   // library fetch completes before the app is revealed, then fades out.
-  // No one-shot guard — the cleanup + re-run from React StrictMode is safe
-  // because the cleanup cancels the timer before the re-run restarts it.
   const [splashHiding, setSplashHiding] = useState(false)
   const [splashGone, setSplashGone] = useState(false)
   const splashLingerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -66,14 +122,8 @@ export default function App(): React.JSX.Element {
   }, [serverStatus])
 
   useEffect(() => {
-    // Load UI state (sort order, active view) before loading the library so the
-    // library is fetched with the correct persisted sort order, not the default.
     loadUiState().then(() => loadLibrary())
 
-    // Connect WebSocket state stream. On close, retry with exponential backoff
-    // (1 s, 2 s, 4 s … capped at 30 s). After 8 failed attempts we give up and
-    // show the offline screen. Attempts reset to 0 on every successful open so
-    // that a sleep/wake cycle always gets a fresh run of retries.
     let attempts = 0
     const MAX_ATTEMPTS = 8
 
@@ -97,9 +147,6 @@ export default function App(): React.JSX.Element {
           void loadQueue()
         },
         () => {
-          // Background scan completed — refresh album list then open track list.
-          // Sequential: loadLibrary and refreshOpenAlbum both spread library state,
-          // so running them concurrently risks one overwriting the other's update.
           void loadLibrary().then(() => refreshOpenAlbum())
         }
       )
@@ -109,11 +156,9 @@ export default function App(): React.JSX.Element {
     return disconnect
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Global keyboard shortcuts — skip when focus is inside a text input,
-  // except for Cmd/Ctrl+K which focuses the search bar from anywhere.
+  // Global keyboard shortcuts
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent): void {
-      // Cmd+K (mac) / Ctrl+K (win/linux) focuses the search bar.
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         searchBarRef.current?.focus()
@@ -121,14 +166,12 @@ export default function App(): React.JSX.Element {
         return
       }
 
-      // Cmd+, (mac) / Ctrl+, (win/linux) opens Preferences.
       if (e.key === ',' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         openPrefs()
         return
       }
 
-      // Escape clears search when the search bar is focused.
       if (e.key === 'Escape' && searchQuery) {
         void setSearchQuery('')
         searchBarRef.current?.blur()
@@ -154,12 +197,17 @@ export default function App(): React.JSX.Element {
         case 'l':
         case 'L':
           void setActiveView(activeView === 'library' ? 'now-playing' : 'library')
+          setActiveExtPanel(null)
           break
         case 'q':
         case 'Q':
           // Don't intercept Cmd+Q (macOS quit) or Ctrl+Q.
           if (e.metaKey || e.ctrlKey) break
           toggleQueuePanel()
+          break
+        case 'a':
+        case 'A':
+          toggleArtistPanel()
           break
       }
     }
@@ -174,29 +222,22 @@ export default function App(): React.JSX.Element {
     searchQuery,
     setSearchQuery,
     toggleQueuePanel,
+    toggleArtistPanel,
     openPrefs
   ])
 
-  // Listen for "open-preferences" IPC from the main process (sent when the
-  // user clicks App Name → Preferences in the native macOS menu bar).
   useEffect(() => {
     if (!window.api.onOpenPreferences) return
     const cleanup = window.api.onOpenPreferences(openPrefs)
     return cleanup
   }, [openPrefs])
 
-  // Discover and load frontend extensions. Each extension entry point is a
-  // plain ES module that exports a `register(api)` function. Extensions call
-  // window.KampAPI.panels.register() to contribute panels; the
-  // useRegisteredPanels hook above picks up the resulting CustomEvents.
+  // Discover and load frontend extensions.
   useEffect(() => {
     async function loadExtensions(): Promise<void> {
       try {
         const extensions = await window.KampAPI.extensions.getAll()
         for (const ext of extensions) {
-          // Create a Blob URL so the renderer can import ES module code
-          // supplied by the main process — file:// imports are blocked by
-          // Chromium when the page is served from an http:// origin (dev mode).
           const blob = new Blob([ext.code], { type: 'text/javascript' })
           const blobUrl = URL.createObjectURL(blob)
           try {
@@ -217,25 +258,23 @@ export default function App(): React.JSX.Element {
     void loadExtensions()
   }, [])
 
-  // Keep viewScrollRef continuously current so we always have the right value
-  // when switching views — reading scrollTop after a DOM update can give a
-  // browser-clamped value if the new content is shorter than the old.
+  // Track scroll position for the active main panel key (built-in name or ext ID).
+  const activeMainKey = activeExtPanel ?? activeView
   useEffect(() => {
     const el = mainContentRef.current
     if (!el) return
     const onScroll = (): void => {
-      viewScrollRef.current[activeView] = el.scrollTop
+      viewScrollRef.current[activeMainKey] = el.scrollTop
     }
     el.addEventListener('scroll', onScroll, { passive: true })
     return () => el.removeEventListener('scroll', onScroll)
-  }, [activeView])
+  }, [activeMainKey])
 
-  // Restore the incoming view's scroll position synchronously before paint.
   useLayoutEffect(() => {
     const el = mainContentRef.current
     if (!el) return
-    el.scrollTop = viewScrollRef.current[activeView] ?? 0
-  }, [activeView])
+    el.scrollTop = viewScrollRef.current[activeMainKey] ?? 0
+  }, [activeMainKey])
 
   if (serverStatus === 'disconnected') {
     return (
@@ -255,6 +294,56 @@ export default function App(): React.JSX.Element {
 
   const showSetup = serverStatus === 'connected' && !hasAlbums
 
+  // Panels to show as tabs in the main area nav bar.
+  const mainPanels = layout.panelsInSlot('main')
+
+  // Determine whether a given main-slot panel tab is active.
+  const isActiveMain = (panel: UnifiedPanel): boolean => {
+    if (activeExtPanel) return panel.id === activeExtPanel
+    if (panel.kind === 'builtin' && panel.id === 'kamp.library') return activeView === 'library'
+    if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing')
+      return activeView === 'now-playing'
+    return false
+  }
+
+  // Activate a main-slot panel tab.
+  const activateMain = (panel: UnifiedPanel): void => {
+    if (panel.kind === 'builtin' && panel.id === 'kamp.library') {
+      void setActiveView('library')
+      setActiveExtPanel(null)
+    } else if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing') {
+      void setActiveView('now-playing')
+      setActiveExtPanel(null)
+    } else if (panel.kind === 'extension') {
+      setActiveExtPanel(panel.id)
+    }
+  }
+
+  // Determine what to render in the main content area.
+  function renderMainContent(): React.JSX.Element {
+    if (showSetup) return <SetupScreen />
+    if (searchQuery) return <SearchView />
+    if (activeExtPanel) {
+      const extPanel = mainPanels.find((p) => p.id === activeExtPanel)
+      if (extPanel && extPanel.kind === 'extension') return <ExtensionPanel panel={extPanel} />
+    }
+    if (activeView === 'now-playing') return <NowPlayingView />
+    return <LibraryView />
+  }
+
+  // Panels for each sidebar/bottom slot (first assigned panel wins).
+  // Panel-specific visibility: each panel's toggle is independent of its slot.
+  const isPanelVisible = (p: UnifiedPanel | undefined): boolean => {
+    if (!p) return false
+    if (p.id === 'kamp.queue') return queueVisible
+    if (p.id === 'kamp.artist-list') return artistPanelVisible
+    return true
+  }
+
+  const leftPanel = layout.panelsInSlot('left')[0]
+  const rightPanel = layout.panelsInSlot('right')[0]
+  const bottomPanel = layout.panelsInSlot('bottom')[0]
+
   return (
     <div className="app">
       {serverStatus === 'reconnecting' && (
@@ -262,58 +351,27 @@ export default function App(): React.JSX.Element {
       )}
       {!showSetup && (
         <nav className="view-tabs">
-          <button
-            className={activeView === 'library' && !activeExtPanel ? 'active' : ''}
-            onClick={() => {
-              void setActiveView('library')
-              setActiveExtPanel(null)
-            }}
-          >
-            Library
-          </button>
-          <button
-            className={activeView === 'now-playing' && !activeExtPanel ? 'active' : ''}
-            onClick={() => {
-              void setActiveView('now-playing')
-              setActiveExtPanel(null)
-            }}
-          >
-            Now Playing
-          </button>
-          {extensionPanels.map((panel) => (
+          {mainPanels.map((panel) => (
             <button
               key={panel.id}
-              className={activeExtPanel === panel.id ? 'active' : ''}
-              onClick={() => setActiveExtPanel(panel.id)}
+              className={isActiveMain(panel) && !searchQuery ? 'active' : ''}
+              onClick={() => activateMain(panel)}
             >
               {panel.title}
             </button>
           ))}
           <SearchBar ref={searchBarRef} />
+          <PanelPicker layout={layout} />
         </nav>
       )}
       <div className="app-body">
-        {!showSetup && activeView === 'library' && !searchQuery && !activeExtPanel && (
-          <ArtistPanel />
-        )}
+        {!showSetup && isPanelVisible(leftPanel) && <SlotPanel panel={leftPanel!} />}
         <main className="main-content" ref={mainContentRef}>
-          {showSetup ? (
-            <SetupScreen />
-          ) : activeExtPanel ? (
-            <ExtensionPanel panel={extensionPanels.find((p) => p.id === activeExtPanel)!} />
-          ) : searchQuery ? (
-            <SearchView />
-          ) : activeView === 'now-playing' ? (
-            <NowPlayingView />
-          ) : selectedAlbum ? (
-            <TrackList />
-          ) : (
-            <AlbumGrid />
-          )}
+          {renderMainContent()}
         </main>
-        {queueVisible && <QueuePanel />}
+        {!showSetup && isPanelVisible(rightPanel) && <SlotPanel panel={rightPanel!} />}
       </div>
-      <TransportBar />
+      {bottomPanel && <SlotPanel panel={bottomPanel} />}
       {!splashGone && <SplashScreen hiding={splashHiding} />}
       <PreferencesDialog />
     </div>

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -276,6 +276,122 @@ body,
   color: var(--text);
 }
 
+/* Panel picker ------------------------------------------------------------- */
+
+.panel-picker-anchor {
+  position: relative;
+  flex-shrink: 0;
+  margin-left: 6px;
+  -webkit-app-region: no-drag;
+}
+
+.panel-picker-trigger {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: color 0.15s, background 0.15s;
+}
+
+.panel-picker-trigger:hover,
+.panel-picker-trigger.active {
+  color: var(--text);
+  background: var(--hover);
+}
+
+.panel-picker-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 200;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  min-width: 280px;
+  padding-bottom: 6px;
+}
+
+.panel-picker-header {
+  padding: 10px 14px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
+.panel-picker-legend {
+  display: flex;
+  gap: 12px;
+  padding: 4px 14px 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
+.panel-picker-row {
+  display: flex;
+  align-items: center;
+  padding: 4px 14px;
+  gap: 8px;
+}
+
+.panel-picker-row:hover {
+  background: var(--hover);
+}
+
+.panel-picker-name {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-picker-controls {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.panel-picker-slot-btn {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 5px;
+  line-height: 1;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.panel-picker-slot-btn:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+
+.panel-picker-slot-btn.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.panel-picker-slot-btn.disabled,
+.panel-picker-slot-btn:disabled {
+  color: var(--text-dim);
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
 /* Search results ----------------------------------------------------------- */
 
 .search-view {

--- a/kamp_ui/src/renderer/src/components/LibraryView.tsx
+++ b/kamp_ui/src/renderer/src/components/LibraryView.tsx
@@ -1,0 +1,17 @@
+/**
+ * Library view: shows the album grid or the track list for the selected album.
+ *
+ * Extracted from App.tsx so it can register as a built-in slot panel
+ * (kamp.library) while keeping the AlbumGrid/TrackList switching logic
+ * in one place.
+ */
+
+import React from 'react'
+import { useStore } from '../store'
+import { AlbumGrid } from './AlbumGrid'
+import { TrackList } from './TrackList'
+
+export function LibraryView(): React.JSX.Element {
+  const selectedAlbum = useStore((s) => s.library.selectedAlbum)
+  return selectedAlbum ? <TrackList /> : <AlbumGrid />
+}

--- a/kamp_ui/src/renderer/src/components/PanelPicker.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelPicker.tsx
@@ -1,0 +1,129 @@
+/**
+ * PanelPicker: floating popover that lets users add, remove, and reposition
+ * panels. Accessible from the gear button in the nav bar.
+ */
+
+import React, { useEffect, useRef, useState } from 'react'
+import { isPanelCompatibleWithSlot } from '../hooks/usePanelLayout'
+import type { PanelLayoutApi, UnifiedPanel } from '../hooks/usePanelLayout'
+import type { SlotId } from '../../../shared/kampAPI'
+
+const SLOT_LABELS: Record<SlotId, string> = {
+  main: 'Main',
+  left: 'Left sidebar',
+  right: 'Right sidebar',
+  bottom: 'Bottom bar'
+}
+
+function PanelRow({
+  panel,
+  currentSlot,
+  onMove,
+  onHide
+}: {
+  panel: UnifiedPanel
+  currentSlot: SlotId | 'hidden'
+  onMove: (slot: SlotId) => void
+  onHide: () => void
+}): React.JSX.Element {
+  const slots: SlotId[] = ['main', 'left', 'right', 'bottom']
+
+  return (
+    <div className="panel-picker-row">
+      <span className="panel-picker-name">{panel.title}</span>
+      <div className="panel-picker-controls">
+        {slots.map((slot) => {
+          const compatible = isPanelCompatibleWithSlot(panel, slot)
+          return (
+            <button
+              key={slot}
+              title={compatible ? SLOT_LABELS[slot] : `${SLOT_LABELS[slot]} (incompatible)`}
+              className={
+                'panel-picker-slot-btn' +
+                (currentSlot === slot ? ' active' : '') +
+                (!compatible ? ' disabled' : '')
+              }
+              disabled={!compatible}
+              onClick={() => (currentSlot === slot ? onHide() : onMove(slot))}
+            >
+              {slotIcon(slot)}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function slotIcon(slot: SlotId): string {
+  switch (slot) {
+    case 'main':
+      return '⊟'
+    case 'left':
+      return '⊢'
+    case 'right':
+      return '⊣'
+    case 'bottom':
+      return '⎵'
+  }
+}
+
+export function PanelPicker({ layout }: { layout: PanelLayoutApi }): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Close when clicking outside
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(e: PointerEvent): void {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  // Build a map of panel ID → current slot (or 'hidden')
+  const slotOf = (id: string): SlotId | 'hidden' => {
+    const slots: SlotId[] = ['main', 'left', 'right', 'bottom']
+    for (const slot of slots) {
+      if (layout.panelsInSlot(slot).some((p) => p.id === id)) return slot
+    }
+    return 'hidden'
+  }
+
+  return (
+    <div className="panel-picker-anchor" ref={ref}>
+      <button
+        className={'panel-picker-trigger' + (open ? ' active' : '')}
+        title="Manage panels"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        ⚙
+      </button>
+      {open && (
+        <div className="panel-picker-popover" role="dialog" aria-label="Manage panels">
+          <div className="panel-picker-header">Panels</div>
+          <div className="panel-picker-legend">
+            <span title="Main">⊟ Main</span>
+            <span title="Left sidebar">⊢ Left</span>
+            <span title="Right sidebar">⊣ Right</span>
+            <span title="Bottom bar">⎵ Bottom</span>
+          </div>
+          {layout.allPanels.map((panel) => (
+            <PanelRow
+              key={panel.id}
+              panel={panel}
+              currentSlot={slotOf(panel.id)}
+              onMove={(slot) => layout.movePanel(panel.id, slot)}
+              onHide={() => layout.hidePanel(panel.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/hooks/usePanelLayout.ts
+++ b/kamp_ui/src/renderer/src/hooks/usePanelLayout.ts
@@ -1,0 +1,200 @@
+/**
+ * Panel layout system: slot assignments, persistence, and built-in registration.
+ *
+ * Built-in panels (React components) register at module level before React
+ * mounts. Extension panels arrive async via KampAPI.panels and are merged in
+ * as they register. Layout is persisted to localStorage so user repositioning
+ * survives app restarts.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import type { PanelManifest, SlotId } from '../../../shared/kampAPI'
+import { useRegisteredPanels } from './useRegisteredPanels'
+
+// ---------------------------------------------------------------------------
+// Built-in panel type (React components, not subject to contextBridge)
+// ---------------------------------------------------------------------------
+
+/** A panel backed by a React component (used for built-in panels). */
+export type BuiltInPanelManifest = {
+  id: string
+  title: string
+  defaultSlot: SlotId
+  /** Slots this panel can occupy. Omit to allow all slots. */
+  compatibleSlots?: SlotId[]
+  component: React.ComponentType
+}
+
+/** Discriminated union used throughout the rendering layer. */
+export type UnifiedPanel =
+  | (BuiltInPanelManifest & { kind: 'builtin' })
+  | (PanelManifest & { kind: 'extension' })
+
+// Module-level registry — populated synchronously before React mounts so the
+// initial layout state can reference all built-ins on first render.
+const builtInRegistry: BuiltInPanelManifest[] = []
+
+/** Register a built-in panel. Idempotent: duplicate IDs are ignored. */
+export function registerBuiltInPanel(manifest: BuiltInPanelManifest): void {
+  if (!builtInRegistry.some((p) => p.id === manifest.id)) {
+    builtInRegistry.push(manifest)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persisted layout state
+// ---------------------------------------------------------------------------
+
+type LayoutState = {
+  version: 1
+  /** Panel IDs assigned to each slot, in display order. */
+  slots: Record<SlotId, string[]>
+  /** Panel IDs hidden by the user (registered but not shown in any slot). */
+  hidden: string[]
+}
+
+const LAYOUT_KEY = 'kamp:panel-layout'
+const SLOTS: SlotId[] = ['left', 'right', 'bottom', 'main']
+
+function buildDefaultLayout(panels: UnifiedPanel[]): LayoutState {
+  const slots: Record<SlotId, string[]> = { left: [], right: [], bottom: [], main: [] }
+  for (const panel of panels) {
+    slots[panel.defaultSlot].push(panel.id)
+  }
+  return { version: 1, slots, hidden: [] }
+}
+
+function loadPersistedLayout(): LayoutState | null {
+  try {
+    const raw = localStorage.getItem(LAYOUT_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as LayoutState
+    if (parsed.version !== 1) return null
+    // Ensure all slot keys exist (in case new slots were added since last save).
+    for (const slot of SLOTS) {
+      if (!Array.isArray(parsed.slots[slot])) parsed.slots[slot] = []
+    }
+    if (!Array.isArray(parsed.hidden)) parsed.hidden = []
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function saveLayout(state: LayoutState): void {
+  localStorage.setItem(LAYOUT_KEY, JSON.stringify(state))
+}
+
+function removeFromAllSlots(prev: LayoutState, id: string): LayoutState {
+  return {
+    ...prev,
+    slots: Object.fromEntries(
+      SLOTS.map((s) => [s, prev.slots[s].filter((i) => i !== id)])
+    ) as Record<SlotId, string[]>,
+    hidden: prev.hidden.filter((i) => i !== id)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// usePanelLayout hook
+// ---------------------------------------------------------------------------
+
+/** Returns true if the panel can be placed in the given slot. */
+export function isPanelCompatibleWithSlot(panel: UnifiedPanel, slot: SlotId): boolean {
+  const { compatibleSlots } = panel
+  return !compatibleSlots || compatibleSlots.includes(slot)
+}
+
+export type PanelLayoutApi = {
+  /** Resolved panels currently assigned to the given slot. */
+  panelsInSlot: (slot: SlotId) => UnifiedPanel[]
+  /** Panels that are registered but not displayed in any slot. */
+  hiddenPanels: UnifiedPanel[]
+  /** All registered panels (built-in + extension), regardless of visibility. */
+  allPanels: UnifiedPanel[]
+  /** Move a panel into a slot (removes it from wherever it currently is). */
+  movePanel: (id: string, slot: SlotId) => void
+  /** Remove a panel from its slot without unregistering it. */
+  hidePanel: (id: string) => void
+  /** Move a hidden panel back into a slot. Equivalent to movePanel. */
+  showPanel: (id: string, slot: SlotId) => void
+}
+
+export function usePanelLayout(): PanelLayoutApi {
+  const extensionPanels = useRegisteredPanels()
+
+  const allPanels: UnifiedPanel[] = useMemo(
+    () => [
+      ...builtInRegistry.map((p) => ({ ...p, kind: 'builtin' as const })),
+      ...extensionPanels.map((p) => ({ ...p, kind: 'extension' as const }))
+    ],
+    [extensionPanels]
+  )
+
+  // baseLayout holds only what is explicitly persisted (user actions).
+  // At init time only built-ins are known; extension panels arrive async.
+  const [baseLayout, setBaseLayout] = useState<LayoutState>(() => {
+    const persisted = loadPersistedLayout()
+    if (persisted) return persisted
+    return buildDefaultLayout(allPanels)
+  })
+
+  // Effective layout: baseLayout extended with any newly registered panels
+  // that haven't been placed or hidden yet. Computed without a side-effect so
+  // we avoid calling setState inside an effect.
+  const layout = useMemo(() => {
+    const placed = new Set([...Object.values(baseLayout.slots).flat(), ...baseLayout.hidden])
+    const newPanels = allPanels.filter((p) => !placed.has(p.id))
+    if (newPanels.length === 0) return baseLayout
+    const next: LayoutState = { ...baseLayout, slots: { ...baseLayout.slots } }
+    for (const panel of newPanels) {
+      next.slots[panel.defaultSlot] = [...next.slots[panel.defaultSlot], panel.id]
+    }
+    return next
+  }, [baseLayout, allPanels])
+
+  // Persist the effective layout whenever it changes. Skip the initial mount
+  // (the value was just loaded from / derived without localStorage needing an
+  // update) by tracking whether this is the first render.
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    saveLayout(layout)
+  }, [layout])
+
+  const findPanel = (id: string): UnifiedPanel | undefined => allPanels.find((p) => p.id === id)
+
+  const panelsInSlot = (slot: SlotId): UnifiedPanel[] =>
+    layout.slots[slot].flatMap((id) => {
+      const p = findPanel(id)
+      return p ? [p] : []
+    })
+
+  const hiddenPanels = layout.hidden.flatMap((id) => {
+    const p = findPanel(id)
+    return p ? [p] : []
+  })
+
+  const movePanel = (id: string, slot: SlotId): void => {
+    setBaseLayout((prev) => {
+      const next = removeFromAllSlots(prev, id)
+      next.slots[slot] = [...next.slots[slot], id]
+      return next
+    })
+  }
+
+  const hidePanel = (id: string): void => {
+    setBaseLayout((prev) => {
+      const next = removeFromAllSlots(prev, id)
+      next.hidden = [...next.hidden, id]
+      return next
+    })
+  }
+
+  const showPanel = (id: string, slot: SlotId): void => movePanel(id, slot)
+
+  return { panelsInSlot, hiddenPanels, allPanels, movePanel, hidePanel, showPanel }
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -43,11 +43,13 @@ type PlayerStore = {
   searchQuery: string
   searchResults: SearchResult | null
   queueVisible: boolean
+  artistPanelVisible: boolean
   queue: QueueState | null
 
   // Actions
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   toggleQueuePanel: () => void
+  toggleArtistPanel: () => void
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (sort: 'album_artist' | 'album' | 'date_added' | 'last_played') => Promise<void>
@@ -121,6 +123,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   searchQuery: '',
   searchResults: null,
   queueVisible: false,
+  // Client-only persistence — no backend endpoint needed for this toggle.
+  artistPanelVisible: localStorage.getItem('kamp:artist-panel-visible') !== 'false',
   queue: null,
   configValues: null,
   prefsOpen: false,
@@ -131,6 +135,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const next = !get().queueVisible
     set({ queueVisible: next })
     void api.setQueuePanelApi(next)
+  },
+
+  toggleArtistPanel: () => {
+    const next = !get().artistPanelVisible
+    set({ artistPanelVisible: next })
+    localStorage.setItem('kamp:artist-panel-visible', String(next))
   },
 
   loadQueue: async () => {

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -5,12 +5,32 @@
  * Must contain only pure TypeScript — no Node.js or Electron imports.
  */
 
+/**
+ * Layout slots available in the host application.
+ *
+ * - `main`   – tabbed content area (Library, Now Playing, extension views)
+ * - `left`   – left sidebar column
+ * - `right`  – right sidebar column
+ * - `bottom` – bottom bar (transport controls)
+ */
+export type SlotId = 'main' | 'left' | 'right' | 'bottom'
+
 /** A panel contributed by a frontend extension. */
 export type PanelManifest = {
   /** Unique identifier for the panel (e.g. "kamp-example-panel.stats"). */
   id: string
   /** Human-readable title shown in the nav tab. */
   title: string
+  /**
+   * Where this panel should appear by default.
+   * Extensions that render full page views should use `'main'`.
+   */
+  defaultSlot: SlotId
+  /**
+   * Slots this panel can occupy. Omit to allow all slots.
+   * The host uses this to disable incompatible slot buttons in the panel picker.
+   */
+  compatibleSlots?: SlotId[]
   /**
    * Mount the panel into `container` and return a cleanup function.
    * Called once when the panel tab is first shown; cleanup is called on unmount.


### PR DESCRIPTION
## Summary

- Adds a slot system (`main`, `left`, `right`, `bottom`) so panels declare where they live by default and which slots they're compatible with
- Five built-in panels registered through the same API as extensions: Library, Now Playing, Artists, Queue, Transport
- New `PanelPicker` (⚙ in nav bar) lets users move panels between slots or hide them; incompatible slot buttons are disabled
- Panel-specific visibility toggles (`Q` for queue, `A` for artists) are slot-agnostic — the shortcut follows the panel wherever it's placed
- Layout persisted to `localStorage`; artist panel visibility also client-persisted

## Test plan

- [x] Default layout loads correctly (Library + Now Playing tabs, Artists left, Queue right, Transport bottom)
- [x] Panel picker opens/closes; moving a panel to a new slot takes effect immediately
- [x] Incompatible slot buttons are greyed out and unclickable (e.g. Transport can only go in Bottom)
- [x] `Q` toggles queue panel in whichever slot it's in; `A` toggles artist panel
- [x] Swapping Artists to right and Queue to left: `Q` still controls Queue, `A` still controls Artists
- [x] Layout survives app restart (localStorage persistence)
- [x] `kamp-example-panel` Stats panel registers to `main` slot and appears as a tab
- [x] Extension panels can only be placed in compatible slots (no `compatibleSlots` = all slots allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)