### PR TITLE
feat(ui): fall back to most-recently-added when New Arrivals window is empty (KAMP-274)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -78,7 +78,8 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
         .filter((a) => a.added_at !== null)
         .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
       const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
-      const inWindow = cutoff !== null ? withDate.filter((a) => (a.added_at ?? 0) >= cutoff) : withDate
+      const inWindow =
+        cutoff !== null ? withDate.filter((a) => (a.added_at ?? 0) >= cutoff) : withDate
       // Fall back to most-recently-added if the date window returns nothing (e.g. older libraries)
       setAlbums((inWindow.length > 0 ? inWindow : withDate).slice(0, count > 0 ? count : undefined))
     })

--- a/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/NewArrivalsModule.tsx
@@ -74,13 +74,13 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
 
   useEffect(() => {
     void Promise.resolve(allAlbums).then((all) => {
+      const withDate = [...all]
+        .filter((a) => a.added_at !== null)
+        .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
       const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
-      setAlbums(
-        [...all]
-          .filter((a) => a.added_at !== null && (cutoff === null || a.added_at >= cutoff))
-          .sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0))
-          .slice(0, count > 0 ? count : undefined)
-      )
+      const inWindow = cutoff !== null ? withDate.filter((a) => (a.added_at ?? 0) >= cutoff) : withDate
+      // Fall back to most-recently-added if the date window returns nothing (e.g. older libraries)
+      setAlbums((inWindow.length > 0 ? inWindow : withDate).slice(0, count > 0 ? count : undefined))
     })
   }, [allAlbums, count, days])
 
@@ -95,11 +95,7 @@ export function NewArrivalsModule({ displayStyle }: ModuleProps): React.JSX.Elem
   }
 
   if (albums.length === 0) {
-    return (
-      <div className="module-empty">
-        {days > 0 ? `No albums added in the last ${days} days.` : 'No albums in your library.'}
-      </div>
-    )
+    return <div className="module-empty">No albums in your library.</div>
   }
 
   if (displayStyle === 'list') return <ListView albums={albums} />


### PR DESCRIPTION
## Summary

- When the configured day-window returns no albums (e.g. an existing library where everything predates the threshold), the New Arrivals module now silently shows the N most recently added albums instead of an empty state
- Empty state message simplified to "No albums in your library." — the only case it's reached now is a genuinely empty library

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Fresh library, albums added recently | Shows date-range results | Unchanged |
| Older library, nothing in window | Empty state | Shows N most recently added |
| Truly empty library | "No albums in your library." | Unchanged |
| `days = 0` (no filter) | Shows all albums | Unchanged |

## Test plan

- [x] Open kamp with a library where all albums predate the configured day window — module should populate with the most recently added albums rather than showing empty
- [x] Confirm fresh library (albums within window) still shows only those albums
- [x] Confirm empty library still shows "No albums in your library."
- [x] Type check passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)