### PR TITLE
feat(playback): gapless track transitions via mpv playlist lookahead (KAMP-30)

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -91,6 +91,18 @@ class PlaybackQueue:
         self._pos = next_pos
         return self.current()
 
+    def peek_next(self) -> Track | None:
+        """Return the next track without advancing the position."""
+        if not self._tracks:
+            return None
+        next_pos = self._pos + 1
+        if next_pos >= len(self._order):
+            if self._repeat:
+                next_pos = 0
+            else:
+                return None
+        return self._tracks[self._order[next_pos]]
+
     def prev(self) -> Track | None:
         if not self._tracks:
             return None
@@ -341,6 +353,9 @@ class MpvPlaybackEngine:
         # Stored here rather than in on_file_loaded so it doesn't clobber the
         # external callback chain wired up after engine creation.
         self._pending_seek: float | None = None
+        # Path of the track pre-appended to mpv's playlist as a gapless lookahead.
+        # None means mpv's playlist has only the current track (slot 0).
+        self._lookahead_path: Path | None = None
         self._start_mpv()
 
     def _start_mpv(self) -> None:  # pragma: no cover
@@ -360,6 +375,9 @@ class MpvPlaybackEngine:
                 # subprocess via MPRemoteCommandCenter (registered by the process
                 # that owns MPNowPlayingInfoCenter, which is now the helper).
                 "--input-media-keys=no",
+                # Pre-buffer the next playlist entry before the current one ends so
+                # track transitions are seamless.
+                "--gapless-audio=yes",
             ],
             stdout=subprocess.DEVNULL,
             # Capture stderr so we can surface it if mpv fails to start.
@@ -406,6 +424,8 @@ class MpvPlaybackEngine:
     # ------------------------------------------------------------------
 
     def play(self, path: Path) -> None:
+        # loadfile replace clears mpv's entire playlist, including any lookahead.
+        self._lookahead_path = None
         self._send_command("loadfile", str(path), "replace")
         # Explicitly unpause so calling play() after pause() always starts playback.
         self._send_command("set_property", "pause", False)
@@ -421,9 +441,39 @@ class MpvPlaybackEngine:
         dropped by mpv.  The position is stored in ``_pending_seek`` rather than
         in ``on_file_loaded`` so it doesn't overwrite callbacks wired externally.
         """
+        # loadfile replace clears mpv's entire playlist, including any lookahead.
+        self._lookahead_path = None
         self._pending_seek = position if position > 0 else None
         self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
+
+    def preload_next(self, next_track: "Track | None") -> None:
+        """Keep mpv's slot-1 playlist entry in sync with next_track.
+
+        Called after file-loaded and after any queue mutation that may change
+        which track follows the current one.  Idempotent: no-op if path unchanged.
+
+        _lookahead_path is cleared before playlist-remove is sent so that a
+        concurrent end-file/eof event on the reader thread sees has_lookahead=False
+        and falls back to engine.play() — correct track, non-gapless.  An optimistic
+        update (set path first) is intentionally avoided: if the old lookahead played
+        gaplessly before the removal landed in mpv, on_track_end would skip
+        engine.play() and queue.next() would advance past the wrong track.
+        """
+        path = next_track.file_path if next_track is not None else None
+        if path == self._lookahead_path:
+            return
+        if self._lookahead_path is not None:
+            self._lookahead_path = None  # clear before sending remove (see docstring)
+            self._send_command("playlist-remove", 1)
+        if path is not None:
+            self._send_command("loadfile", str(path), "append")
+            self._lookahead_path = path
+
+    @property
+    def has_lookahead(self) -> bool:
+        """True when a next-track is pre-appended to mpv's playlist."""
+        return self._lookahead_path is not None
 
     def pause(self) -> None:
         self._send_command("set_property", "pause", True)
@@ -526,6 +576,15 @@ class MpvPlaybackEngine:
                 self.on_file_loaded()
 
         elif name == "end-file":
