### PR TITLE
fix(ui): re-fetch Base Kamp modules once server is reachable (KAMP-237)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -12,10 +12,14 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
   // at EOF before broadcasting track.changed, so the list is already stale by
   // the time this selector fires.
   const currentFilePath = useStore((s) => s.player?.current_track?.file_path ?? null)
+  const serverStatus = useStore((s) => s.serverStatus)
   const [albums, setAlbums] = useState<Album[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    // Skip until the server is reachable; this effect re-fires when serverStatus
+    // transitions to 'connected', so modules populate without a manual reload.
+    if (serverStatus !== 'connected') return
     getAlbums('last_played')
       .then((all) => {
         const played = all.filter((a) => a.last_played_at !== null).slice(0, count)
@@ -23,7 +27,7 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
       })
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [count, currentFilePath])
+  }, [count, currentFilePath, serverStatus])
 
   if (loading) {
     return (

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { getAlbums } from '../../api/client'
 import type { Album } from '../../api/client'
+import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
 import { GridView } from './GridView'
 import type { ModuleProps } from './registry'
@@ -9,10 +10,14 @@ const DAYS = 30
 const CUTOFF_SECONDS = DAYS * 86400
 
 export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Element {
+  const serverStatus = useStore((s) => s.serverStatus)
   const [albums, setAlbums] = useState<Album[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    // Skip until the server is reachable; this effect re-fires when serverStatus
+    // transitions to 'connected', so modules populate without a manual reload.
+    if (serverStatus !== 'connected') return
     getAlbums('date_added')
       .then((all) => {
         const cutoff = Date.now() / 1000 - CUTOFF_SECONDS
@@ -21,7 +26,7 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
       })
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [])
+  }, [serverStatus])
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

- `LastPlayedModule` and `NewArrivalsModule` now read `serverStatus` from the store and add it as a `useEffect` dependency
- A guard (`if (serverStatus !== 'connected') return`) skips the fetch until the server is reachable, so the effect re-fires when the server comes up
- Bonus: the skeleton stays visible during startup instead of flipping prematurely to the empty-state message

## Test plan

- [x] Launch the app; navigate to Base Kamp before the server is fully up — modules should show skeleton, then populate once connected
- [x] Normal launch (server already up) — modules populate on first view, no regression
- [x] Simulate reconnection (stop/start server) — modules refresh after reconnect

Fixes KAMP-237

🤖 Generated with [Claude Code](https://claude.com/claude-code)