### PR TITLE
fix: bandcamp polling interval changes apply immediately (TASK-166)

### DIFF
--- a/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
+++ b/backlog/tasks/task-151 - migrate-Last.fm-session-key-from-config.toml-to-sessions-table.md
@@ -4,7 +4,7 @@ title: migrate Last.fm session key from config.toml to sessions table
 status: Done
 assignee: []
 created_date: '2026-04-18 18:03'
-updated_date: '2026-04-20 16:35'
+updated_date: '2026-04-20 18:45'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-07)
 priority: medium
+ordinal: 5000
 ---
 
 ## Description

--- a/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
+++ b/backlog/tasks/task-152 - add-explicit-path-containment-validation-for-file_path-API-parameters.md
@@ -4,7 +4,7 @@ title: add explicit path containment validation for file_path API parameters
 status: Done
 assignee: []
 created_date: '2026-04-18 18:03'
-updated_date: '2026-04-20 16:47'
+updated_date: '2026-04-20 18:45'
 labels:
   - security
   - chore
@@ -14,6 +14,7 @@ dependencies: []
 references:
   - doc-1 - Database Security Audit — v1.11.0 (FINDING-05)
 priority: low
+ordinal: 4000
 ---
 
 ## Description

--- a/backlog/tasks/task-166 - bandcamp-polling-option-updates-dont-apply-immediately.md
+++ b/backlog/tasks/task-166 - bandcamp-polling-option-updates-dont-apply-immediately.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-166
 title: bandcamp polling option updates don't apply immediately
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-20 16:15'
+updated_date: '2026-04-20 16:57'
 labels: []
 milestone: m-30
 dependencies: []

--- a/backlog/tasks/task-166 - bandcamp-polling-option-updates-dont-apply-immediately.md
+++ b/backlog/tasks/task-166 - bandcamp-polling-option-updates-dont-apply-immediately.md
@@ -1,14 +1,15 @@
 ---
 id: TASK-166
 title: bandcamp polling option updates don't apply immediately
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-20 16:15'
-updated_date: '2026-04-20 16:57'
+updated_date: '2026-04-20 18:45'
 labels: []
 milestone: m-30
 dependencies: []
 priority: medium
+ordinal: 6000
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -449,7 +449,11 @@ class LibraryIndex:
             try:
                 raw = keyring.get_password("kamp", service)
                 if raw is not None:
+                    logger.debug("get_session: keychain hit for service=%s", service)
                     return json.loads(raw)  # type: ignore[no-any-return]
+                logger.debug(
+                    "get_session: keychain returned no entry for service=%s", service
+                )
                 break  # key not present — no point retrying
             except keyring.errors.NoKeyringError:
                 # No keyring backend — fall through to DB
@@ -484,7 +488,11 @@ class LibraryIndex:
             "SELECT session_json FROM sessions WHERE service = ?", (service,)
         ).fetchone()
         if row is None or row["session_json"] is None:
+            logger.debug(
+                "get_session: no entry in keychain or DB for service=%s", service
+            )
             return None
+        logger.debug("get_session: DB fallback hit for service=%s", service)
         return dict(json.loads(row["session_json"]))  # type: ignore[no-any-return]
 
     def set_session(self, service: str, data: dict[str, Any]) -> None:
@@ -498,7 +506,21 @@ class LibraryIndex:
         session_json: str | None = payload
         try:
             keyring.set_password("kamp", service, payload)
