### PR TITLE
fix(ui): retry indefinitely in packaged mode to survive Defender cold start (KAMP-300)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -569,6 +569,10 @@ app.whenReady().then(async () => {
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
 
+  ipcMain.on('kamp:is-packaged', (event) => {
+    event.returnValue = app.isPackaged
+  })
+
   // Forward player state from the preload to the Now Playing helper.
   // The preload sends this on every track.changed / play_state.changed WS event
   // and once on WS open (initial fetch), so the helper stays in sync.

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -569,10 +569,6 @@ app.whenReady().then(async () => {
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
 
-  ipcMain.on('kamp:is-packaged', (event) => {
-    event.returnValue = app.isPackaged
-  })
-
   // Forward player state from the preload to the Now Playing helper.
   // The preload sends this on every track.changed / play_state.changed WS event
   // and once on WS open (initial fetch), so the helper stays in sync.

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     electron: ElectronAPI
     api: {
+      isPackaged: boolean
       openDirectory: () => Promise<string | null>
       onOpenPreferences: (callback: () => void) => () => void
       bandcamp: {

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -5,6 +5,8 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { buildKampAPI, onBandcampSyncStatus, onPipelineStage } from './kampAPI'
 
+const isPackaged: boolean = ipcRenderer.sendSync('kamp:is-packaged')
+
 function _kampTokenFilePath(): string {
   if (process.platform === 'win32') {
     return join(process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'), 'kamp', '.token')
@@ -22,6 +24,7 @@ function _readKampToken(): string | null {
 
 // Custom APIs for renderer
 const api = {
+  isPackaged,
   openDirectory: (): Promise<string | null> => ipcRenderer.invoke('open-directory'),
   onOpenPreferences: (callback: () => void): (() => void) => {
     const handler = (): void => callback()

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -5,7 +5,9 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { buildKampAPI, onBandcampSyncStatus, onPipelineStage } from './kampAPI'
 
-const isPackaged: boolean = ipcRenderer.sendSync('kamp:is-packaged')
+// In packaged apps the preload runs from inside app.asar; in dev it runs
+// directly from the filesystem. The .asar extension in __dirname is definitive.
+const isPackaged: boolean = __dirname.includes('.asar')
 
 function _kampTokenFilePath(): string {
   if (process.platform === 'win32') {

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -146,6 +146,11 @@ export default function App(): React.JSX.Element {
         setSplashHiding(true)
         splashFadeRef.current = setTimeout(() => setSplashGone(true), 500)
       }, 1000)
+    } else {
+      // Reset a mid-fade splash so it stays fully visible while retrying.
+      // No-op if splashGone is already true (splash is not in the DOM).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSplashHiding(false)
     }
     return () => {
       clearTimeout(splashLingerRef.current)

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -153,6 +153,21 @@ export default function App(): React.JSX.Element {
     }
   }, [serverStatus])
 
+  // In packaged mode, show a slow-start hint on the splash after 60s of reconnecting
+  // so users understand a first-launch antivirus scan is the cause of the delay.
+  const [slowStart, setSlowStart] = useState(false)
+  const slowStartTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => {
+    if (serverStatus === 'reconnecting' && window.api.isPackaged) {
+      slowStartTimerRef.current = setTimeout(() => setSlowStart(true), 60_000)
+    } else {
+      clearTimeout(slowStartTimerRef.current)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSlowStart(false)
+    }
+    return () => clearTimeout(slowStartTimerRef.current)
+  }, [serverStatus])
+
   // Determine onboarding requirement once the splash clears (by which time
   // loadConfig has had ~1.5s to complete and configuredLibraryPath is stable).
   // Keyed off library path rather than album count: a returning user with an
@@ -169,7 +184,10 @@ export default function App(): React.JSX.Element {
     void loadConfig()
 
     let attempts = 0
-    const MAX_ATTEMPTS = 8
+    // In packaged mode the daemon is always auto-started; a long startup means
+    // Defender is scanning (first launch), not that the server is permanently down.
+    // Never give up in packaged mode — retry indefinitely at the 30s cap.
+    const MAX_ATTEMPTS = window.api.isPackaged ? Infinity : 8
 
     const connect = (): (() => void) => {
       return connectStateStream(
@@ -416,7 +434,7 @@ export default function App(): React.JSX.Element {
             Start it with <code>kamp server</code>
           </div>
         </div>
-        {!splashGone && <SplashScreen hiding={splashHiding} />}
+        {!splashGone && <SplashScreen hiding={splashHiding} slowStart={slowStart} />}
         <PreferencesDialog
           extensions={allExtensions}
           extState={extState}
@@ -541,7 +559,7 @@ export default function App(): React.JSX.Element {
         {!showSetup && isPanelVisible(rightPanel) && <SlotPanel panel={rightPanel!} />}
       </div>
       {bottomPanel && <SlotPanel panel={bottomPanel} />}
-      {!splashGone && <SplashScreen hiding={splashHiding} />}
+      {!splashGone && <SplashScreen hiding={splashHiding} slowStart={slowStart} />}
       <PreferencesDialog
         extensions={allExtensions}
         extState={extState}

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -104,6 +104,29 @@
   animation-delay: 1.5s;
 }
 
+/* Slow-start hint — fades in after 60s in packaged mode to explain antivirus delay */
+.splash-slow-message {
+  position: absolute;
+  bottom: 48px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--text-muted);
+  padding: 0 32px;
+  animation: splash-fade-in 0.6s ease-out;
+}
+
+@keyframes splash-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 /* Reconnecting banner — shown when connection drops but library is cached */
 .reconnecting-banner {
   background: var(--surface);

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element {
+export function SplashScreen({
+  hiding,
+  slowStart
+}: {
+  hiding: boolean
+  slowStart?: boolean
+}): React.JSX.Element {
   return (
     <div className={`splash-screen${hiding ? ' splash-hiding' : ''}`}>
       <svg
@@ -136,6 +142,13 @@ export function SplashScreen({ hiding }: { hiding: boolean }): React.JSX.Element
         <circle cx="113" cy="173" r="3" fill="none" stroke="#c4aa78" strokeWidth="1.2" />
         <circle cx="113" cy="173" r="1.5" fill="#c4aa78" />
       </svg>
+      {slowStart && (
+        <p className="splash-slow-message">
+          Starting up — antivirus software may be scanning Kamp on first launch.
+          <br />
+          This can take 1–2 minutes.
+        </p>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -404,7 +404,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
       const [albums, artists] = await Promise.all([api.getAlbums(sort), api.getArtists()])
       set((s) => ({ library: { ...s.library, albums, artists }, serverStatus: 'connected' }))
     } catch {
-      set({ serverStatus: 'disconnected' })
+      // During initial startup or mid-session reconnect the server may not be
+      // ready yet — the WebSocket retry loop owns recovery. Only signal
+      // 'disconnected' if we were actually connected when the fetch failed.
+      if (get().serverStatus !== 'reconnecting') {
+        set({ serverStatus: 'disconnected' })
+      }
     }
   },
 

--- a/scripts/build_mpv_windows.ps1
+++ b/scripts/build_mpv_windows.ps1
@@ -52,10 +52,16 @@ function Invoke-Msys($script) {
     }
 }
 
+Write-Host "==> Updating MSYS2 package database"
+# pacman -Syu upgrades pacman itself on the first run, which terminates the
+# MSYS2 process (expected; exit is non-zero). A second run completes the
+# system update with the refreshed pacman binary.
+& $msysBash -lc "pacman -Syu --noconfirm"
+Invoke-Msys "pacman -Syu --noconfirm"
+
 Write-Host "==> Installing mingw-w64 toolchain + mpv build deps via pacman"
 Invoke-Msys @'
 set -euo pipefail
-pacman -Syu --noconfirm
 pacman -S --needed --noconfirm \
     git \
     mingw-w64-x86_64-toolchain \


### PR DESCRIPTION
## Summary

- Removes the `MAX_ATTEMPTS = 8` retry cap when running as a packaged app — the reconnect loop now retries at 30s intervals indefinitely rather than giving up after ~91s
- After 60s of `'reconnecting'` in packaged mode, a hint fades in on the splash screen: *"Starting up — antivirus software may be scanning Kamp on first launch. This can take 1–2 minutes."*
- Dev mode behaviour is unchanged (8-attempt cap, "Start it with `kamp server`" hint still shown on timeout)

## Root cause

Windows Defender scans every file in the PyInstaller bundle on first execution of a newly-installed binary, adding 60–120s to daemon startup. The daemon finishes starting after the old ~91s retry window closed, leaving the UI stuck on a permanent "server not running" screen with no recovery path for that session.

## Test plan

- [ ] **Happy path (packaged):** Normal launch — splash clears within a few seconds, no slow-start message appears
- [ ] **Defender simulation (packaged):** Prevent the daemon from starting (e.g. temporarily rename `kamp.exe`) — after 60s the antivirus hint appears on the splash; after 120s+ the splash remains with retries continuing (no permanent error screen); restoring the daemon causes the app to connect and proceed normally
- [ ] **Dev timeout still works:** Shut down `kamp server` in dev — "kamp server is not running" screen appears after ~91s with no further retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)