### PR TITLE
fix(ui): enable drag-to-queue from search results (TASK-186)

### DIFF
--- a/backlog/tasks/task-174 - support-bandcamp-pre-orders.md
+++ b/backlog/tasks/task-174 - support-bandcamp-pre-orders.md
@@ -4,7 +4,11 @@ title: support bandcamp pre-orders
 status: To Do
 assignee: []
 created_date: '2026-04-24 01:45'
-labels: []
+updated_date: '2026-04-30 23:22'
+labels:
+  - feature
+  - bandcamp
+  - 'estimate: lp'
 milestone: m-1
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-176 - stream-from-bandcamp.md
+++ b/backlog/tasks/task-176 - stream-from-bandcamp.md
@@ -4,7 +4,11 @@ title: stream from bandcamp
 status: To Do
 assignee: []
 created_date: '2026-04-24 01:50'
-labels: []
+updated_date: '2026-04-30 23:22'
+labels:
+  - feature
+  - bandcamp
+  - 'estimate: box set'
 milestone: m-1
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-182 - Bundle-mpv-dylibs-so-mpv-works-on-machines-without-Homebrew.md
+++ b/backlog/tasks/task-182 - Bundle-mpv-dylibs-so-mpv-works-on-machines-without-Homebrew.md
@@ -4,14 +4,14 @@ title: Bundle mpv dylibs so mpv works on machines without Homebrew
 status: Done
 assignee: []
 created_date: '2026-04-26'
-updated_date: '2026-04-30 21:06'
+updated_date: '2026-05-01 12:34'
 labels:
   - build
   - packaging
 milestone: m-32
 dependencies: []
 priority: medium
-ordinal: 1000
+ordinal: 2000
 ---
 
 ## Description

--- a/backlog/tasks/task-183 - Add-otool-audit-step-to-CI-to-catch-Homebrew-linked-dylibs-in-PyInstaller-bundle.md
+++ b/backlog/tasks/task-183 - Add-otool-audit-step-to-CI-to-catch-Homebrew-linked-dylibs-in-PyInstaller-bundle.md
@@ -6,10 +6,11 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-04-26'
-updated_date: '2026-04-30 21:06'
+updated_date: '2026-04-30 23:22'
 labels:
   - build
   - ci
+  - 'estimate: single'
 milestone: m-32
 dependencies: []
 priority: medium

--- a/backlog/tasks/task-184 - Enable-optional-file-logging-from-the-application.md
+++ b/backlog/tasks/task-184 - Enable-optional-file-logging-from-the-application.md
@@ -4,11 +4,12 @@ title: Enable optional file logging from the application
 status: To Do
 assignee: []
 created_date: '2026-04-30'
-updated_date: '2026-04-30 21:06'
+updated_date: '2026-05-01 12:34'
 labels:
   - dx
   - diagnostics
-milestone: m-32
+  - 'estimate: side'
+milestone: m-20
 dependencies: []
 priority: low
 ordinal: 3000

--- a/backlog/tasks/task-185 - Build-minimal-mpv-from-source-with-audio-only-feature-set.md
+++ b/backlog/tasks/task-185 - Build-minimal-mpv-from-source-with-audio-only-feature-set.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-185
 title: Build minimal mpv from source with audio-only feature set
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-30'
-updated_date: '2026-04-30 21:37'
+updated_date: '2026-05-01 02:14'
 labels:
   - build
   - packaging
@@ -93,3 +93,9 @@ With a minimal build, the expected dylib count drops from ~50 to ~15–20.
 - Audio playback works end-to-end in the packaged app on a clean machine (no Homebrew)
 - No VapourSynth, LuaJIT, or other non-audio dylibs appear in mpv-libs/
 <!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Built mpv v0.41.0 from source with audio-only meson flags. Replaced the Homebrew binary copy + VapourSynth post-hoc removal hack. Dylib count: 47 → 32. No VapourSynth, no LuaJIT. Both arm64 and x64 CI runners passed including full sign-and-package. Lessons captured in CLAUDE.md: libplacebo is a hard dep (no disable flag), sdl2 split into three options, pulse not pulseaudio, iterate meson flags locally not in CI.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-186 - click-and-drag-to-queue-from-search-view-doesnt-insert-tracks-in-queue.md
