### PR TITLE
fix(ui): transport position fixed; marquee on hover for long track strings (KAMP-227)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1255,28 +1255,57 @@ body,
 }
 
 .transport-track-info {
+  --track-info-w: 220px;
+  width: var(--track-info-w);
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 180px;
-  max-width: 220px;
+}
+
+/* overflow container + hover target for each text row */
+.track-field {
   overflow: hidden;
+  white-space: nowrap;
+}
+
+/* inline-block so translateX(-100%) is relative to the text's own content width.
+   vertical-align: top prevents baseline-triggered vertical shift when overflow
+   flips between hidden and visible on hover. */
+.track-title,
+.track-artist,
+.track-album {
+  display: inline-block;
+  vertical-align: top;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 100%;
+  transform: translateX(0);
+  transition: transform 0.3s ease;
 }
 
 .track-title {
   font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .track-artist,
 .track-album {
   font-size: 11px;
   color: var(--text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+/* Marquee on hover. max-width: none lets the span grow to full content width so
+   -100% resolves to the actual text width rather than the 220px cap.
+   min(0px, …) keeps non-overflowing strings stationary. */
+.track-field:hover .track-title,
+.track-field:hover .track-artist,
+.track-field:hover .track-album {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+  transform: translateX(min(0px, calc(-100% + var(--track-info-w, 220px))));
+  transition: transform 6s linear 0.5s;
 }
 
 .track-idle {

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -32,9 +32,15 @@ export function TransportBar(): React.JSX.Element {
       <div className="transport-track-info">
         {current_track ? (
           <>
-            <span className="track-title">{current_track.title}</span>
-            <span className="track-artist">{current_track.artist}</span>
-            <span className="track-album">{current_track.album}</span>
+            <div className="track-field">
+              <span className="track-title">{current_track.title}</span>
+            </div>
+            <div className="track-field">
+              <span className="track-artist">{current_track.artist}</span>
+            </div>
+            <div className="track-field">
+              <span className="track-album">{current_track.album}</span>
+            </div>
           </>
         ) : (
           <span className="track-idle">No track loaded</span>


### PR DESCRIPTION
## Summary

- Transport controls were shifting horizontally because `.transport-track-info` used `min/max-width` instead of a fixed width — replaced with `width: 220px; flex-shrink: 0`
- Wraps each track field (title/artist/album) in a `.track-field` overflow container to enable per-row hover targeting
- Adds a CSS transition marquee: on hover, overflowing text slides left to reveal the full string; non-overflowing strings stay put (`min(0px, …)` guard); cursor-out snaps back quickly

## Test plan

- [x] Queue a short-title track and a long-title track; skip between them — transport controls (⏮ ▶ ⏹ ⏭) stay in the same horizontal position
- [x] Hover over a truncated title/artist/album — string scrolls left after ~0.5s to reveal full text
- [x] Hover over a short string that fits in 220px — no movement
- [x] Move cursor away from a scrolling string — snaps back immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)