### PR TITLE
feat: Phase 1 first-party extension allow-list (TASK-86)

### DIFF
--- a/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
+++ b/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-86
 title: Phase 1 first-party extension allow-list
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-05 16:32'
+updated_date: '2026-04-07 02:47'
 labels:
   - feature
   - security

--- a/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
+++ b/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
@@ -4,7 +4,7 @@ title: Phase 1 first-party extension allow-list
 status: In Progress
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-07 02:47'
+updated_date: '2026-04-07 02:52'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-19
 documentation:
   - project/kampground-ideation.md
-ordinal: 8000
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
+++ b/backlog/tasks/task-86 - Phase-1-first-party-extension-allow-list.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-86
 title: Phase 1 first-party extension allow-list
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-07 02:52'
+updated_date: '2026-04-07 02:53'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-19
 documentation:
   - project/kampground-ideation.md
-ordinal: 1000
+ordinal: 15000
 ---
 
 ## Description

--- a/kamp_ui/src/main/extensions.ts
+++ b/kamp_ui/src/main/extensions.ts
@@ -7,12 +7,25 @@
  *
  * A package qualifies when its package.json has "kamp-extension" in `keywords`
  * and its declared entry point (`main`) exists on disk.
+ *
+ * Security phases:
+ *   Phase 1 – First-party: must appear in first-party-allowlist.json AND carry
+ *             the keyword. Receives full contextBridge (KampAPI) access.
+ *   Phase 2 – Community: keyword present but not on the allow-list. Rendered
+ *             in a sandboxed iframe with no contextBridge access.
+ *
+ * The allow-list is the mechanism that prevents arbitrary npm packages from
+ * claiming the keyword and escalating into contextBridge access.
  */
 
 import { app } from 'electron'
 import { readdirSync, readFileSync, existsSync } from 'fs'
 import { join, resolve } from 'path'
 import type { ExtensionInfo } from '../shared/kampAPI'
+import allowlistData from './first-party-allowlist.json'
+
+// Set of package names approved for Phase 1 (contextBridge) access.
+const FIRST_PARTY_IDS = new Set<string>(allowlistData.extensions)
 
 function scanDir(dir: string): ExtensionInfo[] {
   if (!existsSync(dir)) return []
@@ -43,10 +56,16 @@ function scanDir(dir: string): ExtensionInfo[] {
       // renderer never needs a file:// import — it loads via a Blob URL instead.
       const code = readFileSync(entryPath, 'utf8')
 
+      const id = pkg.name ?? entry.name
+      // Phase 1 requires the package to be explicitly on the allow-list;
+      // everything else is Phase 2 (community / sandboxed).
+      const phase: 1 | 2 = FIRST_PARTY_IDS.has(id) ? 1 : 2
+
       results.push({
-        id: pkg.name ?? entry.name,
+        id,
         name: pkg.displayName ?? pkg.name ?? entry.name,
-        code
+        code,
+        phase
       })
     } catch {
       // Skip packages with malformed package.json.

--- a/kamp_ui/src/main/first-party-allowlist.json
+++ b/kamp_ui/src/main/first-party-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "First-party extension allow-list. Only packages listed here AND carrying the 'kamp-extension' npm keyword are granted Phase 1 (contextBridge) access. Any package with the keyword but absent from this list is treated as a Phase 2 community extension (sandboxed iframe). Add entries as '<npm-package-name>' strings. This file is shipped with the app and is version-controlled; changes require a new app release.",
+  "extensions": ["kamp-example-panel"]
+}

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -238,6 +238,17 @@ export default function App(): React.JSX.Element {
       try {
         const extensions = await window.KampAPI.extensions.getAll()
         for (const ext of extensions) {
+          if (ext.phase === 2) {
+            // Phase 2 (community) extensions are not yet sandboxed. Log and skip
+            // rather than granting contextBridge access to an un-vetted package.
+            console.warn(
+              `[kamp] extension "${ext.id}" is not on the first-party allow-list; ` +
+                'Phase 2 sandboxed-iframe support is not yet implemented — skipping.'
+            )
+            continue
+          }
+
+          // Phase 1: extension is on the allow-list; pass full KampAPI.
           const blob = new Blob([ext.code], { type: 'text/javascript' })
           const blobUrl = URL.createObjectURL(blob)
           try {

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -44,6 +44,12 @@ export type ExtensionInfo = {
   name: string
   /** Source code of the extension's entry point, read by the main process. */
   code: string
+  /**
+   * Security phase that governs how this extension is loaded:
+   *   1 – First-party: on the kamp allow-list; receives full contextBridge (KampAPI) access.
+   *   2 – Community: keyword present but not on the allow-list; rendered in a sandboxed iframe.
+   */
+  phase: 1 | 2
 }
 
 /** The full shape of window.KampAPI. */


### PR DESCRIPTION
## Summary

- Introduces `first-party-allowlist.json` — a kamp-controlled list of package names approved for Phase 1 (contextBridge) access
- `ExtensionInfo` gains a `phase: 1 | 2` field; `extensions.ts` sets it based on allow-list membership
- `App.tsx` skips Phase 2 extensions with a console warning instead of granting them `KampAPI` access

## Security model

| Condition | Phase | Access |
|-----------|-------|--------|
| keyword + on allow-list | 1 | Full `window.KampAPI` (contextBridge) |
| keyword only | 2 | Skipped (sandboxed iframe — not yet implemented) |

## Test plan

- [x] Build the app and confirm `kamp-example-panel` (on the list) loads and registers its panel as before
- [x] Add a test package with the `kamp-extension` keyword but a name not in the allow-list; confirm it is skipped with the Phase 2 console warning and receives no `KampAPI` access
- [x] Typecheck passes: `npm run typecheck` ✅
- [x] Lint clean (no new errors): `npm run lint` ✅

Closes TASK-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)