### PR TITLE
fix: clean up build warnings (TASK-141)

### DIFF
--- a/backlog/tasks/task-141 - clean-up-build-warnings.md
+++ b/backlog/tasks/task-141 - clean-up-build-warnings.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-141
 title: clean up build warnings
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-18 02:09'
-updated_date: '2026-04-18 02:26'
+updated_date: '2026-04-18 02:41'
 labels: []
 milestone: m-27
 dependencies: []
 priority: low
+ordinal: 9000
 ---
 
 ## Description

--- a/backlog/tasks/task-141 - clean-up-build-warnings.md
+++ b/backlog/tasks/task-141 - clean-up-build-warnings.md
@@ -1,13 +1,21 @@
 ---
 id: TASK-141
 title: clean up build warnings
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-18 02:09'
+updated_date: '2026-04-18 02:26'
 labels: []
 milestone: m-27
 dependencies: []
 priority: low
 ---
 
+## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clean up build/lint warnings across the stack:
+1. Python: unclosed SQLite connections in syncer worker functions (ResourceWarning in tests)
+2. Python: unused mypy module overrides in pyproject.toml
+3. Frontend: prettier formatting warnings
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -54,14 +54,17 @@ def _sync_worker(
         from .bandcamp import sync_new_purchases
 
         index = LibraryIndex(db_path)
-        paths = sync_new_purchases(
-            bc_config=bc_config,
-            watch_dir=watch_dir,
-            state_file=state_file,
-            index=index,
-            status_callback=lambda msg: status_q.put(msg),
-        )
-        result_q.put(("ok", paths))
+        try:
+            paths = sync_new_purchases(
+                bc_config=bc_config,
+                watch_dir=watch_dir,
+                state_file=state_file,
+                index=index,
+                status_callback=lambda msg: status_q.put(msg),
+            )
+            result_q.put(("ok", paths))
+        finally:
+            index.close()
     except Exception as exc:  # noqa: BLE001
         # NeedsLoginError is identified by class name so the parent process
         # does not need to import bandcamp to handle the login-needed case.
@@ -96,8 +99,13 @@ def _mark_synced_worker(
         from .bandcamp import mark_collection_synced
 
         index = LibraryIndex(db_path)
-        mark_collection_synced(bc_config=bc_config, state_file=state_file, index=index)
-        result_q.put(("ok", None))
+        try:
+            mark_collection_synced(
+                bc_config=bc_config, state_file=state_file, index=index
+            )
+            result_q.put(("ok", None))
+        finally:
+            index.close()
     except Exception as exc:  # noqa: BLE001
         result_q.put(("error", str(exc)))
     finally:
@@ -397,7 +405,10 @@ def logout() -> None:
 
     if db_path.exists():
         index = LibraryIndex(db_path)
-        index.clear_session("bandcamp")
+        try:
+            index.clear_session("bandcamp")
+        finally:
+            index.close()
         logger.info("Bandcamp logout: session cleared from database.")
 
     # Remove legacy session file if it still exists (e.g. migration failed).

--- a/kamp_ui/eslint.config.mjs
+++ b/kamp_ui/eslint.config.mjs
@@ -6,7 +6,16 @@ import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
 export default defineConfig(
-  { ignores: ['**/node_modules', '**/dist', '**/out', 'extensions/**', 'resources/npm/**', 'resources/node/**'] },
+  {
+    ignores: [
+      '**/node_modules',
+      '**/dist',
+      '**/out',
+      'extensions/**',
+      'resources/npm/**',
+      'resources/node/**'
+    ]
+  },
   tseslint.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],

--- a/kamp_ui/src/main/extensions.ts
+++ b/kamp_ui/src/main/extensions.ts
@@ -145,9 +145,7 @@ function runNpm(args: string[]): Promise<void> {
     const bundled = bundledNodeAndNpm()
     // In the packaged app: invoke the bundled node binary running npm-cli.js.
     // In dev: fall back to the system npm on PATH.
-    const [cmd, cmdArgs] = bundled
-      ? [bundled[0], [bundled[1], ...args]]
-      : ['npm', args]
+    const [cmd, cmdArgs] = bundled ? [bundled[0], [bundled[1], ...args]] : ['npm', args]
     execFile(cmd, cmdArgs, { timeout: 60_000 }, (err) => {
       if (err) reject(err)
       else resolve()

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -26,7 +26,7 @@ app.setName('Kamp')
 // via stdin and receives media key events back on stdout.
 
 let _helper: ChildProcess | null = null
-let _isPlaying = false  // tracks current playback state to correctly handle togglePlayPause
+let _isPlaying = false // tracks current playback state to correctly handle togglePlayPause
 // Cache artwork as base64 strings keyed by "album_artist|album" so we only
 // fetch once per album rather than on every position-tick update.
 const _artworkCache = new Map<string, string>()
@@ -71,14 +71,22 @@ function startNowPlayingHelper(): void {
     try {
       const evt = JSON.parse(line) as { event: string }
       switch (evt.event) {
-        case 'play':           postToPlayer('/api/v1/player/resume'); break
-        case 'pause':          postToPlayer('/api/v1/player/pause');  break
+        case 'play':
+          postToPlayer('/api/v1/player/resume')
+          break
+        case 'pause':
+          postToPlayer('/api/v1/player/pause')
+          break
         case 'togglePlayPause':
           // Physical play/pause key fires togglePlayPause — check actual state to toggle.
           postToPlayer(_isPlaying ? '/api/v1/player/pause' : '/api/v1/player/resume')
           break
-        case 'next':           postToPlayer('/api/v1/player/next');   break
-        case 'prev':           postToPlayer('/api/v1/player/prev');   break
+        case 'next':
+          postToPlayer('/api/v1/player/next')
+          break
+        case 'prev':
+          postToPlayer('/api/v1/player/prev')
+          break
       }
     } catch {
       // Ignore malformed lines
@@ -475,7 +483,8 @@ app.whenReady().then(async () => {
           `http://127.0.0.1:8000/api/v1/album-art` +
           `?album_artist=${encodeURIComponent(track.album_artist)}` +
           `&album=${encodeURIComponent(track.album)}`
-        net.fetch(url)
+        net
+          .fetch(url)
           .then((res) => {
             if (!res.ok) return
             return res.arrayBuffer()

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -34,7 +34,12 @@ textarea {
   --text-on-accent: #000;
   --transport-h: 88px;
   --panel-w: 200px;
-  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    'DM Sans',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
   font-size: 13px;
   color: var(--text);
   background: var(--bg);
@@ -135,10 +140,18 @@ body,
 .splash-deco {
   animation: splash-twinkle 2.4s ease-in-out infinite;
 }
-.s1 { animation-delay: 0s; }
-.s2 { animation-delay: 0.8s; }
-.s3 { animation-delay: 1.6s; }
-.s4 { animation-delay: 0.4s; }
+.s1 {
+  animation-delay: 0s;
+}
+.s2 {
+  animation-delay: 0.8s;
+}
+.s3 {
+  animation-delay: 1.6s;
+}
+.s4 {
+  animation-delay: 0.4s;
+}
 
 @keyframes splash-twinkle {
   0%,
@@ -154,8 +167,12 @@ body,
 .splash-note {
   animation: splash-float 3s ease-in-out infinite;
 }
-.n1 { animation-delay: 0s; }
-.n2 { animation-delay: 1.5s; }
+.n1 {
+  animation-delay: 0s;
+}
+.n2 {
+  animation-delay: 1.5s;
+}
 
 @keyframes splash-float {
   0%,
@@ -205,7 +222,9 @@ body,
   font-size: 13px;
   padding: 8px 12px;
   margin-bottom: -1px;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
   /* Buttons must opt out of the drag region so clicks register. */
   -webkit-app-region: no-drag;
 }
@@ -238,7 +257,9 @@ body,
 .search-bar:focus-within {
   border-color: var(--accent);
   width: 280px;
-  transition: width 0.2s ease, border-color 0.15s;
+  transition:
+    width 0.2s ease,
+    border-color 0.15s;
 }
 
 .search-icon {
@@ -294,7 +315,9 @@ body,
   padding: 4px 6px;
   border-radius: 4px;
   line-height: 1;
-  transition: color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    background 0.15s;
 }
 
 .panel-picker-trigger:hover,
@@ -372,7 +395,10 @@ body,
   font-size: 14px;
   padding: 2px 5px;
   line-height: 1;
-  transition: color 0.12s, background 0.12s, border-color 0.12s;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
 }
 
 .panel-picker-slot-btn:hover {
@@ -691,7 +717,6 @@ body,
   scrollbar-color: var(--border) transparent;
 }
 
-
 /* View panes: always mounted so img elements survive view switches and cached
    art appears instantly. The inactive pane is hidden; the active one uses
    display:contents so it has no box of its own and children lay out as if they
@@ -759,7 +784,6 @@ body,
   color: var(--accent);
 }
 
-
 /* Album grid --------------------------------------------------------------- */
 
 .album-grid-container {
@@ -791,7 +815,9 @@ body,
   cursor: pointer;
   font-size: 12px;
   padding: 3px 10px;
-  transition: background 0.1s, color 0.1s;
+  transition:
+    background 0.1s,
+    color 0.1s;
 }
 
 .sort-btn:hover {
@@ -839,7 +865,9 @@ body,
 }
 
 .album-card.playing:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 3px rgba(124, 134, 225, 0.35);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 0 3px rgba(124, 134, 225, 0.35);
 }
 
 .album-art {
@@ -1165,7 +1193,9 @@ body,
   padding: 5px 12px 5px 9px;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 .back-btn:hover {
@@ -1920,7 +1950,9 @@ body,
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-  transition: background 150ms ease, color 150ms ease;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
 }
 
 .prefs-choose-btn:hover {
@@ -1995,7 +2027,9 @@ body,
   padding: 10px 12px 8px;
   margin-bottom: -1px;
   text-transform: uppercase;
-  transition: color 150ms ease, border-color 150ms ease;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
 }
 
 .prefs-tab:hover {
@@ -2079,7 +2113,9 @@ body,
   height: 12px;
   background: var(--text-dim);
   border-radius: 50%;
-  transition: transform 150ms ease, background 150ms ease;
+  transition:
+    transform 150ms ease,
+    background 150ms ease;
 }
 
 .prefs-toggle input:checked + .prefs-toggle-track {
@@ -2184,8 +2220,12 @@ body,
 }
 
 @keyframes prefs-ext-slide {
-  0%   { transform: translateX(-200%); }
-  100% { transform: translateX(350%); }
+  0% {
+    transform: translateX(-200%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
 }
 
 /* Destructive variant of prefs-choose-btn (used for the Remove confirmation). */
@@ -2206,8 +2246,12 @@ body,
 }
 
 @keyframes prefs-ext-highlight-fade {
-  0%   { background: color-mix(in srgb, var(--accent) 45%, transparent); }
-  100% { background: transparent; }
+  0% {
+    background: color-mix(in srgb, var(--accent) 45%, transparent);
+  }
+  100% {
+    background: transparent;
+  }
 }
 
 /* Inline remove confirmation layout. */
@@ -2293,7 +2337,9 @@ body,
   font-size: 12px;
   padding: 6px 14px;
   border-radius: 4px;
-  transition: color 150ms ease, border-color 150ms ease;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
 }
 
 .ext-perm-deny-btn:hover {

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -270,11 +270,18 @@ export function SearchView(): React.JSX.Element {
               setTrackMenu(null)
             }}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24"
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
               fill={trackMenu.favorite ? 'currentColor' : 'none'}
-              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}>
-              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}
+            >
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
             {trackMenu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
           </button>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -183,11 +183,18 @@ export function TrackList(): React.JSX.Element | null {
               setMenu(null)
             }}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24"
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
               fill={menu.favorite ? 'currentColor' : 'none'}
-              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}>
-              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}
+            >
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
             {menu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
           </button>

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -43,10 +43,17 @@ export function TransportBar(): React.JSX.Element {
         title={current_track?.favorite ? 'Remove from favorites' : 'Add to favorites'}
         aria-pressed={current_track?.favorite ?? false}
       >
-        <svg width="16" height="16" viewBox="0 0 24 24"
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
           fill={current_track?.favorite ? 'currentColor' : 'none'}
-          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
         </svg>
       </button>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ python_version = "3.11"
 
 [[tool.mypy.overrides]]
 # musicbrainzngs ships no type stubs
-module = ["musicbrainzngs", "musicbrainzngs.*"]
+module = ["musicbrainzngs"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
@@ -94,12 +94,12 @@ disable_error_code = ["import-untyped", "import-not-found", "no-untyped-call", "
 # mutagen has partial stubs that don't cover ID3 frame classes, MP4 methods, or
 # FLAC tag access (audio.tags is typed as VCFLACDict | MetadataBlock; the union
 # causes false union-attr/index errors on the VCFLACDict branch we always use).
-module = ["kamp_daemon.tagger", "kamp_daemon.mover", "kamp_daemon.artwork", "kamp_core.library", "tests.test_library"]
+module = ["kamp_daemon.tagger", "kamp_daemon.mover", "kamp_daemon.artwork", "kamp_core.library"]
 disable_error_code = ["no-untyped-call", "attr-defined", "unused-ignore", "union-attr", "index", "var-annotated", "assignment", "arg-type"]
 
 [[tool.mypy.overrides]]
 # rumps, AppKit, objc (PyObjC runtime), and setproctitle ship no type stubs
-module = ["rumps", "rumps.*", "AppKit", "AppKit.*", "Foundation", "Foundation.*", "objc", "objc.*", "setproctitle"]
+module = ["rumps", "AppKit", "objc", "setproctitle"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -590,16 +590,19 @@ class TestLogout:
 
         db_path = tmp_path / "library.db"
         index = LibraryIndex(db_path)
-        index.set_session(
-            "bandcamp", {"cookies": [{"name": "js_logged_in", "value": "1"}]}
-        )
-        (tmp_path / "bandcamp_state.json").write_text("{}")
+        try:
+            index.set_session(
+                "bandcamp", {"cookies": [{"name": "js_logged_in", "value": "1"}]}
+            )
+            (tmp_path / "bandcamp_state.json").write_text("{}")
 
-        with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
-            logout()
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                logout()
 
-        assert index.get_session("bandcamp") is None
-        assert not (tmp_path / "bandcamp_state.json").exists()
+            assert index.get_session("bandcamp") is None
+            assert not (tmp_path / "bandcamp_state.json").exists()
+        finally:
+            index.close()
 
     def test_noop_when_db_absent(self, tmp_path: Path) -> None:
         """logout() does not raise when library.db does not exist."""


### PR DESCRIPTION
## Summary

- **Python ResourceWarnings**: Close `LibraryIndex` (SQLite) connections in `_sync_worker`, `_mark_synced_worker`, and `bandcamp_logout` worker functions; same fix in one test fixture — eliminates all `unclosed database` warnings during the test run
- **mypy pyproject.toml**: Remove 7 unused module override patterns (`musicbrainzngs.*`, `rumps.*`, `AppKit.*`, `Foundation`, `Foundation.*`, `objc.*`, `tests.test_library`) that mypy flagged as matching nothing
- **Prettier**: Format 7 frontend files (`extensions.ts`, `index.ts`, `main.css`, `SearchView.tsx`, `TrackList.tsx`, `TransportBar.tsx`, `eslint.config.mjs`)

## Test plan

- [ ] `poetry run pytest --no-cov -q -W all` — no ResourceWarnings, 1054 passed
- [ ] `poetry run mypy kamp_core kamp_daemon` — no warnings or errors
- [ ] `npm run build --prefix kamp_ui` — clean build
- [ ] `npx prettier --check "kamp_ui/src/**/*.{ts,tsx,css}"` — all files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)