### PR TITLE
fix: set restrictive permissions on SQLite database file (TASK-142)

### DIFF
--- a/backlog/docs/doc-1 - Database-Security-Audit-—-v1.11.0.md
+++ b/backlog/docs/doc-1 - Database-Security-Audit-—-v1.11.0.md
@@ -1,0 +1,245 @@
+---
+id: doc-1
+title: Database Security Audit — v1.11.0
+type: other
+created_date: '2026-04-18 17:54'
+---
+# Security Audit Report: kamp Application Database
+
+**Date**: 2026-04-18
+**Scope**: SQLite database, schema, query layer (`library.py`), HTTP API (`server.py`), configuration handling (`config.py`)
+**Deployment model**: Single-user, local-first desktop app; HTTP server binds to 127.0.0.1 only
+**Schema version audited**: 10
+
+---
+
+## 1. Threat Model
+
+### 1.1 Architecture Summary
+
+kamp runs a Python/FastAPI daemon on `127.0.0.1` with an Electron renderer as its primary client. The database lives at `~/.local/share/kamp/library.db` (or the Windows equivalent). There is no cloud backend, no remote authentication, and no multi-user access. The daemon spawns subprocess workers for library scanning and Bandcamp sync.
+
+### 1.2 Realistic Threat Actors
+
+**In scope:**
+
+- **Malicious local processes** — any other process running as the same user (or root) can reach `127.0.0.1:PORT` without authentication. This is the primary attack surface.
+- **Compromised community extensions** — extensions run with the extension_id trust boundary enforced only by audit log filtering in Python code, not by OS-level isolation.
+- **Malicious audio files** — files placed in the watched library directory are parsed by mutagen; a crafted file could attempt to exploit tag parsing.
+- **Ambient filesystem access** — on macOS and Linux, any process running as the user can directly open the database file if file permissions are permissive.
+
+**Out of scope:**
+
+- Remote attackers over the network (the server does not bind to a routable interface)
+- Cross-user attacks (single-user system)
+- Physical access attacks
+- Electron renderer XSS leading to renderer-process compromise (separate surface)
+
+### 1.3 Trust Boundary Map
+
+| Boundary | From | To | Current Controls |
+|---|---|---|---|
+| Loopback → API | Any local process | FastAPI on 127.0.0.1 | None — no authentication |
+| API → Database | FastAPI handlers | SQLite | Parameterized queries, whitelisted column names |
+| Extension → Library | Extension code | `apply_metadata_update` | `_WRITABLE_TRACK_FIELDS` allowlist enforced in Python |
+| Filesystem → DB | Library scanner | SQLite | Mutagen tag parsing; mtime change detection |
+| Electron → API | Electron main/renderer | FastAPI | CORS wildcard; no token |
+
+---
+
+## 2. Findings
+
+### FINDING-01: Bandcamp Session Cookies Exposed Over Unauthenticated Local HTTP
+
+**Severity: High**
+
+`GET /api/v1/bandcamp/session-cookies` returns the full raw Bandcamp cookie list — including `cf_clearance` and authentication cookies — to any caller on the loopback interface with no authentication, token, or origin check. Additionally, the `bandcamp.proxy-fetch` WebSocket push broadcasts the full cookie list to any connected WebSocket client:
+
+```python
+# server.py
+proxy_event = {
+    "type": "bandcamp.proxy-fetch",
+    ...
+    "cookies": broadcast_cookies,  # full cookie list in every WS push
+}
+```
+
+**Attack scenario**: A malicious process opens a WebSocket to the kamp daemon and harvests Bandcamp auth cookies, enabling it to act as the authenticated user against Bandcamp's API.
+
+**Remediation**:
+- Remove `cookies` from the WebSocket broadcast payload immediately. Electron can call `/session-cookies` directly when needed.
+- Long term: add a shared-secret token generated at daemon startup (written to a `chmod 600` file) required as a header on sensitive endpoints.
+
+---
+
+### FINDING-02: No Authentication on HTTP API — Any Local Process Can Control Playback and Modify Library State
+
+**Severity: Medium**
+
+All endpoints — including `POST /api/v1/library/scan`, `POST /api/v1/tracks/favorite`, Bandcamp/Last.fm connect/disconnect — are unauthenticated. CORS is configured with `allow_origins=["*"]`, meaning any page open in any browser can make cross-origin requests to the daemon.
+
+**Attack scenario**: A malicious website calls `fetch("http://127.0.0.1:PORT/api/v1/bandcamp/session-cookies")` and receives the full Bandcamp cookie payload (restricted to `http://` pages by browser mixed-content policy, but still a real risk).
+
+**Remediation**:
+```python
+ALLOWED_ORIGINS = ["http://localhost", "http://127.0.0.1", "file://"]
+# Add "http://localhost:5173" in dev mode only
+app.add_middleware(CORSMiddleware, allow_origins=ALLOWED_ORIGINS, ...)
+```
+
+---
+
+### FINDING-03: Plaintext Session Credential Storage in SQLite
+
+**Severity: Medium**
+
+The `sessions` table stores Bandcamp cookies and the Last.fm session key as plaintext JSON blobs. With world-readable file permissions (Finding-04), these are exposed to any process on the system. Even with correct permissions, backup/sync tools (Time Machine, iCloud Drive, Dropbox) would capture plaintext credentials.
+
+**Remediation**:
+- Short term: `chmod 600` on database file (see Finding-04).
+- Medium term: use macOS Keychain via `keyring` library; fall back to DB storage on platforms without a keyring.
+
+---
+
+### FINDING-04: Database File Permissions — World-Readable by Default
+
+**Severity: Medium**
+
+`sqlite3.connect()` creates the database file using the process umask (typically `022` → `644`). This makes the database, WAL file, and SHM file world-readable, exposing all track metadata, play history, favorites, file paths, and session credentials to any user on the system.
+
+**Remediation** — apply restrictive umask before first connect:
+```python
+def _make_conn(self) -> sqlite3.Connection:
+    old_umask = os.umask(0o077)  # produces 600 for files
+    try:
+        conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+    finally:
+        os.umask(old_umask)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+```
+
+---
+
+### FINDING-05: `file_path` User Input Accepted Without Explicit Path Traversal Validation
+
+**Severity: Low**
+
+Several endpoints accept a `file_path` string and pass it to `index.get_track_by_path(Path(file_path))`. The DB lookup currently acts as an implicit allowlist, but this is not explicit and could break if a future change uses the caller-supplied path directly (e.g. in the `album-art` endpoint).
+
+**Remediation**: Add explicit path containment validation asserting the resolved path lies within the configured library directory, as defense-in-depth.
+
+---
+
+### FINDING-06: Dynamic SQL Built From Audit Log Data — `noqa` Suppresses Safety Signal
+
+**Severity: Low**
+
+`rollback_extension` and `apply_metadata_update` interpolate column names from audit log JSON into a `SET` clause, filtered through `_WRITABLE_TRACK_FIELDS`. The filter is correct, but the `# noqa: S608` comments suppress the linter warning without documenting the safety argument, making the pattern invisible to future readers.
+
+**Remediation**: Replace silent filtering with an explicit invariant guard:
+```python
+unknown = set(safe) - _WRITABLE_TRACK_FIELDS
+if unknown:
+    raise ValueError(f"Unexpected column names in audit log rollback: {unknown}")
+```
+
+---
+
+### FINDING-07: Last.fm Session Key Stored in Plaintext `config.toml`
+
+**Severity: Low**
+
+`config.toml` is created with world-readable permissions (same root cause as Finding-04) and contains the Last.fm `session_key`, which is functionally equivalent to a credential granting full scrobbling API access with no expiry.
+
+**Remediation**: Set `chmod 600` on `config.toml` at creation. Complete the migration of Last.fm session key from TOML into the `sessions` DB table (and then to keyring per Finding-03).
+
+---
+
+### FINDING-08: Deleted Credentials Persist in WAL File Until Checkpoint
+
+**Severity: Informational**
+
+After `clear_session()` deletes a row, the plaintext credential data remains in the WAL file until the next checkpoint. A forensic copy of the WAL file taken immediately after disconnecting Bandcamp would still contain the cookies.
+
+**Remediation**:
+```python
+def clear_session(self, service: str) -> None:
+    self._conn.execute("DELETE FROM sessions WHERE service = ?", (service,))
+    self._conn.commit()
+    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+```
+
+---
+
+### FINDING-09: `proxy-fetch` Accepts Arbitrary URLs — Potential Cookie Leakage to Non-Bandcamp Hosts
+
+**Severity: Informational**
+
+`POST /api/v1/bandcamp/proxy-fetch` accepts any URL without validation and broadcasts it to Electron, which executes `net.fetch(url)` with Bandcamp session cookies attached. A compromised extension or local process could cause authenticated requests to be sent to non-Bandcamp hosts.
+
+**Remediation**:
+```python
+ALLOWED_PROXY_HOSTS = frozenset({"bandcamp.com", "f4.bcbits.com", "t4.bcbits.com"})
+
+def _validate_proxy_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not any(host == h or host.endswith(f".{h}") for h in ALLOWED_PROXY_HOSTS):
+        raise HTTPException(status_code=422, detail=f"Proxy URL host not allowed: {host}")
+    return url
+```
+
+---
+
+## 3. Positive Findings
+
+These practices are done well and should be preserved:
+
+- **Parameterized queries throughout** — zero injection vectors found across all query paths.
+- **Whitelisted sort columns** — `_SORT_CLAUSES` dict ensures dynamic ORDER BY comes from a controlled set, not user input.
+- **FTS input sanitization** — `_make_fts_query` strips FTS5 special chars before the parameterized MATCH call.
+- **`_WRITABLE_TRACK_FIELDS` allowlist** — extensions cannot write to internal columns (`play_count`, `last_played`, `file_path`). Allowlist is a `frozenset` (immutable at runtime).
+- **Append-only audit log with DB-level triggers** — `_audit_log_no_delete` and `_audit_log_no_update` enforce the invariant at the database level, not just in Python.
+- **No password storage** — Last.fm session key is an OAuth-style token obtained post-auth; Bandcamp password is never persisted.
+- **Schema versioning with incremental migrations** — each migration step is idempotent and version-gated.
+- **Per-thread connection model** — `threading.local` avoids cursor-state races without a global mutex.
+
+---
+
+## 4. Prioritized Remediation Roadmap
+
+### v1.11.0 — Hardening Release (all Single-effort changes)
+
+| Priority | Finding | Action |
+|---|---|---|
+| 1 | FINDING-04 | Restrictive umask in `_make_conn` before `sqlite3.connect()` |
+| 2 | FINDING-01 | Remove `cookies` from WebSocket `proxy-fetch` broadcast payload |
+| 3 | FINDING-07 | `chmod 600` on `config.toml` at creation in `first_run_setup` / `load` |
+| 4 | FINDING-08 | `PRAGMA wal_checkpoint(TRUNCATE)` after `clear_session()` |
+| 5 | FINDING-02 | Restrict CORS origins — remove wildcard `"*"` |
+| 6 | FINDING-09 | Validate `proxy-fetch` URL against `bandcamp.com` domain allowlist |
+| 7 | FINDING-06 | Replace `noqa: S608` with explicit `ValueError` guard on unexpected column names |
+
+**Total estimate: Side**
+
+### Medium Term (v1.12.0 or dedicated security sprint)
+
+| Priority | Finding | Action | Effort |
+|---|---|---|---|
+| 1 | FINDING-01 | Shared-secret token for HTTP API; required on sensitive endpoints | LP |
+| 2 | FINDING-03 | Migrate session credentials to OS keychain via `keyring`; DB as fallback | LP |
+| 3 | FINDING-07 | Complete Last.fm session key migration from config.toml → sessions table | Side |
+| 4 | FINDING-05 | Explicit path containment validation for `file_path` parameters | Side |
+
+### Longer Term
+
+- **Full API authentication**: daemon-startup token written to `~/.local/share/kamp/.token` (`chmod 600`), required as `X-Kamp-Token` header. This is the standard pattern used by VS Code, JupyterLab, and similar local-first tools and closes Findings 01 and 02 comprehensively.
+- **Encrypted credential store**: once `keyring` is integrated, the `sessions` table stores only non-sensitive metadata; actual credentials live in the OS keychain, making database backups and sync-service copies safe.
+
+---
+
+## Summary
+
+The most consequential issue is the combination of **no API authentication** and **Bandcamp session cookies accessible to any local process** (Findings 01 and 02). The SQL layer is clean — parameterized queries, column allowlists, and FTS sanitization are all correctly implemented. Security debt is concentrated in credential storage and API access control, both of which have well-established remediation patterns for local-first desktop apps. All v1.11.0 hardening items are single-file changes landable in one session without touching the API surface or requiring migration logic.

