### PR TITLE
feat(windows): bootstrap dev env + Windows CI (KAMP-281, KAMP-36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,31 @@ jobs:
       - name: Run tests
         run: poetry run pytest
 
+  python-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      # Coverage threshold is enforced by the ubuntu-latest `python` job — that
+      # is the canonical reference platform. Skip coverage here since several
+      # POSIX-only paths (launchd service install, SIGUSR1/SIGUSR2 handlers,
+      # st_mode chmod) are skipif'd on Windows and would otherwise pull total
+      # coverage below the 95% threshold for reasons unrelated to regressions.
+      - name: Run tests (no-cov)
+        run: poetry run pytest --no-cov
+
   sandbox-macos:
     runs-on: macos-latest
 
@@ -60,6 +85,31 @@ jobs:
 
   ui:
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: kamp_ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: kamp_ui
+
+      - name: Type-check
+        run: npm run typecheck
+        working-directory: kamp_ui
+
+      - name: Lint
+        run: npm run lint
+        working-directory: kamp_ui
+
+  ui-windows:
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import random
 import secrets
 import shutil
@@ -22,7 +21,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import BinaryIO, Callable
+from typing import Any, Callable
 
 from kamp_core.library import Track
 
@@ -426,19 +425,27 @@ class _UnixSocketTransport(_IPCTransport):
 class _WindowsNamedPipeTransport(_IPCTransport):
     """mpv on Windows binds --input-ipc-server=NAME to a Win32 named pipe.
 
-    We pass a fully-qualified \\\\.\\pipe\\NAME path so mpv and the connecting
-    client agree on the same endpoint regardless of how mpv normalizes the
-    argument internally.
+    Per mpv's own docs (DOCS/man/ipc.rst):
 
-    The pipe is opened with TWO separate file handles — one read-only, one
-    write-only — opened sequentially. Win32 named pipe servers (mpv) treat
-    each CreateFile from a client as a new pipe instance, so the read and
-    write handles correspond to distinct instances even though they refer
-    to the same NAME. Using a single duplex handle (r+b) on Windows leads
-    to a deadlock pattern in practice: a long blocking ReadFile in one
-    thread serializes against a blocking WriteFile in another at the stdio
-    layer, even though the kernel-level operations target independent
-    inbound/outbound buffers. Two handles avoid this entirely.
+        "To be able to simultaneously read and write from the IPC pipe, like
+         on Linux, it's necessary to write an external program that uses
+         overlapped file I/O (or some wrapper like .NET's
+         NamedPipeClientStream)."
+
+    Without FILE_FLAG_OVERLAPPED on the client-side CreateFile, Windows
+    serializes I/O on the handle: a thread parked in ReadFile blocks a
+    concurrent WriteFile on the same handle. Bare os.read / os.write don't
+    escape that — verified by py-spy on a deadlocked daemon (main thread
+    parked in WriteFile, reader thread parked in ReadFile, same fd). Two
+    separate handles avoid the deadlock but lose property events because
+    mpv routes property-change events back on the connection that
+    subscribed; the read-only handle never subscribed.
+
+    The fix matches what python-mpv-jsonipc has shipped for years: open
+    the pipe via _winapi.CreateFile with FILE_FLAG_OVERLAPPED, then wrap
+    the handle in multiprocessing.connection.PipeConnection. send_bytes /
+    recv_bytes issue per-call overlapped I/O, so a parked recv does not
+    block a concurrent send.
     """
 
     # ERROR_PIPE_BUSY: all instances of the named pipe are saturated; retry.
@@ -448,8 +455,15 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         # 16 hex chars = 64 bits of entropy — collision-free across concurrent
         # daemons on the same machine.
         self._pipe_name = rf"\\.\pipe\kamp-mpv-{secrets.token_hex(8)}"
-        self._read_file: BinaryIO | None = None
-        self._write_file: BinaryIO | None = None
+        self._conn: Any = None
+        # send_bytes is overlapped but not self-thread-safe; serialize writes.
+        # MpvPlaybackEngine._lock already wraps _send_command, but a
+        # transport-local lock keeps the contract local to this class.
+        self._write_lock = threading.Lock()
+        # recv_bytes returns one whole frame per call (mpv writes one
+        # newline-terminated JSON message per WriteFile). Buffer leftovers so
+        # the existing recv(n)-style contract is preserved for callers.
+        self._read_buf = bytearray()
 
     @property
     def server_arg(self) -> str:
@@ -458,53 +472,37 @@ class _WindowsNamedPipeTransport(_IPCTransport):
     def open(
         self, timeout: float, proc: subprocess.Popen[bytes]
     ) -> None:  # pragma: no cover
+        # Imported lazily so the module still imports cleanly off Windows
+        # (multiprocessing.connection.PipeConnection is Win32-only).
+        import _winapi
+        from multiprocessing.connection import PipeConnection
+
         deadline = time.monotonic() + timeout
         last_err: OSError | None = None
-        # Open the read handle first; mpv must be listening before either
-        # CreateFile call succeeds. Use os.open (not the "rb" / "wb" modes of
-        # builtins.open) because Python's stdio mode strings imply O_TRUNC
-        # for write modes, which named pipes reject with EINVAL. os.open
-        # with bare O_RDONLY / O_WRONLY avoids that.
         while time.monotonic() < deadline:
             try:
-                fd = os.open(self._pipe_name, os.O_RDONLY | os.O_BINARY)
-                self._read_file = os.fdopen(fd, "rb", buffering=0)
-                break
+                handle = _winapi.CreateFile(
+                    self._pipe_name,
+                    _winapi.GENERIC_READ | _winapi.GENERIC_WRITE,
+                    0,  # dwShareMode
+                    _winapi.NULL,  # lpSecurityAttributes
+                    _winapi.OPEN_EXISTING,
+                    _winapi.FILE_FLAG_OVERLAPPED,
+                    _winapi.NULL,  # hTemplateFile
+                )
             except FileNotFoundError as exc:
                 # mpv has not called CreateNamedPipe yet — retry.
                 last_err = exc
+                time.sleep(0.05)
+                continue
             except OSError as exc:
                 if getattr(exc, "winerror", None) == self._ERROR_PIPE_BUSY:
                     last_err = exc
-                else:
-                    raise
-            time.sleep(0.05)
-        if self._read_file is None:
-            self._raise_open_timeout(proc, timeout, last_err)
-        # Now open a separate write handle. mpv accepts a second client
-        # connection on the same pipe name; reads and writes go through
-        # independent kernel buffers.
-        while time.monotonic() < deadline:
-            try:
-                fd = os.open(self._pipe_name, os.O_WRONLY | os.O_BINARY)
-                self._write_file = os.fdopen(fd, "wb", buffering=0)
-                return
-            except FileNotFoundError as exc:
-                last_err = exc
-            except OSError as exc:
-                if getattr(exc, "winerror", None) == self._ERROR_PIPE_BUSY:
-                    last_err = exc
-                else:
-                    raise
-            time.sleep(0.05)
-        self._raise_open_timeout(proc, timeout, last_err)
-
-    def _raise_open_timeout(
-        self,
-        proc: subprocess.Popen[bytes],
-        timeout: float,
-        last_err: OSError | None,
-    ) -> None:  # pragma: no cover
+                    time.sleep(0.05)
+                    continue
+                raise
+            self._conn = PipeConnection(handle)
+            return
         detail = ""
         if proc.poll() is not None and proc.stderr is not None:
             stderr_bytes = proc.stderr.read()
@@ -516,35 +514,42 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         )
 
     def sendall(self, data: bytes) -> None:  # pragma: no cover
-        if self._write_file is None:
+        if self._conn is None:
             raise OSError("transport closed")
