### PR TITLE
fix(ui): remove translateY lift on album-card hover (KAMP-299)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -5,14 +5,15 @@
   overflow: hidden;
   background: var(--surface);
   transition:
-    transform 0.1s,
     background 0.1s,
     box-shadow 0.1s;
 }
 
+/* Lift cue is shadow-only: a translateY here would shift the hover hit-test box
+   off the cursor at the card's bottom edge, creating a hover/un-hover flicker
+   loop (KAMP-299). The shadow alone is enough visual feedback. */
 .album-card:hover {
   background: var(--surface-hover);
-  transform: translateY(-3px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -473,7 +473,6 @@ html[data-platform='win32'] .view-tabs {
 }
 
 .album-card:active {
-  transform: translateY(0);
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- Removes the `transform: translateY(-3px)` on `.album-card:hover`. The translate shifted the hit-test box off the cursor at the card's bottom edge, producing a hover/un-hover flicker loop ([KAMP-299](https://eightyeighteyes.atlassian.net/browse/KAMP-299)).
- Keeps the box-shadow change on hover — the shadow alone carries the lift cue, and there's nothing for the cursor to chase.
- Drops the now-irrelevant `transform 0.1s` from the transition and the `transform: translateY(0)` from `.album-card:active`.

## Test plan
- [ ] Position cursor at the very bottom edge of an album card in the library grid. Card highlights once and stays stable (no flicker loop).
- [ ] Hover from above/sides/inside still triggers the background-hover + shadow as expected.
- [ ] `.playing` outline still renders on hover.
- [ ] `:active` press feedback (shadow drop) still fires on click.
- [ ] New-arrival highlight styles (shiny, vaporwave, proud, pressed, static, newmoji, boring) still render their hover effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAMP-299]: https://eightyeighteyes.atlassian.net/browse/KAMP-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