--- a/backlog/tasks/task-131 - audit-application-database-for-security.md
+++ b/backlog/tasks/task-131 - audit-application-database-for-security.md
@@ -1,16 +1,18 @@
 ---
 id: TASK-131
 title: audit application database for security
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-15 02:47'
-updated_date: '2026-04-18 17:14'
+updated_date: '2026-04-18 17:54'
 labels:
   - chore
   - security
   - 'estimate: side'
 milestone: m-29
 dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0
 priority: high
 ---
 
@@ -19,3 +21,22 @@ priority: high
 <!-- SECTION:DESCRIPTION:BEGIN -->
 consult with the Security Engineer to provide a security report, including vulnerabilities, attack surfaces, and threat severity, of our application's database, along with recommendations for remediation.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Security audit completed by Security Engineer subagent. Full report saved as doc-1 (Database Security Audit — v1.11.0).
+
+**9 findings across 4 severity levels:**
+
+- **High (1):** FINDING-01 — Bandcamp session cookies exposed via unauthenticated HTTP endpoint and WebSocket broadcast
+- **Medium (3):** FINDING-02 (no API auth, wildcard CORS), FINDING-03 (plaintext credential storage), FINDING-04 (DB file world-readable, 644 permissions)
+- **Low (3):** FINDING-05 (no explicit path traversal check), FINDING-06 (noqa suppresses safety signal on dynamic SQL), FINDING-07 (Last.fm session key in plaintext config.toml)
+- **Informational (2):** FINDING-08 (deleted credentials linger in WAL), FINDING-09 (proxy-fetch accepts arbitrary URLs)
+
+**SQL injection posture is clean** — all queries parameterized, column names allowlist-filtered, FTS input sanitized. No injection vectors found.
+
+**v1.11.0 hardening scope (all Single-effort):** umask fix for DB file permissions, remove cookies from WS broadcast, chmod 600 on config.toml, WAL checkpoint after clear_session, restrict CORS origins, validate proxy-fetch URL domain, replace noqa with explicit guard.
+
+**Medium-term:** shared-secret API token and OS keychain integration for credentials.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-142 - fix-database-file-permissions-—-apply-restrictive-umask-before-sqlite3.connect.md
+++ b/backlog/tasks/task-142 - fix-database-file-permissions-—-apply-restrictive-umask-before-sqlite3.connect.md
@@ -1,0 +1,61 @@
+---
+id: TASK-142
+title: fix database file permissions — apply restrictive umask before sqlite3.connect
+status: Done
+assignee: []
+created_date: '2026-04-18 18:01'
+updated_date: '2026-04-18 18:05'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-04)
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-04 from the v1.11.0 database security audit.
+
+`sqlite3.connect()` creates the database file using the process umask (typically `022` → `644`). This makes `library.db`, `library.db-wal`, and `library.db-shm` world-readable, exposing all track metadata, play history, favorites, file paths, and session credentials to any user on the system.
+
+**Fix:** apply a restrictive umask before the first `sqlite3.connect()` call in `_make_conn`, then restore it:
+
+```python
+def _make_conn(self) -> sqlite3.Connection:
+    old_umask = os.umask(0o077)  # produces 600 for files, 700 for dirs
+    try:
+        conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+    finally:
+        os.umask(old_umask)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+```
+
+The umask approach is preferred over a post-hoc `chmod` because there is no race window between SQLite creating the file and the permission change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Database file is created with 600 permissions (owner read/write only)
+- [ ] #2 WAL and SHM sidecar files also created with 600 permissions
+- [ ] #3 Existing installs: permissions corrected on next startup (apply chmod on open if current mode is too permissive)
+- [ ] #4 No regression in multi-threaded connection behaviour
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Applied in `kamp_core/library.py`:
+
+1. **New files** — `_make_conn` now sets `os.umask(0o077)` before `sqlite3.connect()` and restores the original umask in a `finally` block. This ensures the DB file and all WAL/SHM sidecar files are created with 600 permissions.
+
+2. **Existing installs** — `__init__` calls `db_path.chmod(stat.S_IRUSR | stat.S_IWUSR)` on the existing file before opening it, correcting any pre-existing 644 permissions on upgrade.
+
+Added two tests in `TestDatabaseFilePermissions`: one verifying fresh DB is created 600, one verifying an existing 644 DB is corrected to 600 on re-open. All 106 tests pass.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-143 - remove-Bandcamp-cookies-from-WebSocket-proxy-fetch-broadcast-payload.md
+++ b/backlog/tasks/task-143 - remove-Bandcamp-cookies-from-WebSocket-proxy-fetch-broadcast-payload.md
@@ -1,0 +1,73 @@
+---
+id: TASK-143
+title: remove Bandcamp cookies from WebSocket proxy-fetch broadcast payload
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:01'
+updated_date: '2026-04-18 18:12'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-01)
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-01 (partial) from the v1.11.0 database security audit.
+
+The `bandcamp.proxy-fetch` WebSocket event broadcasts the full Bandcamp cookie list (including `cf_clearance` and auth cookies) to every connected WebSocket client. Any local process that opens a WebSocket connection to the kamp daemon receives these cookies as part of normal operation.
+
+**This is a two-part change — both sides must ship together.**
+
+### Part 1: Python (`kamp_core/server.py`)
+
+Remove `cookies` from the broadcast payload in the `bandcamp_proxy_fetch` endpoint:
+
+```python
+proxy_event: dict[str, Any] = {
+    "type": "bandcamp.proxy-fetch",
+    "id": req_id,
+    "url": req.url,
+    "method": req.method,
+    "headers": req.headers,
+    "body": req.body,
+    # cookies omitted — Electron fetches /session-cookies directly
+}
+```
+
+Also remove the `broadcast_cookies` / `session_data` locals that are no longer needed.
+
+### Part 2: Electron (`kamp_ui/src/main/index.ts`)
+
+The `bandcamp:proxy-fetch` IPC handler currently reads cookies exclusively from `req.cookies` (the WS payload field). It does **not** fall back to the HTTP endpoint — `req.cookies ?? []` silently produces an empty list, which means `net.fetch` runs without auth cookies and gets 403s from Bandcamp.
+
+`GET /api/v1/bandcamp/session-cookies` already exists and returns the right shape `{"cookies": [...]}`. It just needs to be called. Replace the `req.cookies` read with a fetch to that endpoint before injecting into `session.defaultSession`:
+
+```typescript
+// Fetch cookies from the daemon rather than reading from the WS payload,
+// so auth cookies are never broadcast to all WS clients.
+const cookieResp = await net.fetch('http://127.0.0.1:8000/api/v1/bandcamp/session-cookies')
+const { cookies } = await cookieResp.json() as { cookies: BandcampCookie[] }
+```
+
+Then use `cookies` (from the endpoint) in place of `req.cookies` for the injection loop. Remove the `cookies` field from the `req` type annotation on the handler.
+
+### Why the endpoint already exists
+
+`GET /api/v1/bandcamp/session-cookies` was written in anticipation of this change but the Electron wiring was never completed. The endpoint is tested in `tests/test_server.py` but not called from any Electron code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 WebSocket proxy-fetch broadcast no longer includes a cookies field
+- [ ] #2 Electron main process fetches cookies from GET /api/v1/bandcamp/session-cookies before executing net.fetch
+- [ ] #3 The cookies field is removed from the req type annotation on the bandcamp:proxy-fetch IPC handler
+- [ ] #4 Bandcamp proxy flow (library sync, album fetch) continues to work end-to-end after the change
+- [ ] #5 No cookies field appears in the pending proxy-fetch cache (_pending_proxy_fetches) stored in memory
+<!-- AC:END -->

