### PR TITLE
feat: dynamic rotating strings in onboarding Almost Done screen (TASK-169)

### DIFF
--- a/backlog/tasks/task-169 - dynamic-rotating-strings-in-onboarding-Almost-Done-screen.md
+++ b/backlog/tasks/task-169 - dynamic-rotating-strings-in-onboarding-Almost-Done-screen.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-169
 title: dynamic rotating strings in onboarding Almost Done screen
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-22 02:11'
-updated_date: '2026-04-23 01:22'
+updated_date: '2026-04-23 01:48'
 labels:
   - feature
   - ui
@@ -13,7 +13,7 @@ milestone: m-30
 dependencies:
   - TASK-139
 priority: low
-ordinal: 1000
+ordinal: 12000
 ---
 
 ## Description

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1429,7 +1429,7 @@ class LibraryScanner:
     def scan(
         self,
         library_path: Path,
-        on_progress: Callable[[int, int], None] | None = None,
+        on_progress: Callable[[int, int, "Track | None"], None] | None = None,
     ) -> ScanResult:
         """Scan *library_path* recursively and update the index.
 
@@ -1439,8 +1439,9 @@ class LibraryScanner:
         removed.
 
         *on_progress*, if provided, is called after each processed file's tags
-        are read with (current, total) where total = number of files to index
-        (new + updated).
+        are read with (current, total, track) where total = number of files to
+        index (new + updated) and track is the parsed Track (or None if parsing
+        failed).
         """
         if not library_path.exists():
             return ScanResult(added=0, removed=0, unchanged=0)
@@ -1476,7 +1477,7 @@ class LibraryScanner:
             else:
                 logger.warning("Skipped unreadable file: %s", path)
             if on_progress is not None:
