### PR TITLE
fix: remove contact email from config and fix post-ingest pipeline bugs (TASK-126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Bandcamp purchase
 ## Requirements
 
 - Python 3.11+
-- A [MusicBrainz](https://musicbrainz.org) contact email (required by their API policy — used only in the `User-Agent` header)
 - For Bandcamp auto-download: a Bandcamp account
 
 ### Python dependencies
@@ -112,9 +111,7 @@ staging = "~/Music/staging"   # drop ZIPs here; kamp watches this directory
 library = "~/Music"           # finished files land here
 
 [musicbrainz]
-app_name = "kamp"
-app_version = "0.1.0"
-contact = "you@example.com"   # required by MusicBrainz API policy
+# trust-musicbrainz-when-tags-conflict = true
 
 [artwork]
 min_dimension = 1000          # minimum cover art width and height in pixels
@@ -200,7 +197,6 @@ Open the Preferences dialog from **kamp → Preferences** in the macOS menu bar,
 ```bash
 kamp config show
 kamp config set paths.staging ~/Downloads/staging
-kamp config set musicbrainz.contact me@example.com
 kamp config set artwork.min_dimension 500
 ```
 

--- a/backlog/tasks/task-117 - build-intel-arm64-as-separate-binaries.md
+++ b/backlog/tasks/task-117 - build-intel-arm64-as-separate-binaries.md
@@ -4,7 +4,7 @@ title: build intel & arm64 as separate binaries
 status: Done
 assignee: []
 created_date: '2026-04-10 13:39'
-updated_date: '2026-04-12 22:03'
+updated_date: '2026-04-13 22:22'
 labels:
   - chore
   - ci
@@ -12,6 +12,7 @@ labels:
 milestone: m-9
 dependencies: []
 priority: medium
+ordinal: 3500
 ---
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-119 - Replace-Playwright-with-plain-HTTP-in-Bandcamp-sync.md
+++ b/backlog/tasks/task-119 - Replace-Playwright-with-plain-HTTP-in-Bandcamp-sync.md
@@ -4,11 +4,12 @@ title: Replace Playwright with plain HTTP in Bandcamp sync
 status: Done
 assignee: []
 created_date: '2026-04-12 22:35'
-updated_date: '2026-04-13 01:55'
+updated_date: '2026-04-13 22:22'
 labels: []
 milestone: m-9
 dependencies: []
 priority: high
+ordinal: 2500
 ---
 
 ## Description

--- a/backlog/tasks/task-126 - remove-contact-email-from-preferences-and-config.md
+++ b/backlog/tasks/task-126 - remove-contact-email-from-preferences-and-config.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-126
 title: remove 'contact email' from preferences and config
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 02:06'
-updated_date: '2026-04-13 16:34'
+updated_date: '2026-04-13 22:22'
 labels: []
 milestone: m-9
 dependencies: []
 priority: medium
+ordinal: 4500
 ---
 
 ## Description

--- a/backlog/tasks/task-126 - remove-contact-email-from-preferences-and-config.md
+++ b/backlog/tasks/task-126 - remove-contact-email-from-preferences-and-config.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-126
 title: remove 'contact email' from preferences and config
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-13 02:06'
-updated_date: '2026-04-13 02:10'
+updated_date: '2026-04-13 16:34'
 labels: []
 milestone: m-9
 dependencies: []

--- a/backlog/tasks/task-127 - Route-Bandcamp-HTTP-requests-through-Electrons-net-module-to-bypass-Cloudflare-TLS-fingerprinting.md
+++ b/backlog/tasks/task-127 - Route-Bandcamp-HTTP-requests-through-Electrons-net-module-to-bypass-Cloudflare-TLS-fingerprinting.md
@@ -3,10 +3,10 @@ id: TASK-127
 title: >-
   Route Bandcamp HTTP requests through Electron's net module to bypass
   Cloudflare TLS fingerprinting
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 11:17'
-updated_date: '2026-04-13 11:42'
+updated_date: '2026-04-13 22:22'
 labels:
   - bandcamp
   - electron
@@ -14,6 +14,7 @@ labels:
 milestone: m-9
 dependencies: []
 priority: high
+ordinal: 5500
 ---
 
 ## Description

--- a/backlog/tasks/task-50 - Spike-Bandcamp-download-link-scraping-without-full-Playwright-bundle.md
+++ b/backlog/tasks/task-50 - Spike-Bandcamp-download-link-scraping-without-full-Playwright-bundle.md
@@ -4,7 +4,7 @@ title: 'Spike: Bandcamp download link scraping without full Playwright bundle'
 status: Done
 assignee: []
 created_date: '2026-03-31 02:46'
-updated_date: '2026-04-13 01:55'
+updated_date: '2026-04-13 22:22'
 labels:
   - spike
   - bandcamp
@@ -12,6 +12,7 @@ labels:
 milestone: m-9
 dependencies: []
 priority: low
+ordinal: 1500
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -699,6 +699,25 @@ class LibraryIndex:
         ).fetchone()
         return row is not None
 
+    def mark_processed_by(self, extension_id: str, mb_recording_id: str) -> None:
+        """Record that *extension_id* has processed *mb_recording_id*.
+
+        Writes a sentinel audit log entry so that has_been_processed_by()
+        returns True and the post-scan invoker skips this track.  Used by
+        the pipeline to mark built-in extensions (MusicBrainz tagger,
+        Cover Art Archive) that run in-process during ingest — their results
+        would otherwise be redundantly re-fetched on every library re-scan.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO extension_audit_log
+                (extension_id, track_mbid, operation, old_value, new_value, timestamp)
+            VALUES (?, ?, 'pipeline', '{}', '{}', ?)
+            """,
+            (extension_id, mb_recording_id, _time.time()),
+        )
+        self._conn.commit()
+
     def audit_log_for(self, extension_id: str) -> list[dict[str, Any]]:
         """Return all audit log rows for *extension_id* in ascending order.
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -306,18 +306,19 @@ def main() -> None:
             # by Config.load(); print guidance and exit.
             print(
                 f"Config file created at {args.config}. "
-                "Edit it with your staging/library paths and contact email, "
+                "Edit it with your staging/library paths, "
                 "then re-run kamp.",
                 file=sys.stderr,
             )
             sys.exit(1)
 
-    # app_name and app_version are not user-configurable — hardcoded here so the
-    # User-Agent we send to MusicBrainz always accurately identifies the software.
+    # app_name, app_version, and contact are not user-configurable — hardcoded
+    # here so the User-Agent we send to MusicBrainz always accurately identifies
+    # the software and provides a stable contact address.
     musicbrainzngs.set_useragent(
         "kamp",
         _get_version(),
-        config.musicbrainz.contact,
+        "tedd.e.terry+kamp@gmail.com",
     )
 
     if command == "server":
@@ -456,7 +457,7 @@ def _cmd_test_notify(notify_type: str) -> None:
 
         cfg = Config(
             paths=PathsConfig(staging=staging, library=library),
-            musicbrainz=MusicBrainzConfig(contact="test@example.com"),
+            musicbrainz=MusicBrainzConfig(),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
             library=LibraryConfig(
                 path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -787,7 +788,6 @@ def _cmd_daemon(
     _config_values: dict[str, object] = {
         "paths.staging": str(config.paths.staging),
         "paths.library": str(config.paths.library),
-        "musicbrainz.contact": config.musicbrainz.contact,
         "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
@@ -849,6 +849,20 @@ def _cmd_daemon(
         # passed.  The invoker enforces the single-invocation guarantee via the
         # audit log so extensions never see the same track twice.
         if result.new_tracks:
+            # The built-in tagger and artwork source already ran in-process
+            # during the pipeline subprocess.  Mark them as processed for every
+            # new track so the post-scan invoker does not re-run them.
+            _BUILTIN_EXTENSION_IDS = (
+                "kamp_daemon.ext.builtin.musicbrainz.KampMusicBrainzTagger",
+                "kamp_daemon.ext.builtin.coverart.KampCoverArtArchive",
+            )
+            for track in result.new_tracks:
+                if track.mb_recording_id:
+                    for ext_id in _BUILTIN_EXTENSION_IDS:
+                        if not index.has_been_processed_by(
+                            ext_id, track.mb_recording_id
+                        ):
+                            index.mark_processed_by(ext_id, track.mb_recording_id)
             invoke_extensions_for_new_tracks(
                 _extension_registry, result.new_tracks, index
             )

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -36,7 +36,6 @@ staging = "~/Music/staging"
 library = "~/Music"
 
 [musicbrainz]
-contact = "user@example.com"  # Update with your contact email
 # trust-musicbrainz-when-tags-conflict = true  # set to false to skip ID3 tags on artist/album mismatch
 
 [artwork]
@@ -60,7 +59,6 @@ class PathsConfig:
 
 @dataclass
 class MusicBrainzConfig:
-    contact: str
     # When False: if MB returns artist/album that differs from existing file tags,
     # log a warning and skip writing ID3 tags (proceed to artwork only).
     trust_musicbrainz_when_tags_conflict: bool = True
@@ -141,14 +139,10 @@ class Config:
         library = Path(
             _prompt("Library directory (finished files land here)", "~/Music")
         ).expanduser()
-        contact = _prompt(
-            "Your email (sent in MusicBrainz User-Agent; required by their policy)",
-            "user@example.com",
-        )
 
         config = cls(
             paths=PathsConfig(staging=staging, library=library),
-            musicbrainz=MusicBrainzConfig(contact=contact),
+            musicbrainz=MusicBrainzConfig(),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
             library=LibraryConfig(
                 path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -160,11 +154,9 @@ class Config:
         # retains its comments and familiar structure rather than being
         # machine-generated.  Order matters: staging is a prefix of library, so
         # replace the longer string first.
-        toml_content = (
-            DEFAULT_CONFIG_CONTENT.replace('"~/Music/staging"', f'"{staging}"')
-            .replace('"~/Music"', f'"{library}"')
-            .replace('"user@example.com"', f'"{contact}"')
-        )
+        toml_content = DEFAULT_CONFIG_CONTENT.replace(
+            '"~/Music/staging"', f'"{staging}"'
+        ).replace('"~/Music"', f'"{library}"')
         path.write_text(toml_content)
         print(f"\nConfiguration saved to {path}\n")
         return config
@@ -220,7 +212,7 @@ class Config:
             path.write_text(DEFAULT_CONFIG_CONTENT)
             raise FileNotFoundError(
                 f"Config file created at {path}. "
-                "Please edit it with your staging/library paths and contact email, "
+                "Please edit it with your staging/library paths, "
                 "then re-run kamp."
             )
 
@@ -264,7 +256,6 @@ class Config:
                 library=Path(p["library"]).expanduser(),
             ),
             musicbrainz=MusicBrainzConfig(
-                contact=mb["contact"],
                 trust_musicbrainz_when_tags_conflict=bool(
                     mb.get("trust-musicbrainz-when-tags-conflict", True)
                 ),
@@ -291,7 +282,6 @@ class Config:
 _CONFIG_KEY_TYPES: dict[str, type] = {
     "paths.staging": str,
     "paths.library": str,
-    "musicbrainz.contact": str,
     "musicbrainz.trust-musicbrainz-when-tags-conflict": bool,
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,

--- a/kamp_daemon/ext/sandbox/_macos.py
+++ b/kamp_daemon/ext/sandbox/_macos.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import ctypes
 import logging
 import sys
+import sysconfig
 from collections.abc import Callable
 from pathlib import Path
 
@@ -56,6 +57,10 @@ _MINIMAL_PROFILE_TEMPLATE = """\
 
 ;; Python venv and standard library (dynamic imports after sandbox_init)
 (allow file-read* (subpath "{venv}"))
