### PR TITLE
fix(ui): set correct publisher and homepage in package.json (KAMP-311)

### DIFF
--- a/kamp_ui/package.json
+++ b/kamp_ui/package.json
@@ -3,8 +3,8 @@
   "version": "1.18.0",
   "description": "kamp music player",
   "main": "./out/main/index.js",
-  "author": "example.com",
-  "homepage": "https://electron-vite.org",
+  "author": "88eyes",
+  "homepage": "https://kamp.fm",
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
## Summary

- Changes `author` from placeholder `"example.com"` to `"88eyes"` in `kamp_ui/package.json`
- Changes `homepage` from placeholder `"https://electron-vite.org"` to `"https://kamp.fm"`
- electron-builder writes `author` as the `Publisher` value in the Windows NSIS uninstall registry key, which is what "Installed Apps" displays

## Test plan

- [x] Build Windows installer and verify "Installed Apps" shows `88eyes` as publisher
- [x] Verify uninstall registry key `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{AppId}` has correct `Publisher` and `URLInfoAbout` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)