### PR TITLE
refactor(ui): extract shared ContextMenu base component (KAMP-245)

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import React, { useState } from 'react'
 import { useStore } from '../store'
-import { artUrl, getTracksForAlbum } from '../api/client'
+import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
-import { useMenuBounds } from '../hooks/useMenuBounds'
+import { AlbumContextMenu } from './AlbumContextMenu'
 
 type MenuPos = { x: number; y: number }
 
@@ -11,30 +10,14 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)
-  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
-  const playAlbumNext = useStore((s) => s.playAlbumNext)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
   const [artLoaded, setArtLoaded] = useState(false)
   const [menu, setMenu] = useState<MenuPos | null>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
 
   const isActive = album.missing_album
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
-
-  useEffect(() => {
-    if (!menu) return
-    const handler = (e: MouseEvent): void => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [menu])
-
-  useMenuBounds(menuRef, menu)
 
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
@@ -88,53 +71,9 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
         <div className="album-year">{album.year}</div>
       </div>
 
-      {menu &&
-        createPortal(
-          <div
-            ref={menuRef}
-            className="track-context-menu"
-            style={{ top: menu.y, left: menu.x }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void playAlbumNext(album.album_artist, album.album, album.file_path)
-                setMenu(null)
-              }}
-            >
-              ▶ Play Next
-            </button>
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void addAlbumToQueue(album.album_artist, album.album, album.file_path)
-                setMenu(null)
-              }}
-            >
-              + Add to Queue
-            </button>
-            <button
-              className="track-context-menu-item"
-              onClick={async () => {
-                let filePath = album.file_path
-                if (!filePath) {
-                  const tracks = await getTracksForAlbum(album.album_artist, album.album)
-                  filePath = tracks[0]?.file_path ?? ''
-                }
-                if (filePath) window.api.showItemInFolder(filePath)
-                setMenu(null)
-              }}
-            >
-              {window.electron.process.platform === 'darwin'
-                ? '↗ Reveal in Finder'
-                : window.electron.process.platform === 'win32'
-                  ? '↗ Show in Explorer'
-                  : '↗ Show in Files'}
-            </button>
-          </div>,
-          document.body
-        )}
+      {menu && (
+        <AlbumContextMenu x={menu.x} y={menu.y} album={album} onClose={() => setMenu(null)} />
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { useStore } from '../store'
+import { getTracksForAlbum } from '../api/client'
+import type { Album } from '../api/client'
+import { ContextMenu } from './ContextMenu'
+import { revealInFinderLabel } from '../hooks/platformLabel'
+
+interface Props {
+  x: number
+  y: number
+  album: Album
+  onClose: () => void
+}
+
+export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Element {
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+
+  return (
+    <ContextMenu x={x} y={y} onClose={onClose}>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void playAlbumNext(album.album_artist, album.album, album.file_path)
+          onClose()
+        }}
+      >
+        ▶ Play Next
+      </button>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void addAlbumToQueue(album.album_artist, album.album, album.file_path)
+          onClose()
+        }}
+      >
+        + Add to Queue
+      </button>
+      <button
+        className="track-context-menu-item"
+        onClick={async () => {
+          let filePath = album.file_path
+          if (!filePath) {
+            const tracks = await getTracksForAlbum(album.album_artist, album.album)
+            filePath = tracks[0]?.file_path ?? ''
+          }
+          if (filePath) window.api.showItemInFolder(filePath)
+          onClose()
+        }}
+      >
+        {revealInFinderLabel()}
+      </button>
+    </ContextMenu>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/ContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/ContextMenu.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useMenuBounds } from '../hooks/useMenuBounds'
+
+interface Props {
+  x: number
+  y: number
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export function ContextMenu({ x, y, onClose, children }: Props): React.JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [onClose])
+
+  useMenuBounds(ref, true)
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="track-context-menu"
+      style={{ top: y, left: x }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>,
+    document.body
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { useStore } from '../store'
+import { ContextMenu } from './ContextMenu'
+
+interface Props {
+  x: number
+  y: number
+  albumArtist?: string
+  album?: string
+  trackIdx: number | null
+  onClose: () => void
+}
+
+export function QueueContextMenu({
+  x,
+  y,
+  albumArtist,
+  album,
+  trackIdx,
+  onClose
+}: Props): React.JSX.Element {
+  const albums = useStore((s) => s.library.albums)
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const clearQueue = useStore((s) => s.clearQueue)
+  const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
+
+  return (
+    <ContextMenu x={x} y={y} onClose={onClose}>
+      {albumArtist && album && (
+        <>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              const found = albums.find(
+                (a) => a.album_artist === albumArtist && a.album === album
+              ) ?? {
+                album_artist: albumArtist,
+                album,
+                year: '',
+                track_count: 0,
+                has_art: false,
+                missing_album: false,
+                file_path: '',
+                art_version: null,
+                added_at: null,
+                last_played_at: null
+              }
+              void setActiveView('library')
+              void selectAlbum(found)
+              onClose()
+            }}
+          >
+            ⌾ Go to Album
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void setActiveView('library')
+              selectArtist(albumArtist)
+              onClose()
+            }}
+          >
+            ♫ Go to Artist
+          </button>
+          <div className="track-context-menu-divider" />
+        </>
+      )}
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void clearQueue()
+          onClose()
+        }}
+      >
+        Clear Queue
+      </button>
+      {trackIdx !== null && (
+        <button
+          className="track-context-menu-item"
+          onClick={() => {
+            void clearRemainingQueue(trackIdx)
+            onClose()
+          }}
+        >
+          Clear Remaining
+        </button>
+      )}
+    </ContextMenu>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
-import { useMenuBounds } from '../hooks/useMenuBounds'
+import { QueueContextMenu } from './QueueContextMenu'
 
 type ContextMenu = {
   x: number
@@ -15,21 +15,14 @@ export function QueuePanel(): React.JSX.Element {
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
   const skipToQueueTrack = useStore((s) => s.skipToQueueTrack)
-  const clearQueue = useStore((s) => s.clearQueue)
-  const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
   const addToQueue = useStore((s) => s.addToQueue)
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const insertAlbumAt = useStore((s) => s.insertAlbumAt)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
-  const albums = useStore((s) => s.library.albums)
-  const selectAlbum = useStore((s) => s.selectAlbum)
-  const selectArtist = useStore((s) => s.selectArtist)
-  const setActiveView = useStore((s) => s.setActiveView)
   const activeRef = useRef<HTMLLIElement>(null)
   const listRef = useRef<HTMLOListElement>(null)
   const hasMounted = useRef(false)
   const [menu, setMenu] = useState<ContextMenu | null>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
 
   const tracks = queue?.tracks ?? []
   const position = queue?.position ?? -1
@@ -50,20 +43,6 @@ export function QueuePanel(): React.JSX.Element {
     const rowHeight = active.offsetHeight
     list.scrollTo({ top: (position - 5) * rowHeight, behavior })
   }, [position])
-
-  // Dismiss context menu on click outside.
-  useEffect(() => {
-    if (!menu) return
-    const handler = (e: MouseEvent): void => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [menu])
-
-  useMenuBounds(menuRef, menu)
 
   function handleDrop(e: React.DragEvent, dropIdx: number): void {
     e.stopPropagation()
@@ -236,67 +215,14 @@ export function QueuePanel(): React.JSX.Element {
         </ol>
       )}
       {menu && (
-        <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
-          {menu.albumArtist && menu.album && (
-            <>
-              <button
-                className="track-context-menu-item"
-                onClick={() => {
-                  const found = albums.find(
-                    (a) => a.album_artist === menu.albumArtist && a.album === menu.album
-                  ) ?? {
-                    album_artist: menu.albumArtist!,
-                    album: menu.album!,
-                    year: '',
-                    track_count: 0,
-                    has_art: false,
-                    missing_album: false,
-                    file_path: '',
-                    art_version: null,
-                    added_at: null,
-                    last_played_at: null
-                  }
-                  void setActiveView('library')
-                  void selectAlbum(found)
-                  setMenu(null)
-                }}
-              >
-                ⌾ Go to Album
-              </button>
-              <button
-                className="track-context-menu-item"
-                onClick={() => {
-                  void setActiveView('library')
-                  selectArtist(menu.albumArtist!)
-                  setMenu(null)
-                }}
-              >
-                ♫ Go to Artist
-              </button>
-              <div className="track-context-menu-divider" />
-            </>
-          )}
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void clearQueue()
-              setMenu(null)
-            }}
-          >
-            Clear Queue
-          </button>
-          {menu.trackIdx !== null && (
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void clearRemainingQueue(menu.trackIdx as number)
-                setMenu(null)
-              }}
-            >
-              Clear Remaining
-            </button>
-          )}
-        </div>
+        <QueueContextMenu
+          x={menu.x}
+          y={menu.y}
+          albumArtist={menu.albumArtist}
+          album={menu.album}
+          trackIdx={menu.trackIdx}
+          onClose={() => setMenu(null)}
+        />
       )}
     </aside>
   )

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
-import { artUrl, getTracksForAlbum } from '../api/client'
+import { artUrl } from '../api/client'
 import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
