### PR TITLE
feat(ui): configurable days window for Last Played module (KAMP-240)

### DIFF
--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -932,6 +932,8 @@ export function PreferencesDialog({
   const setModuleDisplayStyle = useStore((s) => s.setModuleDisplayStyle)
   const lastPlayedCount = useStore((s) => s.lastPlayedCount)
   const setLastPlayedCount = useStore((s) => s.setLastPlayedCount)
+  const lastPlayedDays = useStore((s) => s.lastPlayedDays)
+  const setLastPlayedDays = useStore((s) => s.setLastPlayedDays)
 
   const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions' | 'home'>(
     () => prefsInitialTab
@@ -1312,6 +1314,25 @@ export function PreferencesDialog({
                       }
                     />
                     <span className="prefs-unit">albums</span>
+                  </div>
+                </div>
+                <div className="prefs-row">
+                  <div className="prefs-row-header">
+                    <span className="prefs-label">Last Played — history window</span>
+                    <span className="prefs-hint">0 = no limit</span>
+                  </div>
+                  <div className="prefs-number-row">
+                    <input
+                      type="number"
+                      min={0}
+                      max={3650}
+                      className="prefs-input prefs-input--number"
+                      value={lastPlayedDays}
+                      onChange={(e) =>
+                        setLastPlayedDays(Math.max(0, parseInt(e.target.value) || 0))
+                      }
+                    />
+                    <span className="prefs-unit">days</span>
                   </div>
                 </div>
               </div>

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -26,7 +26,9 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
       .then((all) => {
         const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
         const played = all
-          .filter((a) => a.last_played_at !== null && (cutoff === null || a.last_played_at >= cutoff))
+          .filter(
+            (a) => a.last_played_at !== null && (cutoff === null || a.last_played_at >= cutoff)
+          )
           .slice(0, count)
         setAlbums(played)
       })

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -9,6 +9,7 @@ import type { ModuleProps } from './registry'
 
 export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Element {
   const count = useStore((s) => s.lastPlayedCount)
+  const days = useStore((s) => s.lastPlayedDays)
   // Re-fetch whenever the current track changes — the server updates last_played
   // at EOF before broadcasting track.changed, so the list is already stale by
   // the time this selector fires.
@@ -23,12 +24,15 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
     if (serverStatus !== 'connected') return
     getAlbums('last_played')
       .then((all) => {
-        const played = all.filter((a) => a.last_played_at !== null).slice(0, count)
+        const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
+        const played = all
+          .filter((a) => a.last_played_at !== null && (cutoff === null || a.last_played_at >= cutoff))
+          .slice(0, count)
         setAlbums(played)
       })
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [count, currentFilePath, serverStatus])
+  }, [count, days, currentFilePath, serverStatus])
 
   if (loading) {
     return (

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -43,6 +43,7 @@ type PlayerStore = {
   moduleOrder: string[]
   moduleDisplayStyles: Record<string, DisplayStyle>
   lastPlayedCount: number
+  lastPlayedDays: number
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
   searchQuery: string
   searchResults: SearchResult | null
@@ -62,6 +63,7 @@ type PlayerStore = {
   setModuleOrder: (ids: string[]) => void
   setModuleDisplayStyle: (id: string, style: DisplayStyle) => void
   setLastPlayedCount: (n: number) => void
+  setLastPlayedDays: (n: number) => void
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
@@ -155,6 +157,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
   lastPlayedCount: (() => {
     const saved = localStorage.getItem('kamp:last-played-count')
     return saved ? parseInt(saved) : 10
+  })(),
+  lastPlayedDays: (() => {
+    const saved = localStorage.getItem('kamp:last-played-days')
+    return saved ? parseInt(saved) : 30
   })(),
   sortOrder: 'album_artist',
   searchQuery: '',
@@ -254,6 +260,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setLastPlayedCount: (n) => {
     localStorage.setItem('kamp:last-played-count', String(n))
     set({ lastPlayedCount: n })
+  },
+
+  setLastPlayedDays: (n) => {
+    localStorage.setItem('kamp:last-played-days', String(n))
+    set({ lastPlayedDays: n })
   },
 
   loadUiState: async () => {


### PR DESCRIPTION
## Summary

- Adds `lastPlayedDays` to the store (default: 30 days, 0 = no limit), persisted to `localStorage` under `kamp:last-played-days`
- `LastPlayedModule` applies a cutoff filter when `days > 0`; re-fetches whenever the setting changes
- Preferences → Base Kamp gains a **Days** number input (range 0–3650) beneath the existing Count input, with a `0 = no limit` hint

## Test plan

- [x] Open Preferences → Base Kamp — confirm "Last Played — history window" row appears next to the count row
- [x] Set Days to 7 — module should only show albums played in the last week
- [x] Set Days to 0 — module should show all played albums (no cutoff)
- [x] Restart the app — setting persists
- [x] Change Days while the module is visible — module re-fetches immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)