### PR TITLE
feat: show tracks without album tags as individual library entries (TASK-137)

### DIFF
--- a/backlog/tasks/task-137 - Files-without-an-Album-tag-are-organized-using-their-Song-Title.md
+++ b/backlog/tasks/task-137 - Files-without-an-Album-tag-are-organized-using-their-Song-Title.md
@@ -1,12 +1,14 @@
 ---
 id: TASK-137
 title: Files without an Album tag are organized using their Song Title
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-17 20:23'
+updated_date: '2026-04-17 22:10'
 labels: []
 milestone: m-27
 dependencies: []
+ordinal: 4000
 ---
 
 ## Description
@@ -20,3 +22,40 @@ With the referenced file, there are two issues:
 
 In the Library view, we should show this file as its own "album" with the song title in *Italics* to indicate the metadata issue.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each track without an Album tag appears as its own album entry in the Library view
+- [ ] #2 The song title is displayed in italics for missing-album entries to indicate the metadata issue
+- [ ] #3 Clicking a missing-album card opens the track list and plays correctly
+- [ ] #4 Context menu Play Next / Add to Queue work for missing-album entries
+- [ ] #5 Search results correctly include missing-album tracks
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Implementation
+
+**Backend (`kamp_core/library.py`, `kamp_core/server.py`)**
+
+- Added `missing_album: bool = False` and `file_path: str = ""` fields to `AlbumInfo` dataclass
+- Rewrote `albums()` to use a UNION ALL query: tracks with albums group as before; tracks with no album tag each get their own entry with `title` as the display album name, `missing_album=True`, and the track's `file_path` as a unique key
+- Updated `_SORT_CLAUSES` to use `sort_date_added`/`sort_last_played` aliases produced by the UNION subquery (previously used `MIN()`/`MAX()` aggregate aliases that don't work across a UNION)
+- Added `missing_album` and `file_path` fields to `AlbumOut` response model
+- All endpoints that look up tracks by `(album_artist, album)` now accept an optional `file_path` parameter and use `get_track_by_path()` when it's provided: `GET /api/v1/tracks`, `GET /api/v1/album-art`, `POST /api/v1/player/play`, and all album queue endpoints
+- Fixed `search_library` to match missing-album entries by `file_path` (since their DB album is `""` but AlbumInfo.album is the display title)
+
+**Frontend (`kamp_ui/src/renderer/src/`)**
+
+- Extended `Album` type with `missing_album: boolean` and `file_path: string`
+- Updated `artUrl`, `getTracksForAlbum`, `playAlbum`, `addAlbumToQueue`, `playAlbumNext`, `insertAlbumAt` in `client.ts` to accept optional `filePath` and include it in requests
+- `AlbumGrid.tsx`: italicize album title when `missing_album`; use `file_path` as React key; `isActive` check uses `file_path` comparison for missing-album cards; drag data includes `file_path`; context menu passes `file_path`
+- `store.ts`: all album actions updated to thread `filePath` through to the API; `loadTracks` uses `file_path` as the cache key for missing-album entries; `selectAlbum` and `refreshOpenAlbum` pass `album.file_path`
+- `TrackList.tsx`, `SearchView.tsx`, `QueuePanel.tsx`: all `playTrack`/`addAlbumToQueue`/`playAlbumNext`/`insertAlbumAt` calls pass `file_path` where applicable
+
+**Tests**
+
+- 3 new `TestLibraryIndex` tests: single missing-album track gets its own entry, two missing-album tracks each get separate entries, missing-album and normal albums coexist correctly
+- 3 new `TestMissingAlbumEndpoints` server tests: `AlbumOut` includes new fields, tracks endpoint uses `file_path` when provided, album-art endpoint uses `file_path` when provided
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 9
+_SCHEMA_VERSION = 10
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -142,8 +142,11 @@ _SORT_CLAUSES: dict[str, str] = {
     "album_artist": "album_artist COLLATE NOCASE, album COLLATE NOCASE",
     "album": "album COLLATE NOCASE, album_artist COLLATE NOCASE",
     # Newest first (largest timestamp); NULLs sort last in DESC.
-    "date_added": "MIN(date_added) DESC, album_artist COLLATE NOCASE",
-    "last_played": "MAX(last_played) DESC, album_artist COLLATE NOCASE",
+    # These reference the sort_date_added / sort_last_played columns produced
+    # by the UNION ALL query in albums() (aliases for MIN/MAX in the grouped
+    # part and the raw value in the single-track missing-album part).
+    "date_added": "sort_date_added DESC, album_artist COLLATE NOCASE",
+    "last_played": "sort_last_played DESC, album_artist COLLATE NOCASE",
 }
 
 
@@ -190,6 +193,10 @@ class AlbumInfo:
     year: str
     track_count: int
     has_art: bool = False
+    # True when the track has no album tag; album field holds the track title
+    # as a display name, and file_path uniquely identifies this virtual album.
+    missing_album: bool = False
+    file_path: str = ""
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -338,6 +345,20 @@ class LibraryIndex:
             self._conn.execute("UPDATE schema_version SET version = 9")
             self._conn.commit()
 
+        if version < 10:
+            # v9 → v10: tag readers now fall back album_artist → artist when the
+            # album-artist tag is absent.  Null file_mtime for tracks that have
+            # an artist but no album_artist so the scanner re-reads them and
+            # derives album_artist from artist on the next scan.
+            # Tracks with both fields empty are left alone — re-reading them
+            # would produce the same empty result.
+            self._conn.execute(
+                "UPDATE tracks SET file_mtime = NULL"
+                " WHERE album_artist = '' AND artist != ''"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 10")
+            self._conn.commit()
+
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
         self._conn.execute("DELETE FROM tracks_fts")
@@ -452,16 +473,36 @@ class LibraryIndex:
     def albums(self, sort: str = "album_artist") -> list[AlbumInfo]:
         """Return one AlbumInfo per (album_artist, album) pair.
 
+        Tracks that have no album tag are each returned as their own entry
+        with ``missing_album=True``; the ``album`` field is set to the track
+        title (for display) and ``file_path`` uniquely identifies the entry.
+
         *sort* must be one of: ``album_artist`` (default), ``album``,
         ``date_added``, ``last_played``.  Unknown values fall back to
         ``album_artist`` so callers never have to guard against bad input.
         """
         order_by = _SORT_CLAUSES.get(sort, _SORT_CLAUSES["album_artist"])
         rows = self._conn.execute(f"""
-            SELECT album_artist, album, year, COUNT(*) AS track_count,
-                   MAX(embedded_art) AS has_art
-            FROM tracks
-            GROUP BY album_artist, album
+            SELECT album_artist, album, year, track_count, has_art,
+                   missing_album, file_path
+            FROM (
+                SELECT album_artist, album, year, COUNT(*) AS track_count,
+                       MAX(embedded_art) AS has_art,
+                       0 AS missing_album, '' AS file_path,
+                       MIN(date_added) AS sort_date_added,
+                       MAX(last_played) AS sort_last_played
+                FROM tracks
+                WHERE album != ''
+                GROUP BY album_artist, album
+                UNION ALL
+                SELECT album_artist, title AS album, year, 1 AS track_count,
+                       embedded_art AS has_art,
+                       1 AS missing_album, file_path,
+                       date_added AS sort_date_added,
+                       last_played AS sort_last_played
+                FROM tracks
+                WHERE album = ''
+            )
             ORDER BY {order_by}
             """).fetchall()  # noqa: S608 — order_by is from a whitelist, not user input
         return [
@@ -471,6 +512,8 @@ class LibraryIndex:
                 year=r["year"],
                 track_count=r["track_count"],
                 has_art=bool(r["has_art"]),
+                missing_album=bool(r["missing_album"]),
+                file_path=r["file_path"],
             )
             for r in rows
         ]
@@ -944,11 +987,12 @@ def _read_mp3_tags(path: Path) -> Track:
         frame = tags.get(frame_key)
         return str(frame) if frame else ""
 
+    artist = _str("TPE1")
     return Track(
         file_path=path,
         ext="mp3",
-        artist=_str("TPE1"),
-        album_artist=_str("TPE2"),
+        artist=artist,
+        album_artist=_str("TPE2") or artist,  # fall back to artist when TPE2 absent
         album=_str("TALB"),
         year=_str("TDRC"),
         title=_str("TIT2"),
@@ -980,11 +1024,12 @@ def _read_m4a_tags(path: Path) -> Track:
     disk = tags.get("disk")
     disc_number = disk[0][0] if disk else 1
 
+    artist = _s("\xa9ART")
     return Track(
         file_path=path,
         ext="m4a",
-        artist=_s("\xa9ART"),
-        album_artist=_s("aART"),
+        artist=artist,
+        album_artist=_s("aART") or artist,  # fall back to artist when aART absent
         album=_s("\xa9alb"),
         year=_s("\xa9day"),
         title=_s("\xa9nam"),
@@ -1019,11 +1064,13 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
         vals = tags.get(key)
         return vals[0] if vals else ""
 
+    artist = _s("ARTIST")
     return Track(
         file_path=path,
         ext="flac" if is_flac else "ogg",
-        artist=_s("ARTIST"),
-        album_artist=_s("ALBUMARTIST"),
+        artist=artist,
+        album_artist=_s("ALBUMARTIST")
+        or artist,  # fall back to artist when ALBUMARTIST absent
         album=_s("ALBUM"),
         year=_s("DATE"),
         title=_s("TITLE"),

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -75,6 +75,10 @@ class AlbumOut(BaseModel):
     year: str
     track_count: int
     has_art: bool
+    missing_album: bool = False
+    # Non-empty only when missing_album=True; used as the unique lookup key
+    # instead of (album_artist, album) for tracks without an album tag.
+    file_path: str = ""
 
 
 class PlayerStateOut(BaseModel):
@@ -89,6 +93,7 @@ class PlayRequest(BaseModel):
     album_artist: str
     album: str
     track_index: int = 0
+    file_path: str = ""  # non-empty for missing-album tracks
 
 
 class SeekRequest(BaseModel):
@@ -150,12 +155,14 @@ class InsertQueueRequest(BaseModel):
 class AlbumQueueRequest(BaseModel):
     album_artist: str
     album: str
+    file_path: str = ""  # non-empty for missing-album tracks
 
 
 class InsertAlbumQueueRequest(BaseModel):
     album_artist: str
     album: str
     index: int
+    file_path: str = ""  # non-empty for missing-album tracks
 
 
 class SkipToRequest(BaseModel):
@@ -314,6 +321,8 @@ def create_app(
                 year=a.year,
                 track_count=a.track_count,
                 has_art=a.has_art,
+                missing_album=a.missing_album,
+                file_path=a.file_path,
             )
             for a in index.albums(sort=sort)
         ]
@@ -323,9 +332,16 @@ def create_app(
         return index.artists()
 
     @app.get("/api/v1/tracks", response_model=list[TrackOut])
-    def get_tracks(album_artist: str, album: str) -> list[TrackOut]:
+    def get_tracks(
+        album_artist: str, album: str, file_path: str = ""
+    ) -> list[TrackOut]:
         # Query parameters instead of path segments — artist/album names may
         # contain slashes (e.g. "AC/DC") which would break URL path routing.
+        # file_path is used for missing-album tracks where (album_artist, album)
+        # is not a unique key; when present it takes precedence.
+        if file_path:
+            track = index.get_track_by_path(Path(file_path))
+            return [TrackOut.from_track(track)] if track else []
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
         ]
@@ -342,8 +358,13 @@ def create_app(
         return {"ok": True}
 
     @app.get("/api/v1/album-art")
-    def get_album_art(album_artist: str, album: str) -> Response:
-        tracks = index.tracks_for_album(album_artist, album)
+    def get_album_art(album_artist: str, album: str, file_path: str = "") -> Response:
+        # file_path overrides (album_artist, album) for missing-album tracks.
+        if file_path:
+            track = index.get_track_by_path(Path(file_path))
+            tracks = [track] if track else []
+        else:
+            tracks = index.tracks_for_album(album_artist, album)
         for track in tracks:
             if track.embedded_art:
                 result = extract_art(track.file_path)
@@ -357,7 +378,10 @@ def create_app(
         fts_tracks = index.search(q)
         # Collect the set of (album_artist, album) keys that appear in FTS results,
         # then filter the pre-sorted album list so the response respects sort order.
+        # Missing-album tracks have album="" in the DB, so also match them by
+        # file_path since their AlbumInfo.album is the display title, not "".
         fts_keys = {(t.album_artist, t.album) for t in fts_tracks}
+        fts_paths = {str(t.file_path) for t in fts_tracks if not t.album}
         albums = [
             AlbumOut(
                 album_artist=a.album_artist,
@@ -365,9 +389,12 @@ def create_app(
                 year=a.year,
                 track_count=a.track_count,
                 has_art=a.has_art,
+                missing_album=a.missing_album,
+                file_path=a.file_path,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys
+            or (a.missing_album and a.file_path in fts_paths)
         ]
         return SearchOut(
             albums=albums, tracks=[TrackOut.from_track(t) for t in fts_tracks]
@@ -615,7 +642,11 @@ def create_app(
 
     @app.post("/api/v1/player/play")
     def play(req: PlayRequest) -> dict[str, Any]:
-        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if req.file_path:
+            track = index.get_track_by_path(Path(req.file_path))
+            tracks = [track] if track else []
+        else:
+            tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.load(tracks, start_index=req.track_index)
@@ -713,7 +744,11 @@ def create_app(
 
     @app.post("/api/v1/player/queue/add-album")
     def queue_add_album(req: AlbumQueueRequest) -> dict[str, Any]:
-        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if req.file_path:
+            track = index.get_track_by_path(Path(req.file_path))
+            tracks = [track] if track else []
+        else:
+            tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.add_album_to_queue(tracks)
@@ -721,7 +756,11 @@ def create_app(
 
     @app.post("/api/v1/player/queue/play-album-next")
     def queue_play_album_next(req: AlbumQueueRequest) -> dict[str, Any]:
-        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if req.file_path:
+            track = index.get_track_by_path(Path(req.file_path))
+            tracks = [track] if track else []
+        else:
+            tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.play_album_next(tracks)
@@ -729,7 +768,11 @@ def create_app(
 
     @app.post("/api/v1/player/queue/insert-album")
     def queue_insert_album(req: InsertAlbumQueueRequest) -> dict[str, Any]:
-        tracks = index.tracks_for_album(req.album_artist, req.album)
+        if req.file_path:
+            track = index.get_track_by_path(Path(req.file_path))
+            tracks = [track] if track else []
+        else:
+            tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.insert_album_at(tracks, req.index)

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -29,6 +29,9 @@ export type Album = {
   year: string
   track_count: number
   has_art: boolean
+  missing_album: boolean
+  // Non-empty when missing_album=true; used as the unique lookup key.
+  file_path: string
 }
 
 export type PlayerState = {
@@ -111,15 +114,22 @@ export const getAlbums = (sort = 'album_artist'): Promise<Album[]> =>
 
 // Returns the URL for an album's cover art; load it in an <img> src.
 // The server returns 404 when no art is embedded — handle with onError.
-export const artUrl = (albumArtist: string, album: string): string =>
-  `${BASE_URL}/api/v1/album-art?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
+// Pass filePath for missing-album tracks to look up by file instead of album key.
+export const artUrl = (albumArtist: string, album: string, filePath = ''): string => {
+  const base = `${BASE_URL}/api/v1/album-art?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
+  return filePath ? `${base}&file_path=${encodeURIComponent(filePath)}` : base
+}
 
 export const getArtists = (): Promise<string[]> => get('/api/v1/artists')
 
-export const getTracksForAlbum = (albumArtist: string, album: string): Promise<Track[]> =>
-  get(
-    `/api/v1/tracks?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
-  )
+export const getTracksForAlbum = (
+  albumArtist: string,
+  album: string,
+  filePath = ''
+): Promise<Track[]> => {
+  const base = `/api/v1/tracks?album_artist=${encodeURIComponent(albumArtist)}&album=${encodeURIComponent(album)}`
+  return get(filePath ? `${base}&file_path=${encodeURIComponent(filePath)}` : base)
+}
 
 export type SearchResult = {
   albums: Album[]
@@ -198,8 +208,18 @@ export const disconnectBandcamp = (): Promise<{ ok: boolean }> => del('/api/v1/b
 
 export const getPlayerState = (): Promise<PlayerState> => get('/api/v1/player/state')
 
-export const playAlbum = (albumArtist: string, album: string, trackIndex = 0): Promise<unknown> =>
-  post('/api/v1/player/play', { album_artist: albumArtist, album, track_index: trackIndex })
+export const playAlbum = (
+  albumArtist: string,
+  album: string,
+  trackIndex = 0,
+  filePath = ''
+): Promise<unknown> =>
+  post('/api/v1/player/play', {
+    album_artist: albumArtist,
+    album,
+    track_index: trackIndex,
+    file_path: filePath
+  })
 
 export const pause = (): Promise<unknown> => post('/api/v1/player/pause')
 export const resume = (): Promise<unknown> => post('/api/v1/player/resume')
@@ -214,16 +234,34 @@ export const setShuffle = (shuffle: boolean): Promise<unknown> =>
   post('/api/v1/player/shuffle', { shuffle })
 export const setRepeat = (repeat: boolean): Promise<unknown> =>
   post('/api/v1/player/repeat', { repeat })
-export const addAlbumToQueue = (albumArtist: string, album: string): Promise<unknown> =>
-  post('/api/v1/player/queue/add-album', { album_artist: albumArtist, album })
-export const playAlbumNext = (albumArtist: string, album: string): Promise<unknown> =>
-  post('/api/v1/player/queue/play-album-next', { album_artist: albumArtist, album })
+export const addAlbumToQueue = (
+  albumArtist: string,
+  album: string,
+  filePath = ''
+): Promise<unknown> =>
+  post('/api/v1/player/queue/add-album', { album_artist: albumArtist, album, file_path: filePath })
+export const playAlbumNext = (
+  albumArtist: string,
+  album: string,
+  filePath = ''
+): Promise<unknown> =>
+  post('/api/v1/player/queue/play-album-next', {
+    album_artist: albumArtist,
+    album,
+    file_path: filePath
+  })
 export const insertAlbumAt = (
   albumArtist: string,
   album: string,
-  index: number
+  index: number,
+  filePath = ''
 ): Promise<unknown> =>
-  post('/api/v1/player/queue/insert-album', { album_artist: albumArtist, album, index })
+  post('/api/v1/player/queue/insert-album', {
+    album_artist: albumArtist,
+    album,
+    index,
+    file_path: filePath
+  })
 export const addToQueue = (filePath: string): Promise<unknown> =>
   post('/api/v1/player/queue/add', { file_path: filePath })
 export const insertIntoQueue = (filePath: string, index: number): Promise<unknown> =>

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -22,8 +22,11 @@ function AlbumCard({
   const playing = useStore((s) => s.player.playing)
   const [artLoaded, setArtLoaded] = useState(false)
 
-  const isActive =
-    currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
+  // For missing-album tracks, match by file_path since album="" in the DB
+  // while album.album holds the track title as a display name.
+  const isActive = album.missing_album
+    ? currentTrack?.file_path === album.file_path
+    : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
   return (
     <div
@@ -36,7 +39,11 @@ function AlbumCard({
       onDragStart={(e) => {
         e.dataTransfer.setData(
           'text/kamp-album',
-          JSON.stringify({ album_artist: album.album_artist, album: album.album })
+          JSON.stringify({
+            album_artist: album.album_artist,
+            album: album.album,
+            file_path: album.file_path
+          })
         )
         e.dataTransfer.effectAllowed = 'copy'
       }}
@@ -45,7 +52,7 @@ function AlbumCard({
         {album.has_art && (
           <img
             className="album-art-img"
-            src={artUrl(album.album_artist, album.album)}
+            src={artUrl(album.album_artist, album.album, album.file_path)}
             alt=""
             onLoad={() => setArtLoaded(true)}
             onError={() => setArtLoaded(false)}
@@ -54,7 +61,13 @@ function AlbumCard({
         {playing && isActive && <div className="now-playing-badge">▶</div>}
       </div>
       <div className="album-info">
-        <div className="album-title">{album.album}</div>
+        {album.missing_album ? (
+          <div className="album-title">
+            <em>{album.album}</em>
+          </div>
+        ) : (
+          <div className="album-title">{album.album}</div>
+        )}
         <div className="album-artist">{album.album_artist}</div>
         <div className="album-year">{album.year}</div>
       </div>
@@ -116,7 +129,7 @@ export function AlbumGrid(): React.JSX.Element {
         <div className="album-grid">
           {visible.map((album) => (
             <AlbumCard
-              key={`${album.album_artist}\0${album.album}`}
+              key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
               album={album}
               onContextMenu={(e, a) => {
                 e.preventDefault()
@@ -132,7 +145,7 @@ export function AlbumGrid(): React.JSX.Element {
           <button
             className="track-context-menu-item"
             onClick={() => {
-              void playAlbumNext(menu.album.album_artist, menu.album.album)
+              void playAlbumNext(menu.album.album_artist, menu.album.album, menu.album.file_path)
               setMenu(null)
             }}
           >
@@ -141,7 +154,7 @@ export function AlbumGrid(): React.JSX.Element {
           <button
             className="track-context-menu-item"
             onClick={() => {
-              void addAlbumToQueue(menu.album.album_artist, menu.album.album)
+              void addAlbumToQueue(menu.album.album_artist, menu.album.album, menu.album.file_path)
               setMenu(null)
             }}
           >

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -41,7 +41,11 @@ export function NowPlayingView(): React.JSX.Element {
       <div className={`now-playing-art${artLoaded ? ' has-art' : ''}`}>
         <span className="now-playing-art-placeholder">♪</span>
         <img
-          src={artUrl(current_track.album_artist, current_track.album)}
+          src={artUrl(
+            current_track.album_artist,
+            current_track.album,
+            current_track.album ? '' : current_track.file_path
+          )}
           onLoad={() => setArtLoaded(true)}
           onError={() => setArtLoaded(false)}
         />

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -79,11 +79,16 @@ export function QueuePanel(): React.JSX.Element {
       void insertIntoQueue(trackPath, dropIdx)
     } else if (albumJson) {
       try {
-        const { album_artist, album } = JSON.parse(albumJson) as {
+        const {
+          album_artist,
+          album,
+          file_path = ''
+        } = JSON.parse(albumJson) as {
           album_artist: string
           album: string
+          file_path?: string
         }
-        void insertAlbumAt(album_artist, album, dropIdx)
+        void insertAlbumAt(album_artist, album, dropIdx, file_path)
       } catch {
         // malformed drag data — ignore
       }
@@ -109,11 +114,16 @@ export function QueuePanel(): React.JSX.Element {
               void addToQueue(trackPath)
             } else if (albumJson) {
               try {
-                const { album_artist, album } = JSON.parse(albumJson) as {
+                const {
+                  album_artist,
+                  album,
+                  file_path = ''
+                } = JSON.parse(albumJson) as {
                   album_artist: string
                   album: string
+                  file_path?: string
                 }
-                void addAlbumToQueue(album_artist, album)
+                void addAlbumToQueue(album_artist, album, file_path)
               } catch {
                 // malformed drag data — ignore
               }
@@ -192,7 +202,9 @@ export function QueuePanel(): React.JSX.Element {
                     album: menu.album!,
                     year: '',
                     track_count: 0,
-                    has_art: false
+                    has_art: false,
+                    missing_album: false,
+                    file_path: ''
                   }
                   void setActiveView('library')
                   void selectAlbum(found)

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -36,7 +36,7 @@ function SearchAlbumCard({
       <div className={`search-album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
           <img
-            src={artUrl(album.album_artist, album.album)}
+            src={artUrl(album.album_artist, album.album, album.file_path)}
             alt=""
             onLoad={() => setArtLoaded(true)}
             onError={() => setArtLoaded(false)}
@@ -63,7 +63,14 @@ function SearchTrackRow({
   const setSearchQuery = useStore((s) => s.setSearchQuery)
 
   const handleClick = (): void => {
-    void playTrack(track.album_artist, track.album, track.track_number - 1)
+    // Pass file_path for tracks with no album so the server can look them up
+    // by path rather than by the empty album key.
+    void playTrack(
+      track.album_artist,
+      track.album,
+      track.track_number - 1,
+      track.album ? '' : track.file_path
+    )
     void setSearchQuery('')
   }
 
@@ -206,7 +213,11 @@ export function SearchView(): React.JSX.Element {
           <button
             className="track-context-menu-item"
             onClick={() => {
-              void playAlbumNext(albumMenu.album.album_artist, albumMenu.album.album)
+              void playAlbumNext(
+                albumMenu.album.album_artist,
+                albumMenu.album.album,
+                albumMenu.album.file_path
+              )
               setAlbumMenu(null)
             }}
           >
@@ -215,7 +226,11 @@ export function SearchView(): React.JSX.Element {
           <button
             className="track-context-menu-item"
             onClick={() => {
-              void addAlbumToQueue(albumMenu.album.album_artist, albumMenu.album.album)
+              void addAlbumToQueue(
+                albumMenu.album.album_artist,
+                albumMenu.album.album,
+                albumMenu.album.file_path
+              )
               setAlbumMenu(null)
             }}
           >

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -63,7 +63,7 @@ export function TrackList(): React.JSX.Element | null {
     <div className="track-list-view">
       {/* Hero: full-width art — image intentionally taller than hero to bleed into track list */}
       <div className={`track-list-hero${album.has_art ? ' has-art' : ''}`}>
-        {album.has_art && <HeroImage src={artUrl(album.album_artist, album.album)} />}
+        {album.has_art && <HeroImage src={artUrl(album.album_artist, album.album, album.file_path)} />}
       </div>
       {/* Overlay spans the full view so the gradient covers both hero and the top of the track list */}
       <div className="track-list-hero-overlay" />
@@ -93,7 +93,7 @@ export function TrackList(): React.JSX.Element | null {
         <button
           className="play-all-btn"
           aria-label="Play all"
-          onClick={() => playTrack(album.album_artist, album.album, 0)}
+          onClick={() => playTrack(album.album_artist, album.album, 0, album.file_path)}
         >
           ▶
         </button>
@@ -115,13 +115,13 @@ export function TrackList(): React.JSX.Element | null {
                   if (isCurrent) {
                     togglePlayPause()
                   } else {
-                    playTrack(album.album_artist, album.album, i)
+                    playTrack(album.album_artist, album.album, i, album.file_path)
                   }
                 }}
                 onKeyDown={(e) => {
                   if (e.key !== 'Enter') return
                   if (isCurrent) togglePlayPause()
-                  else playTrack(album.album_artist, album.album, i)
+                  else playTrack(album.album_artist, album.album, i, album.file_path)
                 }}
                 draggable
                 onDragStart={(e) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -58,9 +58,19 @@ type PlayerStore = {
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
   selectAlbum: (album: Album | null) => Promise<void>
-  loadTracks: (albumArtist: string, album: string) => Promise<void>
-  playAlbum: (albumArtist: string, album: string, trackIndex?: number) => Promise<void>
-  playTrack: (albumArtist: string, album: string, trackIndex: number) => Promise<void>
+  loadTracks: (albumArtist: string, album: string, filePath?: string) => Promise<void>
+  playAlbum: (
+    albumArtist: string,
+    album: string,
+    trackIndex?: number,
+    filePath?: string
+  ) => Promise<void>
+  playTrack: (
+    albumArtist: string,
+    album: string,
+    trackIndex: number,
+    filePath?: string
+  ) => Promise<void>
   togglePlayPause: () => Promise<void>
   stop: () => Promise<void>
   next: () => Promise<void>
@@ -69,9 +79,14 @@ type PlayerStore = {
   setVolume: (volume: number) => Promise<void>
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
-  addAlbumToQueue: (albumArtist: string, album: string) => Promise<void>
-  playAlbumNext: (albumArtist: string, album: string) => Promise<void>
-  insertAlbumAt: (albumArtist: string, album: string, index: number) => Promise<void>
+  addAlbumToQueue: (albumArtist: string, album: string, filePath?: string) => Promise<void>
+  playAlbumNext: (albumArtist: string, album: string, filePath?: string) => Promise<void>
+  insertAlbumAt: (
+    albumArtist: string,
+    album: string,
+    index: number,
+    filePath?: string
+  ) => Promise<void>
   addToQueue: (filePath: string) => Promise<void>
   insertIntoQueue: (filePath: string, index: number) => Promise<void>
   playNext: (filePath: string) => Promise<void>
@@ -230,14 +245,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const { selectedAlbum } = get().library
     if (!selectedAlbum) return
     try {
-      const tracks = await api.getTracksForAlbum(selectedAlbum.album_artist, selectedAlbum.album)
-      set((s) => ({
-        library: {
-          ...s.library,
-          tracks,
-          tracksAlbumKey: `${selectedAlbum.album_artist}\0${selectedAlbum.album}`
-        }
-      }))
+      const tracks = await api.getTracksForAlbum(
+        selectedAlbum.album_artist,
+        selectedAlbum.album,
+        selectedAlbum.file_path
+      )
+      const key = selectedAlbum.file_path || `${selectedAlbum.album_artist}\0${selectedAlbum.album}`
+      set((s) => ({ library: { ...s.library, tracks, tracksAlbumKey: key } }))
     } catch {
       // Best-effort — stale track list is better than a broken UI.
     }
@@ -248,23 +262,25 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   selectAlbum: async (album) => {
     set((s) => ({ library: { ...s.library, selectedAlbum: album } }))
-    if (album) await get().loadTracks(album.album_artist, album.album)
+    if (album) await get().loadTracks(album.album_artist, album.album, album.file_path)
   },
 
-  loadTracks: async (albumArtist, album) => {
-    const key = `${albumArtist}\0${album}`
+  loadTracks: async (albumArtist, album, filePath = '') => {
+    // For missing-album tracks, file_path is the unique key; use it so that
+    // two no-album tracks with the same title don't share a cache entry.
+    const key = filePath || `${albumArtist}\0${album}`
     if (get().library.tracksAlbumKey === key) return
-    const tracks = await api.getTracksForAlbum(albumArtist, album)
+    const tracks = await api.getTracksForAlbum(albumArtist, album, filePath)
     set((s) => ({ library: { ...s.library, tracks, tracksAlbumKey: key } }))
   },
 
-  playAlbum: async (albumArtist, album, trackIndex = 0) => {
-    await api.playAlbum(albumArtist, album, trackIndex)
+  playAlbum: async (albumArtist, album, trackIndex = 0, filePath = '') => {
+    await api.playAlbum(albumArtist, album, trackIndex, filePath)
     void get().loadQueue()
   },
 
-  playTrack: async (albumArtist, album, trackIndex) => {
-    await api.playAlbum(albumArtist, album, trackIndex)
+  playTrack: async (albumArtist, album, trackIndex, filePath = '') => {
+    await api.playAlbum(albumArtist, album, trackIndex, filePath)
     void get().loadQueue()
   },
 
@@ -309,18 +325,18 @@ export const useStore = create<PlayerStore>((set, get) => ({
     await api.setRepeat(repeat)
   },
 
-  addAlbumToQueue: async (albumArtist, album) => {
-    await api.addAlbumToQueue(albumArtist, album)
+  addAlbumToQueue: async (albumArtist, album, filePath = '') => {
+    await api.addAlbumToQueue(albumArtist, album, filePath)
     void get().loadQueue()
   },
 
-  playAlbumNext: async (albumArtist, album) => {
-    await api.playAlbumNext(albumArtist, album)
+  playAlbumNext: async (albumArtist, album, filePath = '') => {
+    await api.playAlbumNext(albumArtist, album, filePath)
     void get().loadQueue()
   },
 
-  insertAlbumAt: async (albumArtist, album, index) => {
-    await api.insertAlbumAt(albumArtist, album, index)
+  insertAlbumAt: async (albumArtist, album, index, filePath = '') => {
+    await api.insertAlbumAt(albumArtist, album, index, filePath)
     void get().loadQueue()
   },
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -123,7 +123,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 9
+        assert version == 10
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -292,6 +292,58 @@ class TestLibraryIndex:
         index.close()
 
         assert albums[0].has_art is True
+
+    def test_missing_album_track_appears_as_own_entry(self, tmp_path: Path) -> None:
+        """A track with no album tag should produce its own AlbumInfo entry."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "standalone.mp3")
+        t.album = ""
+        t.title = "Standalone Track"
+        index.upsert_track(t)
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].missing_album is True
+        assert albums[0].album == "Standalone Track"  # title used as display name
+        assert albums[0].file_path == str(tmp_path / "standalone.mp3")
+
+    def test_two_missing_album_tracks_each_get_own_entry(self, tmp_path: Path) -> None:
+        """Each track without an album tag should be its own entry, not grouped."""
+        index = LibraryIndex(tmp_path / "library.db")
+        for i, title in enumerate(["Track A", "Track B"]):
+            t = _sample_track(tmp_path / f"{i}.mp3")
+            t.album = ""
+            t.title = title
+            index.upsert_track(t)
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 2
+        assert all(a.missing_album for a in albums)
+        assert {a.album for a in albums} == {"Track A", "Track B"}
+
+    def test_missing_album_and_normal_album_coexist(self, tmp_path: Path) -> None:
+        """Normal albums and missing-album tracks appear together in the list."""
+        index = LibraryIndex(tmp_path / "library.db")
+        normal = _sample_track(tmp_path / "normal.mp3")
+        normal.album = "Real Album"
+        index.upsert_track(normal)
+
+        standalone = _sample_track(tmp_path / "standalone.mp3")
+        standalone.album = ""
+        standalone.title = "Lone Track"
+        index.upsert_track(standalone)
+
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 2
+        normal_entry = next(a for a in albums if not a.missing_album)
+        missing_entry = next(a for a in albums if a.missing_album)
+        assert normal_entry.album == "Real Album"
+        assert missing_entry.album == "Lone Track"
+        assert missing_entry.file_path == str(tmp_path / "standalone.mp3")
 
     def test_get_track_by_path_returns_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -812,6 +864,48 @@ class TestTagReaders:
             result = _read_tags(mp3)
         assert result is None
 
+    def test_read_mp3_tags_album_artist_falls_back_to_artist(
+        self, tmp_path: Path
+    ) -> None:
+        """When TPE2 (album artist) is absent, album_artist should equal TPE1 (artist)."""
+        mp3 = tmp_path / "no_tpe2.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        tags = id3.ID3()
+        tags["TPE1"] = id3.TPE1(encoding=3, text="Solo Artist")
+        tags.save(str(mp3))
+        track = _read_mp3_tags(mp3)
+        assert track.artist == "Solo Artist"
+        assert track.album_artist == "Solo Artist"
+
+    def test_read_m4a_tags_album_artist_falls_back_to_artist(
+        self, tmp_path: Path
+    ) -> None:
+        """When aART is absent, album_artist should equal ©ART."""
+        m4a = tmp_path / "no_aart.m4a"
+        m4a.write_bytes(b"\x00" * 32)
+        mock_audio = MagicMock()
+        mock_audio.tags = {"\xa9ART": ["Solo Artist"], "\xa9nam": ["A Track"]}
+        with patch("kamp_core.library.mutagen.mp4.MP4", return_value=mock_audio):
+            track = _read_m4a_tags(m4a)
+        assert track.artist == "Solo Artist"
+        assert track.album_artist == "Solo Artist"
+
+    def test_read_vorbis_tags_album_artist_falls_back_to_artist(
+        self, tmp_path: Path
+    ) -> None:
+        """When ALBUMARTIST is absent, album_artist should equal ARTIST."""
+        ogg = tmp_path / "no_albumartist.ogg"
+        ogg.write_bytes(b"\x00" * 8)
+        mock_audio = MagicMock()
+        mock_audio.tags = {"ARTIST": ["Solo Artist"], "TITLE": ["A Track"]}
+        mock_audio.pictures = []
+        with patch(
+            "kamp_core.library.mutagen.oggvorbis.OggVorbis", return_value=mock_audio
+        ):
+            track = _read_vorbis_tags(ogg, is_flac=False)
+        assert track.artist == "Solo Artist"
+        assert track.album_artist == "Solo Artist"
+
     def test_read_tags_returns_none_for_unknown_extension(self, tmp_path: Path) -> None:
         wav = tmp_path / "file.wav"
         wav.write_bytes(b"")
@@ -970,7 +1064,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 9
+        assert version == 10
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1027,7 +1121,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 9
+        assert version == 10
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1320,7 +1414,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 9
+        assert version == 10
         assert row is not None
         assert row[0] == 0
 
@@ -1433,7 +1527,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 9
+        assert version == 10
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -1614,7 +1708,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 9
+        assert version == 10
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -1682,7 +1776,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 9
+        assert version == 10
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -1690,7 +1784,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 9
+        assert version == 10
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -1757,3 +1851,75 @@ class TestSessionManagement:
         assert by_ext["ogg"] is None, "OGG mtime should be nulled by migration"
         assert by_ext["mp3"] == 3333.0, "MP3 mtime should be unchanged"
         assert by_ext["m4a"] == 4444.0, "M4A mtime should be unchanged"
+
+    def test_migration_v9_to_v10_nulls_missing_album_artist_mtimes(
+        self, tmp_path: Path
+    ) -> None:
+        """v9→v10 resets file_mtime for tracks that have an artist but no album_artist.
+
+        This allows the scanner to re-read those files and apply the new
+        album_artist → artist fallback, so they show up correctly in the library.
+        """
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (9)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path       TEXT UNIQUE NOT NULL,
+                title           TEXT NOT NULL DEFAULT '',
+                artist          TEXT NOT NULL DEFAULT '',
+                album_artist    TEXT NOT NULL DEFAULT '',
+                album           TEXT NOT NULL DEFAULT '',
+                year            TEXT NOT NULL DEFAULT '',
+                track_number    INTEGER,
+                disc_number     INTEGER NOT NULL DEFAULT 1,
+                ext             TEXT NOT NULL DEFAULT '',
+                embedded_art    INTEGER NOT NULL DEFAULT 0,
+                mb_release_id   TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added      TEXT,
+                last_played     TEXT,
+                favorite        INTEGER NOT NULL DEFAULT 0,
+                play_count      INTEGER NOT NULL DEFAULT 0,
+                file_mtime      REAL
+            )
+            """)
+        # has artist but no album_artist → mtime should be nulled
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, artist, album_artist, file_mtime)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("/music/solo.mp3", "mp3", "Solo Artist", "", 1111.0),
+        )
+        # has both fields empty → mtime should be left alone (re-reading would be a no-op)
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, artist, album_artist, file_mtime)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("/music/untagged.mp3", "mp3", "", "", 2222.0),
+        )
+        # already has album_artist → mtime should be unchanged
+        conn.execute(
+            "INSERT INTO tracks (file_path, ext, artist, album_artist, file_mtime)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("/music/tagged.mp3", "mp3", "Band", "The Band", 3333.0),
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        rows = index._conn.execute(
+            "SELECT file_path, file_mtime FROM tracks ORDER BY file_path"
+        ).fetchall()
+        index.close()
+
+        by_path = {r[0]: r[1] for r in rows}
+        assert (
+            by_path["/music/solo.mp3"] is None
+        ), "missing album_artist should be nulled"
+        assert (
+            by_path["/music/untagged.mp3"] == 2222.0
+        ), "fully untagged mtime unchanged"
+        assert by_path["/music/tagged.mp3"] == 3333.0, "already-tagged mtime unchanged"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -184,6 +184,62 @@ class TestArtistsEndpoint:
         assert c.get("/api/v1/artists").json() == ["Aesop Rock", "Zeppelin"]
 
 
+class TestMissingAlbumEndpoints:
+    """Endpoints that support file_path-based lookup for tracks without an album tag."""
+
+    def test_albums_includes_missing_album_fields(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.albums.return_value = [
+            AlbumInfo(
+                album_artist="Mndsgn.",
+                album="Lone Track",
+                year="2020",
+                track_count=1,
+                has_art=False,
+                missing_album=True,
+                file_path="/music/lone.mp3",
+            )
+        ]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        album = c.get("/api/v1/albums").json()[0]
+        assert album["missing_album"] is True
+        assert album["file_path"] == "/music/lone.mp3"
+
+    def test_tracks_endpoint_uses_file_path_when_provided(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1, album="")
+        mock_index.get_track_by_path.return_value = track
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get(
+            "/api/v1/tracks?album_artist=&album=&file_path=%2Fmusic%2F01.mp3"
+        ).json()
+        assert len(data) == 1
+        mock_index.get_track_by_path.assert_called_once_with(Path("/music/01.mp3"))
+        mock_index.tracks_for_album.assert_not_called()
+
+    def test_album_art_endpoint_uses_file_path_when_provided(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1, album="")
+        track.embedded_art = True
+        mock_index.get_track_by_path.return_value = track
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with patch(
+            "kamp_core.server.extract_art", return_value=(b"IMGDATA", "image/jpeg")
+        ):
+            res = c.get(
+                "/api/v1/album-art?album_artist=&album=&file_path=%2Fmusic%2F01.mp3"
+            )
+        assert res.status_code == 200
+        mock_index.get_track_by_path.assert_called_once_with(Path("/music/01.mp3"))
+        mock_index.tracks_for_album.assert_not_called()
+
+
 class TestTracksForAlbumEndpoint:
     def test_returns_tracks_for_album(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Tracks with no Album tag now each appear as their own entry in the Library view, with the title displayed in *italics* to flag the metadata gap
- Falls back to Artist tag when Album Artist tag is absent, so releases with only an Artist tag display correctly
- Art, tracks, playback, queue, and search all work for missing-album entries via `file_path`-based lookup
- Schema migration v9→v10 nulls `file_mtime` for affected tracks so the scanner re-reads their tags on next scan

## Test plan

- [x] Run `poetry run pytest tests/test_library.py tests/test_server.py -v --no-cov` — all tests pass
- [x] Scan a library containing files with no Album tag — they appear as individual entries
- [x] Verify title is italicised for missing-album entries in the grid
- [x] Click a missing-album entry — track list opens and plays correctly
- [x] Album art loads for missing-album entries (both in grid and Now Playing)
- [x] Artist name shows correctly when only Artist (not Album Artist) tag is present
- [x] Search returns missing-album tracks and clicking plays them
- [x] Right-click context menu (Play Next / Add to Queue) works for missing-album entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)