### PR TITLE
feat(ui): play button toggles pause on current album (KAMP-296)

### DIFF
--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
-import { FavoriteIcon } from './TransportIcons'
+import { FavoriteIcon, PlayIcon, PauseIcon } from './TransportIcons'
 
 type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
@@ -95,10 +95,14 @@ export function TrackList(): React.JSX.Element | null {
         </div>
         <button
           className="play-all-btn"
-          aria-label="Play all"
-          onClick={() => playTrack(album.album_artist, album.album, 0, album.file_path)}
+          aria-label={isCurrentAlbum && playing ? 'Pause' : 'Play all'}
+          onClick={() =>
+            isCurrentAlbum
+              ? togglePlayPause()
+              : playTrack(album.album_artist, album.album, 0, album.file_path)
+          }
         >
-          ▶
+          {isCurrentAlbum && playing ? <PauseIcon size={18} /> : <PlayIcon size={18} />}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

- When viewing the album page for the currently playing album, the play button now shows a pause icon and toggles playback instead of restarting from track 1
- Uses existing `PlayIcon`/`PauseIcon` SVG components from `TransportIcons.tsx` (KAMP-291 pattern — no new glyphs)
- `aria-label` updates to match state ("Pause" vs "Play all")

## Test plan

- [x] Start playing an album, navigate to that album's page — button shows pause icon; clicking pauses
- [x] While paused on the current album's page — button shows play icon; clicking resumes (does not restart)
- [x] Navigate to a different album's page while something is playing — button shows play icon; clicking starts that album from track 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)