### PR TITLE
feat(ui): dismiss new arrival highlight after first play (KAMP-275)

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -51,6 +51,8 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const highlightEnabled = useStore((s) => s.highlightEnabled)
   const highlightCutoffSecs = useStore((s) => s.highlightCutoffSecs)
   const highlightStyle = useStore((s) => s.highlightStyle)
+  const dismissedHighlightKeys = useStore((s) => s.dismissedHighlightKeys)
+  const dismissHighlight = useStore((s) => s.dismissHighlight)
   const [artLoaded, setArtLoaded] = useState(false)
   const [menu, setMenu] = useState<MenuPos | null>(null)
 
@@ -58,7 +60,20 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
-  const isNew = highlightEnabled && album.added_at !== null && album.added_at >= highlightCutoffSecs
+  const albumHighlightKey = album.missing_album
+    ? (album.file_path ?? '')
+    : `${album.album_artist}::${album.album}`
+  const isNew =
+    highlightEnabled &&
+    album.added_at !== null &&
+    album.added_at >= highlightCutoffSecs &&
+    album.last_played_at === null &&
+    !dismissedHighlightKeys.has(albumHighlightKey)
+
+  // Dismiss the highlight the first time this album becomes the active playing track.
+  useEffect(() => {
+    if (isNew && isActive && playing) dismissHighlight(album)
+  }, [isNew, isActive, playing]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Start mounting=true so the fast sweep fires immediately; cleared after 1.2s
   const [isMounting, setIsMounting] = useState(isNew)

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -924,10 +924,8 @@ export function PreferencesDialog({
   const scanProgress = useStore((s) => s.scanProgress)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
   const highlightEnabled = useStore((s) => s.highlightEnabled)
-  const highlightDays = useStore((s) => s.highlightDays)
   const highlightStyle = useStore((s) => s.highlightStyle)
   const setHighlightEnabled = useStore((s) => s.setHighlightEnabled)
-  const setHighlightDays = useStore((s) => s.setHighlightDays)
   const setHighlightStyle = useStore((s) => s.setHighlightStyle)
 
   const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions'>(
@@ -1020,10 +1018,6 @@ export function PreferencesDialog({
   const handleHighlightSave = async (key: string, value: string): Promise<void> => {
     if (key === 'highlight.enabled') {
       setHighlightEnabled(value === 'true')
-    } else if (key === 'highlight.days') {
-      const n = parseInt(value)
-      if (!Number.isInteger(n) || n < 1 || n > 365) throw new Error('Must be between 1 and 365.')
-      setHighlightDays(n)
     } else if (key === 'highlight.style') {
       setHighlightStyle(value)
     }
@@ -1139,14 +1133,6 @@ export function PreferencesDialog({
                     />
                     {highlightEnabled && (
                       <>
-                        <InputRow
-                          label="Days to highlight"
-                          configKey="highlight.days"
-                          type="number"
-                          unit="days"
-                          initialValue={String(highlightDays)}
-                          onSave={handleHighlightSave}
-                        />
                         <SelectRow
                           label="Highlight style"
                           configKey="highlight.style"

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -48,9 +48,9 @@ type PlayerStore = {
   recentlyAddedCount: number
   recentlyAddedDays: number
   highlightEnabled: boolean
-  highlightDays: number
   highlightCutoffSecs: number
   highlightStyle: string
+  dismissedHighlightKeys: Set<string>
   topAlbumsCount: number
   baseKampEditMode: boolean
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
@@ -78,8 +78,8 @@ type PlayerStore = {
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
   setHighlightEnabled: (enabled: boolean) => void
-  setHighlightDays: (n: number) => void
   setHighlightStyle: (style: string) => void
+  dismissHighlight: (album: Album) => void
   setTopAlbumsCount: (n: number) => void
   toggleBaseKampEditMode: () => void
   loadLibrary: () => Promise<void>
@@ -193,16 +193,16 @@ export const useStore = create<PlayerStore>((set, get) => ({
     return saved ? parseInt(saved) : 30
   })(),
   highlightEnabled: localStorage.getItem('kamp:highlight-enabled') !== 'false',
-  highlightDays: (() => {
-    const saved = localStorage.getItem('kamp:highlight-days')
-    return saved ? parseInt(saved) : 3
-  })(),
-  highlightCutoffSecs: (() => {
-    const saved = localStorage.getItem('kamp:highlight-days')
-    const days = saved ? parseInt(saved) : 3
-    return Date.now() / 1000 - days * 86400
-  })(),
+  highlightCutoffSecs: Date.now() / 1000 - 5 * 86400,
   highlightStyle: localStorage.getItem('kamp:highlight-style') ?? 'shiny',
+  dismissedHighlightKeys: (() => {
+    try {
+      const saved = localStorage.getItem('kamp:dismissed-highlights')
+      return new Set<string>(saved ? (JSON.parse(saved) as string[]) : [])
+    } catch {
+      return new Set<string>()
+    }
+  })(),
   topAlbumsCount: (() => {
     const saved = localStorage.getItem('kamp:top-albums-count')
     return saved ? parseInt(saved) : 10
@@ -344,14 +344,20 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ highlightEnabled: enabled })
   },
 
-  setHighlightDays: (n) => {
-    localStorage.setItem('kamp:highlight-days', String(n))
-    set({ highlightDays: n, highlightCutoffSecs: Date.now() / 1000 - n * 86400 })
-  },
-
   setHighlightStyle: (style) => {
     localStorage.setItem('kamp:highlight-style', style)
     set({ highlightStyle: style })
+  },
+
+  dismissHighlight: (album) => {
+    const key = album.missing_album
+      ? (album.file_path ?? '')
+      : `${album.album_artist}::${album.album}`
+    const next = new Set(get().dismissedHighlightKeys)
+    if (next.has(key)) return
+    next.add(key)
+    localStorage.setItem('kamp:dismissed-highlights', JSON.stringify([...next]))
+    set({ dismissedHighlightKeys: next })
   },
 
   setTopAlbumsCount: (n) => {


### PR DESCRIPTION
## Summary

- New arrivals lose their highlight the moment you play a track from the album — no more re-discovering albums you've already heard
- `isNew` now checks `last_played_at === null` (server-side, persists across sessions) plus a `dismissedHighlightKeys` localStorage set (client-side, fires immediately without waiting for a library reload)
- Removed the "Days to highlight" preference; window is fixed at 5 days

## How it works

Two complementary dismissal layers:

1. **Cross-session:** `album.last_played_at` is only ever set by kamp's `record_played()` — never imported from file metadata — so `!== null` unambiguously means "played in kamp." On the next library load after listening, the album falls out of `isNew` automatically.

2. **Real-time:** A `useEffect` in `AlbumCard` watches `isActive && playing`. When a highlighted album becomes the active track, it calls `dismissHighlight()`, which adds an `"artist::album"` key to a `Set` in the store (persisted to localStorage). The highlight drops instantly without waiting for a library reload.

## Test plan

- [x] Newly added album shows highlight
- [x] Start playing a track from that album — highlight disappears immediately
- [x] Restart the app — album is still not highlighted
- [x] Album that already has `last_played_at` (played before this update) — no highlight on load
- [x] Preferences dialog: "Days to highlight" row is gone; highlight style selector still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)