### PR TITLE
fix(windows): kill orphan mpv via Job Object (KAMP-283)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -16,11 +16,14 @@
 - Before opening a PR, run all CI steps (testing, linting, type checks, etc) locally
 - Before opening a PR, scan through README.md to make sure it's still valid (nothing it says has drifted from what the application does)
 - When merging a branch, squash commits.
-- Task lifecycle: when work begins on a task, move it to In Progress. When the user confirms it is tested and complete, squash merge the PR and move the task to Done.
+- Task lifecycle: task management is done through Jira. When work begins on a task, move it to In Progress. When the user confirms it is tested and complete, squash merge the PR and move the task to Done.
 - Prefer running single tests, and not the whole test suite, for performance; use `--no-cov` when running a single file to skip the coverage threshold check (e.g. `poetry run pytest tests/test_foo.py -v --no-cov`)
 - Update documentation (README.md) after new features are validated
 - Document rationale in comments: succinctly explain *why* decisions are made
 - After completing a feature, before closing a pull request, retrospect about the development experience and update claude.md with lessons learned.
+
+# Agents
+- When designing a plan, query your available agents and interrogate all relevant agents for enhancements to your plan.
 
 # Lessons Learned
 ## Mutagen
@@ -138,32 +141,3 @@ Don't assume tools are preinstalled on `windows-latest` without checking the [ru
 
 ## Shared debounce and high-volume FSEvents
 `_LibraryHandler._schedule()` (in `watcher.py`) is shared between FSEvents from the library directory and explicit `trigger_scan()` calls. During a large batch sync, continuous FSEvents from files being moved in reset the debounce timer faster than the `_MAX_SETTLE_SECONDS` cap fires. To guarantee a scan fires after each pipeline completion, bypass the debounce entirely: call `_on_library_change` directly in a `threading.Thread` from `on_pipeline_complete` instead of routing through `lib_watcher.trigger_scan()`.
-
-<!-- BACKLOG.MD MCP GUIDELINES START -->
-
-<CRITICAL_INSTRUCTION>
-
-## BACKLOG WORKFLOW INSTRUCTIONS
-
-This project uses Backlog.md MCP for all task and project management activities.
-
-**CRITICAL GUIDANCE**
-
-- If your client supports MCP resources, read `backlog://workflow/overview` to understand when and how to use Backlog for this project.
-- If your client only supports tools or the above request fails, call `backlog.get_backlog_instructions()` to load the tool-oriented overview. Use the `instruction` selector when you need `task-creation`, `task-execution`, or `task-finalization`.
-
-- **First time working here?** Read the overview resource IMMEDIATELY to learn the workflow
-- **Already familiar?** You should have the overview cached ("## Backlog.md Overview (MCP)")
-- **When to read it**: BEFORE creating tasks, or when you're unsure whether to track work
-
-These guides cover:
-- Decision framework for when to create tasks
-- Search-first workflow to avoid duplicates
-- Links to detailed guides for task creation, execution, and finalization
-- MCP tools reference
-
-You MUST read the overview resource to understand the complete workflow. The information is NOT summarized here.
-
-</CRITICAL_INSTRUCTION>
-
-<!-- BACKLOG.MD MCP GUIDELINES END -->

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -567,7 +567,6 @@ _JOB_OBJECT_LIMIT_BREAKAWAY_OK = 0x00000800
 _JobObjectExtendedLimitInformation = 9
 # Process creation flags (winbase.h).
 _CREATE_NO_WINDOW = 0x08000000
-_CREATE_BREAKAWAY_FROM_JOB = 0x01000000
 
 
 class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
@@ -761,12 +760,16 @@ class MpvPlaybackEngine:
     def _start_mpv(self) -> None:  # pragma: no cover
         """Launch mpv and connect to its IPC channel."""
         # Create the Job Object before Popen so we can assign mpv immediately
