### PR TITLE
fix(playback): remove gapless lookahead on seek to prevent seek bar freeze

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -479,6 +479,14 @@ class MpvPlaybackEngine:
         self._send_command("set_property", "pause", False)
 
     def seek(self, position: float) -> None:
+        # A preloaded lookahead in mpv's playlist slot 1 causes an immediate
+        # gapless transition when seeking near the end of the current track,
+        # which stops time-pos events from flowing and freezes the seek bar.
+        # Remove the lookahead first; on_track_end will start the next track
+        # via engine.play() (non-gapless) when the current track reaches EOF.
+        if self._lookahead_path is not None:
+            self._lookahead_path = None
+            self._send_command("playlist-remove", 1)
         self._send_command("seek", position, "absolute")
 
     def stop(self) -> None:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -659,6 +659,35 @@ class TestMpvPlaybackEngine:
         engine.seek(42.5)
         send.assert_called_once_with("seek", 42.5, "absolute")
 
+    def test_seek_removes_lookahead_before_seeking(self) -> None:
+        """Seeking with a lookahead must remove it first to prevent an immediate
+        gapless transition that stops time-pos events from flowing."""
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine.seek(170.0)
+        send.assert_any_call("playlist-remove", 1)
+        assert engine._lookahead_path is None
+
+    def test_seek_sends_playlist_remove_before_seek_command(self) -> None:
+        """playlist-remove must precede the seek command so mpv drops the lookahead
+        before repositioning, preventing a premature gapless EOF."""
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        calls: list[tuple[object, ...]] = []
+        send.side_effect = lambda *a: calls.append(a)
+        engine.seek(170.0)
+        remove_idx = next(i for i, c in enumerate(calls) if c[0] == "playlist-remove")
+        seek_idx = next(i for i, c in enumerate(calls) if c[0] == "seek")
+        assert remove_idx < seek_idx
+
+    def test_seek_without_lookahead_sends_only_seek_command(self) -> None:
+        """No playlist-remove should be sent when there is no active lookahead."""
+        engine, send = _make_engine()
+        engine.seek(42.5)
+        send.assert_called_once_with("seek", 42.5, "absolute")
+
     def test_set_volume_sends_set_property(self) -> None:
         engine, send = _make_engine()
         engine.volume = 75


### PR DESCRIPTION
## Summary

- When a next track is preloaded in mpv's playlist slot 1 (gapless lookahead), seeking to within mpv's gapless buffer window (~10 seconds from the end) causes an immediate gapless transition instead of playing through, stopping `time-pos` events from flowing and freezing the seek bar at the seeked position for the rest of the track's duration.
- `MpvPlaybackEngine.seek()` now removes the lookahead from mpv's playlist before issuing the seek command. The current track plays through to its natural EOF, at which point `on_track_end` starts the next track via `engine.play()` (non-gapless — acceptable trade-off for seeked transitions).
- Three new tests cover: lookahead removal on seek, command ordering (remove before seek), and no-lookahead path unchanged.

## Test plan

- [x] `poetry run pytest tests/test_playback.py -v --no-cov` — all 119 pass
- [x] `poetry run pytest --no-cov -q` — full suite clean (1228 passed, 8 skipped)
- [x] Manual repro: start a track, seek to the last 10 seconds, confirm the seek bar continues moving

Fixes KAMP-261

🤖 Generated with [Claude Code](https://claude.com/claude-code)