--- a/backlog/tasks/task-144 - set-restrictive-permissions-on-config.toml-at-creation.md
+++ b/backlog/tasks/task-144 - set-restrictive-permissions-on-config.toml-at-creation.md
@@ -1,0 +1,41 @@
+---
+id: TASK-144
+title: set restrictive permissions on config.toml at creation
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-07)
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-07 from the v1.11.0 database security audit.
+
+`config.toml` is created with world-readable permissions (default umask `644`) and contains the Last.fm `session_key` — a persistent OAuth-style token granting full scrobbling API access with no expiry. This is functionally equivalent to a credential and should not be world-readable.
+
+**Fix:** set `chmod 600` on `config.toml` at creation in `Config.first_run_setup` and on load if the file already exists with too-permissive modes:
+
+```python
+path.parent.mkdir(parents=True, exist_ok=True)
+path.touch(mode=0o600)
+path.write_text(DEFAULT_CONFIG_CONTENT)
+```
+
+Also apply a corrective `chmod` in `Config.load()` for existing installs where the file was already created with loose permissions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 config.toml created with 600 permissions on fresh install
+- [ ] #2 Existing config.toml with loose permissions corrected to 600 on next load
+- [ ] #3 No change to config read/write behaviour
+<!-- AC:END -->

--- a/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
+++ b/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
@@ -1,0 +1,42 @@
+---
+id: TASK-145
+title: checkpoint WAL after clear_session to promptly remove deleted credentials
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-08)
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-08 from the v1.11.0 database security audit.
+
+After `clear_session()` deletes a row from the `sessions` table, the plaintext credential data (Bandcamp cookies, Last.fm session key) remains in the WAL file (`library.db-wal`) until the next full checkpoint. A forensic copy of the WAL file taken immediately after a user disconnects their Bandcamp account would still contain their cookies.
+
+**Fix:** issue a `PRAGMA wal_checkpoint(TRUNCATE)` immediately after the delete commits:
+
+```python
+def clear_session(self, service: str) -> None:
+    self._conn.execute("DELETE FROM sessions WHERE service = ?", (service,))
+    self._conn.commit()
+    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+```
+
+`TRUNCATE` mode resets the WAL file to zero bytes after checkpointing all frames, minimising the window in which deleted credential data is recoverable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 clear_session() issues PRAGMA wal_checkpoint(TRUNCATE) after commit
+- [ ] #2 WAL file is truncated (zero or near-zero bytes) immediately after a session is cleared
+- [ ] #3 No regression in normal read/write performance
+<!-- AC:END -->

