### PR TITLE
feat: server-push player events — track.changed and play_state.changed (TASK-115)

### DIFF
--- a/backlog/tasks/task-115 - Server-push-player-events-—-proactive-WebSocket-notifications-on-track-change-and-play-state.md
+++ b/backlog/tasks/task-115 - Server-push-player-events-—-proactive-WebSocket-notifications-on-track-change-and-play-state.md
@@ -3,10 +3,10 @@ id: TASK-115
 title: >-
   Server-push player events — proactive WebSocket notifications on track change
   and play state
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-09 13:01'
-updated_date: '2026-04-09 13:02'
+updated_date: '2026-04-09 13:42'
 labels: []
 milestone: m-22
 dependencies: []

--- a/extensions/kamp-groover/index.js
+++ b/extensions/kamp-groover/index.js
@@ -87,45 +87,39 @@ export function register(api) {
       rafId = requestAnimationFrame(animate)
 
       // -----------------------------------------------------------------------
-      // Player state polling
+      // Track-change subscription (replaces polling)
       // -----------------------------------------------------------------------
       let currentArtKey = null
 
-      async function poll() {
-        try {
-          const state = await api.player.getState()
-          const track = state.current_track
-
-          if (!track) {
-            img.style.opacity = '0'
-            currentArtKey = null
-            return
-          }
-
-          // Reload art only when the album changes.
-          const artKey = `${track.album_artist}||${track.album}`
-          if (artKey !== currentArtKey) {
-            currentArtKey = artKey
-            const url = api.library.getAlbumArtUrl(track.album_artist, track.album)
-            img.style.opacity = '0'
-            img.onload = () => { img.style.opacity = '1' }
-            img.onerror = () => { img.style.opacity = '0' }
-            img.src = url
-          }
-        } catch {
-          // Server unreachable — leave last state visible.
+      function updateArt(state) {
+        const track = state.current_track
+        if (!track) {
+          img.style.opacity = '0'
+          currentArtKey = null
+          return
+        }
+        // Reload art only when the album changes.
+        const artKey = `${track.album_artist}||${track.album}`
+        if (artKey !== currentArtKey) {
+          currentArtKey = artKey
+          const url = api.library.getAlbumArtUrl(track.album_artist, track.album)
+          img.style.opacity = '0'
+          img.onload = () => { img.style.opacity = '1' }
+          img.onerror = () => { img.style.opacity = '0' }
+          img.src = url
         }
       }
 
-      void poll()
-      const pollInterval = setInterval(() => void poll(), 2000)
+      // Seed with current state, then subscribe for push updates.
+      api.player.getState().then(updateArt).catch(() => {})
+      const unsubTrack = api.player.onTrackChange(updateArt)
 
       // -----------------------------------------------------------------------
       // Cleanup
       // -----------------------------------------------------------------------
       return () => {
         cancelAnimationFrame(rafId)
-        clearInterval(pollInterval)
+        unsubTrack()
       }
     }
   })

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -328,6 +328,7 @@ class MpvPlaybackEngine:
         self.state = PlaybackState()
         self.on_track_end: Callable[[], None] | None = None
         self.on_file_loaded: Callable[[], None] | None = None
+        self.on_play_state_changed: Callable[[], None] | None = None
         self._mpv_bin = mpv_bin
         self._proc: subprocess.Popen[bytes] | None = None
         self._sock: socket.socket | None = None
@@ -501,7 +502,11 @@ class MpvPlaybackEngine:
             elif prop == "duration" and isinstance(data, (int, float)):
                 self.state.duration = float(data)
             elif prop == "pause" and isinstance(data, bool):
-                self.state.playing = not data
+                new_playing = not data
+                changed = new_playing != self.state.playing
+                self.state.playing = new_playing
+                if changed and self.on_play_state_changed is not None:
+                    self.on_play_state_changed()
 
         elif name == "file-loaded":
             if self.on_file_loaded is not None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -12,7 +12,9 @@ WebSocket:  /api/v1/ws   — client sends "ping", server replies with a
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 
@@ -203,13 +205,41 @@ def create_app(
         "config": dict(config_values) if config_values is not None else {},
     }
 
