### PR TITLE
feat: extension invocation policy — wire tagger/artwork extensions into the pipeline (TASK-90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,52 @@ export function register(api) {
 
 An example first-party extension lives in `kamp_ui/extensions/kamp-example-panel/`.
 
+### Backend extensions
+
+The daemon supports Python backend extensions for custom tagging and artwork sources. Extensions are Python packages that declare an entry point in the `kamp.extensions` group.
+
+**How it works:**
+
+1. On server startup, the daemon calls `discover_extensions()` which loads all installed packages that declare a `kamp.extensions` entry point.
+2. Each class is validated against `BaseTagger` or `BaseArtworkSource` ABC conformance.
+3. At ingest time, after a staging item is processed and new tracks are indexed by `LibraryScanner`, the host invokes registered extensions on each new track.
+4. The host enforces a single-invocation guarantee: each extension is offered each track at most once, using the `extension_audit_log` table to detect prior runs. Re-scans never trigger re-invocation.
+
+**Invocation policy:**
+- Tagger extensions run first (in registration order), then artwork sources.
+- Tracks without a resolved `mb_recording_id` are skipped.
+- A failed extension (crash, exception, or invalid mutation) is logged and skipped; remaining extensions and tracks continue normally.
+- Extensions cannot be re-processed automatically on version update; use `kamp rollback <extension_id>` to revert mutations and allow re-processing on the next ingest.
+
+**Writing a backend tagger:**
+
+```python
+# pyproject.toml
+[project.entry-points."kamp.extensions"]
+my_tagger = "my_package:MyTagger"
+
+# my_package/__init__.py
+from kamp_daemon.ext import BaseTagger
+from kamp_daemon.ext.types import TrackMetadata
+
+class MyTagger(BaseTagger):
+    kampground_permissions = ["network.fetch"]
+    kampground_network_domains = ["api.example.com"]
+
+    def tag(self, track: TrackMetadata) -> TrackMetadata:
+        # Enrich track metadata, then queue the result via KampGround:
+        self._ctx.library.update_metadata(track.mbid, {"title": track.title.strip()})
+        return track
+```
+
+**Audit log and rollback:**
+
+Every mutation is logged to `extension_audit_log`. To revert all changes by an extension:
+
+```bash
+kamp rollback <extension_id>   # e.g. kamp rollback my_package.MyTagger
+```
+
 ---
 
 *Built by [Claude Sonnet 4.6](https://www.anthropic.com/claude) (claude-sonnet-4-6) — Anthropic's AI assistant.*

--- a/backlog/tasks/task-87 - OS-level-backend-extension-sandboxing.md
+++ b/backlog/tasks/task-87 - OS-level-backend-extension-sandboxing.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-87
 title: OS-level backend extension sandboxing
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-05 16:27'
-updated_date: '2026-04-08 17:42'
+updated_date: '2026-04-08 20:26'
 labels:
   - feature
   - security
@@ -14,7 +14,7 @@ dependencies:
   - TASK-17
 documentation:
   - project/kampground-ideation.md
-ordinal: 12000
+ordinal: 19000
 ---
 
 ## Description

--- a/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
+++ b/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-90
 title: Extension invocation policy — wire tagger/artwork extensions into the pipeline
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-06 12:54'
-updated_date: '2026-04-08 20:20'
+updated_date: '2026-04-08 20:33'
 labels:
   - feature
   - design
@@ -13,7 +13,7 @@ milestone: m-2
 dependencies:
   - TASK-85
   - TASK-17
-ordinal: 14000
+ordinal: 20000
 ---
 
 ## Description

--- a/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
+++ b/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-90
 title: Extension invocation policy — wire tagger/artwork extensions into the pipeline
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-06 12:54'
-updated_date: '2026-04-06 18:43'
+updated_date: '2026-04-08 20:15'
 labels:
   - feature
   - design

--- a/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
+++ b/backlog/tasks/task-90 - Extension-invocation-policy-—-wire-tagger-artwork-extensions-into-the-pipeline.md
@@ -4,7 +4,7 @@ title: Extension invocation policy — wire tagger/artwork extensions into the p
 status: In Progress
 assignee: []
 created_date: '2026-04-06 12:54'
-updated_date: '2026-04-08 20:15'
+updated_date: '2026-04-08 20:20'
 labels:
   - feature
   - design
@@ -44,9 +44,9 @@ The invocation policy must therefore guarantee that extensions are not offered t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Registered tagger extensions are invoked at ingest time for new tracks entering the library
-- [ ] #2 Each track is offered to each extension at most once per ingest event — no redundant mutations on re-scan
-- [ ] #3 The host uses the audit log or equivalent mechanism to enforce the single-invocation guarantee, not extension skip logic (extension skip logic is unreliable and not under our control)
-- [ ] #4 Registered artwork-source extensions are invoked under the same policy as taggers
-- [ ] #5 The invocation policy is documented in a comment at the call site explaining why re-scan invocation is explicitly excluded
+- [x] #1 Registered tagger extensions are invoked at ingest time for new tracks entering the library
+- [x] #2 Each track is offered to each extension at most once per ingest event — no redundant mutations on re-scan
+- [x] #3 The host uses the audit log or equivalent mechanism to enforce the single-invocation guarantee, not extension skip logic (extension skip logic is unreliable and not under our control)
+- [x] #4 Registered artwork-source extensions are invoked under the same policy as taggers
+- [x] #5 The invocation policy is documented in a comment at the call site explaining why re-scan invocation is explicitly excluded
 <!-- AC:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -194,6 +194,7 @@ class ScanResult:
     removed: int
     unchanged: int
     updated: int = 0
+    new_tracks: list[Track] = field(default_factory=list)
 
 
 class LibraryIndex:
@@ -685,6 +686,19 @@ class LibraryIndex:
         self._conn.commit()
         return reverted
 
+    def has_been_processed_by(self, extension_id: str, mb_recording_id: str) -> bool:
+        """Return True if *extension_id* has a prior audit log entry for *mb_recording_id*.
+
+        Used by the invocation policy to enforce the single-invocation guarantee:
+        the host checks this before offering a track to an extension so that
+        re-scan events do not trigger redundant mutations.
+        """
+        row = self._conn.execute(
+            "SELECT 1 FROM extension_audit_log WHERE extension_id = ? AND track_mbid = ? LIMIT 1",
+            (extension_id, mb_recording_id),
+        ).fetchone()
+        return row is not None
+
     def audit_log_for(self, extension_id: str) -> list[dict[str, Any]]:
         """Return all audit log rows for *extension_id* in ascending order.
 
@@ -1027,7 +1041,8 @@ class LibraryScanner:
                 on_progress(current, total)
         self._index.upsert_many(tracks_to_upsert)
 
-        added = len([t for t in tracks_to_upsert if t.file_path in to_add])
+        newly_added = [t for t in tracks_to_upsert if t.file_path in to_add]
+        added = len(newly_added)
         updated = len([t for t in tracks_to_upsert if t.file_path in to_update])
 
         removed = 0
@@ -1038,5 +1053,9 @@ class LibraryScanner:
         unchanged = len(on_disk & in_index) - len(to_update)
 
         return ScanResult(
-            added=added, removed=removed, unchanged=unchanged, updated=updated
+            added=added,
+            removed=removed,
+            unchanged=unchanged,
+            updated=updated,
+            new_tracks=newly_added,
         )

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -661,12 +661,28 @@ def _cmd_server(
 
     # Watch the library directory and re-scan when audio files are added or
     # removed, so the UI stays current without requiring a manual scan trigger.
+    from kamp_daemon.ext import (
+        ExtensionRegistry,
+        discover_extensions,
+        invoke_extensions_for_new_tracks,
+    )
     from kamp_daemon.watcher import LibraryWatcher
+
+    _extension_registry = ExtensionRegistry()
+    discover_extensions(_extension_registry)
 
     def _on_library_change() -> None:
         from kamp_core.library import LibraryScanner
 
-        LibraryScanner(index).scan(lib_path)
+        result = LibraryScanner(index).scan(lib_path)
+        # Offer newly ingested tracks to registered extensions.  Re-scan tracks
+        # (to_update) are excluded — only ScanResult.new_tracks (to_add) are
+        # passed.  The invoker enforces the single-invocation guarantee via the
+        # audit log so extensions never see the same track twice.
+        if result.new_tracks:
+            invoke_extensions_for_new_tracks(
+                _extension_registry, result.new_tracks, index
+            )
         # Bump the server's library version so connected WebSocket clients
         # receive a "library.changed" push and reload the album list.
         app.state.notify_library_changed()

--- a/kamp_daemon/ext/__init__.py
+++ b/kamp_daemon/ext/__init__.py
@@ -10,6 +10,7 @@ from .context import (
     UpdateMetadataMutation,
 )
 from .discovery import discover_extensions
+from .invoker import invoke_extensions_for_new_tracks
 from .permissions import ExtensionPermissions, extract_permissions
 from .probe import probe_extension
 from .registry import ExtensionRegistry
@@ -32,6 +33,7 @@ __all__ = [
     "TrackMetadata",
     "UpdateMetadataMutation",
     "discover_extensions",
+    "invoke_extensions_for_new_tracks",
     "apply_mutations",
     "extract_permissions",
     "invoke_extension",

--- a/kamp_daemon/ext/invoker.py
+++ b/kamp_daemon/ext/invoker.py
@@ -1,0 +1,177 @@
+"""Extension invocation policy: offer new tracks to registered extensions at ingest time.
+
+Invocation policy (answers the design questions from TASK-90):
+
+1. **Trigger point**: ingest-time only.  Extensions are offered tracks that have
+   just been added to the library index by LibraryScanner.  Re-scan events do
+   NOT trigger re-invocation because the audit log already has entries for those
+   tracks.  On-demand re-processing is a separate, future feature.
+
+2. **Already-processed detection**: the host queries extension_audit_log before
+   each invocation.  If any row exists for (extension_id, mb_recording_id), the
+   track is skipped.  Extension skip logic is explicitly NOT relied upon — it is
+   unreliable and not under host control (AC#3).
+
+3. **Extension version changes**: not re-processed automatically.  The audit log
+   key is (extension_id, mb_recording_id) without a version component, so a new
+   version of an installed extension will not reprocess existing tracks.
+   Deliberate reprocessing requires an explicit rollback + re-trigger, which is
+   out of scope for this task.
+
+4. **Ordering**: taggers run first (in registration order), then artwork sources.
+   All community extensions run *after* the first-party MusicBrainz / Cover Art
+   Archive steps, which completed during the pipeline subprocess.  Community
+   extensions supplement first-party results — they do not replace them.
+
+Re-scan invocation is explicitly excluded because the audit log is append-only
+and never pruned.  Invoking extensions on every scan would cause the log to grow
+O(library size × number of scans), reaching hundreds of MB within a year on a
+modest library.  Ingest-only invocation keeps growth O(library size).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kamp_core.library import LibraryIndex, Track
+
+from .context import KampGround, PlaybackSnapshot
+from .registry import ExtensionRegistry
+from .types import ArtworkQuery, TrackMetadata
+from .worker import invoke_extension
+from .write_log import apply_mutations
+
+_logger = logging.getLogger(__name__)
+
+
+def _extension_id(cls: type) -> str:
+    """Derive a stable string identifier for an extension class.
+
+    Uses the fully-qualified class name (module + qualname) so the ID is
+    consistent across invocations as long as the extension's module path
+    and class name are unchanged.
+    """
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _track_to_metadata(track: Track) -> TrackMetadata:
+    """Convert a library Track to the TrackMetadata type expected by BaseTagger."""
+    return TrackMetadata(
+        title=track.title,
+        artist=track.artist,
+        album=track.album,
+        album_artist=track.album_artist,
+        year=track.year,
+        track_number=track.track_number,
+        mbid=track.mb_recording_id,
+        release_mbid=track.mb_release_id,
+        # release_group_mbid is not stored in the library index; extensions
+        # that require it should handle an empty string gracefully.
+        release_group_mbid="",
+    )
+
+
+def invoke_extensions_for_new_tracks(
+    registry: ExtensionRegistry,
+    tracks: list[Track],
+    library: LibraryIndex,
+) -> None:
+    """Invoke registered tagger and artwork-source extensions on newly ingested tracks.
+
+    Called by the server's library-change callback after LibraryScanner.scan()
+    has added new tracks to the index.  Only tracks from ScanResult.new_tracks
+    (the to_add set) are passed here — updated tracks on re-scan are explicitly
+    excluded to prevent unbounded audit log growth.
+
+    For each extension, each track is offered at most once.  The host enforces
+    this guarantee by checking extension_audit_log before each invocation (AC#3).
+    Tracks without a resolved mb_recording_id are skipped because mutations are
+    keyed by that identifier; offering them would produce unapplicable mutations.
+
+    Args:
+        registry: The populated extension registry (taggers and artwork sources).
+        tracks: Newly added Track objects from ScanResult.new_tracks.
+        library: LibraryIndex to read audit log state and apply mutations to.
+    """
+    # Only tracks with a resolved recording MBID can be offered to extensions.
+    # Without an MBID the host cannot apply mutations (the audit log and mutation
+    # dispatch both key on mb_recording_id).
+    tagged = [t for t in tracks if t.mb_recording_id]
+    if not tagged:
+        return
+
+    taggers = registry.taggers
+    artwork_sources = registry.artwork_sources
+    if not taggers and not artwork_sources:
+        return
+
+    # Taggers run first so artwork sources can act on enriched metadata if needed.
+    for cls in taggers:
+        ext_id = _extension_id(cls)
+        ctx = KampGround(playback=PlaybackSnapshot(), library_tracks=[])
+        for track in tagged:
+            mbid = track.mb_recording_id
+            # Host-enforced single-invocation guarantee: skip if the audit log
+            # already has an entry for this (extension, track) pair.  This covers
+            # the re-scan case and any prior partial-ingest run.
+            if library.has_been_processed_by(ext_id, mbid):
+                _logger.debug(
+                    "Skipping tagger %s for %s — already in audit log", ext_id, mbid
+                )
+                continue
+            result = invoke_extension(cls, "tag", _track_to_metadata(track), ctx=ctx)
+            if result is False:
+                _logger.warning(
+                    "Tagger extension %s failed for track %s — skipping", ext_id, mbid
+                )
+                continue
+            try:
+                apply_mutations(ext_id, result, library)
+            except ValueError:
+                _logger.exception(
+                    "Tagger extension %s produced an invalid mutation for track %s",
+                    ext_id,
+                    mbid,
+                )
+
+    for art_cls in artwork_sources:
+        ext_id = _extension_id(art_cls)
+        ctx = KampGround(playback=PlaybackSnapshot(), library_tracks=[])
+        for track in tagged:
+            mbid = track.mb_recording_id
+            if library.has_been_processed_by(ext_id, mbid):
+                _logger.debug(
+                    "Skipping artwork source %s for %s — already in audit log",
+                    ext_id,
+                    mbid,
+                )
+                continue
+            query = ArtworkQuery(
+                mbid=track.mb_release_id,
+                # release_group_mbid is not stored in the library index; the
+                # extension must handle an empty string (e.g. skip the fallback
+                # look-up or use album/artist fields instead).
+                release_group_mbid="",
+                album=track.album,
+                artist=track.album_artist or track.artist,
+                # No quality floor from host side: extensions decide their own
+                # minimum dimension and size limits.
+                min_dimension=0,
+                max_bytes=0,
+            )
+            result = invoke_extension(art_cls, "fetch", query, ctx=ctx)
+            if result is False:
+                _logger.warning(
+                    "Artwork source extension %s failed for track %s — skipping",
+                    ext_id,
+                    mbid,
+                )
+                continue
+            try:
+                apply_mutations(ext_id, result, library)
+            except ValueError:
+                _logger.exception(
+                    "Artwork source extension %s produced an invalid mutation for track %s",
+                    ext_id,
+                    mbid,
+                )

--- a/tests/test_extension_invoker.py
+++ b/tests/test_extension_invoker.py
@@ -1,0 +1,596 @@
+"""Tests for TASK-90: extension invocation policy.
+
+Covers all five acceptance criteria:
+
+AC #1 — registered tagger extensions are invoked for new tracks at ingest time.
+AC #2 — each track is offered to each extension at most once per ingest event.
+AC #3 — the host uses the audit log to enforce single-invocation, not extension
+         skip logic.
+AC #4 — registered artwork-source extensions are invoked under the same policy.
+AC #5 — the invocation policy comment at the call site explains why re-scan is
+         excluded (verified structurally by this test file existing alongside
+         invoker.py, which contains the documented policy).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from kamp_core.library import LibraryIndex, Track
+from kamp_daemon.ext.context import KampGround, UpdateMetadataMutation
+from kamp_daemon.ext.invoker import (
+    _extension_id,
+    _track_to_metadata,
+    invoke_extensions_for_new_tracks,
+)
+from kamp_daemon.ext.registry import ExtensionRegistry
+from kamp_daemon.ext.types import ArtworkQuery, TrackMetadata
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_library(tmp_path: Path) -> LibraryIndex:
+    return LibraryIndex(tmp_path / "library.db")
+
+
+def _make_track(
+    path: Path,
+    *,
+    mbid: str = "rec-1",
+    release_mbid: str = "rel-1",
+    title: str = "Title",
+    artist: str = "Artist",
+    album: str = "Album",
+    album_artist: str = "Album Artist",
+) -> Track:
+    return Track(
+        file_path=path,
+        title=title,
+        artist=artist,
+        album_artist=album_artist,
+        album=album,
+        year="2024",
+        track_number=1,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id=release_mbid,
+        mb_recording_id=mbid,
+    )
+
+
+def _fake_tagger_cls(module: str = "ext.fake", name: str = "FakeTagger") -> type:
+    """Return a minimal BaseTagger subclass with a controllable class identity."""
+    from kamp_daemon.ext.abc import BaseTagger
+
+    cls = type(name, (BaseTagger,), {"tag": lambda self, track: track})
+    cls.__module__ = module
+    cls.__qualname__ = name
+    return cls
+
+
+def _fake_artwork_cls(module: str = "ext.fake", name: str = "FakeArtwork") -> type:
+    """Return a minimal BaseArtworkSource subclass."""
+    from kamp_daemon.ext.abc import BaseArtworkSource
+
+    cls = type(name, (BaseArtworkSource,), {"fetch": lambda self, query: None})
+    cls.__module__ = module
+    cls.__qualname__ = name
+    return cls
+
+
+def _make_registry(
+    taggers: list[type] | None = None,
+    artwork_sources: list[type] | None = None,
+) -> ExtensionRegistry:
+    reg = ExtensionRegistry()
+    for cls in taggers or []:
+        reg.register(cls)
+    for cls in artwork_sources or []:
+        reg.register(cls)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# _extension_id helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionId:
+    def test_returns_module_dot_qualname(self) -> None:
+        cls = _fake_tagger_cls(module="my.mod", name="MyClass")
+        assert _extension_id(cls) == "my.mod.MyClass"
+
+    def test_different_classes_have_different_ids(self) -> None:
+        a = _fake_tagger_cls(module="mod.a", name="A")
+        b = _fake_tagger_cls(module="mod.b", name="B")
+        assert _extension_id(a) != _extension_id(b)
+
+
+# ---------------------------------------------------------------------------
+# _track_to_metadata helper
+# ---------------------------------------------------------------------------
+
+
+class TestTrackToMetadata:
+    def test_mbid_maps_to_recording_mbid(self, tmp_path: Path) -> None:
+        track = _make_track(tmp_path / "a.mp3", mbid="rec-abc")
+        meta = _track_to_metadata(track)
+        assert meta.mbid == "rec-abc"
+
+    def test_release_mbid_maps_correctly(self, tmp_path: Path) -> None:
+        track = _make_track(tmp_path / "a.mp3", release_mbid="rel-xyz")
+        meta = _track_to_metadata(track)
+        assert meta.release_mbid == "rel-xyz"
+
+    def test_release_group_mbid_is_empty(self, tmp_path: Path) -> None:
+        track = _make_track(tmp_path / "a.mp3")
+        meta = _track_to_metadata(track)
+        assert meta.release_group_mbid == ""
+
+    def test_all_core_fields_copied(self, tmp_path: Path) -> None:
+        track = _make_track(
+            tmp_path / "a.mp3",
+            title="My Title",
+            artist="My Artist",
+            album="My Album",
+            album_artist="My Album Artist",
+        )
+        meta = _track_to_metadata(track)
+        assert meta.title == "My Title"
+        assert meta.artist == "My Artist"
+        assert meta.album == "My Album"
+        assert meta.album_artist == "My Album Artist"
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — tagger extensions are invoked for new tracks
+# ---------------------------------------------------------------------------
+
+
+class TestTaggerInvocation:
+    def test_tagger_invoked_for_new_track(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        mutations = [UpdateMetadataMutation(mbid="rec-1", fields={"title": "New"})]
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=mutations
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3")], lib
+            )
+
+        mock_invoke.assert_called_once()
+        args = mock_invoke.call_args
+        assert args[0][0] is cls
+        assert args[0][1] == "tag"
+
+        lib.close()
+
+    def test_tagger_receives_track_metadata(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        track = _make_track(tmp_path / "a.mp3", mbid="rec-1", title="Original")
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(reg, [track], lib)
+
+        meta: TrackMetadata = mock_invoke.call_args[0][2]
+        assert meta.mbid == "rec-1"
+        assert meta.title == "Original"
+
+        lib.close()
+
+    def test_multiple_taggers_invoked_in_registration_order(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        cls_a = _fake_tagger_cls(name="TaggerA")
+        cls_b = _fake_tagger_cls(name="TaggerB")
+        reg = _make_registry(taggers=[cls_a, cls_b])
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        call_classes = [c[0][0] for c in mock_invoke.call_args_list]
+        assert call_classes == [cls_a, cls_b]
+
+        lib.close()
+
+    def test_apply_mutations_called_with_extension_id_and_result(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        cls = _fake_tagger_cls(module="my.tagger", name="T")
+        reg = _make_registry(taggers=[cls])
+        mutations = [UpdateMetadataMutation(mbid="rec-1", fields={"title": "X"})]
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension", return_value=mutations):
+            with patch("kamp_daemon.ext.invoker.apply_mutations") as mock_apply:
+                invoke_extensions_for_new_tracks(
+                    reg, [_make_track(tmp_path / "a.mp3")], lib
+                )
+
+        mock_apply.assert_called_once_with("my.tagger.T", mutations, lib)
+
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# AC #2 — each track offered at most once per ingest (no redundant mutations)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleInvocationPerTrack:
+    def test_track_with_empty_mbid_is_skipped(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        untagged = _make_track(tmp_path / "a.mp3", mbid="")
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension") as mock_invoke:
+            invoke_extensions_for_new_tracks(reg, [untagged], lib)
+
+        mock_invoke.assert_not_called()
+        lib.close()
+
+    def test_empty_registry_is_noop(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        reg = _make_registry()
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension") as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3")], lib
+            )
+
+        mock_invoke.assert_not_called()
+        lib.close()
+
+    def test_empty_track_list_is_noop(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension") as mock_invoke:
+            invoke_extensions_for_new_tracks(reg, [], lib)
+
+        mock_invoke.assert_not_called()
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — host enforces single-invocation via audit log, not extension logic
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogEnforcement:
+    def test_already_processed_track_is_skipped(self, tmp_path: Path) -> None:
+        """If an audit log entry exists, invoke_extension must not be called."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        cls = _fake_tagger_cls(module="ext.t", name="T")
+        ext_id = _extension_id(cls)
+        # Simulate a prior run by writing a log entry directly.
+        lib.apply_metadata_update(ext_id, "rec-1", {"title": "Prior"})
+
+        reg = _make_registry(taggers=[cls])
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension") as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        mock_invoke.assert_not_called()
+        lib.close()
+
+    def test_unprocessed_track_is_not_skipped(self, tmp_path: Path) -> None:
+        """No audit log entry → invoke_extension must be called."""
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        mock_invoke.assert_called_once()
+        lib.close()
+
+    def test_different_extension_does_not_count_as_processed(
+        self, tmp_path: Path
+    ) -> None:
+        """An audit log entry for ext-A does not prevent ext-B from running."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        # Write an entry for a *different* extension ID.
+        lib.apply_metadata_update("some.other.Ext", "rec-1", {"title": "X"})
+
+        cls = _fake_tagger_cls(module="my.ext", name="Mine")
+        reg = _make_registry(taggers=[cls])
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        mock_invoke.assert_called_once()
+        lib.close()
+
+    def test_mixed_processed_and_new_tracks(self, tmp_path: Path) -> None:
+        """Only the unprocessed track triggers invoke_extension."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.upsert_track(_make_track(tmp_path / "b.mp3", mbid="rec-2"))
+
+        cls = _fake_tagger_cls(module="ext.t", name="T")
+        ext_id = _extension_id(cls)
+        lib.apply_metadata_update(
+            ext_id, "rec-1", {"title": "Old"}
+        )  # already processed
+
+        reg = _make_registry(taggers=[cls])
+        tracks = [
+            _make_track(tmp_path / "a.mp3", mbid="rec-1"),  # processed → skip
+            _make_track(tmp_path / "b.mp3", mbid="rec-2"),  # new → invoke
+        ]
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(reg, tracks, lib)
+
+        assert mock_invoke.call_count == 1
+        invoked_meta: TrackMetadata = mock_invoke.call_args[0][2]
+        assert invoked_meta.mbid == "rec-2"
+
+        lib.close()
+
+    def test_failed_invoke_does_not_log_to_audit(self, tmp_path: Path) -> None:
+        """A False return from invoke_extension leaves no audit entry (no retry block)."""
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls(module="ext.t", name="T")
+        ext_id = _extension_id(cls)
+        reg = _make_registry(taggers=[cls])
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension", return_value=False):
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        assert lib.audit_log_for(ext_id) == []
+        lib.close()
+
+    def test_failed_invoke_does_not_block_subsequent_track(
+        self, tmp_path: Path
+    ) -> None:
+        """A failure on track A must not prevent track B from being offered."""
+        lib = _make_library(tmp_path)
+        cls = _fake_tagger_cls()
+        reg = _make_registry(taggers=[cls])
+
+        side_effects = [False, []]  # first call fails, second succeeds
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", side_effect=side_effects
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg,
+                [
+                    _make_track(tmp_path / "a.mp3", mbid="rec-1"),
+                    _make_track(tmp_path / "b.mp3", mbid="rec-2"),
+                ],
+                lib,
+            )
+
+        assert mock_invoke.call_count == 2
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — artwork-source extensions invoked under the same policy
+# ---------------------------------------------------------------------------
+
+
+class TestArtworkSourceInvocation:
+    def test_artwork_source_invoked_for_new_track(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cls = _fake_artwork_cls()
+        reg = _make_registry(artwork_sources=[cls])
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        mock_invoke.assert_called_once()
+        args = mock_invoke.call_args[0]
+        assert args[0] is cls
+        assert args[1] == "fetch"
+
+        lib.close()
+
+    def test_artwork_source_receives_artwork_query(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        cls = _fake_artwork_cls()
+        reg = _make_registry(artwork_sources=[cls])
+
+        track = _make_track(
+            tmp_path / "a.mp3",
+            mbid="rec-1",
+            release_mbid="rel-99",
+            album="My Album",
+            album_artist="My Artist",
+        )
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", return_value=[]
+        ) as mock_invoke:
+            invoke_extensions_for_new_tracks(reg, [track], lib)
+
+        query: ArtworkQuery = mock_invoke.call_args[0][2]
+        assert isinstance(query, ArtworkQuery)
+        assert query.mbid == "rel-99"
+        assert query.album == "My Album"
+        assert query.artist == "My Artist"
+
+        lib.close()
+
+    def test_artwork_source_skipped_when_already_processed(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        cls = _fake_artwork_cls(module="ext.art", name="Art")
+        ext_id = _extension_id(cls)
+        lib.apply_set_artwork(ext_id, "rec-1", "image/jpeg")
+
+        reg = _make_registry(artwork_sources=[cls])
+
+        with patch("kamp_daemon.ext.invoker.invoke_extension") as mock_invoke:
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        mock_invoke.assert_not_called()
+        lib.close()
+
+    def test_taggers_run_before_artwork_sources(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        tagger_cls = _fake_tagger_cls(name="Tagger")
+        art_cls = _fake_artwork_cls(name="Art")
+        reg = _make_registry(taggers=[tagger_cls], artwork_sources=[art_cls])
+
+        call_order: list[str] = []
+
+        def _side_effect(cls: type, *args: object, **kwargs: object) -> list:
+            call_order.append(cls.__qualname__)
+            return []
+
+        with patch(
+            "kamp_daemon.ext.invoker.invoke_extension", side_effect=_side_effect
+        ):
+            invoke_extensions_for_new_tracks(
+                reg, [_make_track(tmp_path / "a.mp3", mbid="rec-1")], lib
+            )
+
+        assert call_order == ["Tagger", "Art"]
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# LibraryIndex.has_been_processed_by — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHasBeenProcessedBy:
+    def test_returns_false_when_no_log_entry(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        assert lib.has_been_processed_by("ext-a", "rec-1") is False
+        lib.close()
+
+    def test_returns_true_after_metadata_update(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "X"})
+        assert lib.has_been_processed_by("ext-a", "rec-1") is True
+        lib.close()
+
+    def test_returns_true_after_set_artwork(self, tmp_path: Path) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-2"))
+        lib.apply_set_artwork("ext-b", "rec-2", "image/jpeg")
+        assert lib.has_been_processed_by("ext-b", "rec-2") is True
+        lib.close()
+
+    def test_extension_isolation(self, tmp_path: Path) -> None:
+        """An entry for ext-A must not show as processed for ext-B."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "X"})
+        assert lib.has_been_processed_by("ext-b", "rec-1") is False
+        lib.close()
+
+    def test_track_isolation(self, tmp_path: Path) -> None:
+        """An entry for rec-1 must not show as processed for rec-2."""
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        lib.upsert_track(_make_track(tmp_path / "b.mp3", mbid="rec-2"))
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "X"})
+        assert lib.has_been_processed_by("ext-a", "rec-2") is False
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
+# ScanResult.new_tracks — integration with LibraryScanner
+# ---------------------------------------------------------------------------
+
+
+class TestScanResultNewTracks:
+    def test_newly_added_tracks_included_in_new_tracks(self, tmp_path: Path) -> None:
+        from kamp_core.library import LibraryScanner
+
+        lib = _make_library(tmp_path)
+        lib_dir = tmp_path / "library"
+        lib_dir.mkdir()
+
+        # Write a minimal fake MP3 so the scanner can read its tags.
+        from mutagen import id3
+
+        mp3 = lib_dir / "track.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+
+        result = LibraryScanner(lib).scan(lib_dir)
+        lib.close()
+
+        assert result.added == len(result.new_tracks)
+        assert any(t.file_path == mp3 for t in result.new_tracks)
+
+    def test_rescan_produces_no_new_tracks(self, tmp_path: Path) -> None:
+        from kamp_core.library import LibraryScanner
+
+        lib = _make_library(tmp_path)
+        lib_dir = tmp_path / "library"
+        lib_dir.mkdir()
+
+        from mutagen import id3
+
+        mp3 = lib_dir / "track.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+
+        LibraryScanner(lib).scan(lib_dir)  # first scan adds the track
+        result = LibraryScanner(lib).scan(lib_dir)  # re-scan
+        lib.close()
+
+        # Re-scan with unchanged mtime: no new tracks.
+        assert result.new_tracks == []


### PR DESCRIPTION
## Summary

- Implements the host-side invocation policy for registered `BaseTagger` and `BaseArtworkSource` extensions (TASK-90)
- Extensions are invoked at ingest time only, on newly indexed tracks — re-scans never trigger re-invocation
- Host enforces the single-invocation guarantee via `extension_audit_log`; no reliance on extension skip logic
- Taggers run first (registration order), then artwork sources, supplementing first-party MusicBrainz/CAA results

## Key design decisions

| Question | Decision |
|---|---|
| Trigger point | Ingest-time only (`ScanResult.new_tracks` from `LibraryScanner`) |
| Already-processed detection | `LibraryIndex.has_been_processed_by(ext_id, mbid)` — audit log, host-enforced |
| Extension version changes | Not auto-reprocessed; `kamp rollback` is the escape hatch |
| Ordering | Taggers before artwork sources; community after first-party |

## Changes

- `kamp_core/library.py` — `ScanResult.new_tracks: list[Track]`; `LibraryIndex.has_been_processed_by()`
- `kamp_daemon/ext/invoker.py` — new module with `invoke_extensions_for_new_tracks()` and policy doc
- `kamp_daemon/__main__.py` — server discovers extensions on startup; wires invoker into `_on_library_change()`
- `tests/test_extension_invoker.py` — 30 tests covering all 5 ACs
- `README.md` — backend extension section (entry points, invocation model, rollback)

## Test plan

- [x] All 30 invoker tests pass (`tests/test_extension_invoker.py`)
- [x] Existing library tests pass (84 tests)
- [x] Write log / worker / discovery tests pass (41 tests)
- [x] `mypy kamp_core/ kamp_daemon/` — no issues
- [x] `black` — no formatting issues
- [x] Manual test: tagger pipeline still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)