### PR TITLE
fix: queue panel opens at current track without visible scroll (TASK-95)

### DIFF
--- a/backlog/tasks/task-134 - version-on-built-installer-doesnt-match-release-version.md
+++ b/backlog/tasks/task-134 - version-on-built-installer-doesnt-match-release-version.md
@@ -4,7 +4,7 @@ title: version on built installer doesn't match release version
 status: To Do
 assignee: []
 created_date: '2026-04-15 03:12'
-updated_date: '2026-04-17 15:54'
+updated_date: '2026-04-18 01:22'
 labels:
   - bug
   - packaging
@@ -12,6 +12,7 @@ labels:
 milestone: m-27
 dependencies: []
 priority: medium
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-94 - cache-album-art-images-so-they-dont-reload-every-time-the-library-view-is-loaded.md
+++ b/backlog/tasks/task-94 - cache-album-art-images-so-they-dont-reload-every-time-the-library-view-is-loaded.md
@@ -6,14 +6,15 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-04-08 13:37'
-updated_date: '2026-04-10 14:16'
+updated_date: '2026-04-18 01:22'
 labels:
   - performance
   - ui
   - 'estimate: side'
-milestone: m-26
+milestone: m-27
 dependencies: []
 priority: medium
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-95 - queue-scrolls-from-the-top-every-time-its-opened.md
+++ b/backlog/tasks/task-95 - queue-scrolls-from-the-top-every-time-its-opened.md
@@ -1,17 +1,18 @@
 ---
 id: TASK-95
 title: queue scrolls from the top every time it's opened
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-08 16:58'
-updated_date: '2026-04-10 14:16'
+updated_date: '2026-04-18 01:33'
 labels:
   - bug
   - ui
   - 'estimate: single'
-milestone: m-26
+milestone: m-27
 dependencies: []
 priority: medium
+ordinal: 6000
 ---
 
 ## Description

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -26,6 +26,7 @@ export function QueuePanel(): React.JSX.Element {
   const setActiveView = useStore((s) => s.setActiveView)
   const activeRef = useRef<HTMLLIElement>(null)
   const listRef = useRef<HTMLOListElement>(null)
+  const hasMounted = useRef(false)
   const [menu, setMenu] = useState<ContextMenu | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -33,17 +34,20 @@ export function QueuePanel(): React.JSX.Element {
   const position = queue?.position ?? -1
 
   // Scroll so that up to 5 history rows are visible above the current track.
-  // When position < 5 there is no scrolling needed — the top of the list is fine.
+  // On initial mount use instant scroll to avoid a visible jump from the top;
+  // only animate when the position advances during an active session.
   useEffect(() => {
+    const behavior: ScrollBehavior = hasMounted.current ? 'smooth' : 'instant'
+    hasMounted.current = true
     const list = listRef.current
     const active = activeRef.current
     if (!list || !active || position < 5) {
       // For the first few tracks just ensure the active row is visible.
-      activeRef.current?.scrollIntoView({ block: 'nearest' })
+      activeRef.current?.scrollIntoView({ block: 'nearest', behavior })
       return
     }
     const rowHeight = active.offsetHeight
-    list.scrollTo({ top: (position - 5) * rowHeight, behavior: 'smooth' })
+    list.scrollTo({ top: (position - 5) * rowHeight, behavior })
   }, [position])
 
   // Dismiss context menu on click outside.


### PR DESCRIPTION
## Summary
- Queue panel now jumps instantly to the playing track on open — no more visible scroll animation from the top
- `behavior: 'instant'` used on initial mount; `'smooth'` preserved for position advances during playback

## Test plan
- [x] Open the queue panel while a track is playing beyond the first 5 positions — list should open already at the right offset, no jump
- [x] Advance tracks while the queue is open — scroll animation should still be smooth
- [x] Open queue with no tracks / track in first 5 positions — active track should be visible with no scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)