### PR TITLE
docs(windows): defer code signing, capture option matrix (KAMP-279)

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,6 +1,15 @@
-# macOS Code Signing & Notarization
+# Code Signing
 
-This guide walks through getting the five values needed to sign and notarize
+How kamp's installers are signed (or not) on each platform.
+
+- [macOS](#macos) — signed and notarized.
+- [Windows](#windows-deferred) — currently unsigned; SmartScreen warning expected on first install. Deferred until a revisit trigger fires.
+
+---
+
+## macOS
+
+This section walks through getting the five values needed to sign and notarize
 the Kamp `.app` so macOS accepts it on any machine without a security warning.
 
 **Prerequisites:** An [Apple Developer Program](https://developer.apple.com/programs/) membership ($99/year).
@@ -8,7 +17,7 @@ You do not need to publish to the App Store — Developer ID is the outside-the-
 
 ---
 
-## What you're collecting
+### What you're collecting
 
 | GitHub Secret | What it is |
 |---|---|
@@ -20,7 +29,7 @@ You do not need to publish to the App Store — Developer ID is the outside-the-
 
 ---
 
-## Step 1 — Create a Developer ID Application certificate
+### Step 1 — Create a Developer ID Application certificate
 
 This is the certificate that signs the `.app`. You create a signing request on
 your Mac, upload it to Apple, and download the resulting certificate.
@@ -66,7 +75,7 @@ This copies the base64 string to your clipboard. That's your `CSC_LINK`.
 
 ---
 
-## Step 2 — Find your Team ID
+### Step 2 — Find your Team ID
 
 1. In the Developer Portal, click your name / account icon in the top-right
 2. Select **Membership details**
@@ -76,7 +85,7 @@ That's your `APPLE_TEAM_ID`.
 
 ---
 
-## Step 3 — Create an app-specific password for notarization
+### Step 3 — Create an app-specific password for notarization
 
 Notarization requires submitting the `.app` to Apple's servers. Apple won't
 accept your actual Apple ID password for this — you create a dedicated one-time
@@ -92,7 +101,7 @@ That's your `APPLE_APP_SPECIFIC_PASSWORD`. Your `APPLE_ID` is the email you used
 
 ---
 
-## Step 4 — Add the secrets to GitHub
+### Step 4 — Add the secrets to GitHub
 
 1. Go to your repository on GitHub
 2. **Settings → Secrets and variables → Actions**
@@ -108,7 +117,7 @@ That's your `APPLE_APP_SPECIFIC_PASSWORD`. Your `APPLE_ID` is the email you used
 
 ---
 
-## Step 5 — Enable signing in the CI workflow
+### Step 5 — Enable signing in the CI workflow
 
 In `.github/workflows/build-app.yml`, uncomment the signing and notarization
 environment variables in the **Build DMG** step:
@@ -134,10 +143,63 @@ mac:
 
 ---
 
-## Verification
+### Verification
 
 After a successful signed+notarized build:
 
 - Opening the `.dmg` on any Mac should work without any security dialog
 - To confirm: `codesign -dv --verbose=4 Kamp.app` should show your Developer ID
 - `spctl -a -v Kamp.app` should print `accepted` (source: Developer ID)
+
+---
+
+## Windows (deferred)
+
+kamp's Windows installer is currently **unsigned**. First-run users see "Windows protected your PC" → click *More info* → *Run anyway*. This is acceptable for early/internal distribution. It is not acceptable for a public Windows launch.
+
+This section captures what we've decided and what the next attempt looks like, so picking this up later is cheap.
+
+### Why this can't be a copy of the macOS path
+
+As of June 2023 (CA/B Forum baseline), all newly-issued Windows code-signing certs — OV and EV — must have private keys stored in FIPS 140-2 Level 2 hardware (a physical token or a cloud HSM). The macOS-style pattern of base64-encoding a `.p12` into a GitHub secret (`CSC_LINK` / `CSC_KEY_PASSWORD`) is **not** available for new Windows certs.
+
+Any path forward needs either:
+
+- a cloud signing service (the cert lives in someone else's HSM; CI calls a signing API), or
+- a self-hosted runner with a hardware token plugged into a physical machine.
+
+The cloud-service path is the realistic one for kamp.
+
+### Three viable paths
+
+| Path | Cost | SmartScreen | CI fit | Notes |
+|---|---|---|---|---|
+| **Azure Trusted Signing** *(recommended)* | ~$10/mo + per-signature fee | Immediate (Microsoft is the CA) | Native — `win.azureSignOptions` in electron-builder | US/Canada only; individual-developer track is open. Lowest cost, simplest CI. |
+| SSL.com eSigner (OV) | ~$200–300/yr | Builds over time as downloads accumulate | `signtoolOptions.sign` callback shim (CodeSignTool / eSigner CKA) | Works internationally. Initial users still see SmartScreen warnings until reputation builds. |
+| DigiCert KeyLocker (EV) | ~$500–700/yr | Immediate | `electron/windows-sign` or callback | Requires registered business identity. Most expensive. |
+
+**Recommendation when revisited:** Azure Trusted Signing, individual-developer track, US identity. Cheapest, simplest CI integration, immediate SmartScreen reputation.
+
+### Implementation hook points
+
+When this work is picked up, the changes land in these files:
+
+- [`kamp_ui/electron-builder.yml`](../kamp_ui/electron-builder.yml) — extend the `win:` block with `azureSignOptions` (or `signtoolOptions.sign` for the SSL.com path).
+- [`.github/workflows/build-app.yml`](../.github/workflows/build-app.yml) — `package-windows` job, near the existing *"No code signing in this task"* comment around the `npm run build:win` step. Add the env vars the chosen path needs:
+
+  | Path | Env vars |
+  |---|---|
+  | Azure Trusted Signing | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_CODE_SIGNING_ACCOUNT_NAME`, `AZURE_CERT_PROFILE_NAME` |
+  | SSL.com eSigner (OV) | `SSL_USERNAME`, `SSL_PASSWORD`, `SSL_CREDENTIAL_ID`, `SSL_TOTP_SECRET` |
+  | DigiCert KeyLocker (EV) | `SM_HOST`, `SM_API_KEY`, `SM_CLIENT_CERT_FILE`, `SM_CLIENT_CERT_PASSWORD`, `SM_CODE_SIGNING_CERT_SHA1_HASH` |
+
+- GitHub repo Secrets — add the chosen path's secrets when the cert exists.
+- Update the *"No code signing in this task"* comment in the workflow to point at this section once signing is live.
+
+### Revisit triggers
+
+Reopen [KAMP-279](https://eightyeighteyes.atlassian.net/browse/KAMP-279) when any of these become true:
+
+- Public Windows launch / promoted download link in `README.md`.
+- Reports of Windows users abandoning install at the SmartScreen prompt.
+- More than ~100 monthly Windows installs (the rough threshold where reputation buildup with OV becomes feasible *and* the warning starts hurting more users than the cert costs).


### PR DESCRIPTION
## Summary

- Defer KAMP-279 (Windows installer code signing). The unsigned installer from KAMP-278 stays as-is.
- Restructure `docs/code-signing.md` under a top-level **Code Signing** heading; existing macOS content moves under `## macOS` (unchanged). Append `## Windows (deferred)` covering why the macOS pattern cannot be copied (June 2023 CA/B Forum hardware-key mandate), the three viable paths (Azure Trusted Signing recommended; SSL.com eSigner OV; DigiCert KeyLocker EV) with cost/SmartScreen/CI tradeoffs, the electron-builder + workflow hook points, and the triggers that should reopen the ticket.
- KAMP-279s Jira description was rewritten to mirror the docs section so the ticket remains a useful artifact when it is pulled out of the active sprint. Acceptance Criteria are untouched.

No build-pipeline changes -- `package-windows` still produces an unsigned installer.

## Test plan

- [ ] `docs/code-signing.md` renders correctly on the GitHub PR diff (table, headings, anchor links).
- [ ] All existing macOS instructions (Steps 1-5, Verification) are intact under the new `## macOS` heading -- nothing lost in the demote-to-`###` restructure.
- [ ] The new `## Windows (deferred)` section reads as a self-contained briefing.
- [ ] No CI/build changes; existing Windows pipeline still produces an unsigned installer.

Generated with [Claude Code](https://claude.com/claude-code)