### PR TITLE
security: restrict CORS origins — remove wildcard allow_origins (TASK-146)

### DIFF
--- a/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
+++ b/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-146
 title: restrict CORS origins — remove wildcard allow_origins from FastAPI middleware
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-18 18:02'
-updated_date: '2026-04-18 23:28'
+updated_date: '2026-04-19 00:20'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-02)
 priority: medium
+ordinal: 7000
 ---
 
 ## Description

--- a/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
+++ b/backlog/tasks/task-146 - restrict-CORS-origins-—-remove-wildcard-allow_origins-from-FastAPI-middleware.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-146
 title: restrict CORS origins — remove wildcard allow_origins from FastAPI middleware
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-18 18:02'
+updated_date: '2026-04-18 23:28'
 labels:
   - security
   - chore
@@ -47,8 +48,8 @@ Verify the Electron renderer (production `file://` origin) and Vite dev server c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 CORS no longer uses wildcard allow_origins
-- [ ] #2 Electron renderer (file:// origin) can still reach all API endpoints
-- [ ] #3 Vite dev server (localhost:5173) works in dev mode
-- [ ] #4 Requests from arbitrary browser origins are rejected with CORS error
+- [x] #1 CORS no longer uses wildcard allow_origins
+- [x] #2 Electron renderer (file:// origin) can still reach all API endpoints
+- [x] #3 Vite dev server (localhost:5173) works in dev mode
+- [x] #4 Requests from arbitrary browser origins are rejected with CORS error
 <!-- AC:END -->

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -298,7 +298,9 @@ def create_app(
     _allowed_origins = [
         "http://localhost",
         "http://127.0.0.1",
-        "file://",  # Electron renderer (production file:// pages)
+        # Electron renderer in production loads from file://; Chromium serializes
+        # that as the opaque origin "null" in the Origin request header.
+        "null",
     ]
     if dev_mode:
         _allowed_origins.append("http://localhost:5173")  # Vite dev server

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -224,6 +224,7 @@ def create_app(
     on_bandcamp_login_complete: Callable[[dict[str, Any]], None] | None = None,
     get_bandcamp_session: Callable[[], dict[str, Any] | None] | None = None,
     on_bandcamp_disconnect: Callable[[], None] | None = None,
+    dev_mode: bool = False,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -292,13 +293,20 @@ def create_app(
     # background reader thread whenever mpv's pause property flips.
     engine.on_play_state_changed = _notify_play_state_changed
 
-    # Allow requests from the Electron renderer (Vite dev server and file://).
-    # This server only binds to 127.0.0.1, so wildcard origins are safe.
+    # Restrict to origins kamp actually serves; wildcard would allow any page
+    # open in any browser to read session cookies via cross-origin requests.
+    _allowed_origins = [
+        "http://localhost",
+        "http://127.0.0.1",
+        "file://",  # Electron renderer (production file:// pages)
+    ]
+    if dev_mode:
+        _allowed_origins.append("http://localhost:5173")  # Vite dev server
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_origins=_allowed_origins,
+        allow_methods=["GET", "POST", "DELETE", "PATCH"],
+        allow_headers=["Content-Type"],
     )
 
     def _state_snapshot() -> PlayerStateOut:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -813,6 +813,7 @@ def _cmd_daemon(
         on_bandcamp_login_complete=_on_bandcamp_login_complete,
         get_bandcamp_session=lambda: index.get_session("bandcamp"),
         on_bandcamp_disconnect=_on_bandcamp_disconnect,
+        dev_mode=bool(os.environ.get("KAMP_DEV")),
     )
 
     # Wrap the existing on_track_end callback to also push track.changed events.

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -150,10 +150,15 @@ async function startServer(): Promise<void> {
 
   // detached: true puts the daemon in its own process group so that
   // stopServer() can kill the group (daemon + mpv) all at once.
+  const spawnEnv: NodeJS.ProcessEnv = { ...process.env }
+  if (mpvBin) spawnEnv['KAMP_MPV_BIN'] = mpvBin
+  // Tell the daemon it's running in dev mode so it allows the Vite dev server
+  // origin (http://localhost:5173) in CORS — the renderer loads from there.
+  if (is.dev) spawnEnv['KAMP_DEV'] = '1'
   serverProcess = spawn(binary, ['daemon'], {
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: mpvBin ? { ...process.env, KAMP_MPV_BIN: mpvBin } : process.env
+    env: spawnEnv
   })
 
   serverProcess.stdout?.on('data', (d) => console.log('[kamp daemon]', String(d).trimEnd()))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1901,12 +1901,13 @@ class TestCORSMiddleware:
         resp = self._preflight(client, "http://127.0.0.1")
         assert resp.headers.get("access-control-allow-origin") == "http://127.0.0.1"
 
-    def test_file_origin_allowed(
+    def test_electron_null_origin_allowed(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
+        # Electron's file:// renderer sends Origin: null (opaque origin serialization).
         client = self._make_client(mock_index, mock_engine, mock_queue)
-        resp = self._preflight(client, "file://")
-        assert resp.headers.get("access-control-allow-origin") == "file://"
+        resp = self._preflight(client, "null")
+        assert resp.headers.get("access-control-allow-origin") == "null"
 
     def test_arbitrary_origin_rejected(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1847,3 +1847,86 @@ class TestBandcampProxyEndpoints:
                 ws3.send_text("ping")
                 pong = ws3.receive_json()
                 assert pong["type"] == "player.state"
+
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+
+class TestCORSMiddleware:
+    def _make_client(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        dev_mode: bool = False,
+    ) -> TestClient:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            dev_mode=dev_mode,
+        )
+        return TestClient(app, raise_server_exceptions=True)
+
+    def _preflight(self, client: TestClient, origin: str) -> "requests.Response":
+        return client.options(
+            "/api/v1/albums",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    def test_wildcard_not_used(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue)
+        resp = self._preflight(client, "http://localhost")
+        acao = resp.headers.get("access-control-allow-origin", "")
+        assert acao != "*"
+
+    def test_localhost_origin_allowed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue)
+        resp = self._preflight(client, "http://localhost")
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost"
+
+    def test_127_origin_allowed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue)
+        resp = self._preflight(client, "http://127.0.0.1")
+        assert resp.headers.get("access-control-allow-origin") == "http://127.0.0.1"
+
+    def test_file_origin_allowed(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue)
+        resp = self._preflight(client, "file://")
+        assert resp.headers.get("access-control-allow-origin") == "file://"
+
+    def test_arbitrary_origin_rejected(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue)
+        resp = self._preflight(client, "https://evil.example.com")
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_vite_origin_blocked_without_dev_mode(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue, dev_mode=False)
+        resp = self._preflight(client, "http://localhost:5173")
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_vite_origin_allowed_in_dev_mode(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        client = self._make_client(mock_index, mock_engine, mock_queue, dev_mode=True)
+        resp = self._preflight(client, "http://localhost:5173")
+        assert (
+            resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
+        )


### PR DESCRIPTION
## Summary

- Replaces `allow_origins=["*"]` with an explicit allowlist: `http://localhost`, `http://127.0.0.1`, and `null` (Electron's opaque `file://` origin serialization)
- Adds `dev_mode: bool = False` to `create_app`; when true, also allows `http://localhost:5173` for the Vite dev server
- Threads `KAMP_DEV=1` from Electron's `is.dev` flag through the daemon spawn env so dev mode is detected automatically

Fixes FINDING-02 from the v1.11.0 database security audit — any browser page could previously make cross-origin requests to the daemon and read Bandcamp session cookies.

## Test plan

- [x] 7 new CORS tests: wildcard not used, each allowed origin, arbitrary origin rejected, Vite origin blocked/allowed by dev mode flag
- [x] All 126 server tests pass
- [x] `npm run dev` — renderer connects and app loads normally
- [x] Built `.app` — renderer connects and app loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)