--- a/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
+++ b/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
@@ -1,0 +1,54 @@
+---
+id: TASK-146
+title: restrict CORS origins — remove wildcard allow_origins from FastAPI middleware
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-02)
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-02 from the v1.11.0 database security audit.
+
+The FastAPI server uses `allow_origins=["*"]` in CORSMiddleware. Combined with no API authentication, this means any page open in any browser can make cross-origin requests to the daemon — including calling `GET /api/v1/bandcamp/session-cookies`.
+
+**Fix:** restrict origins to those kamp actually serves:
+
+```python
+ALLOWED_ORIGINS = [
+    "http://localhost",
+    "http://127.0.0.1",
+    "file://",  # Electron renderer in production
+]
+# Vite dev server — only in dev mode
+if dev_mode:
+    ALLOWED_ORIGINS.append("http://localhost:5173")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "POST", "DELETE", "PATCH"],
+    allow_headers=["Content-Type"],
+)
+```
+
+Verify the Electron renderer (production `file://` origin) and Vite dev server continue to work after the change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CORS no longer uses wildcard allow_origins
+- [ ] #2 Electron renderer (file:// origin) can still reach all API endpoints
+- [ ] #3 Vite dev server (localhost:5173) works in dev mode
+- [ ] #4 Requests from arbitrary browser origins are rejected with CORS error
+<!-- AC:END -->