-        # after it spawns. CREATE_BREAKAWAY_FROM_JOB on Popen detaches mpv from
-        # any outer Electron Job before it joins ours; Job creation is
-        # best-effort — log and continue if it fails.
+        # after it spawns. We rely on nested Jobs (Win8+) rather than
+        # CREATE_BREAKAWAY_FROM_JOB — breakaway requires the parent's Job to
+        # set BREAKAWAY_OK, which Electron's default Job does not, and Popen
+        # would fail with ERROR_ACCESS_DENIED. Nested Jobs let mpv be in both
+        # Electron's outer Job and ours; either closing kills mpv, which is
+        # exactly the cleanup we want. Job creation is best-effort — log and
+        # continue if it fails.
         creationflags = 0
         if sys.platform == "win32":
-            creationflags = _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
+            creationflags = _CREATE_NO_WINDOW
             try:
                 self._job = _WindowsJobObject()
             except OSError as exc:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -7,6 +7,7 @@ updated by a background reader thread that consumes mpv's event stream.
 
 from __future__ import annotations
 
+import ctypes
 import json
 import logging
 import random
@@ -19,6 +20,7 @@ import tempfile
 import threading
 import time
 from abc import ABC, abstractmethod
+from ctypes import wintypes
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -559,6 +561,142 @@ class _WindowsNamedPipeTransport(_IPCTransport):
             self._conn = None
 
 
