### PR TITLE
fix(windows): block Windows system roots in path validation (KAMP-285)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
+import sys
 import threading as _threading
 import uuid as _uuid
 from collections.abc import Callable
@@ -137,25 +138,39 @@ class LibraryPathRequest(BaseModel):
 
 
 # Paths that must never be accepted as a library root, regardless of whether they
-# exist and are directories. Covers macOS and Linux system directories.
+# exist and are directories. Entries are platform-specific: POSIX system roots on
+# macOS/Linux, Windows system roots on Windows. Bare drive roots on Windows (e.g.
+# C:\, D:\) are rejected separately in the validator via a len(parts) == 1 check
+# so we don't have to enumerate every possible drive letter.
 _FORBIDDEN_LIBRARY_ROOTS: frozenset[Path] = frozenset(
     Path(p).resolve()
     for p in (
-        "/",
-        "/System",
-        "/usr",
-        "/bin",
-        "/sbin",
-        "/lib",
-        "/etc",
-        "/private/etc",
-        "/var",
-        "/private/var",
-        "/Library",
-        "/Applications",
-        "/dev",
-        "/proc",
-        "/sys",
+        (
+            r"C:\Windows",
+            r"C:\Windows\System32",
+            r"C:\Program Files",
+            r"C:\Program Files (x86)",
+            r"C:\ProgramData",
+            r"C:\Users",
+        )
+        if sys.platform == "win32"
+        else (
+            "/",
+            "/System",
+            "/usr",
+            "/bin",
+            "/sbin",
+            "/lib",
+            "/etc",
+            "/private/etc",
+            "/var",
+            "/private/var",
+            "/Library",
+            "/Applications",
+            "/dev",
+            "/proc",
+            "/sys",
+        )
     )
 )
 
