### PR TITLE
fix(playback): narrow mpv-engine lock + async scrobbler + state-reset (KAMP-284)

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -369,6 +369,12 @@ class _UnixSocketTransport(_IPCTransport):
         self._tmpdir = tempfile.mkdtemp(prefix="kamp-mpv-")
         self._sock_path = str(Path(self._tmpdir) / "mpv.sock")
         self._sock: socket.socket | None = None
+        # Serializes concurrent sendall callers (FastAPI routes vs. reader-thread
+        # callbacks that issue follow-up commands). MpvPlaybackEngine._lock no
+        # longer wraps _send_command (KAMP-284), so this transport-local lock is
+        # what guarantees that two threads' JSON frames don't interleave on the
+        # wire. Mirrors _WindowsNamedPipeTransport._write_lock.
+        self._write_lock = threading.Lock()
 
     @property
     def server_arg(self) -> str:
@@ -400,9 +406,13 @@ class _UnixSocketTransport(_IPCTransport):
         self._sock = sock
 
     def sendall(self, data: bytes) -> None:  # pragma: no cover
-        if self._sock is None:
-            raise OSError("transport closed")
-        self._sock.sendall(data)
+        # Snapshot the socket under the write lock so a concurrent close() that
+        # nulls _sock cannot land between the None-check and the sendall call.
+        with self._write_lock:
+            sock = self._sock
+            if sock is None:
+                raise OSError("transport closed")
+            sock.sendall(data)
 
     def recv(self, n: int) -> bytes:  # pragma: no cover
         if self._sock is None:
@@ -413,12 +423,19 @@ class _UnixSocketTransport(_IPCTransport):
             return b""
 
     def close(self) -> None:
-        if self._sock is not None:
+        # Take the write lock just long enough to detach the socket so any
+        # concurrent sendall() either sees the live socket and completes, or
+        # sees None and raises OSError("transport closed"). The actual
+        # socket.close() runs outside the lock so a slow close cannot stall
+        # an unrelated send.
+        with self._write_lock:
+            sock = self._sock
+            self._sock = None
+        if sock is not None:
             try:
-                self._sock.close()
+                sock.close()
             except OSError:
                 pass
-            self._sock = None
         if self._tmpdir:
             shutil.rmtree(self._tmpdir, ignore_errors=True)
             self._tmpdir = ""
@@ -459,8 +476,9 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         self._pipe_name = rf"\\.\pipe\kamp-mpv-{secrets.token_hex(8)}"
         self._conn: Any = None
         # send_bytes is overlapped but not self-thread-safe; serialize writes.
-        # MpvPlaybackEngine._lock already wraps _send_command, but a
-        # transport-local lock keeps the contract local to this class.
+        # Since KAMP-284 narrowed MpvPlaybackEngine._lock, this transport-local
+        # lock is the sole guarantee that two threads' frames don't interleave
+        # on the wire. Also covers the close-vs-sendall TOCTOU on _conn.
         self._write_lock = threading.Lock()
         # recv_bytes returns one whole frame per call (mpv writes one
         # newline-terminated JSON message per WriteFile). Buffer leftovers so
@@ -523,11 +541,14 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         )
 
     def sendall(self, data: bytes) -> None:  # pragma: no cover
-        if self._conn is None:
-            raise OSError("transport closed")
+        # Snapshot _conn under the write lock so a concurrent close() that
+        # nulls it cannot land between the None-check and send_bytes.
         with self._write_lock:
+            conn = self._conn
+            if conn is None:
+                raise OSError("transport closed")
             try:
-                self._conn.send_bytes(data)
+                conn.send_bytes(data)
             except (BrokenPipeError, EOFError) as exc:
                 raise OSError(str(exc)) from exc
 
@@ -553,12 +574,18 @@ class _WindowsNamedPipeTransport(_IPCTransport):
         return chunk
 
     def close(self) -> None:
-        if self._conn is not None:
+        # Detach _conn under the write lock so any concurrent sendall() either
+        # completes on the live handle or raises OSError("transport closed").
+        # The PipeConnection.close() call itself runs outside the lock to avoid
+        # stalling unrelated sends behind a slow close.
+        with self._write_lock:
+            conn = self._conn
+            self._conn = None
+        if conn is not None:
             try:
-                self._conn.close()
+                conn.close()
             except OSError:
                 pass
-            self._conn = None
 
 
 # Win32 Job Object constants (winnt.h).
@@ -733,11 +760,33 @@ class MpvPlaybackEngine:
     transport-specific endpoint (a temporary Unix socket on macOS/Linux, a
     Win32 named pipe on Windows). A background thread reads the event stream
     and updates self.state. Commands are sent synchronously via _send_command.
+
+    Locking contract (KAMP-284). ``self._lock`` guards the pair
+    ``(self._lookahead_path, the playlist slot it names in mpv)``. Every site
+    that reads ``_lookahead_path`` and conditionally issues
+    ``playlist-remove <slot>`` — ``seek``, ``preload_next``, ``play``,
+    ``load_paused``, and the ``end-file/eof`` handler — must perform the read,
+    the mutation, and the matching IPC send while holding ``_lock``. No user
+    callback and no unrelated ``sendall`` may execute under ``_lock``; the
+    transports own their own write serialization so JSON frames cannot
+    interleave on the wire. Race A (KAMP-261) is prevented by this scope
+    alone: two parallel "I see lookahead, going to remove it" critical
+    sections are impossible because both sit under the same ``_lock``.
+
+    Known boundary glitch: a ``seek`` issued at the exact instant of a
+    natural-EOF transition can land on the new track because the ``seek``
+    command itself is sent outside ``_lock`` (the ``_lookahead_path`` check
+    is not). ``file-loaded`` resets ``state.position = 0`` on the new track,
+    so the misdirected seek is visible for at most one frame.
     """
 
     def __init__(self, mpv_bin: str = "mpv") -> None:
         self.state = PlaybackState()
-        self.on_track_end: Callable[[], None] | None = None
+        # had_lookahead is True when mpv transitioned gaplessly (slot 1 became
+        # slot 0) at this eof; False when mpv went idle. The callback uses this
+        # to decide whether to issue engine.play(next_path) — calling play()
+        # after a gapless transition would clobber it with loadfile replace.
+        self.on_track_end: Callable[[bool], None] | None = None
         self.on_file_loaded: Callable[[], None] | None = None
         self.on_play_state_changed: Callable[[], None] | None = None
         self._mpv_bin = mpv_bin
@@ -748,13 +797,10 @@ class MpvPlaybackEngine:
         self._job: _WindowsJobObject | None = None
         self._ipc: _IPCTransport = _make_ipc_transport()
         self._reader_thread: threading.Thread | None = None
-        # RLock so the reader thread can re-acquire the lock inside callbacks
-        # (e.g. on_track_end → engine.play() → _send_command) while still
-        # holding it across the end-file handler to prevent Race A: a concurrent
-        # seek() on the main thread sending playlist-remove 1 while the reader
-        # thread is already sending playlist-remove 0, which empties mpv's
-        # playlist and stops time-pos events.
-        self._lock = threading.RLock()
+        # See class docstring for the locking contract. Plain Lock (not RLock):
+        # no callback ever runs under this lock, so reentry is impossible and
+        # an RLock would only mask accidental re-acquisitions.
+        self._lock = threading.Lock()
         # One-shot seek applied on the next file-loaded event (set by load_paused).
         # Stored here rather than in on_file_loaded so it doesn't clobber the
         # external callback chain wired up after engine creation.
@@ -843,9 +889,24 @@ class MpvPlaybackEngine:
 
     def play(self, path: Path) -> None:
         # loadfile replace clears mpv's entire playlist, including any lookahead.
-        self._lookahead_path = None
-        self._send_command("loadfile", str(path), "replace")
-        # Explicitly unpause so calling play() after pause() always starts playback.
+        # _lookahead_path mutation and the IPC send are paired under _lock so a
+        # concurrent end-file/eof handler cannot observe a stale lookahead value.
+        # state.position / state.duration are reset HERE (synchronously) so any
+        # WS notification fired by a caller — e.g. _on_track_end_notify's
+        # app.state.notify_track_changed() right after this returns — captures
+        # the new track at 0:00 instead of the finishing track's stale final
+        # position. mpv's later file-loaded event will redundantly re-set these
+        # to the same values, but the timing matters: the reader thread is
+        # single-threaded, so file-loaded cannot be processed until the entire
+        # on_track_end chain returns, by which point a stale notify has already
+        # gone out.
+        logger.info("engine.play: loading %s", path)
+        with self._lock:
+            self._lookahead_path = None
+            self.state.position = 0.0
+            self.state.duration = 0.0
+            self._send_command("loadfile", str(path), "replace")
+        # Pause-toggle is unrelated to the lookahead slot; send outside the lock.
         self._send_command("set_property", "pause", False)
 
     def load_paused(self, path: Path, position: float = 0.0) -> None:
@@ -860,9 +921,13 @@ class MpvPlaybackEngine:
         in ``on_file_loaded`` so it doesn't overwrite callbacks wired externally.
         """
         # loadfile replace clears mpv's entire playlist, including any lookahead.
