### PR TITLE
fix: restore playback position between sessions (TASK-140)

### DIFF
--- a/backlog/tasks/task-140 - regression-current-playback-position-is-no-longer-saved-between-instances.md
+++ b/backlog/tasks/task-140 - regression-current-playback-position-is-no-longer-saved-between-instances.md
@@ -1,12 +1,14 @@
 ---
 id: TASK-140
 title: 'regression: current playback position is no longer saved between instances'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-18 01:52'
+updated_date: '2026-04-18 02:58'
 labels: []
 milestone: m-27
 dependencies: []
+ordinal: 10000
 ---
 
 ## Description

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -335,6 +335,10 @@ class MpvPlaybackEngine:
         self._sock_path = ""
         self._reader_thread: threading.Thread | None = None
         self._lock = threading.Lock()
+        # One-shot seek applied on the next file-loaded event (set by load_paused).
+        # Stored here rather than in on_file_loaded so it doesn't clobber the
+        # external callback chain wired up after engine creation.
+        self._pending_seek: float | None = None
         self._start_mpv()
 
     def _start_mpv(self) -> None:  # pragma: no cover
@@ -409,17 +413,12 @@ class MpvPlaybackEngine:
         Used on daemon startup to restore the previous session state without
         auto-resuming — the user must press play explicitly.
 
-        The seek is deferred to the ``file-loaded`` event callback so it only
-        runs after the demuxer is ready — seek commands sent before that point
-        are silently dropped by mpv.
+        The seek is deferred to the ``file-loaded`` event so it only runs after
+        the demuxer is ready — seek commands sent before that point are silently
+        dropped by mpv.  The position is stored in ``_pending_seek`` rather than
+        in ``on_file_loaded`` so it doesn't overwrite callbacks wired externally.
         """
-        if position > 0:
-            # One-shot: seek to position when mpv confirms the file is ready.
-            def _seek_then_clear() -> None:
-                self.seek(position)
-                self.on_file_loaded = None
-
-            self.on_file_loaded = _seek_then_clear
+        self._pending_seek = position if position > 0 else None
         self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
 
@@ -514,6 +513,9 @@ class MpvPlaybackEngine:
                     self.on_play_state_changed()
 
         elif name == "file-loaded":
+            if self._pending_seek is not None:
+                self.seek(self._pending_seek)
+                self._pending_seek = None
             if self.on_file_loaded is not None:
                 self.on_file_loaded()
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -648,25 +648,44 @@ class TestMpvPlaybackEngine:
         send.assert_any_call("loadfile", "/music/track.mp3", "replace")
         send.assert_any_call("set_property", "pause", True)
 
-    def test_load_paused_registers_file_loaded_callback_when_position_nonzero(
-        self,
-    ) -> None:
+    def test_load_paused_sets_pending_seek_when_position_nonzero(self) -> None:
         engine, _ = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 42.5)
-        assert engine.on_file_loaded is not None
+        assert engine._pending_seek == 42.5
 
-    def test_load_paused_no_callback_when_position_is_zero(self) -> None:
+    def test_load_paused_no_pending_seek_when_position_is_zero(self) -> None:
         engine, _ = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 0.0)
-        assert engine.on_file_loaded is None
+        assert engine._pending_seek is None
 
-    def test_load_paused_callback_seeks_and_clears_itself(self) -> None:
+    def test_load_paused_does_not_overwrite_on_file_loaded(self) -> None:
+        engine, _ = _make_engine()
+        callback = MagicMock()
+        engine.on_file_loaded = callback
+        engine.load_paused(Path("/music/track.mp3"), 42.5)
+        # The external callback must be untouched — this was the regression.
+        assert engine.on_file_loaded is callback
+
+    def test_pending_seek_fires_and_clears_on_file_loaded_event(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"), 42.5)
-        assert engine.on_file_loaded is not None
-        engine.on_file_loaded()  # simulate file-loaded event
+        assert engine._pending_seek == 42.5
+        engine._handle_event({"event": "file-loaded"})
         send.assert_any_call("seek", 42.5, "absolute")
-        assert engine.on_file_loaded is None  # one-shot: cleared after firing
+        assert engine._pending_seek is None  # one-shot: cleared after firing
+
+    def test_pending_seek_fires_before_on_file_loaded_callback(self) -> None:
+        """Seek must happen before the user callback so position is set first."""
+        engine, send = _make_engine()
+        order: list[str] = []
+        send.side_effect = lambda *a: order.append(str(a))
+        callback = MagicMock(side_effect=lambda: order.append("callback"))
+        engine.on_file_loaded = callback
+        engine.load_paused(Path("/music/track.mp3"), 42.5)
+        engine._handle_event({"event": "file-loaded"})
+        seek_idx = next(i for i, s in enumerate(order) if "seek" in s)
+        cb_idx = order.index("callback")
+        assert seek_idx < cb_idx
 
     def test_file_loaded_event_triggers_on_file_loaded_callback(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- `load_paused` stored the deferred seek in `engine.on_file_loaded`, but `__main__.py` overwrote that callback with a no-op a few lines later — so the seek never fired and the track always loaded at position 0
- The state saver then persisted `0` every 5 seconds, destroying the actual saved position
- Fix: deferred seek is now stored in a new `engine._pending_seek` field; `_handle_event` consumes and clears it when `file-loaded` fires, before invoking the external `on_file_loaded` chain

## Test plan

- [x] `test_load_paused_sets_pending_seek_when_position_nonzero` — `_pending_seek` is set
- [x] `test_load_paused_no_pending_seek_when_position_is_zero` — `_pending_seek` stays None
- [x] `test_load_paused_does_not_overwrite_on_file_loaded` — regression guard: external callback is untouched
- [x] `test_pending_seek_fires_and_clears_on_file_loaded_event` — seek issued and field cleared
- [x] `test_pending_seek_fires_before_on_file_loaded_callback` — ordering guarantee
- [x] All 95 playback tests pass, 142 daemon/server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)