### PR TITLE
feat(ui): configurable count and days window for Recently Added module (KAMP-242)

### DIFF
--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -934,6 +934,10 @@ export function PreferencesDialog({
   const setLastPlayedCount = useStore((s) => s.setLastPlayedCount)
   const lastPlayedDays = useStore((s) => s.lastPlayedDays)
   const setLastPlayedDays = useStore((s) => s.setLastPlayedDays)
+  const recentlyAddedCount = useStore((s) => s.recentlyAddedCount)
+  const setRecentlyAddedCount = useStore((s) => s.setRecentlyAddedCount)
+  const recentlyAddedDays = useStore((s) => s.recentlyAddedDays)
+  const setRecentlyAddedDays = useStore((s) => s.setRecentlyAddedDays)
 
   const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions' | 'home'>(
     () => prefsInitialTab
@@ -1301,16 +1305,17 @@ export function PreferencesDialog({
                 <div className="prefs-row">
                   <div className="prefs-row-header">
                     <span className="prefs-label">Last Played — albums to show</span>
+                    <span className="prefs-hint">0 = no limit</span>
                   </div>
                   <div className="prefs-number-row">
                     <input
                       type="number"
-                      min={1}
+                      min={0}
                       max={50}
                       className="prefs-input prefs-input--number"
                       value={lastPlayedCount}
                       onChange={(e) =>
-                        setLastPlayedCount(Math.max(1, parseInt(e.target.value) || 1))
+                        setLastPlayedCount(Math.max(0, parseInt(e.target.value) || 0))
                       }
                     />
                     <span className="prefs-unit">albums</span>
@@ -1330,6 +1335,44 @@ export function PreferencesDialog({
                       value={lastPlayedDays}
                       onChange={(e) =>
                         setLastPlayedDays(Math.max(0, parseInt(e.target.value) || 0))
+                      }
+                    />
+                    <span className="prefs-unit">days</span>
+                  </div>
+                </div>
+                <div className="prefs-row">
+                  <div className="prefs-row-header">
+                    <span className="prefs-label">Recently Added — albums to show</span>
+                    <span className="prefs-hint">0 = no limit</span>
+                  </div>
+                  <div className="prefs-number-row">
+                    <input
+                      type="number"
+                      min={0}
+                      max={50}
+                      className="prefs-input prefs-input--number"
+                      value={recentlyAddedCount}
+                      onChange={(e) =>
+                        setRecentlyAddedCount(Math.max(0, parseInt(e.target.value) || 0))
+                      }
+                    />
+                    <span className="prefs-unit">albums</span>
+                  </div>
+                </div>
+                <div className="prefs-row">
+                  <div className="prefs-row-header">
+                    <span className="prefs-label">Recently Added — history window</span>
+                    <span className="prefs-hint">0 = no limit</span>
+                  </div>
+                  <div className="prefs-number-row">
+                    <input
+                      type="number"
+                      min={0}
+                      max={3650}
+                      className="prefs-input prefs-input--number"
+                      value={recentlyAddedDays}
+                      onChange={(e) =>
+                        setRecentlyAddedDays(Math.max(0, parseInt(e.target.value) || 0))
                       }
                     />
                     <span className="prefs-unit">days</span>

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -29,7 +29,7 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
           .filter(
             (a) => a.last_played_at !== null && (cutoff === null || a.last_played_at >= cutoff)
           )
-          .slice(0, count)
+          .slice(0, count > 0 ? count : undefined)
         setAlbums(played)
       })
       .catch(() => {})

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -7,10 +7,9 @@ import { GridView } from './GridView'
 import { ListView } from './ListView'
 import type { ModuleProps } from './registry'
 
-const DAYS = 30
-const CUTOFF_SECONDS = DAYS * 86400
-
 export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Element {
+  const count = useStore((s) => s.recentlyAddedCount)
+  const days = useStore((s) => s.recentlyAddedDays)
   const serverStatus = useStore((s) => s.serverStatus)
   const [albums, setAlbums] = useState<Album[]>([])
   const [loading, setLoading] = useState(true)
@@ -21,13 +20,15 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
     if (serverStatus !== 'connected') return
     getAlbums('date_added')
       .then((all) => {
-        const cutoff = Date.now() / 1000 - CUTOFF_SECONDS
-        const recent = all.filter((a) => a.added_at !== null && a.added_at >= cutoff)
+        const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
+        const recent = all
+          .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
+          .slice(0, count > 0 ? count : undefined)
         setAlbums(recent)
       })
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [serverStatus])
+  }, [count, days, serverStatus])
 
   if (loading) {
     return (
@@ -40,7 +41,11 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
   }
 
   if (albums.length === 0) {
-    return <div className="module-empty">No albums added in the last {DAYS} days.</div>
+    return (
+      <div className="module-empty">
+        {days > 0 ? `No albums added in the last ${days} days.` : 'No albums in your library.'}
+      </div>
+    )
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -44,6 +44,8 @@ type PlayerStore = {
   moduleDisplayStyles: Record<string, DisplayStyle>
   lastPlayedCount: number
   lastPlayedDays: number
+  recentlyAddedCount: number
+  recentlyAddedDays: number
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
   searchQuery: string
   searchResults: SearchResult | null
@@ -64,6 +66,8 @@ type PlayerStore = {
   setModuleDisplayStyle: (id: string, style: DisplayStyle) => void
   setLastPlayedCount: (n: number) => void
   setLastPlayedDays: (n: number) => void
+  setRecentlyAddedCount: (n: number) => void
+  setRecentlyAddedDays: (n: number) => void
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
@@ -160,6 +164,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
   })(),
   lastPlayedDays: (() => {
     const saved = localStorage.getItem('kamp:last-played-days')
+    return saved ? parseInt(saved) : 30
+  })(),
+  recentlyAddedCount: (() => {
+    const saved = localStorage.getItem('kamp:recently-added-count')
+    return saved ? parseInt(saved) : 10
+  })(),
+  recentlyAddedDays: (() => {
+    const saved = localStorage.getItem('kamp:recently-added-days')
     return saved ? parseInt(saved) : 30
   })(),
   sortOrder: 'album_artist',
@@ -265,6 +277,16 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setLastPlayedDays: (n) => {
     localStorage.setItem('kamp:last-played-days', String(n))
     set({ lastPlayedDays: n })
+  },
+
+  setRecentlyAddedCount: (n) => {
+    localStorage.setItem('kamp:recently-added-count', String(n))
+    set({ recentlyAddedCount: n })
+  },
+
+  setRecentlyAddedDays: (n) => {
+    localStorage.setItem('kamp:recently-added-days', String(n))
+    set({ recentlyAddedDays: n })
   },
 
   loadUiState: async () => {


### PR DESCRIPTION
## Summary
- Adds **albums to show** and **history window (days)** settings for the Recently Added module, mirroring the existing Last Played preferences (KAMP-240)
- Also allows `0` (no limit) for the album count on both Last Played and Recently Added
- Settings are persisted to `localStorage` (`kamp:recently-added-count`, `kamp:recently-added-days`); defaults are 10 albums / 30 days

## Test plan
- [x] Open Preferences → Home tab → Module Settings — verify four rows appear: Last Played count, Last Played days, Recently Added count, Recently Added days
- [x] Set Recently Added count to `5` — verify module shows at most 5 albums
- [x] Set Recently Added count to `0` — verify all matching albums show (no cap)
- [x] Set Recently Added days to `0` — verify all albums show regardless of when they were added
- [x] Set Last Played count to `0` — verify no cap is applied
- [x] Reload the app — verify all four values persist from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)