### PR TITLE
feat(ui): remove module button on Base Kamp inline toolbar (KAMP-255)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2780,34 +2780,11 @@ body,
   flex-shrink: 0;
   opacity: 0.7;
   transition: opacity 0.15s;
-  position: relative;
-}
-
-.base-kamp-remove-btn::after {
-  content: 'Remove Module';
-  position: absolute;
-  bottom: calc(100% + 5px);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--surface-raised, #333);
-  color: var(--text);
-  padding: 3px 7px;
-  border-radius: 3px;
-  font-size: 11px;
-  white-space: nowrap;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s;
-  z-index: 100;
 }
 
 .base-kamp-remove-btn:hover {
   opacity: 1;
   background: var(--hover);
-}
-
-.base-kamp-remove-btn:hover::after {
-  opacity: 1;
 }
 
 .base-kamp-module-body {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2780,11 +2780,34 @@ body,
   flex-shrink: 0;
   opacity: 0.7;
   transition: opacity 0.15s;
+  position: relative;
+}
+
+.base-kamp-remove-btn::after {
+  content: 'Remove Module';
+  position: absolute;
+  bottom: calc(100% + 5px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-raised, #333);
+  color: var(--text);
+  padding: 3px 7px;
+  border-radius: 3px;
+  font-size: 11px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 100;
 }
 
 .base-kamp-remove-btn:hover {
   opacity: 1;
   background: var(--hover);
+}
+
+.base-kamp-remove-btn:hover::after {
+  opacity: 1;
 }
 
 .base-kamp-module-body {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2769,6 +2769,24 @@ body,
   background: var(--hover);
 }
 
+.base-kamp-remove-btn {
+  display: flex;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.base-kamp-remove-btn:hover {
+  opacity: 1;
+  background: var(--hover);
+}
+
 .base-kamp-module-body {
   width: 100%;
   background: var(--surface);

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -113,7 +113,11 @@ export function BaseKampView(): React.JSX.Element {
                     <circle cx="7" cy="11" r="1.5" fill="currentColor" />
                   </svg>
                 </button>
-                <button className="base-kamp-remove-btn" title="Remove Module" onClick={() => hideModule(mod.id)}>
+                <button
+                  className="base-kamp-remove-btn"
+                  title="Remove Module"
+                  onClick={() => hideModule(mod.id)}
+                >
                   <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
                     <circle cx="7" cy="7" r="7" fill="#aa1111" />
                     <rect x="2.5" y="5.5" width="9" height="3" rx="1" fill="white" />

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -113,7 +113,7 @@ export function BaseKampView(): React.JSX.Element {
                     <circle cx="7" cy="11" r="1.5" fill="currentColor" />
                   </svg>
                 </button>
-                <button className="base-kamp-remove-btn" onClick={() => hideModule(mod.id)}>
+                <button className="base-kamp-remove-btn" title="Remove Module" onClick={() => hideModule(mod.id)}>
                   <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
                     <circle cx="7" cy="7" r="7" fill="#aa1111" />
                     <rect x="2.5" y="5.5" width="9" height="3" rx="1" fill="white" />

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -113,10 +113,7 @@ export function BaseKampView(): React.JSX.Element {
                     <circle cx="7" cy="11" r="1.5" fill="currentColor" />
                   </svg>
                 </button>
-                <button
-                  className="base-kamp-remove-btn"
-                  onClick={() => hideModule(mod.id)}
-                >
+                <button className="base-kamp-remove-btn" onClick={() => hideModule(mod.id)}>
                   <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
                     <circle cx="7" cy="7" r="7" fill="#aa1111" />
                     <rect x="2.5" y="5.5" width="9" height="3" rx="1" fill="white" />

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -115,7 +115,6 @@ export function BaseKampView(): React.JSX.Element {
                 </button>
                 <button
                   className="base-kamp-remove-btn"
-                  title="Remove Module"
                   onClick={() => hideModule(mod.id)}
                 >
                   <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -9,6 +9,8 @@ type Menu = { x: number; y: number; id: string }
 export function BaseKampView(): React.JSX.Element {
   const moduleOrder = useStore((s) => s.moduleOrder)
   const setModuleOrder = useStore((s) => s.setModuleOrder)
+  const hiddenModules = useStore((s) => s.hiddenModules)
+  const hideModule = useStore((s) => s.hideModule)
   const moduleDisplayStyles = useStore((s) => s.moduleDisplayStyles)
   const editMode = useStore((s) => s.baseKampEditMode)
   const toggleEditMode = useStore((s) => s.toggleBaseKampEditMode)
@@ -17,6 +19,7 @@ export function BaseKampView(): React.JSX.Element {
   const [dragOverId, setDragOverId] = useState<string | null>(null)
 
   const modules = moduleOrder
+    .filter((id) => !hiddenModules.includes(id))
     .map((id) => MODULE_REGISTRY.find((m) => m.id === id))
     .filter((m): m is ModuleRegistration => m !== undefined)
 
@@ -82,33 +85,45 @@ export function BaseKampView(): React.JSX.Element {
         >
           <div className="base-kamp-module-label">
             {editMode && (
-              <button
-                className="base-kamp-drag-handle"
-                title="Drag to reorder, right-click for options"
-                draggable
-                onDragStart={(e) => {
-                  setDragId(mod.id)
-                  e.dataTransfer.setData('text/kamp-module-id', mod.id)
-                  e.dataTransfer.effectAllowed = 'move'
-                }}
-                onDragEnd={() => {
-                  setDragId(null)
-                  setDragOverId(null)
-                }}
-                onContextMenu={(e) => {
-                  e.preventDefault()
-                  setMenu({ x: e.clientX, y: e.clientY, id: mod.id })
-                }}
-              >
-                <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
-                  <circle cx="3" cy="3" r="1.5" fill="currentColor" />
-                  <circle cx="7" cy="3" r="1.5" fill="currentColor" />
-                  <circle cx="3" cy="7" r="1.5" fill="currentColor" />
-                  <circle cx="7" cy="7" r="1.5" fill="currentColor" />
-                  <circle cx="3" cy="11" r="1.5" fill="currentColor" />
-                  <circle cx="7" cy="11" r="1.5" fill="currentColor" />
-                </svg>
-              </button>
+              <>
+                <button
+                  className="base-kamp-drag-handle"
+                  title="Drag to reorder, right-click for options"
+                  draggable
+                  onDragStart={(e) => {
+                    setDragId(mod.id)
+                    e.dataTransfer.setData('text/kamp-module-id', mod.id)
+                    e.dataTransfer.effectAllowed = 'move'
+                  }}
+                  onDragEnd={() => {
+                    setDragId(null)
+                    setDragOverId(null)
+                  }}
+                  onContextMenu={(e) => {
+                    e.preventDefault()
+                    setMenu({ x: e.clientX, y: e.clientY, id: mod.id })
+                  }}
+                >
+                  <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+                    <circle cx="3" cy="3" r="1.5" fill="currentColor" />
+                    <circle cx="7" cy="3" r="1.5" fill="currentColor" />
+                    <circle cx="3" cy="7" r="1.5" fill="currentColor" />
+                    <circle cx="7" cy="7" r="1.5" fill="currentColor" />
+                    <circle cx="3" cy="11" r="1.5" fill="currentColor" />
+                    <circle cx="7" cy="11" r="1.5" fill="currentColor" />
+                  </svg>
+                </button>
+                <button
+                  className="base-kamp-remove-btn"
+                  title="Remove Module"
+                  onClick={() => hideModule(mod.id)}
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+                    <circle cx="7" cy="7" r="7" fill="#aa1111" />
+                    <rect x="2.5" y="5.5" width="9" height="3" rx="1" fill="white" />
+                  </svg>
+                </button>
+              </>
             )}
             {mod.title}
           </div>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -41,6 +41,7 @@ type PlayerStore = {
   configuredLibraryPath: string | null
   activeView: 'library' | 'now-playing' | 'home'
   moduleOrder: string[]
+  hiddenModules: string[]
   moduleDisplayStyles: Record<string, DisplayStyle>
   lastPlayedCount: number
   lastPlayedDays: number
@@ -64,6 +65,7 @@ type PlayerStore = {
   setSortOrder: (sort: 'album_artist' | 'album' | 'date_added' | 'last_played') => Promise<void>
   setActiveView: (view: 'library' | 'now-playing' | 'home') => Promise<void>
   setModuleOrder: (ids: string[]) => void
+  hideModule: (id: string) => void
   setModuleDisplayStyle: (id: string, style: DisplayStyle) => void
   setLastPlayedCount: (n: number) => void
   setLastPlayedDays: (n: number) => void
@@ -155,6 +157,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
   moduleOrder: (() => {
     const saved = localStorage.getItem('kamp:module-order')
     return saved ? (JSON.parse(saved) as string[]) : ['kamp.new-arrivals', 'kamp.last-played']
+  })(),
+  hiddenModules: (() => {
+    const saved = localStorage.getItem('kamp:hidden-modules')
+    return saved ? (JSON.parse(saved) as string[]) : []
   })(),
   moduleDisplayStyles: (() => {
     const saved = localStorage.getItem('kamp:module-display-styles')
@@ -264,6 +270,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setModuleOrder: (ids) => {
     localStorage.setItem('kamp:module-order', JSON.stringify(ids))
     set({ moduleOrder: ids })
+  },
+
+  hideModule: (id) => {
+    const next = [...get().hiddenModules, id]
+    localStorage.setItem('kamp:hidden-modules', JSON.stringify(next))
+    set({ hiddenModules: next })
   },
 
   setModuleDisplayStyle: (id, style) => {


### PR DESCRIPTION
## Summary

- Adds a "Remove Module" button next to the drag handle in Base Kamp edit mode
- Button renders a no-entry SVG glyph (dark red circle, white bar) — not an emoji
- Clicking hides the module from the view; its config is preserved in localStorage
- Hidden modules are stored under `kamp:hidden-modules` and filtered out at render time, leaving `moduleOrder` intact for position preservation

## Test plan

- [x] Enter edit mode (gear icon)
- [ ] Verify remove button appears to the right of the drag handle for each module
- [x] Hover over it — tooltip reads "Remove Module"
- [x] Click it — module disappears immediately
- [x] Reload — module stays hidden
- [x] Navigate away and back — module still hidden
- [x] Confirm module's config values (count, days, display style) are unaffected by hiding

🤖 Generated with [Claude Code](https://claude.ai/claude-code)