### PR TITLE
feat(ui): boring highlight style — static blue ribbon NEW→wow! (KAMP-266)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -141,6 +141,45 @@
     newmoji-hover-scale 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1 forwards;
 }
 
+/* ── boring ─────────────────────────────────────────────────────────────── */
+
+/* Shared ribbon geometry — ::after (NEW) and .boring-hover span (wow!) */
+.album-card--highlight-boring .album-art::after,
+.album-card--highlight-boring .boring-hover {
+  position: absolute;
+  top: 14px;
+  right: -24px;
+  width: 80px;
+  padding: 3px 0;
+  background: #3B6FD4;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-align: center;
+  transform: rotate(38deg);
+  pointer-events: none;
+  z-index: 2;
+  transition: opacity 80ms ease;
+}
+
+.album-card--highlight-boring .album-art::after {
+  content: 'NEW';
+}
+
+.album-card--highlight-boring .boring-hover {
+  opacity: 0;
+}
+
+.album-card--highlight-boring:hover .album-art::after {
+  opacity: 0;
+}
+
+.album-card--highlight-boring:hover .boring-hover {
+  opacity: 1;
+}
+
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
 
 @media (prefers-reduced-motion: reduce) {

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -149,8 +149,8 @@
 .album-card--highlight-boring .album-art::after,
 .album-card--highlight-boring .boring-hover {
   position: absolute;
-  top: 12px;
-  right: -39px;
+  top: 23px;
+  right: -28px;
   width: 120px;
   padding: 5px 0;
   line-height: 1;
@@ -168,7 +168,7 @@
 }
 
 .album-card--highlight-boring .album-art::after {
-  content: 'NEW';
+  content: 'New';
 }
 
 .album-card--highlight-boring .boring-hover {

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -149,8 +149,8 @@
 .album-card--highlight-boring .album-art::after,
 .album-card--highlight-boring .boring-hover {
   position: absolute;
-  top: 0;
-  right: -50px;
+  top: 12px;
+  right: -39px;
   width: 120px;
   padding: 5px 0;
   line-height: 1;

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -143,14 +143,17 @@
 
 /* ── boring ─────────────────────────────────────────────────────────────── */
 
-/* Shared ribbon geometry — ::after (NEW) and .boring-hover span (wow!) */
+/* Shared ribbon geometry — ::after (NEW) and .boring-hover span (wow!)
+   Width 120px + right:-50px places the center on the corner diagonal (x+y=W)
+   for any square art width W, so overflow:hidden clips all four corners cleanly. */
 .album-card--highlight-boring .album-art::after,
 .album-card--highlight-boring .boring-hover {
   position: absolute;
-  top: 14px;
-  right: -24px;
-  width: 80px;
-  padding: 3px 0;
+  top: 0;
+  right: -50px;
+  width: 120px;
+  padding: 5px 0;
+  line-height: 1;
   background: #3B6FD4;
   color: #fff;
   font-family: system-ui, sans-serif;
@@ -158,7 +161,7 @@
   font-weight: 700;
   letter-spacing: 0.12em;
   text-align: center;
-  transform: rotate(38deg);
+  transform: rotate(45deg);
   pointer-events: none;
   z-index: 2;
   transition: opacity 80ms ease;

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -107,6 +107,11 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
         )}
         {playing && isActive && <div className="now-playing-badge">▶</div>}
         {isNew && highlightStyle === 'shiny' && <span className="shiny-sweep" aria-hidden="true" />}
+        {isNew && highlightStyle === 'boring' && (
+          <span className="boring-hover" aria-hidden="true">
+            wow!
+          </span>
+        )}
       </div>
 
       {isNew &&


### PR DESCRIPTION
## Summary

- Adds the **boring** new arrival highlight style: a static `#3B6FD4` diagonal ribbon in the top-right corner of album art saying `NEW`
- On hover, `NEW` cross-fades to `wow!` (lowercase — that's the joke) over 80ms
- Uses `::after` on `.album-art` for `NEW` and a sibling `.boring-hover` span for `wow!`, both `aria-hidden`; `overflow: hidden` on `.album-art` clips the rotated corners cleanly
- No animation at rest — completely static by design

## Test plan

- [x] Set highlight preference to "boring" and verify ribbon appears on new albums
- [x] Hover an album card — confirm `NEW` fades out and `wow!` fades in over ~80ms
- [x] Verify ribbon is clipped to the art zone (no overflow outside the card)
- [x] Confirm other highlight styles (shiny, newmoji) are unaffected
- [x] Verify no ribbon appears when highlight is disabled or album is not new

🤖 Generated with [Claude Code](https://claude.com/claude-code)