--- a/backlog/tasks/task-147 - validate-proxy-fetch-URL-against-bandcamp.com-domain-allowlist.md
+++ b/backlog/tasks/task-147 - validate-proxy-fetch-URL-against-bandcamp.com-domain-allowlist.md
@@ -1,0 +1,48 @@
+---
+id: TASK-147
+title: validate proxy-fetch URL against bandcamp.com domain allowlist
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-09)
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-09 from the v1.11.0 database security audit.
+
+`POST /api/v1/bandcamp/proxy-fetch` accepts an arbitrary URL string with no validation and broadcasts it to the Electron main process, which executes `net.fetch(url)` with Bandcamp session cookies attached. A compromised extension or any local process making a POST could cause the Electron process to make authenticated requests to arbitrary non-Bandcamp hosts.
+
+**Fix:** validate the URL hostname against an allowlist of known Bandcamp domains before broadcasting:
+
+```python
+from urllib.parse import urlparse
+
+ALLOWED_PROXY_HOSTS = frozenset({"bandcamp.com", "f4.bcbits.com", "t4.bcbits.com"})
+
+def _validate_proxy_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not any(host == h or host.endswith(f".{h}") for h in ALLOWED_PROXY_HOSTS):
+        raise HTTPException(status_code=422, detail=f"Proxy URL host not allowed: {host}")
+    return url
+```
+
+Add additional Bandcamp CDN hostnames to `ALLOWED_PROXY_HOSTS` as needed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 proxy-fetch rejects URLs whose hostname is not in the bandcamp.com allowlist with HTTP 422
+- [ ] #2 Legitimate Bandcamp API and CDN URLs (bandcamp.com, f4.bcbits.com, t4.bcbits.com) are accepted
+- [ ] #3 Non-Bandcamp URLs return a clear error without making a network request
+<!-- AC:END -->

