### PR TITLE
fix: isolate main-panel extension containers with React key (TASK-114)

### DIFF
--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -2,14 +2,13 @@ project_name: "Kamp"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 labels: []
-definition_of_done: []
 date_format: yyyy-mm-dd
 max_column_width: 20
 default_editor: "code --wait"
 auto_open_browser: true
 default_port: 6420
 remote_operations: true
-auto_commit: true
+auto_commit: false
 bypass_git_hooks: false
 check_active_branches: true
 active_branch_days: 30

--- a/backlog/tasks/task-114 - Stats-and-Groover-compete-for-panel-space.md
+++ b/backlog/tasks/task-114 - Stats-and-Groover-compete-for-panel-space.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-114
 title: Stats and Groover compete for panel space
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-09 12:15'
 labels: []

--- a/backlog/tasks/task-114 - Stats-and-Groover-compete-for-panel-space.md
+++ b/backlog/tasks/task-114 - Stats-and-Groover-compete-for-panel-space.md
@@ -1,12 +1,14 @@
 ---
 id: TASK-114
 title: Stats and Groover compete for panel space
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-09 12:15'
+updated_date: '2026-04-09 13:27'
 labels: []
 milestone: m-2
 dependencies: []
+ordinal: 24000
 ---
 
 ## Description

--- a/backlog/tasks/task-97 - Frontend-extension-SDK-—-wrap-REST-API-so-extensions-dont-call-fetch-directly.md
+++ b/backlog/tasks/task-97 - Frontend-extension-SDK-—-wrap-REST-API-so-extensions-dont-call-fetch-directly.md
@@ -6,10 +6,11 @@ title: >-
 status: Done
 assignee: []
 created_date: '2026-04-09 01:18'
-updated_date: '2026-04-09 02:21'
+updated_date: '2026-04-09 13:27'
 labels: []
 milestone: m-2
 dependencies: []
+ordinal: 23000
 ---
 
 ## Description
@@ -51,12 +52,12 @@ When the Bandcamp frontend extension is scoped, decide between options 1 and 2 b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 #1 `KampSDK` type defined in `kamp_ui/src/shared/kampAPI.ts` with at minimum `player.getState()` and `library.getAlbumArt()`
-- [x] #2 #2 SDK implementation wired into the preload and passed to first-party extensions via `register(api)`
-- [x] #3 #3 Sandbox shim updated to pass the SDK into community extensions (serialised or proxied via postMessage)
-- [x] #4 #4 `kamp-groover` example updated to use SDK methods instead of raw fetch
-- [x] #5 #5 `api.serverUrl` removed from `KampAPI` type and all call sites
-- [x] #6 #6 Developer Guide updated to show SDK usage; raw fetch removed from examples
+- [x] #1 #1 #1 `KampSDK` type defined in `kamp_ui/src/shared/kampAPI.ts` with at minimum `player.getState()` and `library.getAlbumArt()`
+- [x] #2 #2 #2 SDK implementation wired into the preload and passed to first-party extensions via `register(api)`
+- [x] #3 #3 #3 Sandbox shim updated to pass the SDK into community extensions (serialised or proxied via postMessage)
+- [x] #4 #4 #4 `kamp-groover` example updated to use SDK methods instead of raw fetch
+- [x] #5 #5 #5 `api.serverUrl` removed from `KampAPI` type and all call sites
+- [x] #6 #6 #6 Developer Guide updated to show SDK usage; raw fetch removed from examples
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Implementation Plan
@@ -90,6 +91,8 @@ When the Bandcamp frontend extension is scoped, decide between options 1 and 2 b
 ### Step 6 — Docs
 - Update Extension Developer Guide: replace raw-fetch examples with SDK calls, remove api.serverUrl
 <!-- SECTION:PLAN:END -->
+
+<!-- AC:END -->
 
 <!-- AC:END -->
 

--- a/extensions/kamp-groover/index.js
+++ b/extensions/kamp-groover/index.js
@@ -14,6 +14,7 @@ export function register(api) {
     id: 'kamp-groover.visualizer',
     title: 'Groover',
     defaultSlot: 'main',
+    compatibleSlots: ['main'],
 
     render(container) {
       // Clear any leftover DOM from a previous mount cycle (React StrictMode

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -428,7 +428,11 @@ export default function App(): React.JSX.Element {
     if (searchQuery) return <SearchView />
     if (activeExtPanel) {
       const extPanel = mainPanels.find((p) => p.id === activeExtPanel)
-      if (extPanel && extPanel.kind === 'extension') return <ExtensionPanel panel={extPanel} />
+      // key=panel.id forces a fresh component+DOM node on panel switch so the
+      // previous extension's container is never reused (and its lingering DOM
+      // never bleeds into the incoming panel).
+      if (extPanel && extPanel.kind === 'extension')
+        return <ExtensionPanel key={extPanel.id} panel={extPanel} />
     }
     if (activeView === 'now-playing') return <NowPlayingView />
     return <LibraryView />


### PR DESCRIPTION
## Summary

- `<ExtensionPanel>` in `renderMainContent()` had no `key` prop, so React reused the same component instance and container `<div>` when switching between extension tabs
- Stats' cleanup only calls `clearInterval` — it leaves its `innerHTML` in place
- When Groover's `render(container)` ran next, it appended its iframe to a container still containing Stats' table markup, producing the "renders inside Stats" symptom
- Fix: add `key={panel.id}` to force a fresh component+DOM node per panel; the incoming extension always gets an empty container

## Test plan

- [x] Enable both Stats and Groover extensions in Main Panel slots
- [x] Click Stats tab → Stats renders normally
- [x] Click Groover tab → Groover renders in full isolation (no Stats content visible)
- [x] Switch back to Stats → Stats renders normally
- [x] Typecheck and lint pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)