### PR TITLE
feat(ui): dogear highlight — CSS triangle lifts & peels on hover (KAMP-270)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -382,6 +382,46 @@
   animation: pressed-glint-once 0.5s ease-in-out forwards;
 }
 
+/* ── dogear ─────────────────────────────────────────────────────────────── */
+
+/* Idle: corner slowly lifts and settles, like a Post-it about to fall off.
+   Frames 0–7%: brief snap-back overshoot at cycle restart (simulates mouse-leave
+   bounce when the idle animation resumes after hover ends). */
+@keyframes dogear-idle {
+  0%    { transform: scale(1) rotate(0deg); }
+  7%    { transform: scale(0.93) rotate(1deg); }
+  50%   { transform: scale(1.15) rotate(-3deg); }
+  100%  { transform: scale(1) rotate(0deg); }
+}
+
+/* Hover expand: peel-back suggestion */
+@keyframes dogear-hover-expand {
+  from { transform: scale(1) rotate(0deg); }
+  to   { transform: scaleX(1.6) scaleY(1.5); }
+}
+
+.dogear {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 22px 22px 0;
+  border-color: transparent var(--surface-hover) transparent transparent;
+  filter: drop-shadow(-2px 2px 3px rgba(0, 0, 0, 0.4));
+  transform-origin: top right;
+  pointer-events: none;
+  z-index: 2;
+  animation: dogear-idle 6s ease-in-out infinite;
+}
+
+/* On hover: expand with bouncy easing. When hover ends, idle animation restarts
+   from frame 0 (scale 0.93 overshoot) — the natural snap-back effect. */
+.album-card--highlight-dogear:hover .dogear {
+  animation: dogear-hover-expand 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
 /* ── Reduced motion: static golden outline only (shiny) ────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -426,5 +466,10 @@
   .pressed-glint,
   .pressed-glint-hover {
     display: none;
+  }
+
+  .dogear {
+    animation: none;
+    transform: scale(1) rotate(0deg);
   }
 }

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -121,9 +121,7 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
             <span className="pressed-glint-hover" aria-hidden="true" />
           </>
         )}
-        {isNew && highlightStyle === 'dogear' && (
-          <span className="dogear" aria-hidden="true" />
-        )}
+        {isNew && highlightStyle === 'dogear' && <span className="dogear" aria-hidden="true" />}
       </div>
 
       {isNew &&

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -121,6 +121,9 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
             <span className="pressed-glint-hover" aria-hidden="true" />
           </>
         )}
+        {isNew && highlightStyle === 'dogear' && (
+          <span className="dogear" aria-hidden="true" />
+        )}
       </div>
 
       {isNew &&

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1150,7 +1150,7 @@ export function PreferencesDialog({
                         <SelectRow
                           label="Highlight style"
                           configKey="highlight.style"
-                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'pressed', 'boring']}
+                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'pressed', 'boring', 'dogear']}
                           initialValue={highlightStyle}
                           onSave={handleHighlightSave}
                         />

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1150,7 +1150,15 @@ export function PreferencesDialog({
                         <SelectRow
                           label="Highlight style"
                           configKey="highlight.style"
-                          options={['shiny', 'newmoji', 'vaporwave', 'proud', 'pressed', 'boring', 'dogear']}
+                          options={[
+                            'shiny',
+                            'newmoji',
+                            'vaporwave',
+                            'proud',
+                            'pressed',
+                            'boring',
+                            'dogear'
+                          ]}
                           initialValue={highlightStyle}
                           onSave={handleHighlightSave}
                         />


### PR DESCRIPTION
## Summary

- Adds `dogear` as a new arrival highlight style: a 22px CSS border-trick triangle in the top-right corner of the album card
- Idle animation (6s loop): corner slowly lifts (scale 1.15, rotate -3°) and settles, like a Post-it about to fall off; brief overshoot at cycle restart simulates mouse-leave snap-back
- Hover: expands to scaleX(1.6) scaleY(1.5) with `cubic-bezier(0.34, 1.56, 0.64, 1)` bouncy easing — suggests peeling back
- Color is intentionally `var(--surface-hover)` — barely visible at rest, becomes clear on hover
- Reduced-motion: static triangle, no animation
- `dogear` added to the Preferences dialog style selector

## Test plan

- [x] Set highlight enabled + style = `dogear` in Preferences; newly added albums show a subtle triangle in the top-right corner
- [x] Idle lift animation runs on a ~6s loop (scale up, rotate slightly, settle back)
- [x] Hover expands the triangle with a bouncy pop; mouse-leave restarts idle with a brief snap-back overshoot
- [ ] `prefers-reduced-motion`: triangle is static, no animation
- [ ] Other highlight styles unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)