-import { useMenuBounds } from '../hooks/useMenuBounds'
+import { AlbumContextMenu } from './AlbumContextMenu'
+import { TrackContextMenu } from './TrackContextMenu'
 
 type AlbumMenu = { x: number; y: number; album: Album }
 type TrackMenu = { x: number; y: number; filePath: string; favorite: boolean }
@@ -114,43 +115,9 @@ function SearchTrackRow({
 export function SearchView(): React.JSX.Element {
   const results = useStore((s) => s.searchResults)
   const query = useStore((s) => s.searchQuery)
-  const playAlbumNext = useStore((s) => s.playAlbumNext)
-  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
-  const playNext = useStore((s) => s.playNext)
-  const addToQueue = useStore((s) => s.addToQueue)
-  const setFavorite = useStore((s) => s.setFavorite)
 
   const [albumMenu, setAlbumMenu] = useState<AlbumMenu | null>(null)
   const [trackMenu, setTrackMenu] = useState<TrackMenu | null>(null)
-  const albumMenuRef = useRef<HTMLDivElement>(null)
-  const trackMenuRef = useRef<HTMLDivElement>(null)
-
-  // Dismiss album menu on click outside.
-  useEffect(() => {
-    if (!albumMenu) return
-    const handler = (e: MouseEvent): void => {
-      if (albumMenuRef.current && !albumMenuRef.current.contains(e.target as Node)) {
-        setAlbumMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [albumMenu])
-
-  // Dismiss track menu on click outside.
-  useEffect(() => {
-    if (!trackMenu) return
-    const handler = (e: MouseEvent): void => {
-      if (trackMenuRef.current && !trackMenuRef.current.contains(e.target as Node)) {
-        setTrackMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [trackMenu])
-
-  useMenuBounds(albumMenuRef, albumMenu)
-  useMenuBounds(trackMenuRef, trackMenu)
 
   if (!results) {
     return <div className="search-empty">Searching…</div>
@@ -209,121 +176,22 @@ export function SearchView(): React.JSX.Element {
       )}
 
       {albumMenu && (
-        <div
-          ref={albumMenuRef}
-          className="track-context-menu"
-          style={{ top: albumMenu.y, left: albumMenu.x }}
-        >
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void playAlbumNext(
-                albumMenu.album.album_artist,
-                albumMenu.album.album,
-                albumMenu.album.file_path
-              )
-              setAlbumMenu(null)
-            }}
-          >
-            ▶ Play Next
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void addAlbumToQueue(
-                albumMenu.album.album_artist,
-                albumMenu.album.album,
-                albumMenu.album.file_path
-              )
-              setAlbumMenu(null)
-            }}
-          >
-            + Add to Queue
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={async () => {
-              let filePath = albumMenu.album.file_path
-              if (!filePath) {
-                const tracks = await getTracksForAlbum(
-                  albumMenu.album.album_artist,
-                  albumMenu.album.album
-                )
-                filePath = tracks[0]?.file_path ?? ''
-              }
-              if (filePath) window.api.showItemInFolder(filePath)
-              setAlbumMenu(null)
-            }}
-          >
-            {window.electron.process.platform === 'darwin'
-              ? '↗ Reveal in Finder'
-              : window.electron.process.platform === 'win32'
-                ? '↗ Show in Explorer'
-                : '↗ Show in Files'}
-          </button>
-        </div>
+        <AlbumContextMenu
+          x={albumMenu.x}
+          y={albumMenu.y}
+          album={albumMenu.album}
+          onClose={() => setAlbumMenu(null)}
+        />
       )}
 
       {trackMenu && (
-        <div
-          ref={trackMenuRef}
-          className="track-context-menu"
-          style={{ top: trackMenu.y, left: trackMenu.x }}
-        >
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void playNext(trackMenu.filePath)
-              setTrackMenu(null)
-            }}
-          >
-            ▶ Play Next
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void addToQueue(trackMenu.filePath)
-              setTrackMenu(null)
-            }}
-          >
-            + Add to Queue
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void setFavorite(trackMenu.filePath, !trackMenu.favorite)
-              setTrackMenu(null)
-            }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill={trackMenu.favorite ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}
-            >
-              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-            </svg>
-            {trackMenu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              window.api.showItemInFolder(trackMenu.filePath)
-              setTrackMenu(null)
-            }}
-          >
-            {window.electron.process.platform === 'darwin'
-              ? '↗ Reveal in Finder'
-              : window.electron.process.platform === 'win32'
-                ? '↗ Show in Explorer'
-                : '↗ Show in Files'}
-          </button>
-        </div>
+        <TrackContextMenu
+          x={trackMenu.x}
+          y={trackMenu.y}
+          filePath={trackMenu.filePath}
+          favorite={trackMenu.favorite}
+          onClose={() => setTrackMenu(null)}
+        />
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { useStore } from '../store'
+import { ContextMenu } from './ContextMenu'
+import { revealInFinderLabel } from '../hooks/platformLabel'
+
+interface Props {
+  x: number
+  y: number
+  filePath: string
+  favorite: boolean
+  onClose: () => void
+}
+
+export function TrackContextMenu({ x, y, filePath, favorite, onClose }: Props): React.JSX.Element {
+  const playNext = useStore((s) => s.playNext)
+  const addToQueue = useStore((s) => s.addToQueue)
+  const setFavorite = useStore((s) => s.setFavorite)
+
+  return (
+    <ContextMenu x={x} y={y} onClose={onClose}>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void playNext(filePath)
+          onClose()
+        }}
+      >
+        ▶ Play Next
+      </button>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void addToQueue(filePath)
+          onClose()
+        }}
+      >
+        + Add to Queue
+      </button>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          void setFavorite(filePath, !favorite)
+          onClose()
+        }}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill={favorite ? 'currentColor' : 'none'}
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}
+        >
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+        </svg>
+        {favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+      </button>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          window.api.showItemInFolder(filePath)
+          onClose()
+        }}
+      >
+        {revealInFinderLabel()}
+      </button>
+    </ContextMenu>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
-import { useMenuBounds } from '../hooks/useMenuBounds'
+import { TrackContextMenu } from './TrackContextMenu'
 
 type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