+;; Python stdlib — may be outside the venv (e.g. pyenv, system Python)
+(allow file-read* (subpath "{stdlib}"))
+;; kamp_daemon package (may be outside venv in editable/dev installs)
+(allow file-read* (subpath "{kamp_pkg}"))
 (allow file-read* (subpath "/usr/lib"))
 (allow file-read* (subpath "/usr/local/lib"))
 (allow file-read* (subpath "/opt/homebrew"))
@@ -93,12 +98,11 @@ _MINIMAL_PROFILE_TEMPLATE = """\
 ;; Signals to self only
 (allow signal (target self))
 
-;; Network: DNS (UDP 53) and outbound HTTPS/HTTP
+;; Network: allow all outbound.
 ;; Domain-level allow-listing is enforced by KampGround.fetch() at the API
-;; layer; the sandbox allows outbound TCP to prevent double-gating.
-(allow network-outbound (remote udp "*:53"))
-(allow network-outbound (remote tcp "*:80"))
-(allow network-outbound (remote tcp "*:443"))
+;; layer — the sandbox does not double-gate at the address/port level.
+;; Includes DNS (mDNSResponder Unix socket) and any ports libraries need.
+(allow network-outbound)
 
 ;; Deny subprocess execution — prevents extensions spawning child processes
 (deny process-exec*)
@@ -110,6 +114,10 @@ _SYNCER_PROFILE_TEMPLATE = """\
 
 ;; Python venv and standard library
 (allow file-read* (subpath "{venv}"))
