### PR TITLE
fix(ui): hide artist panel on all non-library views (KAMP-310)

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -252,8 +252,8 @@ export default function App(): React.JSX.Element {
           break
         case 'a':
         case 'A':
-          // Artist panel is hidden and non-functional in Now Playing.
-          if (activeView !== 'now-playing') toggleArtistPanel()
+          // Artist panel is only relevant in Library.
+          if (activeView === 'library') toggleArtistPanel()
           break
       }
     }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -275,16 +275,19 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setActiveView: async (view) => {
     const { artistPanelVisible, artistPanelSnapshot } = get()
-    if (view === 'now-playing') {
-      // Hide the artist panel (non-functional in Now Playing) and save its state.
-      // Persist false so a restart with Now Playing active doesn't reopen the panel.
-      set({ activeView: view, artistPanelSnapshot: artistPanelVisible, artistPanelVisible: false })
-      localStorage.setItem('kamp:artist-panel-visible', 'false')
-    } else {
-      // Restore the artist panel to its pre-Now-Playing state.
+    if (view === 'library') {
+      // Restore the artist panel to its pre-non-library state.
       const restored = artistPanelSnapshot ?? artistPanelVisible
       set({ activeView: view, artistPanelSnapshot: null, artistPanelVisible: restored })
       localStorage.setItem('kamp:artist-panel-visible', String(restored))
+    } else {
+      // Hide the artist panel (only relevant in Library) on any non-library view.
+      // Preserve any existing snapshot so round-trips through multiple non-library views
+      // (e.g. now-playing → home → library) still restore the original user preference.
+      // Persist false so a restart outside the library doesn't reopen the panel.
+      const snapshot = artistPanelSnapshot ?? artistPanelVisible
+      set({ activeView: view, artistPanelSnapshot: snapshot, artistPanelVisible: false })
+      localStorage.setItem('kamp:artist-panel-visible', 'false')
     }
     try {
       await api.setActiveViewApi(view)


### PR DESCRIPTION
## Summary

- Inverts the `setActiveView` branch in `store.ts`: the artist panel now hides on **any** non-library view (Now Playing, Base Kamp, or future views) and restores only when returning to Library
- Preserves the existing snapshot across multi-hop non-library routes (e.g. now-playing → home → library still restores the original user preference)
- Tightens the `A` keybind guard in `App.tsx` from `activeView !== 'now-playing'` to `activeView === 'library'`

## Test plan

- [x] Library (panel open) → Base Kamp: panel hidden
- [x] Library (panel open) → Now Playing: panel hidden
- [x] Library (panel open) → Now Playing → Base Kamp → Library: panel restored open
- [x] Library (panel closed) → Base Kamp → Library: panel stays closed
- [x] `A` key in Base Kamp and Now Playing: no effect
- [x] `A` key in Library: toggles panel as before

Closes KAMP-310

🤖 Generated with [Claude Code](https://claude.com/claude-code)