### PR TITLE
feat: skip ID3 tags when MusicBrainz conflicts with existing file tags (TASK-88)

### DIFF
--- a/backlog/completed/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
+++ b/backlog/completed/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
@@ -16,6 +16,8 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
+**won't do**
+
 Subprocess isolation is implemented (syncer and pipeline both spawn via `multiprocessing.get_context("spawn")`) but the main process grows from ~35 MB to ~83 MB when sync starts and stays there after sync ends. An additional ~8 MB subprocess also lingers after sync completes.
 
 The subprocess workers themselves are not the resident cost — something in the parent or IPC setup is loading heavy modules or retaining allocations.

--- a/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
+++ b/backlog/tasks/task-30 - Investigate-main-process-inflates-~50-MB-when-Bandcamp-sync-starts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-30
 title: 'Investigate: main process inflates ~50 MB when Bandcamp sync starts'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-03-29 02:58'
-updated_date: '2026-04-03 04:36'
+updated_date: '2026-04-09 19:54'
 labels:
   - bug
   - performance

--- a/backlog/tasks/task-88 - auto-tagging-should-fall-back-to-existing-artist-album-tags.md
+++ b/backlog/tasks/task-88 - auto-tagging-should-fall-back-to-existing-artist-album-tags.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-88
 title: auto-tagging should fall back to existing artist/album tags
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-06 02:33'
+updated_date: '2026-04-09 19:44'
 labels: []
 milestone: m-6
 dependencies: []

--- a/backlog/tasks/task-89 - cover.jpg-.png-should-be-preferred-in-local-artwork-files.md
+++ b/backlog/tasks/task-89 - cover.jpg-.png-should-be-preferred-in-local-artwork-files.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-89
 title: cover.jpg/.png should be preferred in local artwork files
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-06 02:38'
+updated_date: '2026-04-09 19:43'
 labels: []
 milestone: m-6
 dependencies: []