+    # Active WebSocket queues — one asyncio.Queue per connected client.
+    # Events are broadcast to all queues so push notifications wake every client.
+    _ws_queues: set[asyncio.Queue[dict[str, Any]]] = set()
+    # The running event loop, captured on first WS connection (thread-safe puts
+    # need call_soon_threadsafe, which requires the loop reference).
+    _event_loop: asyncio.AbstractEventLoop | None = None
+
+    def _broadcast(event: dict[str, Any]) -> None:
+        """Thread-safe: enqueue *event* for every connected WebSocket client."""
+        if _event_loop is None:
+            return
+        for q in list(_ws_queues):
+            _event_loop.call_soon_threadsafe(q.put_nowait, event)
+
     def _notify_library_changed() -> None:
         """Increment the library version so connected WebSocket clients are notified."""
         _state["library_version"] += 1
 
-    # Expose the notifier on app.state so the caller (__main__.py) can trigger
-    # it after background (watcher-driven) scans complete.
+    def _notify_track_changed() -> None:
+        """Broadcast a track.changed push event to all connected WebSocket clients."""
+        _broadcast({"type": "track.changed", **_state_snapshot().model_dump()})
+
+    def _notify_play_state_changed() -> None:
+        """Broadcast a play_state.changed push event to all connected WebSocket clients."""
+        _broadcast({"type": "play_state.changed", **_state_snapshot().model_dump()})
+
+    # Expose notifiers on app.state so the daemon can wire them into engine
+    # callbacks (e.g. on_track_end, on_play_state_changed).
     app.state.notify_library_changed = _notify_library_changed
+    app.state.notify_track_changed = _notify_track_changed
+    app.state.notify_play_state_changed = _notify_play_state_changed
+
+    # Wire play-state change callback directly — the engine fires it from its
+    # background reader thread whenever mpv's pause property flips.
+    engine.on_play_state_changed = _notify_play_state_changed
 
     # Allow requests from the Electron renderer (Vite dev server and file://).
     # This server only binds to 127.0.0.1, so wildcard origins are safe.
