### PR TITLE
feat(ui): breadcrumb nav in album view (KAMP-236)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -68,31 +68,57 @@
   );
 }
 
-/* Back button floats over the hero */
-.back-btn {
+/* Breadcrumb floats over the hero */
+.breadcrumb {
   position: absolute;
   top: 12px;
   left: 12px;
   z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   background: rgba(20, 20, 20, 0.55);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 20px;
-  color: #ffffff;
   font-size: 13px;
   font-weight: 500;
-  padding: 5px 12px 5px 9px;
-  cursor: pointer;
+  padding: 5px 12px;
   white-space: nowrap;
   transition:
     background 0.15s,
     border-color 0.15s;
 }
 
-.back-btn:hover {
-  background: rgba(20, 20, 20, 0.75);
-  border-color: rgba(255, 255, 255, 0.2);
+.breadcrumb button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.breadcrumb button:hover {
+  color: #ffffff;
+}
+
+.breadcrumb button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.breadcrumb-sep {
+  color: rgba(255, 255, 255, 0.3);
+  pointer-events: none;
+}
+
+/* Current page — album name, not interactive */
+.breadcrumb > span:last-child {
+  color: #ffffff;
 }
 
 /* Scrollable body — transparent so the art can bleed through the top rows. */

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -51,10 +51,28 @@ export function TrackList(): React.JSX.Element | null {
 
       {/* Breadcrumb floats over the hero */}
       <nav className="breadcrumb" aria-label="Navigation">
-        <button onClick={() => { selectAlbum(null); selectArtist(null) }}>Library</button>
-        <span className="breadcrumb-sep" aria-hidden="true">›</span>
-        <button onClick={() => { selectAlbum(null); selectArtist(album.album_artist) }}>{album.album_artist}</button>
-        <span className="breadcrumb-sep" aria-hidden="true">›</span>
+        <button
+          onClick={() => {
+            selectAlbum(null)
+            selectArtist(null)
+          }}
+        >
+          Library
+        </button>
+        <span className="breadcrumb-sep" aria-hidden="true">
+          ›
+        </span>
+        <button
+          onClick={() => {
+            selectAlbum(null)
+            selectArtist(album.album_artist)
+          }}
+        >
+          {album.album_artist}
+        </button>
+        <span className="breadcrumb-sep" aria-hidden="true">
+          ›
+        </span>
         <span>{album.album}</span>
       </nav>
 

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -49,10 +49,14 @@ export function TrackList(): React.JSX.Element | null {
       {/* Overlay spans the full view so the gradient covers both hero and the top of the track list */}
       <div className="track-list-hero-overlay" />
 
-      {/* Back button floats over the hero */}
-      <button className="back-btn" onClick={() => selectAlbum(null)} aria-label="Back to albums">
-        ←
-      </button>
+      {/* Breadcrumb floats over the hero */}
+      <nav className="breadcrumb" aria-label="Navigation">
+        <button onClick={() => { selectAlbum(null); selectArtist(null) }}>Library</button>
+        <span className="breadcrumb-sep" aria-hidden="true">›</span>
+        <button onClick={() => { selectAlbum(null); selectArtist(album.album_artist) }}>{album.album_artist}</button>
+        <span className="breadcrumb-sep" aria-hidden="true">›</span>
+        <span>{album.album}</span>
+      </nav>
 
       {/* Static identity block — does not scroll */}
       <div className="track-list-identity">


### PR DESCRIPTION
## Summary

- Replaces the `← back` button in the album view header with a `Library › Artist › Album` breadcrumb
- **Library** clears both album and artist filters (root grid)
- **Artist** explicitly sets the artist filter to the album's artist, clearing the album selection — works correctly regardless of how the album was entered
- **Album** is non-interactive (current page indicator)
- Separators are purely decorative (`aria-hidden`)
- Frosted-glass pill styling matches the original back button's position and visual weight

## Test plan

- [x] Open any album — breadcrumb shows `Library › <artist> › <album>`
- [x] Click **Library** — lands at root grid with no artist filter
- [x] Click **Artist** — lands at artist-filtered grid for that artist (not "All Artists")
- [x] Album name is displayed but not clickable
- [x] Navigate to an album directly (not via artist filter) and confirm Artist crumb still filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)