### PR TITLE
fix(playback): skip preload_next append near end of track to prevent queue freeze

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -321,6 +321,10 @@ class PlaybackQueue:
 # MpvPlaybackEngine
 # ---------------------------------------------------------------------------
 
+# Seconds from the end of a track within which appending a new lookahead to
+# mpv's playlist triggers an immediate gapless EOF, stopping time-pos events.
+_GAPLESS_GUARD_SECS: float = 10.0
+
 # Properties to observe from mpv for state tracking
 _OBSERVED: list[tuple[int, str]] = [
     (1, "time-pos"),
@@ -464,6 +468,16 @@ class MpvPlaybackEngine:
             self._lookahead_path = None  # clear before sending remove (see docstring)
             self._send_command("playlist-remove", 1)
         if path is not None:
+            # Skip the append when we're within the gapless danger window.
+            # mpv would trigger an immediate EOF transition the moment the
+            # file lands in slot 1, stopping time-pos events and leaving the
+            # queue in a half-transitioned state.  on_track_end will start
+            # the next track via engine.play() when the current track ends.
+            if (
+                self.state.duration > 0
+                and self.state.position > self.state.duration - _GAPLESS_GUARD_SECS
+            ):
+                return
             self._send_command("loadfile", str(path), "append")
             self._lookahead_path = path
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -963,6 +963,54 @@ class TestMpvPlaybackEngine:
         assert engine._lookahead_path is None
 
     # ------------------------------------------------------------------
+    # preload_next near-end guard
+    # ------------------------------------------------------------------
+
+    def test_preload_next_skips_append_within_guard_window(self) -> None:
+        """Appending a new lookahead within the last 10 s triggers an immediate
+        gapless EOF in mpv, freezing time-pos updates.  The append must be
+        skipped so the track plays through to its natural end."""
+        engine, send = _make_engine()
+        engine.state.duration = 180.0
+        engine.state.position = 172.0  # 8 s from end
+        engine.preload_next(_track(2))
+        send.assert_not_called()
+        assert engine._lookahead_path is None
+
+    def test_preload_next_appends_when_outside_guard_window(self) -> None:
+        """preload_next must work normally when the current position is well
+        before the gapless danger window."""
+        engine, send = _make_engine()
+        engine.state.duration = 180.0
+        engine.state.position = 60.0  # 2 minutes from end
+        engine.preload_next(_track(2))
+        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+        assert engine.has_lookahead is True
+
+    def test_preload_next_removes_stale_lookahead_even_within_guard_window(
+        self,
+    ) -> None:
+        """The old lookahead must still be evicted when near the end so the
+        wrong track does not play gaplessly."""
+        engine, send = _make_engine()
+        engine.preload_next(_track(2))  # prime with track 2 while not near end
+        engine.state.duration = 180.0
+        engine.state.position = 172.0  # now near end
+        send.reset_mock()
+        engine.preload_next(_track(3))  # swap to track 3 while near end
+        send.assert_called_once_with("playlist-remove", 1)
+        assert engine._lookahead_path is None  # new track NOT appended
+
+    def test_preload_next_appends_when_duration_unknown(self) -> None:
+        """When duration is 0 (not yet received from mpv), the guard must not
+        block the append — we have no basis to judge nearness to end."""
+        engine, send = _make_engine()
+        engine.state.duration = 0.0
+        engine.state.position = 0.0
+        engine.preload_next(_track(2))
+        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+
+    # ------------------------------------------------------------------
     # end-file gapless cleanup
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Queuing a track to "Play Next" within the last ~10 seconds of the current track causes `preload_next` to append it to mpv's playlist slot 1. mpv immediately fires a gapless EOF transition the moment the file lands, stopping `time-pos` events (freezing the transport bar) and triggering `on_track_end` while the queue is partially updated — producing ghost items in the queue panel.
- Introduced `_GAPLESS_GUARD_SECS = 10.0` and added a guard to the `loadfile append` in `preload_next`: if `position > duration - 10.0` (and duration is known), the append is skipped. The stale lookahead (if any) is still evicted so the wrong track doesn't play gaplessly. `on_track_end` sees `has_lookahead=False` and calls `engine.play()` at natural EOF.
- Four new tests: skips within guard window, appends outside it, still removes stale lookahead when near end, and appends freely when duration is unknown (0).

**Note:** this PR is independent of KAMP-261 (#344) — they touch different methods (`preload_next` vs `seek`) and will merge cleanly.

## Test plan

- [x] `poetry run pytest tests/test_playback.py -v --no-cov` — all 120 pass
- [x] `poetry run pytest --no-cov -q` — full suite clean (1229 passed, 8 skipped)
- [x] Manual repro: play a track, wait until last 10 seconds, queue a new track with Play Next — confirm transport continues moving and queue panel is stable

Fixes KAMP-262

🤖 Generated with [Claude Code](https://claude.com/claude-code)