### PR TITLE
fix(ui): pin preferences dialog to fixed height (KAMP-233)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/preferences.css
+++ b/kamp_ui/src/renderer/src/assets/preferences.css
@@ -12,6 +12,7 @@
 
 .prefs-dialog {
   width: 520px;
+  height: 560px;
   max-height: calc(100vh - 80px);
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

- Adds `height: 560px` to `.prefs-dialog` so the dialog geometry stays fixed regardless of which tab is active
- The body already had `overflow-y: auto` and `flex: 1` — this was the only missing piece
- Taller sections (e.g. Extensions with many installed) scroll within the fixed frame

## Test plan

- [x] Open Preferences → switch between General / Services / Extensions — dialog height does not shift
- [x] Open Preferences on a short viewport (small window) — `max-height: calc(100vh - 80px)` still constrains it correctly
- [x] Extensions tab with drawer open scrolls rather than expanding the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)