### PR TITLE
feat(ui): Reveal in Finder / Show in Explorer / Show in Files (KAMP-222)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -726,6 +726,10 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('kamp:uninstall-extension', (_event, id: string) => uninstallExtension(id))
 
+  ipcMain.on('shell:show-item-in-folder', (_event, filePath: string) => {
+    shell.showItemInFolder(filePath)
+  })
+
   ipcMain.handle('open-directory', async () => {
     const result = await dialog.showOpenDialog({
       properties: ['openDirectory', 'createDirectory'],

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -17,6 +17,7 @@ declare global {
         onStage: (callback: (stage: string) => void) => () => void
       }
       getApiToken: () => string | null
+      showItemInFolder: (filePath: string) => void
     }
     KampAPI: KampAPI
   }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -56,7 +56,9 @@ const api = {
     onStage: onPipelineStage
   },
   // Re-reads from disk so Electron picks up a fresh token after daemon restart.
-  getApiToken: (): string | null => _readKampToken()
+  getApiToken: (): string | null => _readKampToken(),
+  showItemInFolder: (filePath: string): void =>
+    ipcRenderer.send('shell:show-item-in-folder', filePath)
 }
 
 const kampAPI = buildKampAPI()

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 // album → back). Module-level so it survives React unmounting the component.
 let savedScrollTop = 0
 import { useStore } from '../store'
-import { artUrl } from '../api/client'
+import { artUrl, getTracksForAlbum } from '../api/client'
 import type { Album } from '../api/client'
 import { SortControl } from './SortControl'
 import { BandcampButton } from './BandcampButton'
@@ -161,6 +161,24 @@ export function AlbumGrid(): React.JSX.Element {
             }}
           >
             + Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={async () => {
+              let filePath = menu.album.file_path
+              if (!filePath) {
+                const tracks = await getTracksForAlbum(menu.album.album_artist, menu.album.album)
+                filePath = tracks[0]?.file_path ?? ''
+              }
+              if (filePath) window.api.showItemInFolder(filePath)
+              setMenu(null)
+            }}
+          >
+            {window.electron.process.platform === 'darwin'
+              ? '↗ Reveal in Finder'
+              : window.electron.process.platform === 'win32'
+                ? '↗ Show in Explorer'
+                : '↗ Show in Files'}
           </button>
         </div>
       )}

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
-import { artUrl } from '../api/client'
+import { artUrl, getTracksForAlbum } from '../api/client'
 import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
 import { useMenuBounds } from '../hooks/useMenuBounds'
@@ -240,6 +240,27 @@ export function SearchView(): React.JSX.Element {
           >
             + Add to Queue
           </button>
+          <button
+            className="track-context-menu-item"
+            onClick={async () => {
+              let filePath = albumMenu.album.file_path
+              if (!filePath) {
+                const tracks = await getTracksForAlbum(
+                  albumMenu.album.album_artist,
+                  albumMenu.album.album
+                )
+                filePath = tracks[0]?.file_path ?? ''
+              }
+              if (filePath) window.api.showItemInFolder(filePath)
+              setAlbumMenu(null)
+            }}
+          >
+            {window.electron.process.platform === 'darwin'
+              ? '↗ Reveal in Finder'
+              : window.electron.process.platform === 'win32'
+                ? '↗ Show in Explorer'
+                : '↗ Show in Files'}
+          </button>
         </div>
       )}
 
@@ -288,6 +309,19 @@ export function SearchView(): React.JSX.Element {
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
             {trackMenu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              window.api.showItemInFolder(trackMenu.filePath)
+              setTrackMenu(null)
+            }}
+          >
+            {window.electron.process.platform === 'darwin'
+              ? '↗ Reveal in Finder'
+              : window.electron.process.platform === 'win32'
+                ? '↗ Show in Explorer'
+                : '↗ Show in Files'}
           </button>
         </div>
       )}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -192,6 +192,19 @@ export function TrackList(): React.JSX.Element | null {
             </svg>
             {menu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
           </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              window.api.showItemInFolder(menu.filePath)
+              setMenu(null)
+            }}
+          >
+            {window.electron.process.platform === 'darwin'
+              ? '↗ Reveal in Finder'
+              : window.electron.process.platform === 'win32'
+                ? '↗ Show in Explorer'
+                : '↗ Show in Files'}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Adds a platform-aware "Reveal in Finder" (macOS) / "Show in Explorer" (Windows) / "Show in Files" (Linux) item to every track and album context menu
- Covered surfaces: track list, album grid, search results (albums + tracks)
- IPC is fire-and-forget via `ipcRenderer.send` → `shell.showItemInFolder()`
- For regular albums (where `Album.file_path` is empty), fetches the first track via `getTracksForAlbum` to get a representative path — opens the album folder with that file selected

## Related

- Closes KAMP-222
- KAMP-224 (Windows validation) and KAMP-225 (Linux validation) created under their respective epics

## Test plan

- [x] Right-click a track in the track list → "↗ Reveal in Finder" appears; clicking it opens Finder with the file selected
- [x] Right-click an album in the album grid → same item appears; Finder opens the album folder
- [x] Right-click an album in search results → works as above
- [x] Right-click a track in search results → works as above
- [x] Right-click a missing-album track (no proper album) → still works (uses `file_path` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)