### PR TITLE
fix: show Bandcamp connected state and extract username from logout cookie

### DIFF
--- a/backlog/tasks/task-131 - audit-application-database-for-security.md
+++ b/backlog/tasks/task-131 - audit-application-database-for-security.md
@@ -4,7 +4,7 @@ title: audit application database for security
 status: Done
 assignee: []
 created_date: '2026-04-15 02:47'
-updated_date: '2026-04-18 17:54'
+updated_date: '2026-04-18 22:37'
 labels:
   - chore
   - security
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0
 priority: high
+ordinal: 2000
 ---
 
 ## Description

--- a/backlog/tasks/task-132 - move-application-configuration-inside-the-database.md
+++ b/backlog/tasks/task-132 - move-application-configuration-inside-the-database.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-132
 title: move application configuration inside the database
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-15 02:48'
-updated_date: '2026-04-18 21:42'
+updated_date: '2026-04-18 22:37'
 labels:
   - feature
   - backend
@@ -12,6 +12,7 @@ labels:
 milestone: m-29
 dependencies: []
 priority: medium
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-142 - fix-database-file-permissions-—-apply-restrictive-umask-before-sqlite3.connect.md
+++ b/backlog/tasks/task-142 - fix-database-file-permissions-—-apply-restrictive-umask-before-sqlite3.connect.md
@@ -4,7 +4,7 @@ title: fix database file permissions — apply restrictive umask before sqlite3.
 status: Done
 assignee: []
 created_date: '2026-04-18 18:01'
-updated_date: '2026-04-18 18:05'
+updated_date: '2026-04-18 22:37'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-04)
 priority: high
