### PR TITLE
feat(windows): build pipeline for NSIS installer (KAMP-278)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -521,12 +521,34 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Download bundle artifact
-        # No `path:` -- extract at GITHUB_WORKSPACE so the workspace-relative
-        # kamp_ui/resources/ and kamp_ui/build/icon.ico paths from the upload
-        # land in their original locations.
+        # upload-artifact strips the least common ancestor of all `path:` entries
+        # from archive paths -- with `kamp_ui/resources/` + `kamp_ui/build/icon.ico`
+        # the LCA is `kamp_ui/`, so the artifact stores `resources/...` and
+        # `build/icon.ico`. Setting download path to `kamp_ui` restores the
+        # layout electron-builder expects (`kamp_ui/resources/kamp/kamp.exe`).
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: bundle-win-x64
+          path: kamp_ui
+
+      - name: Verify bundle layout
+        # Pre-flight: if extraResources sources are missing, electron-builder
+        # silently produces a daemon-less installer (it logs "file source
+        # doesn't exist" but still succeeds). Fail loudly here instead.
+        run: |
+          $required = @(
+            'kamp_ui\resources\kamp\kamp.exe',
+            'kamp_ui\resources\mpv\mpv.exe',
+            'kamp_ui\resources\node.exe',
+            'kamp_ui\resources\npm\bin\npm-cli.js',
+            'kamp_ui\build\icon.ico'
+          )
+          $missing = $required | Where-Object { -not (Test-Path $_) }
+          if ($missing) {
+            Write-Error "Bundle artifact missing files:`n  $($missing -join "`n  ")"
+            exit 1
+          }
+          Write-Host "OK: bundle layout intact ($($required.Count) required paths present)"
 
       - name: Cache electron-builder binaries
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,4 +1,4 @@
-name: Build macOS App
+name: Build App
 
 on:
   workflow_dispatch: # manual trigger for testing
@@ -41,13 +41,7 @@ jobs:
         env:
           ACOUSTID_KEY: ${{ secrets.ACOUSTID_KEY }}
           ACOUSTID_SALT: ${{ secrets.ACOUSTID_SALT }}
-        run: |
-          ENCODED=$(python scripts/encode_acoustid_key.py "$ACOUSTID_KEY" "$ACOUSTID_SALT")
-          ENCODED_KEY=$(echo "$ENCODED" | sed -n '1p')
-          ENCODED_SALT=$(echo "$ENCODED" | sed -n '2p')
-          # macOS sed requires an explicit empty backup suffix (-i '')
-          sed -i '' "s|^_KEY: bytes = b\"\"|_KEY: bytes = ${ENCODED_KEY}|" kamp_daemon/acoustid.py
-          sed -i '' "s|^_SALT: bytes = b\"\"|_SALT: bytes = ${ENCODED_SALT}|" kamp_daemon/acoustid.py
+        run: python scripts/embed_acoustid_key.py
 
       - name: Build PyInstaller bundle
         run: |
@@ -412,3 +406,176 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             kamp_ui/dist/*.dmg
+
+  build-bundle-windows:
+    runs-on: windows-latest
+    # PyInstaller (~3 min) + MSYS2 deps (~5 min) + mpv compile (~10-15 min)
+    # + node fetch (~1 min) + icon gen (~1 min). Match the macOS budget.
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Python dependencies (includes pyinstaller)
+        run: poetry install
+
+      - name: Embed AcoustID key
+        env:
+          ACOUSTID_KEY: ${{ secrets.ACOUSTID_KEY }}
+          ACOUSTID_SALT: ${{ secrets.ACOUSTID_SALT }}
+        run: python scripts/embed_acoustid_key.py
+
+      - name: Build PyInstaller bundle
+        run: |
+          poetry run pyinstaller `
+            --distpath kamp_ui/resources `
+            --workpath $env:TEMP\pyinstaller-work `
+            --clean -y `
+            kamp.spec
+          if (-not (Test-Path kamp_ui\resources\kamp\kamp.exe)) {
+            Write-Error "PyInstaller did not produce kamp.exe"
+            exit 1
+          }
+          $playwright = Get-ChildItem kamp_ui\resources\kamp\_internal\ -Filter "playwright*" -ErrorAction SilentlyContinue
+          if ($playwright) {
+            Write-Error "Playwright leaked into bundle: $($playwright.Name)"
+            exit 1
+          }
+          Write-Host "OK: kamp.exe built, Playwright excluded"
+
+      - name: Build minimal mpv from source (MSYS2 + mingw-w64)
+        # Mirrors the macOS source-build approach. Pinned to mpv v0.41.0 with
+        # the same audio-only feature set; uses the MSYS2 mingw-w64 toolchain
+        # preinstalled on windows-latest. Output: resources\mpv\mpv.exe + DLLs.
+        run: pwsh scripts/build_mpv_windows.ps1
+
+      - name: Bundle Node.js + npm for extension installs
+        run: pwsh scripts/fetch_node.ps1
+
+      - name: Generate icon.ico from SVG
+        # ImageMagick on windows-latest does not ship a reliable SVG delegate.
+        # Use Inkscape (preinstalled on windows-latest) to render PNGs at
+        # standard Windows shell sizes, then merge them into a single
+        # multi-resolution .ico via ImageMagick (preinstalled).
+        run: |
+          $inkscape = "C:\Program Files\Inkscape\bin\inkscape.exe"
+          if (-not (Test-Path $inkscape)) {
+            Write-Error "Inkscape not found at $inkscape -- windows-latest runner image changed?"
+            exit 1
+          }
+          $svg = (Resolve-Path "kamp_ui/resources/icon_source.svg").Path
+          $build = "kamp_ui/build"
+          New-Item -ItemType Directory -Force -Path $build | Out-Null
+          $sizes = 16, 32, 48, 64, 128, 256
+          $pngs = foreach ($size in $sizes) {
+            $out = Join-Path $env:TEMP "kamp-icon-$size.png"
+            & $inkscape --export-type=png --export-filename=$out -w $size -h $size $svg
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path $out)) {
+              Write-Error "Inkscape failed to render $size px PNG"
+              exit 1
+            }
+            $out
+          }
+          & magick convert @pngs "$build/icon.ico"
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path "$build/icon.ico")) {
+            Write-Error "icon.ico generation failed"
+            exit 1
+          }
+          Write-Host "OK: $build/icon.ico ($((Get-Item "$build/icon.ico").Length) bytes)"
+
+      - name: Upload bundle artifact
+        # upload-artifact preserves workspace-relative paths, so multiple
+        # source paths recreate that layout on download. The package job
+        # downloads to GITHUB_WORKSPACE (no `path:` set) to restore both
+        # kamp_ui/resources/ and kamp_ui/build/icon.ico in one shot.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: bundle-win-x64
+          path: |
+            kamp_ui/resources/
+            kamp_ui/build/icon.ico
+          retention-days: 1
+
+  package-windows:
+    needs: build-bundle-windows
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Download bundle artifact
+        # No `path:` -- extract at GITHUB_WORKSPACE so the workspace-relative
+        # kamp_ui/resources/ and kamp_ui/build/icon.ico paths from the upload
+        # land in their original locations.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: bundle-win-x64
+
+      - name: Cache electron-builder binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: ~\AppData\Local\electron-builder\Cache
+          key: electron-builder-cache-win-x64-${{ hashFiles('kamp_ui/package-lock.json') }}
+          restore-keys: |
+            electron-builder-cache-win-x64-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: kamp_ui/package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: kamp_ui
+
+      - name: Build NSIS installer
+        # No code signing in this task -- KAMP-278 produces an unsigned
+        # installer. Code signing is tracked separately.
+        env:
+          DEBUG: electron-builder
+        run: npm run build:win
+        working-directory: kamp_ui
+
+      - name: Verify installer artifact
+        run: |
+          $exe = Get-ChildItem kamp_ui\dist\*.exe | Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "No NSIS installer produced under kamp_ui\dist"
+            exit 1
+          }
+          Write-Host "-> Installer: $($exe.Name) ($([math]::Round($exe.Length / 1MB, 1)) MB)"
+
+      - name: Compute artifact name
+        id: artifact
+        shell: bash
+        run: |
+          safe="${{ github.ref_name }}"
+          safe="${safe//\//-}"
+          echo "name=Kamp-${safe}-win-x64" >> "$GITHUB_OUTPUT"
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: kamp_ui/dist/*.exe
+          retention-days: 30
+
+      - name: Upload installer to GitHub release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            kamp_ui/dist/*.exe

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -461,14 +461,22 @@ jobs:
         run: pwsh scripts/fetch_node.ps1
 
       - name: Generate icon.ico from SVG
-        # ImageMagick on windows-latest does not ship a reliable SVG delegate.
-        # Use Inkscape (preinstalled on windows-latest) to render PNGs at
-        # standard Windows shell sizes, then merge them into a single
-        # multi-resolution .ico via ImageMagick (preinstalled).
+        # ImageMagick on windows-latest does not ship a reliable SVG delegate,
+        # and Inkscape is no longer guaranteed to be on the runner image.
+        # Use librsvg's rsvg-convert from MSYS2 (already on the box from the
+        # mpv build step's pacman; install explicitly here so this step is
+        # not coupled to a transitive dep) to render PNGs at standard Windows
+        # shell sizes, then merge them into a single multi-resolution .ico
+        # via ImageMagick (magick.exe is preinstalled on windows-latest).
         run: |
-          $inkscape = "C:\Program Files\Inkscape\bin\inkscape.exe"
-          if (-not (Test-Path $inkscape)) {
-            Write-Error "Inkscape not found at $inkscape -- windows-latest runner image changed?"
+          & C:\msys64\usr\bin\bash.exe -lc 'pacman -S --needed --noconfirm mingw-w64-x86_64-librsvg'
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to install mingw-w64-x86_64-librsvg via pacman"
+            exit 1
+          }
+          $rsvg = "C:\msys64\mingw64\bin\rsvg-convert.exe"
+          if (-not (Test-Path $rsvg)) {
+            Write-Error "rsvg-convert not found at $rsvg after pacman install"
             exit 1
           }
           $svg = (Resolve-Path "kamp_ui/resources/icon_source.svg").Path
@@ -477,9 +485,9 @@ jobs:
           $sizes = 16, 32, 48, 64, 128, 256
           $pngs = foreach ($size in $sizes) {
             $out = Join-Path $env:TEMP "kamp-icon-$size.png"
-            & $inkscape --export-type=png --export-filename=$out -w $size -h $size $svg
+            & $rsvg -w $size -h $size $svg -o $out
             if ($LASTEXITCODE -ne 0 -or -not (Test-Path $out)) {
-              Write-Error "Inkscape failed to render $size px PNG"
+              Write-Error "rsvg-convert failed to render $size px PNG"
               exit 1
             }
             $out

--- a/claude.md
+++ b/claude.md
@@ -108,6 +108,30 @@ When building mpv from source, use the latest release tag (v0.41.0 as of 2026-04
 - **Iterate meson flag errors locally**, not in CI: clone mpv, run `meson setup`, check `meson.options` for valid option names, build with ninja, then run dylibbundler to verify final dylib count before pushing.
 - With the minimal flag set (audio-only), expect ~32 bundled dylibs (down from ~47 with Homebrew mpv). The video encoder libs (x264/x265/SVT-AV1/vmaf) come from Homebrew FFmpeg's transitive deps and cannot be avoided without building FFmpeg from source.
 
+### Windows (MSYS2 + mingw-w64) extras
+The macOS audio-only meson flag set is necessary but not sufficient on Windows. The Windows-specific video pipeline (Direct3D 9, D3D11, OpenGL, VAAPI, Caca, EGL/ANGLE) is auto-enabled by default and `video/vaapi.c` indirectly includes `video/out/gpu/d3d11_helpers.h`, which redefines `DXGI_DEBUG_D3D11` against newer mingw-w64 (`d3d11sdklayers.h`) — clean compile failure even though we don't want any video output. Add **all of these** to the Windows meson invocation: `-Dgl=disabled -Dgl-win32=disabled -Dgl-dxinterop=disabled -Dd3d11=disabled -Ddirect3d=disabled -Dd3d-hwaccel=disabled -Dd3d9-hwaccel=disabled -Dvaapi=disabled -Dvaapi-win32=disabled -Dvdpau=disabled -Degl-angle=disabled -Degl-angle-lib=disabled -Degl-angle-win32=disabled -Dcaca=disabled`. `dxva2` is **not** a valid option (do not add); `gl-dxinterop-d3d9` and `zimg-st428` are sub-features that cascade. After the build, the Windows analog of `otool -L` is MSYS2's `ldd` — copy every transitive `/mingw64/bin/*.dll` into the same directory as `mpv.exe` (Windows resolves DLLs from the executable's directory, no `@executable_path` rewriting needed).
+
+## GitHub Actions: upload-artifact LCA stripping
+
+`actions/upload-artifact@v4+` (v7 same generation) strips the **least common ancestor** of all `path:` entries from archive paths. A single-path upload preserves the path-relative-to-LCA layout fine, but multi-path uploads collapse to the deepest shared parent and the `kamp_ui/` (or other) prefix disappears from the archive.
+
+- Symptom: `download-artifact` (with no `path:`) extracts to `$GITHUB_WORKSPACE`, files land in the "wrong" directory, and downstream tools (`electron-builder`, scripts assuming a known layout) silently miss them.
+- Especially dangerous with `electron-builder`: missing `extraResources` sources log `file source doesn't exist from=...` but the build **still exits 0**, producing a silently-broken installer with a green CI conclusion.
+- Fix: either upload a **single path** (matches the macOS `bundle-${arch}` pattern in this repo), or set the download step's `path:` to the LCA so the archive layout restores correctly.
+- Defense in depth: any `package`-style job that consumes a bundle artifact should run a **pre-flight `Test-Path`/`test -f` check** for the required source files and fail loudly if any are missing. Don't rely on the packager to surface the problem.
+
+## PowerShell file encoding (Windows codepage trap)
+
+PowerShell on Windows reads `.ps1` and inline-script files via the system codepage (CP1252) by default, **not** UTF-8. Em-dashes (`—`, U+2014), curly quotes, and other non-ASCII text in `.ps1` sources or in YAML inline scripts that target `pwsh` get reinterpreted byte-by-byte and break the parser ("Unexpected token", "string is missing the terminator"). Use ASCII `--` and straight quotes in PowerShell sources and in any `run:` block on `windows-latest`. AST-parse new `.ps1` files locally before pushing: `[System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errs)`.
+
+## Runner-image fragility (windows-latest)
+
+Don't assume tools are preinstalled on `windows-latest` without checking the [runner-images](https://github.com/actions/runner-images) repo for the current image. Inkscape was on the image historically and is **not** at the time of writing — assuming `C:\Program Files\Inkscape\bin\inkscape.exe` works is a CI-only failure that won't surface in any local check. Prefer tools that are installable via MSYS2 pacman (`mingw-w64-x86_64-librsvg` for SVG → PNG) or that ship with the Python/Node toolchain we already require, both because they're version-pinnable and because they survive runner-image churn.
+
+## Python regex pitfall: backslash escapes in re.subn replacement
+
+`re.sub`/`re.subn` interpret backslash escapes in the **replacement string** as regex backreferences. When rewriting code that contains `\xNN` byte literals (e.g. `b"\x00\x18..."` for AcoustID encoded keys), passing the literal as the replacement raises `re.error: bad escape \x at position N`. Use the callback form: `pattern.subn(lambda _m: replacement, src, count=1)` — callbacks bypass backreference interpretation.
+
 ## CSS height animations in Electron
 
 `grid-template-rows: 0fr → 1fr`, `max-height`, JS-measured `scrollHeight`, and `scaleY` + `max-height` combos all produce inconsistent or jerky results in the Electron renderer. Do not attempt to animate `height` or `max-height` for show/hide transitions. Use `display: none` / `display: block` (instant toggle) instead. If a smooth reveal is ever required, reach for a JS animation library (e.g. Framer Motion) rather than CSS property animation.

--- a/kamp.spec
+++ b/kamp.spec
@@ -2,14 +2,17 @@
 # PyInstaller spec for the kamp server bundle.
 #
 # Bundles kamp_core + kamp_daemon (minus Bandcamp/Playwright) into a onedir
-# executable placed at kamp_ui/resources/kamp/kamp. electron-builder then
-# copies that directory into Kamp.app/Contents/Resources/kamp/ via extraResources.
+# executable placed at kamp_ui/resources/kamp/kamp (or kamp.exe on Windows).
+# electron-builder then copies that directory into Contents/Resources/kamp/
+# (mac) or resources/kamp/ (win) via extraResources.
 #
 # Build:
 #   poetry run pyinstaller \
 #     --distpath kamp_ui/resources \
 #     --workpath /tmp/pyinstaller-work \
 #     --clean -y kamp.spec
+
+import sys
 
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
@@ -40,14 +43,23 @@ hidden_imports = [
     "starlette.responses",
     "anyio",
     "anyio._backends._asyncio",
-    # watchdog macOS FSEvents backend
-    "watchdog.observers.fsevents",
-    # macOS tray (rumps) — included for menu-bar mode parity
-    "rumps",
     # explicit submodule collection for kamp packages
     *collect_submodules("kamp_core"),
     *collect_submodules("kamp_daemon"),
 ]
+
+# Platform-specific watchdog backend + macOS tray (rumps).
+# rumps is darwin-gated in pyproject.toml, so it isn't installed on Windows;
+# listing it unconditionally would emit a noisy PyInstaller warning there.
+if sys.platform == "darwin":
+    hidden_imports += [
+        "watchdog.observers.fsevents",
+        "rumps",
+    ]
+elif sys.platform == "win32":
+    hidden_imports += [
+        "watchdog.observers.read_directory_changes",
+    ]
 
 # ---------------------------------------------------------------------------
 # Excludes — dev/test tooling and unused GUI toolkits only.
@@ -73,7 +85,7 @@ datas = [
     *collect_data_files("uvicorn"),
     *collect_data_files("fastapi"),
     *collect_data_files("starlette"),
-    *collect_data_files("certifi"),   # TLS certs for requests / MusicBrainz
+    *collect_data_files("certifi"),  # TLS certs for requests / MusicBrainz
     # pyproject.toml is used by _get_version() as the canonical version source;
     # include it so the frozen app reports the correct version string.
     ("pyproject.toml", "."),

--- a/kamp_ui/electron-builder.yml
+++ b/kamp_ui/electron-builder.yml
@@ -13,8 +13,10 @@ files:
   # to Contents/Resources/ outside the ASAR, no double-packing).
   - '!resources/kamp/**'
   - '!resources/mpv'
+  - '!resources/mpv/**'
   - '!resources/mpv-libs/**'
   - '!resources/node'
+  - '!resources/node.exe'
   - '!resources/npm/**'
   - '!resources/icon_1024.png'
   - '!resources/now-playing-helper'
@@ -32,44 +34,40 @@ files:
   - '!extensions/kamp-groover/**'
 asarUnpack:
   - resources/**
-extraResources:
-  # PyInstaller onedir bundle → Contents/Resources/kamp/
-  - from: resources/kamp
-    to: kamp
-    filter:
-      - '**/*'
-  # Standalone mpv binary → Contents/Resources/mpv
-  - from: resources/mpv
-    to: mpv
-  # Bundled mpv dylibs → Contents/Resources/mpv-libs/
-  # dylibbundler rewrites mpv's load commands to @executable_path/mpv-libs/<lib>
-  # so this directory must be a sibling of the mpv binary in Contents/Resources/.
-  - from: resources/mpv-libs
-    to: mpv-libs
-    filter:
-      - '**/*'
-  # Swift Now Playing helper → Contents/Resources/now-playing-helper
-  - from: resources/now-playing-helper
-    to: now-playing-helper
-  # Swift Keychain helper → Contents/Resources/kamp-keychain-helper
-  - from: resources/kamp-keychain-helper
-    to: kamp-keychain-helper
-  # Node.js binary + npm CLI — required for extension install/uninstall in the
-  # packaged app where the user may not have Node.js on their machine.
-  - from: resources/node
-    to: node
-  - from: resources/npm
-    to: npm
-    filter:
-      - '**/*'
-  # npm's own bundled node_modules — copied as a separate entry so app-builder
-  # does not strip it (app-builder excludes node_modules from **/* by default).
-  - from: resources/npm/node_modules
-    to: npm/node_modules
-    filter:
-      - '**/*'
+# extraResources is declared per-platform below. electron-builder treats a
+# top-level extraResources entry as a fallback that is fully replaced by any
+# platform-specific block, so the mac and win lists are kept symmetric to
+# avoid surprises when adding new platforms.
 win:
   executableName: kamp
+  icon: build/icon.ico
+  extraResources:
+    # PyInstaller onedir bundle → resources\kamp\
+    - from: resources/kamp
+      to: kamp
+      filter:
+        - '**/*'
+    # mpv directory contains mpv.exe + sibling mingw runtime DLLs. Windows
+    # resolves DLLs from the executable's directory, so the whole folder
+    # ships intact (no rewriting needed, unlike macOS @executable_path).
+    - from: resources/mpv
+      to: mpv
+      filter:
+        - '**/*'
+    # Bundled Node + npm — required for community-extension install where
+    # the user may have no Node.js on their machine.
+    - from: resources/node.exe
+      to: node.exe
+    - from: resources/npm
+      to: npm
+      filter:
+        - '**/*'
+    # npm's own bundled node_modules — copied separately because app-builder
+    # excludes node_modules from **/* by default.
+    - from: resources/npm/node_modules
+      to: npm/node_modules
+      filter:
+        - '**/*'
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}
@@ -97,6 +95,42 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+  extraResources:
+    # PyInstaller onedir bundle → Contents/Resources/kamp/
+    - from: resources/kamp
+      to: kamp
+      filter:
+        - '**/*'
+    # Standalone mpv binary → Contents/Resources/mpv
+    - from: resources/mpv
+      to: mpv
+    # Bundled mpv dylibs → Contents/Resources/mpv-libs/
+    # dylibbundler rewrites mpv's load commands to @executable_path/mpv-libs/<lib>
+    # so this directory must be a sibling of the mpv binary in Contents/Resources/.
+    - from: resources/mpv-libs
+      to: mpv-libs
+      filter:
+        - '**/*'
+    # Swift Now Playing helper → Contents/Resources/now-playing-helper
+    - from: resources/now-playing-helper
+      to: now-playing-helper
+    # Swift Keychain helper → Contents/Resources/kamp-keychain-helper
+    - from: resources/kamp-keychain-helper
+      to: kamp-keychain-helper
+    # Node.js binary + npm CLI — required for extension install/uninstall in the
+    # packaged app where the user may not have Node.js on their machine.
+    - from: resources/node
+      to: node
+    - from: resources/npm
+      to: npm
+      filter:
+        - '**/*'
+    # npm's own bundled node_modules — copied as a separate entry so app-builder
+    # does not strip it (app-builder excludes node_modules from **/* by default).
+    - from: resources/npm/node_modules
+      to: npm/node_modules
+      filter:
+        - '**/*'
 dmg:
   artifactName: ${name}-${version}-${arch}.${ext}
 linux:

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -204,9 +204,18 @@ async function startServer(): Promise<void> {
     return
   }
 
