### PR TITLE
feat(ui): shiny golden aura + shimmer for new arrivals (KAMP-57)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -1,4 +1,5 @@
 .album-card {
+  position: relative;
   cursor: pointer;
   border-radius: 6px;
   overflow: hidden;
@@ -88,4 +89,120 @@
   font-size: 11px;
   color: var(--text-dim);
   margin-top: 1px;
+}
+
+/* ── Shiny: new arrivals (added within 3 days) ─────────────────────────── */
+
+@keyframes shiny-aura {
+  0%, 100% {
+    box-shadow:
+      0 0 6px 2px rgba(255, 215, 0, 0.28),
+      0 0 18px 5px rgba(255, 184, 48, 0.13);
+  }
+  50% {
+    box-shadow:
+      0 0 12px 4px rgba(255, 215, 0, 0.55),
+      0 0 30px 10px rgba(255, 240, 160, 0.25),
+      0 0 44px 14px rgba(255, 184, 48, 0.17);
+  }
+}
+
+.album-card.shiny {
+  animation: shiny-aura 3.2s ease-in-out infinite;
+}
+
+/* Mute the glow on hover — the lift + hover shadow already draws the eye */
+.album-card.shiny:hover {
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 8px 2px rgba(255, 215, 0, 0.22);
+  animation: none;
+}
+
+/* ── Shimmer sweep ─────────────────────────────────────────────────────── */
+
+/* Sweeps across in 22.5% of the 4s cycle (≈ 0.9s), holds off-screen the rest */
+@keyframes shiny-sweep-slow {
+  0%     { transform: translateX(-130%); }
+  22.5%  { transform: translateX(130%); }
+  22.51% { transform: translateX(-130%); }
+  100%   { transform: translateX(-130%); }
+}
+
+/* Sweeps across in 50% of the 1.8s cycle (0.9s), holds off-screen the rest */
+@keyframes shiny-sweep-fast {
+  0%    { transform: translateX(-130%); }
+  50%   { transform: translateX(130%); }
+  50.01%{ transform: translateX(-130%); }
+  100%  { transform: translateX(-130%); }
+}
+
+/* Single full-width sweep for the mount burst */
+@keyframes shiny-sweep-once {
+  from { transform: translateX(-130%); }
+  to   { transform: translateX(130%); }
+}
+
+.shiny-sweep {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+    115deg,
+    transparent 25%,
+    rgba(255, 255, 255, 0.14) 42%,
+    rgba(255, 242, 180, 0.32) 50%,
+    rgba(255, 255, 255, 0.14) 58%,
+    transparent 75%
+  );
+  animation: shiny-sweep-slow 4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+/* Fast single sweep on first mount */
+.album-card.is-mounting .shiny-sweep {
+  animation: shiny-sweep-once 1.2s cubic-bezier(0.4, 0, 0.2, 1) 1;
+}
+
+/* Speed up on hover (not during mount burst) */
+.album-card.shiny:hover:not(.is-mounting) .shiny-sweep {
+  animation: shiny-sweep-fast 1.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+/* ── Star particles ────────────────────────────────────────────────────── */
+
+@keyframes shiny-star-drift {
+  0%   { opacity: 0; transform: translateY(0) rotate(0deg) scale(0.5); }
+  15%  { opacity: 0.85; }
+  100% { opacity: 0; transform: translateY(-58px) rotate(360deg) scale(0.15); }
+}
+
+.shiny-star {
+  position: absolute;
+  left: var(--star-left, 50%);
+  top: var(--star-top, 40%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #fff0a0;
+  box-shadow: 0 0 4px 1px rgba(255, 215, 0, 0.85);
+  pointer-events: none;
+  animation: shiny-star-drift var(--star-dur, 3.6s) var(--star-delay, 0s) ease-out infinite;
+  transform-origin: center;
+}
+
+/* ── Reduced motion: static golden outline only ────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .album-card.shiny {
+    animation: none;
+    box-shadow: none;
+    outline: 2px solid rgba(255, 215, 0, 0.6);
+    outline-offset: 0;
+  }
+
+  .shiny-sweep,
+  .shiny-star {
+    display: none;
+  }
 }

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -1,10 +1,22 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
 import { AlbumContextMenu } from './AlbumContextMenu'
 
 type MenuPos = { x: number; y: number }
+
+const THREE_DAYS_SECS = 3 * 86400
+// Computed once at module load; accurate enough for a 3-day window within a session
+const SHINY_CUTOFF_SECS = Date.now() / 1000 - THREE_DAYS_SECS
+
+interface StarParticle {
+  id: number
+  left: number
+  top: number
+  duration: number
+  delay: number
+}
 
 export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
@@ -19,14 +31,51 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
+  const isShiny = album.added_at !== null && album.added_at >= SHINY_CUTOFF_SECS
+
+  // Start mounting=true so the fast sweep fires immediately; cleared after 1.2s
+  const [isMounting, setIsMounting] = useState(isShiny)
+  const [starParticles, setStarParticles] = useState<StarParticle[]>([])
+
+  useEffect(() => {
+    if (!isShiny) return
+    // Math.random() and setState must be in callbacks, not the effect body directly
+    const initTimer = setTimeout(() => {
+      const count = 3 + Math.floor(Math.random() * 3) // 3–5
+      setStarParticles(
+        Array.from({ length: count }, (_, i) => ({
+          id: i,
+          left: 10 + Math.random() * 80,
+          top: 15 + Math.random() * 50,
+          duration: 2.8 + Math.random() * 1.6,
+          delay: Math.random() * 2
+        }))
+      )
+    }, 0)
+    const mountTimer = setTimeout(() => setIsMounting(false), 1200)
+    return () => {
+      clearTimeout(initTimer)
+      clearTimeout(mountTimer)
+    }
+  }, [isShiny])
+
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
     void selectAlbum(album)
   }
 
+  const cardClass = [
+    'album-card',
+    isActive ? 'playing' : '',
+    isShiny ? 'shiny' : '',
+    isShiny && isMounting ? 'is-mounting' : ''
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
     <div
-      className={`album-card${isActive ? ' playing' : ''}`}
+      className={cardClass}
       tabIndex={0}
       draggable
       onClick={handleSelect}
@@ -58,7 +107,26 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
           />
         )}
         {playing && isActive && <div className="now-playing-badge">▶</div>}
+        {isShiny && <span className="shiny-sweep" aria-hidden="true" />}
       </div>
+
+      {isShiny &&
+        starParticles.map((p) => (
+          <span
+            key={p.id}
+            className="shiny-star"
+            aria-hidden="true"
+            style={
+              {
+                '--star-left': `${p.left}%`,
+                '--star-top': `${p.top}%`,
+                '--star-dur': `${p.duration}s`,
+                '--star-delay': `${p.delay}s`
+              } as React.CSSProperties
+            }
+          />
+        ))}
+
       <div className="album-info">
         {album.missing_album ? (
           <div className="album-title">


### PR DESCRIPTION
## Summary

- AlbumCards for albums added within the past 3 days get a \"shiny\" treatment: breathing golden box-shadow aura, a diagonal shimmer sweep across the art, and 3–5 randomised star particles that drift upward and fade out
- Mount burst: on first render the shimmer fires once fast (1.2s), then settles into a 4s loop; hover speeds it up to 1.8s
- `prefers-reduced-motion` fallback: static gold outline only, no animation
- Stars and sweep are siblings/children of `.album-art` respectively, respecting the existing overflow/stacking architecture

## Test plan

- [x] Add an album to the library and confirm the shiny aura, shimmer, and stars appear on its card
- [x] Confirm non-recent albums show no effect
- [x] Hover a shiny card — aura mutes, shimmer speeds up
- [x] Confirm the mount fast-sweep fires once on first render then slows to the 4s loop
- [x] Confirm the playing outline coexists with the shiny glow (no conflict)
- [x] Enable "Reduce Motion" in macOS Accessibility settings — confirm static gold outline only

🤖 Generated with [Claude Code](https://claude.com/claude-code)