### PR TITLE
ui: auto-hide Artist pane when entering Now Playing, restore on return (TASK-98)

### DIFF
--- a/backlog/tasks/task-98 - Now-Playing-view-should-auto-hide-Artist-pane-if-currently-visible.md
+++ b/backlog/tasks/task-98 - Now-Playing-view-should-auto-hide-Artist-pane-if-currently-visible.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-98
 title: Now Playing view should auto-hide Artist pane (if currently visible)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-09 02:12'
-updated_date: '2026-04-18 17:15'
+updated_date: '2026-04-19 01:12'
 labels:
   - bug
   - ui
@@ -12,6 +12,7 @@ labels:
 milestone: m-29
 dependencies: []
 priority: medium
+ordinal: 10000
 ---
 
 ## Description
@@ -24,9 +25,9 @@ If it was visible in the Library panel, it should be hidden when the user shows 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Artist pane is always hidden when Now Playing panel is active
-- [ ] #2 If Artist pane was visible before switching to Now Playing, it becomes visible again when returning to Library
-- [ ] #3 No Artist pane toggle button visible in Now Playing context
+- [x] #1 Artist pane is always hidden when Now Playing panel is active
+- [x] #2 If Artist pane was visible before switching to Now Playing, it becomes visible again when returning to Library
+- [x] #3 No Artist pane toggle button visible in Now Playing context
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -220,7 +220,8 @@ export default function App(): React.JSX.Element {
           break
         case 'a':
         case 'A':
-          toggleArtistPanel()
+          // Artist panel is hidden and non-functional in Now Playing.
+          if (activeView !== 'now-playing') toggleArtistPanel()
           break
       }
     }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -44,6 +44,7 @@ type PlayerStore = {
   searchResults: SearchResult | null
   queueVisible: boolean
   artistPanelVisible: boolean
+  artistPanelSnapshot: boolean | null // saved visibility before entering Now Playing
   queue: QueueState | null
 
   // Actions
@@ -140,6 +141,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   queueVisible: false,
   // Client-only persistence — no backend endpoint needed for this toggle.
   artistPanelVisible: localStorage.getItem('kamp:artist-panel-visible') !== 'false',
+  artistPanelSnapshot: null,
   queue: null,
   configValues: null,
   prefsOpen: false,
@@ -197,7 +199,16 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   setActiveView: async (view) => {
-    set({ activeView: view })
+    const { artistPanelVisible, artistPanelSnapshot } = get()
+    if (view === 'now-playing') {
+      // Hide the artist panel (non-functional in Now Playing) and save its state.
+      set({ activeView: view, artistPanelSnapshot: artistPanelVisible, artistPanelVisible: false })
+    } else {
+      // Restore the artist panel to its pre-Now-Playing state.
+      const restored = artistPanelSnapshot ?? artistPanelVisible
+      set({ activeView: view, artistPanelSnapshot: null, artistPanelVisible: restored })
+      localStorage.setItem('kamp:artist-panel-visible', String(restored))
+    }
     try {
       await api.setActiveViewApi(view)
     } catch {


### PR DESCRIPTION
## Summary

- Artist pane is force-hidden when switching to Now Playing (non-functional there)
- Visibility is snapshotted in store so it restores correctly on return to Library
- `A` keyboard shortcut is a no-op while in Now Playing context

## Test plan

- [x] Open Artist pane in Library, press `L` → Artist pane hides in Now Playing
- [x] Press `L` again → Artist pane reappears in Library
- [x] Close Artist pane in Library, press `L` → stays hidden in Now Playing
- [x] Press `L` again → stays hidden in Library (not spuriously reopened)
- [x] Press `A` while in Now Playing → no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)