+ordinal: 1000
 ---
 
 ## Description

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -598,6 +598,7 @@ def create_app(
         if get_bandcamp_session is not None:
             session = get_bandcamp_session()
             if session:
+                _state["config"]["bandcamp.connected"] = True
                 _state["config"]["bandcamp.username"] = session.get("username")
         _broadcast({"type": "bandcamp.login-complete"})
         return {"ok": True}
@@ -640,6 +641,7 @@ def create_app(
                 status_code=503, detail="Bandcamp disconnect not configured"
             )
         on_bandcamp_disconnect()
+        _state["config"]["bandcamp.connected"] = False
         _state["config"]["bandcamp.username"] = None
         _broadcast({"type": "bandcamp.disconnected"})
         return {"ok": True}

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -749,20 +749,30 @@ def _cmd_daemon(
         session_data: dict[str, Any] = dict(payload)
         index.set_session("bandcamp", session_data)
         _logger.info("Bandcamp session saved to database from Electron login flow.")
-        # Immediately fetch username from the Bandcamp API so the UI can show
-        # "Connected as {username}" without waiting for the first sync.
-        # Wrapped in try/except — a network failure here should not fail the login.
-        try:
-            from .bandcamp import _get_fan_info, _make_requests_session
+        # Extract username immediately so the UI can show "Connected as {username}".
+        # Primary source: the logout cookie (URL-encoded JSON, always present after
+        # login, no network round-trip required).  Fallback: the collection_summary
+        # API (requires a network call; may return empty if Bandcamp changes the field).
+        from .bandcamp import (
+            _get_fan_info,
+            _make_requests_session,
+            _username_from_logout_cookie,
+        )
 
-            bc_session = _make_requests_session(session_data)
-            _fan_id, username = _get_fan_info(bc_session)
-            if username:
-                session_data["username"] = username
-                index.set_session("bandcamp", session_data)
-                _logger.info("Bandcamp username %r stored in session.", username)
-        except Exception as exc:
-            _logger.warning("Could not fetch Bandcamp username after login: %s", exc)
+        cookies: list[Any] = list(session_data.get("cookies", []))
+        username = _username_from_logout_cookie(cookies)
+        if not username:
+            try:
+                bc_session = _make_requests_session(session_data)
+                _fan_id, username = _get_fan_info(bc_session)
+            except Exception as exc:
+                _logger.warning(
+                    "Could not fetch Bandcamp username after login: %s", exc
+                )
+        if username:
+            session_data["username"] = username
+            index.set_session("bandcamp", session_data)
+            _logger.info("Bandcamp username %r stored in session.", username)
 
     def _on_bandcamp_disconnect() -> None:
         index.clear_session("bandcamp")
@@ -777,6 +787,7 @@ def _cmd_daemon(
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
         "library.path_template": config.library.path_template,
+        "bandcamp.connected": _bc_session is not None,
         "bandcamp.username": _bc_username,
         "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
         "bandcamp.poll_interval_minutes": (

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -31,6 +31,7 @@ import logging
 import re
 import sys
 import time
+import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
@@ -194,6 +195,8 @@ def mark_collection_synced(
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
     fan_id, username = _get_fan_info(session)
+    if not username:
+        username = _username_from_logout_cookie(session_data.get("cookies", []))
     _store_username_in_session(username, session_data, index)
     collection = _fetch_collection(fan_id, session, index)
 
@@ -229,8 +232,9 @@ def sync_new_purchases(
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
     fan_id, username = _get_fan_info(session)
+    if not username:
+        username = _username_from_logout_cookie(session_data.get("cookies", []))
     _store_username_in_session(username, session_data, index)
-    # Use config username as fallback if API didn't return one.
     logger.info("Fetched fan_id=%s for user %r", fan_id, username)
 
     state = _load_state(state_file)
@@ -452,8 +456,30 @@ def _get_fan_info(session: _AnySession) -> tuple[int, str]:
         )
         raise BandcampAPIError(f"collection_summary returned non-JSON: {exc}") from exc
     fan_id: int = data["fan_id"]
-    username: str = data.get("username", "")
+    # Bandcamp moved the username out of the top-level "username" key; fall
+    # back to url_hints.subdomain (the URL slug used in collection page URLs).
+    username: str = data.get("username", "") or data.get("url_hints", {}).get(
+        "subdomain", ""
+    )
     return fan_id, username
+
+
+def _username_from_logout_cookie(cookies: list[dict[str, Any]]) -> str:
+    """Extract username from the Bandcamp ``logout`` cookie.
+
+    Bandcamp's ``logout`` cookie value is URL-encoded JSON: ``{"username":"…"}``.
+    This is a reliable, zero-network-request source of the username that is
+    always present right after login.  Used as a fallback when the API does not
+    return the username field.
+    """
+    for c in cookies:
+        if c.get("name") == "logout":
+            try:
+                payload = json.loads(urllib.parse.unquote(c["value"]))
+                return str(payload.get("username", ""))
+            except Exception:
+                pass
+    return ""
 
 
 def _store_username_in_session(

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -189,6 +189,7 @@ export type ConfigValues = {
   'artwork.min_dimension': number | null
   'artwork.max_bytes': number | null
   'library.path_template': string | null
+  'bandcamp.connected': boolean | null
   'bandcamp.username': string | null
   'bandcamp.format': string | null
   'bandcamp.poll_interval_minutes': number | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -661,10 +661,12 @@ function ExtensionsPanel({
 // ---------------------------------------------------------------------------
 
 function BandcampSection({
+  isConnected,
   connectedUsername,
   onConnected,
   onDisconnected
 }: {
+  isConnected: boolean
   connectedUsername: string | null
   onConnected: () => void
   onDisconnected: () => void
@@ -707,10 +709,14 @@ function BandcampSection({
       <div className="prefs-row-header">
         <span className="prefs-label">Session</span>
       </div>
-      {connectedUsername ? (
+      {isConnected ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <span style={{ fontSize: 13 }}>
-            Connected as <strong>{connectedUsername}</strong>
+            {connectedUsername ? (
+              <>Connected as <strong>{connectedUsername}</strong></>
+            ) : (
+              'Connected'
+            )}
           </span>
           <button
             className="prefs-choose-btn prefs-choose-btn--destructive"
@@ -1103,6 +1109,7 @@ export function PreferencesDialog({
                         onSave={handleSave}
                       />
                       <BandcampSection
+                        isConnected={configValues?.['bandcamp.connected'] ?? false}
                         connectedUsername={configValues?.['bandcamp.username'] ?? null}
                         onConnected={() => void loadConfig()}
                         onDisconnected={() => void loadConfig()}

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -713,7 +713,9 @@ function BandcampSection({
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <span style={{ fontSize: 13 }}>
             {connectedUsername ? (
-              <>Connected as <strong>{connectedUsername}</strong></>
+              <>
+                Connected as <strong>{connectedUsername}</strong>
+              </>
             ) : (
               'Connected'
             )}

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -28,6 +28,7 @@ from kamp_daemon.bandcamp import (
     _paginate,
     _save_state,
     _session_from_cookie_file,
+    _username_from_logout_cookie,
     _validate_session,
     mark_collection_synced,
     sync_new_purchases,
@@ -282,6 +283,30 @@ class TestExtractPagedata:
 # ---------------------------------------------------------------------------
 
 
+class TestUsernameFromLogoutCookie:
+    def test_extracts_username_from_logout_cookie(self) -> None:
+        import urllib.parse
+
+        value = urllib.parse.quote('{"username":"tedd-e-terry"}')
+        cookies = [{"name": "logout", "value": value, "domain": ".bandcamp.com"}]
+        assert _username_from_logout_cookie(cookies) == "tedd-e-terry"
+
+    def test_returns_empty_when_no_logout_cookie(self) -> None:
+        cookies = [{"name": "js_logged_in", "value": "1", "domain": ".bandcamp.com"}]
+        assert _username_from_logout_cookie(cookies) == ""
+
+    def test_returns_empty_on_malformed_value(self) -> None:
+        cookies = [{"name": "logout", "value": "not-json", "domain": ".bandcamp.com"}]
+        assert _username_from_logout_cookie(cookies) == ""
+
+    def test_returns_empty_when_username_key_absent(self) -> None:
+        import urllib.parse
+
+        value = urllib.parse.quote('{"other":"data"}')
+        cookies = [{"name": "logout", "value": value, "domain": ".bandcamp.com"}]
+        assert _username_from_logout_cookie(cookies) == ""
+
+
 class TestGetFanInfo:
     def test_returns_fan_id_and_username_from_collection_summary(self) -> None:
         session = MagicMock()
@@ -291,6 +316,21 @@ class TestGetFanInfo:
             "fan_id": 42,
             "username": "testuser",
             "collection_summary": {},
+        }
+        resp.raise_for_status = MagicMock()
+        session.get.return_value = resp
+        fan_id, username = _get_fan_info(session)
+        assert fan_id == 42
+        assert username == "testuser"
+
+    def test_falls_back_to_url_hints_subdomain(self) -> None:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "fan_id": 42,
+            "username": "",
+            "url_hints": {"subdomain": "testuser"},
         }
         resp.raise_for_status = MagicMock()
         session.get.return_value = resp

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1167,6 +1167,7 @@ _SAMPLE_CONFIG_VALUES = {
     "artwork.min_dimension": 1000,
     "artwork.max_bytes": 1000000,
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
+    "bandcamp.connected": False,
     "bandcamp.username": None,
     "bandcamp.format": None,
     "bandcamp.poll_interval_minutes": None,
@@ -1489,13 +1490,58 @@ class TestBandcampStatus:
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            config_values={"bandcamp.username": "johndoe"},
+            config_values={"bandcamp.connected": True, "bandcamp.username": "johndoe"},
             on_bandcamp_disconnect=lambda: None,
         )
         c = TestClient(app)
         c.delete("/api/v1/bandcamp/connect")
         data = c.get("/api/v1/config").json()
+        assert data["bandcamp.connected"] is False
         assert data["bandcamp.username"] is None
+
+    def test_login_complete_sets_bandcamp_connected(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """bandcamp.connected is set to True even when username fetch fails."""
+        cookies = [{"name": "js_logged_in", "value": "1", "domain": ".bandcamp.com"}]
+        session = {"cookies": cookies, "username": None}
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values={"bandcamp.connected": False, "bandcamp.username": None},
+            on_bandcamp_login_complete=lambda payload: None,
+            get_bandcamp_session=lambda: session,
+        )
+        c = TestClient(app)
+        c.post(
+            "/api/v1/bandcamp/login-complete",
+            json={"cookies": cookies, "origins": []},
+        )
+        data = c.get("/api/v1/config").json()
+        assert data["bandcamp.connected"] is True
+
+    def test_login_complete_sets_username_when_available(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        cookies = [{"name": "js_logged_in", "value": "1", "domain": ".bandcamp.com"}]
+        session = {"cookies": cookies, "username": "johndoe"}
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values={"bandcamp.connected": False, "bandcamp.username": None},
+            on_bandcamp_login_complete=lambda payload: None,
+            get_bandcamp_session=lambda: session,
+        )
+        c = TestClient(app)
+        c.post(
+            "/api/v1/bandcamp/login-complete",
+            json={"cookies": cookies, "origins": []},
+        )
+        data = c.get("/api/v1/config").json()
+        assert data["bandcamp.connected"] is True
+        assert data["bandcamp.username"] == "johndoe"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `BandcampSection` now uses a separate `isConnected` prop (from new `bandcamp.connected` config key) instead of relying on `connectedUsername` being truthy — fixes the case where the username API call fails silently, leaving the user appearing disconnected despite having a valid session
- Username extraction now reads the `logout` cookie first (`{"username":"tedd-e-terry"}` URL-encoded JSON, always present after login, zero network cost), falling back to the `collection_summary` API and then `url_hints.subdomain` — Bandcamp stopped returning a top-level `username` field in the API response
- Same cookie-based fallback applied in both sync entry points so the log correctly identifies the authenticated user

## Test plan

- [x] Connect to Bandcamp — Preferences should show "Connected as tedd-e-terry" immediately after login
- [x] Disconnect — button should switch back to "Connect to Bandcamp"
- [x] Run `kamp sync` — log should show `Fetched fan_id=... for user 'tedd-e-terry'`
- [x] Restart server with an existing session — "Connected as tedd-e-terry" shown on first open of Preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)