### PR TITLE
feat(ui): module drag handles for inline reordering (KAMP-232)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2044,6 +2044,17 @@ body,
   color: var(--accent);
 }
 
+.track-context-menu-item:disabled {
+  color: var(--text-dim);
+  cursor: default;
+  opacity: 0.4;
+}
+
+.track-context-menu-item:disabled:hover {
+  background: none;
+  color: var(--text-dim);
+}
+
 .track-context-menu-divider {
   height: 1px;
   background: var(--border);
@@ -2724,12 +2735,33 @@ body,
 }
 
 .base-kamp-module-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   background: var(--surface);
   border-radius: 6px 6px 0 0;
-  padding: 6px 10px;
+  padding: 4px 10px 4px 6px;
   font-size: 14px;
   font-weight: 400;
   color: var(--text);
+}
+
+.base-kamp-drag-handle {
+  display: flex;
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: grab;
+  padding: 2px 3px;
+  border-radius: 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.base-kamp-drag-handle:hover {
+  color: var(--text);
+  background: var(--hover);
 }
 
 .base-kamp-module-body {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2734,13 +2734,18 @@ body,
   align-items: flex-start;
 }
 
+.base-kamp-module.drag-over > .base-kamp-module-label {
+  outline: 2px solid var(--accent);
+  border-radius: 6px 6px 0 0;
+}
+
 .base-kamp-module-label {
   display: flex;
   align-items: center;
   gap: 6px;
   background: var(--surface);
   border-radius: 6px 6px 0 0;
-  padding: 4px 10px 4px 6px;
+  padding: 6px 10px;
   font-size: 14px;
   font-weight: 400;
   color: var(--text);
@@ -3032,44 +3037,3 @@ body,
 }
 
 /* Preferences — Home tab module order editor */
-.prefs-module-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.prefs-module-actions {
-  display: flex;
-  gap: 4px;
-}
-
-.prefs-module-btn {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  color: var(--text-dim);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 11px;
-  padding: 2px 7px;
-  transition: color 100ms ease, border-color 100ms ease;
-}
-
-.prefs-module-btn:hover:not(:disabled) {
-  color: var(--text);
-  border-color: var(--text-dim);
-}
-
-.prefs-module-btn:disabled {
-  opacity: 0.3;
-  cursor: default;
-}
-
-.prefs-module-btn--remove {
-  color: var(--error);
-  border-color: var(--error);
-}
-
-.prefs-module-btn--remove:hover {
-  opacity: 0.8;
-}

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -3011,16 +3011,6 @@ body,
   gap: 4px;
 }
 
