### PR TITLE
feat: extension settings UI (TASK-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,17 +355,37 @@ The Electron UI supports frontend extensions — npm packages that contribute pa
 
 1. The main process scans `kamp_ui/extensions/` (first-party) and `node_modules/` (installed) for packages with `"kamp-extension"` in their `keywords`.
 2. Each extension's entry point is an ES module that exports a `register(api)` function.
-3. `register` receives `window.KampAPI` and calls `api.panels.register(manifest)` to add a tab.
+3. Extensions are classified into two security phases:
+   - **Phase 1 (first-party):** listed in `kamp_ui/src/main/first-party-allowlist.json`; runs directly in the renderer with full `KampAPI` access.
+   - **Phase 2 (community):** not on the allowlist; runs in a sandboxed `<iframe sandbox="allow-scripts">` with no access to the host DOM, localStorage, or contextBridge. Network access is restricted to the local kamp server. On first load, the user is shown a permission prompt listing the extension's declared capabilities.
+
+**Managing extensions:**
+
+Open **Preferences → Extensions** (Cmd+,) to view all installed extensions, enable/disable them, and configure per-extension settings.
 
 **Writing an extension:**
 
 ```js
-// package.json: { "keywords": ["kamp-extension"], "main": "index.js", "type": "module" }
+// package.json
+{
+  "name": "my-kamp-extension",
+  "version": "1.0.0",
+  "keywords": ["kamp-extension"],
+  "main": "index.js",
+  "kamp": {
+    "permissions": ["player.read", "network.fetch"],
+    "settings": [
+      { "key": "refresh_interval", "label": "Refresh interval (s)", "type": "number", "default": 30 }
+    ]
+  }
+}
 
+// index.js
 export function register(api) {
   api.panels.register({
     id: 'my-extension.my-panel',   // must be globally unique
     title: 'My Panel',
+    defaultSlot: 'main',
     render(container) {
       container.textContent = 'Hello from my panel'
       // Return a cleanup function called on unmount:
@@ -375,7 +395,15 @@ export function register(api) {
 }
 ```
 
-Extensions run in the renderer process with `nodeIntegration: false` — they have no access to `ipcRenderer` or Node.js APIs. The only kamp surface is `window.KampAPI`, which exposes `panels`, `extensions`, and `serverUrl` (the HTTP server base URL for calling the REST API).
+**Declared permissions** (`kamp.permissions`):
+
+| Permission | Grants |
+|---|---|
+| `library.read` | Read library metadata via the REST API |
+| `player.read` | Read playback state |
+| `player.control` | Control playback (play, pause, skip, seek) |
+| `network.fetch` | Make requests to external servers |
+| `settings` | Read and write per-extension settings via `api.settings` |
 
 An example first-party extension lives in `kamp_ui/extensions/kamp-example-panel/`.
 

--- a/backlog/milestones/m-26 - library-polish.md
+++ b/backlog/milestones/m-26 - library-polish.md
@@ -1,0 +1,8 @@
+---
+id: m-26
+title: "Library Polish"
+---
+
+## Description
+
+Milestone: Library Polish

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-07 21:38'
+updated_date: '2026-04-07 21:54'
 labels:
   - feature
   - ui
@@ -23,9 +23,30 @@ Add a settings UI where users can view installed extensions, enable/disable them
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Settings screen lists all installed extensions with name, version, and enabled state
-- [ ] #2 User can enable/disable extensions from the UI
-- [ ] #3 Per-extension settings are rendered from the extension's declared schema
-- [ ] #4 Settings changes take effect without requiring an app restart
-- [ ] #5 First load of a community extension shows a permission prompt listing its declared permissions; the extension only loads after explicit user approval
+- [x] #1 Settings screen lists all installed extensions with name, version, and enabled state
+- [x] #2 User can enable/disable extensions from the UI
+- [x] #3 Per-extension settings are rendered from the extension's declared schema
+- [x] #4 Settings changes take effect without requiring an app restart
+- [x] #5 First load of a community extension shows a permission prompt listing its declared permissions; the extension only loads after explicit user approval
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+### Files changed
+- `kamp_ui/src/shared/kampAPI.ts` — added `ExtensionSettingSchema` type; added `version` and `settings?` to `ExtensionInfo`; added `settings?` API to `KampAPI`
+- `kamp_ui/src/main/extensions.ts` — reads `version` and `kamp.settings` schema from package.json; validates schema entries
+- `kamp_ui/src/renderer/src/hooks/useExtensionState.ts` (new) — localStorage-backed state for disabled set, approved/denied sets, per-extension setting values
+- `kamp_ui/src/renderer/src/components/ExtensionPermissionPrompt.tsx` (new) — permission approval modal for Phase 2 community extensions
+- `kamp_ui/src/renderer/src/components/PreferencesDialog.tsx` — added tab bar (General | Extensions); Extensions tab renders ExtensionsPanel with per-extension rows (toggle, badge, Configure drawer)
+- `kamp_ui/src/renderer/src/App.tsx` — wired useExtensionState; filters disabled extensions; routes Phase 2 through approved/denied/pending sets; shows permission prompt queue; passes settings API to Phase 1 extensions with the 'settings' permission
+- `kamp_ui/src/renderer/src/assets/main.css` — tab bar, toggle switch, extension rows, phase badge, configure drawer, empty state, permission prompt dialog
+
+### Key design decisions
+- **Enable/disable**: disabling marks the id in localStorage; takes effect on next load (reload badge shown). Enabling an extension that was disabled re-triggers the load effect because `disabledIds` is in the effect dependency array.
+- **Per-extension settings (AC#4)**: values live in localStorage; `KampAPI.settings.get(key)` reads directly from the store at any time — no restart required. Only available when the extension declares the `'settings'` permission.
+- **Permission prompt (AC#5)**: Phase 2 extensions not yet in approved/denied sets go into a pending queue. App shows one prompt at a time via `permissionQueue[0]`. Approve → extension loads in its iframe; Deny → skipped, not prompted again.
+- **Settings schema**: extensions declare `kamp.settings` in package.json as an array of `{key, label, type, options?, default?, hint?}`. The host renders `text`, `number`, `boolean` (toggle), and `select` field types.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -1,18 +1,18 @@
 ---
 id: TASK-22
 title: Extension settings UI
-status: In Progress
+status: Done
 assignee:
   - Claude
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-08 16:38'
+updated_date: '2026-04-08 16:57'
 labels:
   - feature
   - ui
   - 'estimate: side'
 milestone: m-2
 dependencies: []
-ordinal: 11000
+ordinal: 18000
 ---
 
 ## Description

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Claude
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-07 21:54'
+updated_date: '2026-04-08 16:38'
 labels:
   - feature
   - ui
@@ -50,3 +50,17 @@ Add a settings UI where users can view installed extensions, enable/disable them
 - **Permission prompt (AC#5)**: Phase 2 extensions not yet in approved/denied sets go into a pending queue. App shows one prompt at a time via `permissionQueue[0]`. Approve → extension loads in its iframe; Deny → skipped, not prompted again.
 - **Settings schema**: extensions declare `kamp.settings` in package.json as an array of `{key, label, type, options?, default?, hint?}`. The host renders `text`, `number`, `boolean` (toggle), and `select` field types.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Sandboxed iframe debugging — lessons learned
+
+**srcdoc iframes inherit the parent document's CSP.** Even if the srcdoc carries its own `<meta http-equiv=Content-Security-Policy>`, the parent's CSP overrides it for script-src. The only way to permit an inline script is to hash-whitelist it in the parent's CSP (`'sha256-...'`). The hash must be recomputed every time the shim changes.
+
+**Sandboxed iframes without allow-same-origin reload on DOM move.** The original holding-area/move strategy (move iframe into visible container on mount, back to holding div on unmount) caused the iframe to reload every time it was moved in the DOM. Chromium treats these iframes as cross-origin and navigates them on reparent. Solution: create a fresh iframe on each panel mount.
+
+**Race condition: kamp:panel-mount arrives before async import() resolves.** Sending kamp:init and kamp:panel-mount synchronously in the same onLoad callback means panel-mount is processed by the shim before the dynamic import() inside kamp:init completes. The render fn (r[panelId]) is still empty. Fix: buffer the pending mount in the shim and fire it inside panels.register() if it arrived early.
+
+**iframe CSP needs img-src for server images.** The srcdoc CSP `default-src 'none'` blocks image loads. Must explicitly add `img-src http://127.0.0.1:8000` to allow album art from the kamp server.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-22 - Extension-settings-UI.md
+++ b/backlog/tasks/task-22 - Extension-settings-UI.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-22
 title: Extension settings UI
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - Claude
 created_date: '2026-03-29 03:12'
-updated_date: '2026-04-07 12:52'
+updated_date: '2026-04-07 21:38'
 labels:
   - feature
   - ui

--- a/backlog/tasks/task-94 - cache-album-art-images-so-they-dont-reload-every-time-the-library-view-is-loaded.md
+++ b/backlog/tasks/task-94 - cache-album-art-images-so-they-dont-reload-every-time-the-library-view-is-loaded.md
@@ -1,0 +1,18 @@
+---
+id: TASK-94
+title: >-
+  cache album art images so they don't reload every time the library view is
+  loaded
+status: To Do
+assignee: []
+created_date: '2026-04-08 13:37'
+labels: []
+milestone: m-26
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+There are a lot of requests to get album art every time the Library view is shown. These should be cached: album art is unlikely to change between view loads.  Album file updates can be the semaphore for cache invalidation.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-95 - queue-scrolls-from-the-top-every-time-its-opened.md
+++ b/backlog/tasks/task-95 - queue-scrolls-from-the-top-every-time-its-opened.md
@@ -1,0 +1,16 @@
+---
+id: TASK-95
+title: queue scrolls from the top every time it's opened
+status: To Do
+assignee: []
+created_date: '2026-04-08 16:58'
+labels: []
+milestone: m-26
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+this is visually distracting: it should just open at the position it wants to scroll to
+<!-- SECTION:DESCRIPTION:END -->

--- a/claude.md
+++ b/claude.md
@@ -48,6 +48,13 @@ When the goal is a runtime property (memory released, latency reduced), write a 
 ## macOS system integration
 Budget at least a Side for any feature touching osacompile, Spotlight registration, or macOS app bundles. Corporate MDM/EDR (Falcon, Jamf) can silently block registration in ways that are hard to diagnose.
 
+## Sandboxed iframes (community extensions)
+
+- **srcdoc iframes inherit the parent document's CSP** — even if the srcdoc has its own `<meta http-equiv=Content-Security-Policy>`, the parent's CSP overrides script-src. To allow an inline script, hash-whitelist it in the parent CSP (`'sha256-...'` in `src/renderer/index.html`). Recompute the hash every time the shim changes: `node -e "const s='...';console.log('sha256-'+require('crypto').createHash('sha256').update(s,'utf8').digest('base64'))"`.
+- **Sandboxed iframes without allow-same-origin reload on DOM move** — Chromium treats them as cross-origin and navigates on reparent. The holding-area/move strategy doesn't work. Create a fresh iframe on each panel mount instead.
+- **Race condition: send init and mount in the same onLoad callback** — `kamp:init` triggers an async `import()`; `kamp:panel-mount` arrives before the import resolves, so `r[panelId]` is empty and mount silently no-ops. Fix: buffer the pending mount id and fire it inside `panels.register()` if it arrived early.
+- **iframe CSP needs explicit img-src** — `default-src 'none'` blocks image loads from the kamp server. Add `img-src http://127.0.0.1:8000` to the srcdoc CSP.
+
 ## macOS notifications
 `NSUserNotificationCenter` (used by `rumps.notification()`) is a no-op on macOS 14+. Use `UNUserNotificationCenter` instead. It requires `CFBundleIdentifier` — embed it in `launcher/main.c` via `__TEXT,__info_plist`. Without the compiled launcher (e.g. dev venv), `UNUserNotificationCenter.currentNotificationCenter()` crashes; wrap it in `try/except` and fall back to `rumps.notification()`.
 

--- a/kamp_ui/src/main/extensions.ts
+++ b/kamp_ui/src/main/extensions.ts
@@ -21,7 +21,7 @@
 import { app } from 'electron'
 import { readdirSync, readFileSync, existsSync } from 'fs'
 import { join, resolve } from 'path'
-import type { ExtensionInfo } from '../shared/kampAPI'
+import type { ExtensionInfo, ExtensionSettingSchema } from '../shared/kampAPI'
 import allowlistData from './first-party-allowlist.json'
 
 // Set of package names approved for Phase 1 (contextBridge) access.
@@ -41,10 +41,11 @@ function scanDir(dir: string): ExtensionInfo[] {
     try {
       const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
         name?: string
+        version?: string
         displayName?: string
         keywords?: string[]
         main?: string
-        kamp?: { permissions?: string[] }
+        kamp?: { permissions?: string[]; settings?: ExtensionSettingSchema[] }
       }
 
       if (!Array.isArray(pkg.keywords) || !pkg.keywords.includes('kamp-extension')) continue
@@ -75,12 +76,27 @@ function scanDir(dir: string): ExtensionInfo[] {
         )
       }
 
+      // Read settings schema, validating that each entry has at minimum key, label, type.
+      const rawSettings = pkg.kamp?.settings
+      const settings: ExtensionSettingSchema[] | undefined = Array.isArray(rawSettings)
+        ? rawSettings.filter(
+            (s): s is ExtensionSettingSchema =>
+              typeof s === 'object' &&
+              s !== null &&
+              typeof s.key === 'string' &&
+              typeof s.label === 'string' &&
+              typeof s.type === 'string'
+          )
+        : undefined
+
       results.push({
         id,
         name: pkg.displayName ?? pkg.name ?? entry.name,
+        version: pkg.version ?? '0.0.0',
         code,
         phase,
-        permissions
+        permissions,
+        settings: settings && settings.length > 0 ? settings : undefined
       })
     } catch {
       // Skip packages with malformed package.json.

--- a/kamp_ui/src/renderer/index.html
+++ b/kamp_ui/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self' blob: 'sha256-5YoNsm/x3siNFa4AZVG+F0NAYy1tRVzzLK9h/d/IUJE='; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
     />
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -14,7 +14,9 @@ import { SetupScreen } from './components/SetupScreen'
 import { SplashScreen } from './components/SplashScreen'
 import { TransportBar } from './components/TransportBar'
 import { SandboxedExtensionLoader } from './components/SandboxedExtensionLoader'
+import { ExtensionPermissionPrompt } from './components/ExtensionPermissionPrompt'
 import { registerBuiltInPanel, usePanelLayout } from './hooks/usePanelLayout'
+import { useExtensionState } from './hooks/useExtensionState'
 import type { UnifiedPanel } from './hooks/usePanelLayout'
 import type { ExtensionInfo } from '../../shared/kampAPI'
 
@@ -92,11 +94,16 @@ export default function App(): React.JSX.Element {
   const openPrefs = useStore((s) => s.openPrefs)
 
   const layout = usePanelLayout()
+  const extState = useExtensionState()
 
   // Active extension panel id, or null when a built-in view is showing.
   const [activeExtPanel, setActiveExtPanel] = useState<string | null>(null)
-  // Phase 2 (community) extensions to render in sandboxed iframes.
+  // All discovered extensions (used by PreferencesDialog for the Extensions tab).
+  const [allExtensions, setAllExtensions] = useState<ExtensionInfo[]>([])
+  // Phase 2 (community) extensions approved and ready to render in sandboxed iframes.
   const [phase2Extensions, setPhase2Extensions] = useState<ExtensionInfo[]>([])
+  // Queue of Phase 2 extensions awaiting permission approval — shown one at a time.
+  const [permissionQueue, setPermissionQueue] = useState<ExtensionInfo[]>([])
 
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
@@ -237,29 +244,58 @@ export default function App(): React.JSX.Element {
   }, [openPrefs])
 
   // Discover and load frontend extensions.
+  // extState.disabledIds is captured at mount; re-runs if the disabled set changes
+  // so that newly-enabled extensions are loaded immediately.
+  const {
+    disabledIds,
+    approvedIds,
+    deniedIds,
+    approve,
+    deny,
+    resetDenied,
+    getSettingValue,
+    setSettingValue
+  } = extState
   useEffect(() => {
     async function loadExtensions(): Promise<void> {
       try {
         const extensions = await window.KampAPI.extensions.getAll()
-        const phase2: ExtensionInfo[] = []
+        setAllExtensions(extensions)
+
+        const phase2Approved: ExtensionInfo[] = []
+        const phase2Pending: ExtensionInfo[] = []
+
         for (const ext of extensions) {
+          // Skip extensions the user has explicitly disabled.
+          if (disabledIds.has(ext.id)) continue
+
           if (ext.phase === 2) {
-            // Phase 2 (community) extensions: collected and passed to
-            // SandboxedExtensionLoader, which renders them in isolated iframes.
-            phase2.push(ext)
+            // Phase 2 (community): route through permission approval.
+            if (approvedIds.has(ext.id)) {
+              phase2Approved.push(ext)
+            } else if (!deniedIds.has(ext.id)) {
+              // Not yet decided — queue for the permission prompt.
+              phase2Pending.push(ext)
+            }
+            // denied extensions are silently skipped.
             continue
           }
 
-          // Phase 1: extension is on the allow-list; pass a permission-scoped KampAPI.
-          // Panels and serverUrl are always available (they are the extension ABC contract).
-          // Future capabilities (library.read, player.read, etc.) will be gated here.
+          // Phase 1: on the allow-list; pass a permission-scoped KampAPI.
           const pset = new Set(ext.permissions)
           const scopedAPI = {
             serverUrl: window.KampAPI.serverUrl,
             panels: window.KampAPI.panels,
             extensions: window.KampAPI.extensions,
-            // Placeholder gates for declared capabilities — expand as the API grows.
-            _permissions: pset
+            // settings API: only present when the extension declared the 'settings' permission.
+            ...(pset.has('settings')
+              ? {
+                  settings: {
+                    get: (key: string) => getSettingValue(ext.id, key),
+                    set: (key: string, value: unknown) => setSettingValue(ext.id, key, value)
+                  }
+                }
+              : {})
           }
           const blob = new Blob([ext.code], { type: 'text/javascript' })
           const blobUrl = URL.createObjectURL(blob)
@@ -274,13 +310,38 @@ export default function App(): React.JSX.Element {
             URL.revokeObjectURL(blobUrl)
           }
         }
-        setPhase2Extensions(phase2)
+
+        setPhase2Extensions(phase2Approved)
+        setPermissionQueue(phase2Pending)
       } catch (err) {
         console.error('[kamp] extension discovery failed:', err)
       }
     }
     void loadExtensions()
-  }, [])
+  }, [disabledIds]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-queue a previously-denied Phase 2 extension for the permission prompt.
+  const handleReviewDenied = (id: string): void => {
+    const ext = allExtensions.find((e) => e.id === id)
+    if (!ext) return
+    resetDenied(id)
+    setPermissionQueue((q) => [...q, ext])
+  }
+
+  // Permission prompt handlers — advance the queue one extension at a time.
+  const handlePermissionApprove = (): void => {
+    const ext = permissionQueue[0]
+    if (!ext) return
+    approve(ext.id)
+    setPhase2Extensions((prev) => [...prev, ext])
+    setPermissionQueue((q) => q.slice(1))
+  }
+  const handlePermissionDeny = (): void => {
+    const ext = permissionQueue[0]
+    if (!ext) return
+    deny(ext.id)
+    setPermissionQueue((q) => q.slice(1))
+  }
 
   // Track scroll position for the active main panel key (built-in name or ext ID).
   const activeMainKey = activeExtPanel ?? activeView
@@ -311,7 +372,11 @@ export default function App(): React.JSX.Element {
           </div>
         </div>
         {!splashGone && <SplashScreen hiding={splashHiding} />}
-        <PreferencesDialog />
+        <PreferencesDialog
+          extensions={allExtensions}
+          extState={extState}
+          onReviewDenied={handleReviewDenied}
+        />
       </>
     )
   }
@@ -397,7 +462,19 @@ export default function App(): React.JSX.Element {
       </div>
       {bottomPanel && <SlotPanel panel={bottomPanel} />}
       {!splashGone && <SplashScreen hiding={splashHiding} />}
-      <PreferencesDialog />
+      <PreferencesDialog
+        extensions={allExtensions}
+        extState={extState}
+        onReviewDenied={handleReviewDenied}
+      />
+      {/* Permission prompt: shown for Phase 2 extensions awaiting user approval. */}
+      {permissionQueue[0] && (
+        <ExtensionPermissionPrompt
+          extension={permissionQueue[0]}
+          onApprove={handlePermissionApprove}
+          onDeny={handlePermissionDeny}
+        />
+      )}
       {/* Phase 2 iframes live here in a hidden holding area until their panel tab is activated */}
       <SandboxedExtensionLoader extensions={phase2Extensions} />
     </div>

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -686,9 +686,11 @@ body,
   min-height: 0;
   overflow-y: auto;
   padding: 16px;
+  position: relative;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
+
 
 /* Now-playing fills its own space — override the shared padding */
 .main-content:has(.now-playing) {
@@ -1948,4 +1950,281 @@ body,
   height: 100%;
   background: var(--accent);
   transition: width 200ms ease;
+}
+
+/* ---- Preferences tab bar ---- */
+
+.prefs-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  padding: 0 16px;
+  flex-shrink: 0;
+}
+
+.prefs-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: 10px 12px 8px;
+  margin-bottom: -1px;
+  text-transform: uppercase;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.prefs-tab:hover {
+  color: var(--text);
+}
+
+.prefs-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.prefs-tab:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ---- Extension rows ---- */
+
+.prefs-ext-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+}
+
+.prefs-ext-version {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.prefs-ext-badge {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  background: var(--surface-hover);
+  white-space: nowrap;
+}
+
+.prefs-ext-badge--first-party {
+  color: var(--accent);
+  border-color: var(--accent-dim);
+  background: var(--accent-dim);
+}
+
+/* ---- Toggle switch ---- */
+
+.prefs-toggle {
+  position: relative;
+  width: 28px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-left: auto;
+  cursor: pointer;
+}
+
+.prefs-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.prefs-toggle-track {
+  position: absolute;
+  inset: 0;
+  background: var(--border);
+  border-radius: 8px;
+  transition: background 150ms ease;
+}
+
+.prefs-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--text-dim);
+  border-radius: 50%;
+  transition: transform 150ms ease, background 150ms ease;
+}
+
+.prefs-toggle input:checked + .prefs-toggle-track {
+  background: var(--accent-dim);
+}
+
+.prefs-toggle input:checked + .prefs-toggle-track::after {
+  transform: translateX(12px);
+  background: var(--accent);
+}
+
+.prefs-toggle input:focus-visible + .prefs-toggle-track {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ---- Configure drawer ---- */
+
+.prefs-ext-configure-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 150ms ease;
+}
+
+.prefs-ext-configure-btn:hover {
+  color: var(--text);
+}
+
+.prefs-ext-configure-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.prefs-ext-drawer {
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Indent nested fields to visually associate them with the extension above. */
+.prefs-ext-drawer .prefs-row {
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
+}
+
+/* ---- Empty state ---- */
+
+.prefs-ext-empty {
+  padding: 32px 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* ---- Extension permission prompt ---- */
+
+.ext-perm-dialog {
+  max-width: 420px;
+}
+
+.ext-perm-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ext-perm-intro {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.ext-perm-version {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.ext-perm-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+}
+
+.ext-perm-item {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.ext-perm-bullet {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.ext-perm-none {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.ext-perm-warning {
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.ext-perm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.ext-perm-deny-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 14px;
+  border-radius: 4px;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.ext-perm-deny-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.ext-perm-approve-btn {
+  background: var(--accent);
+  border: none;
+  color: var(--text-on-accent);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 4px;
+  transition: opacity 150ms ease;
+}
+
+.ext-perm-approve-btn:hover {
+  opacity: 0.85;
+}
+
+.ext-perm-deny-btn:focus-visible,
+.ext-perm-approve-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
 }

--- a/kamp_ui/src/renderer/src/components/ExtensionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ExtensionPanel.tsx
@@ -17,5 +17,11 @@ export function ExtensionPanel({ panel }: { panel: PanelManifest }): React.JSX.E
     return panel.render(el)
   }, [panel])
 
-  return <div className="extension-panel" ref={containerRef} />
+  return (
+    <div
+      className="extension-panel"
+      ref={containerRef}
+      style={{ position: 'absolute', inset: 0, overflow: 'hidden' }}
+    />
+  )
 }

--- a/kamp_ui/src/renderer/src/components/ExtensionPermissionPrompt.tsx
+++ b/kamp_ui/src/renderer/src/components/ExtensionPermissionPrompt.tsx
@@ -1,0 +1,86 @@
+/**
+ * ExtensionPermissionPrompt — shown once per community (Phase 2) extension
+ * before it is loaded. The extension only runs after the user explicitly
+ * approves its declared permissions.
+ *
+ * App.tsx maintains a queue of pending extensions; this component displays
+ * the first one. Approve/deny callbacks advance the queue.
+ */
+
+import React from 'react'
+import type { ExtensionInfo } from '../../../shared/kampAPI'
+
+// Map raw permission ids to human-readable descriptions.
+const PERMISSION_LABELS: Record<string, string> = {
+  'library.read': 'Read your music library (artists, albums, tracks)',
+  'player.read': 'Read playback state (current track, position, volume)',
+  'player.control': 'Control playback (play, pause, skip, seek)',
+  'network.fetch': 'Make requests to external servers on the internet',
+  settings: 'Read and write its own settings'
+}
+
+function permissionLabel(p: string): string {
+  return PERMISSION_LABELS[p] ?? p
+}
+
+interface Props {
+  extension: ExtensionInfo
+  onApprove: () => void
+  onDeny: () => void
+}
+
+export function ExtensionPermissionPrompt({
+  extension,
+  onApprove,
+  onDeny
+}: Props): React.JSX.Element {
+  return (
+    <div className="prefs-overlay ext-perm-overlay">
+      <div
+        className="prefs-dialog ext-perm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Extension permissions"
+      >
+        <div className="prefs-header">
+          <span className="prefs-title">EXTENSION PERMISSIONS</span>
+        </div>
+
+        <div className="ext-perm-body">
+          <p className="ext-perm-intro">
+            <strong>{extension.name}</strong>{' '}
+            <span className="ext-perm-version">{extension.version}</span> is a community extension
+            that requests the following permissions:
+          </p>
+
+          {extension.permissions.length > 0 ? (
+            <ul className="ext-perm-list">
+              {extension.permissions.map((p) => (
+                <li key={p} className="ext-perm-item">
+                  <span className="ext-perm-bullet">•</span>
+                  {permissionLabel(p)}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="ext-perm-none">This extension requests no special permissions.</p>
+          )}
+
+          <p className="ext-perm-warning">
+            Community extensions run in a sandboxed iframe and cannot access your filesystem or
+            system APIs. Only approve extensions you trust.
+          </p>
+        </div>
+
+        <div className="ext-perm-actions">
+          <button className="ext-perm-deny-btn" onClick={onDeny}>
+            Don&apos;t Allow
+          </button>
+          <button className="ext-perm-approve-btn" onClick={onApprove}>
+            Allow Extension
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
+import type { ExtensionStateHook } from '../hooks/useExtensionState'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -278,10 +280,183 @@ function TextareaRow({
 }
 
 // ---------------------------------------------------------------------------
+// Extensions panel sub-components
+// ---------------------------------------------------------------------------
+
+function ExtensionToggle({
+  enabled,
+  onChange
+}: {
+  enabled: boolean
+  onChange: (v: boolean) => void
+}): React.JSX.Element {
+  return (
+    <label className="prefs-toggle" aria-label={enabled ? 'Disable extension' : 'Enable extension'}>
+      <input type="checkbox" checked={enabled} onChange={(e) => onChange(e.target.checked)} />
+      <span className="prefs-toggle-track" />
+    </label>
+  )
+}
+
+function ExtensionSettingField({
+  ext,
+  field,
+  extState
+}: {
+  ext: ExtensionInfo
+  field: ExtensionSettingSchema
+  extState: ExtensionStateHook
+}): React.JSX.Element {
+  const rawDefault = field.default !== undefined ? String(field.default) : ''
+  const stored = extState.getSettingValue(ext.id, field.key)
+  const initialValue = stored !== undefined ? String(stored) : rawDefault
+
+  const onSave = useCallback(
+    async (key: string, value: string): Promise<void> => {
+      const parsed: unknown = field.type === 'number' ? Number(value) : value
+      extState.setSettingValue(ext.id, key, parsed)
+    },
+    [ext.id, field.type, extState]
+  )
+
+  if (field.type === 'boolean') {
+    const checked = stored !== undefined ? Boolean(stored) : Boolean(field.default)
+    return (
+      <div className="prefs-row">
+        <div className="prefs-row-header">
+          <span className="prefs-label">{field.label}</span>
+          <ExtensionToggle
+            enabled={checked}
+            onChange={(v) => extState.setSettingValue(ext.id, field.key, v)}
+          />
+        </div>
+        {field.hint && <p className="prefs-hint">{field.hint}</p>}
+      </div>
+    )
+  }
+
+  if (field.type === 'select' && field.options && field.options.length > 0) {
+    return (
+      <SelectRow
+        label={field.label}
+        configKey={field.key}
+        options={field.options}
+        initialValue={initialValue || field.options[0]}
+        onSave={onSave}
+      />
+    )
+  }
+
+  return (
+    <InputRow
+      label={field.label}
+      configKey={field.key}
+      type={field.type === 'number' ? 'number' : 'text'}
+      hint={field.hint}
+      initialValue={initialValue}
+      onSave={onSave}
+    />
+  )
+}
+
+function ExtensionRow({
+  ext,
+  extState,
+  onReviewDenied
+}: {
+  ext: ExtensionInfo
+  extState: ExtensionStateHook
+  onReviewDenied: (id: string) => void
+}): React.JSX.Element {
+  // A Phase 2 extension that was denied is not running — treat toggle as off.
+  const isDenied = ext.phase === 2 && extState.deniedIds.has(ext.id)
+  const enabled = !isDenied && !extState.disabledIds.has(ext.id)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const hasSettings = ext.settings && ext.settings.length > 0
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{ext.name}</span>
+        <div className="prefs-ext-meta">
+          <span className="prefs-ext-version">{ext.version}</span>
+          <span
+            className={`prefs-ext-badge${ext.phase === 1 ? ' prefs-ext-badge--first-party' : ''}`}
+          >
+            {ext.phase === 1 ? 'First-party' : 'Community'}
+          </span>
+          {/* Denied: offer a way to re-review permissions */}
+          {isDenied && (
+            <button className="prefs-ext-configure-btn" onClick={() => onReviewDenied(ext.id)}>
+              Review permissions...
+            </button>
+          )}
+          {/* Disabled (but not denied): signal reload is needed */}
+          {!isDenied && !enabled && <span className="prefs-restart-badge">↺ reload</span>}
+          {!isDenied && hasSettings && (
+            <button
+              className="prefs-ext-configure-btn"
+              onClick={() => setDrawerOpen((o) => !o)}
+              aria-expanded={drawerOpen}
+            >
+              {drawerOpen ? 'Done' : 'Configure...'}
+            </button>
+          )}
+        </div>
+        <ExtensionToggle enabled={enabled} onChange={() => extState.toggleEnabled(ext.id)} />
+      </div>
+
+      {drawerOpen && hasSettings && (
+        <div className="prefs-ext-drawer">
+          {ext.settings!.map((field) => (
+            <ExtensionSettingField key={field.key} ext={ext} field={field} extState={extState} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ExtensionsPanel({
+  extensions,
+  extState,
+  onReviewDenied
+}: {
+  extensions: ExtensionInfo[]
+  extState: ExtensionStateHook
+  onReviewDenied: (id: string) => void
+}): React.JSX.Element {
+  if (extensions.length === 0) {
+    return (
+      <div className="prefs-section">
+        <p className="prefs-ext-empty">No extensions installed.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="prefs-section">
+      <div className="prefs-section-label">Installed</div>
+      {extensions.map((ext) => (
+        <ExtensionRow key={ext.id} ext={ext} extState={extState} onReviewDenied={onReviewDenied} />
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main dialog
 // ---------------------------------------------------------------------------
 
-export function PreferencesDialog(): React.JSX.Element | null {
+export function PreferencesDialog({
+  extensions,
+  extState,
+  onReviewDenied
+}: {
+  extensions: ExtensionInfo[]
+  extState: ExtensionStateHook
+  onReviewDenied: (id: string) => void
+}): React.JSX.Element | null {
   const prefsOpen = useStore((s) => s.prefsOpen)
   const closePrefs = useStore((s) => s.closePrefs)
   const loadConfig = useStore((s) => s.loadConfig)
@@ -290,6 +465,8 @@ export function PreferencesDialog(): React.JSX.Element | null {
   const scanLibrary = useStore((s) => s.scanLibrary)
   const scanStatus = useStore((s) => s.scanStatus)
   const scanProgress = useStore((s) => s.scanProgress)
+
+  const [activeTab, setActiveTab] = useState<'general' | 'extensions'>('general')
 
   // Load config the first time the dialog opens.
   useEffect(() => {
@@ -310,26 +487,13 @@ export function PreferencesDialog(): React.JSX.Element | null {
 
   if (!prefsOpen) return null
 
-  // Show a loading placeholder while config is being fetched.
-  if (configValues === null) {
-    return (
-      <div className="prefs-overlay">
-        <div className="prefs-dialog">
-          <div className="prefs-header">
-            <span className="prefs-title">PREFERENCES</span>
-            <button className="prefs-close-btn" onClick={closePrefs} aria-label="Close preferences">
-              ✕
-            </button>
-          </div>
-          <div className="prefs-body" />
-        </div>
-      </div>
-    )
-  }
+  // Show a loading placeholder while config is being fetched (General tab only).
+  const generalLoading = configValues === null && activeTab === 'general'
 
-  const hasBandcamp = configValues['bandcamp.username'] !== null
+  const hasBandcamp = configValues !== null && configValues['bandcamp.username'] !== null
 
-  const str = (key: keyof typeof configValues): string => {
+  const str = (key: keyof NonNullable<typeof configValues>): string => {
+    if (!configValues) return ''
     const v = configValues[key]
     return v != null ? String(v) : ''
   }
@@ -358,128 +522,164 @@ export function PreferencesDialog(): React.JSX.Element | null {
           </button>
         </div>
 
-        {/* Scrollable body */}
-        <div className="prefs-body">
-          {/* PATHS */}
-          <div className="prefs-section">
-            <div className="prefs-section-label">Paths</div>
-            <PathRow
-              label="Library folder"
-              configKey="paths.library"
-              initialValue={str('paths.library')}
-              onSave={handleSave}
-            />
-            <PathRow
-              label="Staging folder"
-              configKey="paths.staging"
-              initialValue={str('paths.staging')}
-              onSave={handleSave}
-            />
-            <div className="prefs-row">
-              <div className="prefs-row-header">
-                <span className="prefs-label">Library index</span>
-              </div>
-              {scanStatus === 'scanning' ? (
-                <div className="prefs-scan-status">
-                  <span className="prefs-scan-scanning">Scanning…</span>
-                  {scanProgress && scanProgress.total > 0 && (
-                    <div className="prefs-scan-progress">
-                      <div
-                        className="prefs-scan-progress-fill"
-                        style={{
-                          width: `${(scanProgress.current / scanProgress.total) * 100}%`
-                        }}
+        {/* Tab bar */}
+        <div className="prefs-tabs" role="tablist">
+          <button
+            role="tab"
+            aria-selected={activeTab === 'general'}
+            className={`prefs-tab${activeTab === 'general' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('general')}
+          >
+            General
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'extensions'}
+            className={`prefs-tab${activeTab === 'extensions' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('extensions')}
+          >
+            Extensions
+          </button>
+        </div>
+
+        {/* Scrollable body — content swaps per tab */}
+        <div className="prefs-body" role="tabpanel">
+          {activeTab === 'general' && (
+            <>
+              {generalLoading ? null : (
+                <>
+                  {/* PATHS */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">Paths</div>
+                    <PathRow
+                      label="Library folder"
+                      configKey="paths.library"
+                      initialValue={str('paths.library')}
+                      onSave={handleSave}
+                    />
+                    <PathRow
+                      label="Staging folder"
+                      configKey="paths.staging"
+                      initialValue={str('paths.staging')}
+                      onSave={handleSave}
+                    />
+                    <div className="prefs-row">
+                      <div className="prefs-row-header">
+                        <span className="prefs-label">Library index</span>
+                      </div>
+                      {scanStatus === 'scanning' ? (
+                        <div className="prefs-scan-status">
+                          <span className="prefs-scan-scanning">Scanning…</span>
+                          {scanProgress && scanProgress.total > 0 && (
+                            <div className="prefs-scan-progress">
+                              <div
+                                className="prefs-scan-progress-fill"
+                                style={{
+                                  width: `${(scanProgress.current / scanProgress.total) * 100}%`
+                                }}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <button className="prefs-choose-btn" onClick={() => void scanLibrary()}>
+                          Re-scan Library
+                        </button>
+                      )}
+                      {scanStatus === 'done' && <p className="prefs-hint">Scan complete.</p>}
+                      {scanStatus === 'error' && (
+                        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+                          Scan failed — check server logs.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* LIBRARY */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">Library</div>
+                    <TextareaRow
+                      label="Path template"
+                      configKey="library.path_template"
+                      initialValue={str('library.path_template')}
+                      hint="{album_artist}  {year}  {album}  {track}  {title}  {ext}"
+                      onSave={handleSave}
+                    />
+                  </div>
+
+                  {/* ARTWORK */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">Artwork</div>
+                    <InputRow
+                      label="Minimum dimension"
+                      configKey="artwork.min_dimension"
+                      type="number"
+                      unit="px"
+                      initialValue={str('artwork.min_dimension')}
+                      onSave={handleSave}
+                    />
+                    <InputRow
+                      label="Maximum file size"
+                      configKey="artwork.max_bytes"
+                      type="number"
+                      unit="bytes"
+                      initialValue={str('artwork.max_bytes')}
+                      onSave={handleSave}
+                    />
+                  </div>
+
+                  {/* MUSICBRAINZ */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">MusicBrainz</div>
+                    <InputRow
+                      label="Contact email"
+                      configKey="musicbrainz.contact"
+                      type="email"
+                      initialValue={str('musicbrainz.contact')}
+                      hint="Sent in MusicBrainz User-Agent; required by their policy."
+                      onSave={handleSave}
+                    />
+                  </div>
+
+                  {/* BANDCAMP — only when the section is configured */}
+                  {hasBandcamp && (
+                    <div className="prefs-section">
+                      <div className="prefs-section-label">Bandcamp</div>
+                      <InputRow
+                        label="Username"
+                        configKey="bandcamp.username"
+                        initialValue={str('bandcamp.username')}
+                        onSave={handleSave}
+                      />
+                      <SelectRow
+                        label="Download format"
+                        configKey="bandcamp.format"
+                        options={BANDCAMP_FORMATS}
+                        initialValue={str('bandcamp.format')}
+                        onSave={handleSave}
+                      />
+                      <InputRow
+                        label="Poll interval"
+                        configKey="bandcamp.poll_interval_minutes"
+                        type="number"
+                        unit="min"
+                        initialValue={str('bandcamp.poll_interval_minutes')}
+                        hint="0 = manual only"
+                        onSave={handleSave}
                       />
                     </div>
                   )}
-                </div>
-              ) : (
-                <button className="prefs-choose-btn" onClick={() => void scanLibrary()}>
-                  Re-scan Library
-                </button>
+                </>
               )}
-              {scanStatus === 'done' && <p className="prefs-hint">Scan complete.</p>}
-              {scanStatus === 'error' && (
-                <p className="prefs-hint" style={{ color: 'var(--error)' }}>
-                  Scan failed — check server logs.
-                </p>
-              )}
-            </div>
-          </div>
+            </>
+          )}
 
-          {/* LIBRARY */}
-          <div className="prefs-section">
-            <div className="prefs-section-label">Library</div>
-            <TextareaRow
-              label="Path template"
-              configKey="library.path_template"
-              initialValue={str('library.path_template')}
-              hint="{album_artist}  {year}  {album}  {track}  {title}  {ext}"
-              onSave={handleSave}
+          {activeTab === 'extensions' && (
+            <ExtensionsPanel
+              extensions={extensions}
+              extState={extState}
+              onReviewDenied={onReviewDenied}
             />
-          </div>
-
-          {/* ARTWORK */}
-          <div className="prefs-section">
-            <div className="prefs-section-label">Artwork</div>
-            <InputRow
-              label="Minimum dimension"
-              configKey="artwork.min_dimension"
-              type="number"
-              unit="px"
-              initialValue={str('artwork.min_dimension')}
-              onSave={handleSave}
-            />
-            <InputRow
-              label="Maximum file size"
-              configKey="artwork.max_bytes"
-              type="number"
-              unit="bytes"
-              initialValue={str('artwork.max_bytes')}
-              onSave={handleSave}
-            />
-          </div>
-
-          {/* MUSICBRAINZ */}
-          <div className="prefs-section">
-            <div className="prefs-section-label">MusicBrainz</div>
-            <InputRow
-              label="Contact email"
-              configKey="musicbrainz.contact"
-              type="email"
-              initialValue={str('musicbrainz.contact')}
-              hint="Sent in MusicBrainz User-Agent; required by their policy."
-              onSave={handleSave}
-            />
-          </div>
-
-          {/* BANDCAMP — only when the section is configured */}
-          {hasBandcamp && (
-            <div className="prefs-section">
-              <div className="prefs-section-label">Bandcamp</div>
-              <InputRow
-                label="Username"
-                configKey="bandcamp.username"
-                initialValue={str('bandcamp.username')}
-                onSave={handleSave}
-              />
-              <SelectRow
-                label="Download format"
-                configKey="bandcamp.format"
-                options={BANDCAMP_FORMATS}
-                initialValue={str('bandcamp.format')}
-                onSave={handleSave}
-              />
-              <InputRow
-                label="Poll interval"
-                configKey="bandcamp.poll_interval_minutes"
-                type="number"
-                unit="min"
-                initialValue={str('bandcamp.poll_interval_minutes')}
-                hint="0 = manual only"
-                onSave={handleSave}
-              />
-            </div>
           )}
         </div>
       </div>

--- a/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
+++ b/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
@@ -1,105 +1,106 @@
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import type { ExtensionInfo, SlotId } from '../../../shared/kampAPI'
 
 /**
- * Builds the srcdoc HTML for a sandboxed community extension iframe.
+ * Static shim injected into every community extension iframe via srcdoc.
  *
- * The iframe carries no allow-same-origin — it cannot access the host DOM,
- * localStorage, or contextBridge. All host interaction goes through postMessage.
+ * The shim is static (no per-extension data) so its SHA-256 hash can be
+ * listed in index.html's script-src CSP, satisfying Chromium's rule that
+ * srcdoc iframes inherit the parent document's CSP.
  *
- * CSP connect-src is pinned to the exact kamp server origin so extensions
- * cannot make arbitrary outbound requests (AC#5).
+ * Extension code and metadata arrive via postMessage (kamp:init) sent after
+ * the iframe's onLoad fires. The shim dynamically imports the extension code
+ * as a blob: URL and calls register(). The extension's panels.register() call
+ * sends kamp:register-panel back to the host, which registers a real panel
+ * whose render() creates a fresh iframe on each tab activation.
+ *
+ * Hash (index.html script-src): sha256-fXNWd+rx+M3h78bhaTFeSztcM/uSwO0hPDuYKsxUtKQ=
+ * If you change SANDBOX_SHIM, recompute the hash and update index.html.
+ *
+ * NOTE: sandboxed iframes without allow-same-origin reload when moved in the
+ * DOM, so we do NOT use a holding-area/move strategy. Each panel mount creates
+ * a fresh iframe; state is lost on tab switch.
  */
-function buildSrcdoc(extensionId: string, code: string, serverUrl: string): string {
-  // Embed strings as JSON literals, escaping < > & so the HTML parser never
-  // sees a </script> tag or entity sequence inside the script block.
-  function safeJson(s: string): string {
-    return JSON.stringify(s)
-      .replace(/</g, '\\u003c')
-      .replace(/>/g, '\\u003e')
-      .replace(/&/g, '\\u0026')
-  }
+// prettier-ignore
+// If you change this string, recompute the hash and update index.html script-src:
+//   node -e "const s='<paste shim>';console.log('sha256-'+require('crypto').createHash('sha256').update(s,'utf8').digest('base64'))"
+const SANDBOX_SHIM = `(function(){var r={},c={},pending=null;window.addEventListener('message',function(e){if(e.source!==window.parent)return;var m=e.data;if(!m||typeof m.type!=='string')return;if(m.type==='kamp:init'){var id=m.id,su=m.serverUrl;var K={serverUrl:su,panels:{register:function(p){if(!p||typeof p.id!=='string')return;r[p.id]=p.render;window.parent.postMessage({type:'kamp:register-panel',extensionId:id,manifest:{id:p.id,title:p.title,defaultSlot:p.defaultSlot,compatibleSlots:p.compatibleSlots}},'*');if(pending===p.id&&typeof r[p.id]==='function'){c[p.id]=r[p.id](document.body);pending=null}}}};var b=new Blob([m.code],{type:'text/javascript'});var u=URL.createObjectURL(b);import(u).then(function(mod){if(typeof mod.register==='function')mod.register(K)}).catch(function(err){console.error('[kamp sandbox '+id+']',err)}).finally(function(){URL.revokeObjectURL(u)})}else if(m.type==='kamp:panel-mount'&&m.panelId){if(typeof r[m.panelId]==='function'){c[m.panelId]=r[m.panelId](document.body)}else{pending=m.panelId}}else if(m.type==='kamp:panel-unmount'&&m.panelId){var fn=c[m.panelId];if(typeof fn==='function')fn();delete c[m.panelId];if(pending===m.panelId)pending=null}})})();`
 
-  const escapedCode = safeJson(code)
-  const escapedId = safeJson(extensionId)
-  const escapedServerUrl = safeJson(serverUrl)
-
-  return `<!doctype html>
+const SANDBOX_SRCDOC =
+  `<!doctype html>
 <html>
 <head>
 <meta charset="UTF-8">
 <meta http-equiv="Content-Security-Policy"
-  content="default-src 'none'; script-src 'unsafe-inline' blob:; connect-src ${serverUrl}; style-src 'unsafe-inline'">
+  content="default-src 'none'; script-src blob: 'unsafe-inline'; connect-src http://127.0.0.1:8000; img-src http://127.0.0.1:8000; style-src 'unsafe-inline'">
+<style>html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }</style>
 </head>
 <body>
-<script>(async function () {
-  var __id = ${escapedId}
-  var __serverUrl = ${escapedServerUrl}
-
-  // Panel render functions keyed by panel id.
-  var __renders = {}
-  // Active cleanup functions keyed by panel id.
-  var __cleanups = {}
-
-  // Minimal KampAPI shim. Extensions call panels.register(); the host moves
-  // the iframe into the active container on mount, back to a hidden holding
-  // area on unmount, so the iframe is never reloaded between tab switches.
-  var KampAPI = {
-    serverUrl: __serverUrl,
-    panels: {
-      register: function (manifest) {
-        if (!manifest || typeof manifest.id !== 'string') return
-        __renders[manifest.id] = manifest.render
-        // Notify the host so it can register this panel in the panel layout.
-        window.parent.postMessage({
-          type: 'kamp:register-panel',
-          extensionId: __id,
-          manifest: {
-            id: manifest.id,
-            title: manifest.title,
-            defaultSlot: manifest.defaultSlot,
-            compatibleSlots: manifest.compatibleSlots
-          }
-        }, '*')
-      }
-    }
-  }
-
-  // Host → iframe: mount/unmount lifecycle messages.
-  window.addEventListener('message', function (e) {
-    // Only accept messages from the direct parent (the host renderer).
-    if (e.source !== window.parent) return
-    var msg = e.data
-    if (!msg || typeof msg.type !== 'string') return
-
-    if (msg.type === 'kamp:panel-mount' && msg.panelId) {
-      var render = __renders[msg.panelId]
-      if (typeof render === 'function') {
-        __cleanups[msg.panelId] = render(document.body)
-      }
-    } else if (msg.type === 'kamp:panel-unmount' && msg.panelId) {
-      var cleanup = __cleanups[msg.panelId]
-      if (typeof cleanup === 'function') cleanup()
-      delete __cleanups[msg.panelId]
-    }
-  })
-
-  // Load extension as an ES module via a blob URL. The main process already
-  // read the file contents; we never need a file:// import from the renderer.
-  var blob = new Blob([${escapedCode}], { type: 'text/javascript' })
-  var url = URL.createObjectURL(blob)
-  try {
-    var mod = await import(url)
-    if (typeof mod.register === 'function') mod.register(KampAPI)
-  } catch (err) {
-    console.error('[kamp sandbox ' + __id + ']', err)
-  } finally {
-    URL.revokeObjectURL(url)
-  }
-})()
-<` + `/script>
+<script>${SANDBOX_SHIM}<` +
+  `/script>
 </body>
 </html>`
+
+/**
+ * Creates a discovery iframe for an extension: loads the shim, sends kamp:init,
+ * and waits for the extension to call panels.register() (which sends kamp:register-panel
+ * back to the host). The iframe is removed once registration is complete.
+ *
+ * Returns a cleanup function that removes the iframe if registration hasn't
+ * completed yet (e.g. on component unmount).
+ */
+function createDiscoveryIframe(
+  ext: ExtensionInfo,
+  onRegister: (manifest: {
+    id: string
+    title: string
+    defaultSlot: string
+    compatibleSlots?: string[]
+  }) => void
+): () => void {
+  const iframe = document.createElement('iframe')
+  iframe.sandbox.add('allow-scripts')
+  iframe.srcdoc = SANDBOX_SRCDOC
+  iframe.style.cssText = 'position:absolute;width:0;height:0;border:none;'
+  iframe.title = `Discovery: ${ext.id}`
+
+  let done = false
+
+  function onMessage(event: MessageEvent): void {
+    const msg = event.data as Record<string, unknown> | null
+    if (!msg || msg.type !== 'kamp:register-panel') return
+    if (msg.extensionId !== ext.id) return
+    const manifest = msg.manifest as
+      | { id: string; title: string; defaultSlot: string; compatibleSlots?: string[] }
+      | undefined
+    if (!manifest?.id) return
+    done = true
+    window.removeEventListener('message', onMessage)
+    iframe.remove()
+    onRegister(manifest)
+  }
+
+  window.addEventListener('message', onMessage)
+
+  iframe.addEventListener(
+    'load',
+    () => {
+      iframe.contentWindow?.postMessage(
+        { type: 'kamp:init', id: ext.id, serverUrl: window.KampAPI.serverUrl, code: ext.code },
+        '*'
+      )
+    },
+    { once: true }
+  )
+
+  document.body.appendChild(iframe)
+
+  return () => {
+    if (!done) {
+      window.removeEventListener('message', onMessage)
+      iframe.remove()
+    }
+  }
 }
 
 interface Props {
@@ -107,84 +108,78 @@ interface Props {
 }
 
 /**
- * Renders each community (Phase 2) extension in its own sandboxed iframe.
+ * Registers each community (Phase 2) extension's panels with the host.
  *
- * All iframes live in a hidden holding div. When the user activates an
- * extension panel tab, ExtensionPanel's render() moves the iframe into the
- * visible container div. On deactivation, cleanup() moves it back here.
- * Moving an iframe within the same document does not reload it, so extension
- * state (timers, network sockets, DOM) persists across tab switches.
+ * For each extension, spins up a short-lived discovery iframe to run the
+ * extension code and collect its panels.register() calls. Once registration
+ * is complete the discovery iframe is discarded.
+ *
+ * When a panel tab is activated, render() creates a fresh sandboxed iframe,
+ * sends kamp:init + kamp:panel-mount, and renders the extension content.
+ * On deactivation, cleanup() sends kamp:panel-unmount and removes the iframe.
+ *
+ * State is lost on tab switch — the holding-area/move strategy was abandoned
+ * because Chromium reloads sandboxed cross-origin iframes on DOM move.
  */
-export function SandboxedExtensionLoader({ extensions }: Props): React.JSX.Element {
-  const holdingRef = useRef<HTMLDivElement>(null)
-  const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map())
+export function SandboxedExtensionLoader({ extensions }: Props): null {
+  // Track cleanup functions for in-flight discovery iframes.
+  const cleanupRefs = useRef<Map<string, () => void>>(new Map())
 
   useEffect(() => {
-    function onMessage(event: MessageEvent): void {
-      // Reject messages from anything other than our known sandbox iframes.
-      const knownWindows = Array.from(iframeRefs.current.values())
-        .map((el) => el.contentWindow)
-        .filter(Boolean)
-      if (!knownWindows.includes(event.source as Window | null)) return
+    for (const ext of extensions) {
+      if (cleanupRefs.current.has(ext.id)) continue // already discovering
 
-      const msg = event.data as Record<string, unknown> | null
-      if (!msg || typeof msg !== 'object') return
-
-      if (msg.type === 'kamp:register-panel') {
-        const extensionId = msg.extensionId as string | undefined
-        const manifest = msg.manifest as
-          | { id: string; title: string; defaultSlot: string; compatibleSlots?: string[] }
-          | undefined
-
-        if (!extensionId || !manifest?.id || !manifest?.title || !manifest?.defaultSlot) return
-        const iframeEl = iframeRefs.current.get(extensionId)
-        if (!iframeEl) return
-
-        const panelId = manifest.id
+      const cleanup = createDiscoveryIframe(ext, (manifest) => {
+        cleanupRefs.current.delete(ext.id)
 
         window.KampAPI.panels.register({
-          id: panelId,
+          id: manifest.id,
           title: manifest.title,
           defaultSlot: manifest.defaultSlot as SlotId,
           compatibleSlots: manifest.compatibleSlots as SlotId[] | undefined,
           render(container: HTMLElement): () => void {
-            // Move the live iframe into the active panel container.
-            // Does not reload the iframe — extension state is preserved.
-            container.appendChild(iframeEl)
-            iframeEl.style.display = 'block'
-            iframeEl.contentWindow?.postMessage({ type: 'kamp:panel-mount', panelId }, '*')
+            const panelId = manifest.id
+            const iframe = document.createElement('iframe')
+            iframe.sandbox.add('allow-scripts')
+            iframe.srcdoc = SANDBOX_SRCDOC
+            iframe.style.cssText = 'width:100%;height:100%;border:none;display:block;'
+            iframe.title = `Extension: ${ext.id}`
+
+            iframe.addEventListener(
+              'load',
+              () => {
+                iframe.contentWindow?.postMessage(
+                  {
+                    type: 'kamp:init',
+                    id: ext.id,
+                    serverUrl: window.KampAPI.serverUrl,
+                    code: ext.code
+                  },
+                  '*'
+                )
+                iframe.contentWindow?.postMessage({ type: 'kamp:panel-mount', panelId }, '*')
+              },
+              { once: true }
+            )
+
+            container.appendChild(iframe)
 
             return () => {
-              // Send unmount signal before moving iframe back to the holding area.
-              iframeEl.contentWindow?.postMessage({ type: 'kamp:panel-unmount', panelId }, '*')
-              iframeEl.style.display = 'none'
-              holdingRef.current?.appendChild(iframeEl)
+              iframe.contentWindow?.postMessage({ type: 'kamp:panel-unmount', panelId }, '*')
+              iframe.remove()
             }
           }
         })
-      }
+      })
+
+      cleanupRefs.current.set(ext.id, cleanup)
     }
 
-    window.addEventListener('message', onMessage)
-    return () => window.removeEventListener('message', onMessage)
+    return () => {
+      cleanupRefs.current.forEach((fn) => fn())
+      cleanupRefs.current.clear()
+    }
   }, [extensions])
 
-  return (
-    // Hidden holding area. Iframes here stay loaded but invisible.
-    <div ref={holdingRef} style={{ display: 'none' }} aria-hidden="true">
-      {extensions.map((ext) => (
-        <iframe
-          key={ext.id}
-          ref={(el): void => {
-            if (el) iframeRefs.current.set(ext.id, el)
-            else iframeRefs.current.delete(ext.id)
-          }}
-          sandbox="allow-scripts"
-          srcDoc={buildSrcdoc(ext.id, ext.code, window.KampAPI.serverUrl)}
-          style={{ width: '100%', height: '100%', border: 'none', display: 'none' }}
-          title={`Extension: ${ext.id}`}
-        />
-      ))}
-    </div>
-  )
+  return null
 }

--- a/kamp_ui/src/renderer/src/hooks/useExtensionState.ts
+++ b/kamp_ui/src/renderer/src/hooks/useExtensionState.ts
@@ -1,0 +1,151 @@
+/**
+ * useExtensionState — localStorage-backed state for per-extension settings,
+ * enable/disable toggles, and Phase 2 permission approvals.
+ *
+ * Storage keys:
+ *   kamp:ext:disabled        JSON array of disabled extension ids
+ *   kamp:ext:approved        JSON array of approved community extension ids
+ *   kamp:ext:denied          JSON array of denied community extension ids
+ *   kamp:ext:setting:<id>:<key>  per-extension setting value (JSON-encoded)
+ */
+
+import { useCallback, useState } from 'react'
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+function loadSet(key: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return new Set()
+    return new Set(JSON.parse(raw) as string[])
+  } catch {
+    return new Set()
+  }
+}
+
+function saveSet(key: string, s: Set<string>): void {
+  localStorage.setItem(key, JSON.stringify(Array.from(s)))
+}
+
+function settingKey(extId: string, key: string): string {
+  return `kamp:ext:setting:${extId}:${key}`
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type ExtensionStateHook = {
+  /** Ids of extensions the user has explicitly disabled. */
+  disabledIds: Set<string>
+  /** Ids of Phase 2 community extensions the user has approved. */
+  approvedIds: Set<string>
+  /** Ids of Phase 2 community extensions the user has denied. */
+  deniedIds: Set<string>
+
+  /** Toggle the enabled state of an extension. */
+  toggleEnabled: (id: string) => void
+  /** Mark a community extension as approved by the user. */
+  approve: (id: string) => void
+  /** Mark a community extension as denied by the user. */
+  deny: (id: string) => void
+  /**
+   * Clear the denied state for a community extension so the permission prompt
+   * will be shown again on next load.
+   */
+  resetDenied: (id: string) => void
+
+  /**
+   * Read the stored value for a setting key belonging to `extId`,
+   * or `undefined` if not yet set.
+   */
+  getSettingValue: (extId: string, key: string) => unknown
+  /** Persist a setting value and trigger a re-render. */
+  setSettingValue: (extId: string, key: string, value: unknown) => void
+}
+
+export function useExtensionState(): ExtensionStateHook {
+  const [disabledIds, setDisabledIds] = useState<Set<string>>(() => loadSet('kamp:ext:disabled'))
+  const [approvedIds, setApprovedIds] = useState<Set<string>>(() => loadSet('kamp:ext:approved'))
+  const [deniedIds, setDeniedIds] = useState<Set<string>>(() => loadSet('kamp:ext:denied'))
+  // Incrementing counter so callers re-render when any setting changes.
+  const [, setSettingVersion] = useState(0)
+
+  const toggleEnabled = useCallback((id: string) => {
+    setDisabledIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      saveSet('kamp:ext:disabled', next)
+      return next
+    })
+  }, [])
+
+  const approve = useCallback((id: string) => {
+    setApprovedIds((prev) => {
+      const next = new Set(prev)
+      next.add(id)
+      saveSet('kamp:ext:approved', next)
+      return next
+    })
+    // Remove from denied if previously denied.
+    setDeniedIds((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      saveSet('kamp:ext:denied', next)
+      return next
+    })
+  }, [])
+
+  const deny = useCallback((id: string) => {
+    setDeniedIds((prev) => {
+      const next = new Set(prev)
+      next.add(id)
+      saveSet('kamp:ext:denied', next)
+      return next
+    })
+  }, [])
+
+  const resetDenied = useCallback((id: string) => {
+    setDeniedIds((prev) => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      saveSet('kamp:ext:denied', next)
+      return next
+    })
+  }, [])
+
+  const getSettingValue = useCallback((extId: string, key: string): unknown => {
+    try {
+      const raw = localStorage.getItem(settingKey(extId, key))
+      if (raw === null) return undefined
+      return JSON.parse(raw) as unknown
+    } catch {
+      return undefined
+    }
+  }, [])
+
+  const setSettingValue = useCallback((extId: string, key: string, value: unknown): void => {
+    localStorage.setItem(settingKey(extId, key), JSON.stringify(value))
+    setSettingVersion((v) => v + 1)
+  }, [])
+
+  return {
+    disabledIds,
+    approvedIds,
+    deniedIds,
+    toggleEnabled,
+    approve,
+    deny,
+    resetDenied,
+    getSettingValue,
+    setSettingValue
+  }
+}

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -6,6 +6,20 @@
  */
 
 /**
+ * A single field in an extension's declared settings schema.
+ * Declared in package.json under `kamp.settings`.
+ */
+export type ExtensionSettingSchema = {
+  key: string
+  label: string
+  type: 'text' | 'number' | 'boolean' | 'select'
+  /** Valid values for `type: 'select'`. */
+  options?: string[]
+  default?: string | number | boolean
+  hint?: string
+}
+
+/**
  * Layout slots available in the host application.
  *
  * - `main`   – tabbed content area (Library, Now Playing, extension views)
@@ -42,6 +56,8 @@ export type PanelManifest = {
 export type ExtensionInfo = {
   id: string
   name: string
+  /** Version string from the extension's package.json. */
+  version: string
   /** Source code of the extension's entry point, read by the main process. */
   code: string
   /**
@@ -58,6 +74,11 @@ export type ExtensionInfo = {
    * Known values: "library.read", "player.read", "player.control", "network.fetch", "settings"
    */
   permissions: string[]
+  /**
+   * Settings schema declared in package.json under `kamp.settings`.
+   * The host renders a settings form from this schema in the Extensions preferences panel.
+   */
+  settings?: ExtensionSettingSchema[]
 }
 
 /** The full shape of window.KampAPI. */
@@ -83,5 +104,16 @@ export type KampAPI = {
   extensions: {
     /** Ask the main process to discover installed kamp-extension packages. */
     getAll: () => Promise<ExtensionInfo[]>
+  }
+
+  /**
+   * Per-extension settings access. Only provided when the extension declares
+   * the `"settings"` permission. Values are persisted by the host across sessions.
+   */
+  settings?: {
+    /** Read the current value of a setting key, or undefined if not yet set. */
+    get: (key: string) => unknown
+    /** Persist a new value for a setting key. */
+    set: (key: string, value: unknown) => void
   }
 }


### PR DESCRIPTION
## Summary

- Adds a **General | Extensions** tab bar to the Preferences dialog
- Extensions tab lists all installed extensions with name, version, phase badge, and enable/disable toggle
- Community (Phase 2) extensions show a one-time permission approval prompt on first load; denied extensions show a "Review permissions..." link
- Per-extension settings rendered from schema declared in `package.json` `kamp.settings`, persisted in localStorage, no restart required
- `KampAPI.settings` API passed to Phase 1 extensions that declare the `settings` permission

## Sandboxed iframe lessons (documented in CLAUDE.md)

Several non-obvious Chromium/Electron constraints were encountered and resolved:
- `srcdoc` iframes inherit the parent CSP — inline scripts must be hash-whitelisted in `index.html`
- Sandboxed iframes without `allow-same-origin` reload on DOM move — abandoned the holding-area strategy; fresh iframe created per mount instead
- Race condition: `kamp:panel-mount` arrives before `import()` in `kamp:init` resolves — fixed with a pending-mount buffer in the shim

## Test plan

- [x] Preferences → Extensions tab shows installed extensions
- [x] Enable/disable toggle works; disabled extension shows ↺ reload badge
- [x] Community extension shows permission prompt on first load; approve → tab appears and renders content
- [x] Deny → extension skipped; "Review permissions..." link re-queues the prompt
- [x] localStorage reset (`removeItem('kamp:ext:approved')`, `removeItem('kamp:ext:denied')`) restores blank-slate for testing
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)