### PR TITLE
feat: extract Bandcamp username from session after login (TASK-121)

### DIFF
--- a/backlog/tasks/task-120 - security-move-bandcamp-session-to-db.md
+++ b/backlog/tasks/task-120 - security-move-bandcamp-session-to-db.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-120
 title: 'security: move bandcamp session to db'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 01:47'
-updated_date: '2026-04-14 01:48'
+updated_date: '2026-04-14 02:12'
 labels: []
 milestone: m-1
 dependencies: []
 priority: high
+ordinal: 2000
 ---
 
 ## Description

--- a/backlog/tasks/task-121 - extract-bandcamp-username-after-login.md
+++ b/backlog/tasks/task-121 - extract-bandcamp-username-after-login.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-121
 title: extract bandcamp username after login
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-13 01:49'
-updated_date: '2026-04-14 02:11'
+updated_date: '2026-04-14 02:33'
 labels: []
 milestone: m-1
 dependencies: []
 priority: medium
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-121 - extract-bandcamp-username-after-login.md
+++ b/backlog/tasks/task-121 - extract-bandcamp-username-after-login.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-121
 title: extract bandcamp username after login
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-13 01:49'
-updated_date: '2026-04-13 02:09'
+updated_date: '2026-04-14 02:11'
 labels: []
 milestone: m-1
 dependencies: []

