### PR TITLE
feat: rename track file on disk after tag edit (KAMP-307)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -909,6 +909,26 @@ class LibraryIndex:
         self._rebuild_fts()
         self._conn.commit()
 
+    def move_track(
+        self,
+        old_path: Path,
+        new_path: Path,
+        new_title: str,
+        new_mtime: float,
+    ) -> None:
+        """Update file_path and title for a track, preserving id and all stats.
+
+        Called by the tag-edit endpoint after a file is physically moved on
+        disk.  The row's primary stats (date_added, play_count, last_played,
+        favorite, mb IDs) are intentionally unchanged.
+        """
+        self._conn.execute(
+            "UPDATE tracks SET file_path = ?, title = ?, file_mtime = ? WHERE file_path = ?",
+            (str(new_path), new_title, new_mtime, str(old_path)),
+        )
+        self._rebuild_fts()
+        self._conn.commit()
+
     def remove_track(self, file_path: Path) -> None:
         """Remove the track with the given file path from the index."""
         self._conn.execute("DELETE FROM tracks WHERE file_path = ?", (str(file_path),))
@@ -1057,6 +1077,22 @@ class LibraryIndex:
         """Return the track for *path*, or None if not indexed."""
         row = self._conn.execute(
             "SELECT * FROM tracks WHERE file_path = ?", (str(path),)
+        ).fetchone()
+        return _row_to_track(row) if row else None
+
+    def get_track_by_id(self, track_id: int) -> "Track | None":
+        """Return the track with *track_id*, or None if not indexed."""
+        row = self._conn.execute(
+            "SELECT * FROM tracks WHERE id = ?", (track_id,)
+        ).fetchone()
+        return _row_to_track(row) if row else None
+
+    def get_track_by_recording_id(self, mb_recording_id: str) -> "Track | None":
+        """Return the first track with *mb_recording_id*, or None."""
+        if not mb_recording_id:
+            return None
+        row = self._conn.execute(
+            "SELECT * FROM tracks WHERE mb_recording_id = ?", (mb_recording_id,)
         ).fetchone()
         return _row_to_track(row) if row else None
 
@@ -1602,6 +1638,38 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
     )
 
 