+;; Python stdlib — may be outside the venv (e.g. pyenv, system Python)
+(allow file-read* (subpath "{stdlib}"))
+;; kamp_daemon package (may be outside venv in editable/dev installs)
+(allow file-read* (subpath "{kamp_pkg}"))
 (allow file-read* (subpath "/usr/lib"))
 (allow file-read* (subpath "/usr/local/lib"))
 (allow file-read* (subpath "/opt/homebrew"))
@@ -143,10 +151,8 @@ _SYNCER_PROFILE_TEMPLATE = """\
 (allow ipc-posix-shm)
 (allow signal (target self))
 
-;; Network (Bandcamp APIs + bcbits.com CDN + DNS)
-(allow network-outbound (remote udp "*:53"))
-(allow network-outbound (remote tcp "*:80"))
-(allow network-outbound (remote tcp "*:443"))
+;; Network: allow all outbound (see minimal profile for rationale).
+(allow network-outbound)
 
 ;; Writable paths: kamp state directory + temporary files
 ;; Staging path is not encoded in the profile — Playwright writes downloads
@@ -165,8 +171,13 @@ _SYNCER_PROFILE_TEMPLATE = """\
 """
 
 
-def _render(template: str, venv: str, home: str) -> str:
-    return template.replace("{venv}", venv).replace("{home}", home)
+def _render(template: str, venv: str, stdlib: str, home: str, kamp_pkg: str) -> str:
+    return (
+        template.replace("{venv}", venv)
+        .replace("{stdlib}", stdlib)
+        .replace("{home}", home)
+        .replace("{kamp_pkg}", kamp_pkg)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -217,12 +228,28 @@ def _apply_sandbox(profile: str) -> None:
 # they must be defined at module level — not as closures or lambdas.
 
 
+def _kamp_pkg_dir() -> str:
+    """Return the directory containing the kamp_daemon package.
+
+    In a normal (non-editable) install this is inside sys.prefix; in an
+    editable/dev install it is the project source tree.  Including it
+    explicitly ensures the sandbox allows lazy imports of kamp_daemon submodules
+    in both cases.
+    """
+    # __file__ is .../kamp_daemon/ext/sandbox/_macos.py
+    return str(Path(__file__).parent.parent.parent.parent)
+
+
 def _init_minimal() -> None:  # pragma: no cover
     """Process initializer: apply minimal sandbox profile."""
     profile = _render(
         _MINIMAL_PROFILE_TEMPLATE,
         venv=sys.prefix,
+        # sysconfig.get_path('stdlib') gives the real stdlib root regardless
+        # of whether Python is managed by pyenv, Homebrew, or the system.
+        stdlib=sysconfig.get_path("stdlib"),
         home=str(Path.home()),
+        kamp_pkg=_kamp_pkg_dir(),
     )
     _apply_sandbox(profile)
 
@@ -232,7 +259,9 @@ def _init_syncer() -> None:  # pragma: no cover
     profile = _render(
         _SYNCER_PROFILE_TEMPLATE,
         venv=sys.prefix,
+        stdlib=sysconfig.get_path("stdlib"),
         home=str(Path.home()),
+        kamp_pkg=_kamp_pkg_dir(),
     )
     _apply_sandbox(profile)
 

--- a/kamp_daemon/ext/worker.py
+++ b/kamp_daemon/ext/worker.py
@@ -36,6 +36,7 @@ def _extension_worker(
     ctx: KampGround,
     log_q: Any,
     result_q: Any,
+    initializer: Callable[[], None] | None = None,
 ) -> None:
     """Subprocess entry point: instantiate cls(ctx) and call method_name(*args).
 
