### PR TITLE
security: explicit path containment validation for file_path API params (TASK-152)

### DIFF
--- a/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
+++ b/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-151
 title: migrate Last.fm session key from config.toml to sessions table
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-18 18:03'
-updated_date: '2026-04-19 23:52'
+updated_date: '2026-04-20 16:35'
 labels:
   - security
   - chore

--- a/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
+++ b/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-152
 title: add explicit path containment validation for file_path API parameters
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-18 18:03'
-updated_date: '2026-04-19 23:52'
+updated_date: '2026-04-20 16:35'
 labels:
   - security
   - chore

--- a/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
+++ b/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-152
 title: add explicit path containment validation for file_path API parameters
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-18 18:03'
-updated_date: '2026-04-20 16:35'
+updated_date: '2026-04-20 16:47'
 labels:
   - security
   - chore

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -239,6 +239,19 @@ _ALLOWED_PROXY_HOSTS: frozenset[str] = frozenset(
 )
 
 
+def _validate_library_path(file_path: str, library_path: Path | None) -> Path:
+    """Resolve *file_path* and verify it lies within *library_path*.
+
+    Raises HTTP 400 when a library_path is configured and the resolved path
+    falls outside it — preventing path-traversal attacks from reaching any
+    future code that uses the caller-supplied path directly.
+    """
+    p = Path(file_path).resolve()
+    if library_path is not None and not p.is_relative_to(library_path.resolve()):
+        raise HTTPException(status_code=400, detail="Path outside library directory")
+    return p
+
+
 def _validate_proxy_url(url: str) -> str:
     parsed = urlparse(url)
     host = parsed.hostname or ""
