### PR TITLE
security: remove cookies from WS proxy-fetch broadcast (TASK-143)

### DIFF
--- a/backlog/tasks/task-143 - remove-Bandcamp-cookies-from-WebSocket-proxy-fetch-broadcast-payload.md
+++ b/backlog/tasks/task-143 - remove-Bandcamp-cookies-from-WebSocket-proxy-fetch-broadcast-payload.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-143
 title: remove Bandcamp cookies from WebSocket proxy-fetch broadcast payload
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-18 18:01'
-updated_date: '2026-04-18 18:12'
+updated_date: '2026-04-18 22:56'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-01)
 priority: high
+ordinal: 4000
 ---
 
 ## Description

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -853,19 +853,12 @@ def create_app(
             "event": event,
             "result": None,
         }
-        # Include session cookies in the broadcast so the Electron main
-        # process can inject them into session.defaultSession before calling
-        # net.fetch — no extra HTTP round-trip required.
-        session_data = (
-            get_bandcamp_session() if get_bandcamp_session is not None else None
-        )
-        broadcast_cookies: list[Any] = (
-            session_data.get("cookies", []) if session_data else []
-        )
         # Build the push event.  Save it in _pending_proxy_fetches *before*
         # broadcasting so that a WS client connecting after _broadcast() (but
         # before the request is answered) still receives it on connect.  The
         # entry is removed when /fetch-result arrives.
+        # Cookies are omitted — Electron fetches /api/v1/bandcamp/session-cookies
+        # directly so they are never broadcast to all WS clients.
         proxy_event: dict[str, Any] = {
             "type": "bandcamp.proxy-fetch",
             "id": req_id,
@@ -873,7 +866,6 @@ def create_app(
             "method": req.method,
             "headers": req.headers,
             "body": req.body,
-            "cookies": broadcast_cookies,
         }
         _pending_proxy_fetches[req_id] = proxy_event
         # Notify the Electron preload via the existing WebSocket push channel.

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -523,6 +523,17 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('bandcamp:begin-login', () => openBandcampLogin())
 
+  type BandcampCookie = {
+    name: string
+    value: string
+    domain: string
+    path: string
+    expires: number
+    httpOnly: boolean
+    secure: boolean
+    sameSite: string
+  }
+
   ipcMain.handle(
     'bandcamp:proxy-fetch',
     async (
@@ -533,26 +544,16 @@ app.whenReady().then(async () => {
         method: string
         headers: Record<string, string>
         body: string | null
-        // Cookies are embedded in the broadcast by the server so no extra
-        // HTTP round-trip is needed to load them from the DB.
-        cookies?: Array<{
-          name: string
-          value: string
-          domain: string
-          path: string
-          expires: number
-          httpOnly: boolean
-          secure: boolean
-          sameSite: string
-        }>
       }
     ) => {
       // In the PyInstaller bundle, cookies are stored in library.db rather than
       // in session.defaultSession (cleared after login to avoid plaintext on disk).
-      // The server embeds them in the proxy-fetch broadcast so we can inject them
-      // into session.defaultSession before net.fetch and remove them afterward.
+      // Fetch them from the daemon endpoint rather than reading from the WS payload
+      // so auth cookies are never broadcast to all WS clients.
+      const cookieResp = await net.fetch('http://127.0.0.1:8000/api/v1/bandcamp/session-cookies')
+      const { cookies } = (await cookieResp.json()) as { cookies: BandcampCookie[] }
       const injectedNames: string[] = []
-      for (const c of req.cookies ?? []) {
+      for (const c of cookies) {
         const sameSiteLower = c.sameSite?.toLowerCase()
         const sameSite = (['lax', 'strict', 'no_restriction', 'unspecified'] as const).includes(
           sameSiteLower as never

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1666,8 +1666,8 @@ class TestBandcampProxyEndpoints:
             assert msg["method"] == "GET"
             req_id = msg["id"]
             assert req_id
-            # No session configured — cookies list should be empty.
-            assert msg["cookies"] == []
+            # Cookies must not appear in the broadcast payload.
+            assert "cookies" not in msg
 
             # Simulate Electron posting the net.fetch result.
             result_r = c.post(
@@ -1687,10 +1687,10 @@ class TestBandcampProxyEndpoints:
         assert proxy_response["body"] == '{"fan_id": 42}'
         assert proxy_response["content_type"] == "application/json"
 
-    def test_proxy_broadcast_includes_session_cookies(
+    def test_proxy_broadcast_excludes_cookies(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
-        """Cookies from the stored session are embedded in the proxy-fetch broadcast."""
+        """Cookies must never appear in the proxy-fetch WS broadcast payload."""
         import threading
 
         cookies = [{"name": "js_logged_in", "value": "1", "domain": ".bandcamp.com"}]
@@ -1733,7 +1733,8 @@ class TestBandcampProxyEndpoints:
             )
             t.join(timeout=5)
 
-        assert broadcast["cookies"] == cookies
+        # Cookies must not be broadcast — Electron fetches /session-cookies directly.
+        assert "cookies" not in broadcast
 
     def test_late_joining_client_receives_pending_proxy_fetch(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Removes the `cookies` field from the `bandcamp.proxy-fetch` WebSocket broadcast — auth cookies (`cf_clearance` etc.) were previously sent to every connected WS client
- Electron now fetches cookies via `GET /api/v1/bandcamp/session-cookies` immediately before `net.fetch`, using the endpoint that already existed for this purpose
- Updates two tests: roundtrip test asserts `"cookies" not in msg`; cookies-in-broadcast test renamed and inverted to assert exclusion

## Test plan

- [x] `poetry run pytest tests/test_server.py -k proxy --no-cov` — 5 passed
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] ESLint clean
- [x] End-to-end Bandcamp library sync verified working

Closes TASK-143 (FINDING-01 from v1.11.0 database security audit)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)