### PR TITLE
fix: x64ArchFiles for universal build with arm64-only PyInstaller bundle

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -65,7 +65,9 @@ jobs:
           echo "→ $(file kamp_ui/resources/mpv)"
 
       - name: Bundle Node.js + npm for extension installs
-        run: bash scripts/fetch_node.sh --arch arm64
+        # Universal binary (lipo arm64 + x64) so extension install works on
+        # both Apple Silicon and Intel Macs.
+        run: bash scripts/fetch_node.sh --arch universal
 
       - name: Install librsvg for SVG rendering
         run: brew install librsvg
@@ -99,7 +101,9 @@ jobs:
           # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           DEBUG: electron-builder
-        run: npm run build:mac
+        # --universal produces a single DMG containing a fat binary that runs
+        # natively on both Apple Silicon (arm64) and Intel (x64) Macs.
+        run: npm run build:mac -- --universal
         working-directory: kamp_ui
 
       - name: Verify DMG contents

--- a/kamp_ui/electron-builder.yml
+++ b/kamp_ui/electron-builder.yml
@@ -57,6 +57,11 @@ mac:
   target:
     - dmg
   entitlementsInherit: build/entitlements.mac.plist
+  # PyInstaller .so/.dylib files and mpv are arm64-only (built on the arm64 CI
+  # runner). @electron/universal sees them as "identical in both builds" and
+  # would error without this. x64ArchFiles tells the merger to pass them through
+  # as-is; Intel Macs run them transparently via Rosetta 2.
+  x64ArchFiles: "Contents/Resources/{kamp/**,mpv}"
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.

--- a/scripts/fetch_node.sh
+++ b/scripts/fetch_node.sh
@@ -8,7 +8,10 @@
 # libSystem, libc++) — safe to bundle in Kamp.app without additional dylibs.
 # Homebrew node links against Homebrew-specific dylibs and must NOT be used.
 #
-# Usage: bash scripts/fetch_node.sh [--version 20.18.3] [--arch arm64|x64]
+# Usage: bash scripts/fetch_node.sh [--version 20.18.3] [--arch arm64|x64|universal]
+#
+# --arch universal downloads both arm64 and x64 and lipo-merges the node binary
+# so the bundled node runs on both Apple Silicon and Intel Macs.
 
 set -euo pipefail
 
@@ -31,27 +34,50 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-TARBALL="node-v${NODE_VERSION}-darwin-${ARCH}.tar.gz"
-URL="https://nodejs.org/dist/v${NODE_VERSION}/${TARBALL}"
-STRIP_PREFIX="node-v${NODE_VERSION}-darwin-${ARCH}"
-TMPDIR=$(mktemp -d)
+fetch_arch() {
+  local arch="$1" tmpdir="$2"
+  local tarball="node-v${NODE_VERSION}-darwin-${arch}.tar.gz"
+  local strip_prefix="node-v${NODE_VERSION}-darwin-${arch}"
 
-echo "→ Downloading Node.js ${NODE_VERSION} (${ARCH}) from nodejs.org..."
-curl -fsSL --progress-bar "$URL" -o "$TMPDIR/$TARBALL"
+  echo "→ Downloading Node.js ${NODE_VERSION} (${arch}) from nodejs.org..."
+  curl -fsSL --progress-bar "https://nodejs.org/dist/v${NODE_VERSION}/${tarball}" \
+    -o "$tmpdir/$tarball"
 
-echo "→ Extracting node binary..."
-tar xzf "$TMPDIR/$TARBALL" -C "$TMPDIR" \
-  "${STRIP_PREFIX}/bin/node" \
-  "${STRIP_PREFIX}/lib/node_modules/npm"
+  echo "→ Extracting (${arch})..."
+  tar xzf "$tmpdir/$tarball" -C "$tmpdir" \
+    "${strip_prefix}/bin/node" \
+    "${strip_prefix}/lib/node_modules/npm"
+}
 
 mkdir -p kamp_ui/resources
-cp "$TMPDIR/${STRIP_PREFIX}/bin/node" kamp_ui/resources/node
-chmod +x kamp_ui/resources/node
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
 
-rm -rf kamp_ui/resources/npm
-cp -r "$TMPDIR/${STRIP_PREFIX}/lib/node_modules/npm" kamp_ui/resources/npm
+if [[ "$ARCH" == "universal" ]]; then
+  fetch_arch "arm64" "$TMPDIR"
+  fetch_arch "x64" "$TMPDIR"
 
-rm -rf "$TMPDIR"
+  echo "→ Creating universal node binary with lipo..."
+  lipo -create \
+    "$TMPDIR/node-v${NODE_VERSION}-darwin-arm64/bin/node" \
+    "$TMPDIR/node-v${NODE_VERSION}-darwin-x64/bin/node" \
+    -output kamp_ui/resources/node
+  chmod +x kamp_ui/resources/node
+
+  # npm is pure JS — both arch tarballs ship identical npm; use arm64's copy
+  rm -rf kamp_ui/resources/npm
+  cp -r "$TMPDIR/node-v${NODE_VERSION}-darwin-arm64/lib/node_modules/npm" \
+    kamp_ui/resources/npm
+else
+  fetch_arch "$ARCH" "$TMPDIR"
+
+  cp "$TMPDIR/node-v${NODE_VERSION}-darwin-${ARCH}/bin/node" kamp_ui/resources/node
+  chmod +x kamp_ui/resources/node
+
+  rm -rf kamp_ui/resources/npm
+  cp -r "$TMPDIR/node-v${NODE_VERSION}-darwin-${ARCH}/lib/node_modules/npm" \
+    kamp_ui/resources/npm
+fi
 
 echo "→ node: $(file kamp_ui/resources/node)"
 echo "→ npm-cli: kamp_ui/resources/npm/bin/npm-cli.js"


### PR DESCRIPTION
## Summary

Fixes the `@electron/universal` error when building a universal macOS app:

```
Detected file "Contents/Resources/kamp/_internal/...mypyc...darwin.so"
that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule
```

The PyInstaller bundle (`.so`/`.dylib` files) and `mpv` are arm64-only — they're built/fetched on the arm64 CI runner. When `electron-builder --universal` copies them into both the arm64 and x64 intermediate builds, `@electron/universal` sees identical Mach-O files in both slices and errors.

`x64ArchFiles: "Contents/Resources/{kamp/**,mpv}"` tells the merger to pass those files through as-is rather than attempting to lipo them. Intel Macs run them transparently via Rosetta 2.

## Test plan

- [ ] CI build completes without the x64ArchFiles error
- [ ] `file Kamp.app/Contents/MacOS/Kamp` reports universal binary
- [ ] App launches on Intel Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)