@@ -27,26 +27,8 @@ export function TrackList(): React.JSX.Element | null {
   const selectArtist = useStore((s) => s.selectArtist)
   const playTrack = useStore((s) => s.playTrack)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
-  const addToQueue = useStore((s) => s.addToQueue)
-  const playNext = useStore((s) => s.playNext)
-  const setFavorite = useStore((s) => s.setFavorite)
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  // Dismiss the context menu on any click outside it.
-  useEffect(() => {
-    if (!menu) return
-    const handler = (e: MouseEvent): void => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [menu])
-
-  useMenuBounds(menuRef, menu)
 
   if (!album) return null
 
@@ -151,61 +133,13 @@ export function TrackList(): React.JSX.Element | null {
       </div>
 
       {menu && (
-        <div ref={menuRef} className="track-context-menu" style={{ top: menu.y, left: menu.x }}>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void playNext(menu.filePath)
-              setMenu(null)
-            }}
-          >
-            ▶ Play Next
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void addToQueue(menu.filePath)
-              setMenu(null)
-            }}
-          >
-            + Add to Queue
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void setFavorite(menu.filePath, !menu.favorite)
-              setMenu(null)
-            }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill={menu.favorite ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0 }}
-            >
-              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-            </svg>
-            {menu.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              window.api.showItemInFolder(menu.filePath)
-              setMenu(null)
-            }}
-          >
-            {window.electron.process.platform === 'darwin'
-              ? '↗ Reveal in Finder'
-              : window.electron.process.platform === 'win32'
-                ? '↗ Show in Explorer'
-                : '↗ Show in Files'}
-          </button>
-        </div>
+        <TrackContextMenu
+          x={menu.x}
+          y={menu.y}
+          filePath={menu.filePath}
+          favorite={menu.favorite}
+          onClose={() => setMenu(null)}
+        />
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import React, { useState } from 'react'
 import type { Album } from '../../api/client'
