### PR TITLE
feat: add Services tab to Preferences (TASK-125)

### DIFF
--- a/backlog/tasks/task-118 - sync-doesnt-run-from-built-application.md
+++ b/backlog/tasks/task-118 - sync-doesnt-run-from-built-application.md
@@ -1,13 +1,15 @@
 ---
 id: TASK-118
 title: sync doesn't run from built application
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-12 22:10'
+updated_date: '2026-04-13 22:42'
 labels: []
 milestone: m-9
 dependencies: []
 priority: high
+ordinal: 7500
 ---
 
 ## Description
@@ -19,3 +21,10 @@ Traceback (most recent call last):
   File "kamp_daemon/ext/abc.py", line 87, in sync_once
 NotImplementedError
 <!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking 'Sync now' in the built .app does not raise NotImplementedError or log an unhandled error
+- [ ] #2 The frozen-app stub's sync_once() and mark_synced() return silently (no-op)
+- [ ] #3 Tests cover the stub behaviour in isolation
+<!-- AC:END -->

--- a/backlog/tasks/task-125 - move-musicbrainz-last.fm-and-bandcamp-session-features-to-Services-section-of-preferences.md
+++ b/backlog/tasks/task-125 - move-musicbrainz-last.fm-and-bandcamp-session-features-to-Services-section-of-preferences.md
@@ -3,14 +3,15 @@ id: TASK-125
 title: >-
   move musicbrainz, last.fm and bandcamp session features to 'Services' section
   of preferences
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 01:59'
-updated_date: '2026-04-13 22:28'
+updated_date: '2026-04-13 22:41'
 labels: []
 milestone: m-9
 dependencies: []
 priority: medium
+ordinal: 6500
 ---
 
 ## Description

--- a/backlog/tasks/task-125 - move-musicbrainz-last.fm-and-bandcamp-session-features-to-Services-section-of-preferences.md
+++ b/backlog/tasks/task-125 - move-musicbrainz-last.fm-and-bandcamp-session-features-to-Services-section-of-preferences.md
@@ -3,10 +3,10 @@ id: TASK-125
 title: >-
   move musicbrainz, last.fm and bandcamp session features to 'Services' section
   of preferences
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-13 01:59'
-updated_date: '2026-04-13 02:09'
+updated_date: '2026-04-13 22:28'
 labels: []
 milestone: m-9
 dependencies: []
@@ -28,10 +28,10 @@ The preferences page is getting long. Move MusicBrainz, Last.fm, and Bandcamp se
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A 'Services' tab exists between General and Extensions in Preferences
-- [ ] #2 Bandcamp, Last.fm, and MusicBrainz settings appear only under Services, not under General
-- [ ] #3 General tab is uncluttered (Paths + library settings only)
-- [ ] #4 No regression in save/load behaviour for any moved setting
+- [x] #1 A 'Services' tab exists between General and Extensions in Preferences
+- [x] #2 Bandcamp, Last.fm, and MusicBrainz settings appear only under Services, not under General
+- [x] #3 General tab is uncluttered (Paths + library settings only)
+- [x] #4 No regression in save/load behaviour for any moved setting
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -840,7 +840,7 @@ export function PreferencesDialog({
   const scanStatus = useStore((s) => s.scanStatus)
   const scanProgress = useStore((s) => s.scanProgress)
 
-  const [activeTab, setActiveTab] = useState<'general' | 'extensions'>('general')
+  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions'>('general')
   const [highlightExtId, setHighlightExtId] = useState<string | null>(null)
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -888,8 +888,8 @@ export function PreferencesDialog({
 
   if (!prefsOpen) return null
 
-  // Show a loading placeholder while config is being fetched (General tab only).
-  const generalLoading = configValues === null && activeTab === 'general'
+  // Show a loading placeholder while config is being fetched (General/Services tabs).
+  const configLoading = configValues === null && (activeTab === 'general' || activeTab === 'services')
 
   const hasBandcamp = configValues !== null && configValues['bandcamp.username'] !== null
 
@@ -932,6 +932,14 @@ export function PreferencesDialog({
           </button>
           <button
             role="tab"
+            aria-selected={activeTab === 'services'}
+            className={`prefs-tab${activeTab === 'services' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('services')}
+          >
+            Services
+          </button>
+          <button
+            role="tab"
             aria-selected={activeTab === 'extensions'}
             className={`prefs-tab${activeTab === 'extensions' ? ' prefs-tab--active' : ''}`}
             onClick={() => setActiveTab('extensions')}
@@ -944,7 +952,7 @@ export function PreferencesDialog({
         <div className="prefs-body" role="tabpanel">
           {activeTab === 'general' && (
             <>
-              {generalLoading ? null : (
+              {configLoading ? null : (
                 <>
                   {/* PATHS */}
                   <div className="prefs-section">
@@ -1025,21 +1033,15 @@ export function PreferencesDialog({
                       onSave={handleSave}
                     />
                   </div>
+                </>
+              )}
+            </>
+          )}
 
-                  {/* MUSICBRAINZ */}
-                  <div className="prefs-section">
-                    <div className="prefs-section-label">MusicBrainz</div>
-                    <BoolRow
-                      label="Trust MusicBrainz when tags conflict"
-                      configKey="musicbrainz.trust-musicbrainz-when-tags-conflict"
-                      hint="When off, if MusicBrainz returns a different artist or album than the file's existing tags, the ID3 tags are left unchanged and only artwork is updated."
-                      initialValue={
-                        configValues?.['musicbrainz.trust-musicbrainz-when-tags-conflict'] ?? true
-                      }
-                      onSave={handleSave}
-                    />
-                  </div>
-
+          {activeTab === 'services' && (
+            <>
+              {configLoading ? null : (
+                <>
                   {/* BANDCAMP — only when the section is configured */}
                   {hasBandcamp && (
                     <div className="prefs-section">
@@ -1076,6 +1078,20 @@ export function PreferencesDialog({
                     onConnected={() => void loadConfig()}
                     onDisconnected={() => void loadConfig()}
                   />
+
+                  {/* MUSICBRAINZ */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">MusicBrainz</div>
+                    <BoolRow
+                      label="Trust MusicBrainz when tags conflict"
+                      configKey="musicbrainz.trust-musicbrainz-when-tags-conflict"
+                      hint="When off, if MusicBrainz returns a different artist or album than the file's existing tags, the ID3 tags are left unchanged and only artwork is updated."
+                      initialValue={
+                        configValues?.['musicbrainz.trust-musicbrainz-when-tags-conflict'] ?? true
+                      }
+                      onSave={handleSave}
+                    />
+                  </div>
                 </>
               )}
             </>


### PR DESCRIPTION
## Summary

- Adds a **Services** tab between General and Extensions in the Preferences dialog
- Moves Bandcamp, Last.fm, and MusicBrainz settings out of General and into Services (in that order)
- General tab now contains only: Paths, Library, Artwork

## Test plan

- [x] Open Preferences → confirm three tabs: General, Services, Extensions
- [x] General tab shows only Paths, Library index, Library path template, and Artwork settings
- [x] Services tab shows Bandcamp (if configured), Last.fm, and MusicBrainz sections
- [x] Save/load behaviour unchanged for all moved settings (Bandcamp format, Last.fm connect/disconnect, MusicBrainz trust toggle)
- [x] Extensions tab unaffected

Closes TASK-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)