### PR TITLE
feat(ui): List view for Base Kamp modules (KAMP-88)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2842,6 +2842,86 @@ body,
   padding: 4px 2px 8px;
 }
 
+/* List module view (vertical rows) */
+.module-list {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 0;
+}
+
+.module-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 100ms ease;
+}
+
+.module-list-row:hover {
+  background: var(--surface-hover);
+}
+
+.module-list-row.playing {
+  color: var(--accent);
+}
+
+.module-list-thumb {
+  position: relative;
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+  border-radius: 3px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.module-list-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.module-list-playing-badge {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  font-size: 14px;
+  color: #fff;
+}
+
+.module-list-info {
+  min-width: 0;
+  flex: 1;
+}
+
+.module-list-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.module-list-row.playing .module-list-title {
+  color: var(--accent);
+}
+
+.module-list-artist {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
 .module-empty {
   padding: 48px 16px;
   text-align: center;

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1235,6 +1235,7 @@ export function PreferencesDialog({
                       >
                         <option value="shelf">Shelf</option>
                         <option value="grid">Grid</option>
+                        <option value="list">List</option>
                       </select>
                       <div className="prefs-module-actions">
                         <button

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -4,6 +4,7 @@ import type { Album } from '../../api/client'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
 import { GridView } from './GridView'
+import { ListView } from './ListView'
 import type { ModuleProps } from './registry'
 
 export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Element {
@@ -43,5 +44,6 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
     return <div className="module-empty">No albums played yet.</div>
   }
 
+  if (displayStyle === 'list') return <ListView albums={albums} />
   return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
 }

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import type { Album } from '../../api/client'
+import { artUrl } from '../../api/client'
+import { useStore } from '../../store'
+
+interface ListViewProps {
+  albums: Album[]
+}
+
+function ListRow({ album }: { album: Album }): React.JSX.Element {
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const activeView = useStore((s) => s.activeView)
+  const currentTrack = useStore((s) => s.player.current_track)
+  const playing = useStore((s) => s.player.playing)
+
+  const isActive = album.missing_album
+    ? currentTrack?.file_path === album.file_path
+    : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
+
+  const handleSelect = (): void => {
+    if (activeView !== 'library') void setActiveView('library')
+    void selectAlbum(album)
+  }
+
+  return (
+    <div
+      className={`module-list-row${isActive ? ' playing' : ''}`}
+      tabIndex={0}
+      onClick={handleSelect}
+      onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
+    >
+      <div className="module-list-thumb">
+        {album.has_art && (
+          <img
+            src={artUrl(album.album_artist, album.album, album.file_path, album.art_version)}
+            alt=""
+          />
+        )}
+        {playing && isActive && <div className="module-list-playing-badge">▶</div>}
+      </div>
+      <div className="module-list-info">
+        <div className="module-list-title">
+          {album.missing_album ? <em>{album.album}</em> : album.album}
+        </div>
+        <div className="module-list-artist">{album.album_artist}</div>
+      </div>
+    </div>
+  )
+}
+
+export function ListView({ albums }: ListViewProps): React.JSX.Element {
+  return (
+    <div className="module-list">
+      {albums.map((album) => (
+        <ListRow
+          key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
+          album={album}
+        />
+      ))}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -4,6 +4,7 @@ import type { Album } from '../../api/client'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
 import { GridView } from './GridView'
+import { ListView } from './ListView'
 import type { ModuleProps } from './registry'
 
 const DAYS = 30
@@ -42,5 +43,6 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
     return <div className="module-empty">No albums added in the last {DAYS} days.</div>
   }
 
+  if (displayStyle === 'list') return <ListView albums={albums} />
   return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
 }

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -2,7 +2,7 @@ import type React from 'react'
 import { NewArrivalsModule } from './NewArrivalsModule'
 import { LastPlayedModule } from './LastPlayedModule'
 
-export type DisplayStyle = 'shelf' | 'grid'
+export type DisplayStyle = 'shelf' | 'grid' | 'list'
 
 export interface ModuleProps {
   displayStyle: DisplayStyle


### PR DESCRIPTION
## Summary

- Adds `ListView` component: vertical rows with 48px art thumbnail, album title, and artist name
- Extends `DisplayStyle` union to include `'list'`
- Both `NewArrivalsModule` and `LastPlayedModule` render `ListView` when the list style is selected
- Adds "List" option to the per-module style picker in Preferences → Home
- Rows are clickable (navigates to album in library) and highlight the currently playing album

## Test plan

- [x] Open Preferences → Home, change a module's display style to "List" — rows render with art, title, and artist
- [x] Works for both New Arrivals and Last Played modules
- [x] Currently playing album row is highlighted in accent color with ▶ overlay on thumbnail
- [x] Clicking a row navigates to that album in the Library view
- [x] Shelf and Grid styles still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)