-import { artUrl, getTracksForAlbum } from '../../api/client'
+import { artUrl } from '../../api/client'
 import { useStore } from '../../store'
-import { useMenuBounds } from '../../hooks/useMenuBounds'
+import { AlbumContextMenu } from '../AlbumContextMenu'
 
 type MenuPos = { x: number; y: number }
 
@@ -15,29 +14,13 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)
-  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
-  const playAlbumNext = useStore((s) => s.playAlbumNext)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
   const [menu, setMenu] = useState<MenuPos | null>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
 
   const isActive = album.missing_album
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
-
-  useEffect(() => {
-    if (!menu) return
-    const handler = (e: MouseEvent): void => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenu(null)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [menu])
-
-  useMenuBounds(menuRef, menu)
 
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
@@ -70,53 +53,9 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
         </div>
         <div className="module-list-artist">{album.album_artist}</div>
       </div>
-      {menu &&
-        createPortal(
-          <div
-            ref={menuRef}
-            className="track-context-menu"
-            style={{ top: menu.y, left: menu.x }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void playAlbumNext(album.album_artist, album.album, album.file_path)
-                setMenu(null)
-              }}
-            >
-              ▶ Play Next
-            </button>
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void addAlbumToQueue(album.album_artist, album.album, album.file_path)
-                setMenu(null)
-              }}
-            >
-              + Add to Queue
-            </button>
-            <button
-              className="track-context-menu-item"
-              onClick={async () => {
-                let filePath = album.file_path
-                if (!filePath) {
-                  const tracks = await getTracksForAlbum(album.album_artist, album.album)
-                  filePath = tracks[0]?.file_path ?? ''
-                }
-                if (filePath) window.api.showItemInFolder(filePath)
-                setMenu(null)
-              }}
-            >
-              {window.electron.process.platform === 'darwin'
-                ? '↗ Reveal in Finder'
-                : window.electron.process.platform === 'win32'
-                  ? '↗ Show in Explorer'
-                  : '↗ Show in Files'}
-            </button>
-          </div>,
-          document.body
-        )}
+      {menu && (
+        <AlbumContextMenu x={menu.x} y={menu.y} album={album} onClose={() => setMenu(null)} />
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/hooks/platformLabel.ts
+++ b/kamp_ui/src/renderer/src/hooks/platformLabel.ts
@@ -1,0 +1,6 @@
+export function revealInFinderLabel(): string {
+  const p = window.electron.process.platform
+  if (p === 'darwin') return '↗ Reveal in Finder'
+  if (p === 'win32') return '↗ Show in Explorer'
+  return '↗ Show in Files'
+}


### PR DESCRIPTION
## Summary

- Extracts a `ContextMenu` base component that owns portal rendering, click-outside dismiss, and `useMenuBounds` — eliminating the same boilerplate that was duplicated across five components
- Adds three specific menus (`AlbumContextMenu`, `TrackContextMenu`, `QueueContextMenu`) that wrap the base with their own data shape and items
- Updates `AlbumCard`, `ListView`, `TrackList`, `SearchView`, and `QueuePanel` to use the new components; each now only manages menu trigger state
- Moves the platform-specific "Reveal in Finder / Show in Explorer / Show in Files" label to `hooks/platformLabel.ts` (required by the `react-refresh/only-export-components` rule)
- BandcampButton is out of scope per the ticket (anchor-positioned dropdown, different pattern)

Net: –441 / +310 lines across 10 files.

## Test plan

- [ ] Right-click an album card → Play Next / Add to Queue / Reveal in Finder all work
- [ ] Right-click a list view row (Recently Added, Last Played modules) → same items work
- [ ] Right-click a track in the track list → Play Next / Add to Queue / Toggle Favorite / Reveal in Finder work; heart icon reflects favorite state
- [ ] Right-click a search result album → album menu appears with correct items
- [ ] Right-click a search result track → track menu appears with correct items
- [ ] Right-click a queue track → Go to Album / Go to Artist navigate correctly; Clear Queue / Clear Remaining work
- [ ] Right-click the queue panel background (no track) → only Clear Queue appears (no Go to Album/Artist, no Clear Remaining)
- [ ] Menu is clamped to viewport when opened near an edge
- [ ] Clicking outside any menu dismisses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)