+# Win32 Job Object constants (winnt.h).
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_JOB_OBJECT_LIMIT_BREAKAWAY_OK = 0x00000800
+_JobObjectExtendedLimitInformation = 9
+# Process creation flags (winbase.h).
+_CREATE_NO_WINDOW = 0x08000000
+_CREATE_BREAKAWAY_FROM_JOB = 0x01000000
+
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit", ctypes.c_int64),
+        ("LimitFlags", ctypes.c_uint32),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", ctypes.c_uint32),
+        ("Affinity", ctypes.c_size_t),  # ULONG_PTR
+        ("PriorityClass", ctypes.c_uint32),
+        ("SchedulingClass", ctypes.c_uint32),
+    ]
+
+
+class _IO_COUNTERS(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_uint64),
+        ("WriteOperationCount", ctypes.c_uint64),
+        ("OtherOperationCount", ctypes.c_uint64),
+        ("ReadTransferCount", ctypes.c_uint64),
+        ("WriteTransferCount", ctypes.c_uint64),
+        ("OtherTransferCount", ctypes.c_uint64),
+    ]
+
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo", _IO_COUNTERS),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+class _WindowsJobObject:
+    """Win32 Job Object that auto-kills assigned children when the handle closes.
+
+    Windows does not propagate parent death the way POSIX does — when the
+    daemon dies, child processes (mpv) survive as orphans. Wrapping mpv in a
+    Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE makes the kernel
+    terminate every process in the Job when the last handle to it closes,
+    which the kernel does automatically when the daemon process exits — clean
+    shutdown, crash, or End-Task all release the handle.
+
+    Defined unconditionally so this module imports on POSIX; the win32-only
+    ctypes calls only run when an instance is constructed (which only happens
+    on win32, gated by MpvPlaybackEngine._start_mpv).
+    """
+
+    def __init__(self) -> None:  # pragma: no cover
+        # ctypes.WinDLL is win32-only in typeshed; this constructor only runs
+        # on Windows, but mypy on POSIX CI doesn't know that, hence the ignore.
+        kernel32: Any = ctypes.WinDLL(  # type: ignore[attr-defined,unused-ignore]
+            "kernel32", use_last_error=True
+        )
+
+        kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.SetInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.AssignProcessToJobObject.argtypes = [
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+        ]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        handle = kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise OSError(f"CreateJobObjectW failed (error {ctypes.get_last_error()})")
+
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        # BREAKAWAY_OK lets descendants escape this Job if they ever need to;
+        # KILL_ON_JOB_CLOSE is the actual orphan-killer.
+        info.BasicLimitInformation.LimitFlags = (
+            _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | _JOB_OBJECT_LIMIT_BREAKAWAY_OK
+        )
+
+        if not kernel32.SetInformationJobObject(
+            handle,
+            _JobObjectExtendedLimitInformation,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            last_error = ctypes.get_last_error()
+            kernel32.CloseHandle(handle)
+            raise OSError(f"SetInformationJobObject failed (error {last_error})")
+
+        self._handle: Any = handle
+        self._kernel32: Any = kernel32
+        self._closed = False
+
+    def assign(self, proc_handle: int) -> None:  # pragma: no cover
+        """Assign an existing process handle to this Job Object."""
+        if self._closed:
+            raise OSError("Job Object already closed")
+        if not self._kernel32.AssignProcessToJobObject(
+            self._handle, wintypes.HANDLE(proc_handle)
+        ):
+            raise OSError(
+                f"AssignProcessToJobObject failed (error {ctypes.get_last_error()})"
+            )
+
+    def close(self) -> None:  # pragma: no cover
+        """Release the Job handle. Idempotent.
+
+        Closing the last handle triggers KILL_ON_JOB_CLOSE on any process
+        still in the Job, so this is also the explicit orphan-cleanup path
+        on graceful shutdown.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._kernel32.CloseHandle(self._handle)
+        except OSError:
+            pass
+
+
 def _make_ipc_transport() -> _IPCTransport:
     """Return the IPC transport appropriate for the current platform."""
     if sys.platform == "win32":
@@ -598,6 +736,10 @@ class MpvPlaybackEngine:
         self.on_play_state_changed: Callable[[], None] | None = None
         self._mpv_bin = mpv_bin
         self._proc: subprocess.Popen[bytes] | None = None
+        # Win32 Job Object that the spawned mpv is assigned to so it dies
+        # with the daemon (KAMP-283). Win32-only; None on POSIX or if the
+        # Job Object API is unavailable.
+        self._job: _WindowsJobObject | None = None
         self._ipc: _IPCTransport = _make_ipc_transport()
         self._reader_thread: threading.Thread | None = None
         # RLock so the reader thread can re-acquire the lock inside callbacks
@@ -618,6 +760,23 @@ class MpvPlaybackEngine:
 
     def _start_mpv(self) -> None:  # pragma: no cover
         """Launch mpv and connect to its IPC channel."""
+        # Create the Job Object before Popen so we can assign mpv immediately
+        # after it spawns. CREATE_BREAKAWAY_FROM_JOB on Popen detaches mpv from
+        # any outer Electron Job before it joins ours; Job creation is
+        # best-effort — log and continue if it fails.
+        creationflags = 0
+        if sys.platform == "win32":
+            creationflags = _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
+            try:
+                self._job = _WindowsJobObject()
+            except OSError as exc:
+                logger.warning(
+                    "Could not create Win32 Job Object; mpv may survive "
+                    "daemon exit. (%s)",
+                    exc,
+                )
+                self._job = None
+
         self._proc = subprocess.Popen(
             [
                 self._mpv_bin,
@@ -634,7 +793,21 @@ class MpvPlaybackEngine:
             stdout=subprocess.DEVNULL,
             # Capture stderr so we can surface it if mpv fails to start.
             stderr=subprocess.PIPE,
+            creationflags=creationflags,
         )
+
+        if self._job is not None:
+            try:
+                # Popen._handle is the Win32 process HANDLE; underscore-prefixed
+                # but stable since Python 3.7. getattr keeps mypy happy on POSIX.
+                self._job.assign(int(getattr(self._proc, "_handle")))
+            except OSError as exc:
+                logger.warning(
+                    "Could not assign mpv to Win32 Job Object; mpv may "
+                    "survive daemon exit. (%s)",
+                    exc,
+                )
+
         try:
             self._ipc.open(timeout=5.0, proc=self._proc)
         except RuntimeError as exc:
@@ -765,6 +938,11 @@ class MpvPlaybackEngine:
         if self._proc is not None:
             self._proc.terminate()
             self._proc = None
+        # Releasing the Job handle triggers KILL_ON_JOB_CLOSE, a backstop in
+        # case mpv didn't exit on terminate(). Win32-only; None on POSIX.
+        if self._job is not None:
+            self._job.close()
+            self._job = None
         # Closing the transport unblocks the reader thread's blocking recv()
         # so the daemon shuts down cleanly. Tolerate cleanup errors so a
         # crashing transport never aborts daemon shutdown.

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -571,7 +571,9 @@ _CREATE_NO_WINDOW = 0x08000000
 
 def _win_last_error() -> int:
     """Wrapper for ctypes.get_last_error() — win32-only in typeshed."""
-    return ctypes.get_last_error()  # type: ignore[attr-defined,unused-ignore]
+    # attr-defined suppresses the POSIX-typeshed gate; the int() cast narrows
+    # the otherwise-Any return so strict mypy doesn't flag no-any-return.
+    return int(ctypes.get_last_error())  # type: ignore[attr-defined,unused-ignore]
 
 
 class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -569,6 +569,11 @@ _JobObjectExtendedLimitInformation = 9
 _CREATE_NO_WINDOW = 0x08000000
 
 
+def _win_last_error() -> int:
+    """Wrapper for ctypes.get_last_error() — win32-only in typeshed."""
+    return ctypes.get_last_error()  # type: ignore[attr-defined,unused-ignore]
+
+
 class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
     _fields_ = [
         ("PerProcessUserTimeLimit", ctypes.c_int64),
@@ -646,7 +651,7 @@ class _WindowsJobObject:
 
         handle = kernel32.CreateJobObjectW(None, None)
         if not handle:
-            raise OSError(f"CreateJobObjectW failed (error {ctypes.get_last_error()})")
+            raise OSError(f"CreateJobObjectW failed (error {_win_last_error()})")
 
         info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
         # BREAKAWAY_OK lets descendants escape this Job if they ever need to;
@@ -661,7 +666,7 @@ class _WindowsJobObject:
             ctypes.byref(info),
             ctypes.sizeof(info),
         ):
-            last_error = ctypes.get_last_error()
+            last_error = _win_last_error()
             kernel32.CloseHandle(handle)
             raise OSError(f"SetInformationJobObject failed (error {last_error})")
 
@@ -677,7 +682,7 @@ class _WindowsJobObject:
             self._handle, wintypes.HANDLE(proc_handle)
         ):
             raise OSError(
-                f"AssignProcessToJobObject failed (error {ctypes.get_last_error()})"
+                f"AssignProcessToJobObject failed (error {_win_last_error()})"
             )
 
     def close(self) -> None:  # pragma: no cover

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -12,7 +12,7 @@ import {
 import { join, resolve } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
-import { spawn, ChildProcess } from 'child_process'
+import { spawn, ChildProcess, execFileSync } from 'child_process'
 import { createInterface } from 'readline'
 import * as http from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
@@ -241,10 +241,23 @@ async function startServer(): Promise<void> {
 function stopServer(): void {
   if (serverProcess?.pid) {
     try {
-      // Negative PID kills the entire process group (server + all children).
-      process.kill(-serverProcess.pid, 'SIGKILL')
+      if (process.platform === 'win32') {
+        // process.kill(-pid) is POSIX-only — Node ignores the negative sign on
+        // Windows and the daemon orphans (KAMP-283). taskkill /T recursively
+        // kills the process tree (daemon + sandbox helpers + mpv as belt-and-
+        // suspenders for the daemon-side Job Object); /F is forced (SIGKILL-
+        // equivalent). Synchronous because process.on('exit') is one of the
+        // call sites and won't run async work.
+        execFileSync('taskkill', ['/PID', String(serverProcess.pid), '/T', '/F'], {
+          stdio: 'ignore'
+        })
+      } else {
+        // Negative PID kills the entire process group (daemon + children).
+        process.kill(-serverProcess.pid, 'SIGKILL')
+      }
     } catch {
-      // Process may have already exited.
+      // Process may have already exited; taskkill exits non-zero in that case
+      // and execFileSync throws. Either way, nothing to clean up here.
     }
     serverProcess = null
   }

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -994,6 +995,103 @@ class TestMpvPlaybackEngine:
             engine = MpvPlaybackEngine()
         engine._proc = None
         engine.shutdown()  # should not raise
+
+    # ------------------------------------------------------------------
+    # KAMP-283: Windows Job Object — bind mpv lifetime to the daemon so
+    # the kernel kills mpv when the daemon process exits (clean shutdown,
+    # crash, or End-Task). All four tests stub _start_mpv's collaborators
+    # so the real subprocess.Popen / kernel32 calls never run under test.
+    # ------------------------------------------------------------------
+
+    def test_start_mpv_creates_job_and_assigns_mpv_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "win32")
+
+        fake_proc = MagicMock()
+        fake_proc._handle = 0xCAFE
+        fake_job = MagicMock()
+        fake_job_class = MagicMock(return_value=fake_job)
+
+        with (
+            patch(
+                "kamp_core.playback.subprocess.Popen", return_value=fake_proc
+            ) as mock_popen,
+            patch("kamp_core.playback._WindowsJobObject", fake_job_class),
+            patch(
+                "kamp_core.playback._make_ipc_transport",
+                return_value=MagicMock(),
+            ),
+            patch("kamp_core.playback.threading.Thread"),
+        ):
+            engine = MpvPlaybackEngine()
+
+        fake_job_class.assert_called_once_with()
+        fake_job.assign.assert_called_once_with(0xCAFE)
+        assert engine._job is fake_job
+        # CREATE_BREAKAWAY_FROM_JOB (0x01000000) detaches mpv from any outer
+        # Electron Job before joining ours.
+        _, popen_kwargs = mock_popen.call_args
+        assert popen_kwargs["creationflags"] & 0x01000000
+
+    def test_start_mpv_skips_job_on_posix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "darwin")
+        fake_job_class = MagicMock()
+
+        with (
+            patch("kamp_core.playback.subprocess.Popen") as mock_popen,
+            patch("kamp_core.playback._WindowsJobObject", fake_job_class),
+            patch(
+                "kamp_core.playback._make_ipc_transport",
+                return_value=MagicMock(),
+            ),
+            patch("kamp_core.playback.threading.Thread"),
+        ):
+            engine = MpvPlaybackEngine()
+
+        fake_job_class.assert_not_called()
+        assert engine._job is None
+        _, popen_kwargs = mock_popen.call_args
+        assert popen_kwargs.get("creationflags", 0) == 0
+
+    def test_start_mpv_continues_when_job_creation_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "win32")
+        fake_job_class = MagicMock(side_effect=OSError("simulated failure"))
+
+        with (
+            patch("kamp_core.playback.subprocess.Popen") as mock_popen,
+            patch("kamp_core.playback._WindowsJobObject", fake_job_class),
+            patch(
+                "kamp_core.playback._make_ipc_transport",
+                return_value=MagicMock(),
+            ),
+            patch("kamp_core.playback.threading.Thread"),
+            caplog.at_level(logging.WARNING, logger="kamp_core.playback"),
+        ):
+            engine = MpvPlaybackEngine()
+
+        assert engine._job is None
+        mock_popen.assert_called_once()
+        assert any(
+            "Job Object" in rec.message for rec in caplog.records
+        ), "expected a warning about Job Object failure"
+
+    def test_shutdown_closes_job_object(self) -> None:
+        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
+            engine = MpvPlaybackEngine()
+        mock_job = MagicMock()
+        engine._job = mock_job
+
+        engine.shutdown()
+
+        mock_job.close.assert_called_once()
+        assert engine._job is None
 
     def test_volume_getter_returns_state_volume(self) -> None:
         engine, _ = _make_engine()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1029,10 +1029,13 @@ class TestMpvPlaybackEngine:
         fake_job_class.assert_called_once_with()
         fake_job.assign.assert_called_once_with(0xCAFE)
         assert engine._job is fake_job
-        # CREATE_BREAKAWAY_FROM_JOB (0x01000000) detaches mpv from any outer
-        # Electron Job before joining ours.
+        # CREATE_NO_WINDOW (0x08000000) suppresses the console window mpv
+        # would otherwise pop. We do NOT pass CREATE_BREAKAWAY_FROM_JOB
+        # because Electron's outer Job typically forbids it; nested Jobs
+        # work on Win8+ and give us the cleanup we need.
         _, popen_kwargs = mock_popen.call_args
-        assert popen_kwargs["creationflags"] & 0x01000000
+        assert popen_kwargs["creationflags"] & 0x08000000
+        assert not (popen_kwargs["creationflags"] & 0x01000000)
 
     def test_start_mpv_skips_job_on_posix(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
﻿## Summary

Two-layer fix for orphan processes on Windows. Each level of the spawn chain (Electron -> daemon -> mpv) needs its own explicit cleanup because Windows does not propagate parent death the way POSIX does.

**Layer 1 -- daemon -> mpv** (commits `789d7a4` + `a2b8386`)
- New `_WindowsJobObject` helper in [kamp_core/playback.py](kamp_core/playback.py) wrapping `CreateJobObjectW` / `SetInformationJobObject` / `AssignProcessToJobObject` / `CloseHandle` via stdlib `ctypes` -- no new deps.
- `MpvPlaybackEngine` creates one Job at start, assigns mpv right after Popen, and closes the handle on shutdown. Job creation/assignment are best-effort (log + continue on failure).
- mpv spawns with `CREATE_NO_WINDOW`. We rely on nested Jobs (Win8+) rather than `CREATE_BREAKAWAY_FROM_JOB` -- breakaway requires the parent process Job to set `BREAKAWAY_OK`, which Electron does not, and Popen would fail with `ERROR_ACCESS_DENIED`.

**Layer 2 -- Electron -> daemon** (commit `cbc36d1`)
- `stopServer()` in [kamp_ui/src/main/index.ts](kamp_ui/src/main/index.ts) was calling `process.kill(-pid, "SIGKILL")`, a POSIX `killpg()` idiom. Node ignores the negative sign on Windows, the empty `catch` swallowed the error, and the daemon orphaned -- next launch failed with `[Errno 10048] address already in use`.
- Branch by platform: keep the POSIX path, use `taskkill /T /F` on Windows. `/T` recursively kills the process tree (daemon + sandbox helpers + mpv as belt-and-suspenders); `/F` is forced.

Jira: [KAMP-283](https://eightyeighteyes.atlassian.net/browse/KAMP-283)

## Test plan

Automated:
- [x] 4 new unit tests in [tests/test_playback.py](tests/test_playback.py) covering the win32 happy path, POSIX no-op, fail-soft on Job creation failure, and Job close on shutdown
- [x] `poetry run pytest --no-cov` -- 1195 passed, 35 skipped on Windows
- [x] `poetry run black --check .` clean
- [x] `poetry run mypy kamp_core/ kamp_daemon/` clean (strict mode)
- [x] `npm run typecheck` + `npm run lint` clean (zero new lint errors; pre-existing CRLF warnings unchanged)

Manual on Windows (verified via `npm run dev` in `kamp_ui/`):
- [x] Start playback -- `python.exe` (kamp daemon) and `mpv.exe` show in Task Manager
- [x] **Clean close (AC #1):** click X on the Electron window -- both `python.exe` and `mpv.exe` disappear within ~1s
- [x] **No duplicate python.exe** observed after close
- [x] **No port-bind regression on relaunch** -- uvicorn binds to 47483 cleanly

macOS regression (AC #3):
- [x] Quick interactive playback session on macOS confirms shutdown still cleans up cleanly (POSIX path is untouched)

Generated with [Claude Code](https://claude.com/claude-code)


[KAMP-283]: https://eightyeighteyes.atlassian.net/browse/KAMP-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