@@ -438,6 +468,7 @@ def create_app(
         current = queue.current()
         if current:
             engine.play(current.file_path)
+        _notify_track_changed()
         return {"ok": True}
 
     @app.post("/api/v1/player/pause")
@@ -453,6 +484,7 @@ def create_app(
     @app.post("/api/v1/player/stop")
     def stop() -> dict[str, Any]:
         engine.stop()
+        _notify_track_changed()
         return {"ok": True}
 
     @app.post("/api/v1/player/seek")
@@ -472,6 +504,7 @@ def create_app(
             engine.play(track.file_path)
         else:
             engine.stop()
+        _notify_track_changed()
         return {"ok": True}
 
     @app.post("/api/v1/player/prev")
@@ -479,6 +512,7 @@ def create_app(
         track = queue.prev()
         if track:
             engine.play(track.file_path)
+        _notify_track_changed()
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/clear")
@@ -496,6 +530,7 @@ def create_app(
         track = queue.skip_to(req.position)
         if track:
             engine.play(track.file_path)
+        _notify_track_changed()
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/add")
@@ -570,24 +605,47 @@ def create_app(
 
     @app.websocket("/api/v1/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:
+        nonlocal _event_loop
+        _event_loop = asyncio.get_running_loop()
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        _ws_queues.add(q)
+
         await ws.accept()
         # Push initial snapshot immediately on connect.
         await ws.send_json({"type": "player.state", **_state_snapshot().model_dump()})
         last_library_version: int = _state["library_version"]
         try:
             while True:
-                # Each "ping" from the client triggers a fresh snapshot.
-                await ws.receive_text()
-                await ws.send_json(
-                    {"type": "player.state", **_state_snapshot().model_dump()}
+                # Await either a client ping or a server-push event — whichever
+                # arrives first.  Both paths may fire in the same iteration if a
+                # push event arrives while a ping is also pending.
+                recv_task = asyncio.create_task(ws.receive_text())
+                push_task = asyncio.create_task(q.get())
+                done, pending = await asyncio.wait(
+                    {recv_task, push_task}, return_when=asyncio.FIRST_COMPLETED
                 )
-                # Notify the client if a background scan updated the library
-                # since the last ping so it can refresh the album list.
-                current_version = _state["library_version"]
-                if current_version != last_library_version:
-                    last_library_version = current_version
-                    await ws.send_json({"type": "library.changed"})
+                for t in pending:
+                    t.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await t
+
+                if push_task in done:
+                    await ws.send_json(push_task.result())
+
+                if recv_task in done:
+                    # Each "ping" from the client triggers a fresh snapshot.
+                    await ws.send_json(
+                        {"type": "player.state", **_state_snapshot().model_dump()}
+                    )
+                    # Notify the client if a background scan updated the library
+                    # since the last ping so it can refresh the album list.
+                    current_version = _state["library_version"]
+                    if current_version != last_library_version:
+                        last_library_version = current_version
+                        await ws.send_json({"type": "library.changed"})
         except Exception:
             pass
+        finally:
+            _ws_queues.discard(q)
 
     return app

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -659,6 +659,17 @@ def _cmd_server(
         on_config_set=_on_config_set,
     )
 
+    # Wrap the existing on_track_end callback to also push track.changed events.
+    # Done here (after app creation) so app.state is guaranteed to be available.
+    _original_on_track_end = engine.on_track_end
+
+    def _on_track_end_notify() -> None:
+        if _original_on_track_end is not None:
+            _original_on_track_end()
+        app.state.notify_track_changed()
+
+    engine.on_track_end = _on_track_end_notify
+
     # Watch the library directory and re-scan when audio files are added or
     # removed, so the UI stays current without requiring a manual scan trigger.
     from kamp_daemon.ext import (

--- a/kamp_ui/package.json
+++ b/kamp_ui/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",
+    "shim-hash": "node -e \"const fs=require('fs'),crypto=require('crypto');const src=fs.readFileSync('src/renderer/src/components/SandboxedExtensionLoader.tsx','utf8');const m=src.match(/const SANDBOX_SHIM = \\`([\\s\\S]*?)\\`/);if(!m)throw new Error('SANDBOX_SHIM not found');const hash=crypto.createHash('sha256').update(m[1],'utf8').digest('base64');console.log('sha256-'+hash)\"",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",

--- a/kamp_ui/src/preload/kampAPI.ts
+++ b/kamp_ui/src/preload/kampAPI.ts
@@ -10,11 +10,44 @@ import { ipcRenderer } from 'electron'
 import type { KampAPI, PanelManifest, ExtensionInstallResult, PlayerState } from '../shared/kampAPI'
 
 const SERVER_URL = 'http://127.0.0.1:8000'
+const WS_URL = 'ws://127.0.0.1:8000/api/v1/ws'
 
 const panelRegistry: PanelManifest[] = []
 // Callbacks registered by the renderer via panels.onRegister().
 // contextBridge wraps renderer functions so they can be called from the preload.
 const registerCallbacks = new Set<(manifest: PanelManifest) => void>()
+
+// Push-event subscribers. Populated by onTrackChange / onPlayStateChange.
+// A single shared WebSocket is lazily created and fans out to all subscribers.
+const trackChangeCallbacks = new Set<(state: PlayerState) => void>()
+const playStateChangeCallbacks = new Set<(state: PlayerState) => void>()
+let _pushWs: WebSocket | null = null
+
+function ensurePushWs(): void {
+  if (_pushWs && _pushWs.readyState < WebSocket.CLOSING) return
+  const ws = new WebSocket(WS_URL)
+  ws.addEventListener('message', (evt) => {
+    try {
+      const msg = JSON.parse(evt.data as string) as { type: string } & PlayerState
+      if (msg.type === 'track.changed') {
+        trackChangeCallbacks.forEach((cb) => cb(msg))
+      } else if (msg.type === 'play_state.changed') {
+        playStateChangeCallbacks.forEach((cb) => cb(msg))
+      }
+    } catch {
+      // Ignore malformed messages
+    }
+  })
+  ws.addEventListener('close', () => {
+    // Reconnect after a short delay so subscribers survive server restarts.
+    setTimeout(() => {
+      if (trackChangeCallbacks.size > 0 || playStateChangeCallbacks.size > 0) {
+        ensurePushWs()
+      }
+    }, 2000)
+  })
+  _pushWs = ws
+}
 
 export function buildKampAPI(): KampAPI {
   return {
@@ -52,6 +85,16 @@ export function buildKampAPI(): KampAPI {
         const res = await fetch(`${SERVER_URL}/api/v1/player/state`)
         if (!res.ok) throw new Error(`player.getState failed: ${res.status}`)
         return res.json() as Promise<PlayerState>
+      },
+      onTrackChange(callback: (state: PlayerState) => void): () => void {
+        ensurePushWs()
+        trackChangeCallbacks.add(callback)
+        return () => trackChangeCallbacks.delete(callback)
+      },
+      onPlayStateChange(callback: (state: PlayerState) => void): () => void {
+        ensurePushWs()
+        playStateChangeCallbacks.add(callback)
+        return () => playStateChangeCallbacks.delete(callback)
       }
     },
 

--- a/kamp_ui/src/renderer/index.html
+++ b/kamp_ui/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob: 'sha256-IyJ04Rbq6eUCOWHuijxWFlP4mGP9HCsnZhyJK2DWdSg='; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self' blob: 'sha256-pZ2P3MM/ZsmuxQcGlYScwK38Sz5eE+wn9o/rNUV96gA='; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src https://fonts.bunny.net; img-src 'self' data: http://127.0.0.1:*; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*"
     />
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link

--- a/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
+++ b/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
@@ -13,10 +13,12 @@ import type { ExtensionInfo, SlotId, PlayerState } from '../../../shared/kampAPI
  * and passes it to the extension's register() function.
  *
  * SDK methods available to the shim:
- *   player.getState()        — async, proxied via kamp:sdk-call / kamp:sdk-response
- *   library.getAlbumArtUrl() — sync, constructs URL against the hardcoded server origin
+ *   player.getState()          — async, proxied via kamp:sdk-call / kamp:sdk-response
+ *   player.onTrackChange(cb)   — subscription, proxied via kamp:sdk-subscribe / kamp:sdk-event
+ *   player.onPlayStateChange(cb) — subscription, same pattern
+ *   library.getAlbumArtUrl()   — sync, constructs URL against the hardcoded server origin
  *
- * Hash (index.html script-src): sha256-IyJ04Rbq6eUCOWHuijxWFlP4mGP9HCsnZhyJK2DWdSg=
+ * Hash (index.html script-src): sha256-pZ2P3MM/ZsmuxQcGlYScwK38Sz5eE+wn9o/rNUV96gA=
  * If you change SANDBOX_SHIM, recompute the hash and update index.html:
  *   node -e "const s='<paste shim>';console.log('sha256-'+require('crypto').createHash('sha256').update(s,'utf8').digest('base64'))"
  *
@@ -26,7 +28,7 @@ import type { ExtensionInfo, SlotId, PlayerState } from '../../../shared/kampAPI
  */
 // prettier-ignore
 // If you change this string, recompute the hash and update index.html script-src (see comment above).
-const SANDBOX_SHIM = `(function(){var SERVER="http://127.0.0.1:8000",r={},c={},pending=null,reqs={},rid=0;function rpc(method,args){return new Promise(function(resolve,reject){var id=++rid;reqs[id]={resolve:resolve,reject:reject};window.parent.postMessage({type:"kamp:sdk-call",id:id,method:method,args:args},"*")})}window.addEventListener("message",function(e){if(e.source!==window.parent)return;var m=e.data;if(!m||typeof m.type!=="string")return;if(m.type==="kamp:init"){var id=m.id,perms=m.permissions||[];var K={panels:{register:function(p){if(!p||typeof p.id!=="string")return;r[p.id]=p.render;window.parent.postMessage({type:"kamp:register-panel",extensionId:id,manifest:{id:p.id,title:p.title,defaultSlot:p.defaultSlot,compatibleSlots:p.compatibleSlots}},"*");if(pending===p.id&&typeof r[p.id]==="function"){c[p.id]=r[p.id](document.body);pending=null}}}};if(perms.indexOf("player.read")!==-1){K.player={getState:function(){return rpc("player.getState",[])}}}if(perms.indexOf("library.read")!==-1){K.library={getAlbumArtUrl:function(aa,a){return SERVER+"/api/v1/album-art?album_artist="+encodeURIComponent(aa)+"&album="+encodeURIComponent(a)}}}var b=new Blob([m.code],{type:"text/javascript"});var u=URL.createObjectURL(b);import(u).then(function(mod){if(typeof mod.register==="function")mod.register(K)}).catch(function(err){console.error("[kamp sandbox "+id+"]",err)}).finally(function(){URL.revokeObjectURL(u)})}else if(m.type==="kamp:sdk-response"){var req=reqs[m.id];if(!req)return;delete reqs[m.id];if(m.error)req.reject(new Error(m.error));else req.resolve(m.result)}else if(m.type==="kamp:panel-mount"&&m.panelId){if(typeof r[m.panelId]==="function"){c[m.panelId]=r[m.panelId](document.body)}else{pending=m.panelId}}else if(m.type==="kamp:panel-unmount"&&m.panelId){var fn=c[m.panelId];if(typeof fn==="function")fn();delete c[m.panelId];if(pending===m.panelId)pending=null}})})();`
+const SANDBOX_SHIM = `(function(){var SERVER="http://127.0.0.1:8000",r={},c={},pending=null,reqs={},rid=0,subs={},sid=0;function rpc(method,args){return new Promise(function(resolve,reject){var id=++rid;reqs[id]={resolve:resolve,reject:reject};window.parent.postMessage({type:"kamp:sdk-call",id:id,method:method,args:args},"*")})}function subscribe(event,cb){var id=++sid;subs[id]={event:event,cb:cb};window.parent.postMessage({type:"kamp:sdk-subscribe",subId:id,event:event},"*");return function(){delete subs[id];window.parent.postMessage({type:"kamp:sdk-unsubscribe",subId:id},"*")}}window.addEventListener("message",function(e){if(e.source!==window.parent)return;var m=e.data;if(!m||typeof m.type!=="string")return;if(m.type==="kamp:init"){var id=m.id,perms=m.permissions||[];var K={panels:{register:function(p){if(!p||typeof p.id!=="string")return;r[p.id]=p.render;window.parent.postMessage({type:"kamp:register-panel",extensionId:id,manifest:{id:p.id,title:p.title,defaultSlot:p.defaultSlot,compatibleSlots:p.compatibleSlots}},"*");if(pending===p.id&&typeof r[p.id]==="function"){c[p.id]=r[p.id](document.body);pending=null}}}};if(perms.indexOf("player.read")!==-1){K.player={getState:function(){return rpc("player.getState",[])},onTrackChange:function(cb){return subscribe("track.changed",cb)},onPlayStateChange:function(cb){return subscribe("play_state.changed",cb)}}}if(perms.indexOf("library.read")!==-1){K.library={getAlbumArtUrl:function(aa,a){return SERVER+"/api/v1/album-art?album_artist="+encodeURIComponent(aa)+"&album="+encodeURIComponent(a)}}}var b=new Blob([m.code],{type:"text/javascript"});var u=URL.createObjectURL(b);import(u).then(function(mod){if(typeof mod.register==="function")mod.register(K)}).catch(function(err){console.error("[kamp sandbox "+id+"]",err)}).finally(function(){URL.revokeObjectURL(u)})}else if(m.type==="kamp:sdk-response"){var req=reqs[m.id];if(!req)return;delete reqs[m.id];if(m.error)req.reject(new Error(m.error));else req.resolve(m.result)}else if(m.type==="kamp:sdk-event"){Object.keys(subs).forEach(function(k){if(subs[k].event===m.event)subs[k].cb(m.payload)})}else if(m.type==="kamp:panel-mount"&&m.panelId){if(typeof r[m.panelId]==="function"){c[m.panelId]=r[m.panelId](document.body)}else{pending=m.panelId}}else if(m.type==="kamp:panel-unmount"&&m.panelId){var fn=c[m.panelId];if(typeof fn==="function")fn();delete c[m.panelId];if(pending===m.panelId)pending=null}})})();`
 
 const SANDBOX_SRCDOC =
   `<!doctype html>
@@ -42,6 +44,28 @@ const SANDBOX_SRCDOC =
   `/script>
 </body>
 </html>`
+
+// Tracks active subscriptions from sandboxed iframes.
+// Key: `${sourceWindow}-${subId}` (we use a Map keyed by [source, subId]).
+// Value: the unsubscribe function returned by window.KampAPI.player.on*
+const _activeSubscriptions = new Map<string, () => void>()
+
+function _subKey(source: WindowProxy, subId: number): string {
+  // Use a combination of object identity (via WeakMap index) and subId.
+  // Since we can't stringify a WindowProxy, we use a numeric id instead.
+  return `${_getSourceId(source)}_${subId}`
+}
+
+const _sourceIds = new WeakMap<WindowProxy, number>()
+let _nextSourceId = 0
+function _getSourceId(source: WindowProxy): number {
+  let id = _sourceIds.get(source)
+  if (id === undefined) {
+    id = _nextSourceId++
+    _sourceIds.set(source, id)
+  }
+  return id
+}
 
 /**
  * Handles kamp:sdk-call messages from sandboxed extension iframes.
@@ -70,6 +94,50 @@ function handleSdkCall(
       break
     default:
       respond(undefined, `Unknown SDK method: ${msg.method}`)
+  }
+}
+
+/**
+ * Handles kamp:sdk-subscribe and kamp:sdk-unsubscribe messages from sandboxed iframes.
+ *
+ * When an extension calls api.player.onTrackChange(cb) or api.player.onPlayStateChange(cb),
+ * the shim posts kamp:sdk-subscribe. This handler registers the real subscription on the
+ * host KampAPI and posts kamp:sdk-event back to the iframe whenever the event fires.
+ *
+ * kamp:sdk-unsubscribe cancels the subscription.
+ */
+function handleSdkSubscribe(
+  event: MessageEvent<{ type: string; subId: number; event: string }>
+): void {
+  const msg = event.data
+  if (!msg || (msg.type !== 'kamp:sdk-subscribe' && msg.type !== 'kamp:sdk-unsubscribe')) return
+  const source = event.source as WindowProxy | null
+  if (!source) return
+
+  const key = _subKey(source, msg.subId)
+
+  if (msg.type === 'kamp:sdk-unsubscribe') {
+    const unsub = _activeSubscriptions.get(key)
+    if (unsub) {
+      unsub()
+      _activeSubscriptions.delete(key)
+    }
+    return
+  }
+
+  // kamp:sdk-subscribe
+  const dispatch = (state: PlayerState): void => {
+    source.postMessage({ type: 'kamp:sdk-event', event: msg.event, payload: state }, '*')
+  }
+
+  let unsub: (() => void) | undefined
+  if (msg.event === 'track.changed') {
+    unsub = window.KampAPI.player!.onTrackChange(dispatch)
+  } else if (msg.event === 'play_state.changed') {
+    unsub = window.KampAPI.player!.onPlayStateChange(dispatch)
+  }
+  if (unsub) {
+    _activeSubscriptions.set(key, unsub)
   }
 }
 
@@ -160,10 +228,14 @@ export function SandboxedExtensionLoader({ extensions }: Props): null {
   // Track cleanup functions for in-flight discovery iframes.
   const cleanupRefs = useRef<Map<string, () => void>>(new Map())
 
-  // Global handler for SDK method proxying from all active extension iframes.
+  // Global handlers for SDK method proxying and subscriptions from all active extension iframes.
   useEffect(() => {
     window.addEventListener('message', handleSdkCall)
-    return () => window.removeEventListener('message', handleSdkCall)
+    window.addEventListener('message', handleSdkSubscribe)
+    return () => {
+      window.removeEventListener('message', handleSdkCall)
+      window.removeEventListener('message', handleSdkSubscribe)
+    }
   }, [])
 
   useEffect(() => {

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -150,6 +150,17 @@ export type KampAPI = {
   player?: {
     /** Fetch the current playback state from the kamp server. */
     getState: () => Promise<PlayerState>
+    /**
+     * Subscribe to track-change events. The callback fires whenever the
+     * current track transitions (new track started, queue exhausted, or
+     * playback stopped). Returns an unsubscribe function.
+     */
+    onTrackChange: (callback: (state: PlayerState) => void) => () => void
+    /**
+     * Subscribe to play-state events. The callback fires whenever playback
+     * starts or pauses. Returns an unsubscribe function.
+     */
+    onPlayStateChange: (callback: (state: PlayerState) => void) => () => void
   }
 
   /**

--- a/project/wiki/Extension-Developer-Guide.md
+++ b/project/wiki/Extension-Developer-Guide.md
@@ -233,6 +233,63 @@ Throws if the kamp server is unreachable. Wrap in `try/catch` and degrade gracef
 
 ---
 
+##### `api.player.onTrackChange(callback)`
+
+Subscribe to track-change events. The callback fires whenever the current track transitions: a new track starts playing, the queue is exhausted, or playback stops.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `callback` | `(state: PlayerState) => void` | Called with the full player state at the moment of the transition. |
+
+**Returns:** `() => void` — an unsubscribe function. Call it from your `render` cleanup to avoid memory leaks.
+
+```js
+render(container) {
+  // ...
+
+  const unsub = api.player.onTrackChange((state) => {
+    const track = state.current_track
+    if (track) {
+      container.querySelector('#now-playing').textContent =
+        `${track.artist} — ${track.title}`
+    }
+  })
+
+  // Seed with current state on first mount.
+  api.player.getState().then((state) => { /* same update */ }).catch(() => {})
+
+  return () => unsub()  // cancel subscription on unmount
+}
+```
+
+> **Tip:** Always call `api.player.getState()` once on mount to initialize your UI with the current state, then use `onTrackChange` for subsequent updates. Push events are only sent on *transitions* — the initial state is not replayed when a new subscriber registers.
+
+---
+
+##### `api.player.onPlayStateChange(callback)`
+
+Subscribe to play/pause state changes. The callback fires whenever playback starts or pauses.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `callback` | `(state: PlayerState) => void` | Called with the full player state at the moment of the change. |
+
+**Returns:** `() => void` — an unsubscribe function.
+
+```js
+render(container) {
+  const indicator = container.querySelector('#play-indicator')
+
+  const unsub = api.player.onPlayStateChange((state) => {
+    indicator.textContent = state.playing ? '▶' : '⏸'
+  })
+
+  return () => unsub()
+}
+```
+
+---
+
 #### `api.library` — requires `"library.read"`
 
 ##### `api.library.getAlbumArtUrl(albumArtist, album)`

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -716,6 +716,39 @@ class TestMpvPlaybackEngine:
         )
         assert engine.state.playing is False
 
+    def test_on_play_state_changed_fires_when_pause_flips(self) -> None:
+        engine, _ = _make_engine()
+        callback = MagicMock()
+        engine.on_play_state_changed = callback
+        # Start paused (default), then unpause.
+        engine._handle_event(
+            {"event": "property-change", "name": "pause", "data": False}
+        )
+        callback.assert_called_once()
+
+    def test_on_play_state_changed_not_fired_when_pause_unchanged(self) -> None:
+        """Callback must not fire when the pause state does not actually change."""
+        engine, _ = _make_engine()
+        callback = MagicMock()
+        engine.on_play_state_changed = callback
+        # Initial state is playing=False (paused). Sending pause=True is a no-op.
+        engine._handle_event(
+            {"event": "property-change", "name": "pause", "data": True}
+        )
+        callback.assert_not_called()
+
+    def test_on_play_state_changed_fires_on_each_flip(self) -> None:
+        engine, _ = _make_engine()
+        callback = MagicMock()
+        engine.on_play_state_changed = callback
+        engine._handle_event(
+            {"event": "property-change", "name": "pause", "data": False}
+        )  # paused→playing
+        engine._handle_event(
+            {"event": "property-change", "name": "pause", "data": True}
+        )  # playing→paused
+        assert callback.call_count == 2
+
     def test_initial_state(self) -> None:
         engine, _ = _make_engine()
         assert engine.state == PlaybackState(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -666,6 +666,73 @@ class TestPlayerWebSocket:
         assert msg["playing"] is True
         assert msg["position"] == pytest.approx(5.0)
 
+    def test_websocket_push_track_changed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """notify_track_changed() proactively pushes a track.changed message."""
+        mock_engine.state = PlaybackState()
+        mock_queue.current.return_value = _track(1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # consume initial player.state
+            mock_queue.current.return_value = _track(2)
+            app.state.notify_track_changed()
+            msg = ws.receive_json()
+        assert msg["type"] == "track.changed"
+        assert msg["current_track"]["title"] == "Track 2"
+
+    def test_websocket_push_play_state_changed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """notify_play_state_changed() proactively pushes a play_state.changed message."""
+        mock_engine.state = PlaybackState(playing=False)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # consume initial player.state
+            mock_engine.state = PlaybackState(playing=True)
+            app.state.notify_play_state_changed()
+            msg = ws.receive_json()
+        assert msg["type"] == "play_state.changed"
+        assert msg["playing"] is True
+
+    def test_websocket_engine_on_play_state_changed_wired(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """create_app wires engine.on_play_state_changed to the broadcast notifier."""
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        assert mock_engine.on_play_state_changed is not None
+        assert callable(mock_engine.on_play_state_changed)
+
+    def test_play_endpoint_fires_track_changed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """POST /api/v1/player/play broadcasts a track.changed event."""
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        mock_queue.current.return_value = _track(1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # consume initial player.state
+            c.post("/api/v1/player/play", json={"album_artist": "A", "album": "B"})
+            msg = ws.receive_json()
+        assert msg["type"] == "track.changed"
+
+    def test_next_endpoint_fires_track_changed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """POST /api/v1/player/next broadcasts a track.changed event."""
+        mock_queue.next.return_value = _track(2)
+        mock_queue.current.return_value = _track(2)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # consume initial player.state
+            c.post("/api/v1/player/next")
+            msg = ws.receive_json()
+        assert msg["type"] == "track.changed"
+
 
 # ---------------------------------------------------------------------------
 # Config: set library path


### PR DESCRIPTION
## Summary

- Server proactively pushes `track.changed` and `play_state.changed` WebSocket events on player state transitions — no ping required
- SDK gains `api.player.onTrackChange(cb)` and `api.player.onPlayStateChange(cb)` (both return an unsubscribe function)
- Sandboxed (community) extensions receive push events via `kamp:sdk-subscribe` / `kamp:sdk-event` postMessage
- Groover updated to use `onTrackChange` instead of polling every 2 s
- Extension Developer Guide documents the new subscription API
- `npm run shim-hash` added to `kamp_ui/package.json` to recompute the CSP hash when the sandbox shim changes

## How it works

**Server:** Each connected WebSocket gets an `asyncio.Queue`. The handler uses `asyncio.wait()` to race between client pings and push events. `track.changed` fires from the REST endpoints that transition tracks (play, next, prev, skip-to, stop) and from the `on_track_end` daemon callback. `play_state.changed` fires from a new `MpvPlaybackEngine.on_play_state_changed` callback wired in `create_app`.

**Preload:** A single lazily-created WebSocket fans push events out to all `onTrackChange` / `onPlayStateChange` subscribers. Reconnects automatically on close.

**Sandbox shim:** `subscribe(event, cb)` helper posts `kamp:sdk-subscribe` to the host; the host calls the real `KampAPI.player.on*` and forwards `kamp:sdk-event` back to the iframe. Unsubscribe posts `kamp:sdk-unsubscribe`.

## Test plan

- [x] `tests/test_playback.py` — `on_play_state_changed` fires on flip, not on no-op, fires on each subsequent flip
- [x] `tests/test_server.py` — `notify_track_changed` / `notify_play_state_changed` push correct message type; `play` and `next` REST endpoints emit `track.changed`; engine callback wired correctly
- [x] All 182 existing tests continue to pass
- [x] mypy clean on changed Python files
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)