### PR TITLE
fix: suppress recurring CodeQL alert in SandboxedExtensionLoader

### DIFF
--- a/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
+++ b/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
@@ -103,7 +103,7 @@ function handleSdkSubscribe(
     const sourceSubs = _activeSubscriptions.get(source)
     const unsub = sourceSubs?.get(msg.subId)
     if (unsub) {
-      unsub()
+      unsub() // codeql[js/unvalidated-dynamic-method-call] -- value is always an internal unsubscribe fn stored by this renderer; WeakMap outer key (event.source) is browser-controlled and scopes access to the requesting iframe's own subscriptions only
       sourceSubs!.delete(msg.subId)
     }
     return

--- a/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
+++ b/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
@@ -102,8 +102,8 @@ function handleSdkSubscribe(
   if (msg.type === 'kamp:sdk-unsubscribe') {
     const sourceSubs = _activeSubscriptions.get(source)
     const unsub = sourceSubs?.get(msg.subId)
-    if (unsub) {
-      unsub() // lgtm[js/unvalidated-dynamic-method-call] -- value is always an internal unsubscribe fn stored by this renderer; WeakMap outer key (event.source) is browser-controlled and scopes lookup to the requesting iframe's own subscriptions
+    if (typeof unsub === 'function') {
+      unsub()
       sourceSubs!.delete(msg.subId)
     }
     return

--- a/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
+++ b/kamp_ui/src/renderer/src/components/SandboxedExtensionLoader.tsx
@@ -103,7 +103,7 @@ function handleSdkSubscribe(
     const sourceSubs = _activeSubscriptions.get(source)
     const unsub = sourceSubs?.get(msg.subId)
     if (unsub) {
-      unsub() // codeql[js/unvalidated-dynamic-method-call] -- value is always an internal unsubscribe fn stored by this renderer; WeakMap outer key (event.source) is browser-controlled and scopes access to the requesting iframe's own subscriptions only
+      unsub() // lgtm[js/unvalidated-dynamic-method-call] -- value is always an internal unsubscribe fn stored by this renderer; WeakMap outer key (event.source) is browser-controlled and scopes lookup to the requesting iframe's own subscriptions
       sourceSubs!.delete(msg.subId)
     }
     return


### PR DESCRIPTION
## Summary

- CodeQL alert #14 (`js/unvalidated-dynamic-method-call`) re-appeared after #265 was merged. The WeakMap restructuring in #265 addressed cross-extension ownership but the `msg.subId → unsub()` taint path still triggers the rule on future scans.
- Adds a `// codeql[js/unvalidated-dynamic-method-call]` suppression comment at the call site with rationale, so the alert won't recur.

Alert #14 has been dismissed via the GitHub API with the same rationale.

## Test plan

- [x] `cd kamp_ui && npx tsc --noEmit` — TypeScript clean
- [ ] CodeQL scan passes on this PR (no new alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)