### PR TITLE
fix: prefer exact cover stem over substring matches in local artwork (TASK-89)

### DIFF
--- a/kamp_daemon/artwork.py
+++ b/kamp_daemon/artwork.py
@@ -96,8 +96,11 @@ def has_embedded_art(path: Path, min_dimension: int, max_bytes: int) -> bool:
 def find_local_artwork(directory: Path) -> Path | None:
     """Return the best image file found directly in *directory*, or None.
 
-    Prefers filenames whose stem contains a recognised art keyword
-    (cover, folder, artwork, front) in that priority order.  Falls back to
+    Prefers filenames whose stem matches a recognised art keyword
+    (cover, folder, artwork, front) in that priority order.  Within each
+    keyword, an exact stem match (e.g. "cover.jpg") beats a substring match
+    (e.g. "_Back-Cover.jpg") so that the front cover is not displaced by a
+    back-cover file that happens to contain the same keyword.  Falls back to
     the alphabetically first image if no keyword matches.
     """
     candidates: list[Path] = []
@@ -106,6 +109,11 @@ def find_local_artwork(directory: Path) -> Path | None:
     if not candidates:
         return None
     for hint in _PREFERRED_ART_NAMES:
+        # Exact stem match first (cover.jpg before _Back-Cover.jpg).
+        for p in sorted(candidates):
+            if p.stem.lower() == hint:
+                return p
+        # Substring match as fallback within this hint.
         for p in sorted(candidates):
             if hint in p.stem.lower():
                 return p

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -388,6 +388,28 @@ class TestLocalArtwork:
         assert mock_get.called
 
 
+class TestFindLocalArtworkCoverPriority:
+    def test_exact_cover_stem_beats_back_cover(self, tmp_path: Path) -> None:
+        """cover.jpg is preferred over a file that merely contains 'cover' in its name."""
+        # _Back-Cover.jpg sorts before cover.jpg alphabetically, so a naive
+        # substring search returns the wrong file.
+        (tmp_path / "_Back-Cover.jpg").write_bytes(_make_jpeg(1200, 1200))
+        (tmp_path / "cover.jpg").write_bytes(_make_jpeg(1200, 1200))
+
+        result = find_local_artwork(tmp_path)
+        assert result is not None
+        assert result.name == "cover.jpg"
+
+    def test_exact_cover_stem_beats_front_cover(self, tmp_path: Path) -> None:
+        """cover.jpg wins over Front-Cover.jpg even though both match the hint."""
+        (tmp_path / "Front-Cover.jpg").write_bytes(_make_jpeg(1200, 1200))
+        (tmp_path / "cover.jpg").write_bytes(_make_jpeg(1200, 1200))
+
+        result = find_local_artwork(tmp_path)
+        assert result is not None
+        assert result.name == "cover.jpg"
+
+
 class TestFindLocalArtworkFallback:
     def test_returns_first_alphabetically_when_no_preferred_name(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

- `find_local_artwork` now checks for an exact stem match (e.g. `cover.jpg`) before falling back to substring matches (e.g. `_Back-Cover.jpg`) within each preferred keyword
- Previously, `_Back-Cover.jpg` beat `cover.jpg` because `_` sorts before `c` alphabetically, and the substring search returned the first sorted match

## Root cause

The old logic for each keyword hint:
```python
for p in sorted(candidates):
    if hint in p.stem.lower():   # "cover" in "_back-cover" → True → returned first
        return p
```
`_Back-Cover.jpg` sorts before `cover.jpg`, so the back cover was selected.

The fix adds an exact-stem pass before the substring pass:
```python
for p in sorted(candidates):
    if p.stem.lower() == hint:   # exact match first
        return p
for p in sorted(candidates):
    if hint in p.stem.lower():   # substring fallback
        return p
```

## Test plan

- [x] `test_exact_cover_stem_beats_back_cover` — reproduces the exact TAKAAT scenario
- [x] `test_exact_cover_stem_beats_front_cover` — catches `Front-Cover.jpg` variant
- [x] All 48 existing artwork tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)