### PR TITLE
fix: FLAC/OGG blank tags + Last.fm 400 errors (TASK-136)

### DIFF
--- a/backlog/tasks/task-136 - FLAC-artist-album-song-tags-arent-being-read-correctly.md
+++ b/backlog/tasks/task-136 - FLAC-artist-album-song-tags-arent-being-read-correctly.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-136
 title: FLAC artist / album / song tags aren't being read correctly
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-17 00:45'
-updated_date: '2026-04-17 00:50'
+updated_date: '2026-04-17 19:31'
 labels: []
 milestone: m-27
 dependencies: []

--- a/backlog/tasks/task-136 - FLAC-artist-album-song-tags-arent-being-read-correctly.md
+++ b/backlog/tasks/task-136 - FLAC-artist-album-song-tags-arent-being-read-correctly.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-136
 title: FLAC artist / album / song tags aren't being read correctly
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-17 00:45'
-updated_date: '2026-04-17 19:31'
+updated_date: '2026-04-17 20:23'
 labels: []
 milestone: m-27
 dependencies: []
 priority: medium
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-137 - Files-without-an-Album-tag-are-organized-using-their-Song-Title.md
+++ b/backlog/tasks/task-137 - Files-without-an-Album-tag-are-organized-using-their-Song-Title.md
@@ -1,0 +1,22 @@
+---
+id: TASK-137
+title: Files without an Album tag are organized using their Song Title
+status: To Do
+assignee: []
+created_date: '2026-04-17 20:23'
+labels: []
+milestone: m-27
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+If there is no Album tag in a file, we currently organize it as though there is no artist or album information.
+
+With the referenced file, there are two issues:
+* The Artist is present in the file tags ("Mndsgn.") - It looks like Album Artist isn't present, so we have no fallback.
+* The Album isn't present in file tags, but the file is its own standalone release and shouldn't be grouped with other files that don't have album tags
+
+In the Library view, we should show this file as its own "album" with the song title in *Italics* to indicate the metadata issue.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-138 - the-area-under-the-queue-is-an-active-drop-target-for-Add-to-Queue.md
+++ b/backlog/tasks/task-138 - the-area-under-the-queue-is-an-active-drop-target-for-Add-to-Queue.md
@@ -1,0 +1,22 @@
+---
+id: TASK-138
+title: the area under the queue is an active drop target for Add to Queue
+status: To Do
+assignee: []
+created_date: '2026-04-17 20:43'
+labels: []
+milestone: m-27
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Albums and tracks can be dragged to the queue for insert operations, but the space at the bottom of the queue is currently an invalid drag target.
+
+Given a user wants to add an album to the end of the queue
+When they click and drag the album to the space below the last song in the queue
+Then the album is added to the end of the queue
+
+Same applies for a single track.
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -992,7 +992,13 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
             audio = mutagen.flac.FLAC(str(path))
         else:
             audio = mutagen.oggvorbis.OggVorbis(str(path))
-        tags: dict[str, list[str]] = dict(audio.tags or {})
+        # Vorbis comment keys are case-insensitive; real mutagen VCFLACDict/
+        # VCommentDict yields lowercase keys from dict(), so normalise to
+        # uppercase so that _s("ARTIST") etc. always find a match.
+        tags: dict[str, list[str]] = {
+            k.upper(): (v if isinstance(v, list) else [v])
+            for k, v in dict(audio.tags or {}).items()
+        }
         pictures = getattr(audio, "pictures", [])
     except Exception:
         tags = {}

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 8
+_SCHEMA_VERSION = 9
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -325,6 +325,17 @@ class LibraryIndex:
             # The table is created by _DDL via executescript at the top of
             # _migrate, so we only need to bump the version here.
             self._conn.execute("UPDATE schema_version SET version = 8")
