### PR TITLE
security: replace noqa S608 with explicit ValueError guard in SET clause (TASK-148)

### DIFF
--- a/backlog/tasks/task-148 - replace-noqa-S608-with-explicit-ValueError-guard-in-dynamic-SET-clause-construction.md
+++ b/backlog/tasks/task-148 - replace-noqa-S608-with-explicit-ValueError-guard-in-dynamic-SET-clause-construction.md
@@ -3,9 +3,10 @@ id: TASK-148
 title: >-
   replace noqa S608 with explicit ValueError guard in dynamic SET clause
   construction
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-18 18:02'
+updated_date: '2026-04-19 00:58'
 labels:
   - security
   - chore
@@ -15,6 +16,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-06)
 priority: low
+ordinal: 9000
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -751,13 +751,19 @@ class LibraryIndex:
             ),
         )
 
-        # Apply only the safe, known-writable fields.
+        # Validate against the allowlist — load-bearing; do not remove.
+        # Column names are interpolated directly into SQL; any name outside
+        # this set must raise, not be silently skipped.
+        unknown = set(fields) - _WRITABLE_TRACK_FIELDS
+        if unknown:
+            raise ValueError(f"Unexpected column names in metadata update: {unknown}")
+
         safe = {k: v for k, v in fields.items() if k in _WRITABLE_TRACK_FIELDS}
         if row and safe:
             set_clause = ", ".join(f"{k} = ?" for k in safe)
             params: list[Any] = [*safe.values(), mbid]
             self._conn.execute(
-                f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",  # noqa: S608
+                f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",
                 params,
             )
         self._conn.commit()
@@ -829,12 +835,18 @@ class LibraryIndex:
             old: dict[str, Any] = json.loads(row["old_value"])
 
             if op == "update_metadata":
+                # Audit log entries are written by apply_metadata_update, which
+                # already validated keys against _WRITABLE_TRACK_FIELDS. Raise
+                # here too so a corrupt/tampered log entry cannot inject column names.
+                unknown = set(old) - _WRITABLE_TRACK_FIELDS
+                if unknown:
+                    raise ValueError(f"Unexpected column names in audit log: {unknown}")
                 safe = {k: v for k, v in old.items() if k in _WRITABLE_TRACK_FIELDS}
                 if safe:
                     set_clause = ", ".join(f"{k} = ?" for k in safe)
                     params = [*safe.values(), mbid]
                     self._conn.execute(
-                        f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",  # noqa: S608
+                        f"UPDATE tracks SET {set_clause} WHERE mb_recording_id = ?",
                         params,
                     )
             elif op == "set_artwork":

--- a/tests/test_library_write_log.py
+++ b/tests/test_library_write_log.py
@@ -216,6 +216,34 @@ class TestAuditLogAppendOnly:
 
 
 # ---------------------------------------------------------------------------
+# ValueError guard — unknown column names must raise, not be silently dropped
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownColumnGuard:
+    def test_apply_metadata_update_raises_on_unknown_field(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+
+        with pytest.raises(ValueError, match="Unexpected column names"):
+            lib.apply_metadata_update(
+                "ext-a", "rec-1", {"title": "OK", "internal_col": "bad"}
+            )
+        lib.close()
+
+    def test_apply_metadata_update_does_not_raise_for_known_fields(
+        self, tmp_path: Path
+    ) -> None:
+        lib = _make_library(tmp_path)
+        lib.upsert_track(_make_track(tmp_path / "a.mp3", mbid="rec-1"))
+        # Should not raise
+        lib.apply_metadata_update("ext-a", "rec-1", {"title": "New"})
+        lib.close()
+
+
+# ---------------------------------------------------------------------------
 # AC #4 — rollback_extension() reverts all writes by a given extension_id
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replaces silent `# noqa: S608` suppressions in `apply_metadata_update` and `rollback_extension` with an explicit `ValueError` guard that raises on any column name outside `_WRITABLE_TRACK_FIELDS`
- Adds a matching guard in `rollback_extension` to cover tampered/corrupt audit log entries
- Adds `TestUnknownColumnGuard` with two new tests covering the raise and the happy path

## Test plan

- [x] `tests/test_library_write_log.py` — 22 tests, all pass
- [x] `tests/test_extension_invoker.py` — 30 tests, all pass
- [x] `mypy kamp_core/library.py` — clean
- [x] `black --check` — clean

Closes TASK-148 (FINDING-06 from the v1.11.0 database security audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)