### PR TITLE
security: validate proxy-fetch URL against Bandcamp domain allowlist (TASK-147)

### DIFF
--- a/backlog/tasks/task-147 - validate-proxy-fetch-URL-against-bandcamp.com-domain-allowlist.md
+++ b/backlog/tasks/task-147 - validate-proxy-fetch-URL-against-bandcamp.com-domain-allowlist.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-147
 title: validate proxy-fetch URL against bandcamp.com domain allowlist
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-18 18:02'
+updated_date: '2026-04-19 00:40'
 labels:
   - security
   - chore
@@ -13,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-09)
 priority: medium
+ordinal: 8000
 ---
 
 ## Description

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, Response, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
@@ -199,6 +200,29 @@ class BandcampProxyFetchResult(BaseModel):
     status: int
     body: str
     content_type: str = "text/html"
+
+
+# ---------------------------------------------------------------------------
+# Bandcamp proxy URL allowlist
+# ---------------------------------------------------------------------------
+
+# Only requests targeting these hostnames (or subdomains) may be forwarded to
+# Electron's net.fetch, which carries Bandcamp session cookies.  This prevents
+# a malicious extension or local process from exfiltrating credentials to an
+# arbitrary host.
+_ALLOWED_PROXY_HOSTS: frozenset[str] = frozenset(
+    {"bandcamp.com", "f4.bcbits.com", "t4.bcbits.com"}
+)
+
+
+def _validate_proxy_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not any(host == h or host.endswith(f".{h}") for h in _ALLOWED_PROXY_HOSTS):
+        raise HTTPException(
+            status_code=422, detail=f"Proxy URL host not allowed: {host}"
+        )
+    return url
 
 
 # ---------------------------------------------------------------------------
@@ -843,6 +867,7 @@ def create_app(
 
     @app.post("/api/v1/bandcamp/proxy-fetch")
     async def bandcamp_proxy_fetch(req: BandcampProxyFetchRequest) -> dict[str, Any]:
+        _validate_proxy_url(req.url)
         nonlocal _event_loop
         # Capture the running loop here so _broadcast (which uses
         # call_soon_threadsafe) works even before any WS client has connected.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1848,6 +1848,82 @@ class TestBandcampProxyEndpoints:
                 pong = ws3.receive_json()
                 assert pong["type"] == "player.state"
 
+    # -- URL allowlist tests -------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://bandcamp.com/api/fan/2/collection_summary",
+            "https://api.bandcamp.com/api/tralbum/2/info",
+            "https://f4.bcbits.com/img/a1234567890_10.jpg",
+            "https://t4.bcbits.com/stream/some-track",
+        ],
+    )
+    def test_proxy_fetch_allows_bandcamp_urls(
+        self,
+        client: TestClient,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        url: str,
+    ) -> None:
+        """Legitimate Bandcamp hostnames must not be rejected by the allowlist."""
+        import threading
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        responses: list = []
+
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # discard player.state
+
+            t = threading.Thread(
+                target=lambda: responses.append(
+                    c.post(
+                        "/api/v1/bandcamp/proxy-fetch",
+                        json={"url": url, "method": "GET", "headers": {}, "body": None},
+                    )
+                )
+            )
+            t.start()
+
+            msg = ws.receive_json()
+            req_id = msg["id"]
+
+            c.post(
+                "/api/v1/bandcamp/fetch-result",
+                json={
+                    "id": req_id,
+                    "status": 200,
+                    "body": "{}",
+                    "content_type": "application/json",
+                },
+            )
+            t.join(timeout=5)
+
+        assert responses and responses[0].status_code == 200
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.com/steal-cookies",
+            "https://notbandcamp.com/api",
+            "https://bandcamp.com.evil.com/api",
+            "http://127.0.0.1:9000/internal",
+            "https://bcbits.com/img/fake.jpg",
+        ],
+    )
+    def test_proxy_fetch_rejects_non_bandcamp_urls(
+        self, client: TestClient, url: str
+    ) -> None:
+        """Non-Bandcamp URLs must be rejected with 422 before any broadcast."""
+        response = client.post(
+            "/api/v1/bandcamp/proxy-fetch",
+            json={"url": url, "method": "GET", "headers": {}, "body": None},
+        )
+        assert response.status_code == 422
+        assert "not allowed" in response.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # CORS


### PR DESCRIPTION
## Summary

- Adds `_ALLOWED_PROXY_HOSTS` allowlist (`bandcamp.com`, `f4.bcbits.com`, `t4.bcbits.com`) in `kamp_core/server.py`
- `_validate_proxy_url()` checks the hostname (and subdomains) before any broadcast; raises HTTP 422 on mismatch
- Wired into `POST /api/v1/bandcamp/proxy-fetch` as the first guard, so no WS event is ever emitted for a disallowed URL

Closes FINDING-09 from the v1.11.0 database security audit.

## Test plan

- [x] `test_proxy_fetch_allows_bandcamp_urls` — 4 parametrized cases covering `bandcamp.com`, `api.bandcamp.com`, `f4.bcbits.com`, `t4.bcbits.com` all return 200
- [x] `test_proxy_fetch_rejects_non_bandcamp_urls` — 5 cases including lookalike (`bandcamp.com.evil.com`) and bare `bcbits.com` all return 422
- [x] All 14 `TestBandcampProxyEndpoints` tests pass; mypy + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)