### PR TITLE
feat: add Last.fm login step to onboarding flow (TASK-170)

### DIFF
--- a/backlog/tasks/task-170 - Add-Last.fm-login-step-to-onboarding-flow.md
+++ b/backlog/tasks/task-170 - Add-Last.fm-login-step-to-onboarding-flow.md
@@ -1,15 +1,15 @@
 ---
 id: TASK-170
 title: Add Last.fm login step to onboarding flow
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-04-22 13:12'
-updated_date: '2026-04-22 14:18'
+updated_date: '2026-04-23 01:00'
 labels: []
 milestone: m-30
 dependencies: []
 priority: medium
-ordinal: 2000
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-172 - the-library-folder-is-an-invalid-watch-folder.md
+++ b/backlog/tasks/task-172 - the-library-folder-is-an-invalid-watch-folder.md
@@ -1,0 +1,19 @@
+---
+id: TASK-172
+title: the library folder is an invalid watch folder
+status: To Do
+assignee: []
+created_date: '2026-04-23 01:03'
+labels: []
+milestone: m-30
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+If the user chooses the same folder for the library and watch folders, that's invalid (and the watcher will enter a loop trying to copy files to itself).
+
+Tell the user this is an invalid selection ("Your watch folder can't be the same as your library folder") and have them re-select.
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
+import { connectLastfm } from '../api/client'
 import { useStore } from '../store'
 
-type OnboardingStep = 'welcome' | 'library' | 'watch-folder' | 'bandcamp' | 'almost-done'
+type OnboardingStep = 'welcome' | 'library' | 'watch-folder' | 'bandcamp' | 'lastfm' | 'almost-done'
 type VinylPhase = 'rising' | 'spinning' | 'sinking'
 
 const STEP_TITLES: Record<OnboardingStep, string> = {
@@ -9,6 +10,7 @@ const STEP_TITLES: Record<OnboardingStep, string> = {
   library: 'Library Setup',
   'watch-folder': 'Watch Folder Setup',
   bandcamp: 'Bandcamp Setup',
+  lastfm: 'Last.fm Setup',
   'almost-done': 'Almost Done'
 }
 
@@ -52,6 +54,9 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const [vinylPhase, setVinylPhase] = useState<VinylPhase>('rising')
   const [cardError, setCardError] = useState<string | null>(null)
   const [bandcampBusy, setBandcampBusy] = useState(false)
+  const [lastfmUsername, setLastfmUsername] = useState('')
+  const [lastfmPassword, setLastfmPassword] = useState('')
+  const [lastfmBusy, setLastfmBusy] = useState(false)
   const [stringIndex, setStringIndex] = useState(0)
   const [stringVisible, setStringVisible] = useState(true)
   const [showAllSet, setShowAllSet] = useState(false)
@@ -164,7 +169,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
     try {
       const result = await window.api.bandcamp.beginLogin()
       if (result.ok) {
-        advancePastBandcamp()
+        changeStep('lastfm')
       } else {
         setCardError(result.error ?? 'Login cancelled.')
       }
@@ -175,12 +180,28 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
     }
   }
 
-  function advancePastBandcamp(): void {
+  function advancePastCards(): void {
     if (scanDoneRef.current) {
-      // Scan already finished while we were on a card — done immediately.
       onCompleteRef.current()
     } else {
       changeStep('almost-done')
+    }
+  }
+
+  async function handleLastfmLogin(): Promise<void> {
+    setLastfmBusy(true)
+    setCardError(null)
+    try {
+      const result = await connectLastfm(lastfmUsername, lastfmPassword)
+      if (result.ok) {
+        advancePastCards()
+      } else {
+        setCardError('Login failed.')
+      }
+    } catch {
+      setCardError('Login failed.')
+    } finally {
+      setLastfmBusy(false)
     }
   }
 
@@ -207,7 +228,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
           </div>
         )}
 
-        {(step === 'watch-folder' || step === 'bandcamp') && (
+        {(step === 'watch-folder' || step === 'bandcamp' || step === 'lastfm') && (
           <div className="onboarding-card">
             <div className="onboarding-card-heading">While we&apos;re waiting&hellip;</div>
 
@@ -240,7 +261,44 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                   and put them into your library
                 </p>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
-                <button className="onboarding-skip-btn" onClick={advancePastBandcamp}>
+                <button className="onboarding-skip-btn" onClick={() => changeStep('lastfm')}>
+                  Skip
+                </button>
+              </>
+            )}
+
+            {step === 'lastfm' && (
+              <>
+                <input
+                  className="prefs-input"
+                  type="text"
+                  placeholder="Last.fm username"
+                  value={lastfmUsername}
+                  autoComplete="username"
+                  onChange={(e) => setLastfmUsername(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && void handleLastfmLogin()}
+                />
+                <input
+                  className="prefs-input"
+                  type="password"
+                  placeholder="Password"
+                  value={lastfmPassword}
+                  autoComplete="current-password"
+                  onChange={(e) => setLastfmPassword(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && void handleLastfmLogin()}
+                />
+                <button
+                  className="onboarding-primary-btn"
+                  onClick={handleLastfmLogin}
+                  disabled={lastfmBusy}
+                >
+                  {lastfmBusy ? 'Connecting…' : 'Connect Last.fm'}
+                </button>
+                <p className="onboarding-card-body">
+                  Connect your <strong>Last.fm</strong> account to scrobble what you listen to.
+                </p>
+                {cardError && <div className="onboarding-error">{cardError}</div>}
+                <button className="onboarding-skip-btn" onClick={advancePastCards}>
                   Skip
                 </button>
               </>

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -295,7 +295,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                   {lastfmBusy ? 'Connecting…' : 'Connect Last.fm'}
                 </button>
                 <p className="onboarding-card-body">
-                  Connect your <strong>Last.fm</strong> account to scrobble what you listen to.
+                  Connect your <strong>Last.fm</strong> account to save your listening history.
                 </p>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
                 <button className="onboarding-skip-btn" onClick={advancePastCards}>


### PR DESCRIPTION
## Summary

- Inserts a `lastfm` step between Bandcamp and Almost Done in the onboarding flow
- Username + password fields (using `prefs-input` styling), Enter key submits, Skip is low-friction
- Bandcamp login success and Skip both advance to Last.fm instead of bypassing it
- Extracts `advancePastCards` helper shared by both terminal card handlers (Bandcamp login is no longer the only path to Almost Done)

## Test plan

- [x] Complete Bandcamp login → lands on Last.fm step
- [x] Skip Bandcamp → lands on Last.fm step
- [x] Complete Last.fm login → advances to Almost Done (or completes immediately if scan is already done)
- [x] Skip Last.fm → advances to Almost Done (or completes immediately if scan is already done)
- [x] Enter key on username or password field submits credentials
- [x] Input fields match app styling (dark background, accent focus ring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)