@@ -416,7 +429,8 @@ def create_app(
         # file_path is used for missing-album tracks where (album_artist, album)
         # is not a unique key; when present it takes precedence.
         if file_path:
-            track = index.get_track_by_path(Path(file_path))
+            p = _validate_library_path(file_path, _state["library_path"])
+            track = index.get_track_by_path(p)
             return [TrackOut.from_track(track)] if track else []
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
@@ -424,13 +438,14 @@ def create_app(
 
     @app.post("/api/v1/tracks/favorite")
     def set_track_favorite(req: FavoriteRequest) -> dict[str, Any]:
-        track = index.get_track_by_path(Path(req.file_path))
+        p = _validate_library_path(req.file_path, _state["library_path"])
+        track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
-        index.set_favorite(Path(req.file_path), req.favorite)
+        index.set_favorite(p, req.favorite)
         # Keep the in-memory queue in sync so the next player-state snapshot
         # reflects the new favorite value without requiring a queue reload.
-        queue.update_favorite(Path(req.file_path), req.favorite)
+        queue.update_favorite(p, req.favorite)
         return {"ok": True}
 
     @app.get("/api/v1/album-art")
@@ -439,7 +454,8 @@ def create_app(
     ) -> Response:
         # file_path overrides (album_artist, album) for missing-album tracks.
         if file_path:
-            track = index.get_track_by_path(Path(file_path))
+            p = _validate_library_path(file_path, _state["library_path"])
+            track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
             tracks = index.tracks_for_album(album_artist, album)
@@ -744,7 +760,8 @@ def create_app(
     @app.post("/api/v1/player/play")
     def play(req: PlayRequest) -> dict[str, Any]:
         if req.file_path:
-            track = index.get_track_by_path(Path(req.file_path))
+            p = _validate_library_path(req.file_path, _state["library_path"])
+            track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
             tracks = index.tracks_for_album(req.album_artist, req.album)
@@ -821,7 +838,8 @@ def create_app(
 
     @app.post("/api/v1/player/queue/add")
     def queue_add(req: AddToQueueRequest) -> dict[str, Any]:
-        track = index.get_track_by_path(Path(req.file_path))
+        p = _validate_library_path(req.file_path, _state["library_path"])
+        track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.add_to_queue(track)
@@ -829,7 +847,8 @@ def create_app(
 
     @app.post("/api/v1/player/queue/play-next")
     def queue_play_next(req: AddToQueueRequest) -> dict[str, Any]:
-        track = index.get_track_by_path(Path(req.file_path))
+        p = _validate_library_path(req.file_path, _state["library_path"])
+        track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.play_next(track)
@@ -837,7 +856,8 @@ def create_app(
 
     @app.post("/api/v1/player/queue/insert")
     def queue_insert(req: InsertQueueRequest) -> dict[str, Any]:
-        track = index.get_track_by_path(Path(req.file_path))
+        p = _validate_library_path(req.file_path, _state["library_path"])
+        track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.insert_at(track, req.index)
@@ -846,7 +866,8 @@ def create_app(
     @app.post("/api/v1/player/queue/add-album")
     def queue_add_album(req: AlbumQueueRequest) -> dict[str, Any]:
         if req.file_path:
-            track = index.get_track_by_path(Path(req.file_path))
+            p = _validate_library_path(req.file_path, _state["library_path"])
+            track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
             tracks = index.tracks_for_album(req.album_artist, req.album)
@@ -858,7 +879,8 @@ def create_app(
     @app.post("/api/v1/player/queue/play-album-next")
     def queue_play_album_next(req: AlbumQueueRequest) -> dict[str, Any]:
         if req.file_path:
-            track = index.get_track_by_path(Path(req.file_path))
+            p = _validate_library_path(req.file_path, _state["library_path"])
+            track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
             tracks = index.tracks_for_album(req.album_artist, req.album)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -406,6 +406,143 @@ class TestMissingAlbumEndpoints:
         mock_index.tracks_for_album.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Path containment validation
+# ---------------------------------------------------------------------------
+
+
+class TestPathContainmentValidation:
+    """file_path parameters must resolve within the configured library directory."""
+
+    def _client(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        library_path: Path = Path("/music"),
+    ) -> TestClient:
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            library_path=library_path,
+        )
+        return TestClient(app)
+
+    def test_tracks_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.get("/api/v1/tracks?album_artist=&album=&file_path=/etc/passwd")
+        assert resp.status_code == 400
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_tracks_rejects_traversal_path(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.get(
+            "/api/v1/tracks?album_artist=&album=&file_path=/music/../etc/passwd"
+        )
+        assert resp.status_code == 400
+
+    def test_tracks_accepts_valid_library_path(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = _track(1)
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.get(
+            "/api/v1/tracks?album_artist=&album=&file_path=/music/artist/01.mp3"
+        )
+        assert resp.status_code == 200
+
+    def test_favorite_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/tracks/favorite",
+            json={"file_path": "/etc/passwd", "favorite": True},
+        )
+        assert resp.status_code == 400
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_album_art_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.get("/api/v1/album-art?album_artist=&album=&file_path=/etc/passwd")
+        assert resp.status_code == 400
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_play_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/player/play",
+            json={"file_path": "/etc/passwd", "album_artist": "", "album": ""},
+        )
+        assert resp.status_code == 400
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_queue_add_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post("/api/v1/player/queue/add", json={"file_path": "/etc/passwd"})
+        assert resp.status_code == 400
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_queue_play_next_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/player/queue/play-next", json={"file_path": "/etc/passwd"}
+        )
+        assert resp.status_code == 400
+
+    def test_queue_insert_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/player/queue/insert",
+            json={"file_path": "/etc/passwd", "index": 0},
+        )
+        assert resp.status_code == 400
+
+    def test_queue_add_album_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/player/queue/add-album",
+            json={"file_path": "/etc/passwd", "album_artist": "", "album": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_queue_play_album_next_rejects_path_outside_library(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        c = self._client(mock_index, mock_engine, mock_queue)
+        resp = c.post(
+            "/api/v1/player/queue/play-album-next",
+            json={"file_path": "/etc/passwd", "album_artist": "", "album": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_no_validation_when_library_path_not_configured(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = _track(1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        resp = c.get("/api/v1/tracks?album_artist=&album=&file_path=/music/01.mp3")
+        assert resp.status_code == 200
+
+
 class TestTracksForAlbumEndpoint:
     def test_returns_tracks_for_album(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Adds `_validate_library_path()` helper that resolves caller-supplied `file_path` values and raises HTTP 400 if the resolved path falls outside the configured library directory
- Uses `Path.is_relative_to()` rather than `str.startswith()` to avoid the prefix-collision edge case (e.g. `/musicextra/` matching `/music`)
- No-ops when `library_path` is not configured, preserving existing test behaviour
- Applied to all 9 affected endpoints: `GET /tracks`, `POST /tracks/favorite`, `GET /album-art`, `POST /player/play`, and the 5 queue mutation endpoints

Addresses FINDING-05 from the v1.11.0 database security audit.

## Test plan

- [x] 12 new tests: out-of-bounds paths, `..`-traversal paths, valid paths, and no-library-path passthrough
- [x] Full server test suite: 165/165 pass
- [x] `black` and `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)