@@ -633,6 +648,13 @@ def create_app(
         # would break legitimate use cases (external drives, network mounts).
         candidate = Path(raw).expanduser().resolve()  # noqa: S603
         if candidate in _FORBIDDEN_LIBRARY_ROOTS:
+            raise HTTPException(
+                status_code=422, detail="Path is not allowed as a library root"
+            )
+        # Bare drive root on Windows (C:\, D:\, ...). Can't enumerate every drive
+        # letter, so reject by structure: a resolved absolute path with a single
+        # part is an anchor with no further component.
+        if sys.platform == "win32" and len(candidate.parts) == 1:
             raise HTTPException(
                 status_code=422, detail="Path is not allowed as a library root"
             )

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -116,25 +116,39 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
 # Config keys that accept filesystem paths — validated on write.
 _PATH_CONFIG_KEYS: frozenset[str] = frozenset({"paths.watch_folder", "paths.library"})
 
-# Filesystem roots that must never be accepted as a config path value.
+# Filesystem roots that must never be accepted as a config path value. Entries are
+# platform-specific. Bare drive roots on Windows (C:\, D:\, ...) are rejected
+# separately in the validator via a len(parts) == 1 check so we don't have to
+# enumerate every drive letter.
 _FORBIDDEN_PATH_ROOTS: frozenset[Path] = frozenset(
     Path(p).resolve()
     for p in (
-        "/",
-        "/System",
-        "/usr",
-        "/bin",
-        "/sbin",
-        "/lib",
-        "/etc",
-        "/private/etc",
-        "/var",
-        "/private/var",
-        "/Library",
-        "/Applications",
-        "/dev",
-        "/proc",
-        "/sys",
+        (
+            r"C:\Windows",
+            r"C:\Windows\System32",
+            r"C:\Program Files",
+            r"C:\Program Files (x86)",
+            r"C:\ProgramData",
+            r"C:\Users",
+        )
+        if sys.platform == "win32"
+        else (
+            "/",
+            "/System",
+            "/usr",
+            "/bin",
+            "/sbin",
+            "/lib",
+            "/etc",
+            "/private/etc",
+            "/var",
+            "/private/var",
+            "/Library",
+            "/Applications",
+            "/dev",
+            "/proc",
+            "/sys",
+        )
     )
 )
 
@@ -381,6 +395,12 @@ def config_set(db: "LibraryIndex", key: str, value: str) -> None:
             # traversal; deny-list below blocks system roots and their subtrees.
             resolved = Path(value).expanduser().resolve()  # noqa: S603
             if resolved in _FORBIDDEN_PATH_ROOTS:
+                raise ValueError(
+                    f"Path {value!r} is not allowed as a value for {key!r}"
+                )
+            # Bare drive root on Windows (C:\, D:\, ...). Reject by structure
+            # since we can't enumerate every drive letter.
+            if sys.platform == "win32" and len(resolved.parts) == 1:
                 raise ValueError(
                     f"Path {value!r} is not allowed as a value for {key!r}"
                 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -310,23 +310,30 @@ class TestConfigSet:
         with pytest.raises(ValueError, match="requires an absolute path"):
             config_set(db, "paths.watch_folder", "../escape")
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="forbidden roots list is POSIX-specific; Windows hardening "
-        "(C:\\Windows, etc.) is tracked as a follow-up",
-    )
     @pytest.mark.parametrize(
         "forbidden",
-        [
-            "/",
-            "/etc",
-            "/private/etc",
-            "/System",
-            "/usr",
-            "/bin",
-            "/Library",
-            "/Applications",
-        ],
+        (
+            [
+                r"C:\Windows",
+                r"C:\Windows\System32",
+                r"C:\Program Files",
+                r"C:\Program Files (x86)",
+                r"C:\ProgramData",
+                r"C:\Users",
+                "C:\\",
+            ]
+            if sys.platform == "win32"
+            else [
+                "/",
+                "/etc",
+                "/private/etc",
+                "/System",
+                "/usr",
+                "/bin",
+                "/Library",
+                "/Applications",
+            ]
+        ),
     )
     def test_path_key_forbidden_root_raises(
         self, db: LibraryIndex, forbidden: str

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import threading
 from pathlib import Path
 from typing import Any
@@ -1269,7 +1270,19 @@ class TestSetLibraryPathEndpoint:
 
     @pytest.mark.parametrize(
         "forbidden",
-        ["/", "/etc", "/System", "/usr", "/bin", "/Library", "/Applications"],
+        (
+            [
+                r"C:\Windows",
+                r"C:\Windows\System32",
+                r"C:\Program Files",
+                r"C:\Program Files (x86)",
+                r"C:\ProgramData",
+                r"C:\Users",
+                "C:\\",
+            ]
+            if sys.platform == "win32"
+            else ["/", "/etc", "/System", "/usr", "/bin", "/Library", "/Applications"]
+        ),
     )
     def test_forbidden_system_roots_return_422(
         self,


### PR DESCRIPTION
## Summary
- Gate `_FORBIDDEN_LIBRARY_ROOTS` (`kamp_core/server.py`) and `_FORBIDDEN_PATH_ROOTS` (`kamp_daemon/config.py`) on `sys.platform` so Windows-system roots (`C:\Windows`, `C:\Windows\System32`, `C:\Program Files`, `C:\Program Files (x86)`, `C:\ProgramData`, `C:\Users`) are rejected on Windows while POSIX roots stay enforced on macOS/Linux.
- Add a structural check (`len(resolved.parts) == 1`) in both validators to reject bare drive roots (`C:\`, `D:\`, …) — enumerating every drive letter isn't viable.
- Drop the `skipif(win32)` on `test_path_key_forbidden_root_raises` and mirror the platform-conditional parametrize on `test_forbidden_system_roots_return_422` so both tests run on Windows with Windows-style paths and on POSIX with the existing POSIX paths.

## Test plan
- [x] `pytest tests/test_config.py::TestConfigSet::test_path_key_forbidden_root_raises -v --no-cov` on Windows — 7 cases pass
- [x] `pytest tests/test_server.py::TestSetLibraryPathEndpoint::test_forbidden_system_roots_return_422 -v --no-cov` on Windows — 7 cases pass
- [x] Full `pytest --no-cov` on Windows — 1227 passed, 27 skipped (no regression)
- [x] `black --check` and `mypy` on touched files
- [x] CI on macOS/Linux confirms POSIX cases still pass (no Windows cases attempted)
- [x] Manual UI smoke on Windows: library-path picker rejects `C:\Windows`, `C:\ProgramData`, `C:\` with 422

Closes KAMP-285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)