### PR TITLE
fix(windows): suppress native title bar (KAMP-289)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -468,9 +468,16 @@ function createWindow(): void {
     // Match the app's dark background so the native window surface never
     // shows through as white gutters during resize or repaint.
     backgroundColor: theme.bg,
-    // Remove the native title bar on macOS — the view-tabs nav takes its place
-    // and acts as the drag region. Traffic lights remain visible at top-left.
-    ...(process.platform === 'darwin' ? { titleBarStyle: 'hidden' as const } : {}),
+    // Hide the native title bar on macOS and Windows — the view-tabs nav takes
+    // its place and acts as the drag region. macOS keeps traffic lights at
+    // top-left; Windows keeps min/max/close as an overlay at top-right (see
+    // the .view-tabs right-padding in layout.css that reserves space for it).
+    ...(process.platform === 'darwin' || process.platform === 'win32'
+      ? { titleBarStyle: 'hidden' as const }
+      : {}),
+    ...(process.platform === 'win32'
+      ? { titleBarOverlay: { color: theme.bg, symbolColor: '#e6e6e6' } }
+      : {}),
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -123,12 +123,19 @@
   border-bottom: 1px solid var(--border);
   padding: 0 8px;
   /* Left padding reserves space for macOS traffic lights (close/min/max).
-     On non-macOS this is just a little extra breathing room. */
+     Overridden below on Windows, which has no left-side chrome. */
   padding-left: 76px;
   gap: 2px;
   flex-shrink: 0;
   /* Make the nav bar the window drag region so the user can move the window. */
   -webkit-app-region: drag;
+}
+
+/* Windows: no traffic lights on the left, but reserve space on the right for
+   the titleBarOverlay min/max/close buttons. */
+html[data-platform='win32'] .view-tabs {
+  padding-left: 8px;
+  padding-right: 140px;
 }
 
 .view-tabs button {

--- a/kamp_ui/src/renderer/src/main.tsx
+++ b/kamp_ui/src/renderer/src/main.tsx
@@ -10,6 +10,10 @@ import { theme } from '../../shared/theme'
 // BrowserWindow options (e.g. backgroundColor).
 document.documentElement.style.setProperty('--bg', theme.bg)
 
+// Expose the platform to CSS so platform-specific chrome (e.g. right padding
+// on .view-tabs that clears the Windows titleBarOverlay) can target it.
+document.documentElement.dataset.platform = window.electron.process.platform
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary

- Match the macOS chrome on Windows: hide the native caption via `titleBarStyle: 'hidden'` and keep min/max/close accessible through a `titleBarOverlay` tinted to match `theme.bg`.
- Tag `<html>` with `data-platform` so CSS can target the Windows-only chrome.
- Reserve right-side padding on `.view-tabs` to clear the overlay, and drop the macOS-only 76 px left padding on Windows where there are no traffic lights to clear.

[KAMP-289](https://eightyeighteyes.atlassian.net/browse/KAMP-289)

## Test plan

- [x] Windows dev: `cd kamp_ui && npm run dev` — no native caption bar; min/max/close visible top-right and functional; tabs row drags the window; `SearchBar` / `PanelPicker` clear of the overlay; tabs hug the left edge.
- [x] macOS dev: no regression — traffic lights visible, tabs drag, left padding unchanged.
- [x] `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAMP-289]: https://eightyeighteyes.atlassian.net/browse/KAMP-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