-            # Only fire on natural end-of-file, not user-initiated stops.
-            if event.get("reason") == "eof" and self.on_track_end is not None:
-                self.on_track_end()
+            if event.get("reason") == "eof":
+                # When a lookahead was present, mpv already transitioned gaplessly
+                # and the finished entry sits at slot 0.  Remove it now to maintain
+                # the invariant (current = slot 0, lookahead = slot 1).
+                if self._lookahead_path is not None:
+                    self._send_command("playlist-remove", 0)
+                # Fire on_track_end while _lookahead_path is still set so that
+                # has_lookahead returns True inside the callback — _on_track_end
+                # checks this to avoid calling engine.play() redundantly.
+                if self.on_track_end is not None:
+                    self.on_track_end()
+                self._lookahead_path = None

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -920,18 +920,22 @@ def create_app(
     @app.post("/api/v1/player/queue/clear")
     def queue_clear() -> dict[str, Any]:
         queue.clear()
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/clear-remaining")
     def queue_clear_remaining(req: SkipToRequest) -> dict[str, Any]:
         queue.clear_remaining(req.position)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/skip-to")
     def skip_to_position(req: SkipToRequest) -> dict[str, Any]:
         track = queue.skip_to(req.position)
         if track:
-            engine.play(track.file_path)
+            engine.play(
+                track.file_path
+            )  # play() resets lookahead; file-loaded re-primes it
         _notify_track_changed()
         return {"ok": True}
 
@@ -942,6 +946,7 @@ def create_app(
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.add_to_queue(track)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/play-next")
@@ -951,6 +956,7 @@ def create_app(
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.play_next(track)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/insert")
@@ -960,6 +966,7 @@ def create_app(
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.insert_at(track, req.index)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/add-album")
@@ -973,6 +980,7 @@ def create_app(
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.add_album_to_queue(tracks)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/play-album-next")
@@ -986,6 +994,7 @@ def create_app(
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.play_album_next(tracks)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/insert-album")
@@ -998,6 +1007,7 @@ def create_app(
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.insert_album_at(tracks, req.index)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/move")
@@ -1006,16 +1016,19 @@ def create_app(
             queue.move(req.from_index, req.to_index)
         except IndexError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/shuffle")
     def set_shuffle(req: ShuffleRequest) -> dict[str, Any]:
         queue.set_shuffle(req.shuffle)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/repeat")
     def set_repeat(req: RepeatRequest) -> dict[str, Any]:
         queue.set_repeat(req.repeat)
+        engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     # -----------------------------------------------------------------------

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -629,7 +629,11 @@ def _cmd_daemon(
         if finished is not None:
             index.record_played(finished.file_path)
         if track:
-            engine.play(track.file_path)
+            if not engine.has_lookahead:
+                # No gapless transition was queued — start the next track manually.
+                engine.play(track.file_path)
+            # If has_lookahead: mpv already transitioned gaplessly.  file-loaded
+            # will fire shortly and preload_next will queue the new next track.
         else:
             engine.stop()
             # Queue exhausted — clear saved state so restart starts fresh
@@ -640,7 +644,9 @@ def _cmd_daemon(
     engine.on_track_end = _on_track_end
 
     def _on_file_loaded() -> None:
-        pass  # Now Playing updates are driven by Electron WebSocket subscription.
+        # Prime or refresh the gapless lookahead whenever a new file starts.
+        # Now Playing updates are driven by Electron WebSocket subscription.
+        engine.preload_next(queue.peek_next())
 
     engine.on_file_loaded = _on_file_loaded
 
@@ -857,6 +863,11 @@ def _cmd_daemon(
         app.state.notify_track_changed()
 
     engine.on_track_end = _on_track_end_notify
+
+    # Prime the gapless lookahead for a restored session so the first automatic
+    # advance is seamless.  All callbacks are wired by this point.
+    if queue.current() is not None:
+        engine.preload_next(queue.peek_next())
 
     # Watch the library directory and re-scan when audio files are added or
     # removed, so the UI stays current without requiring a manual scan trigger.

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -81,6 +81,34 @@ class TestPlaybackQueue:
         q.next()
         assert q.next() == tracks[0]
 
+    # ------------------------------------------------------------------
+    # peek_next
+    # ------------------------------------------------------------------
+
+    def test_peek_next_returns_next_track_without_advancing(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        assert q.peek_next() == tracks[1]
+        assert q.current() == tracks[0]  # position unchanged
+
+    def test_peek_next_at_last_track_returns_none(self) -> None:
+        q = PlaybackQueue()
+        q.load([_track(1)])
+        assert q.peek_next() is None
+
+    def test_peek_next_at_last_track_wraps_when_repeat(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        q.set_repeat(True)
+        q.next()
+        q.next()  # now at last track
+        assert q.peek_next() == tracks[0]
+
+    def test_peek_next_on_empty_queue_returns_none(self) -> None:
+        assert PlaybackQueue().peek_next() is None
+
     def test_prev_goes_back(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(3)]
@@ -853,6 +881,117 @@ class TestMpvPlaybackEngine:
         engine, _ = _make_engine()
         engine._handle_event({"event": "seek"})
         assert engine.state == PlaybackState()
+
+    # ------------------------------------------------------------------
+    # preload_next / has_lookahead
+    # ------------------------------------------------------------------
+
+    def test_has_lookahead_false_initially(self) -> None:
+        engine, _ = _make_engine()
+        assert engine.has_lookahead is False
+
+    def test_has_lookahead_true_after_preload_next(self) -> None:
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        assert engine.has_lookahead is True
+
+    def test_has_lookahead_false_after_preload_next_none(self) -> None:
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        engine.preload_next(None)
+        assert engine.has_lookahead is False
+
+    def test_preload_next_sends_loadfile_append(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+
+    def test_preload_next_is_noop_for_same_path(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine.preload_next(_track(2))
+        send.assert_not_called()
+
+    def test_preload_next_replaces_stale_lookahead(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine.preload_next(_track(3))
+        assert send.call_args_list == [
+            call("playlist-remove", 1),
+            call("loadfile", "/music/03.mp3", "append"),
+        ]
+
+    def test_preload_next_with_none_removes_stale_lookahead(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine.preload_next(None)
+        send.assert_called_once_with("playlist-remove", 1)
+        assert engine._lookahead_path is None
+
+    def test_preload_next_with_none_is_noop_when_no_lookahead(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(None)
+        send.assert_not_called()
+
+    def test_preload_next_clears_lookahead_before_sending_remove(self) -> None:
+        """_lookahead_path must be None before playlist-remove is sent."""
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        observed_during_remove: list[bool] = []
+
+        def capture(*_args: object) -> None:
+            observed_during_remove.append(engine._lookahead_path is None)
+
+        send.side_effect = capture
+        engine.preload_next(_track(3))
+        # First send call is playlist-remove — lookahead must already be None then.
+        assert observed_during_remove[0] is True
+
+    def test_play_clears_lookahead_path(self) -> None:
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        engine.play(Path("/music/01.mp3"))
+        assert engine._lookahead_path is None
+
+    def test_load_paused_clears_lookahead_path(self) -> None:
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        engine.load_paused(Path("/music/01.mp3"))
+        assert engine._lookahead_path is None
+
+    # ------------------------------------------------------------------
+    # end-file gapless cleanup
+    # ------------------------------------------------------------------
+
+    def test_end_file_sends_playlist_remove_0_when_lookahead_present(self) -> None:
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        send.assert_any_call("playlist-remove", 0)
+
+    def test_end_file_does_not_send_playlist_remove_when_no_lookahead(self) -> None:
+        engine, send = _make_engine()
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        send.assert_not_called()
+
+    def test_end_file_clears_lookahead_path_after_callback(self) -> None:
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert engine._lookahead_path is None
+
+    def test_on_track_end_called_while_lookahead_still_set(self) -> None:
+        """has_lookahead must be True inside the on_track_end callback."""
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        observed: list[bool] = []
+        engine.on_track_end = lambda: observed.append(engine.has_lookahead)
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert observed == [True]
 
     def test_handle_event_pause_with_non_bool_data_is_ignored(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- Eliminates the audible gap between tracks by maintaining a 2-slot mpv playlist (current + lookahead); mpv pre-buffers the next track's audio before the current one ends (`--gapless-audio=yes`)
- Any queue mutation (play-next, shuffle, move, clear, etc.) calls `engine.preload_next()` to keep the lookahead in sync with kamp's queue state
- User-initiated skips/prev/next go through `engine.play()` which resets the playlist cleanly; the lookahead re-primes on the next `file-loaded` event

## Known issue

KAMP-226 — seek stutter (~500ms) introduced by this change. Will be fixed before release.

## Test plan

- [x] 116 unit tests pass (`tests/test_playback.py`) — covers `peek_next`, `preload_next`, `has_lookahead`, `end-file` cleanup ordering invariant
- [x] Full suite: 1216/1216 pass at 95% coverage
- [x] Manual: listen through 2–3 track boundaries for audible gaps
- [x] Manual: play-next / shuffle / move while playing — confirm correct next track, no glitch
- [x] Manual: rapid next/prev — no stuck state or double-play

🤖 Generated with [Claude Code](https://claude.com/claude-code)