### PR TITLE
feat(ui): add Favorite toggle to queue context menu (KAMP-264)

### DIFF
--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -8,6 +8,8 @@ interface Props {
   albumArtist?: string
   album?: string
   trackIdx: number | null
+  filePath?: string
+  favorite?: boolean
   onClose: () => void
 }
 
@@ -17,6 +19,8 @@ export function QueueContextMenu({
   albumArtist,
   album,
   trackIdx,
+  filePath,
+  favorite,
   onClose
 }: Props): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -25,6 +29,7 @@ export function QueueContextMenu({
   const setActiveView = useStore((s) => s.setActiveView)
   const clearQueue = useStore((s) => s.clearQueue)
   const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
+  const setFavorite = useStore((s) => s.setFavorite)
 
   return (
     <ContextMenu x={x} y={y} onClose={onClose}>
@@ -65,6 +70,17 @@ export function QueueContextMenu({
           >
             ♫ Go to Artist
           </button>
+          {filePath && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void setFavorite(filePath, !favorite)
+                onClose()
+              }}
+            >
+              {favorite ? '♥ Unfavorite' : '♥ Favorite'}
+            </button>
+          )}
           <div className="track-context-menu-divider" />
         </>
       )}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -13,6 +13,8 @@ type ContextMenu = {
   trackIdx: number | null
   albumArtist?: string
   album?: string
+  filePath?: string
+  favorite?: boolean
 }
 
 export function QueuePanel(): React.JSX.Element {
@@ -209,7 +211,9 @@ export function QueuePanel(): React.JSX.Element {
                     y: e.clientY,
                     trackIdx: isUnplayed ? idx : null,
                     albumArtist: track.album_artist,
-                    album: track.album
+                    album: track.album,
+                    filePath: track.file_path,
+                    favorite: track.favorite
                   })
                 }}
               >
@@ -231,6 +235,8 @@ export function QueuePanel(): React.JSX.Element {
           albumArtist={menu.albumArtist}
           album={menu.album}
           trackIdx={menu.trackIdx}
+          filePath={menu.filePath}
+          favorite={menu.favorite}
           onClose={() => setMenu(null)}
         />
       )}


### PR DESCRIPTION
## Summary

- Adds `filePath` and `favorite` props to `QueueContextMenu` (threaded from `QueuePanel`)
- Right-clicking any queue track now shows **♥ Favorite** / **♥ Unfavorite** toggle after "Go to Artist"
- Available on played, current, and unplayed tracks (not gated on queue position)
- Calls existing `setFavorite` store action — optimistic update + `refreshOpenAlbum()` happen automatically

## Test plan

- [x] Right-click an unplayed queue track → menu shows ♥ Favorite; click it → heart indicator appears in the row
- [x] Right-click the same track again → menu shows ♥ Unfavorite; click it → heart indicator disappears
- [x] Right-click a played (greyed-out) track → favorite toggle is present and works
- [x] Right-click the currently playing track → favorite toggle is present and works
- [x] Right-click on empty queue list area (no track) → no favorite item shown
- [x] Favorited track's album view also reflects the change (refreshOpenAlbum fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)