-        self._lookahead_path = None
+        # See play() for the locking + state-reset rationale.
         self._pending_seek = position if position > 0 else None
-        self._send_command("loadfile", str(path), "replace")
+        with self._lock:
+            self._lookahead_path = None
+            self.state.position = 0.0
+            self.state.duration = 0.0
+            self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
 
     def preload_next(self, next_track: "Track | None") -> None:
@@ -877,26 +942,33 @@ class MpvPlaybackEngine:
         update (set path first) is intentionally avoided: if the old lookahead played
         gaplessly before the removal landed in mpv, on_track_end would skip
         engine.play() and queue.next() would advance past the wrong track.
+
+        The entire body runs under _lock so the guard-window check, the
+        _lookahead_path mutation, and the playlist-remove/loadfile send happen
+        atomically with respect to a concurrent end-file/eof handler.
         """
         path = next_track.file_path if next_track is not None else None
-        if path == self._lookahead_path:
-            return
-        if self._lookahead_path is not None:
-            self._lookahead_path = None  # clear before sending remove (see docstring)
-            self._send_command("playlist-remove", 1)
-        if path is not None:
-            # Skip the append when we're within the gapless danger window.
-            # mpv would trigger an immediate EOF transition the moment the
-            # file lands in slot 1, stopping time-pos events and leaving the
-            # queue in a half-transitioned state.  on_track_end will start
-            # the next track via engine.play() when the current track ends.
-            if (
-                self.state.duration > 0
-                and self.state.position > self.state.duration - _GAPLESS_GUARD_SECS
-            ):
+        with self._lock:
+            if path == self._lookahead_path:
                 return
-            self._send_command("loadfile", str(path), "append")
-            self._lookahead_path = path
+            if self._lookahead_path is not None:
+                self._lookahead_path = (
+                    None  # clear before sending remove (see docstring)
+                )
+                self._send_command("playlist-remove", 1)
+            if path is not None:
+                # Skip the append when we're within the gapless danger window.
+                # mpv would trigger an immediate EOF transition the moment the
+                # file lands in slot 1, stopping time-pos events and leaving the
+                # queue in a half-transitioned state.  on_track_end will start
+                # the next track via engine.play() when the current track ends.
+                if (
+                    self.state.duration > 0
+                    and self.state.position > self.state.duration - _GAPLESS_GUARD_SECS
+                ):
+                    return
+                self._send_command("loadfile", str(path), "append")
+                self._lookahead_path = path
 
     @property
     def has_lookahead(self) -> bool:
@@ -912,8 +984,13 @@ class MpvPlaybackEngine:
     def seek(self, position: float) -> None:
         # Hold _lock so this check+clear is atomic with the end-file handler's
         # playlist-remove 0 + _lookahead_path = None sequence on the reader
-        # thread (Race A prevention).  The seek command itself is sent outside
-        # the lock — it does not touch _lookahead_path.
+        # thread (Race A prevention). The seek command itself is sent outside
+        # the lock — it does not touch _lookahead_path. The "boundary glitch"
+        # named in the class docstring lives here: a seek issued at the exact
+        # instant of natural EOF can land on the new track because there is no
+        # lock held between the playlist-remove 1 send and the seek send.
+        # file-loaded resets state.position to 0 immediately, so the
+        # misdirected seek is visible for at most one frame.
         with self._lock:
             # Only remove the lookahead when the seek target lands within the
             # gapless danger window.  Seeking to an early/middle position carries
@@ -966,13 +1043,18 @@ class MpvPlaybackEngine:
     # ------------------------------------------------------------------
 
     def _send_command(self, *args: object) -> None:
-        """Serialize and send a command to mpv over the IPC channel."""
+        """Serialize and send a command to mpv over the IPC channel.
+
+        Does not take ``_lock``; the transport owns its own write lock so JSON
+        frames cannot interleave on the wire. Callers that pair a state
+        mutation with a specific IPC send (``play``, ``preload_next``, the
+        end-file handler, etc.) hold ``_lock`` around the pair themselves.
+        """
         msg = json.dumps({"command": list(args)}) + "\n"
-        with self._lock:
-            try:
-                self._ipc.sendall(msg.encode())
-            except OSError:
-                logger.warning("Failed to send command to mpv: %s", args)
+        try:
+            self._ipc.sendall(msg.encode())
+        except OSError:
+            logger.warning("Failed to send command to mpv: %s", args)
 
     def _read_loop(self) -> None:  # pragma: no cover
         """Background thread: read JSON events from mpv and dispatch them."""
@@ -984,11 +1066,24 @@ class MpvPlaybackEngine:
             buf += chunk
             while b"\n" in buf:
                 line, buf = buf.split(b"\n", 1)
+                event: Any = None
                 try:
                     event = json.loads(line)
                     self._handle_event(event)
                 except json.JSONDecodeError:
                     pass
+                except Exception:
+                    # The reader thread is the ONLY producer of state.position /
+                    # state.duration updates and the ONLY driver of
+                    # on_file_loaded / on_track_end. If it dies, the UI silently
+                    # freezes until daemon restart (KAMP-284 regression).
+                    # Swallow anything a handler or user callback throws, log
+                    # loudly, and keep reading.
+                    logger.exception(
+                        "mpv reader: unhandled exception in _handle_event(%r); "
+                        "continuing",
+                        event if event is not None else line,
+                    )
 
     def _handle_event(self, event: dict[str, object]) -> None:
         """Update state and fire callbacks in response to an mpv event."""
@@ -1022,21 +1117,41 @@ class MpvPlaybackEngine:
 
         elif name == "end-file":
             if event.get("reason") == "eof":
-                # Hold _lock across the entire block so a concurrent seek() on
-                # the main thread cannot send playlist-remove 1 while we are
-                # sending playlist-remove 0 (Race A: double-remove empties mpv's
+                # Hold _lock across the read+send+clear so a concurrent seek()
+                # cannot send playlist-remove 1 while we are sending
+                # playlist-remove 0 (Race A: double-remove empties mpv's
                 # playlist, sending it idle and stopping time-pos events).
-                # _lock is an RLock so on_track_end → engine.play() →
-                # _send_command can re-acquire it on the same thread.
+                # _lookahead_path is cleared INSIDE the lock so callers seeing
+                # has_lookahead==False after this point reflect mpv's true
+                # state. The user callback is invoked OUTSIDE the lock so a
+                # slow callback (e.g. Last.fm scrobble) cannot block FastAPI
+                # threads on seek/pause/resume (KAMP-284).
                 with self._lock:
-                    # When a lookahead was present, mpv already transitioned
-                    # gaplessly and the finished entry sits at slot 0.  Remove it
-                    # now to maintain the invariant (current = slot 0, lookahead = slot 1).
-                    if self._lookahead_path is not None:
+                    had_lookahead = self._lookahead_path is not None
+                    if had_lookahead:
+                        # When a lookahead was present, mpv already transitioned
+                        # gaplessly and the finished entry sits at slot 0.
+                        # Remove it now to restore the invariant
+                        # (current = slot 0, lookahead = slot 1).
                         self._send_command("playlist-remove", 0)
-                    # Fire on_track_end while _lookahead_path is still set so that
-                    # has_lookahead returns True inside the callback — _on_track_end
-                    # checks this to avoid calling engine.play() redundantly.
-                    if self.on_track_end is not None:
-                        self.on_track_end()
+                        # mpv has already transitioned to the new track, but
+                        # state.position/duration still reflect the finishing
+                        # track — file-loaded for the new track can't be
+                        # processed until this whole callback chain returns
+                        # (single-threaded reader). Reset synchronously so any
+                        # WS notify the callback fires (e.g.
+                        # _on_track_end_notify's notify_track_changed) ships
+                        # the new track at 0:00 instead of a stale position.
+                        self.state.position = 0.0
+                        self.state.duration = 0.0
                     self._lookahead_path = None
+                logger.info("eof: had_lookahead=%s firing on_track_end", had_lookahead)
+                # had_lookahead tells the callback whether mpv already advanced
+                # so it can skip calling engine.play(next_path) — calling play()
+                # after a gapless transition would clobber it with loadfile
+                # replace.
+                if self.on_track_end is not None:
+                    self.on_track_end(had_lookahead)
+                logger.info(
+                    "eof: on_track_end returned (had_lookahead=%s)", had_lookahead
+                )

--- a/kamp_core/scrobbler.py
+++ b/kamp_core/scrobbler.py
@@ -4,6 +4,15 @@ Tracks cumulative listening time per play instance and scrobbles when either
 30 seconds have been listened to, or the track reaches natural end-of-file,
 whichever comes first.
 
+Threading model
+---------------
+HTTP work runs on a daemon-thread worker (``_tx_loop``) that consumes a
+``queue.Queue`` of jobs. Callers (engine reader thread for
+``on_track_changed`` / ``on_track_ended``, state-saver thread for ``tick``)
+snapshot the current play-instance state under ``_state_lock`` and enqueue a
+job, then return immediately. A hung Last.fm endpoint can never block the
+caller — it only backs up the queue.
+
 Credential note
 ---------------
 LASTFM_API_KEY and LASTFM_API_SECRET are app-level constants registered with
@@ -17,8 +26,11 @@ access.
 from __future__ import annotations
 
 import logging
+import queue
+import threading
 import time
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 import pylast
 
@@ -26,6 +38,19 @@ if TYPE_CHECKING:
     from kamp_core.library import Track
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ScrobbleJob:
+    """One unit of work for the HTTP worker thread."""
+
+    kind: Literal["now_playing", "scrobble", "shutdown"]
+    track: "Track | None" = None
+    # Scrobble-only fields. Captured under _state_lock so the worker doesn't
+    # need to read mutable per-play-instance state.
+    timestamp: int = 0
+    listened_secs: float = 0.0
+
 
 # App-level credentials registered at https://www.last.fm/api/account/create.
 # See module docstring for the security rationale.
@@ -72,32 +97,146 @@ class Scrobbler:
             api_secret=LASTFM_API_SECRET,
             session_key=session_key,
         )
-        # Per-play-instance state
+        # Per-play-instance state, guarded by _state_lock because tick() runs
+        # on the state-saver thread while on_track_changed/on_track_ended run
+        # on the engine's reader thread.
         self._play_listening_secs: float = 0.0
         self._play_start_timestamp: int = 0  # Unix time; sent with scrobble
         self._scrobbled: bool = False
         self._last_tick_at: float | None = None
         self._last_tick_playing: bool = False
+        self._state_lock = threading.Lock()
+        # HTTP worker — keeps Last.fm latency off the engine's reader thread
+        # so a slow or hung endpoint can never stall mpv event processing
+        # (KAMP-284). The queue is unbounded; under normal operation it never
+        # holds more than one or two items at a time.
+        self._tx_queue: queue.Queue[_ScrobbleJob] = queue.Queue()
+        self._tx_thread = threading.Thread(
+            target=self._tx_loop, daemon=True, name="scrobbler-tx"
+        )
+        self._tx_thread.start()
 
     def on_track_changed(self, track: Track | None) -> None:
         """Call when a new file is loaded. Resets play instance state.
 
         Sends a now-playing notification to Last.fm when *track* is not None.
