### PR TITLE
fix(windows): Bandcamp sync via Electron proxy in dev (KAMP-290)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -70,10 +70,17 @@ If the same sub-problem fails twice in a row, stop and check in before attemptin
 
 **Concrete example (TASK-9 media keys):** next/prev media keys failed six times across multiple sessions because each attempt looked like a fixable bug. The real constraint — `MPRemoteCommandCenter` requires a CFRunLoop on the main thread; asyncio/uvicorn does not run one — was architectural and unfixable by implementation tweaks. Stopping after the second failure, diagnosing the root cause, and creating a task would have saved a full week of token spend. When a sub-problem fails twice: write up what was tried, name the constraint, create a backlog task, and move on.
 
-## Cloudflare TLS fingerprinting in the built app
-PyInstaller bundles its own OpenSSL, which has a different JA3/JA4 TLS fingerprint than a real browser. Cloudflare detects this and serves JS challenge pages (HTTP 200, ~3 KB HTML) instead of the expected response — **even for authenticated JSON API endpoints**, not just HTML page loads. This only manifests in the built `.app`; in dev the system Python uses macOS SecureTransport or a different OpenSSL version that Cloudflare doesn't flag.
+## Cloudflare TLS fingerprinting
+PyInstaller bundles its own OpenSSL, which has a different JA3/JA4 TLS fingerprint than a real browser. Cloudflare detects this and serves JS challenge pages (HTTP 200, ~3 KB HTML body starting with `<!DOCTYPE html>` and a path under `/_fs-ch-...`) instead of the expected response — **even for authenticated JSON API endpoints**, not just HTML page loads.
 
-The only reliable fix for any `bandcamp.com` request in the built app is to route it through Electron's `net` module (Chromium's network stack), which has a real browser TLS fingerprint and already holds the `cf_clearance` cookie. See TASK-127. Do not attempt to fix this by changing User-Agent, tweaking cipher suites, or using a different requests library — the check is at the TLS layer before HTTP headers are read.
+The set of environments that trigger the challenge is broader than originally believed:
+
+- **PyInstaller bundle on any OS** — always affected (KAMP-127).
+- **Windows dev** — also affected (KAMP-290). The Python 3.11 `.venv` on Windows links against a Python-bundled OpenSSL whose fingerprint Cloudflare flags, just like the PyInstaller version.
+- **macOS dev** — not affected. The system Python on macOS uses SecureTransport / LibreSSL, which Cloudflare accepts.
+- **Linux dev** — not affected (at the time of writing; system OpenSSL is generally OK).
+
+The only reliable fix for any `bandcamp.com` request in an affected environment is to route through Electron's `net` module (Chromium's network stack), which has a real browser TLS fingerprint and pulls fresh cookies from the daemon on every call. The gate in `kamp_daemon/bandcamp.py::_needs_proxy_session` is `_is_frozen() or sys.platform == "win32"`. Do not attempt to fix this by changing User-Agent, tweaking cipher suites, or using a different requests library — the check is at the TLS layer before HTTP headers are read.
 
 ## Data Protection Keychain and PyInstaller binaries
 `keychain-access-groups` in a hardened-runtime entitlements file causes macOS to SIGKILL the binary at exec time (before dyld runs) when the binary has no bound `Info.plist` (`Info.plist=not bound` in `codesign -d`). PyInstaller onedir executables are standalone Mach-O files — they have no bundle identity, so macOS cannot validate the entitlement. The binary dies with `EXC_CRASH (SIGKILL - Code Signature Invalid)` and `codeSigningID: ""` in the crash report, even though `codesign --verify` says "valid on disk". Do not add `keychain-access-groups` to standalone (non-bundle) binary entitlements. DPC requires either a compiled launcher with a bound `Info.plist`, or an `--identifier` and `--entitlements` pair where the identifier matches a real bundle ID registered with the team. The DPC code path in `macos_keychain.py` is correct and will activate automatically once the binary has a proper bundle identity; for now it falls back to Login Keychain on `errSecMissingEntitlement`.

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -79,6 +79,24 @@ def _is_frozen() -> bool:
     return bool(getattr(sys, "frozen", False))
 
 