-  // When running from the .app bundle, point the server at the bundled mpv
-  // binary so it works on machines without Homebrew or mpv in PATH.
-  const mpvBin = app.isPackaged ? join(process.resourcesPath, 'mpv') : undefined
+  // When running from the packaged app, point the server at the bundled mpv
+  // binary so it works on machines without Homebrew or mpv in PATH. The
+  // macOS bundle ships a single Mach-O at Contents/Resources/mpv (deps live
+  // in the sibling mpv-libs/ folder, resolved via @executable_path). The
+  // Windows bundle ships mpv.exe alongside its mingw runtime DLLs in a
+  // resources\mpv\ subdirectory (Windows resolves DLLs from the executable's
+  // directory), so the env var must point at the .exe rather than the dir.
+  const mpvBin = app.isPackaged
+    ? process.platform === 'win32'
+      ? join(process.resourcesPath, 'mpv', 'mpv.exe')
+      : join(process.resourcesPath, 'mpv')
+    : undefined
 
   // detached: true puts the daemon in its own process group so that
   // stopServer() can kill the group (daemon + mpv) all at once.

--- a/scripts/build_mpv_windows.ps1
+++ b/scripts/build_mpv_windows.ps1
@@ -74,7 +74,13 @@ Invoke-Msys "rm -rf $mpvSrcUnix && git clone --depth=1 --branch $MpvTag https://
 # Audio-only meson configuration. Windows-only differences from the macOS
 # build: no coreaudio, no avfoundation; WASAPI is built-in (auto-enabled when
 # building on win32 -- no flag needed). All video/scripting/optical-disc