+def write_title_to_file(path: Path, title: str) -> None:
+    """Write a new title tag to an audio file without touching other tags."""
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        try:
+            tags = id3.ID3(str(path))
+        except Exception:
+            tags = id3.ID3()
+        tags["TIT2"] = id3.TIT2(encoding=3, text=title)
+        tags.save(str(path))
+    elif suffix == ".m4a":
+        audio = mutagen.mp4.MP4(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["\xa9nam"] = [title]  # type: ignore[index]
+        audio.save()
+    elif suffix == ".flac":
+        audio = mutagen.flac.FLAC(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["TITLE"] = [title]  # type: ignore[index]
+        audio.save()
+    elif suffix == ".ogg":
+        audio = mutagen.oggvorbis.OggVorbis(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["TITLE"] = [title]  # type: ignore[index]
+        audio.save()
+    else:
+        raise ValueError(f"Unsupported format for title write: {path.suffix}")
+
+
 def _read_tags(path: Path) -> Track | None:
     """Dispatch to the appropriate tag reader; return None on unrecognised format.
 
@@ -1691,16 +1759,50 @@ class LibraryScanner:
                 logger.warning("Skipped unreadable file: %s", path)
             if on_progress is not None:
                 on_progress(current, total, track)
-        self._index.upsert_many(tracks_to_upsert)
 
-        newly_added = [t for t in tracks_to_upsert if t.file_path in to_add]
-        added = len(newly_added)
-        updated = len([t for t in tracks_to_upsert if t.file_path in to_update])
+        # Defence in depth: if a "new" file shares a mb_recording_id with a
+        # track that is about to be removed (i.e. the file was moved outside
+        # Kamp), update the existing row's path rather than creating a duplicate.
+        removed_paths = in_index - on_disk
+        removed_by_mbid: dict[str, Track] = {}
+        for p in removed_paths:
+            t = self._index.get_track_by_path(p)
+            if t is not None and t.mb_recording_id:
+                removed_by_mbid[t.mb_recording_id] = t
+
+        reconciled_old_paths: set[Path] = set()
+        reconciled_new_paths: set[Path] = set()
+        for track in tracks_to_upsert:
+            if track.file_path not in to_add or not track.mb_recording_id:
+                continue
+            old = removed_by_mbid.get(track.mb_recording_id)
+            if old is None:
+                continue
+            self._index.move_track(
+                old.file_path, track.file_path, track.title, track.file_mtime or 0.0
+            )
+            logger.info(
+                "Reconciled moved track by recording id: %s → %s",
+                old.file_path,
+                track.file_path,
+            )
+            reconciled_old_paths.add(old.file_path)
+            reconciled_new_paths.add(track.file_path)
+
+        upsert_subset = [
+            t for t in tracks_to_upsert if t.file_path not in reconciled_new_paths
+        ]
+        self._index.upsert_many(upsert_subset)
+
+        newly_added = [t for t in upsert_subset if t.file_path in to_add]
+        added = len(newly_added) + len(reconciled_new_paths)
+        updated = len([t for t in upsert_subset if t.file_path in to_update])
 
         removed = 0
-        for path in in_index - on_disk:
-            self._index.remove_track(path)
-            removed += 1
+        for path in removed_paths:
+            if path not in reconciled_old_paths:
+                self._index.remove_track(path)
+                removed += 1
 
         unchanged = len(on_disk & in_index) - len(to_update)
 

--- a/kamp_core/path_utils.py
+++ b/kamp_core/path_utils.py
@@ -1,0 +1,68 @@
+"""Shared path-rendering utilities for the library path template.
+
+Used by both the ingest pipeline (kamp_daemon/mover.py) and the tag-edit
+endpoint (kamp_core/server.py) so that file destinations are computed
+identically in both code paths.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def sanitize_path_component(name: str) -> str:
+    """Strip characters that are unsafe in file/directory names."""
+    sanitized = _UNSAFE_CHARS.sub("_", name)
+    # Trim trailing dots and spaces (Windows compatibility)
+    return sanitized.strip(". ")
+
+
+def make_path_vars(
+    artist: str,
+    album_artist: str,
+    album: str,
+    year: str,
+    track: int,
+    disc: int,
+    title: str,
+    ext: str,
+) -> dict[str, object]:
+    return {
+        "artist": artist or "Unknown Artist",
+        "album_artist": album_artist or artist or "Unknown Artist",
+        "album": album or "Unknown Album",
+        "year": year or "0000",
+        "track": track,
+        "disc": disc,
+        "title": title or "Unknown Title",
+        "ext": ext,
+    }
+
+
+def render_destination(
+    tags: dict[str, object],
+    library_root: Path,
+    path_template: str,
+) -> Path:
+    """Compute destination path from explicit tag values without reading the file.
+
+    *tags* must contain the keys produced by make_path_vars().  Sanitizes
+    string values before rendering so that unsafe characters in tag fields
+    (especially '/') are not interpreted as path separators.
+    """
+    safe_tags = {
+        k: sanitize_path_component(v) if isinstance(v, str) else v
+        for k, v in tags.items()
+    }
+    try:
+        rendered = path_template.format(**safe_tags)
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f"Path template error: {exc}") from exc
+
+    # Sanitize each component again as a second layer of defence.
+    parts = Path(rendered).parts
+    safe_parts = [sanitize_path_component(p) for p in parts]
+    return library_root.joinpath(*safe_parts)

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -78,6 +78,18 @@ class PlaybackQueue:
             if t.file_path == file_path:
                 t.favorite = favorite
 
+    def update_track_path(self, old_path: Path, new_path: Path, new_title: str) -> None:
+        """Patch file_path and title in place after a tag-edit file rename.
+
+        Called immediately after the rename so mpv's next file reference and
+        the player-state snapshot both use the new path.  The queue position
+        is preserved — the user hears no gap.
+        """
+        for t in self._tracks:
+            if t.file_path == old_path:
+                t.file_path = new_path
+                t.title = new_title
+
     def current(self) -> Track | None:
         if not self._tracks or self._pos < 0:
             return None

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -574,7 +574,7 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
 
-        if old_path == new_path:
+        if str(old_path) == str(new_path):
             # Path unchanged — just update the title tag and DB.
             write_title_to_file(old_path, req.title)
             index.move_track(old_path, old_path, req.title, _t.time())
@@ -586,9 +586,11 @@ def create_app(
         # Detect case-only renames before the existence check: on case-insensitive
         # filesystems (HFS+, APFS, NTFS) new_path.exists() returns True for the
         # same inode, which would incorrectly trigger a 409 collision.
-        is_case_only = (
-            str(old_path).lower() == str(new_path).lower() and old_path != new_path
-        )
+        # Use str() for both comparisons — WindowsPath.__eq__ is case-insensitive,
+        # which would mis-classify a case-only rename as "same path" above.
+        is_case_only = str(old_path).lower() == str(new_path).lower() and str(
+            old_path
+        ) != str(new_path)
 
         if not is_case_only and new_path.exists():
             if not req.overwrite:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -583,7 +583,14 @@ def create_app(
             updated = index.get_track_by_id(track_id)
             return TrackOut.from_track(updated)  # type: ignore[arg-type]
 
-        if new_path.exists():
+        # Detect case-only renames before the existence check: on case-insensitive
+        # filesystems (HFS+, APFS, NTFS) new_path.exists() returns True for the
+        # same inode, which would incorrectly trigger a 409 collision.
+        is_case_only = (
+            str(old_path).lower() == str(new_path).lower() and old_path != new_path
+        )
+
+        if not is_case_only and new_path.exists():
             if not req.overwrite:
                 existing = index.get_track_by_path(new_path)
                 raise HTTPException(
@@ -594,14 +601,13 @@ def create_app(
                     },
                 )
             # Overwrite requested: remove the conflicting DB entry.
-            if new_path != old_path:
-                index.remove_track(new_path)
+            # (new_path != old_path is guaranteed here: old_path == new_path returns early above)
+            index.remove_track(new_path)
 
         # Order: write tags → move file → update DB.
         write_title_to_file(old_path, req.title)
         new_path.parent.mkdir(parents=True, exist_ok=True)
-        if str(old_path).lower() == str(new_path).lower() and old_path != new_path:
-            # Case-only rename on a case-insensitive filesystem (HFS+, APFS, NTFS).
+        if is_case_only:
             # Two-step via a temp name so the OS doesn't silently treat it as a no-op.
             tmp_path = old_path.with_suffix(f".kamp_rename{old_path.suffix}")
             shutil.move(str(old_path), tmp_path)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -578,6 +578,7 @@ def create_app(
             # Path unchanged — just update the title tag and DB.
             write_title_to_file(old_path, req.title)
             index.move_track(old_path, old_path, req.title, _t.time())
+            queue.update_track_path(old_path, old_path, req.title)
             _notify_library_changed()
             updated = index.get_track_by_id(track_id)
             return TrackOut.from_track(updated)  # type: ignore[arg-type]
@@ -610,6 +611,10 @@ def create_app(
 
         new_mtime = _t.time()
         index.move_track(old_path, new_path, req.title, new_mtime)
+
+        # Patch the in-memory queue so mpv's next file reference and the
+        # player-state snapshot both use the new path immediately.
+        queue.update_track_path(old_path, new_path, req.title)
 
         # Suppress FSEvents from this move and fire a reconciliation scan.
         notify_track_moved = getattr(app.state, "on_track_file_moved", None)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -105,6 +105,7 @@ class PlayerStateOut(BaseModel):
     duration: float
     volume: int
     current_track: TrackOut | None
+    next_track: TrackOut | None = None
 
 
 class PlayRequest(BaseModel):
@@ -251,6 +252,11 @@ class BandcampProxyFetchRequest(BaseModel):
     method: str = "GET"
     headers: dict[str, str] = {}
     body: str | None = None
+
+
+class TrackTagsRequest(BaseModel):
+    title: str
+    overwrite: bool = False
 
 
 class BandcampProxyFetchResult(BaseModel):
@@ -415,6 +421,9 @@ def create_app(
     app.state.notify_play_state_changed = _notify_play_state_changed
     app.state.notify_bandcamp_sync_status = _notify_bandcamp_sync_status
     app.state.notify_pipeline_stage = _notify_pipeline_stage
+    # Wired by the daemon after create_app() to suppress watcher events and
+    # trigger a direct scan following a tag-edit file move.
+    app.state.on_track_file_moved = None
 
     # Wire play-state change callback directly — the engine fires it from its
     # background reader thread whenever mpv's pause property flips.
@@ -458,12 +467,14 @@ def create_app(
 
     def _state_snapshot() -> PlayerStateOut:
         current = queue.current()
+        nxt = queue.peek_next()
         return PlayerStateOut(
             playing=engine.state.playing,
             position=engine.state.position,
             duration=engine.state.duration,
             volume=engine.state.volume,
             current_track=TrackOut.from_track(current) if current else None,
+            next_track=TrackOut.from_track(nxt) if nxt else None,
         )
 
     # -----------------------------------------------------------------------
@@ -509,6 +520,108 @@ def create_app(
         return [
             TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
         ]
+
+    @app.patch("/api/v1/tracks/{track_id}/tags")
+    def patch_track_tags(track_id: int, req: "TrackTagsRequest") -> TrackOut:
+        """Edit a track's title tag and rename the file on disk to match.
+
+        Returns the updated track on success.  Returns 403 if the track is
+        currently playing or queued as the gapless lookahead.  Returns 404 if
+        the track is not in the library.  Returns 409 with collision details if
+        the computed target path already exists on disk; send the request again
+        with overwrite=true to replace it.
+        """
+        import shutil
+        import time as _t
+
+        from kamp_core.library import write_title_to_file
+        from kamp_core.path_utils import make_path_vars, render_destination
+
+        track = index.get_track_by_id(track_id)
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+
+        # Currently-playing and gapless-lookahead are locked in this slice.
+        current = queue.current()
+        lookahead = queue.peek_next()
+        if (current and current.id == track_id) or (
+            lookahead and lookahead.id == track_id
+        ):
+            raise HTTPException(status_code=403, detail="Pause to edit this track")
+
+        lib_path: Path | None = _state["library_path"]
+        if lib_path is None:
+            raise HTTPException(status_code=503, detail="Library path not configured")
+
+        path_template: str = (
+            _state["config"].get("library.path_template")
+            or "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+        )
+
+        tags = make_path_vars(
+            artist=track.artist,
+            album_artist=track.album_artist,
+            album=track.album,
+            year=track.year,
+            track=track.track_number,
+            disc=track.disc_number,
+            title=req.title,
+            ext=track.ext,
+        )
+        old_path = track.file_path
+        try:
+            new_path = render_destination(tags, lib_path, path_template)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+
+        if old_path == new_path:
+            # Path unchanged — just update the title tag and DB.
+            write_title_to_file(old_path, req.title)
+            index.move_track(old_path, old_path, req.title, _t.time())
+            _notify_library_changed()
+            updated = index.get_track_by_id(track_id)
+            return TrackOut.from_track(updated)  # type: ignore[arg-type]
+
+        if new_path.exists():
+            if not req.overwrite:
+                existing = index.get_track_by_path(new_path)
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "target_path": str(new_path),
+                        "existing_track_id": existing.id if existing else None,
+                    },
+                )
+            # Overwrite requested: remove the conflicting DB entry.
+            if new_path != old_path:
+                index.remove_track(new_path)
+
+        # Order: write tags → move file → update DB.
+        write_title_to_file(old_path, req.title)
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        if str(old_path).lower() == str(new_path).lower() and old_path != new_path:
+            # Case-only rename on a case-insensitive filesystem (HFS+, APFS, NTFS).
+            # Two-step via a temp name so the OS doesn't silently treat it as a no-op.
+            tmp_path = old_path.with_suffix(f".kamp_rename{old_path.suffix}")
+            shutil.move(str(old_path), tmp_path)
+            shutil.move(str(tmp_path), new_path)
+        else:
+            shutil.move(str(old_path), new_path)
+
+        new_mtime = _t.time()
+        index.move_track(old_path, new_path, req.title, new_mtime)
+
+        # Suppress FSEvents from this move and fire a reconciliation scan.
+        notify_track_moved = getattr(app.state, "on_track_file_moved", None)
+        if notify_track_moved is not None:
+            try:
+                notify_track_moved(old_path, new_path)
+            except Exception:
+                logger.exception("on_track_file_moved callback raised")
+
+        _notify_library_changed()
+        updated = index.get_track_by_id(track_id)
+        return TrackOut.from_track(updated)  # type: ignore[arg-type]
 
     @app.post("/api/v1/tracks/favorite")
     def set_track_favorite(req: FavoriteRequest) -> dict[str, Any]:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -974,6 +974,14 @@ def _cmd_daemon(
         lib_watcher = LibraryWatcher(lib_path, _on_library_change)
         lib_watcher.start()
 
+    def _on_track_file_moved(old_path: "Path", new_path: "Path") -> None:
+        """Suppress watcher events for a tag-edit move and trigger an immediate scan."""
+        if lib_watcher is not None:
+            lib_watcher.suppress_paths({old_path, new_path})
+            lib_watcher.scan_now()
+
+    app.state.on_track_file_moved = _on_track_file_moved
+
     # --- Start uvicorn in a background thread ---
     # uvicorn.Server.serve() detects it is not on the main thread and skips
     # installing its own signal handlers, so there is no conflict with

--- a/kamp_daemon/mover.py
+++ b/kamp_daemon/mover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import shutil
 from pathlib import Path
 
@@ -12,9 +11,13 @@ import mutagen.id3 as _id3
 import mutagen.mp4
 import mutagen.oggvorbis
 
-logger = logging.getLogger(__name__)
+from kamp_core.path_utils import (
+    make_path_vars,
+    render_destination,
+    sanitize_path_component as _sanitize,
+)
 
-_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+logger = logging.getLogger(__name__)
 
 
 class MoveError(Exception):
@@ -54,25 +57,10 @@ def move_to_library(
 
 def _destination(src: Path, library_root: Path, path_template: str) -> Path:
     tags = _read_tags(src)
-    # Sanitize string values before rendering so that unsafe characters (especially '/')
-    # in tag fields like title don't get interpreted as path separators.
-    safe_tags = {k: _sanitize(v) if isinstance(v, str) else v for k, v in tags.items()}
     try:
-        rendered = path_template.format(**safe_tags)
-    except (KeyError, ValueError) as exc:
+        return render_destination(tags, library_root, path_template)
+    except ValueError as exc:
         raise MoveError(f"Path template error for {src}: {exc}") from exc
-
-    # Sanitize each path component as a second layer of defence.
-    parts = Path(rendered).parts
-    safe_parts = [_sanitize(p) for p in parts]
-    return library_root.joinpath(*safe_parts)
-
-
-def _sanitize(name: str) -> str:
-    """Strip characters that are unsafe in file/directory names."""
-    sanitized = _UNSAFE_CHARS.sub("_", name)
-    # Trim trailing dots and spaces (Windows compatibility)
-    return sanitized.strip(". ")
 
 
 def _read_tags(path: Path) -> dict[str, object]:
@@ -156,29 +144,7 @@ def _read_tags(path: Path) -> dict[str, object]:
     except Exception:
         pass
 
-    return _make_vars(artist, album_artist, album, year, track, disc, title, ext)
-
-
-def _make_vars(
-    artist: str,
-    album_artist: str,
-    album: str,
-    year: str,
-    track: int,
-    disc: int,
-    title: str,
-    ext: str,
-) -> dict[str, object]:
-    return {
-        "artist": artist or "Unknown Artist",
-        "album_artist": album_artist or artist or "Unknown Artist",
-        "album": album or "Unknown Album",
-        "year": year or "0000",
-        "track": track,
-        "disc": disc,
-        "title": title or "Unknown Title",
-        "ext": ext,
-    }
+    return make_path_vars(artist, album_artist, album, year, track, disc, title, ext)
 
 
 def _cleanup_watch_folder(watch_dir: Path) -> None:

--- a/kamp_daemon/watcher.py
+++ b/kamp_daemon/watcher.py
@@ -386,10 +386,14 @@ class _LibraryHandler(FileSystemEventHandler):
         # Monotonic time of the first event in the current debounce window.
         # Reset to None when the timer fires or is cancelled.
         self._batch_start: float | None = None
+        # Paths suppressed until a given monotonic time.  Populated by
+        # LibraryWatcher.suppress_paths() before a tag-edit file move so that
+        # the resulting FSEvents don't trigger a spurious extra scan.
+        self._suppressed_paths: dict[Path, float] = {}
 
     def on_created(self, event: FileSystemEvent) -> None:
         if isinstance(event, FileCreatedEvent) and self._is_audio(event.src_path):
-            self._schedule()
+            self._schedule(Path(os.fsdecode(event.src_path)))
 
     def on_modified(self, event: FileSystemEvent) -> None:
         # FSEvents on macOS coalesces file renames (shutil.move on the same
@@ -397,29 +401,38 @@ class _LibraryHandler(FileSystemEventHandler):
         # emitting FileCreatedEvent for the moved file.  Schedule a rescan on
         # any directory modification so pipeline-ingested tracks are picked up.
         if event.is_directory:
-            self._schedule()
+            self._schedule(Path(os.fsdecode(event.src_path)))
 
     def on_deleted(self, event: FileSystemEvent) -> None:
         # Directory deletions (e.g. entire album folder removed) are caught here
         # in addition to individual audio file deletions.
         if isinstance(event, (FileDeletedEvent, DirDeletedEvent)):
-            self._schedule()
+            self._schedule(Path(os.fsdecode(event.src_path)))
 
     def on_moved(self, event: FileSystemEvent) -> None:
         # Catch both individual audio file moves and whole directory moves (e.g.
         # album folder dragged out of the library).
         if isinstance(event, DirMovedEvent):
-            self._schedule()
+            self._schedule(Path(os.fsdecode(event.dest_path)))
         elif isinstance(event, FileMovedEvent) and (
             self._is_audio(event.src_path) or self._is_audio(event.dest_path)
         ):
-            self._schedule()
+            self._schedule(Path(os.fsdecode(event.dest_path)))
 
     def _is_audio(self, path: bytes | str) -> bool:
         return Path(os.fsdecode(path)).suffix.lower() in AUDIO_EXTENSIONS
 
-    def _schedule(self) -> None:
+    def _schedule(self, trigger_path: Path | None = None) -> None:
         with self._lock:
+            # Skip if the triggering path (or its parent directory) is suppressed.
+            # Populated by LibraryWatcher.suppress_paths() before a tag-edit move.
+            if trigger_path is not None:
+                now_check = time.monotonic()
+                for candidate in (trigger_path, trigger_path.parent):
+                    cutoff = self._suppressed_paths.get(candidate)
+                    if cutoff is not None and now_check < cutoff:
+                        logger.debug("Suppressed library rescan for %s", trigger_path)
+                        return
             now = time.monotonic()
             if self._batch_start is None:
                 self._batch_start = now
@@ -476,6 +489,28 @@ class LibraryWatcher:
         they finish processing, without waiting for FSEvents delivery.
         """
         self._handler._schedule()
+
+    def suppress_paths(self, paths: set[Path], ttl: float = 30.0) -> None:
+        """Tell the watcher to ignore FSEvents for *paths* (and their parents) for *ttl* seconds.
+
+        Call this before moving a file during a tag-edit operation so the
+        resulting filesystem events don't trigger a redundant rescan.
+        """
+        cutoff = time.monotonic() + ttl
+        with self._handler._lock:
+            for p in paths:
+                self._handler._suppressed_paths[p] = cutoff
+                self._handler._suppressed_paths[p.parent] = cutoff
+
+    def scan_now(self) -> None:
+        """Trigger an immediate scan, bypassing the debounce timer.
+
+        Used after a tag-edit file move so the UI stays consistent without
+        waiting for the debounce window to expire.
+        """
+        threading.Thread(
+            target=self._handler._fire, daemon=True, name="library-scan-now"
+        ).start()
 
     def stop(self) -> None:
         self._handler.cancel_pending()

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -52,6 +52,7 @@ export type PlayerState = {
   duration: number
   volume: number
   current_track: Track | null
+  next_track: Track | null
 }
 
 export type ScanResult = {
@@ -317,6 +318,41 @@ export const clearRemainingQueue = (position: number): Promise<unknown> =>
   post('/api/v1/player/queue/clear-remaining', { position })
 export const setTrackFavorite = (track: Track, favorite: boolean): Promise<unknown> =>
   post('/api/v1/tracks/favorite', { file_path: track.file_path, favorite })
+
+export type TrackTagsCollision = {
+  collision: true
+  target_path: string
+  existing_track_id: number | null
+}
+
+export async function patchTrackTags(
+  trackId: number,
+  title: string,
+  overwrite = false
+): Promise<Track | TrackTagsCollision> {
+  const res = await fetch(`${BASE_URL}/api/v1/tracks/${trackId}/tags`, {
+    method: 'PATCH',
+    headers: _authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ title, overwrite })
+  })
+  if (res.status === 409) {
+    const detail = (await res.json()) as {
+      detail: { target_path: string; existing_track_id: number | null }
+    }
+    return { collision: true, ...detail.detail }
+  }
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail && typeof json.detail === 'string') message = json.detail
+    } catch {
+      // ignore
+    }
+    throw new Error(message)
+  }
+  return res.json() as Promise<Track>
+}
 export const setAlbumFavorite = (
   albumArtist: string,
   album: string,

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -131,7 +131,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  background: rgba(20, 20, 20, 0.55);
+  background: rgba(10, 10, 10, 0.70);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -149,8 +149,8 @@
 }
 
 .breadcrumb-edit-btn:hover {
-  color: var(--accent);
-  border-color: rgba(124, 134, 225, 0.5);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.45);
 }
 
 .breadcrumb-edit-btn:focus-visible {

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -385,6 +385,63 @@
   text-overflow: ellipsis;
 }
 
+.track-row-title--input {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  outline: none;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  line-height: inherit;
+  /* Horizontal inset only — no vertical padding so the row height doesn't reflow */
+  padding: 0 4px;
+  margin: 0 -4px;
+  width: 100%;
+  min-width: 0;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.track-row-title--input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+  background: var(--surface-hover);
+}
+
+.track-row-title--input:disabled,
+.track-row-title--input[readonly] {
+  opacity: 0.45;
+  cursor: default;
+  border-color: transparent;
+  background: transparent;
+}
+
+.track-row-title--input.saving {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+  opacity: 0.7;
+  cursor: wait;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .track-row-title--input.saving {
+    animation: saving-pulse 1s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes saving-pulse {
+  from {
+    opacity: 0.7;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .track-row-artist {
   font-size: 11px;
   color: var(--text-dim);

--- a/kamp_ui/src/renderer/src/components/CollisionModal.tsx
+++ b/kamp_ui/src/renderer/src/components/CollisionModal.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react'
+
+type Props = {
+  targetPath: string
+  onOverwrite: () => void
+  onSkip: () => void
+  onCancel: () => void
+}
+
+export function CollisionModal({
+  targetPath,
+  onOverwrite,
+  onSkip,
+  onCancel
+}: Props): React.JSX.Element {
+  // Esc = implicit Cancel.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  const filename = targetPath.split(/[/\\]/).pop() ?? targetPath
+
+  return (
+    // Click-away backdrop = implicit Cancel.
+    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="modal collision-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="collision-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="collision-modal-title" className="modal-title">
+          File already exists
+        </h2>
+        <p className="modal-body">
+          <strong>{filename}</strong> already exists at the target location. What would you like to
+          do?
+        </p>
+        <div className="modal-actions">
+          <button className="modal-btn modal-btn--destructive" onClick={onOverwrite}>
+            Overwrite
+          </button>
+          <button className="modal-btn" onClick={onSkip}>
+            Skip
+          </button>
+          <button className="modal-btn modal-btn--primary" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
@@ -73,6 +73,20 @@ export function EditableTrackTitle({
           e.stopPropagation()
           setValue(title)
           inputRef.current?.blur()
+        } else if (e.key === 'Tab') {
+          const inputs = Array.from(
+            document.querySelectorAll<HTMLInputElement>('.track-row-title--input:not(:disabled)')
+          )
+          const idx = inputRef.current ? inputs.indexOf(inputRef.current) : -1
+          const next = e.shiftKey ? inputs[idx - 1] : inputs[idx + 1]
+          if (next) {
+            // Prevent the browser landing on the <li tabIndex={0}> between inputs.
+            e.preventDefault()
+            e.stopPropagation()
+            inputRef.current?.blur() // commits current edit
+            next.focus()
+          }
+          // No next/prev input: let Tab fall through and blur naturally commits.
         }
       }}
       // Prevent row double-click from triggering play when clicking the input.

--- a/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
@@ -67,8 +67,10 @@ export function EditableTrackTitle({
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           e.preventDefault()
+          e.stopPropagation()
           inputRef.current?.blur()
         } else if (e.key === 'Escape') {
+          e.stopPropagation()
           setValue(title)
           inputRef.current?.blur()
         }

--- a/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
@@ -1,0 +1,81 @@
+import React, { useRef, useState } from 'react'
+
+type Props = {
+  trackId: number
+  title: string
+  editMode: boolean
+  locked: boolean
+  onSave: (trackId: number, title: string) => Promise<void>
+}
+
+export function EditableTrackTitle({
+  trackId,
+  title,
+  editMode,
+  locked,
+  onSave
+}: Props): React.JSX.Element {
+  const [value, setValue] = useState(title)
+  const [prevTitle, setPrevTitle] = useState(title)
+  const [saving, setSaving] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Sync external title changes (e.g. after refreshOpenAlbum) back into local state.
+  // Render-time update avoids the cascading-render issue of useEffect setState.
+  if (title !== prevTitle) {
+    setPrevTitle(title)
+    setValue(title)
+  }
+
+  if (!editMode) {
+    return <span className="track-row-title">{title}</span>
+  }
+
+  if (locked) {
+    return (
+      <input
+        className="track-row-title track-row-title--input"
+        value={title}
+        disabled
+        readOnly
+        title="Pause to edit this track"
+        aria-label={title}
+      />
+    )
+  }
+
+  const commit = async (): Promise<void> => {
+    const trimmed = value.trim()
+    if (!trimmed || trimmed === title || saving) return
+    setSaving(true)
+    try {
+      await onSave(trackId, trimmed)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      className={`track-row-title track-row-title--input${saving ? ' saving' : ''}`}
+      value={value}
+      disabled={saving}
+      aria-label={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => void commit()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          inputRef.current?.blur()
+        } else if (e.key === 'Escape') {
+          setValue(title)
+          inputRef.current?.blur()
+        }
+      }}
+      // Prevent row double-click from triggering play when clicking the input.
+      onDoubleClick={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
-import type { Track } from '../api/client'
+import type { Track, TrackTagsCollision } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
+import { EditableTrackTitle } from './EditableTrackTitle'
+import { CollisionModal } from './CollisionModal'
 import {
   FavoriteIcon,
   PencilIcon,
@@ -42,7 +44,16 @@ export function TrackList(): React.JSX.Element | null {
 
   const albumEditMode = useStore((s) => s.albumEditMode)
   const setAlbumEditMode = useStore((s) => s.setAlbumEditMode)
+  const patchTrackTitle = useStore((s) => s.patchTrackTitle)
+  const nextTrack = useStore((s) => s.player.next_track)
+  const lockedIds = new Set(
+    [currentTrack?.id, nextTrack?.id].filter((id): id is number => id != null)
+  )
+
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
+  const [collision, setCollision] = useState<
+    (TrackTagsCollision & { pendingTrackId: number; pendingTitle: string }) | null
+  >(null)
 
   // Focus the album title heading when entering edit mode so screen readers
   // receive the live-region announcement in context.
@@ -218,7 +229,18 @@ export function TrackList(): React.JSX.Element | null {
                     track.track_number
                   )}
                 </span>
-                <span className="track-row-title">{track.title}</span>
+                <EditableTrackTitle
+                  trackId={track.id}
+                  title={track.title}
+                  editMode={albumEditMode}
+                  locked={lockedIds.has(track.id)}
+                  onSave={async (trackId, newTitle) => {
+                    const result = await patchTrackTitle(trackId, newTitle)
+                    if (result?.collision) {
+                      setCollision({ ...result, pendingTrackId: trackId, pendingTitle: newTitle })
+                    }
+                  }}
+                />
                 <span className="track-row-artist">{track.artist}</span>
               </li>
             )
@@ -228,6 +250,18 @@ export function TrackList(): React.JSX.Element | null {
 
       {menu && (
         <TrackContextMenu x={menu.x} y={menu.y} track={menu.track} onClose={() => setMenu(null)} />
+      )}
+      {collision && (
+        <CollisionModal
+          targetPath={collision.target_path}
+          onOverwrite={() => {
+            const { pendingTrackId, pendingTitle } = collision
+            setCollision(null)
+            void patchTrackTitle(pendingTrackId, pendingTitle, true)
+          }}
+          onSkip={() => setCollision(null)}
+          onCancel={() => setCollision(null)}
+        />
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -606,6 +606,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const result = await api.patchTrackTags(trackId, title, overwrite)
     if ('collision' in result) return result
     await get().refreshOpenAlbum()
+    void get().loadQueue()
     return null
   },
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -126,6 +126,11 @@ type PlayerStore = {
   clearRemainingQueue: (position: number) => Promise<void>
   setFavorite: (track: Track, favorite: boolean) => Promise<void>
   setAlbumFavorite: (albumArtist: string, album: string, favorite: boolean) => Promise<void>
+  patchTrackTitle: (
+    trackId: number,
+    title: string,
+    overwrite?: boolean
+  ) => Promise<api.TrackTagsCollision | null>
   refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
@@ -147,7 +152,8 @@ const initialPlayer: PlayerState = {
   position: 0,
   duration: 0,
   volume: 100,
-  current_track: null
+  current_track: null,
+  next_track: null
 }
 
 export const useStore = create<PlayerStore>((set, get) => ({
@@ -594,6 +600,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }))
     // Reload the open album track list so the heart in track rows updates.
     await get().refreshOpenAlbum()
+  },
+
+  patchTrackTitle: async (trackId, title, overwrite = false) => {
+    const result = await api.patchTrackTags(trackId, title, overwrite)
+    if ('collision' in result) return result
+    await get().refreshOpenAlbum()
+    return null
   },
 
   setAlbumFavorite: async (albumArtist, album, favorite) => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ disable_error_code = ["import-untyped", "import-not-found", "no-untyped-call", "
 # mutagen has partial stubs that don't cover ID3 frame classes, MP4 methods, or
 # FLAC tag access (audio.tags is typed as VCFLACDict | MetadataBlock; the union
 # causes false union-attr/index errors on the VCFLACDict branch we always use).
-module = ["kamp_daemon.tagger", "kamp_daemon.mover", "kamp_daemon.artwork", "kamp_core.library"]
+module = ["kamp_daemon.tagger", "kamp_daemon.mover", "kamp_daemon.artwork", "kamp_core.library", "tests.test_tag_edit"]
 disable_error_code = ["no-untyped-call", "attr-defined", "unused-ignore", "union-attr", "index", "var-annotated", "assignment", "arg-type"]
 
 [[tool.mypy.overrides]]

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -234,6 +234,26 @@ class TestPlaybackQueue:
         q.update_favorite(Path("/nonexistent.mp3"), True)  # should not raise
         assert all(not t.favorite for t in q._tracks)
 
+    def test_update_track_path_patches_matching_track(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        old_path = tracks[1].file_path
+        new_path = Path("/new/path/track.mp3")
+        q.update_track_path(old_path, new_path, "New Title")
+        assert q._tracks[0].file_path == tracks[0].file_path
+        assert q._tracks[1].file_path == new_path
+        assert q._tracks[1].title == "New Title"
+        assert q._tracks[2].file_path == tracks[2].file_path
+
+    def test_update_track_path_no_match_is_noop(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(2)]
+        q.load(tracks)
+        original_paths = [t.file_path for t in q._tracks]
+        q.update_track_path(Path("/nonexistent.mp3"), Path("/other.mp3"), "X")
+        assert [t.file_path for t in q._tracks] == original_paths
+
     def test_shuffle_randomises_order(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(20)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,6 +66,7 @@ def mock_engine() -> MagicMock:
 def mock_queue() -> MagicMock:
     queue = MagicMock()
     queue.current.return_value = None
+    queue.peek_next.return_value = None
     queue.queue_tracks.return_value = ([], -1)
     return queue
 

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -524,3 +524,154 @@ class TestPatchTrackTagsEndpoint:
         assert updated is not None
         assert updated.title == "New"
         db.close()
+
+    def test_returns_503_when_library_path_not_configured(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        track = _sample_track(tmp_path / "01.mp3")
+        db.upsert_track(track)
+        app = create_app(index=db, engine=_mock_engine, queue=_mock_queue)
+        client = TestClient(app, raise_server_exceptions=False)
+        row = db.get_track_by_path(tmp_path / "01.mp3")
+        assert row is not None
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "X"})
+        assert resp.status_code == 503
+        db.close()
+
+    def test_returns_422_on_invalid_template(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old",
+        )
+        track = _sample_track(
+            mp3, title="Old", album_artist="Artist", album="Album", year="2024"
+        )
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        db.upsert_track(track)
+        app = create_app(
+            index=db,
+            engine=_mock_engine,
+            queue=_mock_queue,
+            library_path=tmp_path,
+            config_values={"library.path_template": "{nonexistent_key}"},
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        row = db.get_track_by_path(mp3)
+        assert row is not None
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "New"})
+        assert resp.status_code == 422
+        db.close()
+
+    def test_case_only_rename_uses_two_step(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Case-only rename uses two-step via temp name and does not 409."""
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Hello.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Hello",
+        )
+        track = _sample_track(
+            mp3, title="Hello", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "hello"})
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "hello"
+        # DB updated to new path (case-only change is still a path change in the index).
+        new_mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - hello.mp3"
+        updated = index.get_track_by_path(new_mp3)
+        assert updated is not None
+        assert updated.title == "hello"
+        index.close()
+
+    def test_on_track_file_moved_callback_is_called(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        calls: list[tuple[Path, Path]] = []
+        from fastapi.testclient import TestClient as _TC  # noqa: F401
+
+        # Inject the callback via app.state after client creation.
+        client.app.state.on_track_file_moved = lambda old, new: calls.append((old, new))  # type: ignore[union-attr]
+
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Title"}
+        )
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        assert (
+            calls[0][1] == tmp_path / "Artist" / "2024 - Album" / "01 - New Title.mp3"
+        )
+        index.close()
+
+    def test_on_track_file_moved_callback_exception_is_swallowed(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        def _bad_callback(old: Path, new: Path) -> None:
+            raise RuntimeError("simulated callback failure")
+
+        client.app.state.on_track_file_moved = _bad_callback  # type: ignore[union-attr]
+
+        # Exception in callback must not surface as a 500 — endpoint still succeeds.
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Title"}
+        )
+        assert resp.status_code == 200
+        index.close()

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -273,6 +273,76 @@ class TestPatchTrackTagsEndpoint:
         assert updated.id == row.id  # id preserved
         index.close()
 
+    def test_rename_patches_queue_in_place(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Renaming a queued track updates the queue immediately so mpv keeps working."""
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Title"}
+        )
+        assert resp.status_code == 200
+        new_mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - New Title.mp3"
+        _mock_queue.update_track_path.assert_called_once_with(mp3, new_mp3, "New Title")
+        index.close()
+
+    def test_title_only_edit_patches_queue(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """A same-path title edit also patches the queue title in place."""
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "track.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old",
+        )
+        track = _sample_track(
+            mp3, title="Old", album_artist="Artist", album="Album", year="2024"
+        )
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        db.upsert_track(track)
+        app = create_app(
+            index=db,
+            engine=_mock_engine,
+            queue=_mock_queue,
+            library_path=tmp_path,
+            config_values={
+                "library.path_template": "{album_artist}/{year} - {album}/track.{ext}"
+            },
+        )
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app, raise_server_exceptions=False)
+        row = db.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "New"})
+        assert resp.status_code == 200
+        _mock_queue.update_track_path.assert_called_once_with(mp3, mp3, "New")
+        db.close()
+
     def test_returns_404_for_unknown_track(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
     ) -> None:

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -104,7 +104,9 @@ class TestRenderDestination:
         tags_upper = make_path_vars("Art", "Art", "Alb", "2024", 1, 1, "Norway", "mp3")
         p_lower = render_destination(tags_lower, tmp_path, _TEMPLATE)
         p_upper = render_destination(tags_upper, tmp_path, _TEMPLATE)
-        assert p_lower != p_upper
+        # Compare as strings: WindowsPath equality is case-insensitive, but we want
+        # to verify the rendered strings actually differ in case.
+        assert str(p_lower) != str(p_upper)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -1,0 +1,456 @@
+"""Tests for KAMP-307: tag-edit file rename, path rendering, and server endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import mutagen.id3 as id3
+import pytest
+from fastapi.testclient import TestClient
+
+from kamp_core.library import LibraryIndex, Track, write_title_to_file
+from kamp_core.path_utils import (
+    make_path_vars,
+    render_destination,
+    sanitize_path_component,
+)
+from kamp_core.playback import PlaybackState
+from kamp_core.server import create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TEMPLATE = "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+
+
+def _make_mp3(path: Path, **tags: str) -> None:
+    t = id3.ID3()
+    if "album_artist" in tags:
+        t["TPE2"] = id3.TPE2(encoding=3, text=tags["album_artist"])
+    if "album" in tags:
+        t["TALB"] = id3.TALB(encoding=3, text=tags["album"])
+    if "year" in tags:
+        t["TDRC"] = id3.TDRC(encoding=3, text=tags["year"])
+    if "track" in tags:
+        t["TRCK"] = id3.TRCK(encoding=3, text=tags["track"])
+    if "title" in tags:
+        t["TIT2"] = id3.TIT2(encoding=3, text=tags["title"])
+    path.write_bytes(b"\xff\xfb" * 64)
+    t.save(str(path))
+
+
+def _sample_track(file_path: Path, **overrides: object) -> Track:
+    defaults: dict[str, object] = dict(
+        file_path=file_path,
+        title="Old Title",
+        artist="Artist",
+        album_artist="Artist",
+        album="Album",
+        year="2024",
+        track_number=1,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="rel-1",
+        mb_recording_id="rec-1",
+    )
+    defaults.update(overrides)
+    return Track(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# path_utils
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizePathComponent:
+    def test_replaces_slash(self) -> None:
+        assert sanitize_path_component("a/b") == "a_b"
+
+    def test_replaces_colon(self) -> None:
+        assert sanitize_path_component("a:b") == "a_b"
+
+    def test_strips_trailing_dots(self) -> None:
+        assert sanitize_path_component("foo.") == "foo"
+
+    def test_strips_trailing_spaces(self) -> None:
+        assert sanitize_path_component("foo  ") == "foo"
+
+    def test_passthrough_normal_name(self) -> None:
+        assert sanitize_path_component("My Song (Remix)") == "My Song (Remix)"
+
+
+class TestRenderDestination:
+    def test_renders_standard_template(self, tmp_path: Path) -> None:
+        tags = make_path_vars("Art", "Art", "Alb", "2024", 3, 1, "Title", "mp3")
+        result = render_destination(tags, tmp_path, _TEMPLATE)
+        assert result == tmp_path / "Art" / "2024 - Alb" / "03 - Title.mp3"
+
+    def test_sanitizes_unsafe_chars_in_title(self, tmp_path: Path) -> None:
+        tags = make_path_vars("Art", "Art", "Alb", "2024", 1, 1, "A/B:C", "mp3")
+        result = render_destination(tags, tmp_path, _TEMPLATE)
+        assert "/" not in result.name
+        assert ":" not in result.name
+
+    def test_raises_on_bad_template(self, tmp_path: Path) -> None:
+        tags = make_path_vars("Art", "Art", "Alb", "2024", 1, 1, "Title", "mp3")
+        with pytest.raises(ValueError):
+            render_destination(tags, tmp_path, "{nonexistent_key}")
+
+    def test_case_difference_produces_different_path(self, tmp_path: Path) -> None:
+        tags_lower = make_path_vars("Art", "Art", "Alb", "2024", 1, 1, "norway", "mp3")
+        tags_upper = make_path_vars("Art", "Art", "Alb", "2024", 1, 1, "Norway", "mp3")
+        p_lower = render_destination(tags_lower, tmp_path, _TEMPLATE)
+        p_upper = render_destination(tags_upper, tmp_path, _TEMPLATE)
+        assert p_lower != p_upper
+
+
+# ---------------------------------------------------------------------------
+# write_title_to_file
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTitleToFile:
+    def test_updates_mp3_title_tag(self, tmp_path: Path) -> None:
+        mp3 = tmp_path / "track.mp3"
+        _make_mp3(mp3, title="Old Title")
+
+        write_title_to_file(mp3, "New Title")
+
+        tags = id3.ID3(str(mp3))
+        assert str(tags["TIT2"]) == "New Title"
+
+    def test_raises_on_unsupported_format(self, tmp_path: Path) -> None:
+        f = tmp_path / "track.wav"
+        f.write_bytes(b"\x00" * 16)
+        with pytest.raises(ValueError):
+            write_title_to_file(f, "Title")
+
+
+# ---------------------------------------------------------------------------
+# LibraryIndex.get_track_by_id / move_track
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryIndexTagEdit:
+    def test_get_track_by_id_returns_track(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        track = _sample_track(tmp_path / "01.mp3")
+        index.upsert_track(track)
+        row = index.get_track_by_path(tmp_path / "01.mp3")
+        assert row is not None
+
+        fetched = index.get_track_by_id(row.id)
+        assert fetched is not None
+        assert fetched.title == "Old Title"
+        index.close()
+
+    def test_get_track_by_id_returns_none_for_missing(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        assert index.get_track_by_id(99999) is None
+        index.close()
+
+    def test_move_track_updates_path_and_title(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        old_path = tmp_path / "01.mp3"
+        new_path = tmp_path / "02 - New Title.mp3"
+        track = _sample_track(old_path)
+        index.upsert_track(track)
+        original = index.get_track_by_path(old_path)
+        assert original is not None
+
+        index.move_track(old_path, new_path, "New Title", 1234567890.0)
+
+        # Old path gone, new path present with updated title.
+        assert index.get_track_by_path(old_path) is None
+        updated = index.get_track_by_path(new_path)
+        assert updated is not None
+        assert updated.title == "New Title"
+        # Stats preserved.
+        assert updated.id == original.id
+        assert updated.mb_recording_id == original.mb_recording_id
+        index.close()
+
+    def test_move_track_preserves_stats(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        old_path = tmp_path / "01.mp3"
+        track = _sample_track(old_path)
+        index.upsert_track(track)
+        # Set favorite via the dedicated method (upsert_track doesn't persist it).
+        index.set_favorite(old_path, True)
+        index.record_played(old_path)
+
+        new_path = tmp_path / "01 - New.mp3"
+        index.move_track(old_path, new_path, "New Title", 2000.0)
+
+        updated = index.get_track_by_path(new_path)
+        assert updated is not None
+        assert updated.favorite is True
+        assert updated.last_played is not None
+        assert updated.play_count == 1
+        index.close()
+
+
+# ---------------------------------------------------------------------------
+# Server endpoint: PATCH /api/v1/tracks/{track_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _mock_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.state = PlaybackState()
+    return engine
+
+
+@pytest.fixture()
+def _mock_queue() -> MagicMock:
+    queue = MagicMock()
+    queue.current.return_value = None
+    queue.peek_next.return_value = None
+    queue.queue_tracks.return_value = ([], -1)
+    queue.set_shuffle = MagicMock()
+    queue.set_repeat = MagicMock()
+    return queue
+
+
+class TestPatchTrackTagsEndpoint:
+    def _client_with_track(
+        self,
+        tmp_path: Path,
+        track: Track,
+        engine: MagicMock,
+        queue: MagicMock,
+    ) -> tuple[TestClient, LibraryIndex]:
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        db.upsert_track(track)
+        app = create_app(
+            index=db,
+            engine=engine,
+            queue=queue,
+            library_path=tmp_path,
+        )
+        return TestClient(app, raise_server_exceptions=False), db
+
+    def test_rename_updates_file_and_db(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Title"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "New Title"
+        # Old path gone, new path on disk.
+        assert not mp3.exists()
+        new_mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - New Title.mp3"
+        assert new_mp3.exists()
+        # DB updated.
+        updated = index.get_track_by_path(new_mp3)
+        assert updated is not None
+        assert updated.title == "New Title"
+        assert updated.id == row.id  # id preserved
+        index.close()
+
+    def test_returns_404_for_unknown_track(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        app = create_app(
+            index=db, engine=_mock_engine, queue=_mock_queue, library_path=tmp_path
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch("/api/v1/tracks/99999/tags", json={"title": "X"})
+        assert resp.status_code == 404
+        db.close()
+
+    def test_returns_403_for_currently_playing_track(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old",
+        )
+        track = _sample_track(
+            mp3, title="Old", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+        # Simulate currently-playing.
+        _mock_queue.current.return_value = row
+
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "New"})
+        assert resp.status_code == 403
+        index.close()
+
+    def test_returns_403_for_lookahead_track(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old",
+        )
+        track = _sample_track(
+            mp3, title="Old", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+        # Simulate lookahead (N+1).
+        _mock_queue.current.return_value = None
+        _mock_queue.peek_next.return_value = row
+
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "New"})
+        assert resp.status_code == 403
+        index.close()
+
+    def test_returns_409_on_collision_without_overwrite(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        # Create a file at the destination path to force collision.
+        collision_path = tmp_path / "Artist" / "2024 - Album" / "01 - New Title.mp3"
+        collision_path.write_bytes(b"\xff\xfb" * 64)
+
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Title"}
+        )
+        assert resp.status_code == 409
+        body = resp.json()
+        assert "target_path" in body["detail"]
+        # Original file untouched.
+        assert mp3.exists()
+        index.close()
+
+    def test_overwrite_replaces_existing_file(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "01 - Old Title.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old Title",
+        )
+        collision_path = tmp_path / "Artist" / "2024 - Album" / "01 - New Title.mp3"
+        collision_path.write_bytes(b"\xff\xfb" * 64)
+
+        track = _sample_track(
+            mp3, title="Old Title", album_artist="Artist", album="Album", year="2024"
+        )
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(
+            f"/api/v1/tracks/{row.id}/tags",
+            json={"title": "New Title", "overwrite": True},
+        )
+        assert resp.status_code == 200
+        assert collision_path.exists()
+        assert not mp3.exists()
+        index.close()
+
+    def test_no_rename_when_path_unchanged(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Title edit that doesn't change the rendered path should not move the file."""
+        # Use a template that doesn't include title so the path is always the same.
+        mp3 = tmp_path / "Artist" / "2024 - Album" / "track.mp3"
+        mp3.parent.mkdir(parents=True)
+        _make_mp3(
+            mp3,
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track="1",
+            title="Old",
+        )
+
+        track = _sample_track(
+            mp3, title="Old", album_artist="Artist", album="Album", year="2024"
+        )
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        db.upsert_track(track)
+        app = create_app(
+            index=db,
+            engine=_mock_engine,
+            queue=_mock_queue,
+            library_path=tmp_path,
+            # Template that omits {title} so any title edit leaves path unchanged.
+            config_values={
+                "library.path_template": "{album_artist}/{year} - {album}/track.{ext}"
+            },
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        row = db.get_track_by_path(mp3)
+        assert row is not None
+
+        resp = client.patch(f"/api/v1/tracks/{row.id}/tags", json={"title": "New"})
+        assert resp.status_code == 200
+        assert mp3.exists()  # file not moved
+        updated = db.get_track_by_path(mp3)
+        assert updated is not None
+        assert updated.title == "New"
+        db.close()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -283,6 +283,36 @@ class TestStartupScan:
 
 
 class TestInFlight:
+    def test_enqueue_skips_path_already_in_flight(self, config: Config) -> None:
+        """_enqueue is a no-op when the path is already in _in_flight."""
+        handler = _make_handler(config)
+        path = config.paths.watch_folder / "my-album"
+        handler._in_flight.add(path)
+
+        submitted: list[Path] = []
+        with patch.object(
+            handler._pipeline_pool, "submit", lambda *a: submitted.append(a[1])
+        ):
+            handler._enqueue(path)
+
+        assert submitted == []
+        # The path must stay in _in_flight (we didn't touch it)
+        assert path in handler._in_flight
+
+    def test_enqueue_normal_adds_to_in_flight_and_submits(self, config: Config) -> None:
+        """_enqueue adds the path to _in_flight and submits work to the pool."""
+        handler = _make_handler(config)
+        path = config.paths.watch_folder / "my-album"
+
+        submitted: list[Path] = []
+        with patch.object(
+            handler._pipeline_pool, "submit", lambda *a: submitted.append(a[1])
+        ):
+            handler._enqueue(path)
+
+        assert submitted == [path]
+        assert path in handler._in_flight
+
     def test_in_flight_path_is_not_rescheduled(self, config: Config) -> None:
         """_schedule is a no-op for a path currently being processed."""
         handler = _make_handler(config)
@@ -451,6 +481,16 @@ class TestOnCreated:
 
         mock_schedule.assert_not_called()
 
+    def test_non_file_created_event_is_ignored(self, config: Config) -> None:
+        """A non-directory, non-FileCreatedEvent (e.g. FileModifiedEvent) is ignored."""
+        handler = _make_handler(config)
+        event = FileModifiedEvent(str(config.paths.watch_folder / "track.mp3"))
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_created(event)
+
+        mock_schedule.assert_not_called()
+
 
 class TestOnModifiedFileEvent:
     def test_file_modified_event_is_ignored(self, config: Config) -> None:
@@ -474,6 +514,18 @@ class TestScanStagingRootOSError:
         # Patch at the class level — PosixPath C-methods can't be patched on instances
         with patch("pathlib.Path.iterdir", side_effect=OSError("no access")):
             handler._scan_watch_root()  # must not raise
+
+    def test_scan_watch_root_returns_early_when_watch_root_is_none(
+        self, config: Config
+    ) -> None:
+        """_scan_watch_root is a no-op when watch_root is None (no folder configured yet)."""
+        handler = _make_handler(config)
+        handler._watch_root = None
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler._scan_watch_root()
+
+        mock_schedule.assert_not_called()
 
 
 class TestScheduleTimer:
@@ -511,6 +563,15 @@ class TestWaitForStableSize:
 
         with patch("kamp_daemon.watcher.time.sleep"):
             _wait_for_stable_size(f)  # must not hang
+
+    def test_returns_when_deadline_exceeded(self, tmp_path: Path) -> None:
+        """_wait_for_stable_size returns without blocking when timeout is already past."""
+        from kamp_daemon.watcher import _wait_for_stable_size
+
+        f = tmp_path / "track.mp3"
+        f.write_bytes(b"x" * 100)
+        # timeout=-1 puts the deadline in the past; the while loop exits immediately
+        _wait_for_stable_size(f, timeout=-1.0)
 
     def test_returns_when_file_disappears(self, tmp_path: Path) -> None:
         """_wait_for_stable_size returns if the file is deleted mid-wait."""
@@ -604,7 +665,9 @@ class TestDuplicateRunPrevention:
         extracted_dir = config.paths.watch_folder / "album"
         extracted_dir.mkdir()
 
-        def _fake_run(path: Path, cfg: object, _on_directory: object = None) -> None:
+        def _fake_run(
+            path: Path, cfg: object, _on_directory: object = None, **kw: object
+        ) -> None:
             if callable(_on_directory):
                 _on_directory(extracted_dir)
             # Simulate the pipeline still running — try to schedule the directory
@@ -818,6 +881,68 @@ class TestWatcherReload:
         assert reschedule_calls == [1]
         assert watcher._config.paths.watch_folder == new_watch_folder
 
+    def test_reload_triggers_start_when_not_yet_started(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reload() calls start() when the watcher was never started (onboarding path)."""
+        no_folder_config = Config(
+            paths=PathsConfig(watch_folder=None, library=config.paths.library),
+            musicbrainz=config.musicbrainz,
+            artwork=config.artwork,
+            library=config.library,
+        )
+        watcher = Watcher(no_folder_config)
+        start_calls: list[int] = []
+        monkeypatch.setattr(watcher, "start", lambda: start_calls.append(1))
+
+        watcher.reload(config)
+
+        assert start_calls == [1]
+
+    def test_reload_returns_early_when_new_watch_folder_is_none(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reload() does nothing when the new config has no watch folder."""
+        watcher = self._patched_watcher(config, monkeypatch)
+        unschedule_calls: list[int] = []
+        monkeypatch.setattr(
+            watcher._observer, "unschedule_all", lambda: unschedule_calls.append(1)
+        )
+        new_config = Config(
+            paths=PathsConfig(watch_folder=None, library=config.paths.library),
+            musicbrainz=config.musicbrainz,
+            artwork=config.artwork,
+            library=config.library,
+        )
+        watcher.reload(new_config)
+
+        # Observer was unscheduled but then returned early — no reschedule
+        assert unschedule_calls == [1]
+        assert watcher._config.paths.watch_folder is None
+
+
+class TestWatcherStartNoFolder:
+    def test_start_returns_early_when_no_watch_folder(
+        self, config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """start() is a no-op when no watch folder is configured."""
+        no_folder_config = Config(
+            paths=PathsConfig(watch_folder=None, library=config.paths.library),
+            musicbrainz=config.musicbrainz,
+            artwork=config.artwork,
+            library=config.library,
+        )
+        watcher = Watcher(no_folder_config)
+        schedule_calls: list[int] = []
+        monkeypatch.setattr(
+            watcher._observer, "schedule", lambda *a, **kw: schedule_calls.append(1)
+        )
+
+        watcher.start()
+
+        assert schedule_calls == []
+        assert not watcher._started
+
 
 class TestStageCallback:
     def test_stage_callback_forwarded_to_run(
@@ -1010,6 +1135,17 @@ class TestLibraryHandler:
 
         mock_schedule.assert_called_once()
 
+    def test_on_deleted_ignores_non_delete_event(self, tmp_path: Path) -> None:
+        """on_deleted ignores events that are not FileDeletedEvent or DirDeletedEvent."""
+        handler = _make_library_handler(tmp_path)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_deleted(
+                FileModifiedEvent(str(tmp_path / "library" / "track.mp3"))
+            )
+
+        mock_schedule.assert_not_called()
+
     def test_fires_scan_on_directory_moved_out(self, tmp_path: Path) -> None:
         """Moving an entire album directory out of the library triggers a re-scan."""
         on_scan = MagicMock()
@@ -1024,6 +1160,20 @@ class TestLibraryHandler:
             )
 
         mock_schedule.assert_called_once()
+
+    def test_on_moved_ignores_non_audio_non_dir_event(self, tmp_path: Path) -> None:
+        """on_moved ignores events that are neither DirMovedEvent nor audio FileMovedEvent."""
+        handler = _make_library_handler(tmp_path)
+
+        with patch.object(handler, "_schedule") as mock_schedule:
+            handler.on_moved(
+                FileMovedEvent(
+                    str(tmp_path / "library" / "cover.jpg"),
+                    str(tmp_path / "library" / "artwork.jpg"),
+                )
+            )
+
+        mock_schedule.assert_not_called()
 
     def test_fires_scan_on_directory_modified(self, tmp_path: Path) -> None:
         """DirModifiedEvent schedules a re-scan.
@@ -1123,6 +1273,96 @@ class TestLibraryHandler:
             time.sleep(0.1)
 
         on_scan.assert_called_once()
+
+
+class TestLibraryHandlerSuppression:
+    def test_suppressed_path_skips_schedule(self, tmp_path: Path) -> None:
+        """FSEvents for a suppressed path must not trigger a rescan."""
+        import time as _time
+
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+        audio = tmp_path / "library" / "track.mp3"
+
+        handler._suppressed_paths[audio] = _time.monotonic() + 30.0
+        with patch.object(handler, "_schedule", wraps=handler._schedule) as spy:
+            handler.on_created(FileCreatedEvent(str(audio)))
+        # _schedule called but returned early — on_scan must not be scheduled
+        spy.assert_called_once()
+        on_scan.assert_not_called()
+
+    def test_suppressed_parent_skips_schedule(self, tmp_path: Path) -> None:
+        """FSEvents on the parent directory of a suppressed path are also skipped."""
+        import time as _time
+
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+        audio = tmp_path / "library" / "track.mp3"
+
+        # Suppress the parent directory (what the server actually does).
+        handler._suppressed_paths[audio.parent] = _time.monotonic() + 30.0
+        with patch.object(handler, "_schedule", wraps=handler._schedule) as spy:
+            handler.on_created(FileCreatedEvent(str(audio)))
+        spy.assert_called_once()
+        on_scan.assert_not_called()
+
+    def test_expired_suppression_does_not_skip_schedule(self, tmp_path: Path) -> None:
+        """Expired suppressions do not block rescans."""
+        import time as _time
+
+        on_scan = MagicMock()
+        handler = _make_library_handler(tmp_path, on_scan)
+        audio = tmp_path / "library" / "track.mp3"
+
+        # TTL already in the past.
+        handler._suppressed_paths[audio] = _time.monotonic() - 1.0
+        with patch("kamp_daemon.watcher._SETTLE_SECONDS", 0.0):
+            with patch("kamp_daemon.watcher._MAX_SETTLE_SECONDS", 0.0):
+                handler.on_created(FileCreatedEvent(str(audio)))
+                _time.sleep(0.05)
+        on_scan.assert_called_once()
+
+
+class TestLibraryWatcherSuppressAndScanNow:
+    def test_suppress_paths_sets_cutoffs(self, tmp_path: Path) -> None:
+        lib = tmp_path / "library"
+        lib.mkdir()
+        on_change = MagicMock()
+        watcher = LibraryWatcher(lib, on_change)
+        p = lib / "track.mp3"
+        watcher.suppress_paths({p}, ttl=10.0)
+        import time as _time
+
+        now = _time.monotonic()
+        assert watcher._handler._suppressed_paths[p] > now
+        assert watcher._handler._suppressed_paths[p.parent] > now
+
+    def test_scan_now_calls_on_scan(self, tmp_path: Path) -> None:
+        lib = tmp_path / "library"
+        lib.mkdir()
+        on_change = MagicMock()
+        watcher = LibraryWatcher(lib, on_change)
+        watcher.scan_now()
+        import time as _time
+
+        _time.sleep(0.05)
+        on_change.assert_called_once()
+
+    def test_trigger_scan_without_path_runs_schedule_body(self, tmp_path: Path) -> None:
+        """trigger_scan() calls _schedule(None) — covers the trigger_path-is-None branch."""
+        import time as _time
+
+        lib = tmp_path / "library"
+        lib.mkdir()
+        on_change = MagicMock()
+        watcher = LibraryWatcher(lib, on_change)
+
+        with patch("kamp_daemon.watcher._SETTLE_SECONDS", 0.0):
+            with patch("kamp_daemon.watcher._MAX_SETTLE_SECONDS", 0.0):
+                watcher.trigger_scan()
+                _time.sleep(0.05)
+
+        on_change.assert_called_once()
 
 
 class TestLibraryWatcher:


### PR DESCRIPTION
## Summary

- `PATCH /api/v1/tracks/{id}/tags` writes the title tag to disk, computes the new file path from the path template, moves the file, and updates `tracks.file_path` in place (preserving `tracks.id` and all stats)
- Extracts `sanitize_path_component` / `render_destination` into `kamp_core/path_utils.py` so both `kamp_daemon/mover.py` and `kamp_core/server.py` share the same path-rendering logic without circular deps
- Watcher suppression: `LibraryWatcher.suppress_paths(set[Path], ttl=30s)` prevents FSEvents from the move triggering an unwanted rescan; `scan_now()` fires a fresh scan immediately after
- Scanner reconciliation: after a move, the scanner matches `mb_recording_id` to avoid creating duplicate rows
- Case-only renames (HFS+/APFS/NTFS) handled via two-step temp rename
- 409 collision response (target path already exists, `overwrite=False`) drives an Overwrite/Skip/Cancel modal in the UI
- Currently-playing and gapless-lookahead (N+1) tracks are locked — input disabled with "Pause to edit this track" tooltip
- `next_track` added to `PlayerStateOut` so the UI can identify the lookahead track

## Test plan

- [ ] `poetry run pytest tests/test_tag_edit.py -v --no-cov` — 22 new tests (path utils, library, server endpoint)
- [ ] `poetry run pytest tests/test_server.py -v --no-cov` — existing server tests still pass
- [ ] `poetry run mypy kamp_daemon/__main__.py tests/test_tag_edit.py` — clean
- [ ] `poetry run black --check kamp_core/ kamp_daemon/ tests/` — clean
- [ ] UI: enter edit mode on an album, rename a track, verify file moves and row updates
- [ ] UI: rename to a path that already exists → collision modal → Overwrite / Skip / Cancel
- [x] UI: attempt to rename currently-playing or next-in-queue track → input is disabled with tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)