### PR TITLE
feat: rename staging folder to watch folder (TASK-124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Built with Python 3 by [Claude Sonnet 4.6](https://www.anthropic.com/claude).
 - **Bandcamp auto-download** — polls your Bandcamp collection for new purchases and downloads them automatically; authenticates via a one-time interactive browser login (no credentials stored)
 - **Automatic tagging** — looks up every release on [MusicBrainz](https://musicbrainz.org) and writes canonical tags (artist, album artist, album, year, track number, disc number, MusicBrainz IDs)
 - **Cover art** — fetches front cover art from the [MusicBrainz Cover Art Archive](https://coverartarchive.org), validates minimum dimensions (≥ 1000 × 1000 px) and maximum file size (≤ 1 MB), and embeds it in every track
-- **Filesystem watcher** — monitors your staging directory; drop a ZIP or folder in and it is processed automatically
+- **Filesystem watcher** — monitors your watch folder; drop a ZIP or folder in and it is processed automatically
 - **Configurable library layout** — moves finished files into your library using a template you control (`{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}`)
-- **Error quarantine** — failed items are moved to `staging/errors/` so nothing loops or blocks the queue
+- **Error quarantine** — failed items are moved to `<watch-folder>/errors/` so nothing loops or blocks the queue
 - **Error notifications** — macOS system notifications for pipeline failures (extraction, tagging, artwork, download) and Bandcamp sync failures
 - **macOS menu bar** — optional status-bar icon with pipeline Play/Stop toggle, on-demand Bandcamp sync, and a live sync status indicator with pulse animation
 - **Background service** — one command registers the daemon as a system service that starts at login (macOS launchd)
@@ -27,10 +27,10 @@ Built with Python 3 by [Claude Sonnet 4.6](https://www.anthropic.com/claude).
 Bandcamp purchase
        │
        ▼
-  [bandcamp.py] poll collection API → scrape download links → download ZIP → staging/
+  [bandcamp.py] poll collection API → scrape download links → download ZIP → watch folder/
        │
        ▼
-  [watcher.py] detects new ZIP or folder in staging/
+  [watcher.py] detects new ZIP or folder in watch folder/
        │
        ▼
   [extractor.py] unzip archive
@@ -107,7 +107,7 @@ Edit it before starting:
 
 ```toml
 [paths]
-staging = "~/Music/staging"   # drop ZIPs here; kamp watches this directory
+watch_folder = "~/Music/staging"   # drop ZIPs/folders here for automatic ingest
 library = "~/Music"           # finished files land here
 
 [musicbrainz]
@@ -141,12 +141,12 @@ kamp
 kamp daemon
 ```
 
-Watches the staging directory for new ZIPs and folders, and (if `[bandcamp]` is configured) polls Bandcamp for new purchases on the configured interval.
+Watches the watch folder for new ZIPs and folders, and (if `[bandcamp]` is configured) polls Bandcamp for new purchases on the configured interval.
 
 Override paths without editing the config:
 
 ```bash
-kamp daemon --staging ~/Downloads/staging --library ~/Music
+kamp daemon --watch-folder ~/Downloads/staging --library ~/Music
 ```
 
 ### macOS menu bar
@@ -196,7 +196,7 @@ Open the Preferences dialog from **kamp → Preferences** in the macOS menu bar,
 
 ```bash
 kamp config show
-kamp config set paths.staging ~/Downloads/staging
+kamp config set paths.watch_folder ~/Downloads/staging
 kamp config set artwork.min_dimension 500
 ```
 
@@ -224,7 +224,7 @@ Each command runs the real pipeline (or syncer) up to the named stage, injects a
 kamp sync
 ```
 
-Downloads any purchases not yet in your local state, places them in staging, and exits. The watcher (if running) picks them up automatically.
+Downloads any purchases not yet in your local state, places them in the watch folder, and exits. The watcher (if running) picks them up automatically.
 
 ### First sync behaviour
 
@@ -250,7 +250,7 @@ This also clears the sync state file, so the next sync will re-examine your full
 
 ### Manual ingest
 
-Drop any Bandcamp ZIP or already-extracted folder into your staging directory. The daemon processes it within a few seconds.
+Drop any Bandcamp ZIP or already-extracted folder into your watch folder. The daemon processes it within a few seconds.
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,7 +3,7 @@ Welcome to kamp!
 To get started, run:
    kamp
 
-On first run, you'll be asked for your staging directory, library directory,
+On first run, you'll be asked for your watch folder, library directory,
 and contact email (used in the MusicBrainz User-Agent). Press Enter at each
 prompt to accept the shown default. The config is saved automatically and the
 daemon starts right away.
@@ -11,7 +11,7 @@ daemon starts right away.
 Then install the service so it starts at login:
   kamp install-service
 
-Now move a zip or folder into your staging folder and kamp will take care of the rest!
+Now move a zip or folder into your watch folder and kamp will take care of the rest!
 
 To manage the service:
   kamp stop     # pause

--- a/backlog/tasks/task-124 - rebrand-staging-folder-as-watch-folder.md
+++ b/backlog/tasks/task-124 - rebrand-staging-folder-as-watch-folder.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-124
 title: rebrand "staging folder" as "watch folder"
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-13 01:54'
-updated_date: '2026-04-13 02:09'
+updated_date: '2026-04-13 23:02'
 labels: []
 milestone: m-9
 dependencies: []
@@ -26,9 +26,9 @@ Any user-visible mention of "staging folder" should be changed to "watch folder"
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All user-visible text says 'watch folder' not 'staging folder'
-- [ ] #2 Existing config.toml files with paths.staging continue to work without modification
-- [ ] #3 README updated
+- [x] #1 All user-visible text says 'watch folder' not 'staging folder'
+- [x] #2 Existing config.toml files with paths.staging continue to work without modification
+- [x] #3 README updated
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-124 - rebrand-staging-folder-as-watch-folder.md
+++ b/backlog/tasks/task-124 - rebrand-staging-folder-as-watch-folder.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-124
 title: rebrand "staging folder" as "watch folder"
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 01:54'
-updated_date: '2026-04-13 23:02'
+updated_date: '2026-04-13 23:33'
 labels: []
 milestone: m-9
 dependencies: []
 priority: medium
+ordinal: 8500
 ---
 
 ## Description

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -97,9 +97,9 @@ def main() -> None:
     # daemon subcommand (default) with pause/resume subcommands
     daemon_parser = subparsers.add_parser(
         "daemon",
-        help="Watch staging directory and (optionally) poll Bandcamp. Default when no subcommand given.",
+        help="Watch the watch folder and (optionally) poll Bandcamp. Default when no subcommand given.",
     )
-    daemon_parser.add_argument("--staging", metavar="DIR", type=Path, default=None)
+    daemon_parser.add_argument("--watch-folder", metavar="DIR", type=Path, default=None)
     daemon_parser.add_argument("--library", metavar="DIR", type=Path, default=None)
     daemon_parser.add_argument(
         "--no-menu-bar",
@@ -131,7 +131,7 @@ def main() -> None:
     # sync subcommand
     sync_parser = subparsers.add_parser(
         "sync",
-        help="One-shot: download any new Bandcamp purchases to staging, then exit.",
+        help="One-shot: download any new Bandcamp purchases to the watch folder, then exit.",
     )
     sync_parser.add_argument(
         "--download-all",
@@ -222,9 +222,9 @@ def main() -> None:
     config_sub.add_parser("show", help="Print current configuration.")
     set_parser = config_sub.add_parser(
         "set",
-        help="Set a config value. Keys use dot notation, e.g. paths.staging",
+        help="Set a config value. Keys use dot notation, e.g. paths.watch_folder",
     )
-    set_parser.add_argument("key", help="Dot-notation key (e.g. paths.staging)")
+    set_parser.add_argument("key", help="Dot-notation key (e.g. paths.watch_folder)")
     set_parser.add_argument("value", help="New value")
 
     args = parser.parse_args()
@@ -306,7 +306,7 @@ def main() -> None:
             # by Config.load(); print guidance and exit.
             print(
                 f"Config file created at {args.config}. "
-                "Edit it with your staging/library paths, "
+                "Edit it with your watch folder and library paths, "
                 "then re-run kamp.",
                 file=sys.stderr,
             )
@@ -344,8 +344,8 @@ def main() -> None:
             _cmd_daemon_signal(signal.SIGUSR2, "resume")
         else:
             # daemon (with optional CLI overrides)
-            if hasattr(args, "staging") and args.staging:
-                config.paths.staging = args.staging
+            if hasattr(args, "watch_folder") and args.watch_folder:
+                config.paths.watch_folder = args.watch_folder
             if hasattr(args, "library") and args.library:
                 config.paths.library = args.library
             _cmd_daemon(
@@ -413,7 +413,7 @@ def _cmd_test_notify(notify_type: str) -> None:
     """Run the pipeline (or syncer) to a specific failure point and fire a real notification.
 
     For pipeline types (extraction, tagging, artwork, move): creates a temporary
-    staging item whose name contains a test-injection marker, then runs the full
+    watch folder item whose name contains a test-injection marker, then runs the full
     run_in_subprocess() so the complete IPC path
     (pipeline_impl → stage_q → notification_callback) is exercised.
 
@@ -450,13 +450,13 @@ def _cmd_test_notify(notify_type: str) -> None:
 
     with _tmp.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         library = tmp_path / "library"
-        staging.mkdir()
+        watch_folder.mkdir()
         library.mkdir()
 
         cfg = Config(
-            paths=PathsConfig(staging=staging, library=library),
+            paths=PathsConfig(watch_folder=watch_folder, library=library),
             musicbrainz=MusicBrainzConfig(),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
             library=LibraryConfig(
@@ -464,7 +464,7 @@ def _cmd_test_notify(notify_type: str) -> None:
             ),
         )
 
-        item = staging / _TEST_INJECT[notify_type]
+        item = watch_folder / _TEST_INJECT[notify_type]
         item.mkdir()
 
         if notify_type in ("tagging", "artwork", "move"):
@@ -786,7 +786,7 @@ def _cmd_daemon(
     # Build the initial preference values dict from the loaded config.
     # Bandcamp and Last.fm fields are None when the section is absent.
     _config_values: dict[str, object] = {
-        "paths.staging": str(config.paths.staging),
+        "paths.watch_folder": str(config.paths.watch_folder),
         "paths.library": str(config.paths.library),
         "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
         "artwork.min_dimension": config.artwork.min_dimension,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -208,11 +208,11 @@ def mark_collection_synced(
 
 def sync_new_purchases(
     bc_config: BandcampConfig,
-    staging_dir: Path,
+    watch_dir: Path,
     state_file: Path,
     status_callback: Callable[[str], None] | None = None,
 ) -> list[Path]:
-    """Download any purchases not yet recorded in *state_file* to *staging_dir*.
+    """Download any purchases not yet recorded in *state_file* to *watch_dir*.
 
     Returns a list of paths to the downloaded ZIP files.
     """
@@ -236,7 +236,7 @@ def sync_new_purchases(
     new_item_ids = {item["sale_item_id"] for item in new_items}
     download_links = _get_download_links(bc_config.username, new_item_ids, session)
 
-    staging_dir.mkdir(parents=True, exist_ok=True)
+    watch_dir.mkdir(parents=True, exist_ok=True)
 
     downloaded: list[Path] = []
     for item in new_items:
@@ -256,7 +256,7 @@ def sync_new_purchases(
                 status_callback(
                     f"{item.get('item_title', '?')} by {item.get('band_name', '?')}"
                 )
-            path = _download_item(item, bc_config, staging_dir, session)
+            path = _download_item(item, bc_config, watch_dir, session)
             downloaded.append(path)
             state[str(item["sale_item_id"])] = time.time()
             _save_state(state_file, state)
@@ -616,7 +616,7 @@ def _get_cdn_url(redownload_url: str, fmt: str, session: _AnySession) -> str:
 def _download_item(
     item: dict[str, Any],
     bc_config: BandcampConfig,
-    staging_dir: Path,
+    watch_dir: Path,
     session: _AnySession,
 ) -> Path:
     band_name: str = item.get("band_name", "Unknown Artist")
@@ -631,7 +631,7 @@ def _download_item(
         )
 
     safe_name = re.sub(r'[<>:"/\\|?*]', "_", f"{band_name} - {item_title}")
-    dest = staging_dir / f"{safe_name}.zip"
+    dest = watch_dir / f"{safe_name}.zip"
 
     logger.info("Downloading %r by %r…", item_title, band_name)
     cdn_url = _get_cdn_url(redownload_url, bc_config.format, session)

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG_PATH = _default_config_path()
 
 DEFAULT_CONFIG_CONTENT = """\
 [paths]
-staging = "~/Music/staging"
+watch_folder = "~/Music/staging"   # drop ZIPs/folders here for automatic ingest
 library = "~/Music"
 
 [musicbrainz]
@@ -53,7 +53,7 @@ active_view = "library"  # "library" | "now-playing"
 
 @dataclass
 class PathsConfig:
-    staging: Path
+    watch_folder: Path
     library: Path
 
 
@@ -126,22 +126,22 @@ class Config:
         """Interactively collect key config values, write *path*, and return Config.
 
         Prompts for the three fields with no sensible universal default —
-        staging dir, library dir, and MusicBrainz contact email — then writes
+        watch folder, library dir, and MusicBrainz contact email — then writes
         the TOML file (substituting into DEFAULT_CONFIG_CONTENT to preserve
         comments and formatting) and returns the ready-to-use Config.
         """
         print("\nWelcome to kamp! Let's set up your configuration.")
         print(f"(Config will be saved to {path})\n")
 
-        staging = Path(
-            _prompt("Staging directory (drop ZIPs/folders here)", "~/Music/staging")
+        watch_folder = Path(
+            _prompt("Watch folder (drop ZIPs/folders here)", "~/Music/staging")
         ).expanduser()
         library = Path(
             _prompt("Library directory (finished files land here)", "~/Music")
         ).expanduser()
 
         config = cls(
-            paths=PathsConfig(staging=staging, library=library),
+            paths=PathsConfig(watch_folder=watch_folder, library=library),
             musicbrainz=MusicBrainzConfig(),
             artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
             library=LibraryConfig(
@@ -152,10 +152,11 @@ class Config:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Substitute user values into the canonical TOML template so the file
         # retains its comments and familiar structure rather than being
-        # machine-generated.  Order matters: staging is a prefix of library, so
-        # replace the longer string first.
+        # machine-generated.  Order matters: watch_folder default contains
+        # "staging" which is a substring of nothing else, but replace the longer
+        # path first to be safe.
         toml_content = DEFAULT_CONFIG_CONTENT.replace(
-            '"~/Music/staging"', f'"{staging}"'
+            '"~/Music/staging"', f'"{watch_folder}"'
         ).replace('"~/Music"', f'"{library}"')
         path.write_text(toml_content)
         print(f"\nConfiguration saved to {path}\n")
@@ -212,7 +213,7 @@ class Config:
             path.write_text(DEFAULT_CONFIG_CONTENT)
             raise FileNotFoundError(
                 f"Config file created at {path}. "
-                "Please edit it with your staging/library paths, "
+                "Please edit it with your watch folder and library paths, "
                 "then re-run kamp."
             )
 
@@ -220,6 +221,10 @@ class Config:
             raw = tomllib.load(f)
 
         p = raw["paths"]
+        # paths.staging is the legacy key name; migrate it transparently so
+        # existing config.toml files continue to work without modification.
+        if "watch_folder" not in p and "staging" in p:
+            p = {**p, "watch_folder": p["staging"]}
         mb = raw["musicbrainz"]
         art = raw["artwork"]
         lib = raw["library"]
@@ -252,7 +257,7 @@ class Config:
 
         return cls(
             paths=PathsConfig(
-                staging=Path(p["staging"]).expanduser(),
+                watch_folder=Path(p["watch_folder"]).expanduser(),
                 library=Path(p["library"]).expanduser(),
             ),
             musicbrainz=MusicBrainzConfig(
@@ -280,7 +285,7 @@ class Config:
 # Explicit allowlist of every settable key with its expected Python/TOML type.
 # Drives validation and type coercion in config_set(), and ordering in config_show().
 _CONFIG_KEY_TYPES: dict[str, type] = {
-    "paths.staging": str,
+    "paths.watch_folder": str,
     "paths.library": str,
     "musicbrainz.trust-musicbrainz-when-tags-conflict": bool,
     "artwork.min_dimension": int,
@@ -332,7 +337,7 @@ def config_show(path: Path) -> str:
 def config_set(path: Path, key: str, value: str) -> None:
     """Update a single key in the TOML config file.
 
-    *key* must be a dot-notation string like ``paths.staging`` or
+    *key* must be a dot-notation string like ``paths.watch_folder`` or
     ``artwork.min_dimension``.  *value* is always provided as a string and
     coerced to the appropriate type.  Raises KeyError for unknown or missing
     keys, ValueError for type mismatches.

--- a/kamp_daemon/ext/abc.py
+++ b/kamp_daemon/ext/abc.py
@@ -8,13 +8,13 @@ from .types import ArtworkQuery, ArtworkResult, TrackMetadata
 
 
 class BaseSyncer(ABC):
-    """Polls an external source and deposits new downloads into staging.
+    """Polls an external source and deposits new downloads into the watch folder.
 
     Implementations run in-process within the daemon — the extension host
     already provides process isolation, so a nested subprocess is not needed.
     Third-party syncers that cannot write to the filesystem directly should
     call ``ctx.stage(filename, content)`` to deposit files; the host writes
-    them to the staging directory.
+    them to the watch folder.
 
     Lifecycle
     ---------

--- a/kamp_daemon/ext/builtin/bandcamp.py
+++ b/kamp_daemon/ext/builtin/bandcamp.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class KampBandcampSyncer(BaseSyncer):
-    """Sync Bandcamp purchases to the staging directory.
+    """Sync Bandcamp purchases to the watch folder.
 
     Thin extension wrapper around ``kamp_daemon.syncer.Syncer``.  All public
     methods delegate to the inner syncer; this class exists to register the
@@ -49,7 +49,7 @@ class KampBandcampSyncer(BaseSyncer):
     alongside third-party extensions.
     """
 
-    # stage() deposits downloaded archives into the staging directory.
+    # stage() deposits downloaded archives into the watch folder.
     kampground_permissions = ["library.write"]
     # Needs filesystem writes (session/state files, /tmp) and subprocess spawn
     # (Playwright launches Chromium).  See project/sandbox-profiles.md.

--- a/kamp_daemon/ext/context.py
+++ b/kamp_daemon/ext/context.py
@@ -92,11 +92,11 @@ class SetArtworkMutation:
 
 @dataclass
 class StageMutation:
-    """A queued request to deposit a file in the staging directory.
+    """A queued request to deposit a file in the watch folder.
 
     Collected during extension execution (typically by a BaseSyncer) and
     applied by the host after the worker completes.  The host writes
-    ``content`` to ``staging_dir / filename``.  Extensions must not write
+    ``content`` to ``watch_folder / filename``.  Extensions must not write
     to the filesystem directly — use ``KampGround.stage()`` instead.
 
     Args:
@@ -315,9 +315,9 @@ class KampGround:
         self._pending_mutations.append(SetArtworkMutation(mbid=mbid, artwork=artwork))
 
     def stage(self, filename: str, content: bytes) -> None:
-        """Queue a file to be deposited in the staging directory by the host.
+        """Queue a file to be deposited in the watch folder by the host.
 
-        The host writes ``content`` to ``staging_dir / filename`` after the
+        The host writes ``content`` to ``watch_folder / filename`` after the
         extension completes.  Extensions (particularly ``BaseSyncer``
         implementations) must use this method rather than writing to the
         filesystem directly — doing so would couple the extension to a
@@ -326,7 +326,7 @@ class KampGround:
         Args:
             filename: Base filename for the staged file.  Must not contain
                 path separators (``/`` or ``\\``).  The host rejects names
-                that would escape the staging directory.
+                that would escape the watch folder.
             content: Raw bytes to write (e.g. a downloaded ZIP archive).
 
         Raises:

--- a/kamp_daemon/ext/sandbox/__init__.py
+++ b/kamp_daemon/ext/sandbox/__init__.py
@@ -17,9 +17,9 @@ Two profile tiers are defined:
 
 ``TIER_SYNCER``
     Intended for syncers (e.g. Bandcamp/Playwright) that legitimately need
-    to write to the staging directory, maintain state files, and spawn
-    Chromium subprocesses.  Filesystem writes are restricted to the staging
-    and state directories; subprocess spawning is permitted.
+    to write to the watch folder, maintain state files, and spawn
+    Chromium subprocesses.  Filesystem writes are restricted to the watch
+    folder and state directories; subprocess spawning is permitted.
 
 On platforms without sandbox support the initializer is None (no-op).
 The caller (worker.py) passes None directly to multiprocessing.Process —

--- a/kamp_daemon/ext/sandbox/_linux.py
+++ b/kamp_daemon/ext/sandbox/_linux.py
@@ -227,7 +227,7 @@ def _apply_landlock(allowed_write_paths: list[str]) -> None:
     """Restrict filesystem writes to *allowed_write_paths* via landlock.
 
     Paths not in the list will be read-only.  If a path does not exist it is
-    silently skipped (e.g. staging dir may not be created yet).
+    silently skipped (e.g. watch folder may not be created yet).
 
     Non-fatal: logs a warning and returns if any step fails.
     """
@@ -260,7 +260,7 @@ def _apply_landlock(allowed_write_paths: list[str]) -> None:
         for path_str in allowed_write_paths:
             path = Path(path_str)
             if not path.exists():
-                continue  # skip non-existent paths (e.g. staging not yet created)
+                continue  # skip non-existent paths (e.g. watch folder not yet created)
             try:
                 fd = os.open(str(path), _O_PATH | os.O_CLOEXEC)
             except OSError:

--- a/kamp_daemon/extractor.py
+++ b/kamp_daemon/extractor.py
@@ -1,4 +1,4 @@
-"""Extract ZIP archives and resolve already-extracted folders in the staging area."""
+"""Extract ZIP archives and resolve already-extracted folders from the watch folder."""
 
 from __future__ import annotations
 
@@ -39,7 +39,9 @@ def extract(path: Path) -> Path:
         return dest
 
     if not path.suffix.lower() == ".zip":
-        raise ExtractionError(f"Unsupported staging item (not a ZIP or folder): {path}")
+        raise ExtractionError(
+            f"Unsupported watch folder item (not a ZIP or folder): {path}"
+        )
 
     dest = path.parent / path.stem
     logger.info("Extracting %s → %s", path, dest)

--- a/kamp_daemon/mover.py
+++ b/kamp_daemon/mover.py
@@ -23,7 +23,7 @@ class MoveError(Exception):
 
 def move_to_library(
     audio_files: list[Path],
-    staging_dir: Path,
+    watch_dir: Path,
     library_root: Path,
     path_template: str,
 ) -> list[Path]:
@@ -48,7 +48,7 @@ def move_to_library(
     if errors:
         raise MoveError("Some files could not be moved:\n" + "\n".join(errors))
 
-    _cleanup_staging(staging_dir)
+    _cleanup_watch_folder(watch_dir)
     return destinations
 
 
@@ -181,10 +181,10 @@ def _make_vars(
     }
 
 
-def _cleanup_staging(staging_dir: Path) -> None:
-    """Remove the staging subdirectory and any remaining non-audio files."""
+def _cleanup_watch_folder(watch_dir: Path) -> None:
+    """Remove the watch folder item and any remaining non-audio files."""
     try:
-        shutil.rmtree(staging_dir)
-        logger.info("Removed staging directory %s", staging_dir)
+        shutil.rmtree(watch_dir)
+        logger.info("Removed watch folder item %s", watch_dir)
     except OSError:
-        logger.debug("Could not remove staging directory: %s", staging_dir)
+        logger.debug("Could not remove watch folder item: %s", watch_dir)

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -32,7 +32,7 @@ from .tagger import (
 
 logger = logging.getLogger(__name__)
 
-# Marker embedded in a staging item's name to inject a failure at a specific
+# Marker embedded in a watch folder item's name to inject a failure at a specific
 # pipeline stage.  Used exclusively by `kamp test-notify` so the full
 # IPC notification path (pipeline_impl → stage_q → notification_callback) can
 # be exercised without a real audio file or network access.
@@ -73,9 +73,9 @@ def run(
     stage_callback: Callable[[str], None] | None = None,
     notify_callback: Callable[[str], None] | None = None,
 ) -> None:
-    """Process a single staging item (ZIP or directory) end-to-end.
+    """Process a single watch folder item (ZIP or directory) end-to-end.
 
-    On per-step failure the item is moved to staging/errors/ so the watcher
+    On per-step failure the item is moved to <watch-folder>/errors/ so the watcher
     does not trigger on it again.  *stage_callback* (if provided) is called
     with the current stage name ("Extracting", "Tagging", etc.) and with an
     empty string in a finally block so the caller can always reset its display.
@@ -95,10 +95,10 @@ def run(
         except ExtractionError as exc:
             logger.error("Extraction failed: %s", exc)
             _notify(notify_callback, "Extraction failed", path.name)
-            _quarantine(path, config.paths.staging)
+            _quarantine(path, config.paths.watch_folder)
             return
 
-        # Notify the watcher of the staging directory as early as possible so it
+        # Notify the watcher of the watch folder directory as early as possible so it
         # can cancel any pending debounce timer for this directory.  Without this,
         # extracting a ZIP creates the directory, the watcher schedules it for a
         # second pipeline run, and that run races the first.
@@ -111,11 +111,11 @@ def run(
             _notify(
                 notify_callback, "Extraction failed", f"No audio files in {path.name}"
             )
-            _quarantine(directory, config.paths.staging)
+            _quarantine(directory, config.paths.watch_folder)
             return
 
         # Build a shared KampGround context for this pipeline invocation.
-        # library_tracks is empty because the pipeline acts on staging files
+        # library_tracks is empty because the pipeline acts on watch folder files
         # (not yet in the library); playback snapshot is a default.
         ctx = KampGround(playback=PlaybackSnapshot(), library_tracks=[])
 
@@ -171,7 +171,7 @@ def run(
             except TaggingError as exc:
                 logger.error("Tagging failed: %s", exc)
                 _notify(notify_callback, "Tagging failed", path.name)
-                _quarantine(directory, config.paths.staging)
+                _quarantine(directory, config.paths.watch_folder)
                 return
 
         # --- 3. Artwork -------------------------------------------------------
@@ -209,14 +209,14 @@ def run(
                 raise MoveError("Injected by test-notify --type move")
             destinations = move_to_library(
                 audio_files=audio_files,
-                staging_dir=directory,
+                watch_dir=directory,
                 library_root=config.paths.library,
                 path_template=config.library.path_template,
             )
         except MoveError as exc:
             logger.error("Move failed: %s", exc)
             _notify(notify_callback, "Move failed", path.name)
-            _quarantine(directory, config.paths.staging)
+            _quarantine(directory, config.paths.watch_folder)
             return
 
         logger.info(
@@ -253,7 +253,7 @@ def _fetch_and_embed_via_extension(
     image_bytes: bytes | None = None
     mime_type = "image/jpeg"
 
-    # Local-first: check for a bundled cover image in the staging directory.
+    # Local-first: check for a bundled cover image in the watch folder item directory.
     local = find_local_artwork(directory)
     if local is not None:
         image_bytes = _load_local_artwork(local, min_dimension, max_bytes)
@@ -330,9 +330,9 @@ def _mb_tags_conflict(
     return False
 
 
-def _quarantine(item: Path, staging_root: Path) -> None:
-    """Move *item* to staging/errors/ to prevent reprocessing."""
-    errors_dir = staging_root / "errors"
+def _quarantine(item: Path, watch_root: Path) -> None:
+    """Move *item* to <watch-folder>/errors/ to prevent reprocessing."""
+    errors_dir = watch_root / "errors"
     errors_dir.mkdir(exist_ok=True)
     dest = errors_dir / item.name
     try:

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def _sync_worker(
     bc_config: BandcampConfig,
-    staging_dir: Path,
+    watch_dir: Path,
     state_file: Path,
     status_q: Any,
     log_q: Any,
@@ -51,7 +51,7 @@ def _sync_worker(
 
         paths = sync_new_purchases(
             bc_config=bc_config,
-            staging_dir=staging_dir,
+            watch_dir=watch_dir,
             state_file=state_file,
             status_callback=lambda msg: status_q.put(msg),
         )
@@ -243,7 +243,7 @@ class Syncer:
 
         proc, status_q, log_q, result_q = _spawn_worker(
             _sync_worker,
-            (bc, self._config.paths.staging, state_file),
+            (bc, self._config.paths.watch_folder, state_file),
         )
 
         # Drain both queues while the subprocess runs.  log_q MUST be drained
@@ -286,7 +286,9 @@ class Syncer:
 
         paths = value or []
         if paths:
-            logger.info("Sync complete: %d file(s) downloaded to staging.", len(paths))
+            logger.info(
+                "Sync complete: %d file(s) downloaded to watch folder.", len(paths)
+            )
         else:
             logger.info("Sync complete: nothing new.")
         # Clear the status display in the menu bar (applies to both automatic

--- a/kamp_daemon/watcher.py
+++ b/kamp_daemon/watcher.py
@@ -1,4 +1,4 @@
-"""Filesystem watcher that triggers the ingest pipeline on new staging items."""
+"""Filesystem watcher that triggers the ingest pipeline on new items in the watch folder."""
 
 from __future__ import annotations
 
@@ -31,11 +31,11 @@ _SETTLE_SECONDS = 2.0  # wait for file to stop growing before processing
 _POLL_INTERVAL = 0.5  # how often to check file size during settle
 
 
-class _StagingHandler(FileSystemEventHandler):
+class _WatchHandler(FileSystemEventHandler):
     def __init__(self, config: Config) -> None:
         super().__init__()
         self._config = config
-        self._staging_root = config.paths.staging
+        self._watch_root = config.paths.watch_folder
         # Track paths being debounced: path → timer
         self._pending: dict[Path, threading.Timer] = {}
         # Track paths whose pipeline is currently running to prevent double-execution
@@ -61,18 +61,18 @@ class _StagingHandler(FileSystemEventHandler):
     def on_modified(self, event: FileSystemEvent) -> None:
         # FSEvents on macOS coalesces renames into DirModifiedEvent on the parent
         # directory rather than emitting DirCreatedEvent/DirMovedEvent for the new
-        # item. Scan staging root on every modification and schedule any item that
+        # item. Scan watch root on every modification and schedule any item that
         # has appeared and is not already pending.
         if not event.is_directory:
             return
-        if Path(str(event.src_path)) != self._staging_root:
+        if Path(str(event.src_path)) != self._watch_root:
             return
-        self._scan_staging_root()
+        self._scan_watch_root()
 
-    def _scan_staging_root(self) -> None:
-        """Schedule any directories or ZIPs in staging that are not already pending."""
+    def _scan_watch_root(self) -> None:
+        """Schedule any directories or ZIPs in the watch folder that are not already pending."""
         try:
-            children = list(self._staging_root.iterdir())
+            children = list(self._watch_root.iterdir())
         except OSError:
             return
         with self._lock:
@@ -90,11 +90,11 @@ class _StagingHandler(FileSystemEventHandler):
                 self._schedule(child)
 
     def on_moved(self, event: FileSystemMovedEvent) -> None:
-        # On macOS, dragging a folder/file into staging fires a moved event rather
-        # than a created event. Handle it the same way, but only for items whose
-        # destination is directly inside staging (not nested subdirectories).
+        # On macOS, dragging a folder/file into the watch folder fires a moved event
+        # rather than a created event. Handle it the same way, but only for items whose
+        # destination is directly inside the watch folder (not nested subdirectories).
         dest = Path(str(event.dest_path))
-        if dest.parent != self._staging_root:
+        if dest.parent != self._watch_root:
             return
         if event.is_directory and dest.name != "errors":
             self._schedule(dest)
@@ -180,12 +180,12 @@ def _wait_for_stable_size(path: Path, timeout: float = 60.0) -> None:
 
 
 class Watcher:
-    """Manage a watchdog observer watching the staging directory."""
+    """Manage a watchdog observer watching the watch folder."""
 
     def __init__(self, config: Config) -> None:
         self._config = config
         self._observer = Observer()
-        self._handler = _StagingHandler(config)
+        self._handler = _WatchHandler(config)
         self._paused = False
         self._stage_callback: Callable[[str], None] | None = None
         self._notification_callback: Callable[[str, str, str], None] | None = None
@@ -209,20 +209,20 @@ class Watcher:
         self._handler.notification_callback = cb
 
     def start(self) -> None:
-        staging = self._config.paths.staging
-        staging.mkdir(parents=True, exist_ok=True)
-        self._observer.schedule(self._handler, str(staging), recursive=False)
+        watch_folder = self._config.paths.watch_folder
+        watch_folder.mkdir(parents=True, exist_ok=True)
+        self._observer.schedule(self._handler, str(watch_folder), recursive=False)
         self._observer.start()
-        logger.info("Watching staging directory: %s", staging)
+        logger.info("Watching watch folder: %s", watch_folder)
         # Process any items already present when the daemon starts.
-        self._handler._scan_staging_root()
+        self._handler._scan_watch_root()
 
     def pause(self) -> None:
         """Stop pipeline processing without tearing down the daemon.
 
         Cancels pending debounce timers and stops the observer thread.
-        Items dropped into staging while paused are picked up on resume()
-        via _scan_staging_root().
+        Items dropped into the watch folder while paused are picked up on resume()
+        via _scan_watch_root().
         """
         if self._paused:
             return
@@ -240,14 +240,14 @@ class Watcher:
         if not self._paused:
             return
         self._paused = False
-        staging = self._config.paths.staging
+        watch_folder = self._config.paths.watch_folder
         self._observer = Observer()
-        self._handler = _StagingHandler(self._config)
+        self._handler = _WatchHandler(self._config)
         self._handler.stage_callback = self._stage_callback
         self._handler.notification_callback = self._notification_callback
-        self._observer.schedule(self._handler, str(staging), recursive=False)
+        self._observer.schedule(self._handler, str(watch_folder), recursive=False)
         self._observer.start()
-        self._handler._scan_staging_root()
+        self._handler._scan_watch_root()
         logger.info("Watcher resumed")
 
     def stop(self) -> None:
@@ -261,27 +261,29 @@ class Watcher:
         """Apply a new config live.
 
         Updates the handler's config so future pipeline runs see the new
-        settings.  If the staging path changed the observer is rescheduled to
-        the new directory immediately.
+        settings.  If the watch folder path changed the observer is rescheduled
+        to the new directory immediately.
         """
-        old_staging = self._config.paths.staging
+        old_watch_folder = self._config.paths.watch_folder
         self._config = config
         self._handler._config = config
 
-        if config.paths.staging != old_staging:
+        if config.paths.watch_folder != old_watch_folder:
             logger.info(
-                "Staging path changed (%s → %s); rescheduling observer.",
-                old_staging,
-                config.paths.staging,
+                "Watch folder changed (%s → %s); rescheduling observer.",
+                old_watch_folder,
+                config.paths.watch_folder,
             )
             self._observer.unschedule_all()
-            new_staging = config.paths.staging
-            new_staging.mkdir(parents=True, exist_ok=True)
-            self._handler = _StagingHandler(config)
+            new_watch_folder = config.paths.watch_folder
+            new_watch_folder.mkdir(parents=True, exist_ok=True)
+            self._handler = _WatchHandler(config)
             self._handler.stage_callback = self._stage_callback
             self._handler.notification_callback = self._notification_callback
-            self._observer.schedule(self._handler, str(new_staging), recursive=False)
-            self._handler._scan_staging_root()
+            self._observer.schedule(
+                self._handler, str(new_watch_folder), recursive=False
+            )
+            self._handler._scan_watch_root()
         else:
             logger.info("Watcher config reloaded.")
 
@@ -293,7 +295,7 @@ class Watcher:
 class _LibraryHandler(FileSystemEventHandler):
     """Debounced handler that fires a callback when audio files change in the library.
 
-    Unlike _StagingHandler (one timer per path), a single timer is sufficient
+    Unlike _WatchHandler (one timer per path), a single timer is sufficient
     here because LibraryScanner.scan() always does a full recursive walk; there
     is no benefit to tracking individual paths.
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -161,7 +161,7 @@ export type ScanProgress = { active: boolean; current: number; total: number }
 export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')
 
 export type ConfigValues = {
-  'paths.staging': string | null
+  'paths.watch_folder': string | null
   'paths.library': string | null
   'musicbrainz.contact': string | null
   'musicbrainz.trust-musicbrainz-when-tags-conflict': boolean | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -15,7 +15,7 @@ const INT_KEYS = new Set([
 
 // Keys that require a server restart to take effect.
 const RESTART_KEYS = new Set([
-  'paths.staging',
+  'paths.watch_folder',
   'paths.library',
   'bandcamp.poll_interval_minutes'
 ])
@@ -964,9 +964,9 @@ export function PreferencesDialog({
                       onSave={handleSave}
                     />
                     <PathRow
-                      label="Staging folder"
+                      label="Watch folder"
                       configKey="paths.staging"
-                      initialValue={str('paths.staging')}
+                      initialValue={str('paths.watch_folder')}
                       onSave={handleSave}
                     />
                     <div className="prefs-row">

--- a/project/sandbox-profiles.md
+++ b/project/sandbox-profiles.md
@@ -150,7 +150,7 @@ syncer isolation separately if needed.
 |------|--------|-------|
 | `~/.local/share/kamp/bandcamp_session.json` | read/write | Session cookies |
 | `~/.local/share/kamp/bandcamp_state.json` | read/write | Sync state (downloaded item IDs) |
-| Staging directory (`config.paths.staging`) | write | Downloaded ZIP/audio files |
+| Watch folder (`config.paths.watch_folder`) | write | Downloaded ZIP/audio files |
 | `/tmp` (system temp) | read/write | Playwright session files, download staging |
 | Chromium binary path (`~/.cache/ms-playwright/`) | read/execute | Playwright-managed Chromium |
 
@@ -169,7 +169,7 @@ managed by Playwright (path: `~/.cache/ms-playwright/chromium-*/chrome`).
 
 **TIER_SYNCER profile requirements:**
 - `process-exec*` allowed (macOS) / execve not blocked in seccomp (Linux)
-- Write access to `~/.local/share/kamp/`, `/tmp`, staging dir
+- Write access to `~/.local/share/kamp/`, `/tmp`, watch folder
 - Read/execute access to Playwright Chromium binary path
 
 ⚠️ The Chromium binary path is not currently encoded in the TIER_SYNCER
@@ -243,7 +243,7 @@ Profiles are in `kamp_daemon/ext/sandbox/_macos.py` as string templates.
 
 **Outstanding tightening** (post-profiling):
 - Add Chromium binary path to `file-read*` / `process-exec*`
-- Add staging directory as a writable path (requires runtime parameterisation)
+- Add watch folder as a writable path (requires runtime parameterisation)
 
 ---
 
@@ -299,7 +299,7 @@ older kernels.  CI runs on `ubuntu-latest` (kernel ≥ 6.x as of 2026).
 - [ ] Confirm landlock write restriction does not break PIL (image codec
       temp files?) for CoverArt fetcher
 - [ ] Add Playwright Chromium binary path to TIER_SYNCER landlock allow rules
-- [ ] Add staging directory to TIER_SYNCER landlock allow rules (runtime
+- [ ] Add watch folder to TIER_SYNCER landlock allow rules (runtime
       parameterisation needed)
 
 ---

--- a/project/wiki/Extension-Developer-Guide.md
+++ b/project/wiki/Extension-Developer-Guide.md
@@ -518,7 +518,7 @@ Return `ArtworkResult(image_bytes=..., mime_type="image/jpeg")` on success, or `
 
 #### `BaseSyncer`
 
-Polls an external source and deposits new downloads into the kamp staging directory. The host picks them up for ingest.
+Polls an external source and deposits new downloads into the kamp watch folder. The host picks them up for ingest.
 
 ```python
 class MySyncer(BaseSyncer):
@@ -594,7 +594,7 @@ ctx.update_metadata(track.mbid, {"title": "Alright", "year": "2015"})
 # Set artwork
 ctx.set_artwork(track.mbid, ArtworkResult(image_bytes=b"...", mime_type="image/jpeg"))
 
-# Deposit a file in the staging directory (syncers only)
+# Deposit a file in the watch folder (syncers only)
 ctx.stage("artist-album.zip", zip_bytes)
 ```
 
@@ -647,7 +647,7 @@ Backend extensions run in an OS-level sandboxed subprocess (macOS `sandbox_init`
 | Tier | Default for | Restrictions |
 |---|---|---|
 | `"minimal"` | Taggers, artwork sources | No filesystem writes outside `/dev`; no subprocess spawn; network allowed |
-| `"syncer"` | Syncers | Writes restricted to staging and state directories; subprocess spawn permitted |
+| `"syncer"` | Syncers | Writes restricted to watch folder and state directories; subprocess spawn permitted |
 
 ```python
 class MyTagger(BaseTagger):

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -437,7 +437,7 @@ class TestSyncNewPurchases:
         items: list[dict[str, Any]],
         state: dict[str, float] | None = None,
     ) -> list[Path]:
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         state_file = tmp_path / "state.json"
         session_file = _make_session_file(tmp_path)
         if state:
@@ -449,11 +449,11 @@ class TestSyncNewPurchases:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{item['sale_item_id']}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            path = watch_dir / f"{item['sale_item_id']}.zip"
             path.write_bytes(b"fake zip")
             return path
 
@@ -464,7 +464,7 @@ class TestSyncNewPurchases:
             ),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            return sync_new_purchases(config, staging, state_file)
+            return sync_new_purchases(config, watch_folder, state_file)
 
     def test_downloads_new_items(self, tmp_path: Path) -> None:
         items = [_item(1, "Artist A", "Album 1"), _item(2, "Artist B", "Album 2")]
@@ -487,7 +487,7 @@ class TestSyncNewPurchases:
 
     def test_state_updated_after_download(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
         items = [_item(99)]
@@ -496,11 +496,11 @@ class TestSyncNewPurchases:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{item['sale_item_id']}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            path = watch_dir / f"{item['sale_item_id']}.zip"
             path.write_bytes(b"fake")
             return path
 
@@ -511,13 +511,13 @@ class TestSyncNewPurchases:
             ),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            sync_new_purchases(config, staging, state_file)
+            sync_new_purchases(config, watch_folder, state_file)
 
         assert "99" in _load_state(state_file)
 
     def test_state_persists_across_calls(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
         call_num = 0
@@ -525,13 +525,13 @@ class TestSyncNewPurchases:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
             nonlocal call_num
             call_num += 1
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{item['sale_item_id']}_{call_num}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            path = watch_dir / f"{item['sale_item_id']}_{call_num}.zip"
             path.write_bytes(b"fake")
             return path
 
@@ -541,7 +541,7 @@ class TestSyncNewPurchases:
             patch("kamp_daemon.bandcamp._make_requests_session", return_value=mock1),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            sync_new_purchases(config, staging, state_file)
+            sync_new_purchases(config, watch_folder, state_file)
 
         mock2 = _make_requests_mock([_item(42)])
         with (
@@ -549,12 +549,12 @@ class TestSyncNewPurchases:
             patch("kamp_daemon.bandcamp._make_requests_session", return_value=mock2),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            paths = sync_new_purchases(config, staging, state_file)
+            paths = sync_new_purchases(config, watch_folder, state_file)
 
         assert paths == []
 
     def test_skips_failed_download_continues_others(self, tmp_path: Path) -> None:
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         state_file = tmp_path / "state.json"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
@@ -565,15 +565,15 @@ class TestSyncNewPurchases:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
             nonlocal call_num
             call_num += 1
             if call_num == 1:
                 raise BandcampAPIError("simulated failure")
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{item['sale_item_id']}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            path = watch_dir / f"{item['sale_item_id']}.zip"
             path.write_bytes(b"fake")
             return path
 
@@ -584,13 +584,13 @@ class TestSyncNewPurchases:
             ),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            paths = sync_new_purchases(config, staging, state_file)
+            paths = sync_new_purchases(config, watch_folder, state_file)
 
         assert len(paths) == 1
 
     def test_warns_when_item_not_on_collection_page(self, tmp_path: Path) -> None:
         """Items missing from the HTML scrape should be warned and skipped."""
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         state_file = tmp_path / "state.json"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
@@ -634,11 +634,11 @@ class TestSyncNewPurchases:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{item['sale_item_id']}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            path = watch_dir / f"{item['sale_item_id']}.zip"
             path.write_bytes(b"fake")
             return path
 
@@ -649,7 +649,7 @@ class TestSyncNewPurchases:
             ),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            paths = sync_new_purchases(config, staging, state_file)
+            paths = sync_new_purchases(config, watch_folder, state_file)
 
         assert len(paths) == 1  # only item 2 downloaded
 
@@ -702,7 +702,7 @@ class TestMarkCollectionSynced:
 
     def test_subsequent_sync_downloads_nothing(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
         items = [_item(1), _item(2)]
@@ -720,7 +720,7 @@ class TestMarkCollectionSynced:
             patch("kamp_daemon.bandcamp._make_requests_session", return_value=mock2),
             patch("kamp_daemon.bandcamp._download_item"),
         ):
-            paths = sync_new_purchases(config, staging, state_file)
+            paths = sync_new_purchases(config, watch_folder, state_file)
 
         assert paths == []
 
@@ -739,9 +739,7 @@ class TestNeedsLoginError:
             ),
         ):
             with pytest.raises(NeedsLoginError):
-                sync_new_purchases(
-                    config, tmp_path / "staging", tmp_path / "state.json"
-                )
+                sync_new_purchases(config, tmp_path / "watch", tmp_path / "state.json")
 
     def test_raised_when_session_expired(self, tmp_path: Path) -> None:
         config = _bc_config(tmp_path)
@@ -755,9 +753,7 @@ class TestNeedsLoginError:
         )
         with patch("kamp_daemon.bandcamp._session_file", return_value=sf):
             with pytest.raises(NeedsLoginError):
-                sync_new_purchases(
-                    config, tmp_path / "staging", tmp_path / "state.json"
-                )
+                sync_new_purchases(config, tmp_path / "watch", tmp_path / "state.json")
 
 
 # ---------------------------------------------------------------------------
@@ -1019,9 +1015,9 @@ class TestFetchCollection:
 
 
 class TestDownloadItem:
-    def test_downloads_to_staging_dir(self, tmp_path: Path) -> None:
-        staging = tmp_path / "staging"
-        staging.mkdir()
+    def test_downloads_to_watch_dir(self, tmp_path: Path) -> None:
+        watch_folder = tmp_path / "watch"
+        watch_folder.mkdir()
         config = _bc_config(tmp_path)
         item = {
             "sale_item_id": 42,
@@ -1037,14 +1033,14 @@ class TestDownloadItem:
                 "kamp_daemon.bandcamp._download_file",
                 side_effect=lambda url, dest, sess: dest.write_bytes(b"fake"),
             ):
-                path = _download_item(item, config, staging, session)
+                path = _download_item(item, config, watch_folder, session)
 
         assert path.suffix == ".zip"
-        assert path.parent == staging
+        assert path.parent == watch_folder
 
     def test_raises_when_no_redownload_url(self, tmp_path: Path) -> None:
-        staging = tmp_path / "staging"
-        staging.mkdir()
+        watch_folder = tmp_path / "watch"
+        watch_folder.mkdir()
         config = _bc_config(tmp_path)
         item = {
             "sale_item_id": 42,
@@ -1053,11 +1049,11 @@ class TestDownloadItem:
             "redownload_url": None,
         }
         with pytest.raises(BandcampAPIError, match="No redownload URL"):
-            _download_item(item, config, staging, MagicMock())
+            _download_item(item, config, watch_folder, MagicMock())
 
     def test_sanitises_unsafe_characters_in_filename(self, tmp_path: Path) -> None:
-        staging = tmp_path / "staging"
-        staging.mkdir()
+        watch_folder = tmp_path / "watch"
+        watch_folder.mkdir()
         config = _bc_config(tmp_path)
         item = {
             "sale_item_id": 1,
@@ -1073,7 +1069,7 @@ class TestDownloadItem:
                 "kamp_daemon.bandcamp._download_file",
                 side_effect=lambda url, dest, sess: dest.write_bytes(b"x"),
             ):
-                path = _download_item(item, config, staging, MagicMock())
+                path = _download_item(item, config, watch_folder, MagicMock())
         assert "/" not in path.name
         assert ":" not in path.name
 
@@ -1108,7 +1104,7 @@ class TestDownloadFile:
 class TestSyncStatusCallback:
     def test_status_callback_called_per_item(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
-        staging = tmp_path / "staging"
+        watch_folder = tmp_path / "watch"
         session_file = _make_session_file(tmp_path)
         config = _bc_config(tmp_path)
         items = [_item(1, "Band A", "Album A"), _item(2, "Band B", "Album B")]
@@ -1119,11 +1115,11 @@ class TestSyncStatusCallback:
         def fake_download(
             item: dict[str, Any],
             bc_config: BandcampConfig,
-            staging_dir: Path,
+            watch_dir: Path,
             session: Any,
         ) -> Path:
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            p = staging_dir / f"{item['sale_item_id']}.zip"
+            watch_dir.mkdir(parents=True, exist_ok=True)
+            p = watch_dir / f"{item['sale_item_id']}.zip"
             p.write_bytes(b"x")
             return p
 
@@ -1135,7 +1131,7 @@ class TestSyncStatusCallback:
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
             sync_new_purchases(
-                config, staging, state_file, status_callback=statuses.append
+                config, watch_folder, state_file, status_callback=statuses.append
             )
 
         assert len(statuses) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ class TestFirstRunSetup:
         path = tmp_path / "config.toml"
         Config.first_run_setup(path)
         assert path.exists()
-        assert "staging" in path.read_text()
+        assert "watch_folder" in path.read_text()
 
     def test_returns_config_with_user_values(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -32,7 +32,7 @@ class TestFirstRunSetup:
         inputs = iter(["~/staging", "~/lib"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
         config = Config.first_run_setup(tmp_path / "config.toml")
-        assert "staging" in str(config.paths.staging)
+        assert "staging" in str(config.paths.watch_folder)  # user typed ~/staging
         assert "lib" in str(config.paths.library)
 
     def test_blank_input_uses_default(
@@ -41,7 +41,7 @@ class TestFirstRunSetup:
         """Pressing Enter at a prompt accepts the shown default."""
         monkeypatch.setattr("builtins.input", lambda _: "")
         config = Config.first_run_setup(tmp_path / "config.toml")
-        assert config.paths.staging == Path("~/Music/staging").expanduser()
+        assert config.paths.watch_folder == Path("~/Music/staging").expanduser()
         assert config.paths.library == Path("~/Music").expanduser()
 
     def test_written_toml_is_valid(
@@ -54,7 +54,7 @@ class TestFirstRunSetup:
         Config.first_run_setup(path)
         # Round-trip: load should succeed without error
         loaded = Config.load(path)
-        assert "staging" in str(loaded.paths.staging)
+        assert "staging" in str(loaded.paths.watch_folder)
 
     def test_creates_parent_directories(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -129,7 +129,7 @@ class TestBandcampSetup:
 
 _TOML_WITH_BANDCAMP = """\
 [paths]
-staging = "~/Music/staging"
+watch_folder = "~/Music/staging"
 library = "~/Music"
 
 [musicbrainz]
@@ -183,7 +183,7 @@ class TestConfigSet:
     def test_set_string_key_updates_value(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "paths.staging", "~/new/staging")
+        config_set(path, "paths.watch_folder", "~/new/staging")
         assert "~/new/staging" in path.read_text()
 
     def test_set_int_key_updates_value(self, tmp_path: Path) -> None:
@@ -196,7 +196,7 @@ class TestConfigSet:
     def test_set_preserves_other_keys(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "paths.staging", "~/new/staging")
+        config_set(path, "paths.watch_folder", "~/new/staging")
         text = path.read_text()
         assert "library" in text
         assert "path_template" in text
@@ -204,7 +204,7 @@ class TestConfigSet:
     def test_set_preserves_comments(self, tmp_path: Path) -> None:
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "paths.staging", "~/new/staging")
+        config_set(path, "paths.watch_folder", "~/new/staging")
         # Comments on other lines must survive
         assert "# Available variables" in path.read_text()
 
@@ -242,17 +242,17 @@ class TestConfigSet:
         """Config.load() succeeds and reflects the new value after config_set."""
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "paths.staging", "~/round/trip")
+        config_set(path, "paths.watch_folder", "~/round/trip")
         loaded = Config.load(path)
-        assert "round/trip" in str(loaded.paths.staging)
+        assert "round/trip" in str(loaded.paths.watch_folder)
 
     def test_set_path_value_round_trips(self, tmp_path: Path) -> None:
         """A path set via config_set is written as a string and loaded back correctly."""
         path = tmp_path / "config.toml"
         path.write_text(DEFAULT_CONFIG_CONTENT)
-        config_set(path, "paths.staging", "~/new/staging")
+        config_set(path, "paths.watch_folder", "~/new/staging")
         loaded = Config.load(path)
-        assert "new/staging" in str(loaded.paths.staging)
+        assert "new/staging" in str(loaded.paths.watch_folder)
 
     def test_set_field_missing_from_section_appends_key(self, tmp_path: Path) -> None:
         """config_set appends a missing key into an existing non-optional section.
@@ -321,7 +321,7 @@ class TestConfigSet:
 
 _TOML_WITH_LASTFM = """\
 [paths]
-staging = "~/Music/staging"
+watch_folder = "~/Music/staging"
 library = "~/Music"
 
 [musicbrainz]
@@ -391,3 +391,29 @@ class TestLegacyConfig:
         path.write_text(_TOML_WITH_BANDCAMP)  # _TOML_WITH_BANDCAMP has contact = "..."
         config = Config.load(path)
         assert config.musicbrainz is not None
+
+    def test_load_accepts_legacy_staging_key(self, tmp_path: Path) -> None:
+        """Existing config.toml files with paths.staging load without modification."""
+        path = tmp_path / "config.toml"
+        path.write_text(
+            _TOML_WITH_BANDCAMP.replace(
+                'watch_folder = "~/Music/staging"',
+                'staging = "~/Music/staging"',
+            )
+        )
+        config = Config.load(path)
+        assert config.paths.watch_folder == Path("~/Music/staging").expanduser()
+
+    def test_load_watch_folder_takes_precedence_over_legacy_staging(
+        self, tmp_path: Path
+    ) -> None:
+        """When both keys are present, watch_folder wins over the legacy staging key."""
+        path = tmp_path / "config.toml"
+        path.write_text(
+            _TOML_WITH_BANDCAMP.replace(
+                'watch_folder = "~/Music/staging"',
+                'watch_folder = "~/Music/watch"\nstaging = "~/Music/staging"',
+            )
+        )
+        config = Config.load(path)
+        assert config.paths.watch_folder == Path("~/Music/watch").expanduser()

--- a/tests/test_mover.py
+++ b/tests/test_mover.py
@@ -10,7 +10,7 @@ import pytest
 
 from kamp_daemon.mover import (
     MoveError,
-    _cleanup_staging,
+    _cleanup_watch_folder,
     _destination,
     move_to_library,
 )
@@ -80,19 +80,19 @@ class TestCleanup:
     def test_removes_directory_with_leftover_non_audio_files(
         self, tmp_path: Path
     ) -> None:
-        """Staging dir is fully removed even when non-audio files remain."""
-        staging = tmp_path / "Artist - Album"
-        staging.mkdir()
-        (staging / "cover.jpg").write_bytes(b"fake image")
-        (staging / "booklet.pdf").write_bytes(b"fake pdf")
+        """Watch folder item dir is fully removed even when non-audio files remain."""
+        watch_dir = tmp_path / "Artist - Album"
+        watch_dir.mkdir()
+        (watch_dir / "cover.jpg").write_bytes(b"fake image")
+        (watch_dir / "booklet.pdf").write_bytes(b"fake pdf")
 
-        _cleanup_staging(staging)
+        _cleanup_watch_folder(watch_dir)
 
-        assert not staging.exists()
+        assert not watch_dir.exists()
 
     def test_does_not_raise_when_directory_is_missing(self, tmp_path: Path) -> None:
         """OSError from rmtree is caught; cleanup never raises."""
-        _cleanup_staging(tmp_path / "nonexistent")
+        _cleanup_watch_folder(tmp_path / "nonexistent")
 
 
 class TestM4ADestination:
@@ -365,11 +365,11 @@ class TestOggDestination:
 
 
 class TestMoveToLibrary:
-    def test_moves_files_and_cleans_staging(self, tmp_path: Path) -> None:
-        """move_to_library moves all files and removes the staging dir."""
-        staging = tmp_path / "Artist - Album"
-        staging.mkdir()
-        mp3 = staging / "01.mp3"
+    def test_moves_files_and_cleans_watch_dir(self, tmp_path: Path) -> None:
+        """move_to_library moves all files and removes the watch folder item dir."""
+        watch_dir = tmp_path / "Artist - Album"
+        watch_dir.mkdir()
+        mp3 = watch_dir / "01.mp3"
         _make_mp3(
             mp3,
             album_artist="Artist",
@@ -381,17 +381,17 @@ class TestMoveToLibrary:
         library = tmp_path / "library"
         library.mkdir()
 
-        dests = move_to_library([mp3], staging, library, TEMPLATE)
+        dests = move_to_library([mp3], watch_dir, library, TEMPLATE)
 
         assert len(dests) == 1
         assert dests[0].exists()
-        assert not staging.exists()
+        assert not watch_dir.exists()
 
     def test_raises_move_error_on_failure(self, tmp_path: Path) -> None:
         """move_to_library raises MoveError when shutil.move fails."""
-        staging = tmp_path / "Artist - Album"
-        staging.mkdir()
-        mp3 = staging / "01.mp3"
+        watch_dir = tmp_path / "Artist - Album"
+        watch_dir.mkdir()
+        mp3 = watch_dir / "01.mp3"
         _make_mp3(
             mp3,
             album_artist="Artist",
@@ -404,7 +404,7 @@ class TestMoveToLibrary:
 
         with patch("kamp_daemon.mover.shutil.move", side_effect=OSError("disk full")):
             with pytest.raises(MoveError, match="disk full"):
-                move_to_library([mp3], staging, library, TEMPLATE)
+                move_to_library([mp3], watch_dir, library, TEMPLATE)
 
     def test_template_error_raises_move_error(self, tmp_path: Path) -> None:
         """_destination raises MoveError when the template references a missing key."""

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -44,7 +44,9 @@ _MOCK_TRACKS = [
 
 def _make_config(tmp_path: Path) -> Config:
     return Config(
-        paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
+        paths=PathsConfig(
+            watch_folder=tmp_path / "watch", library=tmp_path / "library"
+        ),
         musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
@@ -158,8 +160,8 @@ class TestPipelineImplNotifications:
 
     def _run(self, tmp_path: Path) -> tuple[Path, Config]:
         config = _make_config(tmp_path)
-        config.paths.staging.mkdir(parents=True)
-        path = config.paths.staging / "my-album"
+        config.paths.watch_folder.mkdir(parents=True)
+        path = config.paths.watch_folder / "my-album"
         path.mkdir()
         return path, config
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -37,7 +37,7 @@ from kamp_daemon.pipeline_impl import (
 def config(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(
-            staging=tmp_path / "staging",
+            watch_folder=tmp_path / "watch",
             library=tmp_path / "library",
         ),
         musicbrainz=MusicBrainzConfig(),
@@ -118,14 +118,14 @@ MB_RELEASE_DETAIL: dict[str, Any] = {
 
 class TestPipelineRun:
     def test_zip_lands_in_library(self, tmp_path: Path, config: Config) -> None:
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
 
-        zip_path = config.paths.staging / "great-album.zip"
+        zip_path = config.paths.watch_folder / "great-album.zip"
         _make_zip(zip_path, ["01 - First Track.mp3", "02 - Second Track.mp3"])
 
         # Write valid ID3 headers so mutagen can read/write tags
-        extracted = config.paths.staging / "great-album"
+        extracted = config.paths.watch_folder / "great-album"
         extracted.mkdir()
         for name in ["01 - First Track.mp3", "02 - Second Track.mp3"]:
             f = extracted / name
@@ -156,14 +156,14 @@ class TestPipelineRun:
     def test_quarantine_on_extraction_failure(
         self, tmp_path: Path, config: Config
     ) -> None:
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
 
-        bad_zip = config.paths.staging / "bad.zip"
+        bad_zip = config.paths.watch_folder / "bad.zip"
         bad_zip.write_bytes(b"not a zip")
 
         run(bad_zip, config)
 
-        errors_dir = config.paths.staging / "errors"
+        errors_dir = config.paths.watch_folder / "errors"
         assert errors_dir.exists()
         quarantined = list(errors_dir.iterdir())
         assert len(quarantined) == 1
@@ -172,21 +172,21 @@ class TestPipelineRun:
         self, tmp_path: Path, config: Config
     ) -> None:
         """An extracted directory with no audio files is quarantined."""
-        config.paths.staging.mkdir(parents=True)
-        album_dir = config.paths.staging / "empty-album"
+        config.paths.watch_folder.mkdir(parents=True)
+        album_dir = config.paths.watch_folder / "empty-album"
         album_dir.mkdir()
         (album_dir / "cover.jpg").write_bytes(b"fake image")
 
         run(album_dir, config)
 
-        assert (config.paths.staging / "errors" / "empty-album").exists()
+        assert (config.paths.watch_folder / "errors" / "empty-album").exists()
 
     def test_artwork_failure_is_nonfatal(self, tmp_path: Path, config: Config) -> None:
         """An ArtworkError is logged as a warning and the pipeline continues."""
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
 
-        album_dir = config.paths.staging / "great-album"
+        album_dir = config.paths.watch_folder / "great-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         mp3.write_bytes(b"\xff\xfb" * 64)
@@ -212,10 +212,10 @@ class TestPipelineRun:
 
     def test_quarantine_on_move_failure(self, tmp_path: Path, config: Config) -> None:
         """A MoveError causes the directory to be quarantined."""
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
 
-        album_dir = config.paths.staging / "great-album"
+        album_dir = config.paths.watch_folder / "great-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         mp3.write_bytes(b"\xff\xfb" * 64)
@@ -236,26 +236,26 @@ class TestPipelineRun:
         ):
             run(album_dir, config)
 
-        assert (config.paths.staging / "errors" / "great-album").exists()
+        assert (config.paths.watch_folder / "errors" / "great-album").exists()
 
     def test_quarantine_tagging_failure(self, tmp_path: Path, config: Config) -> None:
         """A quarantine that itself fails logs an error rather than raising."""
-        config.paths.staging.mkdir(parents=True)
-        item = config.paths.staging / "bad-album"
+        config.paths.watch_folder.mkdir(parents=True)
+        item = config.paths.watch_folder / "bad-album"
         item.mkdir()
 
         with patch(
             "kamp_daemon.pipeline_impl.shutil.move", side_effect=OSError("no space")
         ):
-            _quarantine(item, config.paths.staging)
+            _quarantine(item, config.paths.watch_folder)
         # Should not raise; errors/ dir was created even if move failed
 
     def test_quarantine_on_tagging_failure(
         self, tmp_path: Path, config: Config
     ) -> None:
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
 
-        album_dir = config.paths.staging / "mystery-album"
+        album_dir = config.paths.watch_folder / "mystery-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         mp3.write_bytes(b"\xff\xfb" * 64)
@@ -265,7 +265,7 @@ class TestPipelineRun:
         with patch("musicbrainzngs.search_releases", return_value={"release-list": []}):
             run(album_dir, config)
 
-        errors_dir = config.paths.staging / "errors"
+        errors_dir = config.paths.watch_folder / "errors"
         assert errors_dir.exists()
 
 
@@ -277,10 +277,10 @@ class TestOnDirectoryCallback:
         extraction so the watcher can cancel any pending timer for that directory."""
         import zipfile
 
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
 
-        zip_path = config.paths.staging / "artist-album.zip"
+        zip_path = config.paths.watch_folder / "artist-album.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
             zf.writestr("01 - Track.mp3", b"\xff\xfb" * 64)
 
@@ -299,15 +299,15 @@ class TestOnDirectoryCallback:
             run(zip_path, config, _on_directory=claimed.append)
 
         assert len(claimed) == 1
-        assert claimed[0].parent == config.paths.staging
+        assert claimed[0].parent == config.paths.watch_folder
         assert claimed[0].name == "artist-album"
 
     def test_callback_not_called_on_extraction_failure(
         self, tmp_path: Path, config: Config
     ) -> None:
         """_on_directory must not fire when extraction fails."""
-        config.paths.staging.mkdir(parents=True)
-        bad_zip = config.paths.staging / "bad.zip"
+        config.paths.watch_folder.mkdir(parents=True)
+        bad_zip = config.paths.watch_folder / "bad.zip"
         bad_zip.write_bytes(b"not a zip")
 
         claimed: list[Path] = []
@@ -323,9 +323,9 @@ class TestSkipAlreadyTagged:
 
     def _setup_dir(self, config: Config) -> tuple[Path, Path]:
         """Create staging + library dirs and return (album_dir, mp3)."""
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
-        album_dir = config.paths.staging / "great-album"
+        album_dir = config.paths.watch_folder / "great-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         mp3.write_bytes(b"\xff\xfb" * 64)
@@ -380,9 +380,9 @@ class TestSkipAlreadyTagged:
         self, tmp_path: Path, config: Config
     ) -> None:
         """If any file is untagged, the full MB lookup runs for the whole directory."""
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
-        album_dir = config.paths.staging / "partial-album"
+        album_dir = config.paths.watch_folder / "partial-album"
         album_dir.mkdir()
 
         mp3_a = album_dir / "01.mp3"
@@ -418,9 +418,9 @@ class TestStageCallback:
     """stage_callback receives stage labels in order and is cleared in finally."""
 
     def _setup_dir(self, config: Config) -> Path:
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
-        album_dir = config.paths.staging / "test-album"
+        album_dir = config.paths.watch_folder / "test-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         mp3.write_bytes(b"\xff\xfb" * 64)
@@ -449,8 +449,8 @@ class TestStageCallback:
         self, tmp_path: Path, config: Config
     ) -> None:
         """stage_callback('') fires even when extraction fails."""
-        config.paths.staging.mkdir(parents=True)
-        bad_zip = config.paths.staging / "bad.zip"
+        config.paths.watch_folder.mkdir(parents=True)
+        bad_zip = config.paths.watch_folder / "bad.zip"
         bad_zip.write_bytes(b"not a zip")
         calls: list[str] = []
 
@@ -533,7 +533,7 @@ class TestMbTagsConflict:
 def _make_conflict_config(tmp_path: Path, trust: bool) -> Config:
     return Config(
         paths=PathsConfig(
-            staging=tmp_path / "staging",
+            watch_folder=tmp_path / "watch",
             library=tmp_path / "library",
         ),
         musicbrainz=MusicBrainzConfig(
@@ -574,9 +574,9 @@ class TestMbConflictFallback:
     """When trust=False and MB returns mismatched tags, ID3 writes are skipped."""
 
     def _setup_album(self, config: Config) -> tuple[Path, Path]:
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
-        album_dir = config.paths.staging / "file-album"
+        album_dir = config.paths.watch_folder / "file-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         _make_mp3_with_tags(mp3, artist="File Artist", album="File Album")
@@ -649,9 +649,9 @@ class TestMbConflictFallback:
     def test_writes_id3_when_no_conflict(self, tmp_path: Path) -> None:
         """When tags agree with MB, ID3 is written normally even with trust=False."""
         config = _make_conflict_config(tmp_path, trust=False)
-        config.paths.staging.mkdir(parents=True)
+        config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
-        album_dir = config.paths.staging / "mb-album"
+        album_dir = config.paths.watch_folder / "mb-album"
         album_dir.mkdir()
         mp3 = album_dir / "01.mp3"
         # File tags match the MB result

--- a/tests/test_pipeline_subprocess.py
+++ b/tests/test_pipeline_subprocess.py
@@ -21,7 +21,9 @@ from kamp_daemon.pipeline import _DIR_SENTINEL, _handle_stage_msg, run_in_subpro
 
 def _make_config(tmp_path: Path) -> Config:
     return Config(
-        paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
+        paths=PathsConfig(
+            watch_folder=tmp_path / "watch", library=tmp_path / "library"
+        ),
         musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -21,7 +21,9 @@ from kamp_daemon.syncer import NeedsLoginError, Syncer, logout
 
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
     return Config(
-        paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
+        paths=PathsConfig(
+            watch_folder=tmp_path / "watch", library=tmp_path / "library"
+        ),
         musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(
@@ -38,7 +40,9 @@ def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
 
 def _make_config_no_bandcamp(tmp_path: Path) -> Config:
     return Config(
-        paths=PathsConfig(staging=tmp_path / "staging", library=tmp_path / "library"),
+        paths=PathsConfig(
+            watch_folder=tmp_path / "watch", library=tmp_path / "library"
+        ),
         musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -23,7 +23,7 @@ from watchdog.events import (
 from kamp_daemon.watcher import (
     LibraryWatcher,
     _LibraryHandler,
-    _StagingHandler,
+    _WatchHandler,
     Watcher,
 )
 
@@ -32,7 +32,7 @@ from kamp_daemon.watcher import (
 def config(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(
-            staging=tmp_path / "staging",
+            watch_folder=tmp_path / "watch",
             library=tmp_path / "library",
         ),
         musicbrainz=MusicBrainzConfig(),
@@ -43,9 +43,9 @@ def config(tmp_path: Path) -> Config:
     )
 
 
-def _make_handler(config: Config) -> _StagingHandler:
-    config.paths.staging.mkdir(parents=True, exist_ok=True)
-    return _StagingHandler(config)
+def _make_handler(config: Config) -> _WatchHandler:
+    config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+    return _WatchHandler(config)
 
 
 def _dir_moved_event(src: str, dest: str) -> MagicMock:
@@ -79,19 +79,21 @@ def _dir_created_event(path: str) -> MagicMock:
 
 
 class TestOnMoved:
-    def test_directory_moved_into_staging_is_scheduled(self, config: Config) -> None:
+    def test_directory_moved_into_watch_folder_is_scheduled(
+        self, config: Config
+    ) -> None:
         """Dragging a folder from Finder fires a moved event; it must be scheduled."""
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "my-album")
+        dest = str(config.paths.watch_folder / "my-album")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_dir_moved_event("/tmp/my-album", dest))
 
         mock_schedule.assert_called_once_with(Path(dest))
 
-    def test_zip_moved_into_staging_is_scheduled(self, config: Config) -> None:
+    def test_zip_moved_into_watch_folder_is_scheduled(self, config: Config) -> None:
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "album.zip")
+        dest = str(config.paths.watch_folder / "album.zip")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_file_moved_event("/tmp/album.zip", dest))
@@ -101,7 +103,7 @@ class TestOnMoved:
     def test_directory_moved_into_subdir_is_ignored(self, config: Config) -> None:
         """Items moved into a subdirectory of staging (not directly into root) are skipped."""
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "subdir" / "my-album")
+        dest = str(config.paths.watch_folder / "subdir" / "my-album")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_dir_moved_event("/tmp/my-album", dest))
@@ -110,17 +112,19 @@ class TestOnMoved:
 
     def test_errors_directory_moved_in_is_ignored(self, config: Config) -> None:
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "errors")
+        dest = str(config.paths.watch_folder / "errors")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_dir_moved_event("/tmp/errors", dest))
 
         mock_schedule.assert_not_called()
 
-    def test_audio_file_moved_into_staging_is_scheduled(self, config: Config) -> None:
+    def test_audio_file_moved_into_watch_folder_is_scheduled(
+        self, config: Config
+    ) -> None:
         """Dragging a single audio file into staging fires a moved event; it must be scheduled."""
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "track.mp3")
+        dest = str(config.paths.watch_folder / "track.mp3")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_file_moved_event("/tmp/track.mp3", dest))
@@ -129,7 +133,7 @@ class TestOnMoved:
 
     def test_non_audio_non_zip_file_moved_in_is_ignored(self, config: Config) -> None:
         handler = _make_handler(config)
-        dest = str(config.paths.staging / "cover.jpg")
+        dest = str(config.paths.watch_folder / "cover.jpg")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_moved(_file_moved_event("/tmp/cover.jpg", dest))
@@ -144,32 +148,36 @@ class TestOnModified:
         event.src_path = path
         return event
 
-    def test_staging_root_modified_schedules_new_directory(
+    def test_watch_root_modified_schedules_new_directory(
         self, config: Config, tmp_path: Path
     ) -> None:
         """DirModifiedEvent on staging root (FSEvents rename coalescing) triggers schedule."""
         handler = _make_handler(config)
-        album_dir = config.paths.staging / "my-album"
+        album_dir = config.paths.watch_folder / "my-album"
         album_dir.mkdir()
 
         with patch.object(handler, "_schedule") as mock_schedule:
-            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+            handler.on_modified(
+                self._dir_modified_event(str(config.paths.watch_folder))
+            )
 
         mock_schedule.assert_called_once_with(album_dir)
 
-    def test_staging_root_modified_ignores_errors_dir(self, config: Config) -> None:
+    def test_watch_root_modified_ignores_errors_dir(self, config: Config) -> None:
         handler = _make_handler(config)
-        (config.paths.staging / "errors").mkdir()
+        (config.paths.watch_folder / "errors").mkdir()
 
         with patch.object(handler, "_schedule") as mock_schedule:
-            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+            handler.on_modified(
+                self._dir_modified_event(str(config.paths.watch_folder))
+            )
 
         mock_schedule.assert_not_called()
 
     def test_modified_event_on_subdirectory_is_ignored(self, config: Config) -> None:
         """Modification events inside staging subdirectories are not acted on."""
         handler = _make_handler(config)
-        subdir = config.paths.staging / "subdir"
+        subdir = config.paths.watch_folder / "subdir"
         subdir.mkdir()
 
         with patch.object(handler, "_schedule") as mock_schedule:
@@ -179,7 +187,7 @@ class TestOnModified:
 
     def test_already_pending_items_not_rescheduled(self, config: Config) -> None:
         handler = _make_handler(config)
-        album_dir = config.paths.staging / "my-album"
+        album_dir = config.paths.watch_folder / "my-album"
         album_dir.mkdir()
 
         # Simulate an already-pending path
@@ -187,7 +195,9 @@ class TestOnModified:
         handler._pending[album_dir] = fake_timer
 
         with patch.object(handler, "_schedule") as mock_schedule:
-            handler.on_modified(self._dir_modified_event(str(config.paths.staging)))
+            handler.on_modified(
+                self._dir_modified_event(str(config.paths.watch_folder))
+            )
 
         mock_schedule.assert_not_called()
 
@@ -197,12 +207,12 @@ class TestStartupScan:
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A directory already in staging when the daemon starts gets scheduled."""
-        config.paths.staging.mkdir(parents=True, exist_ok=True)
-        (config.paths.staging / "Artist - Album").mkdir()
+        config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+        (config.paths.watch_folder / "Artist - Album").mkdir()
 
         scheduled: list[Path] = []
         monkeypatch.setattr(
-            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+            _WatchHandler, "_schedule", lambda self, p: scheduled.append(p)
         )
 
         watcher = Watcher(config)
@@ -216,12 +226,12 @@ class TestStartupScan:
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A ZIP already in staging when the daemon starts gets scheduled."""
-        config.paths.staging.mkdir(parents=True, exist_ok=True)
-        (config.paths.staging / "album.zip").write_bytes(b"PK")
+        config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+        (config.paths.watch_folder / "album.zip").write_bytes(b"PK")
 
         scheduled: list[Path] = []
         monkeypatch.setattr(
-            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+            _WatchHandler, "_schedule", lambda self, p: scheduled.append(p)
         )
 
         watcher = Watcher(config)
@@ -235,12 +245,12 @@ class TestStartupScan:
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A lone audio file already in staging when the daemon starts gets scheduled."""
-        config.paths.staging.mkdir(parents=True, exist_ok=True)
-        (config.paths.staging / "track.mp3").write_bytes(b"fake mp3")
+        config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+        (config.paths.watch_folder / "track.mp3").write_bytes(b"fake mp3")
 
         scheduled: list[Path] = []
         monkeypatch.setattr(
-            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+            _WatchHandler, "_schedule", lambda self, p: scheduled.append(p)
         )
 
         watcher = Watcher(config)
@@ -254,12 +264,12 @@ class TestStartupScan:
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The errors/ subdirectory is not scheduled on startup."""
-        config.paths.staging.mkdir(parents=True, exist_ok=True)
-        (config.paths.staging / "errors").mkdir()
+        config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+        (config.paths.watch_folder / "errors").mkdir()
 
         scheduled: list[Path] = []
         monkeypatch.setattr(
-            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+            _WatchHandler, "_schedule", lambda self, p: scheduled.append(p)
         )
 
         watcher = Watcher(config)
@@ -274,22 +284,22 @@ class TestInFlight:
     def test_in_flight_path_is_not_rescheduled(self, config: Config) -> None:
         """_schedule is a no-op for a path currently being processed."""
         handler = _make_handler(config)
-        path = config.paths.staging / "my-album"
+        path = config.paths.watch_folder / "my-album"
         handler._in_flight.add(path)
 
         handler._schedule(path)
 
         assert path not in handler._pending
 
-    def test_scan_staging_root_skips_in_flight(self, config: Config) -> None:
-        """_scan_staging_root does not schedule a path that is currently in-flight."""
+    def test_scan_watch_root_skips_in_flight(self, config: Config) -> None:
+        """_scan_watch_root does not schedule a path that is currently in-flight."""
         handler = _make_handler(config)
-        album = config.paths.staging / "my-album"
+        album = config.paths.watch_folder / "my-album"
         album.mkdir()
         handler._in_flight.add(album)
 
         with patch.object(handler, "_schedule") as mock_schedule:
-            handler._scan_staging_root()
+            handler._scan_watch_root()
 
         mock_schedule.assert_not_called()
 
@@ -298,7 +308,7 @@ class TestInFlight:
     ) -> None:
         """After _process completes, the path is removed from _in_flight."""
         handler = _make_handler(config)
-        album = config.paths.staging / "my-album"
+        album = config.paths.watch_folder / "my-album"
         album.mkdir()
         monkeypatch.setattr(
             "kamp_daemon.watcher.run_in_subprocess", lambda path, cfg, **kw: None
@@ -312,7 +322,7 @@ class TestInFlight:
     ) -> None:
         """_in_flight is cleaned up even when run() raises."""
         handler = _make_handler(config)
-        album = config.paths.staging / "my-album"
+        album = config.paths.watch_folder / "my-album"
         album.mkdir()
 
         def _boom(path: Path, cfg: object) -> None:
@@ -325,9 +335,11 @@ class TestInFlight:
 
 
 class TestOnCreated:
-    def test_directory_created_in_staging_is_scheduled(self, config: Config) -> None:
+    def test_directory_created_in_watch_folder_is_scheduled(
+        self, config: Config
+    ) -> None:
         handler = _make_handler(config)
-        path = str(config.paths.staging / "my-album")
+        path = str(config.paths.watch_folder / "my-album")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_created(_dir_created_event(path))
@@ -336,17 +348,19 @@ class TestOnCreated:
 
     def test_errors_directory_created_is_ignored(self, config: Config) -> None:
         handler = _make_handler(config)
-        path = str(config.paths.staging / "errors")
+        path = str(config.paths.watch_folder / "errors")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             handler.on_created(_dir_created_event(path))
 
         mock_schedule.assert_not_called()
 
-    def test_zip_file_created_in_staging_is_scheduled(self, config: Config) -> None:
+    def test_zip_file_created_in_watch_folder_is_scheduled(
+        self, config: Config
+    ) -> None:
         """A ZIP file created in staging is scheduled for processing."""
         handler = _make_handler(config)
-        path = str(config.paths.staging / "album.zip")
+        path = str(config.paths.watch_folder / "album.zip")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             from watchdog.events import FileCreatedEvent
@@ -355,10 +369,12 @@ class TestOnCreated:
 
         mock_schedule.assert_called_once_with(Path(path))
 
-    def test_audio_file_created_in_staging_is_scheduled(self, config: Config) -> None:
+    def test_audio_file_created_in_watch_folder_is_scheduled(
+        self, config: Config
+    ) -> None:
         """A single audio file created in staging is scheduled for processing."""
         handler = _make_handler(config)
-        path = str(config.paths.staging / "track.mp3")
+        path = str(config.paths.watch_folder / "track.mp3")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             from watchdog.events import FileCreatedEvent
@@ -370,7 +386,7 @@ class TestOnCreated:
     def test_non_zip_file_created_is_ignored(self, config: Config) -> None:
         """A non-ZIP file created in staging is not scheduled."""
         handler = _make_handler(config)
-        path = str(config.paths.staging / "cover.jpg")
+        path = str(config.paths.watch_folder / "cover.jpg")
 
         with patch.object(handler, "_schedule") as mock_schedule:
             from watchdog.events import FileCreatedEvent
@@ -386,9 +402,9 @@ class TestOnModifiedFileEvent:
         handler = _make_handler(config)
         event = MagicMock()
         event.is_directory = False
-        event.src_path = str(config.paths.staging / "track.mp3")
+        event.src_path = str(config.paths.watch_folder / "track.mp3")
 
-        with patch.object(handler, "_scan_staging_root") as mock_scan:
+        with patch.object(handler, "_scan_watch_root") as mock_scan:
             handler.on_modified(event)
 
         mock_scan.assert_not_called()
@@ -396,20 +412,20 @@ class TestOnModifiedFileEvent:
 
 class TestScanStagingRootOSError:
     def test_oserror_during_scan_is_silently_ignored(self, config: Config) -> None:
-        """_scan_staging_root handles OSError from iterdir gracefully."""
+        """_scan_watch_root handles OSError from iterdir gracefully."""
         handler = _make_handler(config)
 
         # Patch at the class level — PosixPath C-methods can't be patched on instances
         with patch("pathlib.Path.iterdir", side_effect=OSError("no access")):
-            handler._scan_staging_root()  # must not raise
+            handler._scan_watch_root()  # must not raise
 
 
 class TestScheduleTimer:
     def test_schedule_adds_to_pending(self, config: Config) -> None:
         """_schedule creates a timer and adds it to _pending."""
         handler = _make_handler(config)
-        path = config.paths.staging / "my-album"
-        (config.paths.staging / "my-album").mkdir()
+        path = config.paths.watch_folder / "my-album"
+        (config.paths.watch_folder / "my-album").mkdir()
 
         handler._schedule(path)
         assert path in handler._pending
@@ -418,7 +434,7 @@ class TestScheduleTimer:
     def test_schedule_cancels_existing_timer(self, config: Config) -> None:
         """_schedule cancels any existing timer for the same path."""
         handler = _make_handler(config)
-        path = config.paths.staging / "my-album"
+        path = config.paths.watch_folder / "my-album"
         path.mkdir()
 
         old_timer = MagicMock()
@@ -473,7 +489,7 @@ class TestDuplicateRunPrevention:
     ) -> None:
         """_process passes a _on_directory callback to run(); verifies callback arg."""
         handler = _make_handler(config)
-        album = config.paths.staging / "my-album"
+        album = config.paths.watch_folder / "my-album"
         album.mkdir()
 
         received_callbacks: list[object] = []
@@ -495,10 +511,10 @@ class TestDuplicateRunPrevention:
         """When the pipeline calls the callback, any pending timer for the
         extracted directory is cancelled and the directory is added to _in_flight."""
         handler = _make_handler(config)
-        zip_path = config.paths.staging / "album.zip"
+        zip_path = config.paths.watch_folder / "album.zip"
         zip_path.write_bytes(b"PK")
 
-        extracted_dir = config.paths.staging / "album"
+        extracted_dir = config.paths.watch_folder / "album"
         extracted_dir.mkdir()
 
         # Simulate a pending timer for the extracted directory (as the watcher
@@ -526,10 +542,10 @@ class TestDuplicateRunPrevention:
     ) -> None:
         """A directory added to _in_flight by the callback cannot be rescheduled."""
         handler = _make_handler(config)
-        zip_path = config.paths.staging / "album.zip"
+        zip_path = config.paths.watch_folder / "album.zip"
         zip_path.write_bytes(b"PK")
 
-        extracted_dir = config.paths.staging / "album"
+        extracted_dir = config.paths.watch_folder / "album"
         extracted_dir.mkdir()
 
         def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
@@ -579,7 +595,7 @@ class TestWatcherPauseResume:
         """pause() cancels any in-flight debounce timers."""
         watcher = self._patched_watcher(config, monkeypatch)
         timer = MagicMock()
-        watcher._handler._pending[config.paths.staging / "album"] = timer
+        watcher._handler._pending[config.paths.watch_folder / "album"] = timer
 
         watcher.pause()
 
@@ -628,12 +644,12 @@ class TestWatcherPauseResume:
 
         assert start_calls == [1]
 
-    def test_resume_scans_staging_for_existing_items(
+    def test_resume_scans_watch_folder_for_existing_items(
         self, config: Config, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """resume() picks up items already in staging."""
-        config.paths.staging.mkdir(parents=True, exist_ok=True)
-        (config.paths.staging / "Artist - Album").mkdir()
+        config.paths.watch_folder.mkdir(parents=True, exist_ok=True)
+        (config.paths.watch_folder / "Artist - Album").mkdir()
         watcher = self._patched_watcher(config, monkeypatch)
         watcher.pause()
 
@@ -643,7 +659,7 @@ class TestWatcherPauseResume:
             lambda: MagicMock(start=lambda: None, schedule=lambda *a, **kw: None),
         )
         monkeypatch.setattr(
-            _StagingHandler, "_schedule", lambda self, p: scheduled.append(p)
+            _WatchHandler, "_schedule", lambda self, p: scheduled.append(p)
         )
 
         watcher.resume()
@@ -733,16 +749,18 @@ class TestWatcherReload:
             "unschedule_all",
             lambda: reschedule_calls.append(1),
         )
-        new_staging = tmp_path / "new_staging"
+        new_watch_folder = tmp_path / "new_watch"
         new_config = Config(
-            paths=PathsConfig(staging=new_staging, library=config.paths.library),
+            paths=PathsConfig(
+                watch_folder=new_watch_folder, library=config.paths.library
+            ),
             musicbrainz=config.musicbrainz,
             artwork=config.artwork,
             library=config.library,
         )
         watcher.reload(new_config)
         assert reschedule_calls == [1]
-        assert watcher._config.paths.staging == new_staging
+        assert watcher._config.paths.watch_folder == new_watch_folder
 
 
 class TestStageCallback:
@@ -751,7 +769,7 @@ class TestStageCallback:
     ) -> None:
         """_process passes handler.stage_callback as stage_callback kwarg to run()."""
         handler = _make_handler(config)
-        album = config.paths.staging / "my-album"
+        album = config.paths.watch_folder / "my-album"
         album.mkdir()
 
         received: dict[str, object] = {}


### PR DESCRIPTION
## Summary

- Renames all references from "staging folder" to "watch folder" for end-to-end consistency — user-visible labels, internal Python identifiers, the TOML config key, the CLI flag, and the TypeScript API key
- Adds a backward-compat migration shim in `Config.load()`: existing `config.toml` files with `paths.staging` continue to work without modification
- New tests for legacy `paths.staging` key acceptance and `paths.watch_folder` precedence

## Key changes

| Before | After |
|---|---|
| `PathsConfig.staging` | `PathsConfig.watch_folder` |
| TOML: `staging = ...` | TOML: `watch_folder = ...` |
| CLI: `--staging` | CLI: `--watch-folder` |
| API key: `paths.staging` | API key: `paths.watch_folder` |
| `_StagingHandler` | `_WatchHandler` |
| `_scan_staging_root` | `_scan_watch_root` |
| `_cleanup_staging` | `_cleanup_watch_folder` |
| `staging_dir` params | `watch_dir` params |

## Test plan

- [x] All 1026 existing tests pass (`poetry run pytest tests/ --no-cov -q`)
- [x] `kamp daemon --watch-folder ~/Downloads/staging` works
- [x] `kamp config set paths.watch_folder ~/Downloads/staging` works
- [x] Existing `config.toml` with `paths.staging` loads without modification
- [x] Preferences dialog shows "Watch folder" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)