### PR TITLE
feat(ui): newmoji highlight style — 🆕 badge with idle bob + hover pop (KAMP-265)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -101,6 +101,46 @@
   transform-origin: center;
 }
 
+/* ── newmoji ────────────────────────────────────────────────────────────── */
+
+/* Idle: slow bob + tilt, 5s loop */
+@keyframes newmoji-idle {
+  0%, 100% { translate: 0 0; rotate: 0deg; scale: 1; }
+  30%       { translate: 0 -3px; rotate: 1deg; scale: 1.05; }
+}
+
+/* Hover pop: scale out to 1.35 with overshoot easing, runs once */
+@keyframes newmoji-hover-scale {
+  0%   { scale: 1; }
+  100% { scale: 1.35; }
+}
+
+/* album-info needs position:relative so the badge can use absolute positioning */
+.album-card--highlight-newmoji .album-info {
+  position: relative;
+}
+
+/* Badge sits at the art/info boundary, overlapping slightly into the art zone */
+.newmoji-badge {
+  position: absolute;
+  top: -10px;
+  left: 6px;
+  font-size: 18px;
+  line-height: 1;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.6));
+  pointer-events: none;
+  transform-origin: bottom left;
+  animation: newmoji-idle 5s ease-in-out infinite;
+  z-index: 2;
+}
+
+/* Hover: idle bob continues (translate/rotate), scale pops once then holds */
+.album-card--highlight-newmoji:hover .newmoji-badge {
+  animation:
+    newmoji-idle 5s ease-in-out infinite,
+    newmoji-hover-scale 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1 forwards;
+}
+
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -114,5 +154,12 @@
   .shiny-sweep,
   .shiny-star {
     display: none;
+  }
+
+  .newmoji-badge {
+    animation: none;
+    translate: 0 0;
+    rotate: 0deg;
+    scale: 1;
   }
 }

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -129,7 +129,9 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
 
       <div className="album-info">
         {isNew && highlightStyle === 'newmoji' && (
-          <span className="newmoji-badge" aria-hidden="true">🆕</span>
+          <span className="newmoji-badge" aria-hidden="true">
+            🆕
+          </span>
         )}
         {album.missing_album ? (
           <div className="album-title">

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -128,6 +128,9 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
         ))}
 
       <div className="album-info">
+        {isNew && highlightStyle === 'newmoji' && (
+          <span className="newmoji-badge" aria-hidden="true">🆕</span>
+        )}
         {album.missing_album ? (
           <div className="album-title">
             <em>{album.album}</em>


### PR DESCRIPTION
## Summary

- Adds **newmoji** as a selectable new-arrival highlight style in `AlbumCard`
- Injects a `<span class="newmoji-badge">🆕</span>` inside `.album-info` (avoids the `overflow: hidden` clip on `.album-art` and `.album-card`)
- Idle animation: 5s loop with gentle `translateY(-3px) rotate(1deg) scale(1.05)` bob at 30%
- Hover pop: scales to 1.35× with `cubic-bezier(0.34, 1.56, 0.64, 1)` overshoot, one shot, then idle resumes — uses CSS individual transform properties (`translate`, `rotate`, `scale`) so bob and scale animations don't conflict
- `prefers-reduced-motion`: badge renders statically (no animation)
- `aria-hidden="true"` — decorative only

## Test plan

- [x] Switch highlight style to **newmoji** in Preferences → verify 🆕 badge appears on new arrival cards at the art/info boundary
- [x] Watch idle bob: badge should gently float up and tilt on a ~5s loop
- [x] Hover a card: badge should pop to 1.35× with a spring overshoot, hold scaled while hovering, bob continuing
- [x] Hover off: badge resumes idle
- [x] Switch to **shiny** style: no badge visible, shiny aura/sweep/stars unaffected
- [x] Toggle highlight off: no badge visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)