--- a/backlog/tasks/task-148 - replace-noqa-S608-with-explicit-ValueError-guard-in-dynamic-SET-clause-construction.md
+++ b/backlog/tasks/task-148 - replace-noqa-S608-with-explicit-ValueError-guard-in-dynamic-SET-clause-construction.md
@@ -1,0 +1,49 @@
+---
+id: TASK-148
+title: >-
+  replace noqa S608 with explicit ValueError guard in dynamic SET clause
+  construction
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - chore
+  - 'estimate: single'
+milestone: m-29
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-06)
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-06 from the v1.11.0 database security audit.
+
+`rollback_extension` and `apply_metadata_update` in `library.py` interpolate column names from audit log JSON into a dynamic `SET` clause, filtered through `_WRITABLE_TRACK_FIELDS`. The filter is correct, but `# noqa: S608` comments suppress the linter's safety warning without documenting the reasoning — making the pattern invisible to future readers who might weaken or remove the guard.
+
+**Fix:** replace the silent filter with an explicit invariant check that raises on unexpected column names:
+
+```python
+# Validate against the allowlist — load-bearing; do not remove.
+# Column names are interpolated directly into SQL; any name outside this
+# set must raise, not be silently skipped.
+unknown = set(fields) - _WRITABLE_TRACK_FIELDS
+if unknown:
+    raise ValueError(f"Unexpected column names in metadata update: {unknown}")
+
+safe = {k: v for k, v in fields.items() if k in _WRITABLE_TRACK_FIELDS}
+set_clause = ", ".join(f"{k} = ?" for k in safe)
+```
+
+Remove the `# noqa: S608` suppressions once the intent is self-documenting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 noqa: S608 suppressions removed from apply_metadata_update and rollback_extension
+- [ ] #2 Passing unexpected column names raises ValueError rather than silently dropping them
+- [ ] #3 Existing tests for metadata update and rollback continue to pass
+<!-- AC:END -->

--- a/backlog/tasks/task-149 - implement-shared-secret-token-authentication-for-the-HTTP-API.md
+++ b/backlog/tasks/task-149 - implement-shared-secret-token-authentication-for-the-HTTP-API.md
@@ -1,0 +1,46 @@
+---
+id: TASK-149
+title: implement shared-secret token authentication for the HTTP API
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - feature
+  - 'estimate: lp'
+milestone: m-15
+dependencies: []
+references:
+  - 'doc-1 - Database Security Audit — v1.11.0 (FINDING-01, FINDING-02)'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-01 and FINDING-02 (comprehensive fix) from the v1.11.0 database security audit.
+
+The HTTP API has no authentication — any local process can call any endpoint, including those that expose Bandcamp session cookies and mutate library state. The CORS wildcard (addressed separately in v1.11.0) is a partial mitigation; full protection requires a shared secret.
+
+**Approach (standard pattern for local-first desktop apps — used by VS Code, JupyterLab):**
+
+1. At daemon startup, generate a cryptographically random token: `secrets.token_hex(32)`
+2. Write it to `~/.local/share/kamp/.token` with `chmod 600`
+3. Electron reads the token from this file at startup and attaches it to all API requests as `X-Kamp-Token: <token>`
+4. FastAPI middleware validates the header on every request; missing or wrong token → HTTP 401
+5. Token is regenerated on each daemon start (stateless — Electron re-reads on reconnect)
+
+Sensitive endpoints (session cookies, config writes) should require the token in v1.11.0's partial fix; this task makes it universal.
+
+This comprehensively closes the "any local process can reach the API" attack surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Daemon generates a random token at startup and writes it to .token (chmod 600)
+- [ ] #2 All API endpoints reject requests missing a valid X-Kamp-Token header with HTTP 401
+- [ ] #3 Electron reads the token file at startup and includes it on all requests
+- [ ] #4 Token is regenerated on each daemon restart; Electron re-reads on reconnect
+- [ ] #5 WebSocket upgrade also validates the token (query param or first message)
+- [ ] #6 No existing Electron↔API flows break after the change
+<!-- AC:END -->

