### PR TITLE
feat(ui): queue and play-next buttons on album page (KAMP-298)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -10,13 +10,7 @@ import {
   screen as electronScreen
 } from 'electron'
 import { dirname, join, resolve } from 'path'
-import {
-  createWriteStream,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync
-} from 'fs'
+import { createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { spawn, ChildProcess, execFileSync } from 'child_process'
 import { createInterface } from 'readline'

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -225,6 +225,31 @@
   filter: brightness(1.12);
 }
 
+.album-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.album-secondary-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.1s, background 0.1s;
+}
+
+.album-secondary-btn:hover {
+  color: var(--accent);
+  background: var(--surface-hover);
+}
+
 .track-list-divider {
   margin: 8px 0 0 0;
   flex-shrink: 0;

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -27,7 +27,9 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
           onClose()
         }}
       >
-        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
           <PlayNextIcon size={12} />
         </span>
         Play Next
@@ -39,7 +41,9 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
           onClose()
         }}
       >
-        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
           <QueueAddIcon size={12} />
         </span>
         Add to Queue

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -4,6 +4,7 @@ import { getTracksForAlbum } from '../api/client'
 import type { Album } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
+import { PlayNextIcon, QueueAddIcon } from './TransportIcons'
 
 interface Props {
   x: number
@@ -26,7 +27,10 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
           onClose()
         }}
       >
-        ▶ Play Next
+        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+          <PlayNextIcon size={12} />
+        </span>
+        Play Next
       </button>
       <button
         className="track-context-menu-item"
@@ -35,7 +39,10 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
           onClose()
         }}
       >
-        + Add to Queue
+        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+          <QueueAddIcon size={12} />
+        </span>
+        Add to Queue
       </button>
       <button
         className="track-context-menu-item"

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -26,7 +26,9 @@ export function TrackContextMenu({ x, y, filePath, favorite, onClose }: Props): 
           onClose()
         }}
       >
-        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
           <PlayNextIcon size={12} />
         </span>
         Play Next
@@ -38,7 +40,9 @@ export function TrackContextMenu({ x, y, filePath, favorite, onClose }: Props): 
           onClose()
         }}
       >
-        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
           <QueueAddIcon size={12} />
         </span>
         Add to Queue

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
+import { PlayNextIcon, QueueAddIcon } from './TransportIcons'
 
 interface Props {
   x: number
@@ -25,7 +26,10 @@ export function TrackContextMenu({ x, y, filePath, favorite, onClose }: Props): 
           onClose()
         }}
       >
-        ▶ Play Next
+        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+          <PlayNextIcon size={12} />
+        </span>
+        Play Next
       </button>
       <button
         className="track-context-menu-item"
@@ -34,7 +38,10 @@ export function TrackContextMenu({ x, y, filePath, favorite, onClose }: Props): 
           onClose()
         }}
       >
-        + Add to Queue
+        <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+          <QueueAddIcon size={12} />
+        </span>
+        Add to Queue
       </button>
       <button
         className="track-context-menu-item"

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
-import { FavoriteIcon, PlayIcon, PauseIcon } from './TransportIcons'
+import { FavoriteIcon, PlayIcon, PauseIcon, QueueAddIcon, PlayNextIcon } from './TransportIcons'
 
 type ContextMenu = { x: number; y: number; filePath: string; favorite: boolean }
 
@@ -29,6 +29,8 @@ export function TrackList(): React.JSX.Element | null {
   const playTrack = useStore((s) => s.playTrack)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const setAlbumFavorite = useStore((s) => s.setAlbumFavorite)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
 
@@ -102,17 +104,35 @@ export function TrackList(): React.JSX.Element | null {
           </h2>
           {album.year && <div className="track-list-album-year">{album.year}</div>}
         </div>
-        <button
-          className="play-all-btn"
-          aria-label={isCurrentAlbum && playing ? 'Pause' : 'Play all'}
-          onClick={() =>
-            isCurrentAlbum
-              ? togglePlayPause()
-              : playTrack(album.album_artist, album.album, 0, album.file_path)
-          }
-        >
-          {isCurrentAlbum && playing ? <PauseIcon size={18} /> : <PlayIcon size={18} />}
-        </button>
+        <div className="album-controls">
+          <button
+            className="album-secondary-btn"
+            title="Add to queue"
+            aria-label="Add album to queue"
+            onClick={() => void addAlbumToQueue(album.album_artist, album.album, album.file_path)}
+          >
+            <QueueAddIcon size={16} />
+          </button>
+          <button
+            className="album-secondary-btn"
+            title="Play next"
+            aria-label="Play album next"
+            onClick={() => void playAlbumNext(album.album_artist, album.album, album.file_path)}
+          >
+            <PlayNextIcon size={16} />
+          </button>
+          <button
+            className="play-all-btn"
+            aria-label={isCurrentAlbum && playing ? 'Pause' : 'Play all'}
+            onClick={() =>
+              isCurrentAlbum
+                ? togglePlayPause()
+                : playTrack(album.album_artist, album.album, 0, album.file_path)
+            }
+          >
+            {isCurrentAlbum && playing ? <PauseIcon size={18} /> : <PlayIcon size={18} />}
+          </button>
+        </div>
       </div>
 
       <div className="track-list-divider" />

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -95,6 +95,27 @@ export function QueueIcon({ size = 20 }: IconProps): React.JSX.Element {
   )
 }
 
+export function QueueAddIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...STROKE_PROPS}>
+      <line x1="3" y1="7" x2="15" y2="7" />
+      <line x1="3" y1="12" x2="15" y2="12" />
+      <line x1="3" y1="17" x2="11" y2="17" />
+      <line x1="18" y1="14" x2="18" y2="20" />
+      <line x1="15" y1="17" x2="21" y2="17" />
+    </svg>
+  )
+}
+
+export function PlayNextIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <rect x="3" y="5" width="2" height="14" />
+      <path d="M7 5 L18 12 L7 19 Z" />
+    </svg>
+  )
+}
+
 interface FavoriteIconProps {
   active: boolean
   size?: number


### PR DESCRIPTION
## Summary

- Adds `QueueAddIcon` and `PlayNextIcon` SVG icon components to `TransportIcons.tsx`, following the KAMP-291 inline-SVG style (currentColor, 24-viewBox, even-pixel vertices)
- Album page header now shows three controls right-aligned: [Add to Queue] [Play Next] [● Play] — two flat ghost icon buttons flanking the existing accent circle, communicating hierarchy without visual competition
- Replaces unicode `▶` / `+` glyphs in `TrackContextMenu` and `AlbumContextMenu` with the same new icons for consistency across surfaces
- No backend changes — `addAlbumToQueue` and `playAlbumNext` store actions and API endpoints were already wired

## Test plan

- [x] Navigate to any album page — confirm three controls appear right-aligned in the header
- [x] Hover the Queue and Play Next buttons — dim text → accent color + surface-hover background
- [x] Click **Add to Queue** — album tracks appear at the end of the queue without interrupting playback
- [x] Click **Play Next** — album tracks appear immediately after the current track
- [x] Existing **Play** circle behavior unchanged (plays from track 1, toggles pause on current album)
- [x] Right-click a track row — "Play Next" and "Add to Queue" items show the new icons
- [x] Right-click an album card — same icons in that context menu
- [ ] `npm run typecheck` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)