### PR TITLE
fix(ui): fix now-playing ring clipping on first shelf card (KAMP-253)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -1166,13 +1166,14 @@ body,
 }
 
 .album-card.playing {
-  box-shadow: 0 0 0 3px rgba(124, 134, 225, 0.35);
+  outline: 3px solid rgba(124, 134, 225, 0.55);
+  outline-offset: 0;
 }
 
 .album-card.playing:hover {
-  box-shadow:
-    0 4px 12px rgba(0, 0, 0, 0.4),
-    0 0 0 3px rgba(124, 134, 225, 0.35);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  outline: 3px solid rgba(124, 134, 225, 0.55);
+  outline-offset: 0;
 }
 
 .album-art {
@@ -2792,7 +2793,7 @@ body,
   background: var(--surface);
   border-radius: 0 5px 5px 5px;
   min-height: 285px;
-  overflow: hidden;
+  overflow: clip;
   padding: 2%;
 }
 
@@ -2940,6 +2941,7 @@ body,
   padding: 12px;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
+  scroll-padding-left: 5px;
   scrollbar-width: none;
   outline: none;
   flex: 1;
@@ -2957,6 +2959,7 @@ body,
 .module-shelf .album-card:first-child {
   margin-left: 5px;
 }
+
 
 .module-shelf-arrow {
   position: absolute;

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -2954,6 +2954,10 @@ body,
   scroll-snap-align: start;
 }
 
+.module-shelf .album-card:first-child {
+  margin-left: 5px;
+}
+
 .module-shelf-arrow {
   position: absolute;
   top: 50%;

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -110,5 +110,9 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} scrollToPlaying />
+  return displayStyle === 'grid' ? (
+    <GridView albums={albums} />
+  ) : (
+    <ShelfView albums={albums} scrollToPlaying />
+  )
 }

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -110,5 +110,5 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
+  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} scrollToPlaying />
 }

--- a/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
@@ -5,11 +5,12 @@ import { useStore } from '../../store'
 
 interface ShelfViewProps {
   albums: Album[]
+  scrollToPlaying?: boolean
 }
 
 const SCROLL_PX = 500
 
-export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
+export function ShelfView({ albums, scrollToPlaying = false }: ShelfViewProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null)
   const hasMounted = useRef(false)
   const currentTrack = useStore((s) => s.player.current_track)
@@ -23,7 +24,7 @@ export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
 
   useEffect(() => {
     const shelf = scrollRef.current
-    if (!shelf) return
+    if (!shelf || !scrollToPlaying) return
     const behavior: ScrollBehavior = hasMounted.current ? 'smooth' : 'instant'
     hasMounted.current = true
 
@@ -46,7 +47,7 @@ export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
     // Matches the CSS layout: padding-left(12) + first-child margin(5) + idx*(card(180)+gap(15)) - scroll-padding(5)
     shelf.scrollTo({ left: 12 + idx * 195, behavior })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentTrack?.album_artist, currentTrack?.album, currentTrack?.file_path, albums])
