### PR TITLE
fix(ui): Status Rail — pipeline & Bandcamp indicators on all views (KAMP-302)

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -9,6 +9,8 @@ import { NowPlayingView } from './components/NowPlayingView'
 import { PanelPicker } from './components/PanelPicker'
 import { PreferencesDialog } from './components/PreferencesDialog'
 import { QueuePanel } from './components/QueuePanel'
+import { BandcampButton } from './components/BandcampButton'
+import { PipelineIndicator } from './components/PipelineIndicator'
 import { SearchBar } from './components/SearchBar'
 import { SearchView } from './components/SearchView'
 import { OnboardingScreen } from './components/OnboardingScreen'
@@ -525,6 +527,10 @@ export default function App(): React.JSX.Element {
           </button>
         ))}
         <SearchBar ref={searchBarRef} />
+        <div className="status-rail">
+          <PipelineIndicator />
+          <BandcampButton />
+        </div>
         <PanelPicker layout={layout} />
       </nav>
       <div className="app-body">

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -163,6 +163,19 @@ html[data-platform='win32'] .view-tabs {
   color: var(--text);
 }
 
+/* Status Rail: pipeline + bandcamp indicators in the view-tabs nav bar ----- */
+
+.status-rail {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  min-width: 58px;
+  justify-content: flex-end;
+  /* Opt out of the window drag region so pointer events register. */
+  -webkit-app-region: no-drag;
+}
+
 /* Bandcamp sync button ----------------------------------------------------- */
 
 .bandcamp-btn-anchor {
@@ -190,12 +203,6 @@ html[data-platform='win32'] .view-tabs {
 
 .bandcamp-btn--syncing {
   animation: bandcamp-pulse 1.4s ease-in-out infinite;
-}
-
-.album-grid-toolbar-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .pipeline-indicator {

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -6,8 +6,6 @@ let savedScrollTop = 0
 import { useStore } from '../store'
 import { AlbumCard } from './AlbumCard'
 import { SortControl } from './SortControl'
-import { BandcampButton } from './BandcampButton'
-import { PipelineIndicator } from './PipelineIndicator'
 
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -32,10 +30,6 @@ export function AlbumGrid(): React.JSX.Element {
     <div className="album-grid-container" ref={containerRef}>
       <div className="album-grid-toolbar">
         <SortControl />
-        <div className="album-grid-toolbar-actions">
-          <PipelineIndicator />
-          <BandcampButton />
-        </div>
       </div>
       {visible.length === 0 ? (
         <div className="album-grid-empty">

--- a/project/design-lexicon.md
+++ b/project/design-lexicon.md
@@ -34,3 +34,12 @@ A shared vocabulary for UI components, layout patterns, and interaction concepts
 ## Transport
 
 **Transport** — The persistent playback bar fixed at the bottom of the app. Contains play/pause, skip, scrubber, volume, and queue toggle.
+
+---
+
+## Status Rail
+
+**Status Rail** — The group of ambient status indicators mounted in the nav bar, between the search bar and the panel picker. Visible on every view. Currently contains:
+
+- **Pipeline indicator** — Shows whether the import pipeline is active. Dims when idle; pulses with the accent color when processing.
+- **Bandcamp button** — Shows when a Bandcamp account is connected. Click to trigger a sync; right-click to open Bandcamp preferences. Hidden when no account is configured.


### PR DESCRIPTION
## Summary

- Moves `PipelineIndicator` and `BandcampButton` from `AlbumGrid`'s per-view toolbar into a shared `.status-rail` wrapper in the persistent `view-tabs` nav bar
- Status Rail sits between the search bar and the panel picker, visible on every view (Library, Now Playing, Home, Search, Setup, extension panels)
- `.status-rail` uses `min-width: 58px` + `justify-content: flex-end` so the layout doesn't shift when `BandcampButton` conditionally disappears; `-webkit-app-region: no-drag` ensures pointer events register correctly in the macOS drag region
- Design lexicon updated with "Status Rail" terminology and component descriptions

## Test plan

- [x] Library — album grid: status rail visible in nav bar; sort control still present in toolbar
- [x] Library — track list view: status rail visible
- [x] Now Playing view: status rail visible
- [x] Home / Base Kamp view: status rail visible
- [x] Search (active search query): status rail visible
- [x] Setup / Onboarding screen: status rail visible
- [x] Bandcamp connected: Bandcamp button appears in rail; layout stable
- [x] Bandcamp not connected: Bandcamp button absent; pipeline indicator and panel picker don't shift
- [x] Pipeline active: pipeline indicator pulses with accent color
- [x] macOS: window draggable from nav bar on either side of the status rail
- [x] Windows: status rail fits within the space left of the 140px title bar overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)