### PR TITLE
feat(windows): DPAPI credential storage + login fix (KAMP-280/282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ All configuration is stored in the SQLite database alongside library and playbac
 
 If you have an existing `config.toml` from a prior install, kamp migrates it automatically on the first startup and leaves the file in place as a backup.
 
+### Credential storage
+
+Bandcamp and Last.fm session credentials are kept out of the application database where possible:
+
+| Platform | Backend | Notes |
+| --- | --- | --- |
+| macOS    | Data Protection Keychain (Login Keychain in dev/unsigned builds) | Per-user, encrypted at rest, survives app updates. |
+| Linux    | `keyring` (Secret Service via libsecret, GNOME Keyring, KWallet, …) | Whatever backend the desktop session provides. |
+| Windows  | DPAPI (`CryptProtectData`) wrapping the SQLite `sessions` row | Windows Credential Manager has a 2560-byte per-credential limit that the Bandcamp session blob exceeds, so kamp DPAPI-encrypts the row in place. The encryption key is tied to your Windows user account; copying `library.db` to another machine or user does not yield readable credentials. |
+
+If no keychain backend is available the credential lands in the database column as plaintext (with a warning logged) — kamp prefers a working session to a failed login.
+
 ### View or update from the command line
 
 ```bash

--- a/claude.md
+++ b/claude.md
@@ -141,3 +141,12 @@ Don't assume tools are preinstalled on `windows-latest` without checking the [ru
 
 ## Shared debounce and high-volume FSEvents
 `_LibraryHandler._schedule()` (in `watcher.py`) is shared between FSEvents from the library directory and explicit `trigger_scan()` calls. During a large batch sync, continuous FSEvents from files being moved in reset the debounce timer faster than the `_MAX_SETTLE_SECONDS` cap fires. To guarantee a scan fires after each pipeline completion, bypass the debounce entirely: call `_on_library_change` directly in a `threading.Thread` from `on_pipeline_complete` instead of routing through `lib_watcher.trigger_scan()`.
+
+## Windows credential storage
+The `keyring` package's `WinVaultKeyring` backend (Windows Credential Manager) caps each credential at **2560 bytes** (`CRED_MAX_CREDENTIAL_BLOB_SIZE = 5 * 512`). The Bandcamp session blob — full cookie jar plus username and metadata — exceeds this, and `CredWrite` fails with `OSError(1783, 'CredWrite', 'The stub received bad data.')` (Win32 error 1783 = `RPC_S_INVALID_TAG`, which for `CredWrite` almost always means the blob exceeds the limit). The error type sits **outside** the keyring exception hierarchy, so `except keyring.errors.KeyringError` does not catch it — without a broader `except Exception` clause it propagates up and turns the FastAPI handler's `try/except` into a 422 (KAMP-282).
+
+Workaround in `kamp_core/win_credential.py`: wrap the JSON blob with **DPAPI** (`CryptProtectData` / `CryptUnprotectData`) and store the resulting ciphertext in the SQLite `sessions.session_json` column. DPAPI has no size limit, the encryption key is tied to the current Windows user account, and the ctypes wiring matches the `macos_keychain.py` pattern (no extra dependency). The wrapped value is detected on read via the `dpapi-v1:` prefix; legacy plaintext rows still work via the same code path. Schema migration v12 → v13 wraps any plaintext rows already on disk on first launch.
+
+Two further notes for future Windows work on this code path:
+- The non-mac branches of `set_session`/`get_session`/`clear_session` in `library.py` should always have a final `except Exception` arm in addition to the typed keyring catches — the keyring exception hierarchy does not cover backend bugs.
+- Don't add `pywin32` for Credential Manager work — `keyring` 25.x's WinVault and our DPAPI wrapper both use ctypes directly, so the dependency is unnecessary.

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -26,6 +26,15 @@ if sys.platform == "darwin":
         _mac_kc = None  # type: ignore[assignment]
 else:
     _mac_kc = None  # type: ignore[assignment]
+
+if sys.platform == "win32":
+    try:
+        from . import win_credential as _win_cred
+    except Exception:
+        _win_cred = None  # type: ignore[assignment]
+else:
+    _win_cred = None  # type: ignore[assignment]
+
 import mutagen.flac
 import mutagen.id3 as id3
 import mutagen.mp4
@@ -33,9 +42,55 @@ import mutagen.oggvorbis
 
 logger = logging.getLogger(__name__)
 
+
+def _maybe_protect(plaintext: str) -> str:
+    """DPAPI-wrap *plaintext* on Windows, return as-is elsewhere.
+
+    On Windows the SQLite ``sessions`` row sits in
+    ``%APPDATA%\\kamp\\library.db`` in a form readable by anyone with
+    file access; DPAPI ties the encryption key to the current Windows
+    user account so a copy of the DB cannot be decrypted off-machine
+    (KAMP-280 AC #3).  If DPAPI itself fails we still write the row —
+    a failed login is worse than a non-encrypted credential — and log
+    a warning.
+    """
+    if _win_cred is None:
+        return plaintext
+    try:
+        return _win_cred.protect_str(plaintext)
+    except Exception as exc:
+        logger.warning(
+            "DPAPI protect failed (%s: %s); storing plaintext fallback",
+            type(exc).__name__,
+            exc,
+        )
+        return plaintext
+
+
+def _maybe_unprotect(text: str) -> str:
+    """Strip DPAPI wrapping from *text* if it carries the DPAPI prefix.
+
+    Returns the input unchanged when the value is plaintext (legacy
+    rows that pre-date the DPAPI rollout) or when DPAPI is unavailable
+    on the current platform.
+    """
+    if _win_cred is None:
+        return text
+    try:
+        unwrapped = _win_cred.unprotect_str(text)
+    except Exception as exc:
+        logger.warning(
+            "DPAPI unprotect failed (%s: %s); treating as plaintext",
+            type(exc).__name__,
+            exc,
+        )
+        return text
+    return unwrapped if unwrapped is not None else text
+
+
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 12
+_SCHEMA_VERSION = 13
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -438,7 +493,44 @@ class LibraryIndex:
                 except keyring.errors.NoKeyringError:
                     # No keyring on this platform; leave remaining rows in DB.
                     break
+                except Exception as exc:
+                    # On Windows, large blobs (e.g. the Bandcamp session)
+                    # exceed CRED_MAX_CREDENTIAL_BLOB_SIZE and CredWrite raises
+                    # OSError outside the keyring exception hierarchy.  Leave
+                    # the row in the DB column so the v13 migration can wrap
+                    # it with DPAPI.  See KAMP-280 / KAMP-282.
+                    logger.warning(
+                        "v11->v12: keyring write failed for service=%s (%s: %s);"
+                        " leaving in DB fallback",
+                        row["service"],
+                        type(exc).__name__,
+                        exc,
+                    )
+                    continue
             self._conn.execute("UPDATE schema_version SET version = 12")
+            self._conn.commit()
+            version = 12
+
+        if version < 13:
+            # v12 -> v13: encrypt any plaintext credential rows with DPAPI on
+            # Windows.  No-op on other platforms (the keyring backends there
+            # already encrypt at rest).  See KAMP-280.
+            if _win_cred is not None:
+                rows = self._conn.execute(
+                    "SELECT service, session_json FROM sessions"
+                    " WHERE session_json IS NOT NULL"
+                ).fetchall()
+                for row in rows:
+                    if _win_cred.is_dpapi_blob(row["session_json"]):
+                        continue  # already wrapped (paranoia)
+                    wrapped = _maybe_protect(row["session_json"])
+                    if wrapped == row["session_json"]:
+                        continue  # protect failed, already logged
+                    self._conn.execute(
+                        "UPDATE sessions SET session_json = ? WHERE service = ?",
+                        (wrapped, row["service"]),
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 13")
             self._conn.commit()
 
     def _rebuild_fts(self) -> None:
@@ -516,7 +608,7 @@ class LibraryIndex:
                 )
                 return None
             logger.debug("get_session: DB fallback hit for service=%s", service)
-            return dict(json.loads(row["session_json"]))  # type: ignore[no-any-return]
+            return dict(json.loads(_maybe_unprotect(row["session_json"])))  # type: ignore[no-any-return]
 
         # --- keyring path (non-macOS)
         _MAX_RETRIES = 3
@@ -581,7 +673,7 @@ class LibraryIndex:
             )
             return None
         logger.debug("get_session: DB fallback hit for service=%s", service)
-        return dict(json.loads(row["session_json"]))  # type: ignore[no-any-return]
+        return dict(json.loads(_maybe_unprotect(row["session_json"])))  # type: ignore[no-any-return]
 
     def set_session(self, service: str, data: dict[str, Any]) -> None:
         """Persist session data for *service*, replacing any existing entry.
@@ -658,6 +750,11 @@ class LibraryIndex:
                     exc,
                 )
 
+        # On Windows, wrap the DB fallback with DPAPI so the SQLite row is
+        # not readable as plaintext (KAMP-280 AC #3).  No-op when the
+        # credential lives in the OS keychain (session_json is None).
+        if session_json is not None:
+            session_json = _maybe_protect(session_json)
         self._conn.execute(
             """
             INSERT INTO sessions (service, session_json, updated_at)

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -552,6 +552,17 @@ class LibraryIndex:
                     exc,
                 )
                 break
+            except Exception as exc:
+                # Backend may raise OSError/RuntimeError outside the keyring
+                # exception hierarchy (e.g. ctypes failures from WinVaultKeyring).
+                # Fall through to the DB row instead of letting it propagate.
+                logger.warning(
+                    "get_session: keychain read raised unexpected %s for service=%s: %s",
+                    type(exc).__name__,
+                    service,
+                    exc,
+                )
+                break
         else:
             logger.warning(
                 "get_session: keychain still locked after %d retries for service=%s;"
@@ -633,6 +644,19 @@ class LibraryIndex:
                     type(exc).__name__,
                     exc,
                 )
+            except Exception as exc:
+                # Backend may raise OSError/RuntimeError outside the keyring
+                # exception hierarchy (e.g. ctypes failures from WinVaultKeyring).
+                # Without this branch the exception bubbles out of set_session
+                # and turns the bandcamp login-complete handler into a 422.
+                # See KAMP-282.
+                logger.warning(
+                    "set_session: keychain write raised unexpected %s for service=%s"
+                    " (%s); credential stored in DB fallback",
+                    type(exc).__name__,
+                    service,
+                    exc,
+                )
 
         self._conn.execute(
             """
@@ -668,6 +692,14 @@ class LibraryIndex:
                     "clear_session: keychain delete failed for service=%s (%s: %s)",
                     service,
                     type(exc).__name__,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "clear_session: keychain delete raised unexpected %s for"
+                    " service=%s: %s",
+                    type(exc).__name__,
+                    service,
                     exc,
                 )
         self._conn.execute("DELETE FROM sessions WHERE service = ?", (service,))

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -610,58 +610,70 @@ class LibraryIndex:
             logger.debug("get_session: DB fallback hit for service=%s", service)
             return dict(json.loads(_maybe_unprotect(row["session_json"])))  # type: ignore[no-any-return]
 
-        # --- keyring path (non-macOS)
-        _MAX_RETRIES = 3
-        for attempt in range(_MAX_RETRIES):
-            try:
-                raw = keyring.get_password("kamp", service)
-                if raw is not None:
-                    logger.debug("get_session: keychain hit for service=%s", service)
-                    return json.loads(raw)  # type: ignore[no-any-return]
-                logger.debug(
-                    "get_session: keychain returned no entry for service=%s", service
-                )
-                break  # key not present — no point retrying
-            except keyring.errors.NoKeyringError:
-                break
-            except keyring.errors.KeyringLocked as exc:
-                delay = 0.5 * (2**attempt)
-                logger.debug(
-                    "get_session: keychain locked for service=%s"
-                    " (attempt %d/%d, retry in %.1fs): %s",
-                    service,
-                    attempt + 1,
+        # --- keyring path (non-macOS, non-Windows-DPAPI) -----
+        # On Windows we skip the OS keyring entirely: WinVaultKeyring caps
+        # credentials at 2560 bytes which the Bandcamp blob exceeds, so the
+        # call always fails for that service.  DPAPI in the DB fallback
+        # provides equivalent per-user encryption without the size limit.
+        # See KAMP-280 / KAMP-282.
+        if _win_cred is None:
+            _MAX_RETRIES = 3
+            for attempt in range(_MAX_RETRIES):
+                try:
+                    raw = keyring.get_password("kamp", service)
+                    if raw is not None:
+                        logger.debug(
+                            "get_session: keychain hit for service=%s", service
+                        )
+                        return json.loads(raw)  # type: ignore[no-any-return]
+                    logger.debug(
+                        "get_session: keychain returned no entry for service=%s",
+                        service,
+                    )
+                    break  # key not present — no point retrying
+                except keyring.errors.NoKeyringError:
+                    break
+                except keyring.errors.KeyringLocked as exc:
+                    delay = 0.5 * (2**attempt)
+                    logger.debug(
+                        "get_session: keychain locked for service=%s"
+                        " (attempt %d/%d, retry in %.1fs): %s",
+                        service,
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        delay,
+                        exc,
+                    )
+                    _time.sleep(delay)
+                except keyring.errors.KeyringError as exc:
+                    logger.warning(
+                        "get_session: keychain read failed for service=%s (%s: %s)",
+                        service,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    break
+                except Exception as exc:
+                    # Backend may raise OSError/RuntimeError outside the keyring
+                    # exception hierarchy (e.g. ctypes failures from
+                    # WinVaultKeyring).  Fall through to the DB row instead of
+                    # letting it propagate.
+                    logger.warning(
+                        "get_session: keychain read raised unexpected %s"
+                        " for service=%s: %s",
+                        type(exc).__name__,
+                        service,
+                        exc,
+                    )
+                    break
+            else:
+                logger.warning(
+                    "get_session: keychain still locked after %d retries for"
+                    " service=%s; credentials may appear missing until the"
+                    " keychain unlocks",
                     _MAX_RETRIES,
-                    delay,
-                    exc,
-                )
-                _time.sleep(delay)
-            except keyring.errors.KeyringError as exc:
-                logger.warning(
-                    "get_session: keychain read failed for service=%s (%s: %s)",
                     service,
-                    type(exc).__name__,
-                    exc,
                 )
-                break
-            except Exception as exc:
-                # Backend may raise OSError/RuntimeError outside the keyring
-                # exception hierarchy (e.g. ctypes failures from WinVaultKeyring).
-                # Fall through to the DB row instead of letting it propagate.
-                logger.warning(
-                    "get_session: keychain read raised unexpected %s for service=%s: %s",
-                    type(exc).__name__,
-                    service,
-                    exc,
-                )
-                break
-        else:
-            logger.warning(
-                "get_session: keychain still locked after %d retries for service=%s;"
-                " credentials may appear missing until the keychain unlocks",
-                _MAX_RETRIES,
-                service,
-            )
 
         # --- DB fallback -------------------------------------
         row = self._conn.execute(
@@ -710,7 +722,9 @@ class LibraryIndex:
                     type(exc).__name__,
                     exc,
                 )
-        else:
+        elif _win_cred is None:
+            # Windows skips this branch — DPAPI-wrapped DB row is the
+            # storage path there (see KAMP-280).
             try:
                 keyring.set_password("kamp", service, payload)
                 verified = keyring.get_password("kamp", service)
@@ -779,7 +793,9 @@ class LibraryIndex:
                     type(exc).__name__,
                     exc,
                 )
-        else:
+        elif _win_cred is None:
+            # Windows skips OS keyring entirely (see KAMP-280); the DELETE
+            # below removes the DPAPI-wrapped row.
             try:
                 keyring.delete_password("kamp", service)
             except (keyring.errors.NoKeyringError, keyring.errors.PasswordDeleteError):

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import logging
 import threading as _threading
 import uuid as _uuid
 from collections.abc import Callable
@@ -25,6 +26,8 @@ from urllib.parse import urlparse
 from fastapi import FastAPI, HTTPException, Request, Response, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 from kamp_core.library import LibraryIndex, LibraryScanner, Track, extract_art
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
@@ -774,6 +777,15 @@ def create_app(
         try:
             on_bandcamp_login_complete({"cookies": req.cookies, "origins": req.origins})
         except Exception as exc:
+            # Redacted payload summary — names only, never cookie values, so we
+            # can diagnose Windows-vs-macOS shape divergence without leaking the
+            # session.  See KAMP-282.
+            cookie_names = [str(c.get("name", "<noname>")) for c in req.cookies]
+            logger.exception(
+                "bandcamp login-complete callback failed: cookie_names=%s origins_count=%d",
+                cookie_names,
+                len(req.origins),
+            )
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         # Read username back from session (populated by the callback when
         # the API call succeeds) and surface it in the config state.

--- a/kamp_core/win_credential.py
+++ b/kamp_core/win_credential.py
@@ -1,0 +1,168 @@
+"""Windows DPAPI wrapper for credential storage.
+
+Windows Credential Manager (the keyring ``WinVaultKeyring`` backend) caps
+each credential at 2560 bytes (``CRED_MAX_CREDENTIAL_BLOB_SIZE`` =
+``5 * 512``).  The Bandcamp session blob — full cookie jar plus username
+and metadata — easily exceeds this, and ``CredWrite`` fails with
+``OSError(1783, 'CredWrite', 'The stub received bad data.')`` (KAMP-282).
+
+DPAPI (``CryptProtectData`` / ``CryptUnprotectData``) has no size limit
+and ties the encryption key to the current Windows user account, so the
+resulting ciphertext can sit safely in the SQLite ``sessions`` table
+even though the column is on disk in plaintext-readable form (KAMP-280
+AC #3).
+
+Public API:
+    protect(plaintext: bytes) -> bytes      # raw encrypt
+    unprotect(ciphertext: bytes) -> bytes   # raw decrypt
+    protect_str(plaintext: str) -> str      # UTF-8 + base64 + DPAPI prefix
+    unprotect_str(text: str) -> str | None  # None when input is not DPAPI
+
+The string variants prefix the ciphertext with ``DPAPI_PREFIX`` so
+callers can distinguish encrypted blobs from legacy plaintext payloads
+without out-of-band metadata.
+
+This module is Windows-only.  Importers must guard with ``sys.platform``.
+"""
+
+from __future__ import annotations
+
+import base64
+import ctypes
+import sys
+from ctypes import wintypes
+from typing import Final
+
+if sys.platform != "win32":
+    raise ImportError("kamp_core.win_credential is Windows-only")
+
+
+DPAPI_PREFIX: Final[str] = "dpapi-v1:"
+
+
+class _DataBlob(ctypes.Structure):
+    _fields_ = (
+        ("cbData", wintypes.DWORD),
+        ("pbData", ctypes.POINTER(ctypes.c_byte)),
+    )
+
+
+class DPAPIError(OSError):
+    """Raised when a DPAPI operation fails."""
+
+
+_crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+_kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+_CryptProtectData = _crypt32.CryptProtectData
+_CryptProtectData.argtypes = (
+    ctypes.POINTER(_DataBlob),  # pDataIn
+    wintypes.LPCWSTR,  # szDataDescr
+    ctypes.POINTER(_DataBlob),  # pOptionalEntropy
+    ctypes.c_void_p,  # pvReserved
+    ctypes.c_void_p,  # pPromptStruct
+    wintypes.DWORD,  # dwFlags
+    ctypes.POINTER(_DataBlob),  # pDataOut
+)
+_CryptProtectData.restype = wintypes.BOOL
+
+_CryptUnprotectData = _crypt32.CryptUnprotectData
+_CryptUnprotectData.argtypes = (
+    ctypes.POINTER(_DataBlob),
+    ctypes.POINTER(wintypes.LPWSTR),  # ppszDataDescr
+    ctypes.POINTER(_DataBlob),
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    wintypes.DWORD,
+    ctypes.POINTER(_DataBlob),
+)
+_CryptUnprotectData.restype = wintypes.BOOL
+
+_LocalFree = _kernel32.LocalFree
+_LocalFree.argtypes = (ctypes.c_void_p,)
+_LocalFree.restype = ctypes.c_void_p
+
+
+def _to_blob(data: bytes) -> _DataBlob:
+    buf = (ctypes.c_byte * len(data))(*data)
+    return _DataBlob(len(data), ctypes.cast(buf, ctypes.POINTER(ctypes.c_byte)))
+
+
+def _from_blob(blob: _DataBlob) -> bytes:
+    out = ctypes.string_at(blob.pbData, blob.cbData)
+    # CryptProtectData / CryptUnprotectData allocate pbData with LocalAlloc;
+    # the docs require LocalFree to release it.  Without this we leak the
+    # ciphertext (or plaintext) buffer for the lifetime of the process.
+    _LocalFree(blob.pbData)
+    return out
+
+
+def protect(plaintext: bytes) -> bytes:
+    """Encrypt *plaintext* with DPAPI under the current Windows user.
+
+    Raises :class:`DPAPIError` (an :class:`OSError` subclass) on failure.
+    """
+    in_blob = _to_blob(plaintext)
+    out_blob = _DataBlob()
+    if not _CryptProtectData(
+        ctypes.byref(in_blob),
+        None,
+        None,
+        None,
+        None,
+        0,
+        ctypes.byref(out_blob),
+    ):
+        err = ctypes.get_last_error()
+        raise DPAPIError(err, f"CryptProtectData failed (Win32 {err})")
+    return _from_blob(out_blob)
+
+
+def unprotect(ciphertext: bytes) -> bytes:
+    """Decrypt DPAPI ciphertext produced by :func:`protect`.
+
+    Raises :class:`DPAPIError` on failure (e.g. tampered ciphertext or
+    a different Windows user account).
+    """
+    in_blob = _to_blob(ciphertext)
+    out_blob = _DataBlob()
+    if not _CryptUnprotectData(
+        ctypes.byref(in_blob),
+        None,
+        None,
+        None,
+        None,
+        0,
+        ctypes.byref(out_blob),
+    ):
+        err = ctypes.get_last_error()
+        raise DPAPIError(err, f"CryptUnprotectData failed (Win32 {err})")
+    return _from_blob(out_blob)
+
+
+def protect_str(plaintext: str) -> str:
+    """UTF-8 encode + DPAPI-encrypt + base64; result is opaque ASCII text.
+
+    The returned string starts with :data:`DPAPI_PREFIX` so callers can
+    detect DPAPI-wrapped payloads without out-of-band metadata.
+    """
+    cipher = protect(plaintext.encode("utf-8"))
+    return DPAPI_PREFIX + base64.b64encode(cipher).decode("ascii")
+
+
+def unprotect_str(text: str) -> str | None:
+    """Inverse of :func:`protect_str`.
+
+    Returns ``None`` when *text* does not start with :data:`DPAPI_PREFIX`,
+    so callers can transparently handle legacy plaintext rows that
+    pre-date the DPAPI rollout.
+    """
+    if not text.startswith(DPAPI_PREFIX):
+        return None
+    cipher = base64.b64decode(text[len(DPAPI_PREFIX) :])
+    return unprotect(cipher).decode("utf-8")
+
+
+def is_dpapi_blob(text: str) -> bool:
+    """Return True when *text* looks like a value produced by :func:`protect_str`."""
+    return text.startswith(DPAPI_PREFIX)

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -573,6 +573,16 @@ def _cmd_daemon(
         install_path,
     )
 
+    # Surface the active credential backend so platform-specific failures
+    # (e.g. WinVaultKeyring vs fail.Keyring on Windows) are visible in logs.
+    # See KAMP-280 / KAMP-282.
+    try:
+        import keyring as _keyring
+
+        _logger.info("keyring backend: %s", _keyring.get_keyring().__class__.__name__)
+    except Exception as _exc:
+        _logger.warning("keyring backend unavailable: %s", _exc)
+
     # --- HTTP server component initialisation (formerly _cmd_server) ---
 
     _raw_lib = library_path or config.paths.library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ omit = [
     "kamp_daemon/ext/sandbox/_linux.py",
     # macOS-only module; raises ImportError on Linux so tests are skipped there.
     "kamp_core/macos_keychain.py",
+    # Windows-only module (DPAPI ctypes wrapper); raises ImportError on Linux
+    # and macOS so the body is never executed in CI.  Real coverage comes
+    # from tests/test_win_credential.py on Windows runners.
+    "kamp_core/win_credential.py",
 ]
 
 [tool.coverage.report]

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2360,6 +2360,77 @@ class TestSessionManagementKeyringErrors:
         index.clear_session("bandcamp")  # must not raise
         index.close()
 
+    def test_set_session_falls_back_to_db_on_unexpected_exception(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """KAMP-282: backends may raise outside the keyring exception hierarchy.
+
+        WinVaultKeyring is ctypes-based and can surface ``OSError`` (or any
+        platform-specific subclass) directly.  Without the broad ``except``
+        in ``set_session`` such exceptions propagated out and turned the
+        Bandcamp ``login-complete`` handler into a 422.  This test pins the
+        hardened behaviour: an unexpected exception type must not propagate;
+        the credential must land in the DB fallback.
+        """
+        mocker.patch(
+            "kamp_core.library.keyring.set_password",
+            side_effect=OSError("ctypes call failed"),
+        )
+        mocker.patch("kamp_core.library.keyring.get_password", return_value=None)
+        mocker.patch("kamp_core.library.keyring.delete_password")
+
+        index = self._make_index(tmp_path)
+        data = {"cookies": [{"name": "js_logged_in", "value": "1"}]}
+        index.set_session("bandcamp", data)  # must not raise
+
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row is not None
+        assert row["session_json"] is not None
+        index.close()
+
+    def test_get_session_falls_back_to_db_on_unexpected_exception(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Counterpart to set_session: read path must also tolerate OSError etc."""
+        mocker.patch(
+            "kamp_core.library.keyring.get_password",
+            side_effect=OSError("ctypes call failed"),
+        )
+        mocker.patch("kamp_core.library.keyring.set_password")
+        mocker.patch("kamp_core.library.keyring.delete_password")
+        sleep_mock = mocker.patch("kamp_core.library._time.sleep")
+
+        index = self._make_index(tmp_path)
+        # Pre-populate the DB row so the fallback has something to return.
+        index._conn.execute(
+            "INSERT INTO sessions (service, session_json, updated_at)"
+            " VALUES ('bandcamp', ?, 0)",
+            ('{"cookies": []}',),
+        )
+        index._conn.commit()
+        result = index.get_session("bandcamp")
+
+        assert result == {"cookies": []}
+        sleep_mock.assert_not_called()
+        index.close()
+
+    def test_clear_session_does_not_raise_on_unexpected_exception(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """clear_session must swallow OSError and still purge the DB row."""
+        mocker.patch(
+            "kamp_core.library.keyring.delete_password",
+            side_effect=OSError("ctypes call failed"),
+        )
+        mocker.patch("kamp_core.library.keyring.get_password", return_value=None)
+        mocker.patch("kamp_core.library.keyring.set_password")
+
+        index = self._make_index(tmp_path)
+        index.clear_session("bandcamp")  # must not raise
+        index.close()
+
 
 # ---------------------------------------------------------------------------
 # Migration v11 → v12: credentials moved from DB to keychain

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1863,6 +1863,10 @@ class TestSessionManagement:
     def no_keyring(self, mocker: MockerFixture) -> None:
         """Simulate a platform without a keyring backend."""
         mocker.patch("kamp_core.library._mac_kc", None)
+        # Force the Linux/keyring code path even on Windows runners (where
+        # _win_cred is otherwise the real DPAPI module and would short-circuit
+        # the keyring branch entirely).  See KAMP-280.
+        mocker.patch("kamp_core.library._win_cred", None)
         err = keyring.errors.NoKeyringError()
         mocker.patch("kamp_core.library.keyring.get_password", side_effect=err)
         mocker.patch("kamp_core.library.keyring.set_password", side_effect=err)
@@ -2127,6 +2131,8 @@ class TestSessionManagementKeyring:
     def mock_keyring(self, mocker: MockerFixture) -> dict[str, str]:
         """In-memory keyring store; returns the backing dict for inspection."""
         mocker.patch("kamp_core.library._mac_kc", None)
+        # Force Linux/keyring path on Windows runners (KAMP-280).
+        mocker.patch("kamp_core.library._win_cred", None)
         store: dict[str, str] = {}
 
         def _set(app: str, service: str, value: str) -> None:
@@ -2212,6 +2218,8 @@ class TestSessionManagementKeyringErrors:
     def force_keyring_path(self, mocker: MockerFixture) -> None:
         """Disable the macOS Data Protection Keychain so these tests exercise keyring."""
         mocker.patch("kamp_core.library._mac_kc", None)
+        # Force Linux/keyring path on Windows runners (KAMP-280).
+        mocker.patch("kamp_core.library._win_cred", None)
 
     def _make_index(self, tmp_path: Path) -> "LibraryIndex":
         return LibraryIndex(tmp_path / "library.db")
@@ -2569,6 +2577,48 @@ class TestSessionManagementWindowsDPAPI:
         assert row["session_json"] is not None
         index.close()
 
+    def test_set_session_does_not_call_keyring_on_windows(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """KAMP-280: when DPAPI is available, skip the OS keyring entirely.
+
+        WinVaultKeyring's 2560-byte size limit means CredWrite will always
+        fail for the Bandcamp blob; calling it just produces a noisy WARNING
+        log line on every login.  With DPAPI available we go straight to
+        the encrypted DB row.
+        """
+        # Reset the keyring mock from the autouse fixture so we can assert
+        # call counts cleanly.
+        mock_set = mocker.patch("kamp_core.library.keyring.set_password")
+        mock_get = mocker.patch(
+            "kamp_core.library.keyring.get_password", return_value=None
+        )
+
+        index = self._make_index(tmp_path)
+        index.set_session("bandcamp", {"cookies": [{"name": "x", "value": "y"}]})
+
+        mock_set.assert_not_called()
+        mock_get.assert_not_called()
+        index.close()
+
+    def test_clear_session_does_not_call_keyring_on_windows(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """clear_session also skips OS keyring when DPAPI is available."""
+        mock_delete = mocker.patch("kamp_core.library.keyring.delete_password")
+
+        index = self._make_index(tmp_path)
+        index.set_session("bandcamp", {"cookies": []})
+        index.clear_session("bandcamp")
+
+        mock_delete.assert_not_called()
+        # And the DB row is gone.
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row is None
+        index.close()
+
 
 # ---------------------------------------------------------------------------
 # Migration v12 → v13: encrypt residual plaintext rows on Windows
@@ -2698,6 +2748,8 @@ class TestMigrationV11ToV12:
     def force_keyring_path(self, mocker: MockerFixture) -> None:
         """Disable the macOS Data Protection Keychain so v11→v12 migration uses keyring."""
         mocker.patch("kamp_core.library._mac_kc", None)
+        # Force Linux/keyring path on Windows runners (KAMP-280).
+        mocker.patch("kamp_core.library._win_cred", None)
 
     def _build_v11_db(self, db_path: Path) -> None:
         """Create a v11 database with a sessions row containing plaintext JSON."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -128,7 +128,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 12
+        assert version == 13
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1134,7 +1134,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 12
+        assert version == 13
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1191,7 +1191,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 12
+        assert version == 13
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1550,7 +1550,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 12
+        assert version == 13
         assert row is not None
         assert row[0] == 0
 
@@ -1663,7 +1663,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 12
+        assert version == 13
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -1844,7 +1844,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 12
+        assert version == 13
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -1935,7 +1935,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 12
+        assert version == 13
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -1943,7 +1943,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 12
+        assert version == 13
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -2433,6 +2433,262 @@ class TestSessionManagementKeyringErrors:
 
 
 # ---------------------------------------------------------------------------
+# Session management — Windows DPAPI wrapping of the DB fallback
+# ---------------------------------------------------------------------------
+
+
+class _FakeDPAPI:
+    """In-memory stand-in for kamp_core.win_credential.
+
+    Lets tests exercise the DPAPI code path on macOS / Linux runners
+    without depending on the real Win32 API.  The "ciphertext" is just
+    the prefix + base64 of the plaintext bytes — opaque enough to
+    distinguish from the original JSON, simple enough to verify by eye
+    in test failures.
+    """
+
+    DPAPI_PREFIX = "dpapi-v1:"
+
+    @staticmethod
+    def _encode(s: str) -> str:
+        import base64
+
+        return _FakeDPAPI.DPAPI_PREFIX + base64.b64encode(s.encode("utf-8")).decode(
+            "ascii"
+        )
+
+    @staticmethod
+    def _decode(s: str) -> str:
+        import base64
+
+        return base64.b64decode(s[len(_FakeDPAPI.DPAPI_PREFIX) :]).decode("utf-8")
+
+    def protect_str(self, plaintext: str) -> str:
+        return self._encode(plaintext)
+
+    def unprotect_str(self, text: str) -> str | None:
+        if not text.startswith(self.DPAPI_PREFIX):
+            return None
+        return self._decode(text)
+
+    def is_dpapi_blob(self, text: str) -> bool:
+        return text.startswith(self.DPAPI_PREFIX)
+
+
+class TestSessionManagementWindowsDPAPI:
+    """Tests the DPAPI wrap/unwrap path used by the Windows DB fallback.
+
+    Uses :class:`_FakeDPAPI` so the test runs on every OS — the real
+    ctypes round-trip is covered separately in ``test_win_credential.py``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def force_db_fallback(self, mocker: MockerFixture) -> _FakeDPAPI:
+        """Force the no-keychain DB-fallback path and inject a fake DPAPI."""
+        mocker.patch("kamp_core.library._mac_kc", None)
+        # Pretend keyring has no backend so set_session falls through to DB.
+        mocker.patch(
+            "kamp_core.library.keyring.set_password",
+            side_effect=keyring.errors.NoKeyringError(),
+        )
+        mocker.patch(
+            "kamp_core.library.keyring.get_password",
+            side_effect=keyring.errors.NoKeyringError(),
+        )
+        mocker.patch("kamp_core.library.keyring.delete_password")
+        fake = _FakeDPAPI()
+        mocker.patch("kamp_core.library._win_cred", fake)
+        return fake
+
+    def _make_index(self, tmp_path: Path) -> LibraryIndex:
+        return LibraryIndex(tmp_path / "library.db")
+
+    def test_set_session_writes_dpapi_wrapped_to_db(self, tmp_path: Path) -> None:
+        """KAMP-280 AC #3: sessions DB row is opaque ciphertext, not plaintext JSON."""
+        index = self._make_index(tmp_path)
+        data = {"cookies": [{"name": "session", "value": "secret-cookie-value"}]}
+        index.set_session("bandcamp", data)
+
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row is not None
+        stored = row["session_json"]
+        assert stored is not None
+        assert stored.startswith(
+            _FakeDPAPI.DPAPI_PREFIX
+        ), "DB row should be DPAPI-wrapped, not plaintext"
+        assert (
+            "secret-cookie-value" not in stored
+        ), "raw cookie value must not appear anywhere in the stored row"
+        index.close()
+
+    def test_get_session_unwraps_dpapi_row(self, tmp_path: Path) -> None:
+        """Round-trip: write encrypted, read decrypted."""
+        index = self._make_index(tmp_path)
+        data = {"cookies": [{"name": "session", "value": "v"}], "username": "alice"}
+        index.set_session("bandcamp", data)
+
+        assert index.get_session("bandcamp") == data
+        index.close()
+
+    def test_get_session_handles_legacy_plaintext_row(self, tmp_path: Path) -> None:
+        """Pre-DPAPI installs may still have plaintext rows; reading them must work."""
+        import json as _json
+
+        index = self._make_index(tmp_path)
+        # Bypass set_session and write a legacy plaintext row directly.
+        index._conn.execute(
+            "INSERT INTO sessions (service, session_json, updated_at)"
+            " VALUES (?, ?, ?)",
+            ("bandcamp", _json.dumps({"cookies": []}), 1.0),
+        )
+        index._conn.commit()
+
+        assert index.get_session("bandcamp") == {"cookies": []}
+        index.close()
+
+    def test_set_session_falls_back_to_plaintext_when_dpapi_raises(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """A DPAPI failure must not block writing — a session row beats no row."""
+        mocker.patch(
+            "kamp_core.library._win_cred.protect_str",
+            side_effect=OSError("CryptProtectData failed"),
+        )
+
+        index = self._make_index(tmp_path)
+        data = {"cookies": [{"name": "x", "value": "y"}]}
+        index.set_session("bandcamp", data)  # must not raise
+
+        # Even on DPAPI failure, the row should still be present (plaintext).
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row is not None
+        assert row["session_json"] is not None
+        index.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration v12 → v13: encrypt residual plaintext rows on Windows
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV12ToV13:
+    """v12 left rows in the DB on Windows when keyring couldn't store them.
+
+    v13 wraps any such residual plaintext rows with DPAPI on first
+    open, so the on-disk credential is no longer readable as plaintext
+    (KAMP-280 AC #3).  Cross-platform — we mock both keyring and DPAPI.
+    """
+
+    @pytest.fixture(autouse=True)
+    def force_db_fallback(self, mocker: MockerFixture) -> _FakeDPAPI:
+        mocker.patch("kamp_core.library._mac_kc", None)
+        mocker.patch(
+            "kamp_core.library.keyring.set_password",
+            side_effect=keyring.errors.NoKeyringError(),
+        )
+        mocker.patch(
+            "kamp_core.library.keyring.get_password",
+            side_effect=keyring.errors.NoKeyringError(),
+        )
+        mocker.patch("kamp_core.library.keyring.delete_password")
+        fake = _FakeDPAPI()
+        mocker.patch("kamp_core.library._win_cred", fake)
+        return fake
+
+    def _build_v12_db(self, db_path: Path) -> None:
+        """Create a v12 database with a plaintext sessions row (the Windows shape)."""
+        import json as _json
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (12)")
+        conn.execute("""
+            CREATE TABLE sessions (
+                service      TEXT NOT NULL PRIMARY KEY,
+                session_json TEXT,
+                updated_at   REAL NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE settings (
+                key   TEXT NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        """)
+        conn.execute(
+            "INSERT INTO sessions (service, session_json, updated_at) VALUES (?, ?, ?)",
+            ("bandcamp", _json.dumps({"cookies": [{"name": "x"}]}), 1.0),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_migration_wraps_plaintext_row_with_dpapi(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v12_db(db_path)
+
+        index = LibraryIndex(db_path)
+
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        assert row["session_json"] is not None
+        assert row["session_json"].startswith(
+            _FakeDPAPI.DPAPI_PREFIX
+        ), "v13 migration should have wrapped the plaintext row"
+        # And the round-trip still works through get_session.
+        assert index.get_session("bandcamp") == {"cookies": [{"name": "x"}]}
+        index.close()
+
+    def test_migration_skips_already_wrapped_rows(self, tmp_path: Path) -> None:
+        """If a row is already DPAPI-wrapped (paranoia), don't double-wrap."""
+        import json as _json
+
+        db_path = tmp_path / "library.db"
+        # Build a v12 DB with an already-wrapped row (simulating a partial
+        # prior migration or a manual repair).
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (12)")
+        conn.execute("""
+            CREATE TABLE sessions (
+                service      TEXT NOT NULL PRIMARY KEY,
+                session_json TEXT,
+                updated_at   REAL NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE settings (
+                key   TEXT NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        """)
+        already_wrapped = _FakeDPAPI().protect_str(_json.dumps({"cookies": []}))
+        conn.execute(
+            "INSERT INTO sessions (service, session_json, updated_at) VALUES (?, ?, ?)",
+            ("bandcamp", already_wrapped, 1.0),
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+
+        row = index._conn.execute(
+            "SELECT session_json FROM sessions WHERE service = 'bandcamp'"
+        ).fetchone()
+        # Still a single DPAPI prefix — not wrapped twice.
+        assert row["session_json"] == already_wrapped
+        index.close()
+
+
+# ---------------------------------------------------------------------------
 # Migration v11 → v12: credentials moved from DB to keychain
 # ---------------------------------------------------------------------------
 
@@ -2514,7 +2770,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 12
+        assert version == 13
 
         index.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1879,6 +1879,85 @@ class TestBandcampStatus:
         assert data["bandcamp.connected"] is True
         assert data["bandcamp.username"] == "johndoe"
 
+    def test_login_complete_accepts_full_electron_cookie_shape(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Regression for KAMP-282: the full Electron payload shape must validate.
+
+        The renderer (`kamp_ui/src/main/index.ts`) sends every field Chromium's
+        cookie store returns — including a float `expires`, capitalised
+        `sameSite`, and `httpOnly`/`secure` booleans.  The Pydantic model is
+        permissive (`list[dict[str, Any]]`) and the handler must accept it.
+        """
+        cookies = [
+            {
+                "name": "session",
+                "value": "abc123",
+                "domain": ".bandcamp.com",
+                "path": "/",
+                "expires": 1893456000.123,  # float, not int
+                "httpOnly": True,
+                "secure": True,
+                "sameSite": "Lax",
+            },
+            {
+                "name": "js_logged_in",
+                "value": "1",
+                "domain": ".bandcamp.com",
+                "path": "/",
+                "expires": -1,  # session cookie
+                "httpOnly": False,
+                "secure": False,
+                "sameSite": "Lax",
+            },
+        ]
+        captured: dict[str, Any] = {}
+
+        def _capture(payload: dict[str, Any]) -> None:
+            captured["payload"] = payload
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values={"bandcamp.connected": False, "bandcamp.username": None},
+            on_bandcamp_login_complete=_capture,
+        )
+        c = TestClient(app)
+        resp = c.post(
+            "/api/v1/bandcamp/login-complete",
+            json={"cookies": cookies, "origins": []},
+        )
+        assert resp.status_code == 200, resp.text
+        assert captured["payload"]["cookies"] == cookies
+
+    def test_login_complete_returns_422_when_callback_raises(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Callback exceptions surface as 422 with the message in `detail`.
+
+        Documents the contract instrumented for KAMP-282 — the handler must
+        log the traceback (verified by capturing logs) but still return 422
+        with the exception message so the renderer can show it.
+        """
+
+        def _boom(payload: dict[str, Any]) -> None:
+            raise RuntimeError("simulated keyring backend failure")
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_bandcamp_login_complete=_boom,
+        )
+        c = TestClient(app)
+        resp = c.post(
+            "/api/v1/bandcamp/login-complete",
+            json={"cookies": [{"name": "x", "value": "y"}], "origins": []},
+        )
+        assert resp.status_code == 422
+        assert "simulated keyring backend failure" in resp.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # Bandcamp manual sync endpoint

--- a/tests/test_win_credential.py
+++ b/tests/test_win_credential.py
@@ -1,0 +1,68 @@
+"""Windows-only tests for the DPAPI wrapper.
+
+These hit the real ``CryptProtectData`` / ``CryptUnprotectData`` APIs.
+On a non-Windows runner the module import fails and the entire file is
+skipped via ``pytest.importorskip`` (mirrors ``tests/test_macos_keychain.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skips the entire module on non-Windows before any ctypes calls happen.
+win_credential = pytest.importorskip(
+    "kamp_core.win_credential",
+    reason="win_credential is Windows-only",
+    exc_type=ImportError,
+)
+
+
+class TestProtectUnprotectRoundtrip:
+    def test_short_payload_roundtrips(self) -> None:
+        cipher = win_credential.protect(b"hello")
+        assert cipher != b"hello"  # actually encrypted
+        assert win_credential.unprotect(cipher) == b"hello"
+
+    def test_large_payload_roundtrips(self) -> None:
+        # The whole point of DPAPI: blobs much larger than CredWrite's
+        # 2560-byte ceiling.  This mimics a real Bandcamp session JSON
+        # (cookies + flags) which is the regression KAMP-280 / KAMP-282
+        # exists to fix.
+        payload = b"x" * 8192
+        cipher = win_credential.protect(payload)
+        assert win_credential.unprotect(cipher) == payload
+
+    def test_unprotect_rejects_tampered_ciphertext(self) -> None:
+        cipher = bytearray(win_credential.protect(b"hello"))
+        cipher[-1] ^= 0xFF  # flip a bit in the trailing MAC
+        with pytest.raises(win_credential.DPAPIError):
+            win_credential.unprotect(bytes(cipher))
+
+
+class TestStringHelpers:
+    def test_protect_str_prefixes_with_marker(self) -> None:
+        wrapped = win_credential.protect_str('{"cookies":[]}')
+        assert wrapped.startswith(win_credential.DPAPI_PREFIX)
+        # Body after the marker is base64 — only ASCII safe chars.
+        body = wrapped[len(win_credential.DPAPI_PREFIX) :]
+        assert body.isascii()
+
+    def test_protect_str_unprotect_str_roundtrips_unicode(self) -> None:
+        plaintext = '{"username":"tedd-é-terry","cookies":["✓"]}'
+        wrapped = win_credential.protect_str(plaintext)
+        assert win_credential.unprotect_str(wrapped) == plaintext
+
+    def test_unprotect_str_returns_none_for_legacy_plaintext(self) -> None:
+        # Pre-DPAPI rows in the sessions table look like JSON.  The helper
+        # must report "not DPAPI" so callers can fall back to treating
+        # the value as plaintext rather than raising.
+        assert win_credential.unprotect_str('{"cookies": []}') is None
+
+    def test_unprotect_str_returns_none_for_empty_string(self) -> None:
+        assert win_credential.unprotect_str("") is None
+
+    def test_is_dpapi_blob_true_for_protected(self) -> None:
+        assert win_credential.is_dpapi_blob(win_credential.protect_str("x"))
+
+    def test_is_dpapi_blob_false_for_plaintext(self) -> None:
+        assert not win_credential.is_dpapi_blob('{"cookies": []}')


### PR DESCRIPTION
## Summary

Two related Windows bugs from the KAMP-281 dev-bootstrap shakedown:

- **KAMP-282** — `POST /api/v1/bandcamp/login-complete` returned 422 on Windows. The 422 was not a Pydantic shape mismatch (the model is `list[dict[str, Any]]`); the handler caught any callback exception and re-raised it as 422 with the message in `detail`, but logged nothing. Adding `logger.exception()` revealed the root cause: `WinVaultKeyring.set_password` raised `OSError(1783, 'CredWrite', 'The stub received bad data.')` — Win32 `RPC_S_INVALID_TAG`, which for `CredWrite` means the credential blob exceeds `CRED_MAX_CREDENTIAL_BLOB_SIZE` (2560 bytes). The Bandcamp session JSON easily exceeds that. The non-mac branches of `set_session`/`get_session`/`clear_session` only caught `KeyringError`, so the `OSError` bubbled out of the FastAPI callback.
- **KAMP-280** — Windows credential storage AC #3 (no plaintext on disk) was unmet because the existing fallback wrote the session JSON into the `sessions.session_json` SQLite column verbatim. Anyone with read access to `%LOCALAPPDATA%\kamp\library.db` could read the cookies.

Both are fixed in three commits, each landing one logical step:

1. `c264fae` — instrument the 422 handler with `logger.exception()`, log the active keyring backend at daemon startup, and broaden the non-mac `set_session`/`get_session`/`clear_session` exception handlers from `KeyringError` to `Exception`. Login no longer 422s; root cause becomes visible from logs alone.
2. `b3a9544` — add `kamp_core/win_credential.py` (DPAPI ctypes wrapper, mirrors `macos_keychain.py`), wire it into the `library.py` DB-fallback writes/reads, and add a `v12 → v13` schema migration that wraps any plaintext rows already on disk. Pure ctypes, no new dependency. Per-user encryption: a copy of `library.db` on another machine or under another Windows account cannot decrypt the credentials.
3. `268a698` — skip the OS keyring entirely on Windows now that DPAPI is the storage path. Eliminates a wasted `CredWrite` per login and the noisy WARNING that came with it.

## Files

| File | Change |
| --- | --- |
| `kamp_core/win_credential.py` | New — DPAPI `protect`/`unprotect` + base64-prefixed string helpers, Windows-only import guard. |
| `kamp_core/library.py` | DPAPI wrap in DB writes / unwrap in DB reads, skip-keyring-on-Windows branches in set/get/clear_session, broadened exception handlers, defensive widening of the v11→v12 migration, new v12→v13 migration. |
| `kamp_core/server.py` | `logger.exception()` + redacted cookie-name list in the `bandcamp_login_complete` 422 path. |
| `kamp_daemon/__main__.py` | One INFO line at startup: active keyring backend class name. |
| `tests/test_win_credential.py` | New — Windows-only ctypes round-trip tests, including 8 KiB blob and tamper detection. |
| `tests/test_library.py` | New `TestSessionManagementWindowsDPAPI` and `TestMigrationV12ToV13` classes (cross-platform via fake DPAPI module); existing keyring-path fixtures patch `_win_cred = None` so they still exercise the keyring branch on Windows runners; schema-version asserts bumped 12 → 13. |
| `tests/test_server.py` | Two regressions: full Electron cookie shape returns 200, callback exceptions surface as 422 with the expected `detail`. |
| `README.md` | Credential-storage table — DPC on macOS, libsecret/etc on Linux, DPAPI on Windows. |
| `CLAUDE.md` | Lessons Learned: WinVault 2560-byte limit, `OSError`-outside-the-keyring-hierarchy gotcha, DPAPI workaround, "do not add `pywin32`" note. |

## Test plan

- [x] `poetry run pytest tests/ --no-cov` — 336 passed, 2 skipped (mac-only)
- [x] `poetry run black --check kamp_core kamp_daemon tests` clean
- [x] `poetry run mypy kamp_core kamp_daemon` clean
- [x] Manual on Windows 11 dev: drove onboarding → Bandcamp login → completed without 422; daemon log shows the username extracted and stored
- [x] Manual on Windows 11 dev: confirmed `sessions.session_json` row starts with `dpapi-v1:` (opaque ciphertext, not plaintext JSON)
- [x] Manual on Windows 11 dev: after the skip-keyring refactor, login no longer emits the `set_session: keychain write raised unexpected error` WARNING
- [x] Restart daemon on Windows, hit `GET /api/v1/bandcamp/status`, verify `connected: true` (DPAPI unwrap on read)
- [x] macOS dev regression: drive the same login flow, verify DPC path still works (no DPAPI involvement, `_win_cred is None`)

## Out of scope / follow-ups

- **KAMP-290** — sync not working on Windows (filed separately).
- The `v11 → v12` migration already shipped; this PR just widens its exception handler so existing Windows installs hitting the same `CredWrite` failure during initial migration don't crash the daemon. Migrations remain forward-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)