### PR TITLE
fix(ci): expand mypy coverage to kamp_core (KAMP-228)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 set -e
 
 poetry run black --check kamp_core/ kamp_daemon/ tests/
-poetry run mypy kamp_daemon/
+poetry run mypy kamp_daemon/ kamp_core/
 
 # Run UI checks only when kamp_ui files are staged — skips on Python-only commits.
 if git diff --cached --name-only | grep -q '^kamp_ui/'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: poetry run black --check .
 
       - name: Type-check
-        run: poetry run mypy kamp_daemon/
+        run: poetry run mypy kamp_daemon/ kamp_core/
 
       - name: Run tests
         run: poetry run pytest

--- a/kamp_core/macos_keychain.py
+++ b/kamp_core/macos_keychain.py
@@ -192,7 +192,7 @@ def _cf_data(s: str) -> c_void_p:
     return c_void_p(_CFDataCreate(None, encoded, len(encoded)))
 
 
-def _make_dict(**kwargs: object) -> c_void_p:
+def _make_dict(**kwargs: str | bool | c_void_p) -> c_void_p:
     """Build a CFDictionary from keyword args.
 
     Keys whose names start with ``kSec`` are resolved as Security.framework
@@ -214,7 +214,7 @@ def _make_dict(**kwargs: object) -> c_void_p:
             else:
                 cf_vals.append(_cf_str(v))
         else:
-            cf_vals.append(v)  # type: ignore[arg-type]
+            cf_vals.append(v)
 
     key_arr = (c_void_p * len(keys))(*cf_keys)
     val_arr = (c_void_p * len(vals))(*cf_vals)
@@ -239,7 +239,7 @@ def _raise_for_status(status: int) -> None:
 
 
 def _read_raw(service: str, username: str, use_dpc: bool) -> str | None:
-    q_kwargs: dict[str, object] = dict(
+    q_kwargs: dict[str, str | bool | c_void_p] = dict(
         kSecClass="kSecClassGenericPassword",
         kSecMatchLimit="kSecMatchLimitOne",
         kSecAttrService=service,
@@ -260,7 +260,7 @@ def _read_raw(service: str, username: str, use_dpc: bool) -> str | None:
 
 
 def _delete_raw(service: str, username: str, use_dpc: bool) -> None:
-    q_kwargs: dict[str, object] = dict(
+    q_kwargs: dict[str, str | bool | c_void_p] = dict(
         kSecClass="kSecClassGenericPassword",
         kSecAttrService=service,
         kSecAttrAccount=username,

--- a/kamp_core/macos_keychain.py
+++ b/kamp_core/macos_keychain.py
@@ -73,6 +73,7 @@ def _run_helper(
     op: str, service: str, username: str, password: str | None = None
 ) -> tuple[int, str]:
     """Invoke the helper binary and return (exit_code, stdout)."""
+    assert _helper_path is not None
     result = subprocess.run(
         [_helper_path, op, service, username],
         input=(password + "\n").encode("utf-8") if password is not None else None,


### PR DESCRIPTION
## Summary
- Extends `mypy` in CI and the pre-commit hook from `kamp_daemon/` to `kamp_daemon/ kamp_core/`
- Fixes `_helper_path: str | None` used in `subprocess.run` list in `kamp_core/macos_keychain.py` — the type error that was silently ignored under the old scope

## Test plan
- [x] CI passes (mypy clean across both packages)
- [x] Pre-commit hook runs `mypy kamp_daemon/ kamp_core/` and passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)