### PR TITLE
fix(ui): add drag-to-queue for Base Kamp list view items (KAMP-244)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -31,11 +31,23 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
     <div
       className={`module-list-row${isActive ? ' playing' : ''}`}
       tabIndex={0}
+      draggable
       onClick={handleSelect}
       onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
       onContextMenu={(e) => {
         e.preventDefault()
         setMenu({ x: e.clientX, y: e.clientY })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'text/kamp-album',
+          JSON.stringify({
+            album_artist: album.album_artist,
+            album: album.album,
+            file_path: album.file_path
+          })
+        )
+        e.dataTransfer.effectAllowed = 'copy'
       }}
     >
       <div className="module-list-thumb">


### PR DESCRIPTION
## Summary

- Base Kamp module list view items were missing `draggable` and `onDragStart` — the same props that `AlbumCard` (grid view) already has
- Added both to `ListRow` in `ListView.tsx`, setting `text/kamp-album` data to match what `QueuePanel`'s drop handler expects

## Test plan

- [x] In Base Kamp, switch a module to list view
- [x] Drag an item from the list view into the Queue panel — confirm it is added
- [x] Confirm grid view drag-to-queue still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)