### PR TITLE
fix: pass X-Kamp-Token header in proxy-fetch requests

### DIFF
--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import requests as _requests
 
-from .config import BandcampConfig
+from .config import BandcampConfig, token_path
 
 if TYPE_CHECKING:
     from kamp_core.library import LibraryIndex
@@ -58,6 +58,14 @@ _UA = (
 
 # URL of the kamp server's Bandcamp HTTP proxy relay endpoint.
 _PROXY_FETCH_URL = "http://127.0.0.1:8000/api/v1/bandcamp/proxy-fetch"
+
+
+def _read_auth_token() -> str | None:
+    """Return the shared-secret token written by the daemon on startup, or None."""
+    try:
+        return token_path().read_text().strip()
+    except OSError:
+        return None
 
 
 def _is_frozen() -> bool:
@@ -135,9 +143,12 @@ class _ProxySession:
         # connection, so the outer timeout must be considerably larger than the
         # inner one.  2× + 10s gives ≥50s headroom for a 20s inner timeout.
         proxy_timeout = float(timeout) * 2 + 10
+        kamp_token = _read_auth_token()
+        post_headers = {"X-Kamp-Token": kamp_token} if kamp_token else None
         resp = _requests.post(
             _PROXY_FETCH_URL,
             json={"url": url, "method": method, "headers": req_headers, "body": body},
+            headers=post_headers,
             timeout=proxy_timeout,
         )
         resp.raise_for_status()

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -1351,3 +1351,40 @@ class TestProxySession:
 
         payload = patched.call_args[1]["json"]
         assert payload["headers"]["User-Agent"] == _UA
+
+    def test_includes_auth_token_header(self, tmp_path: Path) -> None:
+        from kamp_daemon.bandcamp import _ProxySession
+
+        token_file = tmp_path / ".token"
+        token_file.write_text("mysecret")
+
+        sess = _ProxySession()
+        mock_post = self._make_proxy_response(200, "{}")
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._requests.post", return_value=mock_post
+            ) as patched,
+            patch("kamp_daemon.bandcamp.token_path", return_value=token_file),
+        ):
+            sess.get("https://bandcamp.com/api/test")
+
+        assert patched.call_args[1]["headers"] == {"X-Kamp-Token": "mysecret"}
+
+    def test_no_auth_header_when_token_missing(self, tmp_path: Path) -> None:
+        from kamp_daemon.bandcamp import _ProxySession
+
+        missing = tmp_path / ".token"  # does not exist
+
+        sess = _ProxySession()
+        mock_post = self._make_proxy_response(200, "{}")
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._requests.post", return_value=mock_post
+            ) as patched,
+            patch("kamp_daemon.bandcamp.token_path", return_value=missing),
+        ):
+            sess.get("https://bandcamp.com/api/test")
+
+        assert patched.call_args[1]["headers"] is None


### PR DESCRIPTION
## Summary

- `_ProxySession._fetch` in `kamp_daemon/bandcamp.py` was posting to `/api/v1/bandcamp/proxy-fetch` without the `X-Kamp-Token` header introduced by TASK-149
- This caused a 401 on every bundled-app Bandcamp sync, including the initial mark-synced run that fires on first launch
- Fix reads the token from the daemon's token file (same file the daemon writes on startup) and attaches it as `X-Kamp-Token`

## Test plan

- [x] `poetry run pytest tests/test_bandcamp.py -v --no-cov -k "TestProxySession"` — all 6 tests pass
- [x] Verify initial Bandcamp sync no longer 401s in the built app

🤖 Generated with [Claude Code](https://claude.com/claude-code)