### PR TITLE
fix(ui): require double-click to play tracks (TASK-187)

### DIFF
--- a/backlog/milestones/m-33 - build-toolchain.md
+++ b/backlog/milestones/m-33 - build-toolchain.md
@@ -1,0 +1,8 @@
+---
+id: m-33
+title: "Build Toolchain"
+---
+
+## Description
+
+Milestone: Build Toolchain

--- a/backlog/tasks/task-183 - Add-otool-audit-step-to-CI-to-catch-Homebrew-linked-dylibs-in-PyInstaller-bundle.md
+++ b/backlog/tasks/task-183 - Add-otool-audit-step-to-CI-to-catch-Homebrew-linked-dylibs-in-PyInstaller-bundle.md
@@ -6,12 +6,12 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-04-26'
-updated_date: '2026-04-30 23:22'
+updated_date: '2026-05-01 12:51'
 labels:
   - build
   - ci
   - 'estimate: single'
-milestone: m-32
+milestone: m-33
 dependencies: []
 priority: medium
 ordinal: 2000

--- a/backlog/tasks/task-187 - change-behavior-from-single-click-to-play-to-double-click-to-play.md
+++ b/backlog/tasks/task-187 - change-behavior-from-single-click-to-play-to-double-click-to-play.md
@@ -1,13 +1,14 @@
 ---
 id: TASK-187
 title: change behavior from single-click to play to double-click to play
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-01 02:28'
-updated_date: '2026-05-01 02:28'
+updated_date: '2026-05-01 12:50'
 labels: []
 milestone: m-32
 dependencies: []
+ordinal: 4000
 ---
 
 ## Description

--- a/claude.md
+++ b/claude.md
@@ -98,6 +98,16 @@ Variables captured at daemon startup (e.g. `lib_path`, `lib_watcher`) are NOT au
 ## UI config refresh after config-changing events
 The server does NOT push config changes over WebSocket. After any event that changes server-side config (Bandcamp login, library path set, etc.), the UI store must explicitly call `loadConfig()` to pick up the new state. Without this, fields like `bandcamp.connected` stay stale from the initial mount, hiding UI elements that depend on them (e.g. the sync button).
 
+## Building mpv from source in CI
+
+When building mpv from source, use the latest release tag (v0.41.0 as of 2026-04) — older tags are incompatible with Homebrew's current FFmpeg (8.x removed `FF_PROFILE_*` constants and `av_format_inject_global_side_data`).
+
+- **libplacebo is a hard required dep** in v0.41.0 — there is no meson `-Dlibplacebo=disabled` flag. Install it via `brew install libplacebo`; it pulls in shaderc and vulkan-loader transitively.
+- **sdl2 split into three options** in v0.41.0: `-Dsdl2-audio=disabled -Dsdl2-video=disabled -Dsdl2-gamepad=disabled` (the old `-Dsdl2=disabled` errors out).
+- **PulseAudio option is `pulse`**, not `pulseaudio`.
+- **Iterate meson flag errors locally**, not in CI: clone mpv, run `meson setup`, check `meson.options` for valid option names, build with ninja, then run dylibbundler to verify final dylib count before pushing.
+- With the minimal flag set (audio-only), expect ~32 bundled dylibs (down from ~47 with Homebrew mpv). The video encoder libs (x264/x265/SVT-AV1/vmaf) come from Homebrew FFmpeg's transitive deps and cannot be avoided without building FFmpeg from source.
+
 ## Shared debounce and high-volume FSEvents
 `_LibraryHandler._schedule()` (in `watcher.py`) is shared between FSEvents from the library directory and explicit `trigger_scan()` calls. During a large batch sync, continuous FSEvents from files being moved in reset the debounce timer faster than the `_MAX_SETTLE_SECONDS` cap fires. To guarantee a scan fires after each pipeline completion, bypass the debounce entirely: call `_on_library_change` directly in a `threading.Thread` from `on_pipeline_complete` instead of routing through `lib_watcher.trigger_scan()`.
 

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -92,7 +92,7 @@ function SearchTrackRow({
       className="search-track-row"
       tabIndex={0}
       draggable
-      onClick={handleClick}
+      onDoubleClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       onContextMenu={(e) => onContextMenu(e, track)}
       onDragStart={(e) => {

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -109,7 +109,7 @@ export function TrackList(): React.JSX.Element | null {
                 key={`${track.disc_number}-${track.track_number}`}
                 className={`track-row${isCurrent ? ' current' : ''}`}
                 tabIndex={0}
-                onClick={() => {
+                onDoubleClick={() => {
                   if (isCurrent) {
                     togglePlayPause()
                   } else {


### PR DESCRIPTION
## Summary

- Album track rows and search track rows now require a double-click to start playback
- Single-click is now a no-op on track rows, preventing accidental queue replacement
- Keyboard (Enter) and drag behaviour are unchanged
- Queue panel was already using `onDoubleClick` — this aligns the other views with it

## Test plan

- [x] Album view: single-click a track → nothing happens; double-click → playback starts
- [x] Album view: double-click the currently playing track → toggles pause/play
- [x] Search view: single-click a result → nothing happens; double-click → plays and clears search
- [x] Queue panel: double-click still skips to that track (unchanged)
- [x] Keyboard: tab to a track row, press Enter → plays (unchanged)
- [x] Drag from album and search views still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)