-                on_progress(current, total)
+                on_progress(current, total, track)
         self._index.upsert_many(tracks_to_upsert)
 
         newly_added = [t for t in tracks_to_upsert if t.file_path in to_add]

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -302,7 +302,14 @@ def create_app(
     # detect the bump on the next ping and push a "library.changed" notification.
     _state: dict[str, Any] = {
         "library_path": library_path,
-        "scan_progress": {"active": False, "current": 0, "total": 0},
+        "scan_progress": {
+            "active": False,
+            "current": 0,
+            "total": 0,
+            "current_file": None,
+            "current_artist": None,
+            "top_artist": None,
+        },
         "ui_active_view": ui_active_view,
         "ui_sort_order": ui_sort_order,
         "ui_queue_panel_open": ui_queue_panel_open,
@@ -510,20 +517,54 @@ def create_app(
         if _state["library_path"] is None:
             raise HTTPException(status_code=503, detail="Library path not configured")
 
-        def _on_progress(current: int, total: int) -> None:
+        # Running artist frequency map, accumulated across all on_progress calls.
+        artist_counts: dict[str, int] = {}
+
+        def _on_progress(current: int, total: int, track: Track | None) -> None:
+            current_file: str | None = None
+            current_artist: str | None = None
+            if track is not None:
+                current_file = track.title.strip() or track.file_path.stem
+                if track.artist.strip():
+                    current_artist = track.artist.strip()
+                    artist_counts[current_artist] = (
+                        artist_counts.get(current_artist, 0) + 1
+                    )
+            top_artist = (
+                max(artist_counts, key=lambda a: artist_counts[a])
+                if artist_counts
+                else None
+            )
             _state["scan_progress"] = {
                 "active": True,
                 "current": current,
                 "total": total,
+                "current_file": current_file,
+                "current_artist": current_artist,
+                "top_artist": top_artist,
             }
 
-        _state["scan_progress"] = {"active": True, "current": 0, "total": 0}
+        _state["scan_progress"] = {
+            "active": True,
+            "current": 0,
+            "total": 0,
+            "current_file": None,
+            "current_artist": None,
+            "top_artist": None,
+        }
         try:
             result = LibraryScanner(index).scan(
                 _state["library_path"], on_progress=_on_progress
             )
         finally:
-            _state["scan_progress"] = {"active": False, "current": 0, "total": 0}
+            _state["scan_progress"] = {
+                "active": False,
+                "current": 0,
+                "total": 0,
+                "current_file": None,
+                "current_artist": None,
+                "top_artist": None,
+            }
 
         return ScanResult(
             added=result.added,

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -188,7 +188,14 @@ export const setSortOrderApi = (
 export const setQueuePanelApi = (open: boolean): Promise<{ ok: boolean }> =>
   post('/api/v1/ui/queue-panel', { open })
 
-export type ScanProgress = { active: boolean; current: number; total: number }
+export type ScanProgress = {
+  active: boolean
+  current: number
+  total: number
+  current_file?: string | null
+  current_artist?: string | null
+  top_artist?: string | null
+}
 
 export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')
 

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { connectLastfm } from '../api/client'
+import { type ScanProgress, connectLastfm } from '../api/client'
 import { useStore } from '../store'
 
 type OnboardingStep = 'welcome' | 'library' | 'watch-folder' | 'bandcamp' | 'lastfm' | 'almost-done'
@@ -14,14 +14,25 @@ const STEP_TITLES: Record<OnboardingStep, string> = {
   'almost-done': 'Almost Done'
 }
 
-const ALMOST_DONE_STRINGS = [
+const STATIC_STRINGS = [
   'Almost done…',
+  'Just a little bit longer…',
   "In the Library, press 'A' to show or hide the Artist panel",
   "The 'Now Playing' tab shows off your album art",
   "Press 'Q' at any time to show or hide the Queue panel",
   'Good things are worth waiting for…',
   'What are you gonna listen to first?'
 ]
+
+function buildDynamicStrings(progress: ScanProgress | null): string[] {
+  if (!progress?.active) return []
+  const strings: string[] = []
+  if (progress.current_file && progress.current_artist) strings.push(`My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
+  if (progress.top_artist) strings.push(`You ever hear of ${progress.top_artist}?`)
+  if (progress.current_artist) strings.push(`Ooooh, I haven't heard ${progress.current_artist} in ages!`)
+  if (progress.current_artist) strings.push(`I'd sell my left kidney to see ${progress.current_artist} live…`)
+  return strings
+}
 
 // Vinyl proportions derived from the splash screen record (r=86 baseline).
 // All values below are for R=300.
@@ -58,7 +69,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const [lastfmUsername, setLastfmUsername] = useState('')
   const [lastfmPassword, setLastfmPassword] = useState('')
   const [lastfmBusy, setLastfmBusy] = useState(false)
-  const [stringIndex, setStringIndex] = useState(0)
+  const [currentString, setCurrentString] = useState(STATIC_STRINGS[0])
   const [stringVisible, setStringVisible] = useState(true)
   const [showAllSet, setShowAllSet] = useState(false)
   // Fade transition state for content changes
@@ -113,16 +124,28 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
     }
   }, [scanStatus, step])
 
+  // Keep refs so the rotation interval can read the latest values without
+  // needing them as dependencies (which would restart the interval on every poll tick).
+  const dynamicStringsRef = useRef<string[]>([])
+  const stringPosRef = useRef(0)
+  useEffect(() => {
+    dynamicStringsRef.current = buildDynamicStrings(scanProgress)
+  }, [scanProgress])
+
   // Rotate the 'Almost done' strings every 4s with a fade.
+  // The next string is snapshotted during the fade-out so live scanProgress
+  // updates between rotations never mutate the currently visible string.
   useEffect(() => {
     if (step !== 'almost-done') return
     const t = setInterval(() => {
       setStringVisible(false)
       setTimeout(() => {
-        setStringIndex((i) => (i + 1) % ALMOST_DONE_STRINGS.length)
+        const pool = [...STATIC_STRINGS, ...dynamicStringsRef.current]
+        stringPosRef.current = (stringPosRef.current + 1) % pool.length
+        setCurrentString(pool[stringPosRef.current])
         setStringVisible(true)
       }, 350)
-    }, 4000)
+    }, 3000)
     return () => clearInterval(t)
   }, [step])
 
@@ -316,7 +339,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
             className="onboarding-almost-done-text"
             style={{ opacity: showAllSet || stringVisible ? 1 : 0 }}
           >
-            {showAllSet ? 'All set!' : ALMOST_DONE_STRINGS[stringIndex]}
+            {showAllSet ? 'All set!' : currentString}
           </div>
         )}
       </div>

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -27,10 +27,13 @@ const STATIC_STRINGS = [
 function buildDynamicStrings(progress: ScanProgress | null): string[] {
   if (!progress?.active) return []
   const strings: string[] = []
-  if (progress.current_file && progress.current_artist) strings.push(`My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
+  if (progress.current_file && progress.current_artist)
+    strings.push(`My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
   if (progress.top_artist) strings.push(`You ever hear of ${progress.top_artist}?`)
-  if (progress.current_artist) strings.push(`Ooooh, I haven't heard ${progress.current_artist} in ages!`)
-  if (progress.current_artist) strings.push(`I'd sell my left kidney to see ${progress.current_artist} live…`)
+  if (progress.current_artist)
+    strings.push(`Ooooh, I haven't heard ${progress.current_artist} in ages!`)
+  if (progress.current_artist)
+    strings.push(`I'd sell my left kidney to see ${progress.current_artist} live…`)
   return strings
 }
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -827,7 +827,9 @@ class TestLibraryScanner:
 
         calls: list[tuple[int, int]] = []
         index = LibraryIndex(tmp_path / "library.db")
-        LibraryScanner(index).scan(lib, on_progress=lambda c, t: calls.append((c, t)))
+        LibraryScanner(index).scan(
+            lib, on_progress=lambda c, t, _track: calls.append((c, t))
+        )
         index.close()
 
         # One call per new file; total is always 3.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -660,6 +661,39 @@ class TestScanProgressEndpoint:
             data = c.get("/api/v1/library/scan/progress").json()
 
         assert data["active"] is False
+
+    def test_progress_exposes_track_data(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        captured: list[Any] = []
+
+        def _fake_scan(path: object, on_progress: Any = None) -> MagicMock:
+            captured.append(on_progress)
+            return MagicMock(added=1, removed=0, unchanged=0)
+
+        with patch("kamp_core.server.LibraryScanner") as MockScanner:
+            MockScanner.return_value.scan.side_effect = _fake_scan
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                library_path=Path("/music"),
+            )
+            c = TestClient(app)
+            c.post("/api/v1/library/scan")
+
+        # Invoke the captured callback with two tracks to simulate scan progress.
+        track_a = _track(1, artist="Aphex Twin", album="Selected Ambient Works")
+        track_a.title = "Xtal"
+        track_b = _track(2, artist="Aphex Twin", album="Selected Ambient Works")
+        track_b.title = "Tha"
+        captured[0](1, 2, track_a)
+        captured[0](2, 2, track_b)
+
+        data = c.get("/api/v1/library/scan/progress").json()
+        assert data["current_file"] == "Tha"
+        assert data["current_artist"] == "Aphex Twin"
+        assert data["top_artist"] == "Aphex Twin"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extends `GET /api/v1/library/scan/progress` to expose `current_file`, `current_artist`, and `top_artist` (most-frequently-seen artist so far in the scan)
- `LibraryScanner.scan()` now passes the parsed `Track` (or `None`) as a third arg to the `on_progress` callback
- The onboarding Almost Done screen builds a dynamic string pool from live scan data and mixes it with the static strings — e.g. _"My favorite song is Xtal by Aphex Twin…"_, _"You ever hear of Boards of Canada?"_
- Strings are snapshotted at the start of each fade-out transition so polling updates can't mutate the currently visible string mid-display

## Test plan

- [x] Verify the static strings cycle correctly when no scan data is available
- [x] Trigger a library scan and confirm dynamic strings appear once the scanner has processed a few tracks
- [x] Confirm the displayed string doesn't jump/change mid-display between poll ticks
- [x] All CI checks pass (292 Python tests, mypy, frontend typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)