-        # Buffered=0 FileIO writes the buffer in one WriteFile call, but Win32
-        # pipes can do partial writes under load — loop to drain.
-        view = memoryview(data)
-        while view:
-            written = self._write_file.write(view)
-            if not written:
-                raise OSError("named pipe closed during write")
-            view = view[written:]
+        with self._write_lock:
+            try:
+                self._conn.send_bytes(data)
+            except (BrokenPipeError, EOFError) as exc:
+                raise OSError(str(exc)) from exc
 
     def recv(self, n: int) -> bytes:  # pragma: no cover
-        if self._read_file is None:
-            return b""
-        try:
-            chunk = self._read_file.read(n)
-        except OSError:
-            return b""
-        return chunk or b""
+        # Refill the local buffer if empty — recv_bytes returns one whole
+        # mpv frame per call, which is fine for the engine's line-oriented
+        # parser. Do NOT pass `n` to recv_bytes: that argument is maxlength
+        # and raises if the incoming frame is larger.
+        if not self._read_buf:
+            if self._conn is None:
+                return b""
+            try:
+                frame = self._conn.recv_bytes()
+            except (EOFError, OSError):
+                return b""
+            self._read_buf.extend(frame)
+        if len(self._read_buf) <= n:
+            chunk = bytes(self._read_buf)
+            self._read_buf.clear()
+            return chunk
+        chunk = bytes(self._read_buf[:n])
+        del self._read_buf[:n]
+        return chunk
 
     def close(self) -> None:
-        for attr in ("_read_file", "_write_file"):
-            f = getattr(self, attr, None)
-            if f is not None:
-                try:
-                    f.close()
-                except OSError:
-                    pass
-                setattr(self, attr, None)
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except OSError:
+                pass
+            self._conn = None
 
 
 def _make_ipc_transport() -> _IPCTransport:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -393,7 +393,7 @@ class _UnixSocketTransport(_IPCTransport):
         # AF_UNIX exists on POSIX; the typeshed stub elides it on Windows.
         # _UnixSocketTransport is only constructed off Windows (see
         # _make_ipc_transport) so the lookup is runtime-safe.
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # type: ignore[attr-defined]
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # type: ignore[attr-defined,unused-ignore]
         sock.connect(self._sock_path)
         self._sock = sock
 
@@ -473,9 +473,16 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         self, timeout: float, proc: subprocess.Popen[bytes]
     ) -> None:  # pragma: no cover
         # Imported lazily so the module still imports cleanly off Windows
-        # (multiprocessing.connection.PipeConnection is Win32-only).
-        import _winapi
-        from multiprocessing.connection import PipeConnection
+        # (multiprocessing.connection.PipeConnection is Win32-only). Cast to
+        # Any so mypy on Linux/macOS does not flag the platform-conditional
+        # _winapi attributes — this method only runs when sys.platform ==
+        # "win32" (see _make_ipc_transport).
+        import _winapi as _winapi_mod
+        from multiprocessing.connection import (  # type: ignore[attr-defined,unused-ignore]
+            PipeConnection,
+        )
+
+        _winapi: Any = _winapi_mod
 
         deadline = time.monotonic() + timeout
         last_err: OSError | None = None

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import secrets
 import shutil
@@ -427,9 +428,17 @@ class _WindowsNamedPipeTransport(_IPCTransport):
 
     We pass a fully-qualified \\\\.\\pipe\\NAME path so mpv and the connecting
     client agree on the same endpoint regardless of how mpv normalizes the
