### PR TITLE
feat(ui): clicking Library tab resets to All Artists (KAMP-297)

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -101,6 +101,7 @@ export default function App(): React.JSX.Element {
   const artistPanelVisible = useStore((s) => s.artistPanelVisible)
   const toggleArtistPanel = useStore((s) => s.toggleArtistPanel)
   const openPrefs = useStore((s) => s.openPrefs)
+  const selectArtist = useStore((s) => s.selectArtist)
 
   const layout = usePanelLayout()
   const extState = useExtensionState()
@@ -448,6 +449,8 @@ export default function App(): React.JSX.Element {
     } else if (panel.kind === 'builtin' && panel.id === 'kamp.library') {
       void setActiveView('library')
       setActiveExtPanel(null)
+      const { selectedArtist, selectedAlbum } = useStore.getState().library
+      if (selectedArtist !== null || selectedAlbum !== null) selectArtist(null)
     } else if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing') {
       void setActiveView('now-playing')
       setActiveExtPanel(null)


### PR DESCRIPTION
## Summary

- Clicking the Library tab now calls `selectArtist(null)`, which clears both the selected artist and any open album in one store update
- Guarded by a `getState()` check so clicking the tab when already at the root view is a no-op (no state churn / flicker)

## Test plan

- [ ] Navigate to an artist, then click the Library tab — artist panel should revert to "All Artists"
- [ ] Open an album, then click the Library tab — album view should close and return to the grid
- [ ] Click the Library tab while already at the root view — no visible flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)