### PR TITLE
fix(ui): replace transport-bar system glyphs with inline SVGs (KAMP-291)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -78,15 +78,19 @@
   gap: 8px;
 }
 
+/* Button content is now an SVG (KAMP-291) rather than a system-font glyph, so
+   no font-size / line-height — the button height is driven by the SVG box +
+   padding, and inline-flex centers the SVG inside the button. */
 .transport-btn {
   background: none;
   border: none;
   color: var(--text);
-  font-size: 18px;
   cursor: pointer;
   padding: 4px 6px;
   border-radius: 4px;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
     color 0.1s,
     background 0.1s;
@@ -95,10 +99,6 @@
 .transport-btn:hover {
   color: var(--accent);
   background: var(--surface-hover);
-}
-
-.transport-btn.primary {
-  font-size: 22px;
 }
 
 .transport-progress {
@@ -124,7 +124,14 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 14px;
+}
+
+/* Wrap the VolumeIcon SVG in an inline-flex span so its box centers on the
+   flex row's centerline, matching .transport-btn's centering. */
+.volume-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-dim);
 }
 
 .volume-slider {

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -1,5 +1,14 @@
 import React, { useRef, useState } from 'react'
 import { useStore } from '../store'
+import {
+  NextIcon,
+  PauseIcon,
+  PlayIcon,
+  PrevIcon,
+  QueueIcon,
+  StopIcon,
+  VolumeIcon
+} from './TransportIcons'
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -94,21 +103,22 @@ export function TransportBar(): React.JSX.Element {
       </button>
 
       <div className="transport-controls">
-        <button className="transport-btn" onClick={prev} title="Previous (←)">
-          ⏮
+        <button className="transport-btn" onClick={prev} title="Previous (←)" aria-label="Previous">
+          <PrevIcon />
         </button>
         <button
           className="transport-btn primary"
           onClick={togglePlayPause}
           title={playing ? 'Pause (Space)' : 'Play (Space)'}
+          aria-label={playing ? 'Pause' : 'Play'}
         >
-          {playing ? '⏸' : '▶'}
+          {playing ? <PauseIcon /> : <PlayIcon />}
         </button>
-        <button className="transport-btn" onClick={stop} title="Stop">
-          ⏹
+        <button className="transport-btn" onClick={stop} title="Stop" aria-label="Stop">
+          <StopIcon />
         </button>
-        <button className="transport-btn" onClick={next} title="Next (→)">
-          ⏭
+        <button className="transport-btn" onClick={next} title="Next (→)" aria-label="Next">
+          <NextIcon />
         </button>
       </div>
 
@@ -162,7 +172,9 @@ export function TransportBar(): React.JSX.Element {
       </div>
 
       <div className="transport-volume">
-        <span title="Volume">🔊</span>
+        <span className="volume-icon" title="Volume" aria-hidden="true">
+          <VolumeIcon />
+        </span>
         <input
           type="range"
           className="volume-slider"
@@ -179,8 +191,10 @@ export function TransportBar(): React.JSX.Element {
         className={`transport-btn queue-toggle-btn${queueVisible ? ' active' : ''}`}
         onClick={toggleQueuePanel}
         title="Queue (Q)"
+        aria-label="Queue"
+        aria-pressed={queueVisible}
       >
-        ☰
+        <QueueIcon />
       </button>
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+
+// Inline-SVG transport icons. Replace the Unicode glyphs (⏮ ▶ ⏸ ⏹ ⏭ 🔊 ☰)
+// that rendered inconsistently between macOS (Apple Color Emoji / system fallback) and
+// Windows (Segoe UI Symbol / Emoji) — KAMP-291. viewBox 24, currentColor, and even-pixel
+// vertex coords match the existing favorite-heart in TransportBar.tsx.
+
+interface IconProps {
+  size?: number
+}
+
+const FILL_PROPS = {
+  viewBox: '0 0 24 24',
+  fill: 'currentColor',
+  'aria-hidden': true,
+  focusable: 'false'
+} as const
+
+const STROKE_PROPS = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  'aria-hidden': true,
+  focusable: 'false'
+} as const
+
+export function PrevIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <path d="M8 12 L19 5 L19 19 Z" />
+      <rect x="5" y="5" width="2" height="14" />
+    </svg>
+  )
+}
+
+export function PlayIcon({ size = 26 }: IconProps): React.JSX.Element {
+  // M8 5 L19 12 L8 19 Z — nudged 1px left from the geometric center so the
+  // triangle appears optically centered (visual mass of an isoceles triangle
+  // sits ~6% right of its geometric centroid).
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <path d="M8 5 L19 12 L8 19 Z" />
+    </svg>
+  )
+}
+
+export function PauseIcon({ size = 26 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <rect x="7" y="5" width="3" height="14" />
+      <rect x="14" y="5" width="3" height="14" />
+    </svg>
+  )
+}
+
+export function StopIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <rect x="6" y="6" width="12" height="12" />
+    </svg>
+  )
+}
+
+export function NextIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <path d="M5 5 L16 12 L5 19 Z" />
+      <rect x="17" y="5" width="2" height="14" />
+    </svg>
+  )
+}
+
+export function VolumeIcon({ size = 20 }: IconProps): React.JSX.Element {
+  // Speaker cone + two arc waves. Matches Lucide's Volume2 geometry so the
+  // optical weight aligns with other stroke-based icons (the heart).
+  return (
+    <svg width={size} height={size} {...STROKE_PROPS}>
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+    </svg>
+  )
+}
+
+export function QueueIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...STROKE_PROPS}>
+      <line x1="4" y1="7" x2="20" y2="7" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="17" x2="20" y2="17" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- Transport-bar play/pause/prev/next/stop/volume/queue glyphs were Unicode characters rendered via different system fonts on macOS (Apple Color Emoji / SF fallback) and Windows (Segoe UI Symbol / Emoji) — different shapes, baselines, and a colourful 🔊 in an otherwise monochrome row. Replaced with inline SVG components (`viewBox=0 0 24 24`, `currentColor`) matching the existing favorite-heart pattern.
- Dropped `font-size`/`line-height` on `.transport-btn` in favour of `inline-flex` centring, so every control — including the favorite heart — now sits on the same horizontal centerline. Fixes [KAMP-291](https://eightyeighteyes.atlassian.net/browse/KAMP-291).
- Added `aria-label` to every transport button; SVGs carry `aria-hidden="true"` and `focusable="false"`.

## Test plan
- [x] `npm run typecheck` / `npm run lint` clean
- [x] Visual verification on Windows — all transport elements share one centerline; `🔊` is now monochrome
- [x] Visual verification on macOS — same centerline; play/pause behaviour also visibly improved
- [x] Theme/colour: icons inherit `currentColor`, so hover (`--accent`) and dim variants work without per-theme overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAMP-291]: https://eightyeighteyes.atlassian.net/browse/KAMP-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