+        Returns immediately; the HTTP call runs on the scrobbler's worker
+        thread.
         """
-        # Reset play instance
-        self._play_listening_secs = 0.0
-        self._play_start_timestamp = int(time.time())
-        self._scrobbled = False
-        self._last_tick_at = time.monotonic()
-        self._last_tick_playing = False
+        with self._state_lock:
+            self._play_listening_secs = 0.0
+            self._play_start_timestamp = int(time.time())
+            self._scrobbled = False
+            self._last_tick_at = time.monotonic()
+            self._last_tick_playing = False
 
         if track is None:
             return
-
         # Last.fm requires artist and title; skip rather than send a 400.
         if not track.artist or not track.title:
             return
+        self._tx_queue.put(_ScrobbleJob(kind="now_playing", track=track))
 
+    def tick(self, track: Track | None, playing: bool) -> None:
+        """Call at ~1 Hz from the state-saver thread.
+
+        Accumulates listening time while *playing* is True and fires the
+        30-second scrobble when the threshold is crossed. Returns immediately;
+        any HTTP call runs on the scrobbler's worker thread.
+        """
+        now = time.monotonic()
+        should_scrobble = False
+        ts = 0
+        secs = 0.0
+        with self._state_lock:
+            if self._last_tick_at is not None and playing and self._last_tick_playing:
+                self._play_listening_secs += now - self._last_tick_at
+            self._last_tick_at = now
+            self._last_tick_playing = playing
+
+            if (
+                track is not None
+                and not self._scrobbled
+                and self._play_listening_secs >= _SCROBBLE_THRESHOLD_SECS
+            ):
+                self._scrobbled = True
+                should_scrobble = True
+                ts = self._play_start_timestamp
+                secs = self._play_listening_secs
+
+        if should_scrobble and track is not None:
+            self._tx_queue.put(
+                _ScrobbleJob(
+                    kind="scrobble", track=track, timestamp=ts, listened_secs=secs
+                )
+            )
+
+    def on_track_ended(self, track: Track | None) -> None:
+        """Call at natural EOF. Scrobbles if not already done this instance.
+
+        Returns immediately; the HTTP call runs on the worker thread.
+        """
+        if track is None:
+            return
+        should_scrobble = False
+        ts = 0
+        secs = 0.0
+        with self._state_lock:
+            if not self._scrobbled:
+                self._scrobbled = True
+                should_scrobble = True
+                ts = self._play_start_timestamp
+                secs = self._play_listening_secs
+        if should_scrobble:
+            self._tx_queue.put(
+                _ScrobbleJob(
+                    kind="scrobble", track=track, timestamp=ts, listened_secs=secs
+                )
+            )
+
+    def flush(self) -> None:
+        """Block until all enqueued HTTP jobs have completed.
+
+        Intended for tests and for use during ``shutdown()`` so a final scrobble
+        has a chance to land before the worker exits. Production callers
+        otherwise never need this — the whole point of the worker is that
+        callers do not wait on Last.fm.
+        """
+        self._tx_queue.join()
+
+    def shutdown(self, timeout: float = 2.0) -> None:
+        """Stop the worker thread. Best-effort; never blocks daemon shutdown.
+
+        Pushes a sentinel so any in-flight job completes before the worker
+        exits, then joins with the timeout. A hung HTTP call beyond *timeout*
+        is abandoned — the worker is a daemon thread and dies with the
+        process anyway.
+        """
+        self._tx_queue.put(_ScrobbleJob(kind="shutdown"))
+        self._tx_thread.join(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Worker — runs on _tx_thread
+    # ------------------------------------------------------------------
+
+    def _tx_loop(self) -> None:
+        while True:
+            job = self._tx_queue.get()
+            try:
+                if job.kind == "shutdown":
+                    return
+                if job.kind == "now_playing" and job.track is not None:
+                    self._do_now_playing(job.track)
+                elif job.kind == "scrobble" and job.track is not None:
+                    self._do_scrobble(job.track, job.timestamp, job.listened_secs)
+            except Exception:
+                # Never let an exception kill the worker — the next job must
+                # still get a chance to run.
+                logger.warning("Scrobbler worker dispatch failed", exc_info=True)
+            finally:
+                self._tx_queue.task_done()
+
+    def _do_now_playing(self, track: Track) -> None:
         try:
             self._network.update_now_playing(
                 artist=track.artist,
@@ -113,34 +252,7 @@ class Scrobbler:
         except Exception:
             logger.warning("Last.fm now-playing update failed", exc_info=True)
 
-    def tick(self, track: Track | None, playing: bool) -> None:
-        """Call at ~1 Hz from the state-saver thread.
-
-        Accumulates listening time while *playing* is True and fires the
-        30-second scrobble when the threshold is crossed.
-        """
-        now = time.monotonic()
-
-        if self._last_tick_at is not None and playing and self._last_tick_playing:
-            self._play_listening_secs += now - self._last_tick_at
-
-        self._last_tick_at = now
-        self._last_tick_playing = playing
-
-        if (
-            track is not None
-            and not self._scrobbled
-            and self._play_listening_secs >= _SCROBBLE_THRESHOLD_SECS
-        ):
-            self._scrobble(track)
-
-    def on_track_ended(self, track: Track | None) -> None:
-        """Call at natural EOF. Scrobbles if not already done this instance."""
-        if track is not None and not self._scrobbled:
-            self._scrobble(track)
-
-    def _scrobble(self, track: Track) -> None:
-        self._scrobbled = True
+    def _do_scrobble(self, track: Track, timestamp: int, listened_secs: float) -> None:
         # Last.fm requires artist and title; skip rather than send a 400.
         if not track.artist or not track.title:
             return
@@ -148,7 +260,7 @@ class Scrobbler:
             self._network.scrobble(
                 artist=track.artist,
                 title=track.title,
-                timestamp=self._play_start_timestamp,
+                timestamp=timestamp,
                 album=track.album or None,
                 album_artist=(
                     track.album_artist if track.album_artist != track.artist else None
@@ -161,7 +273,7 @@ class Scrobbler:
                 "Scrobbled: %s – %s (%.0f s listened)",
                 track.artist,
                 track.title,
-                self._play_listening_secs,
+                listened_secs,
             )
         except Exception:
             logger.warning(

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -660,17 +660,21 @@ def _cmd_daemon(
     # play-state WebSocket events and forwards them to the helper via stdin.
 
     # Advance the queue automatically at end-of-track; stop cleanly at the end.
-    def _on_track_end() -> None:
+    # had_lookahead is supplied by the engine and is True when mpv transitioned
+    # gaplessly (slot 1 became slot 0). Querying engine.has_lookahead here would
+    # race because the engine clears _lookahead_path under its lock before
+    # firing this callback (KAMP-284).
+    def _on_track_end(had_lookahead: bool) -> None:
         finished = queue.current()
         track = queue.next()
         # Record natural EOF so last_played sort stays accurate.
         if finished is not None:
             index.record_played(finished.file_path)
         if track:
-            if not engine.has_lookahead:
+            if not had_lookahead:
                 # No gapless transition was queued — start the next track manually.
                 engine.play(track.file_path)
-            # If has_lookahead: mpv already transitioned gaplessly.  file-loaded
+            # If had_lookahead: mpv already transitioned gaplessly.  file-loaded
             # will fire shortly and preload_next will queue the new next track.
         else:
             engine.stop()
@@ -699,11 +703,11 @@ def _cmd_daemon(
     # finishing track.  Wrap the callback that was just set above.
     _orig_on_track_end = engine.on_track_end
 
-    def _on_track_end_scrobble() -> None:
+    def _on_track_end_scrobble(had_lookahead: bool) -> None:
         if _scrobbler_ref[0] is not None:
             _scrobbler_ref[0].on_track_ended(queue.current())
         if _orig_on_track_end is not None:
-            _orig_on_track_end()
+            _orig_on_track_end(had_lookahead)
 
     engine.on_track_end = _on_track_end_scrobble
 
@@ -766,10 +770,16 @@ def _cmd_daemon(
     def _on_lastfm_connect(username: str, password: str) -> None:
         session_key = _lastfm_authenticate(username, password)
         index.set_session("lastfm", {"session_key": session_key, "username": username})
+        # Stop any previous scrobbler's HTTP worker before replacing it so we
+        # don't leak threads across repeated connect/disconnect cycles.
+        if _scrobbler_ref[0] is not None:
+            _scrobbler_ref[0].shutdown(timeout=2.0)
         _scrobbler_ref[0] = Scrobbler(session_key)
 
     def _on_lastfm_disconnect() -> None:
         index.clear_session("lastfm")
+        if _scrobbler_ref[0] is not None:
+            _scrobbler_ref[0].shutdown(timeout=2.0)
         _scrobbler_ref[0] = None
 
     def _on_bandcamp_login_complete(payload: dict[str, object]) -> None:
@@ -895,9 +905,9 @@ def _cmd_daemon(
     # Done here (after app creation) so app.state is guaranteed to be available.
     _original_on_track_end = engine.on_track_end
 
-    def _on_track_end_notify() -> None:
+    def _on_track_end_notify(had_lookahead: bool) -> None:
         if _original_on_track_end is not None:
-            _original_on_track_end()
+            _original_on_track_end(had_lookahead)
         app.state.notify_track_changed()
 
     engine.on_track_end = _on_track_end_notify
@@ -1014,6 +1024,11 @@ def _cmd_daemon(
 
     if lib_watcher is not None:
         lib_watcher.stop()
+    # Stop the scrobbler's HTTP worker thread BEFORE the engine so any final
+    # scrobble queued by a closing on_track_ended has a chance to land. The
+    # 2-second join cap makes a hung Last.fm endpoint never stall shutdown.
+    if _scrobbler_ref[0] is not None:
+        _scrobbler_ref[0].shutdown(timeout=2.0)
     engine.shutdown()
     index.close()
 

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -27,6 +27,29 @@ export function TransportBar(): React.JSX.Element {
   const pointerDown = useRef(false)
   const displayPosition = scrubPos !== null ? scrubPos : position
 
+  // Force-clear scrub state when the track changes. Without this, a pointerup
+  // event that didn't reach the slider (release outside its bounds, OS-level
+  // capture glitch, etc.) would leave scrubPos wedged at the user's last seek
+  // target — the slider would then ignore every fresh server position forever
+  // and "stick at the seek position until restart" (KAMP-284 follow-up bug,
+  // surfaced after non-gapless EOF transitions: server reports position=0 for
+  // the new track but the slider keeps showing the wedged scrub value).
+  //
+  // Pattern: "adjust state during rendering" per React docs — store the prior
+  // value in state and compare during render. Avoids the useEffect cascade
+  // warning and runs synchronously so the very first render after a track
+  // change already shows the server position.
+  const currentPath = current_track?.file_path ?? null
+  const [prevPath, setPrevPath] = useState<string | null>(currentPath)
+  if (prevPath !== currentPath) {
+    setPrevPath(currentPath)
+    setScrubPos(null)
+    // pointerDown.current is intentionally not touched here — a fresh
+    // onPointerDown will set it true again, and pointerUp/pointerCancel
+    // remain the canonical clear sites. Mutating a ref during render is
+    // disallowed by the React Compiler lint anyway.
+  }
+
   return (
     <div className="transport-bar">
       <div className="transport-track-info">
@@ -98,9 +121,20 @@ export function TransportBar(): React.JSX.Element {
           max={duration || 1}
           step={0.5}
           value={displayPosition}
-          onPointerDown={() => {
+          onPointerDown={(e) => {
             pointerDown.current = true
             setScrubPos(position)
+            // Pin pointer events to the slider so pointerup is guaranteed to
+            // fire here even if the user releases the pointer outside the
+            // slider bounds. Without this, scrubPos can wedge — the
+            // track-change reset above (currentPath comparison) is the
+            // escape hatch for any wedge that still slips through.
+            try {
+              e.currentTarget.setPointerCapture(e.pointerId)
+            } catch {
+              // Some browsers reject setPointerCapture on non-trusted events
+              // (synthetic pointer events from automation, etc.) — ignore.
+            }
           }}
           onChange={(e) => {
             const val = parseFloat(e.target.value)
@@ -108,6 +142,13 @@ export function TransportBar(): React.JSX.Element {
             if (pointerDown.current) seek(val)
           }}
           onPointerUp={() => {
+            pointerDown.current = false
+            setScrubPos(null)
+          }}
+          onPointerCancel={() => {
+            // Touch-cancel, OS-level capture loss, or a programmatic
+            // releasePointerCapture call — treat exactly like pointerup so
+            // the slider can never stay wedged on scrubPos.
             pointerDown.current = false
             setScrubPos(null)
           }}

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1314,14 +1314,34 @@ class TestMpvPlaybackEngine:
         engine._handle_event({"event": "end-file", "reason": "eof"})
         assert engine._lookahead_path is None
 
-    def test_on_track_end_called_while_lookahead_still_set(self) -> None:
-        """has_lookahead must be True inside the on_track_end callback."""
+    def test_on_track_end_receives_had_lookahead_true_after_gapless(self) -> None:
+        """on_track_end's had_lookahead arg must be True when a lookahead was armed."""
         engine, _ = _make_engine()
         engine.preload_next(_track(2))
         observed: list[bool] = []