+++ b/backlog/tasks/task-186 - click-and-drag-to-queue-from-search-view-doesnt-insert-tracks-in-queue.md
@@ -1,16 +1,17 @@
 ---
 id: TASK-186
 title: click and drag to queue from search view doesn't insert tracks in queue
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-04-30 21:30'
-updated_date: '2026-05-01 11:12'
+updated_date: '2026-05-01 12:34'
 labels:
   - bug
   - ui
   - 'estimate: side'
 milestone: m-32
 dependencies: []
+ordinal: 3000
 ---
 
 ## Description

--- a/backlog/tasks/task-186 - click-and-drag-to-queue-from-search-view-doesnt-insert-tracks-in-queue.md
+++ b/backlog/tasks/task-186 - click-and-drag-to-queue-from-search-view-doesnt-insert-tracks-in-queue.md
@@ -1,0 +1,29 @@
+---
+id: TASK-186
+title: click and drag to queue from search view doesn't insert tracks in queue
+status: In Progress
+assignee: []
+created_date: '2026-04-30 21:30'
+updated_date: '2026-05-01 11:12'
+labels:
+  - bug
+  - ui
+  - 'estimate: side'
+milestone: m-32
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+to repro:
+start with a populated queue
+search for 'Neurosis'
+click and drag their latest, "An Undying Love for a Burning World", into the middle of the queue somewhere after the playing track
+
+expected:
+album is inserted into queue at drop position
+
+actual:
+nothing is insert into queue
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-187 - change-behavior-from-single-click-to-play-to-double-click-to-play.md
+++ b/backlog/tasks/task-187 - change-behavior-from-single-click-to-play-to-double-click-to-play.md
@@ -1,0 +1,19 @@
+---
+id: TASK-187
+title: change behavior from single-click to play to double-click to play
+status: To Do
+assignee: []
+created_date: '2026-05-01 02:28'
+updated_date: '2026-05-01 02:28'
+labels: []
+milestone: m-32
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+it's too easy for a user to lose an entire queue of songs because they click on a track.
+
+double-click is a standard behavior, plus we will want to enable click-to-select at some point in the future.
+<!-- SECTION:DESCRIPTION:END -->

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -30,9 +30,21 @@ function SearchAlbumCard({
     <div
       className="search-album-card"
       tabIndex={0}
+      draggable
       onClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       onContextMenu={(e) => onContextMenu(e, album)}
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'text/kamp-album',
+          JSON.stringify({
+            album_artist: album.album_artist,
+            album: album.album,
+            file_path: album.file_path
+          })
+        )
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
     >
       <div className={`search-album-art${artLoaded ? ' has-art' : ''}`}>
         {album.has_art && (
@@ -79,9 +91,14 @@ function SearchTrackRow({
     <div
       className="search-track-row"
       tabIndex={0}
+      draggable
       onClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       onContextMenu={(e) => onContextMenu(e, track)}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
     >
       <span className="search-track-fav" aria-hidden="true">
         {track.favorite ? '♥' : ''}


### PR DESCRIPTION
## Summary

- `SearchAlbumCard` and `SearchTrackRow` in `SearchView.tsx` had no `draggable` attribute or `onDragStart` handler, so the browser never initiated a drag and nothing reached the queue drop target
- Added `draggable` + `onDragStart` to both components, mirroring the existing pattern in `AlbumCard` (`AlbumGrid.tsx`) and `TrackList.tsx`
- No changes to `QueuePanel.tsx` — it already handles `text/kamp-album` and `text/kamp-track-path` for both insert-at-index and append-to-end drops

## Test plan

- [x] Start app with a populated queue
- [x] Search for an artist with multiple albums
- [x] Drag an album card from search results onto a specific queue row → album inserts at that position
- [x] Drag an album card and drop below all queue rows → album appends to end
- [x] Drag a single track row from search results → same insert/append behaviour
- [x] Right-click context menu "Add to Queue" still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)