### PR TITLE
fix(ui): add New Folder button to library location picker (KAMP-223)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -728,7 +728,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('open-directory', async () => {
     const result = await dialog.showOpenDialog({
-      properties: ['openDirectory'],
+      properties: ['openDirectory', 'createDirectory'],
       title: 'Choose Music Library Folder',
       defaultPath: join(homedir(), 'Music')
     })


### PR DESCRIPTION
## Summary
- Adds `createDirectory` to the `showOpenDialog` properties array, enabling the native macOS "New Folder" button in the library location picker
- Users can now create a subfolder (e.g. `~/Music/Kamp`) directly from the dialog without leaving the app

## Test plan
- [x] Open Preferences → Library path picker
- [x] Verify a "New Folder" button appears in the macOS directory picker
- [x] Create a new folder and confirm it can be selected as the library location

🤖 Generated with [Claude Code](https://claude.com/claude-code)