### PR TITLE
security: migrate Last.fm session key from settings table to OS keychain (TASK-151)

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -736,12 +736,11 @@ def _cmd_daemon(
 
     def _on_lastfm_connect(username: str, password: str) -> None:
         session_key = _lastfm_authenticate(username, password)
-        _config_set(index, "lastfm.username", username)
-        _config_set(index, "lastfm.session_key", session_key)
+        index.set_session("lastfm", {"session_key": session_key, "username": username})
         _scrobbler_ref[0] = Scrobbler(session_key)
 
     def _on_lastfm_disconnect() -> None:
-        _config_set(index, "lastfm.session_key", "")
+        index.clear_session("lastfm")
         _scrobbler_ref[0] = None
 
     def _on_bandcamp_login_complete(payload: dict[str, object]) -> None:

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -95,7 +95,8 @@ def _prompt(label: str, default: str) -> str:
     return value if value else default
 
 
-# Default values for all 13 active config keys (stored as text in the DB).
+# Default values for all 11 active config keys (stored as text in the DB).
+# Last.fm credentials are stored in the OS keychain via the sessions table, not here.
 _CONFIG_DEFAULTS: dict[str, str] = {
     "paths.watch_folder": "~/Music/staging",
     "paths.library": "~/Music",
@@ -105,8 +106,6 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",
-    "lastfm.username": "",
-    "lastfm.session_key": "",
     "ui.active_view": "library",
     "ui.sort_order": "album_artist",
     "ui.queue_panel_open": "0",
@@ -123,8 +122,6 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "library.path_template": str,
     "bandcamp.format": str,
     "bandcamp.poll_interval_minutes": int,
-    "lastfm.username": str,
-    "lastfm.session_key": str,
     "ui.active_view": str,
     "ui.sort_order": str,
     "ui.queue_panel_open": int,
@@ -155,10 +152,16 @@ _FORBIDDEN_PATH_ROOTS: frozenset[Path] = frozenset(
     )
 )
 
-# Keys deprecated in TASK-132; providing them as an argument to config_set() is an error.
-_DEPRECATED_KEYS: frozenset[str] = frozenset(
-    {"bandcamp.username", "bandcamp.cookie_file"}
-)
+# Keys that are no longer settable via config_set(); each maps to a user-facing hint.
+_DEPRECATED_KEY_MESSAGES: dict[str, str] = {
+    # Deprecated in TASK-132: Bandcamp credentials moved to session store.
+    "bandcamp.username": "Bandcamp credentials are managed via 'kamp login'.",
+    "bandcamp.cookie_file": "Bandcamp credentials are managed via 'kamp login'.",
+    # Deprecated in TASK-151: Last.fm credentials moved to OS keychain.
+    "lastfm.session_key": "Last.fm credentials are managed via the Last.fm connect flow.",
+    "lastfm.username": "Last.fm credentials are managed via the Last.fm connect flow.",
+}
+_DEPRECATED_KEYS: frozenset[str] = frozenset(_DEPRECATED_KEY_MESSAGES)
 
 # Keys whose values must come from a fixed set of choices.
 _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
@@ -250,6 +253,24 @@ class Config:
             if not existing:
                 raise FileNotFoundError("No configuration found.")
 
+        # One-time migration: move Last.fm session key from the settings table
+        # (where it was stored as plaintext) to the OS keychain via the sessions
+        # table.  Runs once on first load after upgrading; afterwards the settings
+        # rows are empty and the session lives in the keychain.
+        _session_key = existing.get("lastfm.session_key", "")
+        if _session_key:
+            _username = existing.get("lastfm.username", "")
+            db.set_session(
+                "lastfm", {"session_key": _session_key, "username": _username}
+            )
+            db.set_setting("lastfm.session_key", "")
+            db.set_setting("lastfm.username", "")
+            existing["lastfm.session_key"] = ""
+            existing["lastfm.username"] = ""
+            logger.info(
+                "Migrated Last.fm session key from settings table to session store."
+            )
+
         # Back-fill defaults for any keys added after the initial setup
         # (e.g. when a new config key is introduced in a later release).
         for key, default in _CONFIG_DEFAULTS.items():
@@ -257,11 +278,11 @@ class Config:
                 db.set_setting(key, default)
                 existing[key] = default
 
-        return cls._from_settings(existing)
+        return cls._from_settings(existing, db)
 
     @classmethod
-    def _from_settings(cls, settings: dict[str, str]) -> "Config":
-        """Build a Config from a flat key→str settings dict."""
+    def _from_settings(cls, settings: dict[str, str], db: "LibraryIndex") -> "Config":
+        """Build a Config from a flat key→str settings dict and live DB (for sessions)."""
 
         def _get(key: str) -> str:
             return settings.get(key, _CONFIG_DEFAULTS.get(key, ""))
@@ -275,12 +296,12 @@ class Config:
             except (ValueError, TypeError):
                 return int(_CONFIG_DEFAULTS[key])
 
-        session_key = _get("lastfm.session_key")
         lastfm: LastfmConfig | None = None
-        if session_key:
+        _lastfm_session = db.get_session("lastfm")
+        if _lastfm_session and _lastfm_session.get("session_key"):
             lastfm = LastfmConfig(
-                username=_get("lastfm.username"),
-                session_key=session_key,
+                username=_lastfm_session.get("username", ""),
+                session_key=_lastfm_session["session_key"],
             )
 
         return cls(
@@ -366,10 +387,16 @@ def _migrate_from_toml(db: "LibraryIndex", toml_path: Path) -> dict[str, str]:
     # bandcamp.username and bandcamp.cookie_file are intentionally not migrated.
 
     lf = raw.get("lastfm", {})
-    if "username" in lf:
-        settings["lastfm.username"] = str(lf["username"])
-    if "session_key" in lf:
-        settings["lastfm.session_key"] = str(lf["session_key"])
+    if "session_key" in lf and lf["session_key"]:
+        # Write directly to the session store rather than the settings table so
+        # the session key is never stored as plaintext config.
+        db.set_session(
+            "lastfm",
+            {
+                "session_key": str(lf["session_key"]),
+                "username": str(lf.get("username", "")),
+            },
+        )
 
     ui = raw.get("ui", {})
     if "active_view" in ui:
@@ -425,9 +452,9 @@ def config_set(db: "LibraryIndex", key: str, value: str) -> None:
     keys, ValueError for type mismatches or invalid choices.
     """
     if key in _DEPRECATED_KEYS:
+        hint = _DEPRECATED_KEY_MESSAGES[key]
         raise KeyError(
-            f"Key {key!r} has been deprecated and is no longer supported. "
-            "Bandcamp credentials are managed via 'kamp login'."
+            f"Key {key!r} has been deprecated and is no longer supported. {hint}"
         )
 
     if key not in _CONFIG_KEY_TYPES:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,9 @@
 
 from pathlib import Path
 
+import keyring.errors
 import pytest
+from pytest_mock import MockerFixture
 
 from kamp_core.library import LibraryIndex
 from kamp_daemon.config import (
@@ -16,8 +18,12 @@ from kamp_daemon.config import (
 
 
 @pytest.fixture()
-def db(tmp_path: Path) -> LibraryIndex:
-    """Return a fresh LibraryIndex backed by a temp DB."""
+def db(tmp_path: Path, mocker: MockerFixture) -> LibraryIndex:
+    """Return a fresh LibraryIndex backed by a temp DB, with keyring mocked out."""
+    err = keyring.errors.NoKeyringError()
+    mocker.patch("kamp_core.library.keyring.get_password", side_effect=err)
+    mocker.patch("kamp_core.library.keyring.set_password", side_effect=err)
+    mocker.patch("kamp_core.library.keyring.delete_password", side_effect=err)
     index = LibraryIndex(tmp_path / "library.db")
     yield index
     index.close()
@@ -29,7 +35,7 @@ def db(tmp_path: Path) -> LibraryIndex:
 
 
 class TestWriteDefaults:
-    def test_writes_all_13_keys(self, db: LibraryIndex) -> None:
+    def test_writes_all_11_keys(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
         settings = db.get_all_settings()
         assert len(settings) == len(_CONFIG_DEFAULTS)
@@ -81,21 +87,36 @@ class TestLoad:
         config = Config.load(db)
         assert config.artwork.min_dimension == 1000
 
-    def test_load_lastfm_when_session_key_present(self, db: LibraryIndex) -> None:
+    def test_load_lastfm_when_session_present(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
-        db.set_setting("lastfm.username", "myuser")
-        db.set_setting("lastfm.session_key", "mysecret")
+        db.set_session("lastfm", {"session_key": "mysecret", "username": "myuser"})
         config = Config.load(db)
         assert config.lastfm is not None
         assert isinstance(config.lastfm, LastfmConfig)
         assert config.lastfm.username == "myuser"
         assert config.lastfm.session_key == "mysecret"
 
-    def test_load_lastfm_none_when_session_key_empty(self, db: LibraryIndex) -> None:
+    def test_load_lastfm_none_when_no_session(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
-        db.set_setting("lastfm.session_key", "")
         config = Config.load(db)
         assert config.lastfm is None
+
+    def test_load_migrates_lastfm_from_settings_table(self, db: LibraryIndex) -> None:
+        """One-time migration: session_key in settings → moved to session store."""
+        Config.write_defaults(db)
+        db.set_setting("lastfm.username", "olduser")
+        db.set_setting("lastfm.session_key", "oldkey")
+        config = Config.load(db)
+        assert config.lastfm is not None
+        assert config.lastfm.session_key == "oldkey"
+        assert config.lastfm.username == "olduser"
+        # Credentials must be cleared from the settings table after migration.
+        assert db.get_setting("lastfm.session_key") == ""
+        assert db.get_setting("lastfm.username") == ""
+        # Session store must hold the migrated data.
+        session = db.get_session("lastfm")
+        assert session is not None
+        assert session["session_key"] == "oldkey"
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +245,7 @@ class TestTomlMigration:
         assert db.get_setting("bandcamp.username") is None
         assert db.get_setting("bandcamp.cookie_file") is None
 
-    def test_all_13_active_keys_present_after_migration(
+    def test_all_active_keys_present_after_migration(
         self, db: LibraryIndex, tmp_path: Path
     ) -> None:
         toml_path = tmp_path / "config.toml"
@@ -259,6 +280,8 @@ class TestTomlMigration:
         assert config.lastfm is not None
         assert config.lastfm.username == "myuser"
         assert config.lastfm.session_key == "abc123sessionkey"
+        # Session key must not be in the settings table after TOML migration.
+        assert not db.get_setting("lastfm.session_key")
 
     def test_migrates_legacy_staging_key(
         self, db: LibraryIndex, tmp_path: Path
@@ -288,8 +311,9 @@ class TestConfigShow:
         assert "[artwork]" in output
         assert "[library]" in output
         assert "[bandcamp]" in output
-        assert "[lastfm]" in output
         assert "[ui]" in output
+        # Last.fm credentials are in the session store, not config — no [lastfm] section.
+        assert "[lastfm]" not in output
 
     def test_includes_key_value_pairs(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
@@ -379,17 +403,13 @@ class TestConfigSet:
         with pytest.raises(KeyError, match="deprecated"):
             config_set(db, "bandcamp.cookie_file", "/tmp/cookies.txt")
 
-    def test_set_lastfm_username(self, db: LibraryIndex) -> None:
-        Config.write_defaults(db)
-        config_set(db, "lastfm.username", "newuser")
-        assert db.get_setting("lastfm.username") == "newuser"
+    def test_set_lastfm_username_raises_deprecated(self, db: LibraryIndex) -> None:
+        with pytest.raises(KeyError, match="deprecated"):
+            config_set(db, "lastfm.username", "newuser")
 
-    def test_set_lastfm_session_key(self, db: LibraryIndex) -> None:
-        Config.write_defaults(db)
-        config_set(db, "lastfm.session_key", "newkey")
-        config = Config.load(db)
-        assert config.lastfm is not None
-        assert config.lastfm.session_key == "newkey"
+    def test_set_lastfm_session_key_raises_deprecated(self, db: LibraryIndex) -> None:
+        with pytest.raises(KeyError, match="deprecated"):
+            config_set(db, "lastfm.session_key", "newkey")
 
     def test_path_key_relative_raises(self, db: LibraryIndex) -> None:
         with pytest.raises(ValueError, match="requires an absolute path"):


### PR DESCRIPTION
## Summary

- `lastfm.session_key` and `lastfm.username` are removed from the settings table and are no longer config keys — `config_set()` rejects them with a deprecation error pointing to the Last.fm connect flow
- `Config.load()` runs a one-time migration: if `lastfm.session_key` is found in the settings table on upgrade, it is moved to `index.set_session("lastfm", {...})` and the settings rows are cleared
- `_from_settings()` now reads the Last.fm session from `db.get_session("lastfm")` — the same pattern as Bandcamp credentials
- `_migrate_from_toml()` writes the Last.fm session directly to the session store, never to the settings table
- `_on_lastfm_connect` / `_on_lastfm_disconnect` in `__main__.py` updated to use `index.set_session` / `index.clear_session`

Depends on #268 (keyring session store) being merged first.

## Test plan

- [ ] `test_load_lastfm_when_session_present` — session key read from session store
- [ ] `test_load_lastfm_none_when_no_session` — no session → `config.lastfm is None`
- [ ] `test_load_migrates_lastfm_from_settings_table` — one-time migration clears settings rows and populates session store
- [ ] `test_migrates_lastfm_section` (TOML migration) — session key goes to session store, not settings table
- [ ] `test_set_lastfm_username_raises_deprecated` / `test_set_lastfm_session_key_raises_deprecated` — config_set() rejects these keys
- [ ] Full suite: 1105 passed, 8 skipped

Closes TASK-151 (FINDING-07 from the v1.11.0 database security audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)