### PR TITLE
feat(ui): replace ♥ glyphs with shared FavoriteIcon SVG (KAMP-234)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -80,9 +80,10 @@
 .queue-track-fav {
   grid-row: 1 / 3;
   align-self: center;
-  font-size: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--accent);
-  text-align: center;
 }
 
 .queue-track-num {

--- a/kamp_ui/src/renderer/src/assets/search.css
+++ b/kamp_ui/src/renderer/src/assets/search.css
@@ -176,9 +176,10 @@
 .search-track-fav {
   width: 12px;
   flex-shrink: 0;
-  font-size: 9px;
-  color: var(--error);
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
 }
 
 .search-track-title {

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -220,9 +220,10 @@
 }
 
 .track-row-fav {
-  font-size: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--accent);
-  text-align: center;
 }
 
 .track-row-num {

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { QueueContextMenu } from './QueueContextMenu'
+import { FavoriteIcon } from './TransportIcons'
 
 const QUEUE_DROP_TYPES = new Set(['text/kamp-track-path', 'text/kamp-album', 'text/kamp-queue-idx'])
 function isQueueDrop(types: DOMStringList | readonly string[]): boolean {
@@ -217,8 +218,8 @@ export function QueuePanel(): React.JSX.Element {
                   })
                 }}
               >
-                <span className="queue-track-fav" aria-hidden="true">
-                  {track.favorite ? '♥' : ''}
+                <span className="queue-track-fav">
+                  {track.favorite && <FavoriteIcon active size={10} />}
                 </span>
                 <span className="queue-track-num">{idx + 1}</span>
                 <span className="queue-track-title">{track.title}</span>

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -5,6 +5,7 @@ import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
 import { AlbumContextMenu } from './AlbumContextMenu'
 import { TrackContextMenu } from './TrackContextMenu'
+import { FavoriteIcon } from './TransportIcons'
 
 type AlbumMenu = { x: number; y: number; album: Album }
 type TrackMenu = { x: number; y: number; filePath: string; favorite: boolean }
@@ -101,8 +102,8 @@ function SearchTrackRow({
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >
-      <span className="search-track-fav" aria-hidden="true">
-        {track.favorite ? '♥' : ''}
+      <span className="search-track-fav">
+        {track.favorite && <FavoriteIcon active size={10} />}
       </span>
       <span className="search-track-title">{track.title}</span>
       <span className="search-track-meta">

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
+import { FavoriteIcon } from './TransportIcons'
 
 type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
@@ -118,8 +119,8 @@ export function TrackList(): React.JSX.Element | null {
                   })
                 }}
               >
-                <span className="track-row-fav" aria-hidden="true">
-                  {track.favorite ? '♥' : ''}
+                <span className="track-row-fav">
+                  {track.favorite && <FavoriteIcon active size={10} />}
                 </span>
                 <span className="track-row-num">
                   {isCurrent ? (playing ? '▶' : '▐▐') : track.track_number}

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react'
 import { useStore } from '../store'
 import {
+  FavoriteIcon,
   NextIcon,
   PauseIcon,
   PlayIcon,
@@ -88,18 +89,7 @@ export function TransportBar(): React.JSX.Element {
         title={current_track?.favorite ? 'Remove from favorites' : 'Add to favorites'}
         aria-pressed={current_track?.favorite ?? false}
       >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill={current_track?.favorite ? 'currentColor' : 'none'}
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-        </svg>
+        <FavoriteIcon active={current_track?.favorite ?? false} />
       </button>
 
       <div className="transport-controls">

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -94,3 +94,27 @@ export function QueueIcon({ size = 20 }: IconProps): React.JSX.Element {
     </svg>
   )
 }
+
+interface FavoriteIconProps {
+  active: boolean
+  size?: number
+}
+
+export function FavoriteIcon({ active, size = 16 }: FavoriteIconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `FavoriteIcon` to `TransportIcons.tsx` — same Feather-style heart path as TransportBar, `active` prop drives fill vs. stroke-only
- Replaces `{track.favorite ? '♥' : ''}` Unicode glyphs in TrackList, QueuePanel, and SearchView with `<FavoriteIcon active size={10} />`
- Updates TransportBar to use the shared component instead of an inlined SVG block
- Fixes `.search-track-fav` color from `var(--error)` (red) → `var(--accent)` (purple) — was wrong before this change
- Updates fav-span CSS in all three stylesheets: removes `font-size`/`text-align` (text-only props), adds `display: flex; align-items: center; justify-content: center` to properly center the SVG in the 12 px grid column

## Test plan

- [x] Favorite a track and verify the heart appears (filled, purple) in the track list, queue panel, and search results
- [x] Unfavorite and verify the heart disappears in all three views
- [x] Check TransportBar heart still fills/unfills correctly
- [x] Confirm no layout shifts or regressions in track list, queue, or search row sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)