### PR TITLE
fix: guard against watch folder matching library folder (TASK-172)

### DIFF
--- a/backlog/tasks/task-169 - dynamic-rotating-strings-in-onboarding-Almost-Done-screen.md
+++ b/backlog/tasks/task-169 - dynamic-rotating-strings-in-onboarding-Almost-Done-screen.md
@@ -4,14 +4,16 @@ title: dynamic rotating strings in onboarding Almost Done screen
 status: To Do
 assignee: []
 created_date: '2026-04-22 02:11'
+updated_date: '2026-04-23 01:22'
 labels:
   - feature
   - ui
   - 'estimate: side'
-milestone: m-28
+milestone: m-30
 dependencies:
   - TASK-139
 priority: low
+ordinal: 1000
 ---
 
 ## Description

--- a/backlog/tasks/task-170 - Add-Last.fm-login-step-to-onboarding-flow.md
+++ b/backlog/tasks/task-170 - Add-Last.fm-login-step-to-onboarding-flow.md
@@ -1,15 +1,15 @@
 ---
 id: TASK-170
 title: Add Last.fm login step to onboarding flow
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-22 13:12'
-updated_date: '2026-04-23 01:00'
+updated_date: '2026-04-23 01:22'
 labels: []
 milestone: m-30
 dependencies: []
 priority: medium
-ordinal: 1000
+ordinal: 10000
 ---
 
 ## Description

--- a/backlog/tasks/task-172 - the-library-folder-is-an-invalid-watch-folder.md
+++ b/backlog/tasks/task-172 - the-library-folder-is-an-invalid-watch-folder.md
@@ -1,13 +1,15 @@
 ---
 id: TASK-172
 title: the library folder is an invalid watch folder
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-23 01:03'
+updated_date: '2026-04-23 01:22'
 labels: []
 milestone: m-30
 dependencies: []
 priority: medium
+ordinal: 11000
 ---
 
 ## Description

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -49,6 +49,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const setLibraryPath = useStore((s) => s.setLibraryPath)
   const scanLibrary = useStore((s) => s.scanLibrary)
   const setWatchFolderPath = useStore((s) => s.setWatchFolderPath)
+  const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
 
   const [step, setStep] = useState<OnboardingStep>('welcome')
   const [vinylPhase, setVinylPhase] = useState<VinylPhase>('rising')
@@ -154,6 +155,10 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
     setCardError(null)
     const dir = await window.api.openDirectory()
     if (dir === null) return
+    if (dir === configuredLibraryPath) {
+      setCardError("Your watch folder can't be the same as your library folder.")
+      return
+    }
     try {
       await setWatchFolderPath(dir)
     } catch {

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -954,6 +954,13 @@ export function PreferencesDialog({
         throw new Error('Enter a whole number (0 or greater).')
     }
 
+    if (key === 'paths.watch_folder' && value === str('paths.library')) {
+      throw new Error("Your watch folder can't be the same as your library folder.")
+    }
+    if (key === 'paths.library' && value === str('paths.watch_folder')) {
+      throw new Error("Your library folder can't be the same as your watch folder.")
+    }
+
     await setConfigValue(key, value)
   }
 


### PR DESCRIPTION
## Summary

- Blocks selection of a watch folder identical to the library folder in the onboarding flow (`OnboardingScreen`)
- Same guard added to the preferences dialog (`PreferencesDialog`) — validates both directions (watch = library and library = watch)
- Error message: *"Your watch folder can't be the same as your library folder."* / reverse for the library row

## Why

The watcher would enter a copy-to-itself loop if both paths were the same.

## Test plan

- [x] During onboarding, choose the same directory for both library and watch folder — error message appears, step does not advance
- [x] In Preferences > General > Paths, try setting watch folder to match library folder — error shown under the row
- [x] In Preferences, try setting library folder to match the current watch folder — error shown under the row
- [x] Valid (different) path selections still save and advance normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)