@@ -45,7 +46,22 @@ def _extension_worker(
     Logging is forwarded to the parent via log_q.  The QueueHandler is removed
     in the finally block so that _drain_log_queue re-emission in tests does not
     loop back through the root logger's handler (same invariant as pipeline.py).
+
+    The sandbox initializer (if any) runs first, before extension code loads.
     """
+    if initializer is not None:
+        initializer()
+    # Spawn-mode subprocesses start with a clean interpreter — re-apply global
+    # state that was set in the parent.  See CLAUDE.md "Subprocess isolation".
+    import importlib.metadata
+
+    import musicbrainzngs
+
+    musicbrainzngs.set_useragent(
+        "kamp",
+        importlib.metadata.version("kamp"),
+        "tedd.e.terry+kamp@gmail.com",
+    )
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)
     queue_handler = logging.handlers.QueueHandler(log_q)
@@ -93,13 +109,12 @@ def _spawn_extension_worker(
     mp_ctx = multiprocessing.get_context("spawn")
     log_q: Any = mp_ctx.Queue()
     result_q: Any = mp_ctx.Queue()
-    proc = mp_ctx.Process(  # type: ignore[call-arg]
+    # Pass the sandbox initializer as a regular arg so the worker calls it
+    # before extension code loads.  multiprocessing.Process does not accept
+    # an initializer kwarg (unlike Pool); the initializer runs inside the child.
+    proc = mp_ctx.Process(
         target=_extension_worker,
-        args=(cls, method_name, args, ctx, log_q, result_q),
-        # initializer=None is explicitly supported by multiprocessing — no
-        # sandbox is applied when the platform is unsupported or the tier
-        # has no registered initializer for this platform.
-        initializer=initializer,
+        args=(cls, method_name, args, ctx, log_q, result_q, initializer),
     )
     proc.start()
     return proc, log_q, result_q

--- a/kamp_daemon/pipeline.py
+++ b/kamp_daemon/pipeline.py
@@ -67,7 +67,7 @@ def _pipeline_worker(
         musicbrainzngs.set_useragent(
             "kamp",
             importlib.metadata.version("kamp"),
-            config.musicbrainz.contact,
+            "tedd.e.terry+kamp@gmail.com",
         )
 
         run(

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -144,7 +144,8 @@ def run(
                 ):
                     # MB returned different artist/album than the existing file
                     # tags — likely a mis-match for a release not yet in the DB.
-                    # Keep the existing tags; proceed to artwork with no MBID.
+                    # Keep the existing ID3 tags but still use the MB MBID for
+                    # artwork: the MBID is valid even if the name strings differ.
                     first = tracks[0] if tracks else None
                     logger.warning(
                         "MusicBrainz tags conflict with existing file tags "
@@ -154,8 +155,8 @@ def run(
                         enriched[0].artist if enriched else "",
                         enriched[0].album if enriched else "",
                     )
-                    mbid = ""
-                    rg_mbid = ""
+                    mbid = enriched[0].release_mbid if enriched else ""
+                    rg_mbid = enriched[0].release_group_mbid if enriched else ""
                     title = first.album if first else directory.name
                 else:
                     total = len(audio_files)

--- a/kamp_daemon/tagger.py
+++ b/kamp_daemon/tagger.py
@@ -196,13 +196,17 @@ def read_track_metadata_from_file(path: Path) -> TrackMetadata:
             if audio.tags is not None:
                 t = audio.tags
                 art_v = t.get("\xa9ART")
-                artist = str(art_v[0]) if art_v else ""
+                # Fall back to sort-artist tag (soar) — some iTunes Store
+                # purchases omit ©ART and only ship sort-order atoms.
+                artist = str(art_v[0]) if art_v else str((t.get("soar") or [""])[0])
                 aar_v = t.get("aART")
                 album_artist = str(aar_v[0]) if aar_v else artist
                 alb_v = t.get("\xa9alb")
-                album = str(alb_v[0]) if alb_v else ""
+                # Fall back to sort-album tag (soal).
+                album = str(alb_v[0]) if alb_v else str((t.get("soal") or [""])[0])
                 nam_v = t.get("\xa9nam")
-                title = str(nam_v[0]) if nam_v else ""
+                # Fall back to sort-name tag (sonm).
+                title = str(nam_v[0]) if nam_v else str((t.get("sonm") or [""])[0])
                 day_v = t.get("\xa9day")
                 year = str(day_v[0])[:4] if day_v else ""
                 trkn_v = t.get("trkn")

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -17,7 +17,6 @@ const INT_KEYS = new Set([
 const RESTART_KEYS = new Set([
   'paths.staging',
   'paths.library',
-  'musicbrainz.contact',
   'bandcamp.poll_interval_minutes'
 ])
 
@@ -906,10 +905,7 @@ export function PreferencesDialog({
       if (value.trim() === '' || !Number.isInteger(n) || n < 0)
         throw new Error('Enter a whole number (0 or greater).')
     }
-    if (key === 'musicbrainz.contact') {
-      if (!value.includes('@') || value.trim() === '')
-        throw new Error('Enter a valid email address.')
-    }
+
     await setConfigValue(key, value)
   }
 
@@ -1033,14 +1029,6 @@ export function PreferencesDialog({
                   {/* MUSICBRAINZ */}
                   <div className="prefs-section">
                     <div className="prefs-section-label">MusicBrainz</div>
-                    <InputRow
-                      label="Contact email"
-                      configKey="musicbrainz.contact"
-                      type="email"
-                      initialValue={str('musicbrainz.contact')}
-                      hint="Sent in MusicBrainz User-Agent; required by their policy."
-                      onSave={handleSave}
-                    />
                     <BoolRow
                       label="Trust MusicBrainz when tags conflict"
                       configKey="musicbrainz.trust-musicbrainz-when-tags-conflict"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,22 +18,22 @@ class TestFirstRunSetup:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """first_run_setup writes a TOML file at the given path."""
-        inputs = iter(["~/staging", "~/music", "me@example.com"])
+        inputs = iter(["~/staging", "~/music"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
         path = tmp_path / "config.toml"
         Config.first_run_setup(path)
         assert path.exists()
-        assert "me@example.com" in path.read_text()
+        assert "staging" in path.read_text()
 
     def test_returns_config_with_user_values(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Returned Config reflects the prompted values."""
-        inputs = iter(["~/staging", "~/lib", "test@test.com"])
+        inputs = iter(["~/staging", "~/lib"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
         config = Config.first_run_setup(tmp_path / "config.toml")
-        assert config.musicbrainz.contact == "test@test.com"
         assert "staging" in str(config.paths.staging)
+        assert "lib" in str(config.paths.library)
 
     def test_blank_input_uses_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -41,7 +41,6 @@ class TestFirstRunSetup:
         """Pressing Enter at a prompt accepts the shown default."""
         monkeypatch.setattr("builtins.input", lambda _: "")
         config = Config.first_run_setup(tmp_path / "config.toml")
-        assert config.musicbrainz.contact == "user@example.com"
         assert config.paths.staging == Path("~/Music/staging").expanduser()
         assert config.paths.library == Path("~/Music").expanduser()
 
@@ -49,13 +48,13 @@ class TestFirstRunSetup:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The written TOML file can be loaded back by Config.load()."""
-        inputs = iter(["~/staging", "~/music", "me@example.com"])
+        inputs = iter(["~/staging", "~/music"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
         path = tmp_path / "config.toml"
         Config.first_run_setup(path)
         # Round-trip: load should succeed without error
         loaded = Config.load(path)
-        assert loaded.musicbrainz.contact == "me@example.com"
+        assert "staging" in str(loaded.paths.staging)
 
     def test_creates_parent_directories(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -71,9 +70,9 @@ def _base_config(tmp_path: Path) -> Path:
     """Write a minimal valid config (without [bandcamp]) and return its path."""
     path = tmp_path / "config.toml"
     path.write_text(
-        DEFAULT_CONFIG_CONTENT.replace('"~/Music/staging"', '"/staging"')
-        .replace('"~/Music"', '"/library"')
-        .replace('"user@example.com"', '"me@example.com"')
+        DEFAULT_CONFIG_CONTENT.replace('"~/Music/staging"', '"/staging"').replace(
+            '"~/Music"', '"/library"'
+        )
     )
     return path
 
@@ -184,9 +183,8 @@ class TestConfigSet:
     def test_set_string_key_updates_value(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "musicbrainz.contact", "new@example.com")
-        assert "new@example.com" in path.read_text()
-        assert "user@example.com" not in path.read_text()
+        config_set(path, "paths.staging", "~/new/staging")
+        assert "~/new/staging" in path.read_text()
 
     def test_set_int_key_updates_value(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
@@ -198,16 +196,15 @@ class TestConfigSet:
     def test_set_preserves_other_keys(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "musicbrainz.contact", "new@example.com")
+        config_set(path, "paths.staging", "~/new/staging")
         text = path.read_text()
-        assert "staging" in text
         assert "library" in text
         assert "path_template" in text
 
     def test_set_preserves_comments(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "musicbrainz.contact", "new@example.com")
+        config_set(path, "paths.staging", "~/new/staging")
         # Comments on other lines must survive
         assert "# Available variables" in path.read_text()
 
@@ -245,9 +242,9 @@ class TestConfigSet:
         """Config.load() succeeds and reflects the new value after config_set."""
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "musicbrainz.contact", "round@trip.com")
+        config_set(path, "paths.staging", "~/round/trip")
         loaded = Config.load(path)
-        assert loaded.musicbrainz.contact == "round@trip.com"
+        assert "round/trip" in str(loaded.paths.staging)
 
     def test_set_path_value_round_trips(self, tmp_path: Path) -> None:
         """A path set via config_set is written as a string and loaded back correctly."""
@@ -385,3 +382,12 @@ class TestLastfmConfig:
         path.write_text(_TOML_WITH_LASTFM)
         config_set(path, "lastfm.session_key", "newkey")
         assert 'session_key = "newkey"' in path.read_text()
+
+
+class TestLegacyConfig:
+    def test_load_succeeds_with_legacy_contact_key(self, tmp_path: Path) -> None:
+        """Existing config.toml files with musicbrainz.contact load without error."""
+        path = tmp_path / "config.toml"
+        path.write_text(_TOML_WITH_BANDCAMP)  # _TOML_WITH_BANDCAMP has contact = "..."
+        config = Config.load(path)
+        assert config.musicbrainz is not None

--- a/tests/test_extension_sandbox_common.py
+++ b/tests/test_extension_sandbox_common.py
@@ -154,10 +154,10 @@ class TestSpawnWorkerInitializer:
 
     def test_minimal_tier_passes_initializer(self) -> None:
         kwargs = self._capture_process_kwargs(_TaggerMinimal)
-        # On supported platforms the initializer is a callable; on unsupported
-        # platforms (Windows) it is None.  Both are valid values for the
-        # multiprocessing.Process `initializer` parameter.
-        initializer = kwargs.get("initializer")
+        # The initializer is passed as the last element of args (not a kwarg)
+        # because multiprocessing.Process does not support an `initializer`
+        # parameter — that is a Pool-only feature.
+        initializer = kwargs["args"][-1]
         if sys.platform in ("darwin", "linux"):
             assert callable(
                 initializer
@@ -167,7 +167,7 @@ class TestSpawnWorkerInitializer:
 
     def test_syncer_tier_passes_initializer(self) -> None:
         kwargs = self._capture_process_kwargs(_TaggerSyncer)
-        initializer = kwargs.get("initializer")
+        initializer = kwargs["args"][-1]
         if sys.platform in ("darwin", "linux"):
             # Syncer initializer must be a different callable from minimal.
             assert callable(initializer)
@@ -179,7 +179,7 @@ class TestSpawnWorkerInitializer:
             pytest.skip("initializers are None on unsupported platforms")
         kwargs_min = self._capture_process_kwargs(_TaggerMinimal)
         kwargs_syn = self._capture_process_kwargs(_TaggerSyncer)
-        assert kwargs_min["initializer"] is not kwargs_syn["initializer"]
+        assert kwargs_min["args"][-1] is not kwargs_syn["args"][-1]
 
     def test_class_without_sandbox_tier_defaults_to_minimal(self) -> None:
         """A class that doesn't declare _sandbox_tier gets TIER_MINIMAL."""
@@ -192,4 +192,4 @@ class TestSpawnWorkerInitializer:
         assert _NoTierTagger._sandbox_tier == TIER_MINIMAL
         kwargs = self._capture_process_kwargs(_NoTierTagger)
         if sys.platform in ("darwin", "linux"):
-            assert callable(kwargs.get("initializer"))
+            assert callable(kwargs["args"][-1])

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -45,7 +45,7 @@ _MOCK_TRACKS = [
 def _make_config(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -40,7 +40,7 @@ def config(tmp_path: Path) -> Config:
             staging=tmp_path / "staging",
             library=tmp_path / "library",
         ),
-        musicbrainz=MusicBrainzConfig(contact="test@example.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -537,7 +537,6 @@ def _make_conflict_config(tmp_path: Path, trust: bool) -> Config:
             library=tmp_path / "library",
         ),
         musicbrainz=MusicBrainzConfig(
-            contact="test@example.com",
             trust_musicbrainz_when_tags_conflict=trust,
         ),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
@@ -622,10 +621,11 @@ class TestMbConflictFallback:
             run(album_dir, config)
 
         mock_art.assert_called_once()
-        # MBIDs must be empty — we don't trust the conflicting lookup result
+        # MBIDs come from the enriched tracks even on conflict — artwork fetch
+        # needs a valid MBID; only ID3 tag writes are skipped.
         call_kwargs = mock_art.call_args
-        assert call_kwargs.kwargs["release_mbid"] == ""
-        assert call_kwargs.kwargs["release_group_mbid"] == ""
+        assert call_kwargs.kwargs["release_mbid"] == "rel-123"
+        assert call_kwargs.kwargs["release_group_mbid"] == "rg-123"
 
     def test_writes_id3_when_trusted_despite_conflict(self, tmp_path: Path) -> None:
         """When trust=True (default), MB tags are written even if they differ."""

--- a/tests/test_pipeline_subprocess.py
+++ b/tests/test_pipeline_subprocess.py
@@ -22,7 +22,7 @@ from kamp_daemon.pipeline import _DIR_SENTINEL, _handle_stage_msg, run_in_subpro
 def _make_config(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -137,7 +137,7 @@ class TestRunInSubprocess:
         mock_run.assert_called_once()
 
     def test_worker_calls_set_useragent(self, tmp_path: Path) -> None:
-        """_pipeline_worker calls musicbrainzngs.set_useragent with the config contact."""
+        """_pipeline_worker calls musicbrainzngs.set_useragent with the hardcoded contact."""
         with (
             patch("kamp_daemon.pipeline_impl.run"),
             patch("musicbrainzngs.set_useragent") as mock_ua,
@@ -147,7 +147,7 @@ class TestRunInSubprocess:
 
         mock_ua.assert_called_once()
         _, _, contact = mock_ua.call_args.args
-        assert contact == "t@t.com"
+        assert contact == "tedd.e.terry+kamp@gmail.com"
 
     def test_worker_exception_propagates(self, tmp_path: Path) -> None:
         """Exceptions raised in the worker are re-raised by run_in_subprocess()."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1061,7 +1061,6 @@ class TestFavoriteEndpoint:
 _SAMPLE_CONFIG_VALUES = {
     "paths.staging": "~/Music/staging",
     "paths.library": "~/Music",
-    "musicbrainz.contact": "user@example.com",
     "artwork.min_dimension": 1000,
     "artwork.max_bytes": 1000000,
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
@@ -1086,7 +1085,6 @@ class TestConfigEndpoints:
         data = response.json()
         assert data["paths.staging"] == "~/Music/staging"
         assert data["paths.library"] == "~/Music"
-        assert data["musicbrainz.contact"] == "user@example.com"
         assert data["artwork.min_dimension"] == 1000
         assert data["artwork.max_bytes"] == 1000000
         assert data["library.path_template"].startswith("{album_artist}")

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -22,7 +22,7 @@ from kamp_daemon.syncer import NeedsLoginError, Syncer, logout
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -39,7 +39,7 @@ def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
 def _make_config_no_bandcamp(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
-        musicbrainz=MusicBrainzConfig(contact="t@t.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -160,9 +160,9 @@ class TestReload:
         """reload() replaces the stored config."""
         syncer = Syncer(_make_config(tmp_path, poll_interval=0))
         new_config = _make_config(tmp_path, poll_interval=0)
-        new_config.musicbrainz.contact = "new@example.com"
+        new_config.musicbrainz.trust_musicbrainz_when_tags_conflict = False
         syncer.reload(new_config)
-        assert syncer._config.musicbrainz.contact == "new@example.com"
+        assert syncer._config.musicbrainz.trust_musicbrainz_when_tags_conflict is False
 
     def test_reload_changed_interval_no_existing_thread(self, tmp_path: Path) -> None:
         """reload() with interval change when no thread was running starts one."""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -35,7 +35,7 @@ def config(tmp_path: Path) -> Config:
             staging=tmp_path / "staging",
             library=tmp_path / "library",
         ),
-        musicbrainz=MusicBrainzConfig(contact="test@example.com"),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"


### PR DESCRIPTION
## Summary

- **TASK-126**: Remove `musicbrainz.contact` from config schema, Preferences UI, first-run wizard, README, and CLI help; hardcode `tedd.e.terry+kamp@gmail.com` in all `set_useragent()` calls
- **Artwork fix**: When MB tags conflict with file tags and ID3 write is skipped, preserve the release/release-group MBIDs so Cover Art Archive fetch gets a valid URL (was producing `https://coverartarchive.org/release/` → 400)
- **Extension worker fixes**: `multiprocessing.Process` doesn't accept `initializer` kwarg (Pool-only); moved sandbox initializer into worker args so it actually runs. Also call `set_useragent()` inside the worker (spawn subprocesses don't inherit parent state)
- **Sandbox profile fixes**: Add stdlib path via `sysconfig` (pyenv stdlib lives outside venv), add kamp_daemon package path for editable installs, broaden `network-outbound` to allow all outbound (macOS DNS goes via mDNSResponder Unix socket, not UDP 53)
- **Post-ingest re-tagging loop**: Built-in extensions already run in-process during the pipeline; add `mark_processed_by()` to `LibraryIndex` and pre-mark them in `_on_library_change` so the post-scan invoker doesn't re-run them on every library change
- **M4A tag fallback**: Some iTunes Store purchases omit `©ART`/`©alb`/`©nam` and only write sort-order atoms (`soar`/`soal`/`sonm`); fall back to those when primary tags are absent

## Test plan

- [x] `poetry run pytest --no-cov -q` — 1024 passed, 8 skipped
- [x] Drop a ZIP with MP3s into staging — pipeline runs, tracks appear in library, no re-tagging loop
- [x] Drop an iTunes Store M4A (sort-order-only tags) into staging — title/artist/album resolved correctly
- [x] Preferences dialog — MusicBrainz section shows only the conflict toggle, no contact email field

🤖 Generated with [Claude Code](https://claude.com/claude-code)