-        engine.on_track_end = lambda: observed.append(engine.has_lookahead)
+        engine.on_track_end = lambda had_lookahead: observed.append(had_lookahead)
         engine._handle_event({"event": "end-file", "reason": "eof"})
         assert observed == [True]
+
+    def test_on_track_end_receives_had_lookahead_false_without_preload(self) -> None:
+        """Without a preloaded lookahead, had_lookahead must be False."""
+        engine, _ = _make_engine()
+        observed: list[bool] = []
+        engine.on_track_end = lambda had_lookahead: observed.append(had_lookahead)
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert observed == [False]
+
+    def test_lookahead_cleared_before_on_track_end_fires(self) -> None:
+        """has_lookahead must read False inside on_track_end — the engine
+        clears _lookahead_path under the lock before firing the callback so
+        a callback that queries the property sees mpv's true current state.
+        """
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        observed: list[bool] = []
+        engine.on_track_end = lambda _: observed.append(engine.has_lookahead)
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert observed == [False]
 
     def test_handle_event_pause_with_non_bool_data_is_ignored(self) -> None:
         engine, _ = _make_engine()

--- a/tests/test_playback_threaded.py
+++ b/tests/test_playback_threaded.py
@@ -1,0 +1,632 @@
+"""Real-thread regression tests for MpvPlaybackEngine locking (KAMP-284).
+
+Single-threaded tests in tests/test_playback.py assert command order under
+manual ``_handle_event`` injection, with ``_send_command`` patched and the
+reader thread suppressed. These tests fill the gap by spawning the actual
+reader thread against a controllable fake IPC transport, then verifying:
+
+* a slow ``on_track_end`` callback (simulating a hung Last.fm scrobble) does
+  not block a concurrent ``engine.seek()`` on the main thread (KAMP-284);
+* the "double playlist-remove" race between ``seek()`` and the reader-thread
+  EOF handler (KAMP-261, "Race A") stays prevented under real concurrency;
+* ``on_file_loaded`` runs strictly after ``on_track_end`` returns even when
+  the latter sleeps (preserved by the single reader thread);
+* the transport-level write lock serializes concurrent ``_send_command``
+  callers so JSON frames never interleave on the wire.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kamp_core.library import Track
+from kamp_core.playback import (
+    MpvPlaybackEngine,
+    _IPCTransport,
+    _UnixSocketTransport,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _track(n: int) -> Track:
+    return Track(
+        file_path=Path(f"/music/{n:02d}.mp3"),
+        title=f"Track {n}",
+        artist="Artist",
+        album_artist="Artist",
+        album="Album",
+        year="2024",
+        track_number=n,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+    )
+
+
+class FakeIPCTransport(_IPCTransport):
+    """Controllable in-memory transport for engine-threading tests.
+
+    Mirrors the production transports' contract: ``sendall`` is serialized
+    by an internal write lock, ``recv`` is blocking and reads one event at
+    a time from a test-controlled queue. Setting ``pause_send`` parks the
+    next ``sendall`` caller on the event so tests can pin write-side timing.
+    """
+
+    def __init__(self) -> None:
+        # Mirrors the production transports: serialize concurrent sendall via
+        # a transport-local lock. This is exactly the contract the engine
+        # depends on now that ``_send_command`` no longer takes ``_lock``.
+        self._write_lock = threading.Lock()
+        self._send_log: list[bytes] = []
+        self._recv_queue: queue.Queue[bytes] = queue.Queue()
+        self._closed = False
+
+    @property
+    def server_arg(self) -> str:
+        return "fake://test"
+
+    def open(self, timeout: float, proc: Any) -> None:  # pragma: no cover
+        return None
+
+    def sendall(self, data: bytes) -> None:
+        with self._write_lock:
+            if self._closed:
+                raise OSError("transport closed")
+            self._send_log.append(data)
+
+    def recv(self, n: int) -> bytes:
+        if self._closed:
+            return b""
+        try:
+            chunk = self._recv_queue.get(timeout=10.0)
+        except queue.Empty:
+            return b""
+        return chunk
+
+    def close(self) -> None:
+        self._closed = True
+        # Push a sentinel so the reader thread breaks out of its blocking recv.
+        self._recv_queue.put(b"")
+
+    # -- test helpers --
+
+    def push_event(self, event: dict[str, object]) -> None:
+        """Inject an mpv event (newline-delimited JSON) into recv()."""
+        self._recv_queue.put((json.dumps(event) + "\n").encode())
+
+    def send_log_snapshot(self) -> list[bytes]:
+        with self._write_lock:
+            return list(self._send_log)
+
+    def commands_sent(self) -> list[list[object]]:
+        """Return the list of decoded mpv command arrays in send order."""
+        out: list[list[object]] = []
+        for raw in self.send_log_snapshot():
+            try:
+                msg = json.loads(raw.decode().strip())
+            except Exception:
+                continue
+            cmd = msg.get("command")
+            if isinstance(cmd, list):
+                out.append(cmd)
+        return out
+
+
+def _make_threaded_engine() -> tuple[MpvPlaybackEngine, FakeIPCTransport]:
+    """Construct an engine with a real reader thread reading from a fake transport.
+
+    Bypasses ``_start_mpv`` (no subprocess) and ``_make_ipc_transport`` (no real
+    socket / pipe), then manually wires the fake into ``engine._ipc`` and
+    spawns the reader thread.
+    """
+    fake = FakeIPCTransport()
+    with (
+        patch("kamp_core.playback._make_ipc_transport", return_value=fake),
+        patch.object(MpvPlaybackEngine, "_start_mpv"),
+    ):
+        engine = MpvPlaybackEngine()
+    engine._ipc = fake
+    reader = threading.Thread(
+        target=engine._read_loop, daemon=True, name="mpv-reader-test"
+    )
+    engine._reader_thread = reader
+    reader.start()
+    return engine, fake
+
+
+def _stop_engine(engine: MpvPlaybackEngine, fake: FakeIPCTransport) -> None:
+    """Unblock the reader thread and join it. Best-effort cleanup."""
+    fake.close()
+    if engine._reader_thread is not None:
+        engine._reader_thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# KAMP-284 — slow callback must not block main-thread seek
+# ---------------------------------------------------------------------------
+
+
+class TestSlowCallbackDoesNotBlockSeek:
+    def test_seek_completes_while_on_track_end_is_parked(self) -> None:
+        """The original KAMP-284 symptom: a hung Last.fm scrobble inside
+        ``on_track_end`` used to hold ``_lock`` indefinitely, freezing every
+        FastAPI player route. After the refactor the callback runs OUTSIDE
+        ``_lock``, so a concurrent seek must complete with low latency.
+        """
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.state.duration = 180.0
+            engine.state.position = 60.0
+            callback_started = threading.Event()
+            callback_release = threading.Event()
+
+            def _slow_on_track_end(had_lookahead: bool) -> None:
+                callback_started.set()
+                callback_release.wait(timeout=5.0)
+
+            engine.on_track_end = _slow_on_track_end
+            fake.push_event({"event": "end-file", "reason": "eof"})
+            assert callback_started.wait(
+                timeout=2.0
+            ), "reader thread never entered on_track_end"
+            start = time.monotonic()
+            engine.seek(30.0)
+            elapsed = time.monotonic() - start
+            assert elapsed < 0.2, (
+                f"seek() blocked for {elapsed:.3f}s while on_track_end was "
+                f"parked; expected <0.2s. This is the KAMP-284 regression."
+            )
+            cmds = fake.commands_sent()
+            assert any(
+                c[0] == "seek" and c[1] == 30.0 for c in cmds
+            ), f"seek command never reached the transport. commands={cmds}"
+            callback_release.set()
+        finally:
+            _stop_engine(engine, fake)
+
+    def test_pause_completes_while_on_track_end_is_parked(self) -> None:
+        """Same shape as the seek test, but for ``pause()`` — that route is
+        also hit by media keys and the play/pause button."""
+        engine, fake = _make_threaded_engine()
+        try:
+            callback_release = threading.Event()
+            entered = threading.Event()
+
+            def _slow(had_lookahead: bool) -> None:
+                entered.set()
+                callback_release.wait(timeout=5.0)
+
+            engine.on_track_end = _slow
+            fake.push_event({"event": "end-file", "reason": "eof"})
+            assert entered.wait(timeout=2.0)
+            start = time.monotonic()
+            engine.pause()
+            elapsed = time.monotonic() - start
+            assert elapsed < 0.2
+            callback_release.set()
+        finally:
+            _stop_engine(engine, fake)
+
+
+# ---------------------------------------------------------------------------
+# KAMP-261 — Race A: seek vs end-file/eof under real concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestRaceAUnderRealConcurrency:
+    def test_no_double_playlist_remove_when_seek_races_eof(self) -> None:
+        """Run seek() and reader-thread eof in lockstep across many iterations.
+        Each iteration arms a fresh lookahead, then triggers the two paths
+        simultaneously. The invariant: across the cycle, mpv sees AT MOST one
+        ``playlist-remove`` per slot — Race A would emit BOTH
+        ``playlist-remove 0`` and ``playlist-remove 1`` for the same lookahead,
+        emptying mpv's playlist and stopping time-pos events.
+        """
+        iterations = 50
+        for i in range(iterations):
+            engine, fake = _make_threaded_engine()
+            try:
+                # Arm a lookahead in slot 1. preload_next runs on the main
+                # thread; the reader is idle until we push the eof event.
+                engine.state.duration = 180.0
+                engine.state.position = 50.0  # outside guard so the append happens
+                engine.preload_next(_track(i + 1))
+                # Now move into the guard window so seek() will try to remove.
+                engine.state.position = 175.0
+                assert engine.has_lookahead is True
+
+                barrier = threading.Barrier(2)
+
+                def _do_seek() -> None:
+                    barrier.wait(timeout=5.0)
+                    engine.seek(178.0)
+
+                seek_thread = threading.Thread(target=_do_seek)
+                seek_thread.start()
+                barrier.wait(timeout=5.0)
+                fake.push_event({"event": "end-file", "reason": "eof"})
+                seek_thread.join(timeout=5.0)
+                # Give the reader a moment to drain the eof event.
+                deadline = time.monotonic() + 1.0
+                while time.monotonic() < deadline and engine.has_lookahead:
+                    time.sleep(0.005)
+
+                cmds = fake.commands_sent()
+                # The lookahead's life-cycle commands:
+                # - "loadfile" "append" (during preload_next)
+                # - exactly one of: "playlist-remove" 0 (eof won) or
+                #   "playlist-remove" 1 (seek won), but never both.
+                rm0 = sum(1 for c in cmds if c[:2] == ["playlist-remove", 0])
+                rm1 = sum(1 for c in cmds if c[:2] == ["playlist-remove", 1])
+                # rm0 + rm1 counts how many removes fired against the original
+                # lookahead. The Race-A bug shows up as rm0 >= 1 AND rm1 >= 1
+                # in the same cycle (double-remove).
+                assert not (rm0 >= 1 and rm1 >= 1), (
+                    f"Race A: both playlist-remove 0 and playlist-remove 1 "
+                    f"fired in iteration {i}. commands={cmds}"
+                )
+                assert engine._lookahead_path is None, (
+                    f"iteration {i}: _lookahead_path not cleared after eof. "
+                    f"commands={cmds}"
+                )
+            finally:
+                _stop_engine(engine, fake)
+
+
+# ---------------------------------------------------------------------------
+# Callback ordering — single reader thread guarantees on_track_end completes
+# before on_file_loaded fires for the next track.
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackOrdering:
+    def test_on_file_loaded_starts_after_on_track_end_returns(self) -> None:
+        engine, fake = _make_threaded_engine()
+        try:
+            order: list[str] = []
+            order_lock = threading.Lock()
+
+            def _on_te(had_lookahead: bool) -> None:
+                with order_lock:
+                    order.append("te_enter")
+                time.sleep(0.05)
+                with order_lock:
+                    order.append("te_exit")
+
+            def _on_fl() -> None:
+                with order_lock:
+                    order.append("fl_enter")
+
+            engine.on_track_end = _on_te
+            engine.on_file_loaded = _on_fl
+            fake.push_event({"event": "end-file", "reason": "eof"})
+            fake.push_event({"event": "file-loaded"})
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                with order_lock:
+                    if "fl_enter" in order:
+                        break
+                time.sleep(0.01)
+            with order_lock:
+                snapshot = list(order)
+            te_exit_idx = snapshot.index("te_exit")
+            fl_enter_idx = snapshot.index("fl_enter")
+            assert (
+                te_exit_idx < fl_enter_idx
+            ), f"on_file_loaded started before on_track_end returned: {snapshot}"
+        finally:
+            _stop_engine(engine, fake)
+
+
+# ---------------------------------------------------------------------------
+# Transport write-lock — concurrent _send_command callers must not interleave
+# JSON frames on the wire. With the engine lock narrowed (KAMP-284), this
+# responsibility moved entirely to the transport.
+# ---------------------------------------------------------------------------
+
+
+class TestTransportWriteLock:
+    def test_fake_transport_serializes_concurrent_sends(self) -> None:
+        """Validates the FakeIPCTransport mirrors the production contract:
+        no two threads' frames ever interleave inside one log entry."""
+        engine, fake = _make_threaded_engine()
+        try:
+            n_threads = 8
+            sends_per_thread = 250
+            start_barrier = threading.Barrier(n_threads)
+
+            def _worker(label: int) -> None:
+                start_barrier.wait(timeout=5.0)
+                for i in range(sends_per_thread):
+                    engine._send_command("set_property", f"label-{label}", i)
+
+            threads = [
+                threading.Thread(target=_worker, args=(j,)) for j in range(n_threads)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10.0)
+            entries = fake.send_log_snapshot()
+            # Each entry must be exactly one well-formed JSON line ending in \n.
+            for raw in entries:
+                assert raw.endswith(
+                    b"\n"
+                ), f"frame did not end on newline: {raw!r} — frames interleaved"
+                # Must round-trip as a single JSON object with a "command" list.
+                msg = json.loads(raw.decode().strip())
+                assert isinstance(msg.get("command"), list)
+            assert len(entries) == n_threads * sends_per_thread
+        finally:
+            _stop_engine(engine, fake)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="_UnixSocketTransport is POSIX-only",
+    )
+    def test_posix_transport_write_lock_exists(self) -> None:
+        """The POSIX transport gained a write lock in KAMP-284 so it
+        symmetrically protects sendall from concurrent callers (the Windows
+        named-pipe transport already had one)."""
+        t = _UnixSocketTransport()
+        try:
+            assert hasattr(t, "_write_lock"), "_UnixSocketTransport missing _write_lock"
+            # Confirm it is actually a Lock (not just any attribute).
+            assert isinstance(t._write_lock, type(threading.Lock()))
+        finally:
+            t.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: non-gapless EOF flow (regression coverage for the "stuck
+# position bar after seek-near-end" report). The original KAMP-284 refactor
+# shipped without a test that runs the full daemon-style callback chain
+# through a non-gapless EOF, so a regression here had no failing test.
+# ---------------------------------------------------------------------------
+
+
+class TestNonGaplessEofFlow:
+    def test_seek_into_guard_window_then_eof_advances_to_next_track(self) -> None:
+        """User scenario: a queued lookahead is in slot 1, user seeks within
+        the gapless guard window (so seek() removes the lookahead), the
+        track ends naturally a few seconds later. The daemon callback must
+        call engine.play(next_track) and that loadfile must land on the
+        transport — otherwise mpv goes idle, time-pos stops, position bar
+        freezes (the exact user-reported symptom).
+        """
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.state.duration = 180.0
+            engine.state.position = 60.0
+            engine.preload_next(_track(2))
+            assert engine.has_lookahead is True
+
+            # Daemon-shaped callback: advance a fake queue and call play(next)
+            # iff !had_lookahead, mirroring kamp_daemon/__main__.py:_on_track_end.
+            queue_tracks = [_track(1), _track(2), _track(3)]
+            qpos = [0]
+            captured: list[tuple[bool, Path]] = []
+
+            def _on_te(had_lookahead: bool) -> None:
+                qpos[0] += 1
+                if qpos[0] < len(queue_tracks):
+                    next_path = queue_tracks[qpos[0]].file_path
+                    if not had_lookahead:
+                        engine.play(next_path)
+                    captured.append((had_lookahead, next_path))
+
+            engine.on_track_end = _on_te
+
+            # Move into the guard window and seek — clears _lookahead_path.
+            engine.state.position = 175.0
+            engine.seek(175.0)
+            assert engine.has_lookahead is False
+
+            # Track ends naturally. Reader processes eof on its own thread.
+            fake.push_event({"event": "end-file", "reason": "eof"})
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and not captured:
+                time.sleep(0.01)
+
+            assert captured == [(False, queue_tracks[1].file_path)], (
+                f"on_track_end did not fire with had_lookahead=False, or queue "
+                f"never advanced. captured={captured}"
+            )
+            cmds = fake.commands_sent()
+            assert any(
+                c[:3] == ["loadfile", str(queue_tracks[1].file_path), "replace"]
+                for c in cmds
+            ), (
+                f"loadfile replace for next track never reached transport — "
+                f"mpv would go idle. cmds={cmds}"
+            )
+        finally:
+            _stop_engine(engine, fake)
+
+    def test_state_is_reset_at_notify_time_after_non_gapless_eof(self) -> None:
+        """At the moment the daemon's notify_track_changed fires (end of
+        the on_track_end chain), state.position and state.duration must
+        reflect the NEW track's starting values, not the finishing track's
+        stale ones. Otherwise the track.changed WS event ships position=175
+        / duration=180 for the new track and the UI renders a stuck slider —
+        the user-reported KAMP-284 regression after seek-near-EOF.
+        """
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.state.duration = 180.0
+            engine.state.position = 175.0
+            engine.preload_next(_track(2))
+            engine.seek(175.0)  # clears lookahead via guard window
+            assert engine.has_lookahead is False
+
+            snap: dict[str, float] = {}
+            queue_tracks = [_track(1), _track(2)]
+            qpos = [0]
+
+            def _on_te(had_lookahead: bool) -> None:
+                qpos[0] += 1
+                if qpos[0] < len(queue_tracks) and not had_lookahead:
+                    engine.play(queue_tracks[qpos[0]].file_path)
+                # _on_track_end_notify fires app.state.notify_track_changed()
+                # right after this callback returns — capture the state it
+                # would see.
+                snap["pos"] = engine.state.position
+                snap["dur"] = engine.state.duration
+
+            engine.on_track_end = _on_te
+            fake.push_event({"event": "end-file", "reason": "eof"})
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and "pos" not in snap:
+                time.sleep(0.01)
+            assert snap.get("pos") == 0.0, (
+                f"state.position={snap.get('pos')!r} at notify time; "
+                f"expected 0.0. UI would render the new track at the "
+                f"finishing track's stale position bar."
+            )
+            assert (
+                snap.get("dur") == 0.0
+            ), f"state.duration={snap.get('dur')!r} at notify time; expected 0.0."
+        finally:
+            _stop_engine(engine, fake)
+
+    def test_state_is_reset_at_notify_time_after_gapless_eof(self) -> None:
+        """Gapless counterpart: when had_lookahead=True at EOF, mpv has
+        already transitioned but state.position/duration still reflect the
+        finished track until file-loaded for the new track is processed
+        (which the reader can't do until on_track_end returns). The engine
+        must reset state synchronously inside the eof handler so the
+        callback's WS notify sees the new track at 0:00.
+        """
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.state.duration = 180.0
+            engine.state.position = 100.0  # outside guard so lookahead survives
+            engine.preload_next(_track(2))
+            assert engine.has_lookahead is True
+
+            snap: dict[str, float] = {}
+
+            def _on_te(had_lookahead: bool) -> None:
+                snap["pos"] = engine.state.position
+                snap["dur"] = engine.state.duration
+                snap["had_lookahead"] = float(had_lookahead)
+
+            engine.on_track_end = _on_te
+            fake.push_event({"event": "end-file", "reason": "eof"})
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and "pos" not in snap:
+                time.sleep(0.01)
+            assert snap.get("had_lookahead") == 1.0, "gapless path not exercised"
+            assert (
+                snap.get("pos") == 0.0
+            ), f"state.position={snap.get('pos')!r} at notify time; expected 0.0"
+            assert snap.get("dur") == 0.0
+        finally:
+            _stop_engine(engine, fake)
+
+    def test_natural_eof_with_lookahead_does_not_call_play(self) -> None:
+        """Counterpart to the above: when there IS a lookahead at eof (mpv
+        already transitioned gaplessly), the callback must NOT call
+        engine.play, because that would clobber the gapless transition with
+        a loadfile replace.
+        """
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.state.duration = 180.0
+            engine.state.position = 60.0
+            engine.preload_next(_track(2))
+            assert engine.has_lookahead is True
+
+            queue_tracks = [_track(1), _track(2), _track(3)]
+            qpos = [0]
+            captured_had: list[bool] = []
+            replace_calls: list[str] = []
+
+            def _on_te(had_lookahead: bool) -> None:
+                qpos[0] += 1
+                captured_had.append(had_lookahead)
+                if qpos[0] < len(queue_tracks) and not had_lookahead:
+                    engine.play(queue_tracks[qpos[0]].file_path)
+
+            engine.on_track_end = _on_te
+
+            # Stay OUTSIDE the guard window so the lookahead survives to eof.
+            engine.state.position = 100.0
+            fake.push_event({"event": "end-file", "reason": "eof"})
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and not captured_had:
+                time.sleep(0.01)
+
+            assert captured_had == [True]
+            cmds = fake.commands_sent()
+            for c in cmds:
+                if c[:1] == ["loadfile"] and len(c) >= 3 and c[2] == "replace":
+                    replace_calls.append(c[1])
+            assert (
+                replace_calls == []
+            ), f"engine.play was wrongly called after a gapless EOF: {replace_calls}"
+        finally:
+            _stop_engine(engine, fake)
+
+
+# ---------------------------------------------------------------------------
+# Defense in depth: the reader thread must survive any callback exception so
+# a buggy on_track_end can't silently wedge the daemon until restart.
+# ---------------------------------------------------------------------------
+
+
+class TestReaderSurvivesCallbackException:
+    def test_zero_division_in_on_track_end_does_not_kill_reader(self) -> None:
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.on_track_end = lambda _: 1 / 0
+            fake.push_event({"event": "end-file", "reason": "eof"})
+            # Give the bad callback a moment to fire (and be swallowed).
+            time.sleep(0.1)
+            # If the reader is alive, this time-pos must reach state.position.
+            fake.push_event(
+                {"event": "property-change", "name": "time-pos", "data": 42.5}
+            )
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and engine.state.position != 42.5:
+                time.sleep(0.01)
+            assert engine.state.position == 42.5, (
+                "reader thread died from the on_track_end exception; "
+                "time-pos updates stopped flowing"
+            )
+        finally:
+            _stop_engine(engine, fake)
+
+    def test_attribute_error_in_on_file_loaded_does_not_kill_reader(self) -> None:
+        engine, fake = _make_threaded_engine()
+        try:
+            engine.on_file_loaded = lambda: None.foo  # type: ignore[attr-defined]
+            fake.push_event({"event": "file-loaded"})
+            time.sleep(0.1)
+            fake.push_event(
+                {"event": "property-change", "name": "duration", "data": 123.0}
+            )
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and engine.state.duration != 123.0:
+                time.sleep(0.01)
+            assert engine.state.duration == 123.0
+        finally:
+            _stop_engine(engine, fake)

--- a/tests/test_scrobbler.py
+++ b/tests/test_scrobbler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -9,7 +11,7 @@ import pytest
 
 from kamp_core.library import Track
 from kamp_core import scrobbler as _mod
-from kamp_core.scrobbler import Scrobbler, authenticate
+from kamp_core.scrobbler import Scrobbler, _ScrobbleJob, authenticate
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,10 +43,24 @@ def _track(
 
 
 def _make_scrobbler() -> tuple[Scrobbler, MagicMock]:
-    """Return a Scrobbler and its mocked pylast network."""
+    """Return a Scrobbler and its mocked pylast network.
+
+    The scrobbler's HTTP work runs on a worker thread in production (KAMP-284),
+    but unit tests assert synchronously. Wrap ``_tx_queue.put`` so each test
+    sees a drained queue immediately after the action. The dedicated
+    ``test_call_returns_immediately`` case bypasses this wrapper to validate
+    the actual async path.
+    """
     mock_network = MagicMock()
     with patch("kamp_core.scrobbler.pylast.LastFMNetwork", return_value=mock_network):
         s = Scrobbler(session_key="test-session-key")
+    _orig_put = s._tx_queue.put
+
+    def _draining_put(job: _ScrobbleJob) -> None:
+        _orig_put(job)
+        s.flush()
+
+    s._tx_queue.put = _draining_put  # type: ignore[method-assign,assignment]
     return s, mock_network
 
 
@@ -365,3 +381,80 @@ class TestOnTrackEnded:
         s.on_track_changed(t)
         s.on_track_ended(t)
         assert net.scrobble.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Worker-thread async behaviour — explicit, no draining helper (KAMP-284)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncWorker:
+    """The caller (engine reader thread, state-saver thread) must NEVER block
+    on Last.fm latency. These tests stand up the real async worker and prove
+    the contract by hanging pylast on the worker side.
+    """
+
+    def _make_async_scrobbler(self) -> tuple[Scrobbler, MagicMock]:
+        """Like _make_scrobbler but WITHOUT the draining put-wrapper."""
+        mock_network = MagicMock()
+        with patch(
+            "kamp_core.scrobbler.pylast.LastFMNetwork", return_value=mock_network
+        ):
+            s = Scrobbler(session_key="test-session-key")
+        return s, mock_network
+
+    def test_on_track_ended_returns_immediately_when_http_is_slow(self) -> None:
+        """The whole point of the worker (KAMP-284): a 5s Last.fm response
+        must not delay the engine's reader thread by more than a few ms."""
+        s, net = self._make_async_scrobbler()
+        net.scrobble.side_effect = lambda **_: time.sleep(5.0)
+        t = _track()
+        s.on_track_changed(t)
+        start = time.monotonic()
+        s.on_track_ended(t)
+        elapsed = time.monotonic() - start
+        # Generous bound: production needs sub-100ms; we just need to prove
+        # we're not waiting on the side_effect's 5s sleep.
+        assert elapsed < 0.2, f"on_track_ended took {elapsed:.3f}s; expected <0.2s"
+
+    def test_on_track_changed_returns_immediately_when_http_is_slow(self) -> None:
+        s, net = self._make_async_scrobbler()
+        net.update_now_playing.side_effect = lambda **_: time.sleep(5.0)
+        t = _track()
+        start = time.monotonic()
+        s.on_track_changed(t)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.2, f"on_track_changed took {elapsed:.3f}s; expected <0.2s"
+
+    def test_flush_blocks_until_worker_drains(self) -> None:
+        """flush() is the test-side synchronization primitive — it must block
+        until the worker has processed every queued job."""
+        s, net = self._make_async_scrobbler()
+        gate = threading.Event()
+        observed_order: list[str] = []
+
+        def _slow_scrobble(**_: object) -> None:
+            gate.wait(timeout=2.0)
+            observed_order.append("worker_done")
+
+        net.scrobble.side_effect = _slow_scrobble
+        t = _track()
+        s.on_track_changed(t)
+        s.on_track_ended(t)
+        # The worker is currently parked in _slow_scrobble waiting on the gate.
+        # Releasing the gate, then flush() must wait for the worker to finish.
+        gate.set()
+        s.flush()
+        observed_order.append("flush_returned")
+        assert observed_order == ["worker_done", "flush_returned"]
+
+    def test_shutdown_drains_pending_work(self) -> None:
+        """shutdown() drains the queue best-effort within the timeout."""
+        s, net = self._make_async_scrobbler()
+        t = _track()
+        s.on_track_changed(t)
+        s.on_track_ended(t)
+        s.shutdown(timeout=2.0)
+        # All enqueued HTTP work completed before the worker exited.
+        net.update_now_playing.assert_called()
+        net.scrobble.assert_called()


### PR DESCRIPTION
## Summary

Three concerns landed on this branch, originally framed by KAMP-284 (lock-around-sendall reentry risk) and expanded after the user hit two follow-on regressions during local testing.

- **Lock + threading model.** `MpvPlaybackEngine._lock` is now a plain `Lock` guarding only the `(_lookahead_path, mpv playlist slot)` pair. User callbacks fire **outside** the lock, so a slow `on_track_end` (e.g. a Last.fm hang) can never freeze main-thread `seek` / `pause` / `resume` again. Lock contract is applied uniformly across `play` / `load_paused` / `preload_next` / `seek` / EOF handler. `on_track_end` signature: `()` → `(had_lookahead: bool)`. POSIX `_UnixSocketTransport` gains a `_write_lock` symmetric to the Windows named pipe's. Close-while-send TOCTOU fixed on both transports.
- **Scrobbler async worker.** pylast HTTP now runs on a dedicated `scrobbler-tx` daemon thread. Callers snapshot state under a new `_state_lock` and enqueue. `flush()` for tests, `shutdown(timeout=2.0)` wired into daemon shutdown and Last.fm connect/disconnect.
- **State-reset at transition.** `engine.play` / `engine.load_paused` / EOF handler (`had_lookahead=True` branch) now reset `state.position = 0.0` / `state.duration = 0.0` synchronously under the lock. Without this, the in-flight `track.changed` WS event shipped the **finishing** track's stale position/duration with the **new** track's title — the UI rendered a stuck slider until daemon restart. The old synchronous Last.fm scrobble parked the reader long enough to mask this; moving scrobbling off the reader exposed the latent bug.
- **Reader resilience.** `_read_loop` catches any callback exception with `logger.exception(...)` and continues. Was: only `JSONDecodeError` caught; anything else killed the reader and silently froze the UI. INFO log lines on the EOF path stay as a diagnostic anchor.

## Test plan

- [x] `poetry run pytest --no-cov -q` — 1244 passed, 28 skipped (28 are unrelated POSIX-only / cross-platform skips on Windows)
- [x] `poetry run black --check kamp_core kamp_daemon tests` — clean
- [x] `poetry run mypy kamp_core kamp_daemon` — clean
- [x] New `tests/test_playback_threaded.py` exercises the **real reader thread** against a controllable fake IPC transport:
  - [x] Race A under concurrency (KAMP-261) — 50 iterations, no double `playlist-remove`
  - [x] Slow `on_track_end` does not block main-thread `seek` / `pause` (KAMP-284 symptom)
  - [x] Callback ordering preserved (single reader thread → `on_track_end` finishes before `on_file_loaded` starts)
  - [x] Transport write-lock serializes 8 threads × 250 sends with no frame interleaving
  - [x] **State is reset before notify fires on both gapless and non-gapless EOF paths** (regression coverage for the stuck-slider symptom)
  - [x] Reader survives `on_track_end` / `on_file_loaded` exceptions
- [x] `tests/test_scrobbler.py` gains `TestAsyncWorker` — caller returns within 200 ms while pylast sleeps 5 s
- [x] Manual: rerun seek-near-EOF scenario on the live daemon. The `eof: had_lookahead=... / engine.play: loading ... / eof: on_track_end returned` log block stays as a diagnostic anchor; UI must show new track at 0:00 immediately after transition.
- [x] Manual: gapless playback through Trans Am *Futureworld* (KAMP-276 regression check)
- [x] Manual: queue \"Play Next\" within last 10s of current track (KAMP-262 regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)