--- a/backlog/tasks/task-150 - migrate-session-credentials-to-OS-keychain-via-keyring.md
+++ b/backlog/tasks/task-150 - migrate-session-credentials-to-OS-keychain-via-keyring.md
@@ -1,0 +1,63 @@
+---
+id: TASK-150
+title: migrate session credentials to OS keychain via keyring
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:02'
+labels:
+  - security
+  - feature
+  - 'estimate: lp'
+milestone: m-15
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-03)
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-03 from the v1.11.0 database security audit.
+
+Bandcamp cookies and the Last.fm session key are stored as plaintext JSON in the `sessions` table. Even with correct file permissions (600), backup/sync tools (Time Machine, iCloud Drive, Dropbox) capture plaintext credentials. The correct platform mechanism for credential storage is the OS keychain.
+
+**Approach:**
+
+Use the `keyring` library to store credentials in the macOS Keychain, Windows Credential Manager, or Linux Secret Service. Fall back to the existing `sessions` table on platforms where no keyring is available:
+
+```python
+import keyring
+import keyring.errors
+
+def set_session(self, service: str, data: dict[str, Any]) -> None:
+    try:
+        keyring.set_password("kamp", service, json.dumps(data))
+    except keyring.errors.NoKeyringError:
+        self._store_session_in_db(service, data)
+
+def get_session(self, service: str) -> dict[str, Any] | None:
+    try:
+        raw = keyring.get_password("kamp", service)
+        if raw is not None:
+            return json.loads(raw)
+    except keyring.errors.NoKeyringError:
+        pass
+    return self._get_session_from_db(service)
+```
+
+Once keyring is integrated, the `sessions` table retains only non-sensitive metadata (service name, `updated_at`) and the actual credential payload lives in the OS keychain — making database file backups and forensic copies safe.
+
+One-time migration: on first load after upgrade, move any existing `sessions` rows into the keychain and clear the `session_json` column in the DB.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 keyring added as a dependency
+- [ ] #2 set_session writes to OS keychain when available; falls back to DB otherwise
+- [ ] #3 get_session reads from OS keychain first, then DB fallback
+- [ ] #4 clear_session removes from both keychain and DB
+- [ ] #5 One-time migration moves existing DB session data into the keychain on upgrade
+- [ ] #6 After migration, session_json in DB is cleared (no plaintext credentials at rest)
+- [ ] #7 Bandcamp and Last.fm auth flows work end-to-end on macOS, with graceful degradation on platforms without a keyring
+<!-- AC:END -->

--- a/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
+++ b/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
@@ -1,0 +1,44 @@
+---
+id: TASK-151
+title: migrate Last.fm session key from config.toml to sessions table
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:03'
+labels:
+  - security
+  - chore
+  - 'estimate: side'
+milestone: m-15
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-07)
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-07 (completion) from the v1.11.0 database security audit.
+
+The Last.fm `session_key` is currently stored in `config.toml` under `[lastfm]`. It is a persistent OAuth-style token with no expiry that grants full scrobbling API access. It belongs in the `sessions` table alongside the Bandcamp session (and ultimately in the OS keychain per the keyring migration task).
+
+**Fix:**
+
+During `Config.load()`, if `lastfm.session_key` is present in the TOML file:
+1. Read the value
+2. Write it to `index.set_session("lastfm", {"session_key": value, "username": lastfm_username})`
+3. Remove `session_key` (and `username`) from the TOML file
+4. Log a one-time info message: "Migrated Last.fm session key from config.toml → database"
+
+After migration, `LastfmConfig` no longer has `session_key` or `username` fields — the Last.fm session is read via `index.get_session("lastfm")` the same way the Bandcamp session is.
+
+This task depends on TASK-132 (config → DB migration) being complete first, or can be done independently if config.toml is still in use at the time.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Last.fm session_key is no longer stored in config.toml after first load post-migration
+- [ ] #2 Session key is written to the sessions table (and later the keychain, per the keyring task)
+- [ ] #3 Last.fm scrobbling continues to work end-to-end after migration
+- [ ] #4 LastfmConfig no longer exposes session_key as a config field
+<!-- AC:END -->