+def _needs_proxy_session() -> bool:
+    """Return True when bandcamp.com requests must route through Electron.
+
+    Two situations require the proxy:
+
+    * **Bundled app (any OS):** PyInstaller ships its own OpenSSL whose JA3/JA4
+      fingerprint Cloudflare flags as non-browser.  See KAMP-127.
+    * **Windows dev:** the Python 3.11 .venv on Windows links against an
+      OpenSSL build whose fingerprint Cloudflare also flags.  This is **not**
+      hypothetical -- the previous "dev mode is safe" assumption only held on
+      macOS, where dev Python uses the system SecureTransport / LibreSSL.
+      See KAMP-290.
+
+    macOS and Linux dev continue to use a direct ``requests.Session``.
+    """
+    return _is_frozen() or sys.platform == "win32"
+
+
 class _ProxyResponse:
     """Minimal requests.Response lookalike backed by a proxy-fetch result.
 
@@ -344,16 +362,18 @@ def _make_requests_session(
 ) -> Union[_requests.Session, _ProxySession]:
     """Build an HTTP session authenticated with cookies from *session_data*.
 
-    In the PyInstaller bundle (``sys.frozen`` is True), returns a ``_ProxySession``
-    that routes all requests through the local kamp server, which forwards them
-    via Electron's net module (Chromium TLS, real browser fingerprint).  In dev,
-    returns a normal ``requests.Session`` with the cookies loaded directly.
+    Returns a :class:`_ProxySession` (routing through Electron's ``net``
+    module, i.e. Chromium TLS with a real browser fingerprint) when
+    :func:`_needs_proxy_session` reports True -- that covers the
+    PyInstaller bundle on every OS plus Windows dev, where the .venv
+    Python's OpenSSL is also fingerprinted by Cloudflare.  Otherwise
+    returns a plain :class:`requests.Session` with the cookies loaded
+    directly from *session_data*.
     """
-    if _is_frozen():
-        # In the bundled app, Electron's session.defaultSession holds the
-        # Bandcamp cookies (set during the interactive login flow) and
-        # _ProxySession routes requests through Electron's net module which
-        # automatically attaches them.
+    if _needs_proxy_session():
+        # Electron's session.defaultSession does *not* need to be pre-populated
+        # with cookies: the proxy-fetch handler in kamp_ui/src/main/index.ts
+        # pulls them from the daemon's session storage on every call.
         return _ProxySession()
 
     session = _requests.Session()

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytest_mock import MockerFixture
 
 from kamp_daemon.bandcamp import (
     BandcampAPIError,
@@ -835,6 +836,18 @@ class TestNeedsLoginError:
 
 
 class TestMakeRequestsSession:
+    """Direct ``requests.Session`` path — exercised on macOS / Linux dev.
+
+    Force ``sys.platform`` to ``"linux"`` so the path runs identically on
+    every CI runner including Windows (where ``_needs_proxy_session`` would
+    otherwise return ``_ProxySession`` and these assertions about
+    ``session.cookies`` would no longer apply).  See KAMP-290.
+    """
+
+    @pytest.fixture(autouse=True)
+    def force_direct_path(self, mocker: MockerFixture) -> None:
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "linux")
+
     def test_loads_cookies_from_session_data(self) -> None:
         session = _make_requests_session(_make_session_data())
         assert session.cookies.get("js_logged_in", domain=".bandcamp.com") == "1"
@@ -1397,22 +1410,67 @@ class TestIsFrozen:
 
 
 class TestMakeRequestsSessionFrozen:
-    def test_returns_proxy_session_when_frozen(self) -> None:
+    def test_returns_proxy_session_when_frozen(self, mocker: MockerFixture) -> None:
         import sys
 
         from kamp_daemon.bandcamp import _ProxySession, _make_requests_session
 
+        # Pin platform to linux so we are isolating the frozen-only signal.
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "linux")
         with patch.object(sys, "frozen", True, create=True):
             sess = _make_requests_session({"cookies": []})
 
         assert isinstance(sess, _ProxySession)
 
-    def test_returns_requests_session_when_not_frozen(self) -> None:
+    def test_returns_requests_session_when_not_frozen(
+        self, mocker: MockerFixture
+    ) -> None:
         import requests
 
         from kamp_daemon.bandcamp import _make_requests_session
 
+        # Pin platform to linux so this exercises the dev/non-Windows path.
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "linux")
         sess = _make_requests_session({"cookies": []})
+        assert isinstance(sess, requests.Session)
+
+
+class TestMakeRequestsSessionWindowsDev:
+    """KAMP-290: Windows dev must use the proxy too, not bare requests.
+
+    The Python 3.11 .venv on Windows ships an OpenSSL whose JA3/JA4
+    fingerprint Cloudflare flags for ``bandcamp.com``, returning an HTML
+    anti-bot interstitial instead of the JSON API body.  We force the same
+    Electron proxy path used in the bundled app so the request goes out
+    with Chromium's TLS handshake.  Linux / macOS dev are unaffected.
+    """
+
+    def test_windows_dev_returns_proxy_session(self, mocker: MockerFixture) -> None:
+        from kamp_daemon.bandcamp import _ProxySession, _make_requests_session
+
+        # sys.frozen is False (the default for an interpreter); we are only
+        # toggling sys.platform here.  This is the dev-mode signal.
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "win32")
+
+        sess = _make_requests_session(_make_session_data())
+        assert isinstance(sess, _ProxySession)
+
+    def test_macos_dev_returns_direct_session(self, mocker: MockerFixture) -> None:
+        import requests
+
+        from kamp_daemon.bandcamp import _make_requests_session
+
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "darwin")
+        sess = _make_requests_session(_make_session_data())
+        assert isinstance(sess, requests.Session)
+
+    def test_linux_dev_returns_direct_session(self, mocker: MockerFixture) -> None:
+        import requests
+
+        from kamp_daemon.bandcamp import _make_requests_session
+
+        mocker.patch("kamp_daemon.bandcamp.sys.platform", "linux")
+        sess = _make_requests_session(_make_session_data())
         assert isinstance(sess, requests.Session)
 
 


### PR DESCRIPTION
## Summary

KAMP-290: Bandcamp sync on Windows fails with `_get_fan_info: JSON decode failed — status=200 response_head='<!DOCTYPE html>...'`. The HTML body is a **Cloudflare anti-bot interstitial** (path prefix `/_fs-ch-...`, single-inline-script CSP) — Cloudflare flagged the TLS handshake and served a challenge page instead of the JSON API response.

This is the same fingerprinting failure CLAUDE.md documented for the **built app**, but the lesson assumed dev mode was always safe ("the system Python uses macOS SecureTransport or a different OpenSSL version that Cloudflare doesn't flag"). That assumption only held on macOS dev. The Python 3.11 `.venv` on Windows links against an OpenSSL whose JA3/JA4 fingerprint Cloudflare flags identically to PyInstaller's.

## Fix

Widen the gate that selects `_ProxySession` (which routes through Electron's `net` module — Chromium TLS) from `_is_frozen()` to `_is_frozen() or sys.platform == "win32"`. Extracted into a named helper `_needs_proxy_session()` for clarity and testability.

| Environment | Session class | Why |
| --- | --- | --- |
| Bundled app, any OS | `_ProxySession` | PyInstaller OpenSSL fingerprint flagged. (Unchanged.) |
| **Windows dev** | **`_ProxySession`** | **`.venv` OpenSSL fingerprint also flagged. (New.)** |
| macOS dev | `requests.Session` | System SecureTransport / LibreSSL accepted by Cloudflare. (Unchanged.) |
| Linux dev | `requests.Session` | System OpenSSL accepted. (Unchanged.) |

The Electron-side proxy handler at [kamp_ui/src/main/index.ts:643](kamp_ui/src/main/index.ts#L643) is already self-sufficient: it pulls fresh cookies from `/api/v1/bandcamp/session-cookies` and sets them in `session.defaultSession` before each `net.fetch`. So Windows dev needs zero JS-side changes — the same handler works.

## Files

| File | Change |
| --- | --- |
| `kamp_daemon/bandcamp.py` | New `_needs_proxy_session()` helper; `_make_requests_session` calls it instead of `_is_frozen()`. |
| `tests/test_bandcamp.py` | New `TestMakeRequestsSessionWindowsDev` (3 tests pinning the gate matrix). Existing `TestMakeRequestsSession` and `TestMakeRequestsSessionFrozen` fixtures pin `sys.platform="linux"` so the direct-request assertions stay valid on Windows runners. Adds `MockerFixture` import. |
| `CLAUDE.md` | Renamed lesson (no longer "in the built app" specifically), explicit affected-environments table, points at the new gate helper. |

## Test plan

- [x] `poetry run pytest tests/test_bandcamp.py -v --no-cov` — 88 passed
- [x] `poetry run pytest --no-cov` — 1220 passed, 35 skipped
- [x] `poetry run black --check kamp_core kamp_daemon tests` clean
- [x] `poetry run mypy kamp_core kamp_daemon` clean
- [x] Manual on Windows 11 dev: Electron app running → click Sync in the UI → daemon log shows a successful JSON parse from `_get_fan_info` and the sync proceeds (no more `JSON decode failed — status=200 response_head='<!DOCTYPE html>...'`)
- [ ] macOS dev regression: same Sync flow → confirms the direct `requests.Session` path still works (no `_ProxySession` involvement)

## Known scope limit

Windows dev now **requires** the Electron app to be running for sync to work — a bare `kamp sync` from PowerShell with no UI process has nothing to forward proxy requests to. Same constraint as the bundled app, but worth flagging for anyone running headless tests on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)