### PR TITLE
feat(ui): New Arrivals module with shared AlbumCard (KAMP-84)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -220,6 +220,9 @@ class AlbumInfo:
     # MAX(file_mtime) across the album's tracks — used as a cache-busting key
     # in image URLs so the browser only re-fetches art when files change.
     art_version: float | None = None
+    # MIN(date_added) across the album's tracks — exposed so callers can filter
+    # by recency without a separate query.
+    added_at: float | None = None
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -779,7 +782,7 @@ class LibraryIndex:
         order_by = _SORT_CLAUSES.get(sort, _SORT_CLAUSES["album_artist"])
         rows = self._conn.execute(f"""
             SELECT album_artist, album, year, track_count, has_art,
-                   missing_album, file_path, art_version
+                   missing_album, file_path, art_version, sort_date_added
             FROM (
                 SELECT album_artist, album, year, COUNT(*) AS track_count,
                        MAX(embedded_art) AS has_art,
@@ -812,6 +815,7 @@ class LibraryIndex:
                 missing_album=bool(r["missing_album"]),
                 file_path=r["file_path"],
                 art_version=r["art_version"],
+                added_at=r["sort_date_added"],
             )
             for r in rows
         ]

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -83,6 +83,8 @@ class AlbumOut(BaseModel):
     # MAX(file_mtime) across the album's tracks — appended to art URLs as ?v=
     # so the browser caches images by URL and only re-fetches when files change.
     art_version: float | None = None
+    # MIN(date_added) across the album's tracks — used by the New Arrivals module.
+    added_at: float | None = None
 
 
 class PlayerStateOut(BaseModel):
@@ -443,6 +445,7 @@ def create_app(
                 missing_album=a.missing_album,
                 file_path=a.file_path,
                 art_version=a.art_version,
+                added_at=a.added_at,
             )
             for a in index.albums(sort=sort)
         ]
@@ -527,6 +530,7 @@ def create_app(
                 missing_album=a.missing_album,
                 file_path=a.file_path,
                 art_version=a.art_version,
+                added_at=a.added_at,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -35,6 +35,8 @@ export type Album = {
   // MAX(file_mtime) across the album's tracks; appended to art URLs as ?v=
   // so the browser caches by URL and only re-fetches when files change on disk.
   art_version: number | null
+  // MIN(date_added) across the album's tracks — used by the New Arrivals module.
+  added_at: number | null
 }
 
 export type PlayerState = {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2755,8 +2755,8 @@ body,
 }
 
 .module-skeleton-card {
-  flex: 0 0 160px;
-  height: 240px;
+  flex: 0 0 180px;
+  height: 255px;
   background: var(--border);
   border-radius: 5px;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
@@ -2781,7 +2781,7 @@ body,
 }
 
 .module-new-arrivals .album-card {
-  flex: 0 0 150px;
+  flex: 0 0 180px;
 }
 
 .module-empty {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2772,6 +2772,25 @@ body,
   }
 }
 
+/* New Arrivals module carousel */
+.module-new-arrivals {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  overflow-x: auto;
+}
+
+.module-new-arrivals .album-card {
+  flex: 0 0 150px;
+}
+
+.module-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
 /* Preferences — Home tab module order editor */
 .prefs-module-row {
   display: flex;

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useStore } from '../store'
+import { artUrl, getTracksForAlbum } from '../api/client'
+import type { Album } from '../api/client'
+import { useMenuBounds } from '../hooks/useMenuBounds'
+
+type MenuPos = { x: number; y: number }
+
+export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const activeView = useStore((s) => s.activeView)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
+  const currentTrack = useStore((s) => s.player.current_track)
+  const playing = useStore((s) => s.player.playing)
+  const [artLoaded, setArtLoaded] = useState(false)
+  const [menu, setMenu] = useState<MenuPos | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const isActive = album.missing_album
+    ? currentTrack?.file_path === album.file_path
+    : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
+
+  useEffect(() => {
+    if (!menu) return
+    const handler = (e: MouseEvent): void => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
+
+  useMenuBounds(menuRef, menu)
+
+  const handleSelect = (): void => {
+    if (activeView !== 'library') void setActiveView('library')
+    void selectAlbum(album)
+  }
+
+  return (
+    <div
+      className={`album-card${isActive ? ' playing' : ''}`}
+      tabIndex={0}
+      draggable
+      onClick={handleSelect}
+      onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'text/kamp-album',
+          JSON.stringify({
+            album_artist: album.album_artist,
+            album: album.album,
+            file_path: album.file_path
+          })
+        )
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
+        {album.has_art && (
+          <img
+            className="album-art-img"
+            src={artUrl(album.album_artist, album.album, album.file_path, album.art_version)}
+            alt=""
+            onLoad={() => setArtLoaded(true)}
+            onError={() => setArtLoaded(false)}
+          />
+        )}
+        {playing && isActive && <div className="now-playing-badge">▶</div>}
+      </div>
+      <div className="album-info">
+        {album.missing_album ? (
+          <div className="album-title">
+            <em>{album.album}</em>
+          </div>
+        ) : (
+          <div className="album-title">{album.album}</div>
+        )}
+        <div className="album-artist">{album.album_artist}</div>
+        <div className="album-year">{album.year}</div>
+      </div>
+
+      {menu &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="track-context-menu"
+            style={{ top: menu.y, left: menu.x }}
+            onClick={(e) => e.stopPropagation()}
+          >
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void playAlbumNext(album.album_artist, album.album, album.file_path)
+              setMenu(null)
+            }}
+          >
+            ▶ Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addAlbumToQueue(album.album_artist, album.album, album.file_path)
+              setMenu(null)
+            }}
+          >
+            + Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={async () => {
+              let filePath = album.file_path
+              if (!filePath) {
+                const tracks = await getTracksForAlbum(album.album_artist, album.album)
+                filePath = tracks[0]?.file_path ?? ''
+              }
+              if (filePath) window.api.showItemInFolder(filePath)
+              setMenu(null)
+            }}
+          >
+            {window.electron.process.platform === 'darwin'
+              ? '↗ Reveal in Finder'
+              : window.electron.process.platform === 'win32'
+                ? '↗ Show in Explorer'
+                : '↗ Show in Files'}
+          </button>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -96,42 +96,42 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
             style={{ top: menu.y, left: menu.x }}
             onClick={(e) => e.stopPropagation()}
           >
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void playAlbumNext(album.album_artist, album.album, album.file_path)
-              setMenu(null)
-            }}
-          >
-            ▶ Play Next
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void addAlbumToQueue(album.album_artist, album.album, album.file_path)
-              setMenu(null)
-            }}
-          >
-            + Add to Queue
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={async () => {
-              let filePath = album.file_path
-              if (!filePath) {
-                const tracks = await getTracksForAlbum(album.album_artist, album.album)
-                filePath = tracks[0]?.file_path ?? ''
-              }
-              if (filePath) window.api.showItemInFolder(filePath)
-              setMenu(null)
-            }}
-          >
-            {window.electron.process.platform === 'darwin'
-              ? '↗ Reveal in Finder'
-              : window.electron.process.platform === 'win32'
-                ? '↗ Show in Explorer'
-                : '↗ Show in Files'}
-          </button>
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void playAlbumNext(album.album_artist, album.album, album.file_path)
+                setMenu(null)
+              }}
+            >
+              ▶ Play Next
+            </button>
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void addAlbumToQueue(album.album_artist, album.album, album.file_path)
+                setMenu(null)
+              }}
+            >
+              + Add to Queue
+            </button>
+            <button
+              className="track-context-menu-item"
+              onClick={async () => {
+                let filePath = album.file_path
+                if (!filePath) {
+                  const tracks = await getTracksForAlbum(album.album_artist, album.album)
+                  filePath = tracks[0]?.file_path ?? ''
+                }
+                if (filePath) window.api.showItemInFolder(filePath)
+                setMenu(null)
+              }}
+            >
+              {window.electron.process.platform === 'darwin'
+                ? '↗ Reveal in Finder'
+                : window.electron.process.platform === 'win32'
+                  ? '↗ Show in Explorer'
+                  : '↗ Show in Files'}
+            </button>
           </div>,
           document.body
         )}

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -1,91 +1,18 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
 
 // Persists scroll position across AlbumGrid mount/unmount cycles (e.g. open
 // album → back). Module-level so it survives React unmounting the component.
 let savedScrollTop = 0
 import { useStore } from '../store'
-import { artUrl, getTracksForAlbum } from '../api/client'
-import type { Album } from '../api/client'
+import { AlbumCard } from './AlbumCard'
 import { SortControl } from './SortControl'
 import { BandcampButton } from './BandcampButton'
 import { PipelineIndicator } from './PipelineIndicator'
-import { useMenuBounds } from '../hooks/useMenuBounds'
-
-type ContextMenu = { x: number; y: number; album: Album }
-
-function AlbumCard({
-  album,
-  onContextMenu
-}: {
-  album: Album
-  onContextMenu: (e: React.MouseEvent, album: Album) => void
-}): React.JSX.Element {
-  const selectAlbum = useStore((s) => s.selectAlbum)
-  const currentTrack = useStore((s) => s.player.current_track)
-  const playing = useStore((s) => s.player.playing)
-  const [artLoaded, setArtLoaded] = useState(false)
-
-  // For missing-album tracks, match by file_path since album="" in the DB
-  // while album.album holds the track title as a display name.
-  const isActive = album.missing_album
-    ? currentTrack?.file_path === album.file_path
-    : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
-
-  return (
-    <div
-      className={`album-card${isActive ? ' playing' : ''}`}
-      tabIndex={0}
-      draggable
-      onClick={() => selectAlbum(album)}
-      onKeyDown={(e) => e.key === 'Enter' && selectAlbum(album)}
-      onContextMenu={(e) => onContextMenu(e, album)}
-      onDragStart={(e) => {
-        e.dataTransfer.setData(
-          'text/kamp-album',
-          JSON.stringify({
-            album_artist: album.album_artist,
-            album: album.album,
-            file_path: album.file_path
-          })
-        )
-        e.dataTransfer.effectAllowed = 'copy'
-      }}
-    >
-      <div className={`album-art${artLoaded ? ' has-art' : ''}`}>
-        {album.has_art && (
-          <img
-            className="album-art-img"
-            src={artUrl(album.album_artist, album.album, album.file_path, album.art_version)}
-            alt=""
-            onLoad={() => setArtLoaded(true)}
-            onError={() => setArtLoaded(false)}
-          />
-        )}
-        {playing && isActive && <div className="now-playing-badge">▶</div>}
-      </div>
-      <div className="album-info">
-        {album.missing_album ? (
-          <div className="album-title">
-            <em>{album.album}</em>
-          </div>
-        ) : (
-          <div className="album-title">{album.album}</div>
-        )}
-        <div className="album-artist">{album.album_artist}</div>
-        <div className="album-year">{album.year}</div>
-      </div>
-    </div>
-  )
-}
 
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
-  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
-  const playAlbumNext = useStore((s) => s.playAlbumNext)
 
-  const [menu, setMenu] = useState<ContextMenu | null>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
@@ -98,19 +25,6 @@ export function AlbumGrid(): React.JSX.Element {
       if (scroller) savedScrollTop = scroller.scrollTop
     }
   }, [])
-
-  useEffect(() => {
-    if (!menu) return
-    const handler = (e: MouseEvent): void => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [menu])
-
-  useMenuBounds(menuRef, menu)
 
   const visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
 
@@ -133,53 +47,8 @@ export function AlbumGrid(): React.JSX.Element {
             <AlbumCard
               key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
               album={album}
-              onContextMenu={(e, a) => {
-                e.preventDefault()
-                setMenu({ x: e.clientX, y: e.clientY, album: a })
-              }}
             />
           ))}
-        </div>
-      )}
-
-      {menu && (
-        <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void playAlbumNext(menu.album.album_artist, menu.album.album, menu.album.file_path)
-              setMenu(null)
-            }}
-          >
-            ▶ Play Next
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void addAlbumToQueue(menu.album.album_artist, menu.album.album, menu.album.file_path)
-              setMenu(null)
-            }}
-          >
-            + Add to Queue
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={async () => {
-              let filePath = menu.album.file_path
-              if (!filePath) {
-                const tracks = await getTracksForAlbum(menu.album.album_artist, menu.album.album)
-                filePath = tracks[0]?.file_path ?? ''
-              }
-              if (filePath) window.api.showItemInFolder(filePath)
-              setMenu(null)
-            }}
-          >
-            {window.electron.process.platform === 'darwin'
-              ? '↗ Reveal in Finder'
-              : window.electron.process.platform === 'win32'
-                ? '↗ Show in Explorer'
-                : '↗ Show in Files'}
-          </button>
         </div>
       )}
     </div>

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -252,7 +252,8 @@ export function QueuePanel(): React.JSX.Element {
                     has_art: false,
                     missing_album: false,
                     file_path: '',
-                    art_version: null
+                    art_version: null,
+                    added_at: null
                   }
                   void setActiveView('library')
                   void selectAlbum(found)

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -1,10 +1,47 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { getAlbums } from '../../api/client'
+import type { Album } from '../../api/client'
+import { AlbumCard } from '../AlbumCard'
+
+const DAYS = 30
+const CUTOFF_SECONDS = DAYS * 86400
 
 export function NewArrivalsModule(): React.JSX.Element {
+  const [albums, setAlbums] = useState<Album[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getAlbums('date_added')
+      .then((all) => {
+        const cutoff = Date.now() / 1000 - CUTOFF_SECONDS
+        const recent = all.filter((a) => a.added_at !== null && a.added_at >= cutoff)
+        setAlbums(recent)
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="module-skeleton-row">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="module-skeleton-card" />
+        ))}
+      </div>
+    )
+  }
+
+  if (albums.length === 0) {
+    return <div className="module-empty">No albums added in the last {DAYS} days.</div>
+  }
+
   return (
-    <div className="module-skeleton-row">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="module-skeleton-card" />
+    <div className="module-new-arrivals">
+      {albums.map((album) => (
+        <AlbumCard
+          key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
+          album={album}
+        />
       ))}
     </div>
   )

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -375,6 +375,17 @@ class TestLibraryIndex:
 
         assert albums[0].art_version is None
 
+    def test_albums_exposes_added_at(self, tmp_path: Path) -> None:
+        """albums() exposes the MIN(date_added) per album as added_at."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "0.mp3")
+        t.date_added = 1234567890.0
+        index.upsert_track(t)
+        albums = index.albums(sort="date_added")
+        index.close()
+
+        assert albums[0].added_at == pytest.approx(1234567890.0)
+
     def test_missing_album_art_version_is_file_mtime(self, tmp_path: Path) -> None:
         """art_version for a missing-album track is its own file_mtime."""
         index = LibraryIndex(tmp_path / "library.db")


### PR DESCRIPTION
## Summary

- Exposes `added_at` (MIN date_added per album) through the backend stack (`AlbumInfo` → `AlbumOut` → `Album` type) so the frontend can filter by recency without a separate query
- Implements the **New Arrivals** Base Kamp module: albums added in the last 30 days, sorted newest first, with a loading skeleton and empty state; clicking an album navigates to the Library view and opens its track list
- Extracts `AlbumCard` into a shared component (`components/AlbumCard.tsx`) — self-contained with context menu (Play Next, Add to Queue, Reveal in Finder), drag-to-queue, keyboard nav, and now-playing highlight; `AlbumGrid` now imports the shared card, and future modules get full feature parity for free

## Test plan

- [x] New Arrivals module renders album carousel on the Home view
- [x] Empty state shows when no albums were added in the last 30 days
- [x] Clicking an album switches to Library view and opens its track list
- [x] Right-click context menu works on cards in both the New Arrivals module and the library grid (Play Next, Add to Queue, Reveal in Finder)
- [x] Drag-to-queue works from both contexts
- [x] `poetry run pytest tests/test_library.py tests/test_server.py` — all passing
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)