--- a/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
+++ b/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
@@ -1,0 +1,45 @@
+---
+id: TASK-152
+title: add explicit path containment validation for file_path API parameters
+status: To Do
+assignee: []
+created_date: '2026-04-18 18:03'
+labels:
+  - security
+  - chore
+  - 'estimate: side'
+milestone: m-15
+dependencies: []
+references:
+  - doc-1 - Database Security Audit — v1.11.0 (FINDING-05)
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+FINDING-05 from the v1.11.0 database security audit.
+
+Several API endpoints accept a `file_path` string from the HTTP request and pass it directly to `index.get_track_by_path(Path(file_path))`. The DB lookup currently acts as an implicit path allowlist — only indexed paths can be returned. However, this is not explicit, and a future change that uses the caller-supplied path directly (e.g. for performance in the `album-art` endpoint) would silently introduce a path traversal vulnerability.
+
+**Fix:** add a shared validation helper and call it in each affected endpoint:
+
+```python
+def _validate_library_path(file_path: str, library_path: Path | None) -> Path:
+    p = Path(file_path).resolve()
+    if library_path is not None:
+        if not str(p).startswith(str(library_path.resolve())):
+            raise HTTPException(status_code=400, detail="Path outside library directory")
+    return p
+```
+
+Affected endpoints: `GET /api/v1/tracks`, `POST /api/v1/tracks/favorite`, `GET /api/v1/album-art`, `POST /api/v1/player/play`, `POST /api/v1/player/queue/add`, and any other endpoint that accepts a raw `file_path`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All file_path-accepting endpoints validate that the resolved path lies within the configured library directory
+- [ ] #2 Requests with paths outside the library directory return HTTP 400
+- [ ] #3 No regression for valid library paths
+- [ ] #4 Validation helper is shared (not duplicated per endpoint)
+<!-- AC:END -->

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import sqlite3
+import stat
 import threading
 import time as _time
 from collections.abc import Callable
@@ -226,6 +228,10 @@ class LibraryIndex:
         # all down cleanly at server shutdown.
         self._all_conns: list[sqlite3.Connection] = []
         self._all_conns_lock = threading.Lock()
+        # Correct permissions on existing installs where the file was created
+        # with the default umask (644).
+        if db_path.exists():
+            db_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
         self._migrate()
 
     def _make_conn(self) -> sqlite3.Connection:
@@ -233,7 +239,13 @@ class LibraryIndex:
         # check_same_thread=False: each connection is only *used* by the thread
         # that created it (enforced by threading.local), but close() is called
         # from the main thread at shutdown and needs to reach all connections.
-        conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        # Apply a restrictive umask so SQLite creates library.db (and its WAL/SHM
+        # sidecar files) with 600 permissions rather than the default 644.
+        old_umask = os.umask(0o077)
+        try:
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        finally:
+            os.umask(old_umask)
         conn.row_factory = sqlite3.Row
         # WAL allows concurrent reads from other thread-connections while a
         # write (e.g. library scan) is in progress.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1963,3 +1963,29 @@ class TestSessionManagement:
             by_path["/music/untagged.mp3"] == 2222.0
         ), "fully untagged mtime unchanged"
         assert by_path["/music/tagged.mp3"] == 3333.0, "already-tagged mtime unchanged"
+
+
+class TestDatabaseFilePermissions:
+    def test_new_database_created_with_owner_only_permissions(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "library.db"
+        index = LibraryIndex(db_path)
+        index.close()
+        mode = db_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 600, got {oct(mode)}"
+
+    def test_existing_world_readable_database_corrected_on_open(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "library.db"
+        # Simulate a pre-existing DB with the old default 644 permissions.
+        index = LibraryIndex(db_path)
+        index.close()
+        db_path.chmod(0o644)
+        assert db_path.stat().st_mode & 0o777 == 0o644
+
+        index2 = LibraryIndex(db_path)
+        index2.close()
+        mode = db_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 600 after re-open, got {oct(mode)}"


### PR DESCRIPTION
## Summary

- Applies `umask(0o077)` before `sqlite3.connect()` in `_make_conn` so `library.db` and its WAL/SHM sidecar files are created with `600` permissions instead of the default `644` (world-readable)
- Corrects permissions on existing installs by calling `chmod 600` on the DB file in `__init__` if it already exists
- Adds two tests in `TestDatabaseFilePermissions` covering fresh creation and correction of existing loose permissions

Addresses FINDING-04 from the v1.11.0 database security audit (doc-1).

Also includes all backlog work from this session: TASK-131 completed (database security audit report), new tasks TASK-142–TASK-152 created from audit findings.

## Test plan

- [x] `poetry run pytest tests/test_library.py -v --no-cov` — 106 tests pass
- [x] `TestDatabaseFilePermissions::test_new_database_created_with_owner_only_permissions` passes
- [x] `TestDatabaseFilePermissions::test_existing_world_readable_database_corrected_on_open` passes
- [x] Verify on a real install: `stat ~/.local/share/kamp/library.db` shows `600` after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)