-            session_json = None  # stored in keychain; keep DB row metadata-only
+            # Verify the write actually persisted — keyring.set_password can return
+            # without raising yet still fail silently on some backends/OS versions.
+            verified = keyring.get_password("kamp", service)
+            if verified == payload:
+                session_json = None  # stored in keychain; keep DB row metadata-only
+                logger.debug(
+                    "set_session: keychain write verified for service=%s", service
+                )
+            else:
+                logger.warning(
+                    "set_session: keychain write for service=%s did not verify"
+                    " (read-back returned %s); falling back to DB",
+                    service,
+                    "wrong value" if verified is not None else "None",
+                )
         except keyring.errors.NoKeyringError:
             pass
         except keyring.errors.KeyringError as exc:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -741,6 +741,9 @@ def _cmd_daemon(
         # Raises KeyError / ValueError on invalid key or value — server
         # catches these and returns HTTP 422 to the client.
         _config_set(index, key, value)
+        # Propagate the change to the running pipeline so settings like
+        # bandcamp.poll_interval_minutes take effect without a restart.
+        core.reload(Config.load(index))
 
     def _on_lastfm_connect(username: str, password: str) -> None:
         session_key = _lastfm_authenticate(username, password)

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -305,7 +305,7 @@ def _ensure_session(bc_config: BandcampConfig, index: "LibraryIndex") -> dict[st
         return data
 
     if data is not None:
-        logger.info("Bandcamp session expired — login required.")
+        logger.info("Bandcamp session expired — clearing session and prompting login.")
         index.clear_session("bandcamp")
     else:
         # get_session returns None for two distinct reasons: credentials are
@@ -552,7 +552,11 @@ def _paginate(
         )
 
         if resp.status_code in (401, 403, 302):
-            # Session expired mid-sync — clear DB row so the next run re-prompts login.
+            # Session expired mid-sync — clear keychain+DB so the next run re-prompts login.
+            logger.info(
+                "Bandcamp session rejected by API (HTTP %d) — clearing session.",
+                resp.status_code,
+            )
             index.clear_session("bandcamp")
             raise BandcampAPIError(
                 f"Bandcamp session expired (HTTP {resp.status_code}) — "

--- a/kamp_daemon/daemon_core.py
+++ b/kamp_daemon/daemon_core.py
@@ -104,6 +104,12 @@ class DaemonCore:
         self._syncer.resume()
         self._state = "running"
 
+    def reload(self, config: Config) -> None:
+        """Apply updated config to running components without restarting the daemon."""
+        self._config = config
+        self._watcher.reload(config)
+        self._syncer.reload(config)
+
     def shutdown(self) -> None:
         """Stop all components and unblock wait()."""
         _logger.info("Shutting down…")

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -249,6 +249,27 @@ class TestSignalHandlers:
             mock_resume.assert_called_once()
 
 
+class TestReload:
+    def test_reload_delegates_to_watcher_and_syncer(
+        self,
+        core: DaemonCore,
+        mock_watcher: MagicMock,
+        mock_syncer: MagicMock,
+        config: Config,
+    ) -> None:
+        new_config = MagicMock(spec=Config)
+        core.reload(new_config)
+        mock_watcher.return_value.reload.assert_called_once_with(new_config)
+        mock_syncer.return_value.reload.assert_called_once_with(new_config)
+
+    def test_reload_updates_stored_config(
+        self, core: DaemonCore, config: Config
+    ) -> None:
+        new_config = MagicMock(spec=Config)
+        core.reload(new_config)
+        assert core._config is new_config
+
+
 class TestWait:
     def test_returns_after_shutdown(self, core: DaemonCore, mock_pid: Path) -> None:
         with patch.object(core, "_install_signal_handlers"):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2194,6 +2194,27 @@ class TestSessionManagementKeyringErrors:
         sleep_mock.assert_not_called()
         index.close()
 
+    def test_set_session_falls_back_to_db_when_readback_fails(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """When keychain write appears to succeed but read-back returns None, fall back to DB."""
+        mocker.patch("kamp_core.library.keyring.set_password")
+        mocker.patch("kamp_core.library.keyring.get_password", return_value=None)
+        mocker.patch("kamp_core.library.keyring.delete_password")
+
+        index = self._make_index(tmp_path)
+        data = {"cookies": [{"name": "js_logged_in", "value": "1"}]}
+        index.set_session("bandcamp", data)
+
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row is not None
+        assert (
+            row["session_json"] is not None
+        ), "should fall back to DB when read-back returns None"
+        index.close()
+
     def test_set_session_falls_back_to_db_on_keyring_error(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:


### PR DESCRIPTION
## Summary

- **TASK-166 fix:** wires `_on_config_set` to call `core.reload(Config.load(index))` after persisting a config change to the DB, so the running syncer and watcher pick up the new poll interval without a restart. `DaemonCore.reload()` was added to delegate to both `watcher.reload()` and `syncer.reload()` — the individual reload methods already existed and were tested; they just weren't being called.
- **Keychain hardening:** `set_session` now performs a read-back after writing to detect silent write failures. If the read-back returns `None` or a wrong value, it falls back to the DB column and logs a `WARNING` instead of silently losing the credential.
- **Logging improvements:** added `DEBUG`/`WARNING` log lines in `get_session` and `set_session` to make keychain behaviour observable; added explicit `INFO` logs before `clear_session` calls in the Bandcamp sync paths.

## Test plan

- [x] Change Bandcamp poll interval from 0 → 1 in preferences: sync should start immediately and repeat every minute without restarting the app
- [x] Change poll interval from 1 → 0: polling should stop (manual sync only)
- [x] Log in to Bandcamp and confirm `set_session: keychain write verified` appears at DEBUG level (run with `--log-level debug` or check that no WARNING fires)
- [x] `security find-generic-password -s "kamp" -a "bandcamp" -w` should show the session after login
- [x] All 219 tests pass: `poetry run pytest tests/test_daemon_core.py tests/test_library.py tests/test_bandcamp.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)