+            self._conn.commit()
+
+        if version < 9:
+            # v8 → v9: fix blank tags caused by the buggy FLAC/OGG tag reader
+            # (which looked up uppercase keys in a lowercase dict).  Nulling
+            # file_mtime for all FLAC/OGG tracks forces the scanner to re-read
+            # their tags on the next startup scan.
+            self._conn.execute(
+                "UPDATE tracks SET file_mtime = NULL WHERE ext IN ('flac', 'ogg')"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 9")
             self._conn.commit()
 
     def _rebuild_fts(self) -> None:

--- a/kamp_core/scrobbler.py
+++ b/kamp_core/scrobbler.py
@@ -94,6 +94,10 @@ class Scrobbler:
         if track is None:
             return
 
+        # Last.fm requires artist and title; skip rather than send a 400.
+        if not track.artist or not track.title:
+            return
+
         try:
             self._network.update_now_playing(
                 artist=track.artist,
@@ -137,6 +141,9 @@ class Scrobbler:
 
     def _scrobble(self, track: Track) -> None:
         self._scrobbled = True
+        # Last.fm requires artist and title; skip rather than send a 400.
+        if not track.artist or not track.title:
+            return
         try:
             self._network.scrobble(
                 artist=track.artist,

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 8
+        assert version == 9
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -970,7 +970,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 8
+        assert version == 9
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1027,7 +1027,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 8
+        assert version == 9
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1320,7 +1320,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 8
+        assert version == 9
         assert row is not None
         assert row[0] == 0
 
@@ -1433,7 +1433,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 8
+        assert version == 9
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -1614,7 +1614,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 8
+        assert version == 9
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -1682,4 +1682,78 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 8
+        assert version == 9
+
+    def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
+        index = self._make_index(tmp_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        index.close()
+        assert version == 9
+
+    def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
+        """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
+
+        This fixes the case where blank tags (written by the buggy tag reader)
+        were cached in the DB and would never be refreshed without this nudge.
+        """
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (8)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path       TEXT UNIQUE NOT NULL,
+                title           TEXT NOT NULL DEFAULT '',
+                artist          TEXT NOT NULL DEFAULT '',
+                album_artist    TEXT NOT NULL DEFAULT '',
+                album           TEXT NOT NULL DEFAULT '',
+                year            TEXT NOT NULL DEFAULT '',
+                track_number    INTEGER,
+                disc_number     INTEGER NOT NULL DEFAULT 1,
+                ext             TEXT NOT NULL DEFAULT '',
+                embedded_art    INTEGER NOT NULL DEFAULT 0,
+                mb_release_id   TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added      TEXT,
+                last_played     TEXT,
+                favorite        INTEGER NOT NULL DEFAULT 0,
+                play_count      INTEGER NOT NULL DEFAULT 0,
+                file_mtime      REAL
+            )
+            """)
+        # Insert one of each format: FLAC/OGG should have mtime nulled; MP3/M4A kept.
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, file_mtime) VALUES (?, ?, ?)",
+            ("/music/a.flac", "flac", 1111.0),
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, file_mtime) VALUES (?, ?, ?)",
+            ("/music/b.ogg", "ogg", 2222.0),
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, file_mtime) VALUES (?, ?, ?)",
+            ("/music/c.mp3", "mp3", 3333.0),
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, file_mtime) VALUES (?, ?, ?)",
+            ("/music/d.m4a", "m4a", 4444.0),
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        rows = index._conn.execute(
+            "SELECT ext, file_mtime FROM tracks ORDER BY file_path"
+        ).fetchall()
+        index.close()
+
+        by_ext = {r[0]: r[1] for r in rows}
+        assert by_ext["flac"] is None, "FLAC mtime should be nulled by migration"
+        assert by_ext["ogg"] is None, "OGG mtime should be nulled by migration"
+        assert by_ext["mp3"] == 3333.0, "MP3 mtime should be unchanged"
+        assert by_ext["m4a"] == 4444.0, "M4A mtime should be unchanged"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -643,6 +643,38 @@ class TestLibraryScanner:
         assert t.mb_release_id == "mbid-flac"
         assert t.ext == "flac"
 
+    def test_scan_reads_flac_tags_lowercase_keys(self, tmp_path: Path) -> None:
+        """Real mutagen VCFLACDict yields lowercase keys; the reader must handle them."""
+        lib = tmp_path / "music"
+        lib.mkdir()
+        (lib / "01.flac").write_bytes(b"fLaC")
+
+        mock_audio = MagicMock()
+        mock_audio.tags = {
+            "artist": ["Stereolab"],
+            "albumartist": ["Stereolab"],
+            "album": ["Emperor Tomato Ketchup"],
+            "date": ["1996"],
+            "title": ["Metronomic Underground"],
+            "tracknumber": ["1"],
+            "discnumber": ["1"],
+            "musicbrainz_albumid": ["mbid-etk"],
+        }
+        mock_audio.pictures = []
+
+        with patch("kamp_core.library.mutagen.flac.FLAC", return_value=mock_audio):
+            index = LibraryIndex(tmp_path / "library.db")
+            LibraryScanner(index).scan(lib)
+            tracks = index.all_tracks()
+            index.close()
+
+        t = tracks[0]
+        assert t.artist == "Stereolab"
+        assert t.album == "Emperor Tomato Ketchup"
+        assert t.title == "Metronomic Underground"
+        assert t.year == "1996"
+        assert t.mb_release_id == "mbid-etk"
+
     def test_scan_reads_ogg_tags(self, tmp_path: Path) -> None:
         lib = tmp_path / "music"
         lib.mkdir()

--- a/tests/test_scrobbler.py
+++ b/tests/test_scrobbler.py
@@ -139,6 +139,18 @@ class TestOnTrackChanged:
         call_kwargs = net.update_now_playing.call_args.kwargs
         assert call_kwargs.get("album_artist") == "Various Artists"
 
+    def test_skips_now_playing_when_artist_is_blank(self) -> None:
+        """Tracks with no artist tag must not be sent to Last.fm (400 error)."""
+        s, net = _make_scrobbler()
+        s.on_track_changed(_track(artist="", title="Metronomic Underground"))
+        net.update_now_playing.assert_not_called()
+
+    def test_skips_now_playing_when_title_is_blank(self) -> None:
+        """Tracks with no title tag must not be sent to Last.fm (400 error)."""
+        s, net = _make_scrobbler()
+        s.on_track_changed(_track(artist="Stereolab", title=""))
+        net.update_now_playing.assert_not_called()
+
     def test_now_playing_exception_does_not_propagate(self) -> None:
         """pylast exceptions must never crash the player."""
         s, net = _make_scrobbler()
@@ -265,6 +277,12 @@ class TestTick:
         t = _track()
         # Should not raise
         self._advance(s, t, 35.0)
+
+    def test_skips_scrobble_when_artist_is_blank(self) -> None:
+        """Tracks with no artist tag must not be scrobbled (Last.fm rejects them)."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(artist="", title="Metronomic Underground"), 35.0)
+        net.scrobble.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause:** `mutagen`'s `VCFLACDict`/`VCommentDict` normalises keys to lowercase in its `dict()` representation, but `_read_vorbis_tags` looked up uppercase keys (`"ARTIST"`, `"ALBUM"`, etc.) — always returning `""`. Album art was unaffected because it reads `audio.pictures` directly.
- **Tag reader fix:** Normalise keys to uppercase at dict-construction time so lookups succeed regardless of original casing.
- **DB migration (v8→v9):** Nulls `file_mtime` for all existing FLAC/OGG rows, forcing the next startup scan to re-read their tags. Without this, already-indexed tracks with blank tags would never be refreshed (scanner skips files whose mtime hasn't changed).
- **Scrobbler guard:** Skip `update_now_playing` and `_scrobble` when `artist` or `title` is blank — Last.fm returns 400 "missing required parameter" for those calls, causing noisy warnings in the log.

## Test plan

- [x] `poetry run pytest tests/test_library.py tests/test_scrobbler.py --no-cov` — all 124 pass
- [x] Restart the daemon against the live library; Stereolab's Emperor Tomato Ketchup should appear with correct artist/album/title after the startup scan
- [x] Play a FLAC track; Last.fm now-playing updates cleanly (no 400 errors in log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)