### PR TITLE
fix(ui): add context menu to module List View items (KAMP-243)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -1,7 +1,11 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { Album } from '../../api/client'
-import { artUrl } from '../../api/client'
+import { artUrl, getTracksForAlbum } from '../../api/client'
 import { useStore } from '../../store'
+import { useMenuBounds } from '../../hooks/useMenuBounds'
+
+type MenuPos = { x: number; y: number }
 
 interface ListViewProps {
   albums: Album[]
@@ -11,12 +15,29 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
+  const [menu, setMenu] = useState<MenuPos | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   const isActive = album.missing_album
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
+
+  useEffect(() => {
+    if (!menu) return
+    const handler = (e: MouseEvent): void => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenu(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [menu])
+
+  useMenuBounds(menuRef, menu)
 
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
@@ -29,6 +50,10 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
       tabIndex={0}
       onClick={handleSelect}
       onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY })
+      }}
     >
       <div className="module-list-thumb">
         {album.has_art && (
@@ -45,6 +70,53 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
         </div>
         <div className="module-list-artist">{album.album_artist}</div>
       </div>
+      {menu &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="track-context-menu"
+            style={{ top: menu.y, left: menu.x }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void playAlbumNext(album.album_artist, album.album, album.file_path)
+                setMenu(null)
+              }}
+            >
+              ▶ Play Next
+            </button>
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void addAlbumToQueue(album.album_artist, album.album, album.file_path)
+                setMenu(null)
+              }}
+            >
+              + Add to Queue
+            </button>
+            <button
+              className="track-context-menu-item"
+              onClick={async () => {
+                let filePath = album.file_path
+                if (!filePath) {
+                  const tracks = await getTracksForAlbum(album.album_artist, album.album)
+                  filePath = tracks[0]?.file_path ?? ''
+                }
+                if (filePath) window.api.showItemInFolder(filePath)
+                setMenu(null)
+              }}
+            >
+              {window.electron.process.platform === 'darwin'
+                ? '↗ Reveal in Finder'
+                : window.electron.process.platform === 'win32'
+                  ? '↗ Show in Explorer'
+                  : '↗ Show in Files'}
+            </button>
+          </div>,
+          document.body
+        )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `ListRow` in `ListView.tsx` was missing the context menu that `AlbumCard` has in grid/shelf views
- Added `onContextMenu` handler, menu state, click-outside dismiss, `useMenuBounds`, and portal-rendered menu with Play Next / Add to Queue / Reveal in Finder

## Test plan
- [x] Set a module (Last Played or Recently Added) to List View in preferences
- [x] Right-click a row — context menu should appear with Play Next, Add to Queue, and Reveal in Finder
- [x] Click outside the menu — it should dismiss
- [x] Verify grid/shelf views are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)