-# features are disabled the same way as on macOS.
+# features are disabled the same way as on macOS, plus the Windows-specific
+# video output and hwaccel backends (d3d11, direct3d/D3D9, gl/gl-win32/
+# gl-dxinterop, vaapi/vaapi-win32, vdpau, egl-angle, caca, d3d-hwaccel/
+# d3d9-hwaccel) which would otherwise auto-enable and pull video/vaapi.c
+# via video/out/d3d11/context.h -- triggering a DXGI_DEBUG_D3D11 redefinition
+# clash with newer mingw-w64 d3d11sdklayers.h. All flag names verified
+# against mpv v0.41.0's meson.options.
 Write-Host "==> Configuring mpv with audio-only feature set"
 Invoke-Msys @"
 set -euo pipefail
@@ -100,7 +106,21 @@ meson setup build \
     -Dalsa=disabled \
     -Dvulkan=disabled \
     -Dshaderc=disabled \
-    -Dpipewire=disabled
+    -Dpipewire=disabled \
+    -Dgl=disabled \
+    -Dgl-win32=disabled \
+    -Dgl-dxinterop=disabled \
+    -Dd3d11=disabled \
+    -Ddirect3d=disabled \
+    -Dd3d-hwaccel=disabled \
+    -Dd3d9-hwaccel=disabled \
+    -Dvaapi=disabled \
+    -Dvaapi-win32=disabled \
+    -Dvdpau=disabled \
+    -Degl-angle=disabled \
+    -Degl-angle-lib=disabled \
+    -Degl-angle-win32=disabled \
+    -Dcaca=disabled
 "@
 
 Write-Host "==> Building mpv (ninja)"

