### PR TITLE
feat(ui): proud highlight — Progress Pride barber pole (KAMP-268)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -288,7 +288,7 @@
   background-clip: padding-box, border-box;
   background-size: auto, 170px 170px;
   box-shadow: inset 0 0 8px 1px rgba(85, 205, 252, 0.15);
-  animation: proud-barber 3s linear infinite;
+  animation: proud-barber 6s linear infinite;
 }
 
 /* .album-card:hover uses the `background` shorthand, resetting background-image,
@@ -313,7 +313,7 @@
   background-origin: padding-box, border-box;
   background-clip: padding-box, border-box;
   background-size: auto, 170px 170px;
-  animation-duration: 0.8s;
+  animation-duration: 1.6s;
 }
 
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -247,29 +247,70 @@
 
 /* ── proud ──────────────────────────────────────────────────────────────── */
 
-/* Progress Pride flag: 10 stops, black omitted (dead frame against dark bg),
-   brown luminance-boosted from #784F17 → #C47A2B (original near-invisible as glow) */
-@keyframes proud-cycle {
-  0%   { box-shadow: 0 0 0 2px #FFFFFF, 0 0 10px 4px rgba(255, 255, 255, 0.5); }
-  10%  { box-shadow: 0 0 0 2px #F7A8B8, 0 0 10px 4px rgba(247, 168, 184, 0.5); }
-  20%  { box-shadow: 0 0 0 2px #55CDFC, 0 0 10px 4px rgba( 85, 205, 252, 0.5); }
-  30%  { box-shadow: 0 0 0 2px #C47A2B, 0 0 10px 4px rgba(196, 122,  43, 0.5); }
-  40%  { box-shadow: 0 0 0 2px #E40303, 0 0 10px 4px rgba(228,   3,   3, 0.5); }
-  50%  { box-shadow: 0 0 0 2px #FF8C00, 0 0 10px 4px rgba(255, 140,   0, 0.5); }
-  60%  { box-shadow: 0 0 0 2px #FFED00, 0 0 10px 4px rgba(255, 237,   0, 0.5); }
-  70%  { box-shadow: 0 0 0 2px #008026, 0 0 10px 4px rgba(  0, 128,  38, 0.5); }
-  80%  { box-shadow: 0 0 0 2px #004DFF, 0 0 10px 4px rgba(  0,  77, 255, 0.5); }
-  90%  { box-shadow: 0 0 0 2px #750787, 0 0 10px 4px rgba(117,   7, 135, 0.5); }
-  100% { box-shadow: 0 0 0 2px #FFFFFF, 0 0 10px 4px rgba(255, 255, 255, 0.5); }
+/* Progress Pride flag barber pole: diagonal stripes scroll across the border.
+   Technique: dual background-image layers on the element itself.
+     Layer 1: linear-gradient(--surface) fills the padding box, masking the center.
+     Layer 2: repeating diagonal gradient fills the border box — visible only in
+              the 3px border zone. border-radius: 6px works correctly with this.
+   IMPORTANT: .album-card:hover sets `background` (shorthand), which resets
+   background-image to none. The hover rule below must redeclare the full
+   background-image to keep the stripes alive.
+   Brown luminance-boosted from #784F17 → #C47A2B (original near-invisible as glow).
+   Black omitted entirely — dead frame against dark surface. */
+
+@keyframes proud-barber {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 0 0, 120px 120px; }
 }
 
 .album-card--highlight-proud {
-  animation: proud-cycle 24s linear infinite;
+  border: 3px solid transparent;
+  background-color: var(--surface);
+  background-image:
+    linear-gradient(var(--surface), var(--surface)),
+    repeating-linear-gradient(
+      135deg,
+      #FFFFFF   0px,  #FFFFFF  12px,
+      #F7A8B8  12px,  #F7A8B8  24px,
+      #55CDFC  24px,  #55CDFC  36px,
+      #C47A2B  36px,  #C47A2B  48px,
+      #E40303  48px,  #E40303  60px,
+      #FF8C00  60px,  #FF8C00  72px,
+      #FFED00  72px,  #FFED00  84px,
+      #008026  84px,  #008026  96px,
+      #004DFF  96px,  #004DFF 108px,
+      #750787 108px,  #750787 120px
+    );
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  background-size: auto, 120px 120px;
+  box-shadow: inset 0 0 8px 1px rgba(85, 205, 252, 0.15);
+  animation: proud-barber 3s linear infinite;
 }
 
-/* Freeze on whatever color the user catches — the frozen color is the reward */
+/* .album-card:hover uses the `background` shorthand, resetting background-image,
+   -origin, -clip, and -size to their defaults. Redeclare all of them here. */
 .album-card--highlight-proud:hover {
-  animation-play-state: paused;
+  background-color: var(--surface-hover);
+  background-image:
+    linear-gradient(var(--surface-hover), var(--surface-hover)),
+    repeating-linear-gradient(
+      135deg,
+      #FFFFFF   0px,  #FFFFFF  12px,
+      #F7A8B8  12px,  #F7A8B8  24px,
+      #55CDFC  24px,  #55CDFC  36px,
+      #C47A2B  36px,  #C47A2B  48px,
+      #E40303  48px,  #E40303  60px,
+      #FF8C00  60px,  #FF8C00  72px,
+      #FFED00  72px,  #FFED00  84px,
+      #008026  84px,  #008026  96px,
+      #004DFF  96px,  #004DFF 108px,
+      #750787 108px,  #750787 120px
+    );
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  background-size: auto, 120px 120px;
+  animation-duration: 0.8s;
 }
 
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
@@ -305,6 +346,6 @@
 
   .album-card--highlight-proud {
     animation: none;
-    box-shadow: 0 0 0 2px #750787, 0 0 10px 4px rgba(117, 7, 135, 0.5);
+    /* static stripes — identity signal without motion */
   }
 }

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -258,9 +258,12 @@
    Brown luminance-boosted from #784F17 → #C47A2B (original near-invisible as glow).
    Black omitted entirely — dead frame against dark surface. */
 
+/* Seamless tile size for 135deg diagonal: W = stripe_period × √2 = 120 × 1.414 ≈ 169.7px.
+   Rounded to 170px — error is ~0.2px per stripe, invisible. Using 120px produces
+   a visible seam every tile and an apparent random reset as it sweeps the border. */
 @keyframes proud-barber {
   from { background-position: 0 0, 0 0; }
-  to   { background-position: 0 0, 120px 120px; }
+  to   { background-position: 0 0, 170px 170px; }
 }
 
 .album-card--highlight-proud {
@@ -283,7 +286,7 @@
     );
   background-origin: padding-box, border-box;
   background-clip: padding-box, border-box;
-  background-size: auto, 120px 120px;
+  background-size: auto, 170px 170px;
   box-shadow: inset 0 0 8px 1px rgba(85, 205, 252, 0.15);
   animation: proud-barber 3s linear infinite;
 }
@@ -309,7 +312,7 @@
     );
   background-origin: padding-box, border-box;
   background-clip: padding-box, border-box;
-  background-size: auto, 120px 120px;
+  background-size: auto, 170px 170px;
   animation-duration: 0.8s;
 }
 

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -245,6 +245,33 @@
   opacity: 0;
 }
 
+/* ── proud ──────────────────────────────────────────────────────────────── */
+
+/* Progress Pride flag: 10 stops, black omitted (dead frame against dark bg),
+   brown luminance-boosted from #784F17 → #C47A2B (original near-invisible as glow) */
+@keyframes proud-cycle {
+  0%   { box-shadow: 0 0 0 2px #FFFFFF, 0 0 10px 4px rgba(255, 255, 255, 0.5); }
+  10%  { box-shadow: 0 0 0 2px #F7A8B8, 0 0 10px 4px rgba(247, 168, 184, 0.5); }
+  20%  { box-shadow: 0 0 0 2px #55CDFC, 0 0 10px 4px rgba( 85, 205, 252, 0.5); }
+  30%  { box-shadow: 0 0 0 2px #C47A2B, 0 0 10px 4px rgba(196, 122,  43, 0.5); }
+  40%  { box-shadow: 0 0 0 2px #E40303, 0 0 10px 4px rgba(228,   3,   3, 0.5); }
+  50%  { box-shadow: 0 0 0 2px #FF8C00, 0 0 10px 4px rgba(255, 140,   0, 0.5); }
+  60%  { box-shadow: 0 0 0 2px #FFED00, 0 0 10px 4px rgba(255, 237,   0, 0.5); }
+  70%  { box-shadow: 0 0 0 2px #008026, 0 0 10px 4px rgba(  0, 128,  38, 0.5); }
+  80%  { box-shadow: 0 0 0 2px #004DFF, 0 0 10px 4px rgba(  0,  77, 255, 0.5); }
+  90%  { box-shadow: 0 0 0 2px #750787, 0 0 10px 4px rgba(117,   7, 135, 0.5); }
+  100% { box-shadow: 0 0 0 2px #FFFFFF, 0 0 10px 4px rgba(255, 255, 255, 0.5); }
+}
+
+.album-card--highlight-proud {
+  animation: proud-cycle 24s linear infinite;
+}
+
+/* Freeze on whatever color the user catches — the frozen color is the reward */
+.album-card--highlight-proud:hover {
+  animation-play-state: paused;
+}
+
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -274,5 +301,10 @@
 
   .vaporwave-scanlines {
     display: none;
+  }
+
+  .album-card--highlight-proud {
+    animation: none;
+    box-shadow: 0 0 0 2px #750787, 0 0 10px 4px rgba(117, 7, 135, 0.5);
   }
 }

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1150,13 +1150,7 @@ export function PreferencesDialog({
                         <SelectRow
                           label="Highlight style"
                           configKey="highlight.style"
-                          options={[
-                            'shiny',
-                            'newmoji',
-                            'vaporwave',
-                            'proud',
-                            'boring'
-                          ]}
+                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'boring']}
                           initialValue={highlightStyle}
                           onSave={handleHighlightSave}
                         />

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1154,9 +1154,7 @@ export function PreferencesDialog({
                             'shiny',
                             'newmoji',
                             'vaporwave',
-                            'proud-rainbow',
-                            'proud-trans',
-                            'proud-agender',
+                            'proud',
                             'boring'
                           ]}
                           initialValue={highlightStyle}


### PR DESCRIPTION
## Summary

- Adds a **proud** new-arrival highlight style: diagonal Progress Pride flag stripes that scroll across the album card border like a barber pole
- Uses the CSS gradient-border trick (dual `background-image` layers) so it stacks cleanly with the playing-state outline and doesn't fight `overflow: hidden`
- Hover speeds up the animation (6s → 1.6s); reduced-motion users get static stripes
- Consolidates the picker from three placeholder `proud-*` variants down to a single `'proud'` option

## Technical notes

- `background-clip: padding-box / border-box` keeps the card surface masked; only the 3px border zone shows the gradient
- Tile size is `170px` (= `120px × √2`, rounded) — the mathematically correct seamless size for a 135° diagonal; using `120px` caused visible seams and apparent resets as the tiling discontinuity swept through the border
- `.album-card:hover` resets `background-image` via the `background` shorthand, so the hover rule redeclares the full gradient

## Test plan

- [x] Select "proud" in Preferences → Highlight style; confirm new-arrival cards show the scrolling diagonal stripe border
- [x] Hover a highlighted card — stripe animation speeds up noticeably
- [x] Confirm no seams or resets visible in the border animation
- [x] Confirm the playing-state outline stacks cleanly on a highlighted card that is also playing
- [x] Enable "Reduce Motion" in macOS accessibility settings — confirm stripes are static

🤖 Generated with [Claude Code](https://claude.com/claude-code)