### PR TITLE
feat(ui): New Arrivals live update on library change (KAMP-241)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -1,6 +1,4 @@
-import React, { useEffect, useState } from 'react'
-import { getAlbums } from '../../api/client'
-import type { Album } from '../../api/client'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
 import { GridView } from './GridView'
@@ -69,27 +67,18 @@ export function NewArrivalsConfig(): React.JSX.Element {
 export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Element {
   const count = useStore((s) => s.recentlyAddedCount)
   const days = useStore((s) => s.recentlyAddedDays)
+  const allAlbums = useStore((s) => s.library.albums)
   const serverStatus = useStore((s) => s.serverStatus)
-  const [albums, setAlbums] = useState<Album[]>([])
-  const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    // Skip until the server is reachable; this effect re-fires when serverStatus
-    // transitions to 'connected', so modules populate without a manual reload.
-    if (serverStatus !== 'connected') return
-    getAlbums('date_added')
-      .then((all) => {
-        const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
-        const recent = all
-          .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
-          .slice(0, count > 0 ? count : undefined)
-        setAlbums(recent)
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false))
-  }, [count, days, serverStatus])
+  const albums = useMemo(() => {
+    const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
+    return [...allAlbums]
+      .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
+      .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
+      .slice(0, count > 0 ? count : undefined)
+  }, [allAlbums, count, days])
 
-  if (loading) {
+  if (serverStatus !== 'connected') {
     return (
       <div className="module-skeleton-row">
         {Array.from({ length: 4 }).map((_, i) => (

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import type { Album } from '../../api/client'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
 import { GridView } from './GridView'
@@ -69,13 +70,18 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
   const days = useStore((s) => s.recentlyAddedDays)
   const allAlbums = useStore((s) => s.library.albums)
   const serverStatus = useStore((s) => s.serverStatus)
+  const [albums, setAlbums] = useState<Album[]>([])
 
-  const albums = useMemo(() => {
-    const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
-    return [...allAlbums]
-      .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
-      .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
-      .slice(0, count > 0 ? count : undefined)
+  useEffect(() => {
+    void Promise.resolve(allAlbums).then((all) => {
+      const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
+      setAlbums(
+        [...all]
+          .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
+          .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
+          .slice(0, count > 0 ? count : undefined)
+      )
+    })
   }, [allAlbums, count, days])
 
   if (serverStatus !== 'connected') {

--- a/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import type { Album } from '../../api/client'
 import { AlbumCard } from '../AlbumCard'
 
@@ -10,6 +10,19 @@ const SCROLL_PX = 500
 
 export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null)
+  // undefined = not yet initialized (skip scroll on first load)
+  const prevFirstAddedAt = useRef<number | null | undefined>(undefined)
+
+  useEffect(() => {
+    const firstAddedAt = albums[0]?.added_at ?? null
+    if (prevFirstAddedAt.current !== undefined) {
+      const prev = prevFirstAddedAt.current
+      if (firstAddedAt !== null && (prev === null || firstAddedAt > prev)) {
+        scrollRef.current?.scrollTo({ left: 0, behavior: 'smooth' })
+      }
+    }
+    prevFirstAddedAt.current = firstAddedAt
+  }, [albums])
 
   const scroll = (dir: 'left' | 'right'): void => {
     scrollRef.current?.scrollBy({


### PR DESCRIPTION
## Summary

- `NewArrivalsModule` previously made its own isolated `getAlbums('date_added')` call, so it never reacted to the `library.changed` WebSocket event
- Now reads from `store.library.albums` (already populated by `loadLibrary()` on each `library.changed`) and re-filters in a `useEffect` when `allAlbums`, `count`, or `days` changes
- Adds an explicit sort by `added_at DESC` so the order is correct regardless of the store's active sort order
- Removes the separate network round-trip entirely

## Test plan

- [x] Sync an album from Bandcamp — it should appear in New Arrivals immediately without a page reload
- [x] Change the Days / Albums config values — list updates correctly
- [x] Disconnect and reconnect the server — skeleton shown while disconnected, albums populate on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)