### PR TITLE
feat(ui): add module inline from Base Kamp edit mode (KAMP-254)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2804,22 +2804,32 @@ body,
 }
 
 .base-kamp-add-module {
+  width: 100%;
+  background: var(--surface);
+  border-radius: 5px;
+  min-height: 88px;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  font-size: 13px;
-  color: var(--text-dim);
+  justify-content: center;
+  gap: 12px;
+}
+
+.base-kamp-add-module span {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
 }
 
 .base-kamp-add-module select {
-  background: var(--surface);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--text);
   font-size: 12px;
-  padding: 3px 6px;
+  font-weight: 500;
+  padding: 4px 8px;
   cursor: pointer;
+  height: 24px;
 }
 
 .base-kamp-header {

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2803,6 +2803,25 @@ body,
   font-size: 13px;
 }
 
+.base-kamp-add-module {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.base-kamp-add-module select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 12px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+
 .base-kamp-header {
   display: flex;
   justify-content: flex-end;

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -11,6 +11,7 @@ export function BaseKampView(): React.JSX.Element {
   const setModuleOrder = useStore((s) => s.setModuleOrder)
   const hiddenModules = useStore((s) => s.hiddenModules)
   const hideModule = useStore((s) => s.hideModule)
+  const showModule = useStore((s) => s.showModule)
   const moduleDisplayStyles = useStore((s) => s.moduleDisplayStyles)
   const editMode = useStore((s) => s.baseKampEditMode)
   const toggleEditMode = useStore((s) => s.toggleBaseKampEditMode)
@@ -22,6 +23,9 @@ export function BaseKampView(): React.JSX.Element {
     .filter((id) => !hiddenModules.includes(id))
     .map((id) => MODULE_REGISTRY.find((m) => m.id === id))
     .filter((m): m is ModuleRegistration => m !== undefined)
+
+  const visibleIds = new Set(modules.map((m) => m.id))
+  const addableModules = MODULE_REGISTRY.filter((m) => !visibleIds.has(m.id))
 
   function moveModule(id: string, direction: 'top' | 'up' | 'down' | 'bottom'): void {
     const idx = moduleOrder.indexOf(id)
@@ -46,7 +50,7 @@ export function BaseKampView(): React.JSX.Element {
     setModuleOrder(next)
   }
 
-  if (modules.length === 0) {
+  if (modules.length === 0 && addableModules.length === 0) {
     return <div className="base-kamp-empty">No modules configured.</div>
   }
 
@@ -135,6 +139,26 @@ export function BaseKampView(): React.JSX.Element {
           </div>
         </section>
       ))}
+      {editMode && addableModules.length > 0 && (
+        <div className="base-kamp-add-module">
+          <span>Add Module</span>
+          <select
+            value=""
+            onChange={(e) => {
+              if (e.target.value) showModule(e.target.value)
+            }}
+          >
+            <option value="" disabled>
+              Select…
+            </option>
+            {addableModules.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} onClose={() => setMenu(null)}>
           <button

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -282,7 +282,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   showModule: (id) => {
     const { hiddenModules, moduleOrder } = get()
     const nextHidden = hiddenModules.filter((h) => h !== id)
-    const nextOrder = moduleOrder.includes(id) ? moduleOrder : [...moduleOrder, id]
+    // Always place the re-added module at the bottom
+    const nextOrder = [...moduleOrder.filter((oid) => oid !== id), id]
     localStorage.setItem('kamp:hidden-modules', JSON.stringify(nextHidden))
     localStorage.setItem('kamp:module-order', JSON.stringify(nextOrder))
     set({ hiddenModules: nextHidden, moduleOrder: nextOrder })

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -66,6 +66,7 @@ type PlayerStore = {
   setActiveView: (view: 'library' | 'now-playing' | 'home') => Promise<void>
   setModuleOrder: (ids: string[]) => void
   hideModule: (id: string) => void
+  showModule: (id: string) => void
   setModuleDisplayStyle: (id: string, style: DisplayStyle) => void
   setLastPlayedCount: (n: number) => void
   setLastPlayedDays: (n: number) => void
@@ -276,6 +277,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const next = [...get().hiddenModules, id]
     localStorage.setItem('kamp:hidden-modules', JSON.stringify(next))
     set({ hiddenModules: next })
+  },
+
+  showModule: (id) => {
+    const { hiddenModules, moduleOrder } = get()
+    const nextHidden = hiddenModules.filter((h) => h !== id)
+    const nextOrder = moduleOrder.includes(id) ? moduleOrder : [...moduleOrder, id]
+    localStorage.setItem('kamp:hidden-modules', JSON.stringify(nextHidden))
+    localStorage.setItem('kamp:module-order', JSON.stringify(nextOrder))
+    set({ hiddenModules: nextHidden, moduleOrder: nextOrder })
   },
 
   setModuleDisplayStyle: (id, style) => {


### PR DESCRIPTION
## Summary

- In edit mode, an **Add Module** row appears at the bottom of Base Kamp listing all registry modules that aren't currently visible
- Selecting a module from the dropdown immediately re-adds it (removes from hidden, appends to order if missing)
- The row is hidden when all modules are already visible, or when not in edit mode
- Also fixes the edge case where all modules are hidden: the early return now only shows "No modules configured." when the registry itself is empty

## Test plan

- [x] Enable edit mode (⚙) with both modules visible → Add Module row does NOT appear
- [x] Remove one module via the red button → Add Module row appears with the removed module in the dropdown
- [x] Select the module in the dropdown → it re-appears in the list; Add Module row disappears
- [x] Remove both modules → Add Module row shows both; re-adding one leaves the other in the dropdown
- [x] Exit edit mode → Add Module row is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)