### PR TITLE
ci: audit PyInstaller bundle for Homebrew-linked dylibs (KAMP-70)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -59,6 +59,18 @@ jobs:
           echo "→ Bundle: $(ls kamp_ui/resources/kamp/kamp)"
           echo "→ Playwright absent: $(ls kamp_ui/resources/kamp/_internal/ | grep -c playwright || echo 0) files"
 
+      - name: Audit bundle for Homebrew-linked dylibs
+        run: |
+          HOMEBREW_LEAKS=$(find kamp_ui/resources/kamp -type f \( -name "*.so" -o -name "*.dylib" \) \
+            -exec otool -L {} \; 2>/dev/null \
+            | grep -E '/opt/homebrew|/usr/local/Cellar' | wc -l)
+          echo "→ Homebrew-linked deps found: $HOMEBREW_LEAKS"
+          if [ "$HOMEBREW_LEAKS" -gt 0 ]; then
+            find kamp_ui/resources/kamp -type f \( -name "*.so" -o -name "*.dylib" \) \
+              -exec sh -c 'otool -L "$1" | grep -E "/opt/homebrew|/usr/local/Cellar" && echo "  ↑ in $1"' _ {} \;
+            exit 1
+          fi
+
       - name: Verify bundle excludes Playwright
         run: |
           if ls kamp_ui/resources/kamp/_internal/ | grep -q playwright; then


### PR DESCRIPTION
## Summary

- Adds an `otool` scan step to `build-app.yml` immediately after the PyInstaller build
- Fails CI if any `.so` or `.dylib` in the bundle links against `/opt/homebrew` or `/usr/local/Cellar`
- Prints the offending file and library path so the fix is immediately obvious

## Test plan

- [ ] Trigger the Build macOS App workflow on this branch and confirm the audit step passes (clean bundle = zero Homebrew leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)