### PR TITLE
feat(ui): Base Kamp landing view with module registry (KAMP-83)

### DIFF
--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -92,7 +92,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",
-    "ui.active_view": "library",
+    "ui.active_view": "home",
     "ui.sort_order": "album_artist",
     "ui.queue_panel_open": "0",
 }
@@ -154,7 +154,7 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
     "bandcamp.format": frozenset(
         {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
     ),
-    "ui.active_view": frozenset({"library", "now-playing"}),
+    "ui.active_view": frozenset({"library", "now-playing", "home"}),
     "ui.sort_order": frozenset({"album_artist", "album", "date_added", "last_played"}),
 }
 

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { useStore } from './store'
 import { connectStateStream } from './api/client'
 import { ArtistPanel } from './components/ArtistPanel'
+import { BaseKampView } from './components/BaseKampView'
 import { ExtensionPanel } from './components/ExtensionPanel'
 import { LibraryView } from './components/LibraryView'
 import { NowPlayingView } from './components/NowPlayingView'
@@ -24,6 +25,13 @@ import type { ExtensionInfo } from '../../shared/kampAPI'
 // Register built-in panels before the component mounts.
 // Each call is idempotent — safe across HMR and React StrictMode re-runs.
 // ---------------------------------------------------------------------------
+registerBuiltInPanel({
+  id: 'kamp.base-kamp',
+  title: 'Base Kamp',
+  defaultSlot: 'main',
+  compatibleSlots: ['main'],
+  component: BaseKampView
+})
 registerBuiltInPanel({
   id: 'kamp.library',
   title: 'Library',
@@ -425,6 +433,7 @@ export default function App(): React.JSX.Element {
   // Determine whether a given main-slot panel tab is active.
   const isActiveMain = (panel: UnifiedPanel): boolean => {
     if (activeExtPanel) return panel.id === activeExtPanel
+    if (panel.kind === 'builtin' && panel.id === 'kamp.base-kamp') return activeView === 'home'
     if (panel.kind === 'builtin' && panel.id === 'kamp.library') return activeView === 'library'
     if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing')
       return activeView === 'now-playing'
@@ -433,7 +442,10 @@ export default function App(): React.JSX.Element {
 
   // Activate a main-slot panel tab.
   const activateMain = (panel: UnifiedPanel): void => {
-    if (panel.kind === 'builtin' && panel.id === 'kamp.library') {
+    if (panel.kind === 'builtin' && panel.id === 'kamp.base-kamp') {
+      void setActiveView('home')
+      setActiveExtPanel(null)
+    } else if (panel.kind === 'builtin' && panel.id === 'kamp.library') {
       void setActiveView('library')
       setActiveExtPanel(null)
     } else if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing') {
@@ -458,6 +470,7 @@ export default function App(): React.JSX.Element {
     // artLoaded state) survive view switches. The inactive pane is hidden via
     // display:none (.view-pane) and the active one uses display:contents
     // (.view-pane--active) so it has no layout box of its own.
+    const isHomePane = !searchQuery && !activeExtPanel && activeView === 'home'
     const isLibraryPane = !searchQuery && !activeExtPanel && activeView === 'library'
     const isNowPlayingPane = !searchQuery && !activeExtPanel && activeView === 'now-playing'
     return (
@@ -466,6 +479,9 @@ export default function App(): React.JSX.Element {
             switch so the previous extension's container is never reused. */}
         {extPanel?.kind === 'extension' && <ExtensionPanel key={extPanel.id} panel={extPanel} />}
         {searchQuery && <SearchView />}
+        <div className={isHomePane ? 'view-pane view-pane--active' : 'view-pane'}>
+          <BaseKampView />
+        </div>
         <div className={isLibraryPane ? 'view-pane view-pane--active' : 'view-pane'}>
           <LibraryView />
         </div>

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -174,14 +174,15 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
   post('/api/v1/config/library-path', { path })
 
 export type UiState = {
-  active_view: 'library' | 'now-playing'
+  active_view: 'library' | 'now-playing' | 'home'
   sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played'
   queue_panel_open: boolean
 }
 
 export const getUiState = (): Promise<UiState> => get('/api/v1/ui')
-export const setActiveViewApi = (view: 'library' | 'now-playing'): Promise<{ ok: boolean }> =>
-  post('/api/v1/ui/active-view', { view })
+export const setActiveViewApi = (
+  view: 'library' | 'now-playing' | 'home'
+): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/sort-order', { sort_order: sortOrder })

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2713,7 +2713,7 @@ body,
 .base-kamp {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 23px;
   padding: 8px;
 }
 
@@ -2724,17 +2724,17 @@ body,
 }
 
 .base-kamp-module-label {
-  background: var(--surface-hover);
-  border-radius: 5px 5px 0 0;
-  padding: 5px 10px;
-  font-size: 11px;
-  font-weight: 500;
+  background: var(--surface);
+  border-radius: 6px 6px 0 0;
+  padding: 6px 10px;
+  font-size: 14px;
+  font-weight: 400;
   color: var(--text);
 }
 
 .base-kamp-module-body {
   width: 100%;
-  background: var(--surface-hover);
+  background: var(--surface);
   border-radius: 0 5px 5px 5px;
   min-height: 285px;
   overflow: hidden;

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2705,3 +2705,112 @@ body,
   outline: 1px solid var(--accent);
   outline-offset: 2px;
 }
+
+/* ---------------------------------------------------------------------------
+ * Base Kamp view
+ * ------------------------------------------------------------------------- */
+
+.base-kamp {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 8px;
+}
+
+.base-kamp-module {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.base-kamp-module-label {
+  background: var(--surface-hover);
+  border-radius: 5px 5px 0 0;
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.base-kamp-module-body {
+  width: 100%;
+  background: var(--surface-hover);
+  border-radius: 0 5px 5px 5px;
+  min-height: 285px;
+  overflow: hidden;
+}
+
+.base-kamp-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+/* Skeleton cards inside stub modules */
+.module-skeleton-row {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+}
+
+.module-skeleton-card {
+  flex: 0 0 160px;
+  height: 240px;
+  background: var(--border);
+  border-radius: 5px;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+/* Preferences — Home tab module order editor */
+.prefs-module-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.prefs-module-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.prefs-module-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 2px 7px;
+  transition: color 100ms ease, border-color 100ms ease;
+}
+
+.prefs-module-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.prefs-module-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.prefs-module-btn--remove {
+  color: var(--error);
+  border-color: var(--error);
+}
+
+.prefs-module-btn--remove:hover {
+  opacity: 0.8;
+}

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useStore } from '../store'
+import { MODULE_REGISTRY } from './modules/registry'
+import type { ModuleRegistration } from './modules/registry'
+
+export function BaseKampView(): React.JSX.Element {
+  const moduleOrder = useStore((s) => s.moduleOrder)
+
+  const modules = moduleOrder
+    .map((id) => MODULE_REGISTRY.find((m) => m.id === id))
+    .filter((m): m is ModuleRegistration => m !== undefined)
+
+  if (modules.length === 0) {
+    return (
+      <div className="base-kamp-empty">
+        No modules configured. Add some in Preferences → Home.
+      </div>
+    )
+  }
+
+  return (
+    <div className="base-kamp">
+      {modules.map((mod) => (
+        <section key={mod.id} className="base-kamp-module">
+          <div className="base-kamp-module-label">{mod.title}</div>
+          <div className="base-kamp-module-body">
+            <mod.component />
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -12,9 +12,7 @@ export function BaseKampView(): React.JSX.Element {
 
   if (modules.length === 0) {
     return (
-      <div className="base-kamp-empty">
-        No modules configured. Add some in Preferences → Home.
-      </div>
+      <div className="base-kamp-empty">No modules configured. Add some in Preferences → Home.</div>
     )
   }
 

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -4,6 +4,7 @@ import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kamp
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
 import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
+import { MODULE_REGISTRY } from './modules/registry'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -924,7 +925,10 @@ export function PreferencesDialog({
   const scanProgress = useStore((s) => s.scanProgress)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
 
-  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions'>(
+  const moduleOrder = useStore((s) => s.moduleOrder)
+  const setModuleOrder = useStore((s) => s.setModuleOrder)
+
+  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions' | 'home'>(
     () => prefsInitialTab
   )
 
@@ -1031,6 +1035,14 @@ export function PreferencesDialog({
             onClick={() => setActiveTab('general')}
           >
             General
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'home'}
+            className={`prefs-tab${activeTab === 'home' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('home')}
+          >
+            Home
           </button>
           <button
             role="tab"
@@ -1196,6 +1208,73 @@ export function PreferencesDialog({
                 </>
               )}
             </>
+          )}
+
+          {activeTab === 'home' && (
+            <div className="prefs-section">
+              <div className="prefs-section-label">Modules</div>
+              {moduleOrder.length === 0 && (
+                <p className="prefs-hint">No modules enabled. Add one below.</p>
+              )}
+              {moduleOrder.map((id, idx) => {
+                const mod = MODULE_REGISTRY.find((m) => m.id === id)
+                if (!mod) return null
+                return (
+                  <div key={id} className="prefs-row prefs-module-row">
+                    <span className="prefs-label">{mod.title}</span>
+                    <div className="prefs-module-actions">
+                      <button
+                        className="prefs-module-btn"
+                        disabled={idx === 0}
+                        onClick={() => {
+                          const next = [...moduleOrder]
+                          ;[next[idx - 1], next[idx]] = [next[idx], next[idx - 1]]
+                          setModuleOrder(next)
+                        }}
+                        aria-label="Move up"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        className="prefs-module-btn"
+                        disabled={idx === moduleOrder.length - 1}
+                        onClick={() => {
+                          const next = [...moduleOrder]
+                          ;[next[idx], next[idx + 1]] = [next[idx + 1], next[idx]]
+                          setModuleOrder(next)
+                        }}
+                        aria-label="Move down"
+                      >
+                        ↓
+                      </button>
+                      <button
+                        className="prefs-module-btn prefs-module-btn--remove"
+                        onClick={() => setModuleOrder(moduleOrder.filter((i) => i !== id))}
+                        aria-label="Remove module"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+              {MODULE_REGISTRY.filter((m) => !moduleOrder.includes(m.id)).map((mod) => (
+                <div key={mod.id} className="prefs-row prefs-module-row prefs-module-row--disabled">
+                  <span className="prefs-label" style={{ color: 'var(--text-dim)' }}>
+                    {mod.title}
+                  </span>
+                  <div className="prefs-module-actions">
+                    <button
+                      className="prefs-module-btn"
+                      onClick={() => setModuleOrder([...moduleOrder, mod.id])}
+                      aria-label="Add module"
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
 
           {activeTab === 'extensions' && (

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1042,7 +1042,7 @@ export function PreferencesDialog({
             className={`prefs-tab${activeTab === 'home' ? ' prefs-tab--active' : ''}`}
             onClick={() => setActiveTab('home')}
           >
-            Home
+            Base Kamp
           </button>
           <button
             role="tab"

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export function LastPlayedModule(): React.JSX.Element {
+  return (
+    <div className="module-skeleton-row">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="module-skeleton-card" />
+      ))}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export function NewArrivalsModule(): React.JSX.Element {
+  return (
+    <div className="module-skeleton-row">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="module-skeleton-card" />
+      ))}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -1,0 +1,16 @@
+import type React from 'react'
+import { NewArrivalsModule } from './NewArrivalsModule'
+import { LastPlayedModule } from './LastPlayedModule'
+
+export interface ModuleProps {}
+
+export interface ModuleRegistration {
+  id: string
+  title: string
+  component: React.ComponentType<ModuleProps>
+}
+
+export const MODULE_REGISTRY: ModuleRegistration[] = [
+  { id: 'kamp.new-arrivals', title: 'New Arrivals', component: NewArrivalsModule },
+  { id: 'kamp.last-played', title: 'Last Played', component: LastPlayedModule },
+]

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -12,5 +12,5 @@ export interface ModuleRegistration {
 
 export const MODULE_REGISTRY: ModuleRegistration[] = [
   { id: 'kamp.new-arrivals', title: 'New Arrivals', component: NewArrivalsModule },
-  { id: 'kamp.last-played', title: 'Last Played', component: LastPlayedModule },
+  { id: 'kamp.last-played', title: 'Last Played', component: LastPlayedModule }
 ]

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -38,7 +38,8 @@ type PlayerStore = {
   scanProgress: ScanProgress | null
 
   configuredLibraryPath: string | null
-  activeView: 'library' | 'now-playing'
+  activeView: 'library' | 'now-playing' | 'home'
+  moduleOrder: string[]
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
   searchQuery: string
   searchResults: SearchResult | null
@@ -54,7 +55,8 @@ type PlayerStore = {
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (sort: 'album_artist' | 'album' | 'date_added' | 'last_played') => Promise<void>
-  setActiveView: (view: 'library' | 'now-playing') => Promise<void>
+  setActiveView: (view: 'library' | 'now-playing' | 'home') => Promise<void>
+  setModuleOrder: (ids: string[]) => void
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
@@ -105,10 +107,10 @@ type PlayerStore = {
   // Preferences
   configValues: ConfigValues | null
   prefsOpen: boolean
-  prefsInitialTab: 'general' | 'services' | 'extensions'
+  prefsInitialTab: 'general' | 'services' | 'extensions' | 'home'
   loadConfig: () => Promise<void>
   setConfigValue: (key: string, value: string) => Promise<void>
-  openPrefs: (tab?: 'general' | 'services' | 'extensions') => void
+  openPrefs: (tab?: 'general' | 'services' | 'extensions' | 'home') => void
   closePrefs: () => void
 }
 
@@ -137,6 +139,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
   scanProgress: null,
   configuredLibraryPath: null,
   activeView: 'library',
+  moduleOrder: (() => {
+    const saved = localStorage.getItem('kamp:module-order')
+    return saved
+      ? (JSON.parse(saved) as string[])
+      : ['kamp.new-arrivals', 'kamp.last-played']
+  })(),
   sortOrder: 'album_artist',
   searchQuery: '',
   searchResults: null,
@@ -219,6 +227,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
     } catch {
       // Best-effort — view is already updated locally; daemon will sync on next connect.
     }
+  },
+
+  setModuleOrder: (ids) => {
+    localStorage.setItem('kamp:module-order', JSON.stringify(ids))
+    set({ moduleOrder: ids })
   },
 
   loadUiState: async () => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -141,9 +141,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   activeView: 'library',
   moduleOrder: (() => {
     const saved = localStorage.getItem('kamp:module-order')
-    return saved
-      ? (JSON.parse(saved) as string[])
-      : ['kamp.new-arrivals', 'kamp.last-played']
+    return saved ? (JSON.parse(saved) as string[]) : ['kamp.new-arrivals', 'kamp.last-played']
   })(),
   sortOrder: 'album_artist',
   searchQuery: '',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,7 @@ class TestLoad:
         assert config.bandcamp.format == "mp3-v0"
         assert config.bandcamp.poll_interval_minutes == 0
         assert config.lastfm is None
-        assert config.ui.active_view == "library"
+        assert config.ui.active_view == "home"
         assert config.ui.sort_order == "album_artist"
         assert config.ui.queue_panel_open == 0
 
@@ -267,6 +267,12 @@ class TestConfigSet:
         config_set(db, "ui.active_view", "now-playing")
         config = Config.load(db)
         assert config.ui.active_view == "now-playing"
+
+    def test_ui_active_view_home_is_valid(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        config_set(db, "ui.active_view", "home")
+        config = Config.load(db)
+        assert config.ui.active_view == "home"
 
     def test_ui_sort_order_valid(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)


### PR DESCRIPTION
## Summary

- Adds `BaseKampView` as a new first tab ("Base Kamp"), the default view on app open
- Module registry pattern: static `MODULE_REGISTRY` array mapping IDs to React components; order persisted in `localStorage` (`kamp:module-order`) so modules can be added/removed without code changes
- Two stub modules (`NewArrivalsModule`, `LastPlayedModule`) render skeleton placeholder cards — to be filled in by KAMP-71 and KAMP-72
- **Home tab in Preferences** with up/down reorder arrows, Remove, and Add buttons
- Server: `'home'` added to valid `ui.active_view` choices; default changed from `'library'` to `'home'` for fresh installs
- Folder-tab CSS: label pill and body block share `--surface-hover` (#222), label has `border-radius: 5px 5px 0 0` and body has `border-radius: 0 5px 5px 5px` so they flush together

## Test plan

- [x] `poetry run pytest tests/test_config.py -v --no-cov` — all 45 tests pass (includes new `test_ui_active_view_home_is_valid`)
- [x] `npm run typecheck && npm run lint` pass (confirmed by pre-commit hook)
- [x] App opens to "Base Kamp" tab by default on fresh DB
- [x] Two skeleton modules visible in folder-tab layout
- [x] Preferences → Home tab: up/down reorders, Remove removes, Add re-adds; order persists across reload
- [x] Empty state message appears when all modules removed
- [x] Library and Now Playing tabs still work; artist panel behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)