--- a/backlog/tasks/task-122 - bandcamp-logout-in-preferences.md
+++ b/backlog/tasks/task-122 - bandcamp-logout-in-preferences.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-122
 title: bandcamp logout in preferences
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-13 01:51'
-updated_date: '2026-04-13 02:09'
+updated_date: '2026-04-14 02:40'
 labels: []
 milestone: m-1
 dependencies: []
 priority: medium
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -212,6 +212,8 @@ def create_app(
     on_lastfm_connect: Callable[[str, str], None] | None = None,
     on_lastfm_disconnect: Callable[[], None] | None = None,
     on_bandcamp_login_complete: Callable[[dict[str, Any]], None] | None = None,
+    get_bandcamp_session: Callable[[], dict[str, Any] | None] | None = None,
+    on_bandcamp_disconnect: Callable[[], None] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -531,9 +533,9 @@ def create_app(
         """Receive cookies collected by the Electron BrowserWindow and persist them.
 
         Called by the Electron main process after the user successfully logs in.
-        The payload is written to ``bandcamp_session.json`` in the same Playwright
-        storage_state format that ``_validate_session`` and ``_make_requests_session``
-        already read — no changes to the sync path are required.
+        The callback also attempts to fetch the Bandcamp username and store it
+        in the session; if successful, _state["config"]["bandcamp.username"] is
+        updated so GET /config immediately reflects the connected account.
         """
         if on_bandcamp_login_complete is None:
             raise HTTPException(status_code=503, detail="Bandcamp login not configured")
@@ -541,7 +543,39 @@ def create_app(
             on_bandcamp_login_complete({"cookies": req.cookies, "origins": req.origins})
         except Exception as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+        # Read username back from session (populated by the callback when
+        # the API call succeeds) and surface it in the config state.
+        if get_bandcamp_session is not None:
+            session = get_bandcamp_session()
+            if session:
+                _state["config"]["bandcamp.username"] = session.get("username")
         _broadcast({"type": "bandcamp.login-complete"})
+        return {"ok": True}
+
+    @app.get("/api/v1/bandcamp/status")
+    def get_bandcamp_status() -> dict[str, Any]:
+        """Return the current Bandcamp session status.
+
+        ``connected`` is True when a session exists in the DB.
+        ``username`` is the Bandcamp username extracted after login, or None.
+        """
+        if get_bandcamp_session is None:
+            return {"connected": False, "username": None}
+        session = get_bandcamp_session()
+        if session is None:
+            return {"connected": False, "username": None}
+        return {"connected": True, "username": session.get("username")}
+
+    @app.delete("/api/v1/bandcamp/connect")
+    def delete_bandcamp_connect() -> dict[str, Any]:
+        """Disconnect the Bandcamp session (clear session from DB)."""
+        if on_bandcamp_disconnect is None:
+            raise HTTPException(
+                status_code=503, detail="Bandcamp disconnect not configured"
+            )
+        on_bandcamp_disconnect()
+        _state["config"]["bandcamp.username"] = None
+        _broadcast({"type": "bandcamp.disconnected"})
         return {"ok": True}
 
     # -----------------------------------------------------------------------

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -11,6 +11,7 @@ Syncer, Config, etc.).
 from __future__ import annotations
 
 import argparse
+from typing import Any
 import asyncio
 import importlib.metadata
 import logging
@@ -793,11 +794,35 @@ def _cmd_daemon(
 
     def _on_bandcamp_login_complete(payload: dict[str, object]) -> None:
         # Persist cookies to DB so they are never written to plaintext on disk.
-        index.set_session("bandcamp", dict(payload))
+        session_data: dict[str, Any] = dict(payload)
+        index.set_session("bandcamp", session_data)
         _logger.info("Bandcamp session saved to database from Electron login flow.")
+        # Immediately fetch username from the Bandcamp API so the UI can show
+        # "Connected as {username}" without waiting for the first sync.
+        # Wrapped in try/except — a network failure here should not fail the login.
+        try:
+            from .bandcamp import _get_fan_info, _make_requests_session
+
+            bc_session = _make_requests_session(session_data)
+            _fan_id, username = _get_fan_info(bc_session)
+            if username:
+                session_data["username"] = username
+                index.set_session("bandcamp", session_data)
+                _logger.info("Bandcamp username %r stored in session.", username)
+        except Exception as exc:
+            _logger.warning("Could not fetch Bandcamp username after login: %s", exc)
+
+    def _on_bandcamp_disconnect() -> None:
+        index.clear_session("bandcamp")
 
     # Build the initial preference values dict from the loaded config.
     # Bandcamp and Last.fm fields are None when the section is absent.
+    # For bandcamp.username, prefer the value stored in the session (extracted
+    # automatically after login) over any value in config.toml.
+    _bc_session = index.get_session("bandcamp") if config.bandcamp else None
+    _bc_username: str | None = (
+        _bc_session.get("username") if _bc_session else None
+    ) or (config.bandcamp.username if config.bandcamp else None)
     _config_values: dict[str, object] = {
         "paths.watch_folder": str(config.paths.watch_folder),
         "paths.library": str(config.paths.library),
@@ -805,7 +830,7 @@ def _cmd_daemon(
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
         "library.path_template": config.library.path_template,
-        "bandcamp.username": config.bandcamp.username if config.bandcamp else None,
+        "bandcamp.username": _bc_username,
         "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
         "bandcamp.poll_interval_minutes": (
             config.bandcamp.poll_interval_minutes if config.bandcamp else None
@@ -828,6 +853,8 @@ def _cmd_daemon(
         on_lastfm_connect=_on_lastfm_connect,
         on_lastfm_disconnect=_on_lastfm_disconnect,
         on_bandcamp_login_complete=_on_bandcamp_login_complete,
+        get_bandcamp_session=lambda: index.get_session("bandcamp"),
+        on_bandcamp_disconnect=_on_bandcamp_disconnect,
     )
 
     # Wrap the existing on_track_end callback to also push track.changed events.

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -188,7 +188,8 @@ def mark_collection_synced(
     """
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
-    fan_id = _get_fan_id(session)
+    fan_id, username = _get_fan_info(session)
+    _store_username_in_session(username, session_data, index)
     collection = _fetch_collection(fan_id, session, index)
 
     state = _load_state(state_file)
@@ -222,8 +223,12 @@ def sync_new_purchases(
     """
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
-    fan_id = _get_fan_id(session)
-    logger.info("Fetched fan_id=%s for user %r", fan_id, bc_config.username)
+    fan_id, username = _get_fan_info(session)
+    _store_username_in_session(username, session_data, index)
+    # Use config username as fallback if API didn't return one.
+    if not username:
+        username = bc_config.username or ""
+    logger.info("Fetched fan_id=%s for user %r", fan_id, username)
 
     state = _load_state(state_file)
     collection = _fetch_collection(fan_id, session, index)
@@ -238,7 +243,7 @@ def sync_new_purchases(
 
     # Scrape download-page URLs from the collection page HTML.
     new_item_ids = {item["sale_item_id"] for item in new_items}
-    download_links = _get_download_links(bc_config.username, new_item_ids, session)
+    download_links = _get_download_links(username, new_item_ids, session)
 
     watch_dir.mkdir(parents=True, exist_ok=True)
 
@@ -423,8 +428,8 @@ def _session_from_cookie_file(cookie_file: Path) -> dict[str, Any]:
 _COLLECTION_SUMMARY_URL = "https://bandcamp.com/api/fan/2/collection_summary"
 
 
-def _get_fan_id(session: _AnySession) -> int:
-    """Return the numeric fan_id for the authenticated session.
+def _get_fan_info(session: _AnySession) -> tuple[int, str]:
+    """Return (fan_id, username) for the authenticated session.
 
     Uses the authenticated collection_summary API endpoint rather than scraping
     the profile page HTML.  The profile page is served behind Cloudflare's bot
@@ -442,13 +447,28 @@ def _get_fan_id(session: _AnySession) -> int:
         data: dict[str, Any] = resp.json()
     except Exception as exc:
         logger.error(
-            "_get_fan_id: JSON decode failed — status=%s response_head=%r",
+            "_get_fan_info: JSON decode failed — status=%s response_head=%r",
             resp.status_code,
             resp.text[:500],
         )
         raise BandcampAPIError(f"collection_summary returned non-JSON: {exc}") from exc
     fan_id: int = data["fan_id"]
-    return fan_id
+    username: str = data.get("username", "")
+    return fan_id, username
+
+
+def _store_username_in_session(
+    username: str,
+    session_data: dict[str, Any],
+    index: "LibraryIndex",
+) -> None:
+    """Persist *username* into the stored session row if it has changed.
+
+    No-op when *username* is empty or already matches the stored value.
+    """
+    if username and session_data.get("username") != username:
+        session_data["username"] = username
+        index.set_session("bandcamp", session_data)
 
 
 def _extract_pagedata(html: str, url: str) -> dict[str, Any]:

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -92,7 +92,7 @@ class LastfmConfig:
 
 @dataclass
 class BandcampConfig:
-    username: str
+    username: str | None  # extracted from session after login; optional in config
     cookie_file: Path | None  # if set, bypasses interactive login
     format: str  # e.g. "mp3-v0", "mp3-320", "flac"
     poll_interval_minutes: int  # 0 = manual only
@@ -173,13 +173,6 @@ class Config:
         print("\nNo Bandcamp section found in config. Let's set it up.")
         print(f"(Adding [bandcamp] to {path})\n")
 
-        # username is required — loop until non-empty
-        username = ""
-        while not username:
-            username = _prompt("Bandcamp username", "")
-            if not username:
-                print("  Username is required.")
-
         cookie_file_str = _prompt(
             "Cookie file path (leave blank to use interactive login)", ""
         )
@@ -187,10 +180,10 @@ class Config:
         poll_str = _prompt("Poll interval in minutes (0 = manual sync only)", "0")
         poll_interval = int(poll_str) if poll_str.isdigit() else 0
 
-        # Build the TOML snippet — omit cookie_file when not provided
+        # Build the TOML snippet — omit cookie_file when not provided;
+        # username is omitted because it is extracted automatically after login.
         lines = [
             "\n[bandcamp]",
-            f'username = "{username}"',
         ]
         if cookie_file_str:
             lines.append(f'cookie_file = "{cookie_file_str}"')
@@ -234,7 +227,7 @@ class Config:
         if bc_raw:
             cf = bc_raw.get("cookie_file")
             bandcamp = BandcampConfig(
-                username=bc_raw["username"],
+                username=bc_raw.get("username"),
                 cookie_file=Path(cf).expanduser() if cf else None,
                 format=bc_raw.get("format", "mp3-v0"),
                 poll_interval_minutes=int(bc_raw.get("poll_interval_minutes", 0)),

--- a/kamp_daemon/menu_bar.py
+++ b/kamp_daemon/menu_bar.py
@@ -14,7 +14,6 @@ import platform
 import signal
 import subprocess
 import threading
-import urllib.request
 
 _logger = logging.getLogger(__name__)
 
@@ -79,16 +78,12 @@ class MenuBarApp(rumps.App):
         self._toggle_item = rumps.MenuItem("Stop", callback=self._on_toggle)
         self._sync_item = rumps.MenuItem("Bandcamp Sync", callback=self._on_sync)
         self._status_item = rumps.MenuItem("Status: Idle")
-        self._login_item = rumps.MenuItem("Bandcamp Login", callback=self._on_login)
-        self._logout_item = rumps.MenuItem("Bandcamp Logout", callback=self._on_logout)
 
         self.menu = [
             self._toggle_item,
             None,  # separator
             self._sync_item,
             self._status_item,
-            self._login_item,
-            self._logout_item,
             None,  # separator
             rumps.MenuItem("About Kamp", callback=self._on_about),
             rumps.MenuItem("Quit", callback=self._on_quit),
@@ -131,40 +126,16 @@ class MenuBarApp(rumps.App):
             try:
                 syncer.sync_once()
             except NeedsLoginError:
-                # No session — open the Bandcamp login window instead of
-                # logging a traceback.  _on_login POSTs to begin-login which
-                # triggers the Electron BrowserWindow via WebSocket push.
-                self._on_login(None)
+                # No valid session — direct the user to Preferences to reconnect.
+                logger.warning(
+                    "Bandcamp sync requires login. Open Preferences → Services to connect."
+                )
             except Exception:
                 logger.exception("Unhandled error during manual Bandcamp sync")
             finally:
                 self._sync_in_progress = False
 
         threading.Thread(target=_run, daemon=True).start()
-
-    def _on_login(self, sender: rumps.MenuItem) -> None:
-        """Signal the Electron UI to open a Bandcamp login BrowserWindow.
-
-        POSTs to the kamp HTTP server's begin-login endpoint, which broadcasts
-        a ``bandcamp.needs-login`` WebSocket push.  The Electron renderer
-        receives this push and invokes the ``bandcamp:begin-login`` IPC handler
-        in the Electron main process, which opens the actual BrowserWindow.
-        """
-        try:
-            req = urllib.request.Request(
-                "http://127.0.0.1:8000/api/v1/bandcamp/begin-login",
-                data=b"",
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=3)  # noqa: S310
-        except Exception as exc:
-            _logger.warning("Bandcamp begin-login request failed: %s", exc)
-
-    def _on_logout(self, sender: rumps.MenuItem) -> None:
-        from .syncer import logout
-
-        logout()
-        self._refresh_bandcamp_items()
 
     def _on_notification(self, title: str, subtitle: str, message: str) -> None:
         """Fire a macOS notification.
@@ -340,35 +311,19 @@ class MenuBarApp(rumps.App):
             _logger.warning("Pulse animation failed: %s", exc)
 
     def _refresh_bandcamp_items(self) -> None:
-        """Disable Bandcamp items when config or conditions prevent use."""
-        bc = self._core._config.bandcamp
-        has_bandcamp = bc is not None
+        """Enable/disable Bandcamp Sync based on config and sync state."""
+        has_bandcamp = self._core._config.bandcamp is not None
         sync_available = has_bandcamp and not self._sync_in_progress
-        # Login/Logout are disabled mid-sync to avoid touching the session while it's in use.
-        login_available = has_bandcamp and not self._sync_in_progress
-        logout_available = has_bandcamp and not self._sync_in_progress
 
         if sync_available:
             self._sync_item.set_callback(self._on_sync)
         else:
             self._sync_item.set_callback(None)
 
-        if login_available:
-            self._login_item.set_callback(self._on_login)
-        else:
-            self._login_item.set_callback(None)
-
-        if logout_available:
-            self._logout_item.set_callback(self._on_logout)
-        else:
-            self._logout_item.set_callback(None)
-
         # setEnabled_ controls the visual gray-out at the AppKit level;
         # set_callback(None) alone only removes the click handler.
         try:
             self._sync_item._menuitem.setEnabled_(sync_available)
             self._status_item._menuitem.setEnabled_(has_bandcamp)
-            self._login_item._menuitem.setEnabled_(login_available)
-            self._logout_item._menuitem.setEnabled_(logout_available)
         except Exception:
             pass

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -185,14 +185,12 @@ export const connectLastfm = (
 ): Promise<{ ok: boolean; username: string }> =>
   post('/api/v1/lastfm/connect', { username, password })
 
-export const disconnectLastfm = (): Promise<{ ok: boolean }> =>
-  del('/api/v1/lastfm/connect')
+export const disconnectLastfm = (): Promise<{ ok: boolean }> => del('/api/v1/lastfm/connect')
 
 export const getBandcampStatus = (): Promise<{ connected: boolean; username: string | null }> =>
   get('/api/v1/bandcamp/status')
 
-export const disconnectBandcamp = (): Promise<{ ok: boolean }> =>
-  del('/api/v1/bandcamp/connect')
+export const disconnectBandcamp = (): Promise<{ ok: boolean }> => del('/api/v1/bandcamp/connect')
 
 // ---------------------------------------------------------------------------
 // Player

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -188,6 +188,12 @@ export const connectLastfm = (
 export const disconnectLastfm = (): Promise<{ ok: boolean }> =>
   del('/api/v1/lastfm/connect')
 
+export const getBandcampStatus = (): Promise<{ connected: boolean; username: string | null }> =>
+  get('/api/v1/bandcamp/status')
+
+export const disconnectBandcamp = (): Promise<{ ok: boolean }> =>
+  del('/api/v1/bandcamp/connect')
+
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -3,7 +3,12 @@ import { useStore } from '../store'
 import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
-import { connectLastfm, disconnectLastfm, getBandcampStatus, disconnectBandcamp } from '../api/client'
+import {
+  connectLastfm,
+  disconnectLastfm,
+  getBandcampStatus,
+  disconnectBandcamp
+} from '../api/client'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -721,11 +726,19 @@ function BandcampSection({
       <div className="prefs-row-header">
         <span className="prefs-label">Session</span>
       </div>
-      {connectedUsername !== undefined && (
-        connectedUsername !== null ? (
+      {connectedUsername !== undefined &&
+        (connectedUsername !== null ? (
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <span style={{ fontSize: 13 }}>
-              Connected{connectedUsername ? <> as <strong>{connectedUsername}</strong></> : ''}
+              Connected
+              {connectedUsername ? (
+                <>
+                  {' '}
+                  as <strong>{connectedUsername}</strong>
+                </>
+              ) : (
+                ''
+              )}
             </span>
             <button
               className="prefs-choose-btn prefs-choose-btn--destructive"
@@ -745,9 +758,12 @@ function BandcampSection({
               {busy ? 'Waiting…' : 'Connect to Bandcamp'}
             </button>
           </div>
-        )
+        ))}
+      {error && (
+        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+          {error}
+        </p>
       )}
-      {error && <p className="prefs-hint" style={{ color: 'var(--error)' }}>{error}</p>}
     </div>
   )
 }
@@ -849,7 +865,11 @@ function LastfmSection({
               onKeyDown={(e) => e.key === 'Enter' && void handleConnect()}
             />
           </div>
-          {error && <p className="prefs-hint" style={{ color: 'var(--error)' }}>{error}</p>}
+          {error && (
+            <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+              {error}
+            </p>
+          )}
           <div className="prefs-row" style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
             <button
               className="prefs-choose-btn"
@@ -940,7 +960,8 @@ export function PreferencesDialog({
   if (!prefsOpen) return null
 
   // Show a loading placeholder while config is being fetched (General/Services tabs).
-  const configLoading = configValues === null && (activeTab === 'general' || activeTab === 'services')
+  const configLoading =
+    configValues === null && (activeTab === 'general' || activeTab === 'services')
 
   const hasBandcamp = configValues !== null && configValues['bandcamp.format'] !== null
 

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -3,12 +3,7 @@ import { useStore } from '../store'
 import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
-import {
-  connectLastfm,
-  disconnectLastfm,
-  getBandcampStatus,
-  disconnectBandcamp
-} from '../api/client'
+import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -666,28 +661,16 @@ function ExtensionsPanel({
 // ---------------------------------------------------------------------------
 
 function BandcampSection({
+  connectedUsername,
   onConnected,
   onDisconnected
 }: {
+  connectedUsername: string | null
   onConnected: () => void
   onDisconnected: () => void
 }): React.JSX.Element {
-  const [connectedUsername, setConnectedUsername] = useState<string | null | undefined>(undefined)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  const loadStatus = useCallback(async (): Promise<void> => {
-    try {
-      const s = await getBandcampStatus()
-      setConnectedUsername(s.connected ? (s.username ?? '') : null)
-    } catch {
-      setConnectedUsername(null)
-    }
-  }, [])
-
-  useEffect(() => {
-    void loadStatus()
-  }, [loadStatus])
 
   const handleConnect = async (): Promise<void> => {
     setBusy(true)
@@ -695,7 +678,6 @@ function BandcampSection({
     try {
       const result = await window.api.bandcamp.beginLogin()
       if (result.ok) {
-        await loadStatus()
         onConnected()
       } else {
         setError(result.error ?? 'Login cancelled.')
@@ -712,7 +694,6 @@ function BandcampSection({
     setError(null)
     try {
       await disconnectBandcamp()
-      setConnectedUsername(null)
       onDisconnected()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Disconnect failed.')
@@ -726,39 +707,26 @@ function BandcampSection({
       <div className="prefs-row-header">
         <span className="prefs-label">Session</span>
       </div>
-      {connectedUsername !== undefined &&
-        (connectedUsername !== null ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <span style={{ fontSize: 13 }}>
-              Connected
-              {connectedUsername ? (
-                <>
-                  {' '}
-                  as <strong>{connectedUsername}</strong>
-                </>
-              ) : (
-                ''
-              )}
-            </span>
-            <button
-              className="prefs-choose-btn prefs-choose-btn--destructive"
-              onClick={() => void handleDisconnect()}
-              disabled={busy}
-            >
-              Disconnect
-            </button>
-          </div>
-        ) : (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <button
-              className="prefs-choose-btn"
-              onClick={() => void handleConnect()}
-              disabled={busy}
-            >
-              {busy ? 'Waiting…' : 'Connect to Bandcamp'}
-            </button>
-          </div>
-        ))}
+      {connectedUsername ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 13 }}>
+            Connected as <strong>{connectedUsername}</strong>
+          </span>
+          <button
+            className="prefs-choose-btn prefs-choose-btn--destructive"
+            onClick={() => void handleDisconnect()}
+            disabled={busy}
+          >
+            Disconnect
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <button className="prefs-choose-btn" onClick={() => void handleConnect()} disabled={busy}>
+            {busy ? 'Waiting…' : 'Connect to Bandcamp'}
+          </button>
+        </div>
+      )}
       {error && (
         <p className="prefs-hint" style={{ color: 'var(--error)' }}>
           {error}
@@ -1135,6 +1103,7 @@ export function PreferencesDialog({
                         onSave={handleSave}
                       />
                       <BandcampSection
+                        connectedUsername={configValues?.['bandcamp.username'] ?? null}
                         onConnected={() => void loadConfig()}
                         onDisconnected={() => void loadConfig()}
                       />

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -3,7 +3,7 @@ import { useStore } from '../store'
 import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
-import { connectLastfm, disconnectLastfm } from '../api/client'
+import { connectLastfm, disconnectLastfm, getBandcampStatus, disconnectBandcamp } from '../api/client'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -657,29 +657,60 @@ function ExtensionsPanel({
 }
 
 // ---------------------------------------------------------------------------
-// Bandcamp login row
+// Bandcamp section
 // ---------------------------------------------------------------------------
 
-function BandcampLoginRow(): React.JSX.Element {
+function BandcampSection({
+  onConnected,
+  onDisconnected
+}: {
+  onConnected: () => void
+  onDisconnected: () => void
+}): React.JSX.Element {
+  const [connectedUsername, setConnectedUsername] = useState<string | null | undefined>(undefined)
   const [busy, setBusy] = useState(false)
-  const [status, setStatus] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const handleLogin = async (): Promise<void> => {
+  const loadStatus = useCallback(async (): Promise<void> => {
+    try {
+      const s = await getBandcampStatus()
+      setConnectedUsername(s.connected ? (s.username ?? '') : null)
+    } catch {
+      setConnectedUsername(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
+
+  const handleConnect = async (): Promise<void> => {
     setBusy(true)
     setError(null)
-    setStatus('Opening Bandcamp login window…')
     try {
       const result = await window.api.bandcamp.beginLogin()
       if (result.ok) {
-        setStatus('Logged in. Sync will use the new session.')
+        await loadStatus()
+        onConnected()
       } else {
-        setStatus(null)
         setError(result.error ?? 'Login cancelled.')
       }
     } catch (e) {
-      setStatus(null)
       setError(e instanceof Error ? e.message : 'Login failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDisconnect = async (): Promise<void> => {
+    setBusy(true)
+    setError(null)
+    try {
+      await disconnectBandcamp()
+      setConnectedUsername(null)
+      onDisconnected()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Disconnect failed.')
     } finally {
       setBusy(false)
     }
@@ -690,12 +721,32 @@ function BandcampLoginRow(): React.JSX.Element {
       <div className="prefs-row-header">
         <span className="prefs-label">Session</span>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button className="prefs-choose-btn" onClick={() => void handleLogin()} disabled={busy}>
-          {busy ? 'Waiting…' : 'Connect to Bandcamp'}
-        </button>
-        {status && <span style={{ fontSize: 12 }}>{status}</span>}
-      </div>
+      {connectedUsername !== undefined && (
+        connectedUsername !== null ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span style={{ fontSize: 13 }}>
+              Connected{connectedUsername ? <> as <strong>{connectedUsername}</strong></> : ''}
+            </span>
+            <button
+              className="prefs-choose-btn prefs-choose-btn--destructive"
+              onClick={() => void handleDisconnect()}
+              disabled={busy}
+            >
+              Disconnect
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <button
+              className="prefs-choose-btn"
+              onClick={() => void handleConnect()}
+              disabled={busy}
+            >
+              {busy ? 'Waiting…' : 'Connect to Bandcamp'}
+            </button>
+          </div>
+        )
+      )}
       {error && <p className="prefs-hint" style={{ color: 'var(--error)' }}>{error}</p>}
     </div>
   )
@@ -891,7 +942,7 @@ export function PreferencesDialog({
   // Show a loading placeholder while config is being fetched (General/Services tabs).
   const configLoading = configValues === null && (activeTab === 'general' || activeTab === 'services')
 
-  const hasBandcamp = configValues !== null && configValues['bandcamp.username'] !== null
+  const hasBandcamp = configValues !== null && configValues['bandcamp.format'] !== null
 
   const str = (key: keyof NonNullable<typeof configValues>): string => {
     if (!configValues) return ''
@@ -1046,12 +1097,6 @@ export function PreferencesDialog({
                   {hasBandcamp && (
                     <div className="prefs-section">
                       <div className="prefs-section-label">Bandcamp</div>
-                      <InputRow
-                        label="Username"
-                        configKey="bandcamp.username"
-                        initialValue={str('bandcamp.username')}
-                        onSave={handleSave}
-                      />
                       <SelectRow
                         label="Download format"
                         configKey="bandcamp.format"
@@ -1068,7 +1113,10 @@ export function PreferencesDialog({
                         hint="0 = manual only"
                         onSave={handleSave}
                       />
-                      <BandcampLoginRow />
+                      <BandcampSection
+                        onConnected={() => void loadConfig()}
+                        onDisconnected={() => void loadConfig()}
+                      />
                     </div>
                   )}
 

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -22,7 +22,7 @@ from kamp_daemon.bandcamp import (
     _fetch_collection,
     _get_cdn_url,
     _get_download_links,
-    _get_fan_id,
+    _get_fan_info,
     _load_state,
     _make_requests_session,
     _paginate,
@@ -280,19 +280,36 @@ class TestExtractPagedata:
 
 
 # ---------------------------------------------------------------------------
-# _get_fan_id
+# _get_fan_info
 # ---------------------------------------------------------------------------
 
 
-class TestGetFanId:
-    def test_returns_fan_id_from_collection_summary(self) -> None:
+class TestGetFanInfo:
+    def test_returns_fan_id_and_username_from_collection_summary(self) -> None:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "fan_id": 42,
+            "username": "testuser",
+            "collection_summary": {},
+        }
+        resp.raise_for_status = MagicMock()
+        session.get.return_value = resp
+        fan_id, username = _get_fan_info(session)
+        assert fan_id == 42
+        assert username == "testuser"
+
+    def test_returns_empty_username_when_absent(self) -> None:
         session = MagicMock()
         resp = MagicMock()
         resp.status_code = 200
         resp.json.return_value = {"fan_id": 42, "collection_summary": {}}
         resp.raise_for_status = MagicMock()
         session.get.return_value = resp
-        assert _get_fan_id(session) == 42
+        fan_id, username = _get_fan_info(session)
+        assert fan_id == 42
+        assert username == ""
 
     def test_raises_needs_login_on_401(self) -> None:
         session = MagicMock()
@@ -300,7 +317,7 @@ class TestGetFanId:
         resp.status_code = 401
         session.get.return_value = resp
         with pytest.raises(NeedsLoginError):
-            _get_fan_id(session)
+            _get_fan_info(session)
 
     def test_raises_needs_login_on_302(self) -> None:
         session = MagicMock()
@@ -308,7 +325,7 @@ class TestGetFanId:
         resp.status_code = 302
         session.get.return_value = resp
         with pytest.raises(NeedsLoginError):
-            _get_fan_id(session)
+            _get_fan_info(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,13 +83,15 @@ class TestBandcampSetup:
     ) -> None:
         """bandcamp_setup appends [bandcamp] without clobbering existing content."""
         path = _base_config(tmp_path)
-        inputs = iter(["bcuser", "", "mp3-320", "60"])
+        # username is no longer prompted — inputs: cookie_file, format, poll_interval
+        inputs = iter(["", "mp3-320", "60"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         config = Config.bandcamp_setup(path)
 
         assert config.bandcamp is not None
-        assert config.bandcamp.username == "bcuser"
+        # username is None at setup time; extracted automatically after login
+        assert config.bandcamp.username is None
         assert config.bandcamp.format == "mp3-320"
         assert config.bandcamp.poll_interval_minutes == 60
         assert config.bandcamp.cookie_file is None
@@ -100,27 +102,13 @@ class TestBandcampSetup:
     ) -> None:
         """cookie_file is written and parsed when the user provides a path."""
         path = _base_config(tmp_path)
-        inputs = iter(["bcuser", "/tmp/cookie", "mp3-v0", "0"])
+        inputs = iter(["/tmp/cookie", "mp3-v0", "0"])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         config = Config.bandcamp_setup(path)
 
         assert config.bandcamp is not None
         assert config.bandcamp.cookie_file == Path("/tmp/cookie")
-
-    def test_blank_username_reprompts(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Entering a blank username re-prompts rather than saving an empty string."""
-        path = _base_config(tmp_path)
-        # first two responses are blank (username reprompt), then a valid name
-        inputs = iter(["", "", "realuser", "", "mp3-v0", "0"])
-        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
-
-        config = Config.bandcamp_setup(path)
-
-        assert config.bandcamp is not None
-        assert config.bandcamp.username == "realuser"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1299,6 +1299,103 @@ class TestLastfmEndpoints:
 
 
 # ---------------------------------------------------------------------------
+# Bandcamp session status / disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestBandcampStatus:
+    def test_status_returns_disconnected_when_no_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        response = TestClient(app).get("/api/v1/bandcamp/status")
+        assert response.status_code == 200
+        assert response.json() == {"connected": False, "username": None}
+
+    def test_status_returns_connected_with_username(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        session = {"cookies": [], "username": "johndoe"}
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            get_bandcamp_session=lambda: session,
+        )
+        response = TestClient(app).get("/api/v1/bandcamp/status")
+        assert response.status_code == 200
+        assert response.json() == {"connected": True, "username": "johndoe"}
+
+    def test_status_returns_connected_without_username(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        session: dict = {"cookies": []}
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            get_bandcamp_session=lambda: session,
+        )
+        response = TestClient(app).get("/api/v1/bandcamp/status")
+        assert response.status_code == 200
+        assert response.json() == {"connected": True, "username": None}
+
+    def test_status_returns_disconnected_when_session_is_none(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            get_bandcamp_session=lambda: None,
+        )
+        response = TestClient(app).get("/api/v1/bandcamp/status")
+        assert response.status_code == 200
+        assert response.json() == {"connected": False, "username": None}
+
+    def test_disconnect_calls_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        called: list[bool] = []
+
+        def _on_disconnect() -> None:
+            called.append(True)
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_bandcamp_disconnect=_on_disconnect,
+        )
+        response = TestClient(app).delete("/api/v1/bandcamp/connect")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        assert called == [True]
+
+    def test_disconnect_returns_503_when_no_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        response = TestClient(app).delete("/api/v1/bandcamp/connect")
+        assert response.status_code == 503
+
+    def test_disconnect_clears_bandcamp_username_in_config(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values={"bandcamp.username": "johndoe"},
+            on_bandcamp_disconnect=lambda: None,
+        )
+        c = TestClient(app)
+        c.delete("/api/v1/bandcamp/connect")
+        data = c.get("/api/v1/config").json()
+        assert data["bandcamp.username"] is None
+
+
+# ---------------------------------------------------------------------------
 # Bandcamp proxy endpoints
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `_get_fan_id` renamed to `_get_fan_info`, now returns `(fan_id, username)` extracted from the `collection_summary` API response
- `BandcampConfig.username` made optional — no longer a required field in `config.toml`; username is fetched automatically after login and stored in the DB session
- After login, `_on_bandcamp_login_complete` immediately fetches the username and persists it, so `GET /api/v1/config` reflects it without waiting for a sync
- Added `GET /api/v1/bandcamp/status` and `DELETE /api/v1/bandcamp/connect` endpoints
- Preferences Bandcamp section now mirrors Last.fm: shows "Connected as **{username}**" + Disconnect button, or "Connect to Bandcamp" button — Username `InputRow` removed

## Test plan

- [x] All 1040 existing tests pass (`poetry run pytest --no-cov`)
- [x] New `TestGetFanInfo` tests cover fan_id + username extraction and graceful missing-username handling
- [x] New `TestBandcampStatus` tests cover status/disconnect endpoints (connected, disconnected, with/without username)
- [x] Config tests updated: `bandcamp_setup` no longer prompts for username
- [x] Manually verify: log in to Bandcamp via Preferences → section shows "Connected as {username}" immediately; Disconnect clears it

🤖 Generated with [Claude Code](https://claude.com/claude-code)