+  }, [currentTrack?.album_artist, currentTrack?.album, currentTrack?.file_path, albums, scrollToPlaying])
 
   return (
     <div className="module-shelf-wrapper">

--- a/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
@@ -1,6 +1,7 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import type { Album } from '../../api/client'
 import { AlbumCard } from '../AlbumCard'
+import { useStore } from '../../store'
 
 interface ShelfViewProps {
   albums: Album[]
@@ -10,6 +11,8 @@ const SCROLL_PX = 500
 
 export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null)
+  const hasMounted = useRef(false)
+  const currentTrack = useStore((s) => s.player.current_track)
 
   const scroll = (dir: 'left' | 'right'): void => {
     scrollRef.current?.scrollBy({
@@ -17,6 +20,33 @@ export function ShelfView({ albums }: ShelfViewProps): React.JSX.Element {
       behavior: 'smooth'
     })
   }
+
+  useEffect(() => {
+    const shelf = scrollRef.current
+    if (!shelf) return
+    const behavior: ScrollBehavior = hasMounted.current ? 'smooth' : 'instant'
+    hasMounted.current = true
+
+    if (!currentTrack) {
+      shelf.scrollTo({ left: 0, behavior })
+      return
+    }
+
+    const idx = albums.findIndex((a) =>
+      a.missing_album
+        ? a.file_path === currentTrack.file_path
+        : a.album === currentTrack.album && a.album_artist === currentTrack.album_artist
+    )
+
+    if (idx === -1) {
+      shelf.scrollTo({ left: 0, behavior })
+      return
+    }
+
+    // Matches the CSS layout: padding-left(12) + first-child margin(5) + idx*(card(180)+gap(15)) - scroll-padding(5)
+    shelf.scrollTo({ left: 12 + idx * 195, behavior })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentTrack?.album_artist, currentTrack?.album, currentTrack?.file_path, albums])
 
   return (
     <div className="module-shelf-wrapper">

--- a/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
@@ -47,7 +47,13 @@ export function ShelfView({ albums, scrollToPlaying = false }: ShelfViewProps): 
     // Matches the CSS layout: padding-left(12) + first-child margin(5) + idx*(card(180)+gap(15)) - scroll-padding(5)
     shelf.scrollTo({ left: 12 + idx * 195, behavior })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentTrack?.album_artist, currentTrack?.album, currentTrack?.file_path, albums, scrollToPlaying])
+  }, [
+    currentTrack?.album_artist,
+    currentTrack?.album,
+    currentTrack?.file_path,
+    albums,
+    scrollToPlaying
+  ])
 
   return (
     <div className="module-shelf-wrapper">

--- a/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
@@ -84,5 +84,9 @@ export function TopAlbumsModule({ displayStyle }: ModuleProps): React.JSX.Elemen
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} scrollToPlaying />
+  return displayStyle === 'grid' ? (
+    <GridView albums={albums} />
+  ) : (
+    <ShelfView albums={albums} scrollToPlaying />
+  )
 }

--- a/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
@@ -84,9 +84,5 @@ export function TopAlbumsModule({ displayStyle }: ModuleProps): React.JSX.Elemen
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? (
-    <GridView albums={albums} />
-  ) : (
-    <ShelfView albums={albums} scrollToPlaying />
-  )
+  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
 }

--- a/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
@@ -84,5 +84,5 @@ export function TopAlbumsModule({ displayStyle }: ModuleProps): React.JSX.Elemen
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
+  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} scrollToPlaying />
 }


### PR DESCRIPTION
## Summary

- `scroll-snap-type: x mandatory` was snapping the first card flush to the scrollport's left edge, pushing the 3px now-playing ring into negative viewport space. Fixed with `scroll-padding-left: 5px` on `.module-shelf`.
- `margin-left: 5px` on `.module-shelf .album-card:first-child` retained as belt-and-suspenders for content-edge paint clipping.
- Changed `.base-kamp-module-body` from `overflow: hidden` to `overflow: clip` so ink overflow (outlines/shadows) on descendants is never clipped.
- Switched the now-playing ring from `box-shadow` to `outline` — outline follows `border-radius` in Chrome 94+ and doesn't contribute to scroll overflow.
- `ShelfView` now scrolls to the now-playing album (smooth) when the track changes, or back to the start if the album isn't in the list. Uses `instant` on initial mount to avoid a visible jump.

## Test plan

- [ ] Play an album that appears in a shelf — confirm the 3px ring is fully visible on the left edge when the card is snapped to position 0
- [ ] Scroll the shelf to the right, then start playing a different album in that shelf — confirm it scrolls back smoothly to show the now-playing card
- [ ] Play an album not in the shelf — confirm the shelf scrolls back to the start
- [ ] Reload app while an album is playing — confirm shelf snaps instantly to the playing card, no visible jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)