-    argument internally. The connection is a duplex file handle obtained by
-    open(path, "r+b", buffering=0); read/write map to ReadFile/WriteFile on
-    the underlying handle.
+    argument internally.
+
+    The pipe is opened with TWO separate file handles — one read-only, one
+    write-only — opened sequentially. Win32 named pipe servers (mpv) treat
+    each CreateFile from a client as a new pipe instance, so the read and
+    write handles correspond to distinct instances even though they refer
+    to the same NAME. Using a single duplex handle (r+b) on Windows leads
+    to a deadlock pattern in practice: a long blocking ReadFile in one
+    thread serializes against a blocking WriteFile in another at the stdio
+    layer, even though the kernel-level operations target independent
+    inbound/outbound buffers. Two handles avoid this entirely.
     """
 
     # ERROR_PIPE_BUSY: all instances of the named pipe are saturated; retry.
@@ -439,7 +448,8 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         # 16 hex chars = 64 bits of entropy — collision-free across concurrent
         # daemons on the same machine.
         self._pipe_name = rf"\\.\pipe\kamp-mpv-{secrets.token_hex(8)}"
-        self._file: BinaryIO | None = None
+        self._read_file: BinaryIO | None = None
+        self._write_file: BinaryIO | None = None
 
     @property
     def server_arg(self) -> str:
@@ -450,10 +460,16 @@ class _WindowsNamedPipeTransport(_IPCTransport):
     ) -> None:  # pragma: no cover
         deadline = time.monotonic() + timeout
         last_err: OSError | None = None
+        # Open the read handle first; mpv must be listening before either
+        # CreateFile call succeeds. Use os.open (not the "rb" / "wb" modes of
+        # builtins.open) because Python's stdio mode strings imply O_TRUNC
+        # for write modes, which named pipes reject with EINVAL. os.open
+        # with bare O_RDONLY / O_WRONLY avoids that.
         while time.monotonic() < deadline:
             try:
-                self._file = open(self._pipe_name, "r+b", buffering=0)
-                return
+                fd = os.open(self._pipe_name, os.O_RDONLY | os.O_BINARY)
+                self._read_file = os.fdopen(fd, "rb", buffering=0)
+                break
             except FileNotFoundError as exc:
                 # mpv has not called CreateNamedPipe yet — retry.
                 last_err = exc
@@ -463,6 +479,32 @@ class _WindowsNamedPipeTransport(_IPCTransport):
                 else:
                     raise
             time.sleep(0.05)
+        if self._read_file is None:
+            self._raise_open_timeout(proc, timeout, last_err)
+        # Now open a separate write handle. mpv accepts a second client
+        # connection on the same pipe name; reads and writes go through
+        # independent kernel buffers.
+        while time.monotonic() < deadline:
+            try:
+                fd = os.open(self._pipe_name, os.O_WRONLY | os.O_BINARY)
+                self._write_file = os.fdopen(fd, "wb", buffering=0)
+                return
+            except FileNotFoundError as exc:
+                last_err = exc
+            except OSError as exc:
+                if getattr(exc, "winerror", None) == self._ERROR_PIPE_BUSY:
+                    last_err = exc
+                else:
+                    raise
+            time.sleep(0.05)
+        self._raise_open_timeout(proc, timeout, last_err)
+
+    def _raise_open_timeout(
+        self,
+        proc: subprocess.Popen[bytes],
+        timeout: float,
+        last_err: OSError | None,
+    ) -> None:  # pragma: no cover
         detail = ""
         if proc.poll() is not None and proc.stderr is not None:
             stderr_bytes = proc.stderr.read()
@@ -474,33 +516,35 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         )
 
     def sendall(self, data: bytes) -> None:  # pragma: no cover
-        if self._file is None:
+        if self._write_file is None:
             raise OSError("transport closed")
-        # Buffered=0 FileIO writes the buffer in one ReadFile/WriteFile call,
-        # but Win32 pipes can do partial writes under load — loop to drain.
+        # Buffered=0 FileIO writes the buffer in one WriteFile call, but Win32
+        # pipes can do partial writes under load — loop to drain.
         view = memoryview(data)
         while view:
-            written = self._file.write(view)
+            written = self._write_file.write(view)
             if not written:
                 raise OSError("named pipe closed during write")
             view = view[written:]
 
     def recv(self, n: int) -> bytes:  # pragma: no cover
-        if self._file is None:
+        if self._read_file is None:
             return b""
         try:
-            chunk = self._file.read(n)
+            chunk = self._read_file.read(n)
         except OSError:
             return b""
         return chunk or b""
 
     def close(self) -> None:
-        if self._file is not None:
-            try:
-                self._file.close()
-            except OSError:
-                pass
-            self._file = None
+        for attr in ("_read_file", "_write_file"):
+            f = getattr(self, attr, None)
+            if f is not None:
+                try:
+                    f.close()
+                except OSError:
+                    pass
+                setattr(self, attr, None)
 
 
 def _make_ipc_transport() -> _IPCTransport:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -10,15 +10,18 @@ from __future__ import annotations
 import json
 import logging
 import random
+import secrets
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import threading
 import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import BinaryIO, Callable
 
 from kamp_core.library import Track
 
@@ -318,6 +321,196 @@ class PlaybackQueue:
 
 
 # ---------------------------------------------------------------------------
+# IPC transport
+# ---------------------------------------------------------------------------
+
+# mpv's JSON IPC channel is a Unix domain socket on macOS/Linux and a Win32
+# named pipe on Windows. Both speak the same wire protocol (newline-delimited
+# JSON), but the connect step differs: Unix selects via filesystem path and
+# AF_UNIX, Windows selects via \\.\pipe\NAME and a duplex file handle.
+# _IPCTransport keeps that platform branch isolated so MpvPlaybackEngine
+# stays platform-neutral.
+
+
+class _IPCTransport(ABC):
+    """mpv JSON-IPC transport with a uniform sendall/recv surface."""
+
+    @property
+    @abstractmethod
+    def server_arg(self) -> str:
+        """Value passed to mpv's --input-ipc-server flag."""
+
+    @abstractmethod
+    def open(self, timeout: float, proc: subprocess.Popen[bytes]) -> None:
+        """Block until mpv has bound the IPC endpoint, then connect.
+
+        Reads any captured stderr from *proc* into the diagnostic message if
+        mpv exits before the endpoint appears.
+        """
+
+    @abstractmethod
+    def sendall(self, data: bytes) -> None:
+        """Write *data* to mpv. Raises OSError if the channel is dead."""
+
+    @abstractmethod
+    def recv(self, n: int) -> bytes:
+        """Read up to *n* bytes; returns b'' on EOF or error."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the connection and remove any filesystem artifacts."""
+
+
+class _UnixSocketTransport(_IPCTransport):
+    def __init__(self) -> None:
+        # Hold the tmpdir so cleanup can rm the socket file mpv leaves behind.
+        self._tmpdir = tempfile.mkdtemp(prefix="kamp-mpv-")
+        self._sock_path = str(Path(self._tmpdir) / "mpv.sock")
+        self._sock: socket.socket | None = None
+
+    @property
+    def server_arg(self) -> str:
+        return self._sock_path
+
+    def open(
+        self, timeout: float, proc: subprocess.Popen[bytes]
+    ) -> None:  # pragma: no cover
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if Path(self._sock_path).exists():
+                break
+            time.sleep(0.05)
+        else:
+            detail = ""
+            if proc.poll() is not None and proc.stderr is not None:
+                stderr_bytes = proc.stderr.read()
+                if stderr_bytes:
+                    detail = f": {stderr_bytes.decode(errors='replace').strip()}"
+            raise RuntimeError(
+                f"mpv IPC socket did not appear at {self._sock_path} "
+                f"within {timeout}s{detail}."
+            )
+        # AF_UNIX exists on POSIX; the typeshed stub elides it on Windows.
+        # _UnixSocketTransport is only constructed off Windows (see
+        # _make_ipc_transport) so the lookup is runtime-safe.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # type: ignore[attr-defined]
+        sock.connect(self._sock_path)
+        self._sock = sock
+
+    def sendall(self, data: bytes) -> None:  # pragma: no cover
+        if self._sock is None:
+            raise OSError("transport closed")
+        self._sock.sendall(data)
+
+    def recv(self, n: int) -> bytes:  # pragma: no cover
+        if self._sock is None:
+            return b""
+        try:
+            return self._sock.recv(n)
+        except OSError:
+            return b""
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            self._tmpdir = ""
+
+
+class _WindowsNamedPipeTransport(_IPCTransport):
+    """mpv on Windows binds --input-ipc-server=NAME to a Win32 named pipe.
+
+    We pass a fully-qualified \\\\.\\pipe\\NAME path so mpv and the connecting
+    client agree on the same endpoint regardless of how mpv normalizes the
+    argument internally. The connection is a duplex file handle obtained by
+    open(path, "r+b", buffering=0); read/write map to ReadFile/WriteFile on
+    the underlying handle.
+    """
+
+    # ERROR_PIPE_BUSY: all instances of the named pipe are saturated; retry.
+    _ERROR_PIPE_BUSY = 231
+
+    def __init__(self) -> None:
+        # 16 hex chars = 64 bits of entropy — collision-free across concurrent
+        # daemons on the same machine.
+        self._pipe_name = rf"\\.\pipe\kamp-mpv-{secrets.token_hex(8)}"
+        self._file: BinaryIO | None = None
+
+    @property
+    def server_arg(self) -> str:
+        return self._pipe_name
+
+    def open(
+        self, timeout: float, proc: subprocess.Popen[bytes]
+    ) -> None:  # pragma: no cover
+        deadline = time.monotonic() + timeout
+        last_err: OSError | None = None
+        while time.monotonic() < deadline:
+            try:
+                self._file = open(self._pipe_name, "r+b", buffering=0)
+                return
+            except FileNotFoundError as exc:
+                # mpv has not called CreateNamedPipe yet — retry.
+                last_err = exc
+            except OSError as exc:
+                if getattr(exc, "winerror", None) == self._ERROR_PIPE_BUSY:
+                    last_err = exc
+                else:
+                    raise
+            time.sleep(0.05)
+        detail = ""
+        if proc.poll() is not None and proc.stderr is not None:
+            stderr_bytes = proc.stderr.read()
+            if stderr_bytes:
+                detail = f": {stderr_bytes.decode(errors='replace').strip()}"
+        raise RuntimeError(
+            f"mpv IPC pipe at {self._pipe_name} did not become connectable "
+            f"within {timeout}s{detail}: {last_err!r}"
+        )
+
+    def sendall(self, data: bytes) -> None:  # pragma: no cover
+        if self._file is None:
+            raise OSError("transport closed")
+        # Buffered=0 FileIO writes the buffer in one ReadFile/WriteFile call,
+        # but Win32 pipes can do partial writes under load — loop to drain.
+        view = memoryview(data)
+        while view:
+            written = self._file.write(view)
+            if not written:
+                raise OSError("named pipe closed during write")
+            view = view[written:]
+
+    def recv(self, n: int) -> bytes:  # pragma: no cover
+        if self._file is None:
+            return b""
+        try:
+            chunk = self._file.read(n)
+        except OSError:
+            return b""
+        return chunk or b""
+
+    def close(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            except OSError:
+                pass
+            self._file = None
+
+
+def _make_ipc_transport() -> _IPCTransport:
+    """Return the IPC transport appropriate for the current platform."""
+    if sys.platform == "win32":
+        return _WindowsNamedPipeTransport()
+    return _UnixSocketTransport()
+
+
+# ---------------------------------------------------------------------------
 # MpvPlaybackEngine
 # ---------------------------------------------------------------------------
 
@@ -334,11 +527,12 @@ _OBSERVED: list[tuple[int, str]] = [
 
 
 class MpvPlaybackEngine:
-    """Controls mpv via its JSON IPC socket.
+    """Controls mpv via its JSON IPC channel.
 
-    mpv is started as a subprocess with --input-ipc-server pointing at a
-    temporary Unix socket. A background thread reads the event stream and
-    updates self.state. Commands are sent synchronously via _send_command.
+    mpv is started as a subprocess with --input-ipc-server pointing at the
+    transport-specific endpoint (a temporary Unix socket on macOS/Linux, a
+    Win32 named pipe on Windows). A background thread reads the event stream
+    and updates self.state. Commands are sent synchronously via _send_command.
     """
 
     def __init__(self, mpv_bin: str = "mpv") -> None:
@@ -348,9 +542,7 @@ class MpvPlaybackEngine:
         self.on_play_state_changed: Callable[[], None] | None = None
         self._mpv_bin = mpv_bin
         self._proc: subprocess.Popen[bytes] | None = None
-        self._sock: socket.socket | None = None
-        self._sock_path = ""
-        self._sock_tmpdir = ""
+        self._ipc: _IPCTransport = _make_ipc_transport()
         self._reader_thread: threading.Thread | None = None
         # RLock so the reader thread can re-acquire the lock inside callbacks
         # (e.g. on_track_end → engine.play() → _send_command) while still
@@ -369,17 +561,14 @@ class MpvPlaybackEngine:
         self._start_mpv()
 
     def _start_mpv(self) -> None:  # pragma: no cover
-        """Launch mpv and connect to its IPC socket."""
-        tmpdir = tempfile.mkdtemp(prefix="kamp-mpv-")
-        self._sock_tmpdir = tmpdir
-        self._sock_path = str(Path(tmpdir) / "mpv.sock")
+        """Launch mpv and connect to its IPC channel."""
         self._proc = subprocess.Popen(
             [
                 self._mpv_bin,
                 "--no-video",
                 "--idle=yes",
                 "--really-quiet",
-                f"--input-ipc-server={self._sock_path}",
+                f"--input-ipc-server={self._ipc.server_arg}",
                 # Prevent mpv from intercepting media keys via its IOKit HID tap.
                 # Media key events are now handled by the Electron now-playing-helper
                 # subprocess via MPRemoteCommandCenter (registered by the process
@@ -390,36 +579,19 @@ class MpvPlaybackEngine:
             # Capture stderr so we can surface it if mpv fails to start.
             stderr=subprocess.PIPE,
         )
-        self._connect_socket()
+        try:
+            self._ipc.open(timeout=5.0, proc=self._proc)
+        except RuntimeError as exc:
+            # Re-raise with the binary path so PATH/installation issues are
+            # obvious in logs (the transport doesn't know which mpv we asked for).
+            raise RuntimeError(
+                f"{exc} Is '{self._mpv_bin}' installed and on PATH?"
+            ) from None
         self._observe_properties()
         self._reader_thread = threading.Thread(
             target=self._read_loop, daemon=True, name="mpv-reader"
         )
         self._reader_thread.start()
-
-    def _connect_socket(self, timeout: float = 5.0) -> None:  # pragma: no cover
-        """Poll until mpv creates its IPC socket, then connect."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if Path(self._sock_path).exists():
-                break
-            time.sleep(0.05)
-        else:
-            # Try to collect any error output from mpv before raising.
-            assert self._proc is not None
-            detail = ""
-            if self._proc.poll() is not None and self._proc.stderr:
-                stderr_bytes = self._proc.stderr.read()
-                if stderr_bytes:
-                    detail = f": {stderr_bytes.decode(errors='replace').strip()}"
-            raise RuntimeError(
-                f"mpv IPC socket did not appear at {self._sock_path} "
-                f"within {timeout}s{detail}. "
-                f"Is '{self._mpv_bin}' installed and in PATH?"
-            )
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.connect(self._sock_path)
-        self._sock = sock
 
     def _observe_properties(self) -> None:  # pragma: no cover
         """Ask mpv to stream property changes for state tracking."""
@@ -537,41 +709,32 @@ class MpvPlaybackEngine:
         if self._proc is not None:
             self._proc.terminate()
             self._proc = None
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-        if self._sock_tmpdir:
-            shutil.rmtree(self._sock_tmpdir, ignore_errors=True)
-            self._sock_tmpdir = ""
+        # Closing the transport unblocks the reader thread's blocking recv()
+        # so the daemon shuts down cleanly. Tolerate cleanup errors so a
+        # crashing transport never aborts daemon shutdown.
+        try:
+            self._ipc.close()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # Internal: IPC send/receive
     # ------------------------------------------------------------------
 
     def _send_command(self, *args: object) -> None:
-        """Serialize and send a command to mpv over the IPC socket."""
-        if self._sock is None:
-            return
+        """Serialize and send a command to mpv over the IPC channel."""
         msg = json.dumps({"command": list(args)}) + "\n"
         with self._lock:
             try:
-                self._sock.sendall(msg.encode())
+                self._ipc.sendall(msg.encode())
             except OSError:
                 logger.warning("Failed to send command to mpv: %s", args)
 
     def _read_loop(self) -> None:  # pragma: no cover
         """Background thread: read JSON events from mpv and dispatch them."""
-        if self._sock is None:
-            return
         buf = b""
         while True:
-            try:
-                chunk = self._sock.recv(4096)
-            except OSError:
-                break
+            chunk = self._ipc.recv(4096)
             if not chunk:
                 break
             buf += chunk

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -413,11 +413,16 @@ def create_app(
         # that as the opaque origin "null" in the Origin request header.
         "null",
     ]
-    if dev_mode:
-        _allowed_origins.append("http://localhost:5173")  # Vite dev server
+    # In dev mode, Vite picks the first free port from 5173 upward (5174, 5175,
+    # …) when an earlier dev session left a stale listener behind. Match any
+    # localhost port via regex so the renderer keeps working across restarts.
+    _allowed_origin_regex: str | None = (
+        r"^http://(localhost|127\.0\.0\.1):\d+$" if dev_mode else None
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=_allowed_origins,
+        allow_origin_regex=_allowed_origin_regex,
         allow_methods=["GET", "POST", "DELETE", "PATCH"],
         # X-Kamp-Token must be listed so CORS preflight allows it.
         allow_headers=["Content-Type", "X-Kamp-Token"],
@@ -615,7 +620,10 @@ def create_app(
     @app.post("/api/v1/config/library-path")
     def set_library_path(req: LibraryPathRequest) -> dict[str, Any]:
         raw = req.path
-        if not raw.startswith("/") and not raw.startswith("~"):
+        # Path.is_absolute is platform-aware: matches "/..." on POSIX and
+        # "C:\\..." on Windows. Allow a leading ~ as a special case since it
+        # becomes absolute only after expanduser() below.
+        if not raw.startswith("~") and not Path(raw).is_absolute():
             raise HTTPException(status_code=422, detail="Path must be absolute")
         # nosec: py/path-injection — absolute-path requirement above rejects traversal;
         # deny-list below blocks system roots and their subtrees. Restricting to Path.home()

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -42,6 +42,17 @@ from .daemon_core import DaemonCore, _PID_PATH
 _HOMEBREW_KAMP_PATHS = ["/opt/homebrew/bin/kamp", "/usr/local/bin/kamp"]
 _HOMEBREW_MPV_PATHS = ["/opt/homebrew/bin/mpv", "/usr/local/bin/mpv"]
 
+# Common Windows mpv install locations. Checked in order when the daemon is
+# spawned by Electron with a stale PATH (PowerShell sessions don't refresh
+# PATH after a Scoop/Choco install in the same session, so PATH-based lookup
+# may miss mpv even though the user has it installed).
+_WIN_MPV_PATHS = [
+    str(Path.home() / "scoop" / "shims" / "mpv.exe"),
+    str(Path.home() / "scoop" / "apps" / "mpv" / "current" / "mpv.exe"),
+    r"C:\ProgramData\chocolatey\bin\mpv.exe",
+    r"C:\Program Files\mpv\mpv.exe",
+]
+
 _SERVICE_LABEL = "com.kamp"
 _PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_SERVICE_LABEL}.plist"
 _LOG_PATH = _state_dir() / "daemon.log"
@@ -69,6 +80,16 @@ def _get_version() -> str:
 
 
 def main() -> None:
+    # Windows consoles default to a legacy code page (cp1252 on en-US) that
+    # rejects Unicode characters used in our startup banner ("→") and other
+    # log output. Reconfigure stdout/stderr to UTF-8 so prints never crash
+    # the daemon on a missing-glyph encode error. No-op on POSIX where the
+    # default is already UTF-8.
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
     # Rename the process so `ps` output shows "kamp" instead of
     # "Python".  setproctitle updates argv[0] which is sufficient on Linux;
     # on macOS it also helps ps, but Activity Monitor reads the kernel-level
@@ -1164,13 +1185,15 @@ def _resolve_mpv_binary() -> str:
     """Return the absolute path to the mpv binary.
 
     The .app bundle sets KAMP_MPV_BIN to the bundled binary path; check that
-    first. For launchd (which runs with a minimal PATH that excludes Homebrew),
-    fall back to the stable Homebrew install locations, then PATH.
+    first. For launchd (macOS minimal PATH) or an Electron-spawned daemon on
+    Windows (stale parent-shell PATH), fall back to platform-typical install
+    locations before relying on PATH.
     """
     env_path = os.environ.get("KAMP_MPV_BIN")
     if env_path and Path(env_path).exists():
         return env_path
-    for path in _HOMEBREW_MPV_PATHS:
+    fallback_paths = _WIN_MPV_PATHS if sys.platform == "win32" else _HOMEBREW_MPV_PATHS
+    for path in fallback_paths:
         if Path(path).exists():
             return path
     return shutil.which("mpv") or "mpv"

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -370,7 +370,10 @@ def config_set(db: "LibraryIndex", key: str, value: str) -> None:
     else:
         normalized_value = value
         if key in _PATH_CONFIG_KEYS:
-            if not value.startswith("/") and not value.startswith("~"):
+            # Path.is_absolute is platform-aware: matches "/..." on POSIX and
+            # "C:\\..." on Windows. Allow a leading ~ as a special case since
+            # it becomes absolute only after expanduser() below.
+            if not value.startswith("~") and not Path(value).is_absolute():
                 raise ValueError(
                     f"Key {key!r} requires an absolute path, got {value!r}"
                 )

--- a/kamp_daemon/ext/sandbox/_linux.py
+++ b/kamp_daemon/ext/sandbox/_linux.py
@@ -266,7 +266,7 @@ def _apply_landlock(allowed_write_paths: list[str]) -> None:
                 # Windows. _linux.py is only loaded by the Linux sandbox
                 # dispatch, so the lookup is runtime-safe even though mypy
                 # checks this file when running on Windows.
-                fd = os.open(str(path), _O_PATH | os.O_CLOEXEC)  # type: ignore[attr-defined]
+                fd = os.open(str(path), _O_PATH | os.O_CLOEXEC)  # type: ignore[attr-defined,unused-ignore]
             except OSError:
                 continue
             try:

--- a/kamp_daemon/ext/sandbox/_linux.py
+++ b/kamp_daemon/ext/sandbox/_linux.py
@@ -262,7 +262,11 @@ def _apply_landlock(allowed_write_paths: list[str]) -> None:
             if not path.exists():
                 continue  # skip non-existent paths (e.g. watch folder not yet created)
             try:
-                fd = os.open(str(path), _O_PATH | os.O_CLOEXEC)
+                # O_CLOEXEC exists on POSIX; the typeshed stub omits it on
+                # Windows. _linux.py is only loaded by the Linux sandbox
+                # dispatch, so the lookup is runtime-safe even though mypy
+                # checks this file when running on Windows.
+                fd = os.open(str(path), _O_PATH | os.O_CLOEXEC)  # type: ignore[attr-defined]
             except OSError:
                 continue
             try:

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp_ui",
-  "version": "1.12.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp_ui",
-      "version": "1.12.0",
+      "version": "1.17.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -95,6 +95,10 @@ function postToPlayer(path: string): void {
 }
 
 function startNowPlayingHelper(): void {
+  // The helper wraps MPRemoteCommandCenter / MPNowPlayingInfoCenter, both
+  // macOS-only frameworks. Skip on every other platform — Windows SMTC and
+  // Linux MPRIS integration are tracked as separate work.
+  if (process.platform !== 'darwin') return
   const binary = findNowPlayingBinary()
   if (!binary) {
     console.warn('[kamp] now-playing-helper binary not found — media keys disabled')
@@ -146,18 +150,34 @@ function stopNowPlayingHelper(): void {
 
 let serverProcess: ChildProcess | null = null
 
-function findKampBinary(): string | null {
+type KampInvocation = { command: string; args: string[] }
+
+function findKampInvocation(): KampInvocation | null {
+  const isWindows = process.platform === 'win32'
   if (app.isPackaged) {
-    // Inside Kamp.app, electron-builder places extraResources directly under
-    // Contents/Resources/. The PyInstaller onedir bundle's executable is at
-    // Resources/kamp/kamp.
-    const bundled = join(process.resourcesPath, 'kamp', 'kamp')
-    if (existsSync(bundled)) return bundled
+    // Inside the .app/installer, electron-builder places extraResources
+    // directly under Contents/Resources/. The PyInstaller onedir bundle's
+    // executable is named "kamp" on POSIX and "kamp.exe" on Windows; both
+    // are direct binaries so the invocation has no extra args.
+    const bundled = join(process.resourcesPath, 'kamp', isWindows ? 'kamp.exe' : 'kamp')
+    if (existsSync(bundled)) return { command: bundled, args: [] }
   }
-  // Dev fallback: app.getAppPath() returns the kamp_ui directory;
-  // .venv lives one level up (repo root).
-  const venvBin = resolve(app.getAppPath(), '../.venv/bin/kamp')
-  if (existsSync(venvBin)) return venvBin
+  // Dev fallback: app.getAppPath() returns the kamp_ui directory; the Poetry
+  // venv lives one level up (repo root). On POSIX Poetry produces a single
+  // .venv/bin/kamp script with a shebang. On Windows Poetry produces a pair
+  // — .venv\Scripts\kamp (Python script) and .venv\Scripts\kamp.cmd (batch
+  // wrapper). Spawning the .cmd from Node needs `shell: true`, which opens
+  // argument-quoting hazards. Invoke python.exe directly against the script
+  // file instead.
+  const venvRoot = resolve(app.getAppPath(), '../.venv')
+  if (isWindows) {
+    const py = join(venvRoot, 'Scripts', 'python.exe')
+    const script = join(venvRoot, 'Scripts', 'kamp')
+    if (existsSync(py) && existsSync(script)) return { command: py, args: [script] }
+  } else {
+    const bin = join(venvRoot, 'bin', 'kamp')
+    if (existsSync(bin)) return { command: bin, args: [] }
+  }
   return null
 }
 
@@ -178,8 +198,8 @@ function isServerRunning(): Promise<boolean> {
 async function startServer(): Promise<void> {
   if (await isServerRunning()) return
 
-  const binary = findKampBinary()
-  if (!binary) {
+  const invocation = findKampInvocation()
+  if (!invocation) {
     console.error('[kamp] kamp binary not found — start the server manually')
     return
   }
@@ -195,7 +215,7 @@ async function startServer(): Promise<void> {
   // Tell the daemon it's running in dev mode so it allows the Vite dev server
   // origin (http://localhost:5173) in CORS — the renderer loads from there.
   if (is.dev) spawnEnv['KAMP_DEV'] = '1'
-  serverProcess = spawn(binary, ['daemon'], {
+  serverProcess = spawn(invocation.command, [...invocation.args, 'daemon'], {
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
     env: spawnEnv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for kamp_daemon.config (DB-backed configuration)."""
 
+import sys
 from pathlib import Path
 
 import keyring.errors
@@ -304,6 +305,11 @@ class TestConfigSet:
         with pytest.raises(ValueError, match="requires an absolute path"):
             config_set(db, "paths.watch_folder", "../escape")
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="forbidden roots list is POSIX-specific; Windows hardening "
+        "(C:\\Windows, etc.) is tracked as a follow-up",
+    )
     @pytest.mark.parametrize(
         "forbidden",
         [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,9 @@ class TestLoad:
         db.set_setting("paths.watch_folder", "/my/staging")
         db.set_setting("artwork.min_dimension", "500")
         config = Config.load(db)
-        assert str(config.paths.watch_folder) == "/my/staging"
+        # Compare via Path so the test is platform-neutral — Windows will
+        # stringify with backslashes.
+        assert config.paths.watch_folder == Path("/my/staging")
         assert config.artwork.min_dimension == 500
 
     def test_load_backfills_new_keys(self, db: LibraryIndex) -> None:
@@ -216,8 +218,10 @@ class TestConfigShow:
 class TestConfigSet:
     def test_set_string_key(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
-        config_set(db, "paths.watch_folder", "/new/staging")
-        assert db.get_setting("paths.watch_folder") == "/new/staging"
+        # Use ~ so the path-validator accepts the value on Windows too —
+        # `/new/staging` lacks a drive letter and is not absolute on Windows.
+        config_set(db, "paths.watch_folder", "~/new/staging")
+        assert db.get_setting("paths.watch_folder") == "~/new/staging"
 
     def test_set_int_key(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
@@ -236,7 +240,8 @@ class TestConfigSet:
         Config.write_defaults(db)
         config_set(db, "paths.watch_folder", "~/round/trip")
         config = Config.load(db)
-        assert "round/trip" in str(config.paths.watch_folder)
+        # as_posix() always uses forward slashes — works on every platform.
+        assert "round/trip" in config.paths.watch_folder.as_posix()
 
     def test_unknown_key_raises_key_error(self, db: LibraryIndex) -> None:
         with pytest.raises(KeyError, match="Unknown config key"):

--- a/tests/test_daemon_core.py
+++ b/tests/test_daemon_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -10,6 +11,14 @@ import pytest
 
 from kamp_daemon.config import Config
 from kamp_daemon.daemon_core import DaemonCore, _PID_PATH
+
+# SIGUSR1 / SIGUSR2 don't exist on Windows — the daemon's pause/resume signal
+# wiring is POSIX-only. Skip those tests on Windows; the SIGINT shutdown path
+# still runs cross-platform.
+_skip_on_windows_sigusr = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SIGUSR1 / SIGUSR2 are POSIX-only signals",
+)
 
 
 @pytest.fixture
@@ -216,6 +225,7 @@ class TestSignalHandlers:
             sigint_handler(int(_signal.SIGINT), None)  # type: ignore[call-arg]
             mock_shutdown.assert_called_once()
 
+    @_skip_on_windows_sigusr
     def test_sigusr1_triggers_stop(self, core: DaemonCore) -> None:
         import signal as _signal
 
@@ -232,6 +242,7 @@ class TestSignalHandlers:
             handler(int(_signal.SIGUSR1), None)  # type: ignore[call-arg]
             mock_stop.assert_called_once()
 
+    @_skip_on_windows_sigusr
     def test_sigusr2_triggers_resume(self, core: DaemonCore) -> None:
         import signal as _signal
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -2083,6 +2084,11 @@ class TestSessionManagement:
         assert by_path["/music/tagged.mp3"] == 3333.0, "already-tagged mtime unchanged"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file-permission semantics (chmod / st_mode 0o600) do not "
+    "apply on Windows; see KAMP-281 for Windows ACL hardening follow-up",
+)
 class TestDatabaseFilePermissions:
     def test_new_database_created_with_owner_only_permissions(
         self, tmp_path: Path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,20 @@
 
 import logging
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Tests that exercise the launchd-specific service install/start/stop paths
+# call _launchd_domain(), which uses os.getuid() — POSIX-only. Mark them so
+# the suite stays green on Windows. The rest of the file (status checks,
+# log-suppression, binary resolution without launchd, etc.) runs cross-platform.
+_skip_on_windows_launchd = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="launchd command is macOS-specific (uses os.getuid via _launchd_domain)",
+)
 
 from kamp_daemon.__main__ import (
     _SERVICE_LABEL,
@@ -118,6 +128,7 @@ class TestCmdStop:
             _cmd_stop()
         assert "already stopped" in capsys.readouterr().out
 
+    @_skip_on_windows_launchd
     def test_stops_running_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -155,6 +166,7 @@ class TestCmdPlay:
             _cmd_play()
         assert "already running" in capsys.readouterr().out
 
+    @_skip_on_windows_launchd
     def test_starts_unregistered_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -172,6 +184,7 @@ class TestCmdPlay:
         )
         assert "started" in capsys.readouterr().out
 
+    @_skip_on_windows_launchd
     def test_kickstarts_registered_but_stopped_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -324,6 +337,7 @@ class TestResolveKampBinary:
         assert result == shim_path
         assert "pyenv shim" in capsys.readouterr().out
 
+    @_skip_on_windows_launchd
     def test_plist_uses_resolved_binary(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.toml"
         config_path.touch()
@@ -339,6 +353,7 @@ class TestResolveKampBinary:
 
 
 class TestCmdInstallService:
+    @_skip_on_windows_launchd
     def test_runs_first_run_setup_when_no_settings(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:

--- a/tests/test_mover.py
+++ b/tests/test_mover.py
@@ -72,8 +72,12 @@ class TestDestination:
         library = tmp_path / "library"
         result = _destination(mp3, library, TEMPLATE)
 
-        assert ":" not in str(result)
-        assert "?" not in str(result)
+        # Inspect only the path components rendered from tags — the absolute
+        # prefix on Windows includes the drive letter (e.g. "C:") which is not
+        # a sanitization target.
+        rendered = result.relative_to(library)
+        assert ":" not in str(rendered)
+        assert "?" not in str(rendered)
 
 
 class TestCleanup:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -619,6 +619,99 @@ class TestPlaybackQueue:
 
 
 # ---------------------------------------------------------------------------
+# IPC transport (Unix socket / Windows named pipe)
+# ---------------------------------------------------------------------------
+
+
+class TestIPCTransport:
+    """Cross-platform constructor + server-arg generation.
+
+    The actual open/recv/send paths are real I/O against mpv and are exercised
+    by the integration test that boots the daemon; here we only verify the
+    factory selects the right class and that each transport produces a
+    server_arg in the shape mpv expects on its platform.
+    """
+
+    def test_factory_returns_unix_socket_when_platform_is_posix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "darwin")
+        from kamp_core.playback import _make_ipc_transport, _UnixSocketTransport
+
+        transport = _make_ipc_transport()
+        try:
+            assert isinstance(transport, _UnixSocketTransport)
+        finally:
+            transport.close()
+
+    def test_factory_returns_named_pipe_when_platform_is_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "win32")
+        from kamp_core.playback import (
+            _make_ipc_transport,
+            _WindowsNamedPipeTransport,
+        )
+
+        transport = _make_ipc_transport()
+        try:
+            assert isinstance(transport, _WindowsNamedPipeTransport)
+        finally:
+            transport.close()
+
+    def test_unix_socket_server_arg_is_filesystem_path(self) -> None:
+        from kamp_core.playback import _UnixSocketTransport
+
+        transport = _UnixSocketTransport()
+        try:
+            arg = transport.server_arg
+            assert arg.endswith("mpv.sock")
+            assert "kamp-mpv-" in arg
+            # Filesystem path: parent dir must already exist (tempfile.mkdtemp).
+            assert Path(arg).parent.is_dir()
+        finally:
+            transport.close()
+
+    def test_windows_named_pipe_server_arg_uses_pipe_namespace(self) -> None:
+        from kamp_core.playback import _WindowsNamedPipeTransport
+
+        transport = _WindowsNamedPipeTransport()
+        try:
+            arg = transport.server_arg
+            # mpv on Windows binds --input-ipc-server=NAME to a Win32 named
+            # pipe; using the fully-qualified \\.\pipe\NAME path keeps client
+            # and server unambiguously aligned.
+            assert arg.startswith(r"\\.\pipe\kamp-mpv-")
+        finally:
+            transport.close()
+
+    def test_two_transports_use_distinct_server_args(self) -> None:
+        """Each engine instance must get its own IPC endpoint so multiple
+        daemons (e.g. dev + tests) can run side-by-side without fighting over
+        a single socket/pipe name."""
+        from kamp_core.playback import (
+            _UnixSocketTransport,
+            _WindowsNamedPipeTransport,
+        )
+
+        a = _UnixSocketTransport()
+        b = _UnixSocketTransport()
+        try:
+            assert a.server_arg != b.server_arg
+        finally:
+            a.close()
+            b.close()
+
+        c = _WindowsNamedPipeTransport()
+        d = _WindowsNamedPipeTransport()
+        try:
+            assert c.server_arg != d.server_arg
+        finally:
+            c.close()
+            d.close()
+
+
+# ---------------------------------------------------------------------------
 # MpvPlaybackEngine
 # ---------------------------------------------------------------------------
 
@@ -636,7 +729,9 @@ class TestMpvPlaybackEngine:
     def test_play_sends_loadfile_command(self) -> None:
         engine, send = _make_engine()
         engine.play(Path("/music/01.mp3"))
-        send.assert_any_call("loadfile", "/music/01.mp3", "replace")
+        # str(Path) yields OS-native separators — assert in that form so the
+        # test is platform-neutral (Windows uses backslashes).
+        send.assert_any_call("loadfile", str(Path("/music/01.mp3")), "replace")
 
     def test_play_always_unpauses(self) -> None:
         """play() must unpause mpv so a paused engine resumes on the new track."""
@@ -739,7 +834,7 @@ class TestMpvPlaybackEngine:
     def test_load_paused_loads_and_pauses(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"))
-        send.assert_any_call("loadfile", "/music/track.mp3", "replace")
+        send.assert_any_call("loadfile", str(Path("/music/track.mp3")), "replace")
         send.assert_any_call("set_property", "pause", True)
 
     def test_load_paused_sets_pending_seek_when_position_nonzero(self) -> None:
@@ -878,20 +973,20 @@ class TestMpvPlaybackEngine:
 
         mock_proc.terminate.assert_called_once()
 
-    def test_shutdown_closes_socket(self) -> None:
+    def test_shutdown_closes_ipc_transport(self) -> None:
         with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
             engine = MpvPlaybackEngine()
-        mock_sock = MagicMock()
-        engine._sock = mock_sock
+        mock_ipc = MagicMock()
+        engine._ipc = mock_ipc
         engine.shutdown()
-        mock_sock.close.assert_called_once()
+        mock_ipc.close.assert_called_once()
 
-    def test_shutdown_ignores_socket_close_error(self) -> None:
+    def test_shutdown_ignores_ipc_close_error(self) -> None:
         with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
             engine = MpvPlaybackEngine()
-        mock_sock = MagicMock()
-        mock_sock.close.side_effect = OSError("already closed")
-        engine._sock = mock_sock
+        mock_ipc = MagicMock()
+        mock_ipc.close.side_effect = OSError("already closed")
+        engine._ipc = mock_ipc
         engine.shutdown()  # should not raise
 
     def test_shutdown_handles_none_proc(self) -> None:
@@ -900,47 +995,27 @@ class TestMpvPlaybackEngine:
         engine._proc = None
         engine.shutdown()  # should not raise
 
-    def test_shutdown_removes_sock_tmpdir(self) -> None:
-        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
-            engine = MpvPlaybackEngine()
-        with patch("kamp_core.playback.shutil.rmtree") as mock_rmtree:
-            engine._sock_tmpdir = "/tmp/kamp-mpv-abc123"
-            engine.shutdown()
-        mock_rmtree.assert_called_once_with("/tmp/kamp-mpv-abc123", ignore_errors=True)
-
-    def test_shutdown_skips_rmtree_when_no_tmpdir(self) -> None:
-        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
-            engine = MpvPlaybackEngine()
-        with patch("kamp_core.playback.shutil.rmtree") as mock_rmtree:
-            engine.shutdown()
-        mock_rmtree.assert_not_called()
-
-    def test_send_command_is_noop_when_no_socket(self) -> None:
-        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
-            engine = MpvPlaybackEngine()
-        engine._send_command("stop")  # _sock is None — should not raise
-
     def test_volume_getter_returns_state_volume(self) -> None:
         engine, _ = _make_engine()
         assert engine.volume == 100
 
-    def test_send_command_sends_json_over_socket(self) -> None:
+    def test_send_command_sends_json_over_ipc(self) -> None:
         with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
             engine = MpvPlaybackEngine()
-        mock_sock = MagicMock()
-        engine._sock = mock_sock
+        mock_ipc = MagicMock()
+        engine._ipc = mock_ipc
         engine._send_command("loadfile", "/music/01.mp3", "replace")
         expected = (
             json.dumps({"command": ["loadfile", "/music/01.mp3", "replace"]}) + "\n"
         )
-        mock_sock.sendall.assert_called_once_with(expected.encode())
+        mock_ipc.sendall.assert_called_once_with(expected.encode())
 
     def test_send_command_logs_warning_on_oserror(self) -> None:
         with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
             engine = MpvPlaybackEngine()
-        mock_sock = MagicMock()
-        mock_sock.sendall.side_effect = OSError("broken pipe")
-        engine._sock = mock_sock
+        mock_ipc = MagicMock()
+        mock_ipc.sendall.side_effect = OSError("broken pipe")
+        engine._ipc = mock_ipc
         engine._send_command("stop")  # should not raise
 
     def test_handle_event_unknown_event_is_ignored(self) -> None:
@@ -970,7 +1045,7 @@ class TestMpvPlaybackEngine:
     def test_preload_next_sends_loadfile_append(self) -> None:
         engine, send = _make_engine()
         engine.preload_next(_track(2))
-        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+        send.assert_called_once_with("loadfile", str(_track(2).file_path), "append")
 
     def test_preload_next_is_noop_for_same_path(self) -> None:
         engine, send = _make_engine()
@@ -986,7 +1061,7 @@ class TestMpvPlaybackEngine:
         engine.preload_next(_track(3))
         assert send.call_args_list == [
             call("playlist-remove", 1),
-            call("loadfile", "/music/03.mp3", "append"),
+            call("loadfile", str(_track(3).file_path), "append"),
         ]
 
     def test_preload_next_with_none_removes_stale_lookahead(self) -> None:
@@ -1050,7 +1125,7 @@ class TestMpvPlaybackEngine:
         engine.state.duration = 180.0
         engine.state.position = 60.0  # 2 minutes from end
         engine.preload_next(_track(2))
-        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+        send.assert_called_once_with("loadfile", str(_track(2).file_path), "append")
         assert engine.has_lookahead is True
 
     def test_preload_next_removes_stale_lookahead_even_within_guard_window(
@@ -1074,7 +1149,7 @@ class TestMpvPlaybackEngine:
         engine.state.duration = 0.0
         engine.state.position = 0.0
         engine.preload_next(_track(2))
-        send.assert_called_once_with("loadfile", "/music/02.mp3", "append")
+        send.assert_called_once_with("loadfile", str(_track(2).file_path), "append")
 
     def test_file_loaded_resets_state_so_lookahead_re_arms_after_gapless(
         self,

--- a/tests/test_resolve_mpv_binary.py
+++ b/tests/test_resolve_mpv_binary.py
@@ -16,24 +16,51 @@ def test_env_var_takes_priority(tmp_path):
 def test_env_var_ignored_when_path_missing(tmp_path):
     """KAMP_MPV_BIN is ignored when the file does not exist; falls through to next check."""
     nonexistent = str(tmp_path / "mpv_does_not_exist")
-    homebrew_mpv = tmp_path / "homebrew_mpv"
-    homebrew_mpv.touch()
+    fallback_mpv = tmp_path / "fallback_mpv"
+    fallback_mpv.touch()
+    # Patch both fallback lists so the assertion holds on any platform — the
+    # resolver picks one list based on sys.platform.
     with (
         patch.dict("os.environ", {"KAMP_MPV_BIN": nonexistent}),
-        patch("kamp_daemon.__main__._HOMEBREW_MPV_PATHS", [str(homebrew_mpv)]),
+        patch("kamp_daemon.__main__._HOMEBREW_MPV_PATHS", [str(fallback_mpv)]),
+        patch("kamp_daemon.__main__._WIN_MPV_PATHS", [str(fallback_mpv)]),
     ):
-        assert _resolve_mpv_binary() == str(homebrew_mpv)
+        assert _resolve_mpv_binary() == str(fallback_mpv)
 
 
-def test_env_var_not_set_falls_back_to_homebrew(tmp_path):
-    """Without KAMP_MPV_BIN, Homebrew paths are checked."""
-    homebrew_mpv = tmp_path / "mpv"
+def test_env_var_not_set_falls_back_to_platform_paths(tmp_path):
+    """Without KAMP_MPV_BIN, the platform's known install paths are checked."""
+    fallback_mpv = tmp_path / "mpv"
+    fallback_mpv.touch()
+    without_kamp_mpv_bin = {
+        k: v for k, v in __import__("os").environ.items() if k != "KAMP_MPV_BIN"
+    }
+    with (
+        patch.dict("os.environ", without_kamp_mpv_bin, clear=True),
+        patch("kamp_daemon.__main__._HOMEBREW_MPV_PATHS", [str(fallback_mpv)]),
+        patch("kamp_daemon.__main__._WIN_MPV_PATHS", [str(fallback_mpv)]),
+    ):
+        assert _resolve_mpv_binary() == str(fallback_mpv)
+
+
+def test_windows_uses_win_paths_not_homebrew(tmp_path):
+    """On win32 the resolver must check _WIN_MPV_PATHS, not _HOMEBREW_MPV_PATHS.
+
+    A daemon spawned by Electron with a stale PATH cannot rely on shutil.which,
+    so the fallback list must include Scoop / Chocolatey / Program Files
+    locations to find a user-installed mpv.
+    """
+    win_mpv = tmp_path / "win_mpv.exe"
+    win_mpv.touch()
+    homebrew_mpv = tmp_path / "homebrew_mpv"
     homebrew_mpv.touch()
     without_kamp_mpv_bin = {
         k: v for k, v in __import__("os").environ.items() if k != "KAMP_MPV_BIN"
     }
     with (
         patch.dict("os.environ", without_kamp_mpv_bin, clear=True),
+        patch("kamp_daemon.__main__.sys.platform", "win32"),
+        patch("kamp_daemon.__main__._WIN_MPV_PATHS", [str(win_mpv)]),
         patch("kamp_daemon.__main__._HOMEBREW_MPV_PATHS", [str(homebrew_mpv)]),
     ):
-        assert _resolve_mpv_binary() == str(homebrew_mpv)
+        assert _resolve_mpv_binary() == str(win_mpv)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -386,7 +386,11 @@ class TestMissingAlbumEndpoints:
             "/api/v1/tracks?album_artist=&album=&file_path=%2Fmusic%2F01.mp3"
         ).json()
         assert len(data) == 1
-        mock_index.get_track_by_path.assert_called_once_with(Path("/music/01.mp3"))
+        # Server resolves the path before lookup; on Windows that prepends the
+        # current drive letter, so assert against the same resolved form.
+        mock_index.get_track_by_path.assert_called_once_with(
+            Path("/music/01.mp3").resolve()
+        )
         mock_index.tracks_for_album.assert_not_called()
 
     def test_album_art_endpoint_uses_file_path_when_provided(
@@ -404,7 +408,9 @@ class TestMissingAlbumEndpoints:
                 "/api/v1/album-art?album_artist=&album=&file_path=%2Fmusic%2F01.mp3"
             )
         assert res.status_code == 200
-        mock_index.get_track_by_path.assert_called_once_with(Path("/music/01.mp3"))
+        mock_index.get_track_by_path.assert_called_once_with(
+            Path("/music/01.mp3").resolve()
+        )
         mock_index.tracks_for_album.assert_not_called()
 
 
@@ -1441,9 +1447,13 @@ class TestFavoriteEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
-        mock_index.set_favorite.assert_called_once_with(Path("/music/01.mp3"), True)
+        mock_index.set_favorite.assert_called_once_with(
+            Path("/music/01.mp3").resolve(), True
+        )
         # Queue must also be updated so the next player-state snapshot is correct.
-        mock_queue.update_favorite.assert_called_once_with(Path("/music/01.mp3"), True)
+        mock_queue.update_favorite.assert_called_once_with(
+            Path("/music/01.mp3").resolve(), True
+        )
 
     def test_set_favorite_returns_404_for_unknown_track(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2492,3 +2492,24 @@ class TestCORSMiddleware:
         assert (
             resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
         )
+
+    def test_vite_alternate_port_allowed_in_dev_mode(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Vite rolls forward to 5174/5175/... when 5173 is occupied (e.g. a
+        stale dev session). dev_mode CORS must accept any localhost port so
+        the renderer keeps working across restarts."""
+        client = self._make_client(mock_index, mock_engine, mock_queue, dev_mode=True)
+        resp = self._preflight(client, "http://localhost:5174")
+        assert (
+            resp.headers.get("access-control-allow-origin") == "http://localhost:5174"
+        )
+
+    def test_non_localhost_origin_rejected_even_in_dev_mode(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """The dev regex must only match localhost/127.0.0.1, not arbitrary
+        origins. Otherwise an attacker on the LAN could hit the dev daemon."""
+        client = self._make_client(mock_index, mock_engine, mock_queue, dev_mode=True)
+        resp = self._preflight(client, "http://192.168.1.10:5173")
+        assert "access-control-allow-origin" not in resp.headers


### PR DESCRIPTION
## Summary

Land Windows dev support so the kamp UI runs end-to-end on Windows 11 and PRs are validated against `windows-latest` in CI.

- **Dev bootstrap (KAMP-281):** Win32 named-pipe IPC for mpv with `FILE_FLAG_OVERLAPPED` (py-spy confirmed the deadlock signature: main parked in `WriteFile`, reader in `ReadFile`, same fd), UTF-8 stdout reconfig for the cp1252 console, `_WIN_MPV_PATHS` fallback for Electron-spawned daemons with stale PATH, platform-aware library-path validation (`Path.is_absolute()`), CORS regex for any localhost port (Vite roll-forward), and Electron-side fixes (Now Playing helper darwin-gated, Poetry-venv kamp invocation refactor).
- **Windows CI (KAMP-36):** new `python-windows` and `ui-windows` jobs in `.github/workflows/ci.yml`. Python tests run with `--no-cov` on Windows — the ubuntu-latest job remains the canonical 95% coverage gate; POSIX-only tests `skipif`'d where they exercise launchd / SIGUSR1/2 / `chmod 0o600`.
- 1191 passed, 35 skipped on Windows; macOS/Linux behaviour unchanged.

## Test plan

- [x] CI: `python` (ubuntu) green
- [x] CI: `python-windows` green
- [x] CI: `sandbox-macos` green
- [x] CI: `ui` (ubuntu) green
- [x] CI: `ui-windows` green
- [x] Local on Windows 11: `poetry run kamp daemon` reaches "Application startup complete"
- [x] Local on Windows 11: Electron auto-spawns daemon via `npm run dev`
- [x] Local on Windows 11: library picker accepts `C:\…` and `G:\…` (cloud) paths
- [x] Local on Windows 11: audio plays, position bar advances, play/pause toggles, stop works

## Follow-ups (already filed)

- KAMP-282 — Bandcamp login fails on Windows (`POST /api/v1/bandcamp/login-complete` returns 422)
- KAMP-283 — Bind mpv lifetime to daemon on Windows via Win32 Job Object (kill orphan mpv)
- KAMP-284 — Audit `_send_command` lock-around-sendall reentry risk in `MpvPlaybackEngine`
- KAMP-285 — Add Windows-specific forbidden roots to library/watch-folder path validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
