### PR TITLE
security: replace insecure tempfile.mktemp with mkdtemp in playback.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ htmlcov/
 .DS_Store
 
 # Claude
-.claude/*.json
+.claude/
 
 # App bundle build artifacts (generated; not committed)
 kamp_ui/resources/kamp/

--- a/backlog/completed/task-162 - security-upgrade-vite-to-7.3.2-3-CVEs-—-file-read-fs.deny-bypass-map-path-traversal.md
+++ b/backlog/completed/task-162 - security-upgrade-vite-to-7.3.2-3-CVEs-—-file-read-fs.deny-bypass-map-path-traversal.md
@@ -3,9 +3,10 @@ id: TASK-162
 title: >-
   security: upgrade vite to 7.3.2 (3 CVEs — file read, fs.deny bypass, map path
   traversal)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 13:58'
+updated_date: '2026-04-19 19:33'
 labels:
   - security
   - dependabot
@@ -47,7 +48,7 @@ Dependabot alerts #4, #5, #6 — all fixed by upgrading vite to 7.3.2.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 npm list vite shows >= 7.3.2
-- [ ] #2 npm run build completes without errors
-- [ ] #3 Dependabot alerts #4, #5, #6 are resolved
+- [x] #1 npm list vite shows >= 7.3.2
+- [x] #2 npm run build completes without errors
+- [x] #3 Dependabot alerts #4, #5, #6 are resolved
 <!-- AC:END -->

--- a/backlog/completed/task-163 - security-force-lodash-4.18.0-via-npm-overrides-2-CVEs-—-code-injection-prototype-pollution.md
+++ b/backlog/completed/task-163 - security-force-lodash-4.18.0-via-npm-overrides-2-CVEs-—-code-injection-prototype-pollution.md
@@ -3,9 +3,10 @@ id: TASK-163
 title: >-
   security: force lodash >= 4.18.0 via npm overrides (2 CVEs — code injection,
   prototype pollution)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 13:59'
+updated_date: '2026-04-19 19:33'
 labels:
   - security
   - dependabot
@@ -46,7 +47,7 @@ Then run `npm install` and verify with `npm list lodash`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 npm list lodash shows >= 4.18.0 for all instances
-- [ ] #2 npm run build completes without errors
-- [ ] #3 Dependabot alerts #2 and #3 are resolved
+- [x] #1 npm list lodash shows >= 4.18.0 for all instances
+- [x] #2 npm run build completes without errors
+- [x] #3 Dependabot alerts #2 and #3 are resolved
 <!-- AC:END -->

--- a/backlog/completed/task-164 - security-force-xmldom-xmldom-0.8.12-via-npm-overrides-XML-injection-via-CDATA.md
+++ b/backlog/completed/task-164 - security-force-xmldom-xmldom-0.8.12-via-npm-overrides-XML-injection-via-CDATA.md
@@ -3,9 +3,10 @@ id: TASK-164
 title: >-
   security: force @xmldom/xmldom >= 0.8.12 via npm overrides (XML injection via
   CDATA)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 13:59'
+updated_date: '2026-04-19 19:33'
 labels:
   - security
   - dependabot
@@ -40,7 +41,7 @@ Run `npm install` and verify with `npm list @xmldom/xmldom`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 npm list @xmldom/xmldom shows >= 0.8.12
-- [ ] #2 npm run build completes without errors
-- [ ] #3 Dependabot alert #1 is resolved
+- [x] #1 npm list @xmldom/xmldom shows >= 0.8.12
+- [x] #2 npm run build completes without errors
+- [x] #3 Dependabot alert #1 is resolved
 <!-- AC:END -->

--- a/backlog/tasks/task-155 - enable-GitHub-secret-scanning-push-protection-and-Dependabot.md
+++ b/backlog/tasks/task-155 - enable-GitHub-secret-scanning-push-protection-and-Dependabot.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-155
 title: 'enable GitHub secret scanning, push protection, and Dependabot'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-19 02:58'
-updated_date: '2026-04-19 03:17'
+updated_date: '2026-04-19 19:31'
 labels:
   - security
   - chore
@@ -14,7 +14,7 @@ dependencies: []
 references:
   - backlog/docs/doc-2 - GitHub Repository Security Checklist — kamp.md
 priority: medium
-ordinal: 1000
+ordinal: 16000
 ---
 
 ## Description

--- a/backlog/tasks/task-157 - harden-branch-protection-rules-on-main.md
+++ b/backlog/tasks/task-157 - harden-branch-protection-rules-on-main.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-157
 title: harden branch protection rules on main
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-19 02:58'
-updated_date: '2026-04-19 03:17'
+updated_date: '2026-04-19 19:31'
 labels:
   - security
   - chore
@@ -14,7 +14,7 @@ dependencies: []
 references:
   - backlog/docs/doc-2 - GitHub Repository Security Checklist — kamp.md
 priority: medium
-ordinal: 2000
+ordinal: 15000
 ---
 
 ## Description

--- a/backlog/tasks/task-158 - security-replace-insecure-tempfile.mktemp-in-playback.py.md
+++ b/backlog/tasks/task-158 - security-replace-insecure-tempfile.mktemp-in-playback.py.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-158
 title: 'security: replace insecure tempfile.mktemp in playback.py'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-19 13:48'
+updated_date: '2026-04-19 19:36'
 labels:
   - security
   - codeql

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -354,7 +354,7 @@ class MpvPlaybackEngine:
                 "--no-video",
                 "--idle=yes",
                 "--really-quiet",
-                f"--input-ipc-server={tmp}",
+                f"--input-ipc-server={self._sock_path}",
                 # Prevent mpv from intercepting media keys via its IOKit HID tap.
                 # Media key events are now handled by the Electron now-playing-helper
                 # subprocess via MPRemoteCommandCenter (registered by the process

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import shutil
 import socket
 import subprocess
 import tempfile
@@ -333,6 +334,7 @@ class MpvPlaybackEngine:
         self._proc: subprocess.Popen[bytes] | None = None
         self._sock: socket.socket | None = None
         self._sock_path = ""
+        self._sock_tmpdir = ""
         self._reader_thread: threading.Thread | None = None
         self._lock = threading.Lock()
         # One-shot seek applied on the next file-loaded event (set by load_paused).
@@ -343,8 +345,9 @@ class MpvPlaybackEngine:
 
     def _start_mpv(self) -> None:  # pragma: no cover
         """Launch mpv and connect to its IPC socket."""
-        tmp = tempfile.mktemp(suffix=".sock", prefix="kamp-mpv-")
-        self._sock_path = tmp
+        tmpdir = tempfile.mkdtemp(prefix="kamp-mpv-")
+        self._sock_tmpdir = tmpdir
+        self._sock_path = str(Path(tmpdir) / "mpv.sock")
         self._proc = subprocess.Popen(
             [
                 self._mpv_bin,
@@ -457,6 +460,9 @@ class MpvPlaybackEngine:
             except OSError:
                 pass
             self._sock = None
+        if self._sock_tmpdir:
+            shutil.rmtree(self._sock_tmpdir, ignore_errors=True)
+            self._sock_tmpdir = ""
 
     # ------------------------------------------------------------------
     # Internal: IPC send/receive

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -806,6 +806,21 @@ class TestMpvPlaybackEngine:
         engine._proc = None
         engine.shutdown()  # should not raise
 
+    def test_shutdown_removes_sock_tmpdir(self) -> None:
+        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
+            engine = MpvPlaybackEngine()
+        with patch("kamp_core.playback.shutil.rmtree") as mock_rmtree:
+            engine._sock_tmpdir = "/tmp/kamp-mpv-abc123"
+            engine.shutdown()
+        mock_rmtree.assert_called_once_with("/tmp/kamp-mpv-abc123", ignore_errors=True)
+
+    def test_shutdown_skips_rmtree_when_no_tmpdir(self) -> None:
+        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
+            engine = MpvPlaybackEngine()
+        with patch("kamp_core.playback.shutil.rmtree") as mock_rmtree:
+            engine.shutdown()
+        mock_rmtree.assert_not_called()
+
     def test_send_command_is_noop_when_no_socket(self) -> None:
         with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
             engine = MpvPlaybackEngine()


### PR DESCRIPTION
## Summary

- Replaces `tempfile.mktemp()` with `tempfile.mkdtemp()` to eliminate TOCTOU race on mpv IPC socket path
- Socket now lives at `<exclusive-tmpdir>/mpv.sock`; directory is removed in `shutdown()` via `shutil.rmtree`
- Fixes CodeQL alert #1 (`py/insecure-temporary-file`)

Closes TASK-158.

## Test plan

- [x] Smoke test: daemon starts, playback works, daemon stops cleanly
- [x] 97 unit tests pass (`poetry run pytest tests/test_playback.py --no-cov`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)