### PR TITLE
feat(ui): pressed highlight — white vinyl glint + breathing ring

### DIFF
--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -316,6 +316,72 @@
   animation-duration: 1.6s;
 }
 
+/* ── pressed ────────────────────────────────────────────────────────────── */
+
+/* Breathing ring: slow cycle between bright and dim white.
+   One-pixel tight ring + diffuse outer bloom — thin and premium.
+   Use box-shadow, not outline — .playing already owns outline. */
+@keyframes pressed-breath {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.25),
+      0 0 8px 4px rgba(255, 255, 255, 0.07);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.65),
+      0 0 16px 6px rgba(255, 255, 255, 0.18);
+  }
+}
+
+.album-card--highlight-pressed {
+  animation: pressed-breath 4s ease-in-out infinite;
+}
+
+/* Glint sweep: narrow (10%) silver-white diagonal band at 45°.
+   5s cycle, 0.9s active sweep (18% of cycle), holds off-screen the rest. */
+@keyframes pressed-glint-loop {
+  0%     { transform: translateX(-150%); }
+  18%    { transform: translateX(150%); }
+  18.01% { transform: translateX(-150%); }
+  100%   { transform: translateX(-150%); }
+}
+
+/* Single sweep for the hover double-flash */
+@keyframes pressed-glint-once {
+  from { transform: translateX(-150%); }
+  to   { transform: translateX(150%); }
+}
+
+.pressed-glint,
+.pressed-glint-hover {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+    135deg,
+    transparent 42%,
+    rgba(255, 255, 255, 0.05) 46%,
+    rgba(235, 242, 255, 0.28) 50%,
+    rgba(255, 255, 255, 0.05) 54%,
+    transparent 58%
+  );
+}
+
+.pressed-glint {
+  animation: pressed-glint-loop 5s ease-in-out infinite;
+}
+
+.pressed-glint-hover {
+  transform: translateX(-150%);
+}
+
+/* On hover: fire an immediate sweep alongside the periodic glint */
+.album-card--highlight-pressed:hover .pressed-glint-hover {
+  animation: pressed-glint-once 0.5s ease-in-out forwards;
+}
+
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -350,5 +416,15 @@
   .album-card--highlight-proud {
     animation: none;
     /* static stripes — identity signal without motion */
+  }
+
+  .album-card--highlight-pressed {
+    animation: none;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.50);
+  }
+
+  .pressed-glint,
+  .pressed-glint-hover {
+    display: none;
   }
 }

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -115,6 +115,12 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
         {isNew && highlightStyle === 'vaporwave' && (
           <span className="vaporwave-scanlines" aria-hidden="true" />
         )}
+        {isNew && highlightStyle === 'pressed' && (
+          <>
+            <span className="pressed-glint" aria-hidden="true" />
+            <span className="pressed-glint-hover" aria-hidden="true" />
+          </>
+        )}
       </div>
 
       {isNew &&

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1150,7 +1150,7 @@ export function PreferencesDialog({
                         <SelectRow
                           label="Highlight style"
                           configKey="highlight.style"
-                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'boring']}
+                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'pressed', 'boring']}
                           initialValue={highlightStyle}
                           onSave={handleHighlightSave}
                         />


### PR DESCRIPTION
## Summary

- Adds `pressed` as a new highlight style for new arrival AlbumCards (KAMP-269)
- Breathing white ring: 4s ease-in-out box-shadow cycle (0.25 → 0.65 opacity), 1px tight ring + diffuse outer bloom — no color, all restraint
- Glint sweep: narrow 10% silver-white diagonal band at 45°, fires every 5s (0.9s active), two spans inside `.album-art` — one looping, one hover-triggered double-flash (pure CSS, no JS state)
- Reduced motion: static 50% white 1px ring, glints hidden

## Test plan

- [x] Set highlight style to `pressed` in Preferences → Library
- [x] Confirm breathing ring pulses slowly (4s) with no color
- [x] Confirm glint sweeps across album art every ~5s
- [x] Hover an album — verify a second glint fires immediately (double-flash)
- [x] Verify `playing` outline (accent color) coexists with the ring — no conflict
- [x] Test with `prefers-reduced-motion: reduce` — static ring only, no glints

🤖 Generated with [Claude Code](https://claude.com/claude-code)