### PR TITLE
fix(server): add 'home' to active-view allow-list (KAMP-238)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -645,7 +645,7 @@ def create_app(
     @app.post("/api/v1/ui/active-view")
     def set_active_view(req: dict[str, Any]) -> dict[str, Any]:
         view = req.get("view", "library")
-        if view not in ("library", "now-playing"):
+        if view not in ("library", "now-playing", "home"):
             raise HTTPException(status_code=422, detail="Invalid view")
         _state["ui_active_view"] = view
         if on_ui_state_set is not None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1397,6 +1397,15 @@ class TestUiStateEndpoints:
         assert resp.status_code == 200
         assert client.get("/api/v1/ui").json()["sort_order"] == "last_played"
 
+    def test_set_active_view_home_returns_200(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/ui/active-view", json={"view": "home"})
+        assert resp.status_code == 200
+        assert client.get("/api/v1/ui").json()["active_view"] == "home"
+
+    def test_set_active_view_invalid_returns_422(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/ui/active-view", json={"view": "bogus"})
+        assert resp.status_code == 422
+
     def test_set_sort_order_invalid_returns_422(self, client: TestClient) -> None:
         resp = client.post("/api/v1/ui/sort-order", json={"sort_order": "bogus"})
         assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- `POST /api/v1/ui/active-view` rejected `{"view": "home"}` with 422 because the allow-list in `server.py` only included `"library"` and `"now-playing"` — predating the Base Kamp view
- Added `"home"` to the tuple; no other logic changed

## Test plan

- [x] `TestUiStateEndpoints::test_set_active_view_home_returns_200` — `'home'` accepted, persisted, and returned by `GET /api/v1/ui`
- [x] `TestUiStateEndpoints::test_set_active_view_invalid_returns_422` — unknown values still rejected
- [x] All existing `TestUiStateEndpoints` tests pass (no regression for `library`, `now-playing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)