-.prefs-module-style-select {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text);
-  font-size: 12px;
-  padding: 2px 6px;
-  cursor: pointer;
-}
-
 .prefs-module-btn {
   background: none;
   border: 1px solid var(--border);

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -1,23 +1,44 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
 import { MODULE_REGISTRY } from './modules/registry'
 import type { ModuleRegistration } from './modules/registry'
+import { ContextMenu } from './ContextMenu'
+
+type Menu = { x: number; y: number; id: string }
 
 export function BaseKampView(): React.JSX.Element {
   const moduleOrder = useStore((s) => s.moduleOrder)
+  const setModuleOrder = useStore((s) => s.setModuleOrder)
   const moduleDisplayStyles = useStore((s) => s.moduleDisplayStyles)
   const editMode = useStore((s) => s.baseKampEditMode)
   const toggleEditMode = useStore((s) => s.toggleBaseKampEditMode)
+  const [menu, setMenu] = useState<Menu | null>(null)
 
   const modules = moduleOrder
     .map((id) => MODULE_REGISTRY.find((m) => m.id === id))
     .filter((m): m is ModuleRegistration => m !== undefined)
+
+  function moveModule(id: string, direction: 'top' | 'up' | 'down' | 'bottom'): void {
+    const idx = moduleOrder.indexOf(id)
+    if (idx === -1) return
+    const next = [...moduleOrder]
+    next.splice(idx, 1)
+    if (direction === 'top') next.unshift(id)
+    else if (direction === 'bottom') next.push(id)
+    else if (direction === 'up') next.splice(idx - 1, 0, id)
+    else next.splice(idx + 1, 0, id)
+    setModuleOrder(next)
+  }
 
   if (modules.length === 0) {
     return (
       <div className="base-kamp-empty">No modules configured. Add some in Preferences → Home.</div>
     )
   }
+
+  const menuIdx = menu ? moduleOrder.indexOf(menu.id) : -1
+  const menuAtTop = menuIdx === 0
+  const menuAtBottom = menuIdx === moduleOrder.length - 1
 
   return (
     <div className="base-kamp">
@@ -32,7 +53,23 @@ export function BaseKampView(): React.JSX.Element {
       </div>
       {modules.map((mod) => (
         <section key={mod.id} className="base-kamp-module">
-          <div className="base-kamp-module-label">{mod.title}</div>
+          <div className="base-kamp-module-label">
+            <button
+              className="base-kamp-drag-handle"
+              title="Reorder module"
+              onClick={(e) => setMenu({ x: e.clientX, y: e.clientY, id: mod.id })}
+            >
+              <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+                <circle cx="3" cy="3" r="1.5" fill="currentColor" />
+                <circle cx="7" cy="3" r="1.5" fill="currentColor" />
+                <circle cx="3" cy="7" r="1.5" fill="currentColor" />
+                <circle cx="7" cy="7" r="1.5" fill="currentColor" />
+                <circle cx="3" cy="11" r="1.5" fill="currentColor" />
+                <circle cx="7" cy="11" r="1.5" fill="currentColor" />
+              </svg>
+            </button>
+            {mod.title}
+          </div>
           <div className={`base-kamp-config-row${editMode ? ' visible' : ''}`}>
             {mod.configComponent && <mod.configComponent />}
           </div>
@@ -41,6 +78,50 @@ export function BaseKampView(): React.JSX.Element {
           </div>
         </section>
       ))}
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} onClose={() => setMenu(null)}>
+          <button
+            className="track-context-menu-item"
+            disabled={menuAtTop}
+            onClick={() => {
+              moveModule(menu.id, 'top')
+              setMenu(null)
+            }}
+          >
+            Move to Top
+          </button>
+          <button
+            className="track-context-menu-item"
+            disabled={menuAtTop}
+            onClick={() => {
+              moveModule(menu.id, 'up')
+              setMenu(null)
+            }}
+          >
+            Move Up
+          </button>
+          <button
+            className="track-context-menu-item"
+            disabled={menuAtBottom}
+            onClick={() => {
+              moveModule(menu.id, 'down')
+              setMenu(null)
+            }}
+          >
+            Move Down
+          </button>
+          <button
+            className="track-context-menu-item"
+            disabled={menuAtBottom}
+            onClick={() => {
+              moveModule(menu.id, 'bottom')
+              setMenu(null)
+            }}
+          >
+            Move to Bottom
+          </button>
+        </ContextMenu>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -13,6 +13,8 @@ export function BaseKampView(): React.JSX.Element {
   const editMode = useStore((s) => s.baseKampEditMode)
   const toggleEditMode = useStore((s) => s.toggleBaseKampEditMode)
   const [menu, setMenu] = useState<Menu | null>(null)
+  const [dragId, setDragId] = useState<string | null>(null)
+  const [dragOverId, setDragOverId] = useState<string | null>(null)
 
   const modules = moduleOrder
     .map((id) => MODULE_REGISTRY.find((m) => m.id === id))
@@ -30,10 +32,19 @@ export function BaseKampView(): React.JSX.Element {
     setModuleOrder(next)
   }
 
+  function dropModule(targetId: string): void {
+    if (!dragId || dragId === targetId) return
+    const fromIdx = moduleOrder.indexOf(dragId)
+    const toIdx = moduleOrder.indexOf(targetId)
+    if (fromIdx === -1 || toIdx === -1) return
+    const next = [...moduleOrder]
+    next.splice(fromIdx, 1)
+    next.splice(toIdx, 0, dragId)
+    setModuleOrder(next)
+  }
+
   if (modules.length === 0) {
-    return (
-      <div className="base-kamp-empty">No modules configured. Add some in Preferences → Home.</div>
-    )
+    return <div className="base-kamp-empty">No modules configured.</div>
   }
 
   const menuIdx = menu ? moduleOrder.indexOf(menu.id) : -1
@@ -52,22 +63,52 @@ export function BaseKampView(): React.JSX.Element {
         </button>
       </div>
       {modules.map((mod) => (
-        <section key={mod.id} className="base-kamp-module">
+        <section
+          key={mod.id}
+          className={`base-kamp-module${dragOverId === mod.id && dragId !== mod.id ? ' drag-over' : ''}`}
+          onDragOver={(e) => {
+            if (!dragId) return
+            e.preventDefault()
+            e.dataTransfer.dropEffect = 'move'
+            if (dragId !== mod.id) setDragOverId(mod.id)
+          }}
+          onDragLeave={() => setDragOverId(null)}
+          onDrop={(e) => {
+            e.preventDefault()
+            dropModule(mod.id)
+            setDragId(null)
+            setDragOverId(null)
+          }}
+        >
           <div className="base-kamp-module-label">
-            <button
-              className="base-kamp-drag-handle"
-              title="Reorder module"
-              onClick={(e) => setMenu({ x: e.clientX, y: e.clientY, id: mod.id })}
-            >
-              <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
-                <circle cx="3" cy="3" r="1.5" fill="currentColor" />
-                <circle cx="7" cy="3" r="1.5" fill="currentColor" />
-                <circle cx="3" cy="7" r="1.5" fill="currentColor" />
-                <circle cx="7" cy="7" r="1.5" fill="currentColor" />
-                <circle cx="3" cy="11" r="1.5" fill="currentColor" />
-                <circle cx="7" cy="11" r="1.5" fill="currentColor" />
-              </svg>
-            </button>
+            {editMode && (
+              <button
+                className="base-kamp-drag-handle"
+                title="Drag to reorder, right-click for options"
+                draggable
+                onDragStart={(e) => {
+                  setDragId(mod.id)
+                  e.dataTransfer.effectAllowed = 'move'
+                }}
+                onDragEnd={() => {
+                  setDragId(null)
+                  setDragOverId(null)
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  setMenu({ x: e.clientX, y: e.clientY, id: mod.id })
+                }}
+              >
+                <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+                  <circle cx="3" cy="3" r="1.5" fill="currentColor" />
+                  <circle cx="7" cy="3" r="1.5" fill="currentColor" />
+                  <circle cx="3" cy="7" r="1.5" fill="currentColor" />
+                  <circle cx="7" cy="7" r="1.5" fill="currentColor" />
+                  <circle cx="3" cy="11" r="1.5" fill="currentColor" />
+                  <circle cx="7" cy="11" r="1.5" fill="currentColor" />
+                </svg>
+              </button>
+            )}
             {mod.title}
           </div>
           <div className={`base-kamp-config-row${editMode ? ' visible' : ''}`}>

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -88,6 +88,7 @@ export function BaseKampView(): React.JSX.Element {
                 draggable
                 onDragStart={(e) => {
                   setDragId(mod.id)
+                  e.dataTransfer.setData('text/kamp-module-id', mod.id)
                   e.dataTransfer.effectAllowed = 'move'
                 }}
                 onDragEnd={() => {

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -4,7 +4,6 @@ import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kamp
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
 import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
-import { MODULE_REGISTRY } from './modules/registry'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -925,10 +924,7 @@ export function PreferencesDialog({
   const scanProgress = useStore((s) => s.scanProgress)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
 
-  const moduleOrder = useStore((s) => s.moduleOrder)
-  const setModuleOrder = useStore((s) => s.setModuleOrder)
-
-  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions' | 'home'>(
+  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions'>(
     () => prefsInitialTab
   )
 
@@ -1035,14 +1031,6 @@ export function PreferencesDialog({
             onClick={() => setActiveTab('general')}
           >
             General
-          </button>
-          <button
-            role="tab"
-            aria-selected={activeTab === 'home'}
-            className={`prefs-tab${activeTab === 'home' ? ' prefs-tab--active' : ''}`}
-            onClick={() => setActiveTab('home')}
-          >
-            Base Kamp
           </button>
           <button
             role="tab"
@@ -1207,78 +1195,6 @@ export function PreferencesDialog({
                   </div>
                 </>
               )}
-            </>
-          )}
-
-          {activeTab === 'home' && (
-            <>
-              <div className="prefs-section">
-                <div className="prefs-section-label">Modules</div>
-                {moduleOrder.length === 0 && (
-                  <p className="prefs-hint">No modules enabled. Add one below.</p>
-                )}
-                {moduleOrder.map((id, idx) => {
-                  const mod = MODULE_REGISTRY.find((m) => m.id === id)
-                  if (!mod) return null
-                  return (
-                    <div key={id} className="prefs-row prefs-module-row">
-                      <span className="prefs-label">{mod.title}</span>
-                      <div className="prefs-module-actions">
-                        <button
-                          className="prefs-module-btn"
-                          disabled={idx === 0}
-                          onClick={() => {
-                            const next = [...moduleOrder]
-                            ;[next[idx - 1], next[idx]] = [next[idx], next[idx - 1]]
-                            setModuleOrder(next)
-                          }}
-                          aria-label="Move up"
-                        >
-                          ↑
-                        </button>
-                        <button
-                          className="prefs-module-btn"
-                          disabled={idx === moduleOrder.length - 1}
-                          onClick={() => {
-                            const next = [...moduleOrder]
-                            ;[next[idx], next[idx + 1]] = [next[idx + 1], next[idx]]
-                            setModuleOrder(next)
-                          }}
-                          aria-label="Move down"
-                        >
-                          ↓
-                        </button>
-                        <button
-                          className="prefs-module-btn prefs-module-btn--remove"
-                          onClick={() => setModuleOrder(moduleOrder.filter((i) => i !== id))}
-                          aria-label="Remove module"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    </div>
-                  )
-                })}
-                {MODULE_REGISTRY.filter((m) => !moduleOrder.includes(m.id)).map((mod) => (
-                  <div
-                    key={mod.id}
-                    className="prefs-row prefs-module-row prefs-module-row--disabled"
-                  >
-                    <span className="prefs-label" style={{ color: 'var(--text-dim)' }}>
-                      {mod.title}
-                    </span>
-                    <div className="prefs-module-actions">
-                      <button
-                        className="prefs-module-btn"
-                        onClick={() => setModuleOrder([...moduleOrder, mod.id])}
-                        aria-label="Add module"
-                      >
-                        Add
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
             </>
           )}
 

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -5,7 +5,6 @@ import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
 import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
 import { MODULE_REGISTRY } from './modules/registry'
-import type { DisplayStyle } from './modules/registry'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -928,16 +927,6 @@ export function PreferencesDialog({
 
   const moduleOrder = useStore((s) => s.moduleOrder)
   const setModuleOrder = useStore((s) => s.setModuleOrder)
-  const moduleDisplayStyles = useStore((s) => s.moduleDisplayStyles)
-  const setModuleDisplayStyle = useStore((s) => s.setModuleDisplayStyle)
-  const lastPlayedCount = useStore((s) => s.lastPlayedCount)
-  const setLastPlayedCount = useStore((s) => s.setLastPlayedCount)
-  const lastPlayedDays = useStore((s) => s.lastPlayedDays)
-  const setLastPlayedDays = useStore((s) => s.setLastPlayedDays)
-  const recentlyAddedCount = useStore((s) => s.recentlyAddedCount)
-  const setRecentlyAddedCount = useStore((s) => s.setRecentlyAddedCount)
-  const recentlyAddedDays = useStore((s) => s.recentlyAddedDays)
-  const setRecentlyAddedDays = useStore((s) => s.setRecentlyAddedDays)
 
   const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions' | 'home'>(
     () => prefsInitialTab
@@ -1234,15 +1223,6 @@ export function PreferencesDialog({
                   return (
                     <div key={id} className="prefs-row prefs-module-row">
                       <span className="prefs-label">{mod.title}</span>
-                      <select
-                        className="prefs-module-style-select"
-                        value={moduleDisplayStyles[id] ?? 'shelf'}
-                        onChange={(e) => setModuleDisplayStyle(id, e.target.value as DisplayStyle)}
-                      >
-                        <option value="shelf">Shelf</option>
-                        <option value="grid">Grid</option>
-                        <option value="list">List</option>
-                      </select>
                       <div className="prefs-module-actions">
                         <button
                           className="prefs-module-btn"
@@ -1300,85 +1280,6 @@ export function PreferencesDialog({
                 ))}
               </div>
 
-              <div className="prefs-section">
-                <div className="prefs-section-label">Module Settings</div>
-                <div className="prefs-row">
-                  <div className="prefs-row-header">
-                    <span className="prefs-label">Last Played — albums to show</span>
-                    <span className="prefs-hint">0 = no limit</span>
-                  </div>
-                  <div className="prefs-number-row">
-                    <input
-                      type="number"
-                      min={0}
-                      max={50}
-                      className="prefs-input prefs-input--number"
-                      value={lastPlayedCount}
-                      onChange={(e) =>
-                        setLastPlayedCount(Math.max(0, parseInt(e.target.value) || 0))
-                      }
-                    />
-                    <span className="prefs-unit">albums</span>
-                  </div>
-                </div>
-                <div className="prefs-row">
-                  <div className="prefs-row-header">
-                    <span className="prefs-label">Last Played — history window</span>
-                    <span className="prefs-hint">0 = no limit</span>
-                  </div>
-                  <div className="prefs-number-row">
-                    <input
-                      type="number"
-                      min={0}
-                      max={3650}
-                      className="prefs-input prefs-input--number"
-                      value={lastPlayedDays}
-                      onChange={(e) =>
-                        setLastPlayedDays(Math.max(0, parseInt(e.target.value) || 0))
-                      }
-                    />
-                    <span className="prefs-unit">days</span>
-                  </div>
-                </div>
-                <div className="prefs-row">
-                  <div className="prefs-row-header">
-                    <span className="prefs-label">Recently Added — albums to show</span>
-                    <span className="prefs-hint">0 = no limit</span>
-                  </div>
-                  <div className="prefs-number-row">
-                    <input
-                      type="number"
-                      min={0}
-                      max={50}
-                      className="prefs-input prefs-input--number"
-                      value={recentlyAddedCount}
-                      onChange={(e) =>
-                        setRecentlyAddedCount(Math.max(0, parseInt(e.target.value) || 0))
-                      }
-                    />
-                    <span className="prefs-unit">albums</span>
-                  </div>
-                </div>
-                <div className="prefs-row">
-                  <div className="prefs-row-header">
-                    <span className="prefs-label">Recently Added — history window</span>
-                    <span className="prefs-hint">0 = no limit</span>
-                  </div>
-                  <div className="prefs-number-row">
-                    <input
-                      type="number"
-                      min={0}
-                      max={3650}
-                      className="prefs-input prefs-input--number"
-                      value={recentlyAddedDays}
-                      onChange={(e) =>
-                        setRecentlyAddedDays(Math.max(0, parseInt(e.target.value) || 0))
-                      }
-                    />
-                    <span className="prefs-unit">days</span>
-                  </div>
-                </div>
-              </div>
             </>
           )}
 

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1279,7 +1279,6 @@ export function PreferencesDialog({
                   </div>
                 ))}
               </div>
-
             </>
           )}
 

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -2,6 +2,11 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { QueueContextMenu } from './QueueContextMenu'
 
+const QUEUE_DROP_TYPES = new Set(['text/kamp-track-path', 'text/kamp-album', 'text/kamp-queue-idx'])
+function isQueueDrop(types: DOMStringList | readonly string[]): boolean {
+  return Array.from(types).some((t) => QUEUE_DROP_TYPES.has(t))
+}
+
 type ContextMenu = {
   x: number
   y: number
@@ -116,7 +121,10 @@ export function QueuePanel(): React.JSX.Element {
       {tracks.length === 0 ? (
         <div
           className="queue-empty"
-          onDragOver={(e) => e.preventDefault()}
+          onDragOver={(e) => {
+            if (!isQueueDrop(e.dataTransfer.types)) return
+            e.preventDefault()
+          }}
           onDrop={(e) => {
             const trackPath = e.dataTransfer.getData('text/kamp-track-path')
             const albumJson = e.dataTransfer.getData('text/kamp-album')
@@ -151,6 +159,7 @@ export function QueuePanel(): React.JSX.Element {
             setMenu({ x: e.clientX, y: e.clientY, trackIdx: null })
           }}
           onDragOver={(e) => {
+            if (!isQueueDrop(e.dataTransfer.types)) return
             e.preventDefault()
             e.currentTarget.classList.add('queue-tail-drop')
           }}
@@ -179,6 +188,7 @@ export function QueuePanel(): React.JSX.Element {
                   e.dataTransfer.effectAllowed = 'move'
                 }}
                 onDragOver={(e) => {
+                  if (!isQueueDrop(e.dataTransfer.types)) return
                   e.preventDefault()
                   e.stopPropagation()
                   e.currentTarget.classList.add('drag-over')

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -120,10 +120,10 @@ type PlayerStore = {
   // Preferences
   configValues: ConfigValues | null
   prefsOpen: boolean
-  prefsInitialTab: 'general' | 'services' | 'extensions' | 'home'
+  prefsInitialTab: 'general' | 'services' | 'extensions'
   loadConfig: () => Promise<void>
   setConfigValue: (key: string, value: string) => Promise<void>
-  openPrefs: (tab?: 'general' | 'services' | 'extensions' | 'home') => void
+  openPrefs: (tab?: 'general' | 'services' | 'extensions') => void
   closePrefs: () => void
 }
 


### PR DESCRIPTION
## Summary

- Adds a grip handle to each Base Kamp module label (visible only in edit mode via the gear toggle)
- Dragging the handle reorders modules via HTML5 DnD; the drop target shows an accent outline as feedback
- Right-clicking the handle opens a context menu with Move to Top / Move Up / Move Down / Move to Bottom, with boundary checks disabling irrelevant actions
- Removes the Base Kamp preferences tab entirely — module ordering and configuration are now handled inline
- Cleans up dead CSS (`prefs-module-*` block, `.prefs-module-style-select`) and the previously-redundant display-style select and Module Settings section from preferences

## Test plan

- [x] In Base Kamp view, gear button is inactive — no drag handles visible
- [x] Click gear → handles appear on each module label
- [x] Drag a handle to reorder modules — drop target shows accent outline, order updates on drop
- [x] Right-click a handle → context menu appears; Move to Top/Up disabled for first module, Down/Bottom disabled for last
- [x] All four move actions work correctly
- [x] Click gear again → handles disappear, config rows collapse
- [x] Preferences dialog no longer has a "Base Kamp" tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)