### PR TITLE
security: pin action SHAs and add permissions block to ci.yml (TASK-156)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
 
@@ -107,7 +107,7 @@ jobs:
         run: bash scripts/make_icns.sh kamp_ui/resources/icon_1024.png
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: bundle-${{ matrix.arch }}
           path: kamp_ui/resources/
@@ -127,10 +127,10 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Download bundle artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: bundle-${{ matrix.arch }}
           path: kamp_ui/resources/
@@ -231,7 +231,7 @@ jobs:
       - name: Cache electron-builder binaries
         # electron-builder downloads dmgbuild and other native helpers on first run.
         # Caching avoids transient network failures and speeds up subsequent builds.
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/Library/Caches/electron-builder
           key: electron-builder-cache-${{ matrix.arch }}-${{ hashFiles('kamp_ui/package-lock.json') }}
@@ -239,7 +239,7 @@ jobs:
             electron-builder-cache-${{ matrix.arch }}-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: 24
           cache: npm
@@ -274,7 +274,7 @@ jobs:
           echo "name=Kamp-${safe}-mac-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: kamp_ui/dist/*.dmg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -13,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 
@@ -39,10 +42,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 
@@ -59,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/publish-kamp-groover.yml
+++ b/.github/workflows/publish-kamp-groover.yml
@@ -18,8 +18,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5  # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

- Pin all `uses:` references in every workflow to full commit SHAs (floating tags like `@v6` can be silently redirected to malicious code that exfiltrates secrets during a release run)
- Add `permissions: contents: read` to `ci.yml` — it was the only workflow with no `permissions:` block, leaving it with the repo default (potentially `contents: write`)
- All other workflows (`release.yml`, `build-app.yml`, `publish-kamp-groover.yml`, `release-please.yml`) already had explicit permissions blocks and were left unchanged

## Actions pinned

| Action | Tag | Commit SHA |
|--------|-----|------------|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/setup-python` | v6 | `a309ff8b` |
| `actions/setup-node` | v6 | `53b83947` |
| `actions/upload-artifact` | v7 | `043fb46d` |
| `actions/download-artifact` | v8 | `3e5f45b2` |
| `actions/cache` | v5 | `27d5ce7f` |
| `googleapis/release-please-action` | v4 | `8b8fd2cc` |

## Test plan

- [ ] CI passes on this PR
- [ ] Verify no `uses:.*@v\d` pattern remains in `.github/workflows/`
- [ ] Once `dependabot.yml` is added (TASK-155), it will keep these SHAs current automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)