--- a/scripts/build_mpv_windows.ps1
+++ b/scripts/build_mpv_windows.ps1
@@ -1,0 +1,158 @@
+# scripts/build_mpv_windows.ps1
+#
+# Builds a minimal audio-only mpv from source on Windows using the MSYS2
+# mingw-w64 toolchain that is pre-installed on `windows-latest` GitHub runners.
+# Produces kamp_ui\resources\mpv\mpv.exe plus the runtime DLLs it needs.
+#
+# Mirrors the macOS source-build in build-app.yml: pinned to mpv v0.41.0 with
+# the same audio-only meson feature set. Windows uses WASAPI for audio output;
+# all video, scripting, optical-disc, and X11/Wayland features are disabled.
+#
+# Output layout (sibling DLL pattern is the Windows analog of macOS mpv-libs/):
+#   kamp_ui\resources\mpv\mpv.exe
+#   kamp_ui\resources\mpv\<dll>.dll       # mingw-supplied transitive deps
+#
+# Usage: pwsh scripts/build_mpv_windows.ps1
+
+[CmdletBinding()]
+param(
+    [string]$MpvTag = "v0.41.0"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$out = Join-Path $repo "kamp_ui\resources\mpv"
+if (Test-Path $out) { Remove-Item -Recurse -Force $out }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+# windows-latest runners ship MSYS2 at C:\msys64. Use the mingw64 bash so
+# pacman, meson, and ninja resolve the mingw-w64 toolchain consistently.
+$msys2 = "C:\msys64"
+if (-not (Test-Path $msys2)) {
+    throw "MSYS2 not found at $msys2. windows-latest runners are expected to have MSYS2 preinstalled."
+}
+$msysBash = Join-Path $msys2 "usr\bin\bash.exe"
+
+# Inherit the Windows PATH so curl/git/etc. resolve, but prepend mingw64 so
+# the mingw toolchain takes precedence inside the bash session.
+$env:MSYS2_PATH_TYPE = "inherit"
+$env:CHERE_INVOKING = "1"
+$env:MSYSTEM = "MINGW64"
+
+# All MSYS2 commands run through a single bash -lc invocation per logical step
+# so that pacman/PATH state propagates within the step. Shell-quoting note:
+# we use single-quoted PowerShell here-strings (@'...'@) so $vars are passed
+# through to bash literally rather than expanded by PowerShell.
+
+function Invoke-Msys($script) {
+    & $msysBash -lc $script
+    if ($LASTEXITCODE -ne 0) {
+        throw "MSYS2 step failed (exit $LASTEXITCODE)"
+    }
+}
+
+Write-Host "==> Installing mingw-w64 toolchain + mpv build deps via pacman"
+Invoke-Msys @'
+set -euo pipefail
+pacman -Syu --noconfirm
+pacman -S --needed --noconfirm \
+    git \
+    mingw-w64-x86_64-toolchain \
+    mingw-w64-x86_64-meson \
+    mingw-w64-x86_64-ninja \
+    mingw-w64-x86_64-pkgconf \
+    mingw-w64-x86_64-ffmpeg \
+    mingw-w64-x86_64-libass \
+    mingw-w64-x86_64-libplacebo
+'@
+
+Write-Host "==> Cloning mpv $MpvTag"
+$mpvSrcUnix = "/tmp/mpv-src"
+Invoke-Msys "rm -rf $mpvSrcUnix && git clone --depth=1 --branch $MpvTag https://github.com/mpv-player/mpv.git $mpvSrcUnix"
+
+# Audio-only meson configuration. Windows-only differences from the macOS
+# build: no coreaudio, no avfoundation; WASAPI is built-in (auto-enabled when
+# building on win32 -- no flag needed). All video/scripting/optical-disc
+# features are disabled the same way as on macOS.
+Write-Host "==> Configuring mpv with audio-only feature set"
+Invoke-Msys @"
+set -euo pipefail
+export PATH=/mingw64/bin:`$PATH
+cd $mpvSrcUnix
+meson setup build \
+    -Dbuildtype=release \
+    -Dvapoursynth=disabled \
+    -Djavascript=disabled \
+    -Dlua=disabled \
+    -Dlibbluray=disabled \
+    -Ddvdnav=disabled \
+    -Dcdda=disabled \
+    -Ddrm=disabled \
+    -Dwayland=disabled \
+    -Dx11=disabled \
+    -Dsdl2-audio=disabled \
+    -Dsdl2-video=disabled \
+    -Dsdl2-gamepad=disabled \
+    -Dopenal=disabled \
+    -Djack=disabled \
+    -Dpulse=disabled \
+    -Dalsa=disabled \
+    -Dvulkan=disabled \
+    -Dshaderc=disabled \
+    -Dpipewire=disabled
+"@
+
+Write-Host "==> Building mpv (ninja)"
+Invoke-Msys "export PATH=/mingw64/bin:`$PATH && cd $mpvSrcUnix && ninja -C build"
+
+# Copy the built executable. mpv's meson build emits 'mpv.exe' on Windows.
+$mpvExeWin = Join-Path $msys2 "tmp\mpv-src\build\mpv.exe"
+if (-not (Test-Path $mpvExeWin)) {
+    throw "Expected build artifact $mpvExeWin not found after ninja"
+}
+Copy-Item -Force $mpvExeWin (Join-Path $out "mpv.exe")
+
+# Walk mpv.exe's import table via ldd (the MSYS2 analog of macOS otool -L)
+# and copy every transitive dep that lives under /mingw64/bin into the same
+# directory as mpv.exe. Windows resolves bare DLL names from the executable's
+# directory first, so siblings need no further rewriting (unlike the macOS
+# @executable_path/mpv-libs/ rewrite handled by dylibbundler).
+Write-Host "==> Walking dependency tree and copying mingw runtime DLLs"
+$lddRaw = & $msysBash -lc "ldd $mpvSrcUnix/build/mpv.exe"
+if ($LASTEXITCODE -ne 0) {
+    throw "ldd on built mpv.exe failed"
+}
+
+$copiedDlls = New-Object System.Collections.Generic.HashSet[string]
+foreach ($line in $lddRaw) {
+    if ($line -match '=>\s+(/mingw64/bin/[^\s]+\.dll)') {
+        $unixPath = $matches[1]
+        $rel = $unixPath.Substring("/mingw64/bin/".Length)
+        $winPath = Join-Path $msys2 "mingw64\bin\$rel"
+        if (Test-Path $winPath) {
+            Copy-Item -Force $winPath (Join-Path $out $rel)
+            [void]$copiedDlls.Add($rel)
+        }
+    }
+}
+
+Write-Host "-> Copied $($copiedDlls.Count) mingw DLLs alongside mpv.exe"
+$copiedDlls | Sort-Object | ForEach-Object { Write-Host "    $_" }
+
+# Smoke test: a sibling-DLL layout problem would surface here as a
+# 0xc0000135 ("DLL not found") exit code. This is the Windows analog of
+# the macOS Homebrew-leak audit.
+Write-Host "==> Smoke-testing mpv.exe --version from staged directory"
+Push-Location $out
+try {
+    & .\mpv.exe --version | Select-Object -First 5 | ForEach-Object { Write-Host "    $_" }
+    if ($LASTEXITCODE -ne 0) {
+        throw "mpv.exe --version exited with code $LASTEXITCODE -- check that all transitive DLLs were copied"
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "==> mpv build complete: $out"

--- a/scripts/embed_acoustid_key.py
+++ b/scripts/embed_acoustid_key.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Patch kamp_daemon/acoustid.py with the encoded AcoustID key/salt at build time.
+
+Reads ACOUSTID_KEY and ACOUSTID_SALT from the environment, encodes them via
+the same XOR scheme as scripts/encode_acoustid_key.py, and rewrites the
+two ``b""`` placeholder lines in-place.
+
+Used by both the macOS and Windows release jobs in build-app.yml so the
+embedding logic is identical across platforms (replacing the previous
+sed/PowerShell-specific shell snippets).
+
+Usage:
+    ACOUSTID_KEY=... ACOUSTID_SALT=... python scripts/embed_acoustid_key.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Reuse the existing encoder so the byte-literal format matches exactly.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from encode_acoustid_key import encode  # noqa: E402
+
+_TARGET = _HERE.parent / "kamp_daemon" / "acoustid.py"
+_KEY_LINE = re.compile(r'^_KEY:\s*bytes\s*=\s*b""\s*$', re.MULTILINE)
+_SALT_LINE = re.compile(r'^_SALT:\s*bytes\s*=\s*b""\s*$', re.MULTILINE)
+
+
+def main() -> int:
+    key = os.environ.get("ACOUSTID_KEY", "")
+    salt = os.environ.get("ACOUSTID_SALT", "")
+    if not key or not salt:
+        print(
+            "ACOUSTID_KEY and ACOUSTID_SALT must be set in the environment",
+            file=sys.stderr,
+        )
+        return 1
+
+    encoded_key, encoded_salt = encode(key, salt)
+    src = _TARGET.read_text(encoding="utf-8")
+
+    # Use callback-form subn so backslash escapes in the replacement string
+    # (the encoded byte literals contain \xNN sequences) are passed through
+    # literally instead of being interpreted as regex backreferences.
+    key_repl = f"_KEY: bytes = {encoded_key}"
+    salt_repl = f"_SALT: bytes = {encoded_salt}"
+    new_src, key_count = _KEY_LINE.subn(lambda _m: key_repl, src, count=1)
+    new_src, salt_count = _SALT_LINE.subn(lambda _m: salt_repl, new_src, count=1)
+
+    # Fail loudly if the placeholder lines moved — silent no-op patches in
+    # CI would ship a build with no API key and only surface as runtime
+    # AcoustID lookup failures.
+    if key_count != 1 or salt_count != 1:
+        print(
+            f"Failed to locate placeholder lines in {_TARGET} "
+            f"(_KEY matches={key_count}, _SALT matches={salt_count})",
+            file=sys.stderr,
+        )
+        return 2
+
+    _TARGET.write_text(new_src, encoding="utf-8")
+    print(f"Embedded AcoustID key/salt into {_TARGET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch_node.ps1
+++ b/scripts/fetch_node.ps1
@@ -1,0 +1,68 @@
+# scripts/fetch_node.ps1
+#
+# Windows analog of scripts/fetch_node.sh. Downloads the official Node.js LTS
+# binary + npm from nodejs.org and places them at kamp_ui\resources\node.exe
+# and kamp_ui\resources\npm\.
+#
+# Used by the windows-latest job in .github/workflows/build-app.yml so the
+# packaged app can install community extensions on a machine with no Node.js
+# preinstalled.
+#
+# Usage: pwsh scripts/fetch_node.ps1 [-Version 20.18.3]
+
+[CmdletBinding()]
+param(
+    [string]$Version = "20.18.3"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$resources = Join-Path $repo "kamp_ui\resources"
+New-Item -ItemType Directory -Force -Path $resources | Out-Null
+
+$arch = "x64"  # KAMP-278 ships x64 only; ARM64 deferred to a follow-up.
+$archive = "node-v$Version-win-$arch.zip"
+$stripPrefix = "node-v$Version-win-$arch"
+$url = "https://nodejs.org/dist/v$Version/$archive"
+
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("kamp-node-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tmpRoot | Out-Null
+try {
+    $zipPath = Join-Path $tmpRoot $archive
+    Write-Host "-> Downloading Node.js $Version ($arch) from nodejs.org..."
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+
+    Write-Host "-> Extracting..."
+    Expand-Archive -Path $zipPath -DestinationPath $tmpRoot -Force
+
+    $extracted = Join-Path $tmpRoot $stripPrefix
+    if (-not (Test-Path $extracted)) {
+        throw "Expected extracted directory $extracted not found"
+    }
+
+    # node.exe lives at the archive root on Windows (no bin/ subdir as on macOS).
+    $nodeSrc = Join-Path $extracted "node.exe"
+    $nodeDest = Join-Path $resources "node.exe"
+    Copy-Item -Force $nodeSrc $nodeDest
+
+    # npm CLI is identical across platforms (pure JS). On Windows the archive
+    # ships it under node_modules\npm rather than lib\node_modules\npm.
+    $npmDest = Join-Path $resources "npm"
+    if (Test-Path $npmDest) { Remove-Item -Recurse -Force $npmDest }
+    $npmSrc = Join-Path $extracted "node_modules\npm"
+    Copy-Item -Recurse -Force $npmSrc $npmDest
+}
+finally {
+    Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
+}
+
+Write-Host "-> node.exe: $(Get-Item (Join-Path $resources 'node.exe') | Select-Object -ExpandProperty Length) bytes"
+Write-Host "-> npm-cli: kamp_ui\resources\npm\bin\npm-cli.js"
+
+# Sanity-run node to confirm the binary launches without missing DLLs.
+$nodeRun = Join-Path $resources "node.exe"
+& $nodeRun --version
+if ($LASTEXITCODE -ne 0) {
+    throw "node.exe failed to run from staged location"
+}


### PR DESCRIPTION
## Summary

Adds Windows to the release pipeline. A tag push (or manual workflow_dispatch) now produces a working NSIS installer alongside the existing macOS DMGs, with the same upload-to-release behavior.

- New `build-bundle-windows` and `package-windows` jobs in [.github/workflows/build-app.yml](.github/workflows/build-app.yml). Workflow renamed `Build macOS App` -> `Build App`.
- Builds mpv v0.41.0 from source on Windows via MSYS2 + mingw-w64 + meson, mirroring the macOS approach with an audio-only feature set (script: [scripts/build_mpv_windows.ps1](scripts/build_mpv_windows.ps1)).
- New [scripts/fetch_node.ps1](scripts/fetch_node.ps1) (Windows analog of `fetch_node.sh`) for the bundled node + npm needed by community-extension installs.
- New [scripts/embed_acoustid_key.py](scripts/embed_acoustid_key.py) replaces the macOS-only `sed` step with a cross-platform Python rewrite of the AcoustID `_KEY`/`_SALT` placeholders. Used by both mac and win jobs.
- [kamp.spec](kamp.spec) gates `rumps` + `watchdog.observers.fsevents` to darwin and adds `watchdog.observers.read_directory_changes` for win32.
- [kamp_ui/electron-builder.yml](kamp_ui/electron-builder.yml) splits `extraResources` into symmetric `mac.extraResources` and `win.extraResources`; adds `win.icon: build/icon.ico` (icon generated in CI from the SVG via MSYS2 `rsvg-convert` + ImageMagick).
- [kamp_ui/src/main/index.ts](kamp_ui/src/main/index.ts) points `KAMP_MPV_BIN` at `mpv\mpv.exe` on Windows because the bundled mpv ships with sibling mingw runtime DLLs in a subdirectory.
- Code signing remains out of scope (separate KAMP subtask). x64 only; ARM64 deferred.

## Verification

End-to-end installer flow validated:

1. CI run on the branch: https://github.com/eightyeighteyes/kamp/actions/runs/25610389577 — all 6 jobs green (windows + 2 mac arches + their package jobs).
2. Pre-flight bundle-layout check in `package-windows` confirmed the daemon, mpv, node, npm, and icon are all present in the bundle before electron-builder runs.
3. Installer downloaded and run on a clean Windows 11 box. App launches, daemon (`kamp.exe`) starts, library loads, audio playback works through the bundled mpv.

## Iteration log (kept here so the diff makes sense)

| Iter | Issue | Fix |
|------|-------|-----|
| 1 | mpv compile failed: `DXGI_DEBUG_D3D11` redefinition vs newer mingw-w64 | Disabled Windows video VOs in meson config |
| 2 | Inkscape not on `windows-latest` runner | Switched icon-gen to MSYS2 `rsvg-convert` |
| 3 | extraResources silently dropped (LCA-stripped artifact + no path on download) | `path: kamp_ui` on download + bundle-layout pre-flight in package-windows |
| 4 | Green CI, real 183 MB installer, daemon starts, audio plays | Done |

Five lessons folded into [claude.md](claude.md) so future Windows work doesnt re-hit these.

Closes KAMP-278.

## Test plan

- [x] CI green on branch (run 25610389577)
- [x] Manual install + launch on a clean Windows machine
- [x] Audio playback exercises the bundled mpv
- [ ] Followup small tasks tracked separately for cosmetic install-dir / Task Manager naming (`kamp_ui` -> `Kamp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)