### PR TITLE
feat: onboarding exit polish — "All set!" string and art-preload delay (TASK-171)

### DIFF
--- a/backlog/tasks/task-171 - Onboarding-exit-polish-All-set-string-and-delay-until-album-art-loads.md
+++ b/backlog/tasks/task-171 - Onboarding-exit-polish-All-set-string-and-delay-until-album-art-loads.md
@@ -1,15 +1,15 @@
 ---
 id: TASK-171
 title: 'Onboarding exit polish: "All set!" string and delay until album art loads'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-22 13:12'
-updated_date: '2026-04-22 14:18'
+updated_date: '2026-04-23 00:36'
 labels: []
 milestone: m-30
 dependencies: []
 priority: medium
-ordinal: 1000
+ordinal: 9000
 ---
 
 ## Description

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -54,6 +54,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const [bandcampBusy, setBandcampBusy] = useState(false)
   const [stringIndex, setStringIndex] = useState(0)
   const [stringVisible, setStringVisible] = useState(true)
+  const [showAllSet, setShowAllSet] = useState(false)
   // Fade transition state for content changes
   const [contentVisible, setContentVisible] = useState(true)
 
@@ -92,10 +93,17 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   useEffect(() => {
     if (scanStatus !== 'done' || scanDoneRef.current) return
     scanDoneRef.current = true
-    setVinylPhase('sinking')
     if (step === 'almost-done') {
-      // Delay matches the CSS sinking animation (~600ms).
-      setTimeout(() => onCompleteRef.current(), 700)
+      // Snap rotating strings to "All set!" immediately (deferred to avoid sync setState in effect).
+      setTimeout(() => setShowAllSet(true), 0)
+      // After the 500ms hold, sink the vinyl; then wait for sink + art-preload buffer.
+      setTimeout(() => {
+        setVinylPhase('sinking')
+        // ~600ms CSS sink + ~1s buffer for the browser to begin fetching album art.
+        setTimeout(() => onCompleteRef.current(), 1600)
+      }, 500)
+    } else {
+      setTimeout(() => setVinylPhase('sinking'), 0)
     }
   }, [scanStatus, step])
 
@@ -241,8 +249,11 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
         )}
 
         {step === 'almost-done' && (
-          <div className="onboarding-almost-done-text" style={{ opacity: stringVisible ? 1 : 0 }}>
-            {ALMOST_DONE_STRINGS[stringIndex]}
+          <div
+            className="onboarding-almost-done-text"
+            style={{ opacity: showAllSet || stringVisible ? 1 : 0 }}
+          >
+            {showAllSet ? 'All set!' : ALMOST_DONE_STRINGS[stringIndex]}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- When the library scan finishes on the "Almost Done" step, the rotating tip strings now snap to a static **"All set!"** message instead of continuing to rotate
- The "All set!" message is held for ~500ms before the vinyl sinks, giving the user a moment to read it
- After the vinyl sinks, `onComplete` is deferred by ~1.6s total (600ms sink animation + ~1s buffer) so the browser has time to begin fetching album art before the library view appears — avoiding a flash of broken/missing thumbnails

## Test plan

- [x] Run through onboarding to the "Almost Done" screen; confirm tips rotate normally during the scan
- [x] When the scan finishes, confirm the string snaps to "All set!" (no fade needed)
- [x] Confirm the vinyl sinks ~500ms after "All set!" appears
- [x] Confirm the library view doesn't appear until after the sink completes
- [x] Confirm album art thumbnails are visible (or loading) rather than broken on first library view

🤖 Generated with [Claude Code](https://claude.com/claude-code)