### PR TITLE
fix(daemon): suppress album-art access-log noise (KAMP-288)

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -255,17 +255,24 @@ def main() -> None:
         # PIL.TiffImagePlugin emits per-tag DEBUG lines when decoding TIFF/JPEG EXIF
         # data, which floods the log during every artwork embed.
         logging.getLogger("PIL.TiffImagePlugin").setLevel(logging.WARNING)
-        # The Bandcamp proxy relay (proxy-fetch / fetch-result) emits one access log
-        # line per Bandcamp API call, flooding sync logs with internal housekeeping.
-        # These are already visible as daemon log entries; suppress the uvicorn noise.
-        _relay_paths = ("/api/v1/bandcamp/proxy-fetch", "/api/v1/bandcamp/fetch-result")
+        # Suppress uvicorn access-log entries for high-frequency, low-signal routes:
+        #   * Bandcamp proxy relay (proxy-fetch / fetch-result) — one entry per Bandcamp
+        #     API call during sync; already visible as daemon log entries.
+        #   * /api/v1/album-art — the UI renders one <img> request per album on every
+        #     load, which floods the log with hundreds of lines at startup.
+        # Both routes still log at DEBUG; the filter only applies at the default INFO.
+        _quiet_paths = (
+            "/api/v1/bandcamp/proxy-fetch",
+            "/api/v1/bandcamp/fetch-result",
+            "/api/v1/album-art",
+        )
 
-        class _RelayFilter(logging.Filter):
+        class _QuietPathsFilter(logging.Filter):
             def filter(self, record: logging.LogRecord) -> bool:
                 msg = record.getMessage()
-                return not any(p in msg for p in _relay_paths)
+                return not any(p in msg for p in _quiet_paths)
 
-        logging.getLogger("uvicorn.access").addFilter(_RelayFilter())
+        logging.getLogger("uvicorn.access").addFilter(_QuietPathsFilter())
 
     # Default to daemon when no subcommand given
     command = args.command or "daemon"


### PR DESCRIPTION
## Summary
- Adds `/api/v1/album-art` to the existing INFO-level uvicorn access-log filter in [kamp_daemon/__main__.py](kamp_daemon/__main__.py), so library page loads no longer flood the daemon log with one entry per album.
- Renames `_relay_paths` → `_quiet_paths` and `_RelayFilter` → `_QuietPathsFilter` to reflect the now-broader purpose (previously only the Bandcamp proxy-relay routes were quieted).
- Filter is still scoped to INFO only — running the daemon at `--log-level DEBUG` shows everything, including album-art requests, for diagnosis.

No new caching layer is introduced. Electron's HTTP cache (keyed on the `?v=<file_mtime>` query param already on the URL) handles request coalescing on its own; we only needed to silence the log spam.

## Test plan
- [x] `poetry run black --check kamp_core/ kamp_daemon/ tests/` — clean
- [x] `poetry run mypy kamp_daemon/ kamp_core/` — clean
- [x] `pytest tests/test_main.py` — 25 passed / 5 skipped (`TestLogNoiseSuppression` unaffected by the rename)
- [x] Full suite: 1220 passed / 35 skipped
- [x] Runtime check via an ad-hoc filter exercise:
  - At INFO: filter attached; drops `/api/v1/album-art`, `/api/v1/bandcamp/proxy-fetch`, `/api/v1/bandcamp/fetch-result`; keeps `/api/v1/albums` and `/api/v1/library/state`.
  - At DEBUG: no filter attached; nothing dropped.
- [ ] Manual smoke: start daemon at INFO, open the UI, confirm no `GET /api/v1/album-art…` lines appear in the daemon log while the grid renders.

Closes KAMP-288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)