### PR TITLE
security: checkpoint WAL after clear_session to purge deleted credentials (TASK-145)

### DIFF
--- a/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
+++ b/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-145
 title: checkpoint WAL after clear_session to promptly remove deleted credentials
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-18 18:02'
+updated_date: '2026-04-18 23:14'
 labels:
   - security
   - chore

--- a/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
+++ b/backlog/tasks/task-145 - checkpoint-WAL-after-clear_session-to-promptly-remove-deleted-credentials.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-145
 title: checkpoint WAL after clear_session to promptly remove deleted credentials
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-18 18:02'
-updated_date: '2026-04-18 23:14'
+updated_date: '2026-04-18 23:17'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-08)
 priority: medium
+ordinal: 6000
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -426,6 +426,9 @@ class LibraryIndex:
         """Remove the session row for *service* (no-op if absent)."""
         self._conn.execute("DELETE FROM sessions WHERE service = ?", (service,))
         self._conn.commit()
+        # Truncate the WAL so deleted credential data (cookies, session keys) is
+        # not recoverable from the WAL file after disconnect.
+        self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
     # ------------------------------------------------------------------
     # Settings (application configuration)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1797,6 +1797,18 @@ class TestSessionManagement:
         index.clear_session("bandcamp")  # must not raise
         index.close()
 
+    def test_clear_session_truncates_wal(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        index = LibraryIndex(db_path)
+        index.set_session(
+            "bandcamp", {"cookies": [{"name": "js_logged_in", "value": "1"}]}
+        )
+        wal_path = db_path.with_suffix(".db-wal")
+        index.clear_session("bandcamp")
+        wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+        assert wal_size == 0, f"WAL not truncated after clear_session: {wal_size} bytes"
+        index.close()
+
     def test_multiple_services_are_independent(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
         bc_data = {"cookies": [{"name": "js_logged_in", "value": "1"}]}


### PR DESCRIPTION
## Summary

- After `clear_session()` deletes a credential row, the plaintext data (Bandcamp cookies, Last.fm session key) lingered in the WAL file until the next automatic checkpoint
- Added `PRAGMA wal_checkpoint(TRUNCATE)` immediately after commit in `clear_session()` to zero the WAL file and close the forensic recovery window
- Addresses FINDING-08 from the v1.11.0 database security audit

## Test plan

- [x] `TestSessionManagement::test_clear_session_truncates_wal` — verifies WAL file is 0 bytes immediately after `clear_session()` is called
- [x] All existing `TestSessionManagement` tests pass
- [x] black + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)