--- a/backlog/tasks/task-96 - refactor-server-into-daemon.md
+++ b/backlog/tasks/task-96 - refactor-server-into-daemon.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-96
 title: refactor server into daemon
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-08 18:27'
-updated_date: '2026-04-09 17:44'
+updated_date: '2026-04-09 19:43'
 labels: []
 milestone: m-6
 dependencies: []

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -440,6 +440,8 @@ def create_app(
     _INT_CONFIG_KEYS = frozenset(
         {"artwork.min_dimension", "artwork.max_bytes", "bandcamp.poll_interval_minutes"}
     )
+    # Boolean config keys — stored as Python bool so JSON serialises as true/false.
+    _BOOL_CONFIG_KEYS = frozenset({"musicbrainz.trust-musicbrainz-when-tags-conflict"})
 
     @app.patch("/api/v1/config")
     def patch_config(req: ConfigPatchRequest) -> dict[str, Any]:
@@ -449,7 +451,12 @@ def create_app(
             except (KeyError, ValueError) as exc:
                 raise HTTPException(status_code=422, detail=str(exc)) from exc
         # Coerce to the correct Python type before caching in memory.
-        coerced: Any = int(req.value) if req.key in _INT_CONFIG_KEYS else req.value
+        if req.key in _INT_CONFIG_KEYS:
+            coerced: Any = int(req.value)
+        elif req.key in _BOOL_CONFIG_KEYS:
+            coerced = req.value.lower() == "true"
+        else:
+            coerced = req.value
         _state["config"][req.key] = coerced
         return {"ok": True}
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -767,6 +767,7 @@ def _cmd_daemon(
         "paths.staging": str(config.paths.staging),
         "paths.library": str(config.paths.library),
         "musicbrainz.contact": config.musicbrainz.contact,
+        "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
         "library.path_template": config.library.path_template,

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -37,6 +37,7 @@ library = "~/Music"
 
 [musicbrainz]
 contact = "user@example.com"  # Update with your contact email
+# trust-musicbrainz-when-tags-conflict = true  # set to false to skip ID3 tags on artist/album mismatch
 
 [artwork]
 min_dimension = 1000   # minimum width and height in pixels
@@ -60,6 +61,9 @@ class PathsConfig:
 @dataclass
 class MusicBrainzConfig:
     contact: str
+    # When False: if MB returns artist/album that differs from existing file tags,
+    # log a warning and skip writing ID3 tags (proceed to artwork only).
+    trust_musicbrainz_when_tags_conflict: bool = True
 
 
 @dataclass
@@ -259,7 +263,12 @@ class Config:
                 staging=Path(p["staging"]).expanduser(),
                 library=Path(p["library"]).expanduser(),
             ),
-            musicbrainz=MusicBrainzConfig(contact=mb["contact"]),
+            musicbrainz=MusicBrainzConfig(
+                contact=mb["contact"],
+                trust_musicbrainz_when_tags_conflict=bool(
+                    mb.get("trust-musicbrainz-when-tags-conflict", True)
+                ),
+            ),
             artwork=ArtworkConfig(
                 min_dimension=int(art["min_dimension"]),
                 max_bytes=int(art["max_bytes"]),
@@ -283,6 +292,7 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "paths.staging": str,
     "paths.library": str,
     "musicbrainz.contact": str,
+    "musicbrainz.trust-musicbrainz-when-tags-conflict": bool,
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,
     "library.path_template": str,
@@ -342,7 +352,11 @@ def config_set(path: Path, key: str, value: str) -> None:
         raise KeyError(f"Unknown config key {key!r}. Valid keys: {valid}")
 
     target_type = _CONFIG_KEY_TYPES[key]
-    if target_type == int:
+    if target_type == bool:
+        if value.lower() not in ("true", "false"):
+            raise ValueError(f"Key {key!r} requires true or false, got {value!r}")
+        toml_value = value.lower()  # unquoted TOML boolean
+    elif target_type == int:
         try:
             int_value = int(value)
         except ValueError:

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -19,7 +19,7 @@ from .config import Config
 from .ext.builtin.coverart import KampCoverArtArchive
 from .ext.builtin.musicbrainz import KampMusicBrainzTagger
 from .ext.context import KampGround, PlaybackSnapshot
-from .ext.types import ArtworkQuery, ArtworkResult
+from .ext.types import ArtworkQuery, ArtworkResult, TrackMetadata
 from .extractor import ExtractionError, extract, find_audio_files
 from .mover import MoveError, move_to_library
 from .tagger import (
@@ -138,20 +138,40 @@ def run(
                 tracks = [read_track_metadata_from_file(f) for f in audio_files]
                 tagger = KampMusicBrainzTagger(ctx)
                 enriched = tagger.tag_release(tracks)
-                total = len(audio_files)
-                for audio_file, track in zip(audio_files, enriched):
-                    write_tags_from_track_metadata(
-                        audio_file, track, total_tracks=total
+                if (
+                    not config.musicbrainz.trust_musicbrainz_when_tags_conflict
+                    and _mb_tags_conflict(tracks, enriched)
+                ):
+                    # MB returned different artist/album than the existing file
+                    # tags — likely a mis-match for a release not yet in the DB.
+                    # Keep the existing tags; proceed to artwork with no MBID.
+                    first = tracks[0] if tracks else None
+                    logger.warning(
+                        "MusicBrainz tags conflict with existing file tags "
+                        "(existing: %r / %r, MB: %r / %r) — skipping ID3 write",
+                        first.artist if first else "",
+                        first.album if first else "",
+                        enriched[0].artist if enriched else "",
+                        enriched[0].album if enriched else "",
                     )
+                    mbid = ""
+                    rg_mbid = ""
+                    title = first.album if first else directory.name
+                else:
+                    total = len(audio_files)
+                    for audio_file, track in zip(audio_files, enriched):
+                        write_tags_from_track_metadata(
+                            audio_file, track, total_tracks=total
+                        )
+                    # Use the first enriched track to carry release-level IDs forward.
+                    mbid = enriched[0].release_mbid if enriched else ""
+                    rg_mbid = enriched[0].release_group_mbid if enriched else ""
+                    title = enriched[0].album if enriched else directory.name
             except TaggingError as exc:
                 logger.error("Tagging failed: %s", exc)
                 _notify(notify_callback, "Tagging failed", path.name)
                 _quarantine(directory, config.paths.staging)
                 return
-            # Use the first enriched track to carry release-level IDs forward.
-            mbid = enriched[0].release_mbid if enriched else ""
-            rg_mbid = enriched[0].release_group_mbid if enriched else ""
-            title = enriched[0].album if enriched else directory.name
 
         # --- 3. Artwork -------------------------------------------------------
         # Always run: even if art is already embedded, a higher-quality image may
@@ -282,6 +302,31 @@ def _fetch_and_embed_via_extension(
     )
     for audio_file in audio_files:
         _embed(audio_file, image_bytes)
+
+
+def _mb_tags_conflict(
+    original: list[TrackMetadata],
+    enriched: list[TrackMetadata],
+) -> bool:
+    """Return True if MB-enriched artist or album differs from existing file tags.
+
+    Only flags a conflict when the file already has non-empty artist/album tags
+    — files with no tags at all can't conflict, only be filled in.
+    Comparison is case-insensitive and whitespace-normalised.
+    """
+    if not original or not enriched:
+        return False
+    orig = original[0]
+    enr = enriched[0]
+
+    def _norm(s: str) -> str:
+        return s.strip().lower()
+
+    if orig.artist and enr.artist and _norm(orig.artist) != _norm(enr.artist):
+        return True
+    if orig.album and enr.album and _norm(orig.album) != _norm(enr.album):
+        return True
+    return False
 
 
 def _quarantine(item: Path, staging_root: Path) -> None:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -164,6 +164,7 @@ export type ConfigValues = {
   'paths.staging': string | null
   'paths.library': string | null
   'musicbrainz.contact': string | null
+  'musicbrainz.trust-musicbrainz-when-tags-conflict': boolean | null
   'artwork.min_dimension': number | null
   'artwork.max_bytes': number | null
   'library.path_template': string | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -224,6 +224,51 @@ function SelectRow({
   )
 }
 
+// A boolean toggle row for on/off config settings.
+function BoolRow({
+  label,
+  configKey,
+  hint,
+  initialValue,
+  onSave
+}: {
+  label: string
+  configKey: string
+  hint?: string
+  initialValue: boolean
+  onSave: (key: string, value: string) => Promise<void>
+}): React.JSX.Element {
+  const [checked, setChecked] = useState(initialValue)
+  const [saved, setSaved] = useState(false)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handleChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.checked
+      setChecked(value)
+      await onSave(configKey, String(value))
+      setSaved(true)
+      clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSaved(false), 1500)
+    },
+    [configKey, onSave]
+  )
+
+  return (
+    <div className="prefs-row">
+      <div className="prefs-row-header">
+        <span className="prefs-label">{label}</span>
+        <SavedCheck visible={saved} />
+        <label className="prefs-toggle" aria-label={label}>
+          <input type="checkbox" checked={checked} onChange={(e) => void handleChange(e)} />
+          <span className="prefs-toggle-track" />
+        </label>
+      </div>
+      {hint && <p className="prefs-hint">{hint}</p>}
+    </div>
+  )
+}
+
 // A textarea row (used for path_template).
 function TextareaRow({
   label,
@@ -949,6 +994,15 @@ export function PreferencesDialog({
                       type="email"
                       initialValue={str('musicbrainz.contact')}
                       hint="Sent in MusicBrainz User-Agent; required by their policy."
+                      onSave={handleSave}
+                    />
+                    <BoolRow
+                      label="Trust MusicBrainz when tags conflict"
+                      configKey="musicbrainz.trust-musicbrainz-when-tags-conflict"
+                      hint="When off, if MusicBrainz returns a different artist or album than the file's existing tags, the ID3 tags are left unchanged and only artwork is updated."
+                      initialValue={
+                        configValues?.['musicbrainz.trust-musicbrainz-when-tags-conflict'] ?? true
+                      }
                       onSave={handleSave}
                     />
                   </div>

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -21,7 +21,12 @@ from kamp_daemon.ext.builtin.musicbrainz import KampMusicBrainzTagger
 from kamp_daemon.ext.context import KampGround, PlaybackSnapshot
 from kamp_daemon.ext.types import ArtworkResult, TrackMetadata
 from kamp_daemon.mover import MoveError
-from kamp_daemon.pipeline_impl import _fetch_and_embed_via_extension, _quarantine, run
+from kamp_daemon.pipeline_impl import (
+    _fetch_and_embed_via_extension,
+    _mb_tags_conflict,
+    _quarantine,
+    run,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -464,6 +469,207 @@ class TestStageCallback:
             run(album_dir, config, stage_callback=calls.append)
 
         assert calls[-1] == ""
+
+
+# ---------------------------------------------------------------------------
+# _mb_tags_conflict
+# ---------------------------------------------------------------------------
+
+
+class TestMbTagsConflict:
+    """Unit tests for the _mb_tags_conflict helper."""
+
+    def _track(self, artist: str = "", album: str = "") -> TrackMetadata:
+        return TrackMetadata(
+            title="T",
+            artist=artist,
+            album=album,
+            album_artist=artist,
+            year="2024",
+            track_number=1,
+            mbid="",
+        )
+
+    def test_no_conflict_when_tags_match(self) -> None:
+        orig = [self._track(artist="Artist", album="Album")]
+        enr = [self._track(artist="Artist", album="Album")]
+        assert not _mb_tags_conflict(orig, enr)
+
+    def test_artist_mismatch_is_conflict(self) -> None:
+        orig = [self._track(artist="Real Artist", album="Album")]
+        enr = [self._track(artist="Wrong Artist", album="Album")]
+        assert _mb_tags_conflict(orig, enr)
+
+    def test_album_mismatch_is_conflict(self) -> None:
+        orig = [self._track(artist="Artist", album="Real Album")]
+        enr = [self._track(artist="Artist", album="Wrong Album")]
+        assert _mb_tags_conflict(orig, enr)
+
+    def test_comparison_is_case_insensitive(self) -> None:
+        orig = [self._track(artist="cool artist", album="great album")]
+        enr = [self._track(artist="Cool Artist", album="Great Album")]
+        assert not _mb_tags_conflict(orig, enr)
+
+    def test_no_conflict_when_original_artist_empty(self) -> None:
+        """Empty original tags can't conflict — MB is just filling them in."""
+        orig = [self._track(artist="", album="Album")]
+        enr = [self._track(artist="Any Artist", album="Album")]
+        assert not _mb_tags_conflict(orig, enr)
+
+    def test_no_conflict_when_original_album_empty(self) -> None:
+        orig = [self._track(artist="Artist", album="")]
+        enr = [self._track(artist="Artist", album="Any Album")]
+        assert not _mb_tags_conflict(orig, enr)
+
+    def test_no_conflict_on_empty_lists(self) -> None:
+        assert not _mb_tags_conflict([], [])
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz conflict fallback behaviour in pipeline run()
+# ---------------------------------------------------------------------------
+
+
+def _make_conflict_config(tmp_path: Path, trust: bool) -> Config:
+    return Config(
+        paths=PathsConfig(
+            staging=tmp_path / "staging",
+            library=tmp_path / "library",
+        ),
+        musicbrainz=MusicBrainzConfig(
+            contact="test@example.com",
+            trust_musicbrainz_when_tags_conflict=trust,
+        ),
+        artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
+        library=LibraryConfig(
+            path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+        ),
+    )
+
+
+def _make_mp3_with_tags(path: Path, artist: str, album: str) -> None:
+    """Write a fake MP3 with ID3 artist/album tags."""
+    path.write_bytes(b"\xff\xfb" * 64)
+    tags = id3.ID3()
+    tags["TPE1"] = id3.TPE1(encoding=3, text=artist)
+    tags["TALB"] = id3.TALB(encoding=3, text=album)
+    tags.save(str(path))
+
+
+MB_CONFLICTING_TRACKS = [
+    TrackMetadata(
+        title="MB Track",
+        artist="MB Artist",  # differs from file tags ("File Artist")
+        album="MB Album",  # differs from file tags ("File Album")
+        album_artist="MB Artist",
+        year="2024",
+        track_number=1,
+        mbid="rec-123",
+        release_mbid="rel-123",
+        release_group_mbid="rg-123",
+    )
+]
+
+
+class TestMbConflictFallback:
+    """When trust=False and MB returns mismatched tags, ID3 writes are skipped."""
+
+    def _setup_album(self, config: Config) -> tuple[Path, Path]:
+        config.paths.staging.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        album_dir = config.paths.staging / "file-album"
+        album_dir.mkdir()
+        mp3 = album_dir / "01.mp3"
+        _make_mp3_with_tags(mp3, artist="File Artist", album="File Album")
+        return album_dir, mp3
+
+    def test_skips_id3_write_on_conflict_when_not_trusted(self, tmp_path: Path) -> None:
+        """When trust=False and tags conflict, write_tags_from_track_metadata is not called."""
+        config = _make_conflict_config(tmp_path, trust=False)
+        album_dir, mp3 = self._setup_album(config)
+
+        with (
+            patch.object(
+                KampMusicBrainzTagger, "tag_release", return_value=MB_CONFLICTING_TRACKS
+            ),
+            patch(
+                "kamp_daemon.pipeline_impl.write_tags_from_track_metadata"
+            ) as mock_write,
+            patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
+            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[mp3]),
+        ):
+            run(album_dir, config)
+
+        mock_write.assert_not_called()
+
+    def test_artwork_still_runs_on_conflict_when_not_trusted(
+        self, tmp_path: Path
+    ) -> None:
+        """Artwork step always runs even when ID3 tags are skipped due to conflict."""
+        config = _make_conflict_config(tmp_path, trust=False)
+        album_dir, mp3 = self._setup_album(config)
+
+        with (
+            patch.object(
+                KampMusicBrainzTagger, "tag_release", return_value=MB_CONFLICTING_TRACKS
+            ),
+            patch("kamp_daemon.pipeline_impl.write_tags_from_track_metadata"),
+            patch(
+                "kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"
+            ) as mock_art,
+            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[mp3]),
+        ):
+            run(album_dir, config)
+
+        mock_art.assert_called_once()
+        # MBIDs must be empty — we don't trust the conflicting lookup result
+        call_kwargs = mock_art.call_args
+        assert call_kwargs.kwargs["release_mbid"] == ""
+        assert call_kwargs.kwargs["release_group_mbid"] == ""
+
+    def test_writes_id3_when_trusted_despite_conflict(self, tmp_path: Path) -> None:
+        """When trust=True (default), MB tags are written even if they differ."""
+        config = _make_conflict_config(tmp_path, trust=True)
+        album_dir, mp3 = self._setup_album(config)
+
+        with (
+            patch.object(
+                KampMusicBrainzTagger, "tag_release", return_value=MB_CONFLICTING_TRACKS
+            ),
+            patch(
+                "kamp_daemon.pipeline_impl.write_tags_from_track_metadata"
+            ) as mock_write,
+            patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
+            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[mp3]),
+        ):
+            run(album_dir, config)
+
+        mock_write.assert_called_once()
+
+    def test_writes_id3_when_no_conflict(self, tmp_path: Path) -> None:
+        """When tags agree with MB, ID3 is written normally even with trust=False."""
+        config = _make_conflict_config(tmp_path, trust=False)
+        config.paths.staging.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        album_dir = config.paths.staging / "mb-album"
+        album_dir.mkdir()
+        mp3 = album_dir / "01.mp3"
+        # File tags match the MB result
+        _make_mp3_with_tags(mp3, artist="MB Artist", album="MB Album")
+
+        with (
+            patch.object(
+                KampMusicBrainzTagger, "tag_release", return_value=MB_CONFLICTING_TRACKS
+            ),
+            patch(
+                "kamp_daemon.pipeline_impl.write_tags_from_track_metadata"
+            ) as mock_write,
+            patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
+            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[mp3]),
+        ):
+            run(album_dir, config)
+
+        mock_write.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `[musicbrainz] trust-musicbrainz-when-tags-conflict` config option (default `true`)
- When set to `false`: if MusicBrainz returns a different artist or album than the existing file tags, the pipeline logs a warning, skips writing ID3 tags, and proceeds to artwork-only — so the file lands in the library with its original correct tags
- Conflict detection is case-insensitive; only non-empty existing tags can conflict (files with no tags are filled in normally)
- Exposes the toggle in the Preferences dialog under the MusicBrainz section

## Test plan

- [x] `TestMbTagsConflict` — 7 unit tests for the conflict detection helper
- [x] `TestMbConflictFallback` — 4 integration tests: skip on conflict+trust=False, artwork still runs with empty MBIDs, write on trust=True, write when no conflict
- [x] All 968 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)