### PR TITLE
feat: area below queue tracks is a drop target (TASK-138)

### DIFF
--- a/backlog/milestones/m-28 - onboarding-experience.md
+++ b/backlog/milestones/m-28 - onboarding-experience.md
@@ -1,0 +1,8 @@
+---
+id: m-28
+title: "Onboarding Experience"
+---
+
+## Description
+
+Milestone: Onboarding Experience

--- a/backlog/tasks/task-138 - the-area-under-the-queue-is-an-active-drop-target-for-Add-to-Queue.md
+++ b/backlog/tasks/task-138 - the-area-under-the-queue-is-an-active-drop-target-for-Add-to-Queue.md
@@ -1,12 +1,14 @@
 ---
 id: TASK-138
 title: the area under the queue is an active drop target for Add to Queue
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-17 20:43'
+updated_date: '2026-04-18 01:19'
 labels: []
 milestone: m-27
 dependencies: []
+ordinal: 5000
 ---
 
 ## Description

--- a/backlog/tasks/task-139 - a-pleasant-and-straightforward-UI-exists-to-get-users-library-and-watch-folders-set-up.md
+++ b/backlog/tasks/task-139 - a-pleasant-and-straightforward-UI-exists-to-get-users-library-and-watch-folders-set-up.md
@@ -1,0 +1,20 @@
+---
+id: TASK-139
+title: >-
+  a pleasant and straightforward UI exists to get users library and watch
+  folders set up
+status: To Do
+assignee:
+  - 88eyes
+created_date: '2026-04-17 22:28'
+updated_date: '2026-04-17 22:28'
+labels: []
+milestone: m-28
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+needs Figma
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1627,6 +1627,12 @@ body,
   border-top: 2px solid var(--accent);
 }
 
+/* Drop zone at the bottom of the queue (empty space below the last track row) */
+.queue-track-list.queue-tail-drop {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* Right-click context menu on track rows */
 .track-context-menu {
   position: fixed;

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -68,6 +68,7 @@ export function QueuePanel(): React.JSX.Element {
   }, [menu])
 
   function handleDrop(e: React.DragEvent, dropIdx: number): void {
+    e.stopPropagation()
     e.currentTarget.classList.remove('drag-over')
     const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
     const trackPath = e.dataTransfer.getData('text/kamp-track-path')
@@ -89,6 +90,37 @@ export function QueuePanel(): React.JSX.Element {
           file_path?: string
         }
         void insertAlbumAt(album_artist, album, dropIdx, file_path)
+      } catch {
+        // malformed drag data — ignore
+      }
+    }
+  }
+
+  function handleListDrop(e: React.DragEvent): void {
+    // Fires only when dropping on the empty space below all track rows (li handlers
+    // stop propagation, so this never fires when the target is a track row).
+    e.currentTarget.classList.remove('queue-tail-drop')
+    const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
+    const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+    const albumJson = e.dataTransfer.getData('text/kamp-album')
+    if (queueIdx !== '') {
+      const from = Number(queueIdx)
+      const last = tracks.length - 1
+      if (from !== last) void moveQueueTrack(from, last)
+    } else if (trackPath) {
+      void addToQueue(trackPath)
+    } else if (albumJson) {
+      try {
+        const {
+          album_artist,
+          album,
+          file_path = ''
+        } = JSON.parse(albumJson) as {
+          album_artist: string
+          album: string
+          file_path?: string
+        }
+        void addAlbumToQueue(album_artist, album, file_path)
       } catch {
         // malformed drag data — ignore
       }
@@ -140,6 +172,18 @@ export function QueuePanel(): React.JSX.Element {
             e.preventDefault()
             setMenu({ x: e.clientX, y: e.clientY, trackIdx: null })
           }}
+          onDragOver={(e) => {
+            e.preventDefault()
+            e.currentTarget.classList.add('queue-tail-drop')
+          }}
+          onDragLeave={(e) => {
+            // Only remove the indicator when the pointer leaves the <ol> entirely,
+            // not when entering a child <li> (which stops its own drag events).
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              e.currentTarget.classList.remove('queue-tail-drop')
+            }
+          }}
+          onDrop={handleListDrop}
         >
           {tracks.map((track, idx) => {
             const isCurrent = idx === position
@@ -158,9 +202,11 @@ export function QueuePanel(): React.JSX.Element {
                 }}
                 onDragOver={(e) => {
                   e.preventDefault()
+                  e.stopPropagation()
                   e.currentTarget.classList.add('drag-over')
                 }}
                 onDragLeave={(e) => {
+                  e.stopPropagation()
                   e.currentTarget.classList.remove('drag-over')
                 }}
                 onDrop={(e) => handleDrop(e, idx)}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -70,6 +70,7 @@ export function QueuePanel(): React.JSX.Element {
   function handleDrop(e: React.DragEvent, dropIdx: number): void {
     e.stopPropagation()
     e.currentTarget.classList.remove('drag-over')
+    listRef.current?.classList.remove('queue-tail-drop')
     const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
     const trackPath = e.dataTransfer.getData('text/kamp-track-path')
     const albumJson = e.dataTransfer.getData('text/kamp-album')
@@ -204,6 +205,8 @@ export function QueuePanel(): React.JSX.Element {
                   e.preventDefault()
                   e.stopPropagation()
                   e.currentTarget.classList.add('drag-over')
+                  // Clear tail-drop outline when pointer enters a row.
+                  listRef.current?.classList.remove('queue-tail-drop')
                 }}
                 onDragLeave={(e) => {
                   e.stopPropagation()


### PR DESCRIPTION
## Summary

- The empty space below queue track rows is now a valid drag target for adding tracks/albums to the end of the queue
- `<li>` drag handlers now stop propagation so row-level insert drops don't bubble to the parent `<ol>`
- `<ol>` gets `onDragOver`/`onDrop` handlers; these only fire when dragging over the empty area below all tracks
- Dragging a track → `addToQueue`, an album → `addAlbumToQueue`, a queue row → `moveQueueTrack` to last position
- Subtle outline appears on the `<ol>` while dragging over the tail area

## Test plan

- [ ] With a non-empty queue, drag a track from the library to the blank space below the last queue row — track appends to end
- [ ] Same for an album — all tracks from the album append to end
- [ ] Drag a queue row to the tail area — row moves to last position
- [ ] Drag a track/album onto an existing queue row — still inserts at that row (no regression)
- [ ] Drag into an empty queue — still works via the existing `queue-empty` drop zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)