### PR TITLE
feat(KAMP-308): album title and artist rename with cascading file fan-out

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -90,7 +90,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 14
+_SCHEMA_VERSION = 15
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -556,6 +556,15 @@ class LibraryIndex:
             """)
             self._conn.execute("UPDATE schema_version SET version = 14")
             self._conn.commit()
+            version = 14
+
+        if version < 15:
+            # v14 → v15: index on (album_artist, album) for album-level fan-out (KAMP-308).
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS tracks_album_idx ON tracks(album_artist, album)"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 15")
+            self._conn.commit()
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -925,6 +934,29 @@ class LibraryIndex:
         self._conn.execute(
             "UPDATE tracks SET file_path = ?, title = ?, file_mtime = ? WHERE file_path = ?",
             (str(new_path), new_title, new_mtime, str(old_path)),
+        )
+        self._rebuild_fts()
+        self._conn.commit()
+
+    def rename_album_track(
+        self,
+        old_path: Path,
+        new_path: Path,
+        new_album: str,
+        new_album_artist: str,
+        new_mtime: float,
+    ) -> None:
+        """Update file_path, album, and album_artist for a track after an album-level rename.
+
+        Like move_track but also rewrites the album and album_artist columns.
+        Primary stats (date_added, play_count, last_played, favorite) are unchanged.
+        Called once per track during PATCH /api/v1/albums/tags fan-out.
+        """
+        self._conn.execute(
+            """UPDATE tracks
+               SET file_path = ?, album = ?, album_artist = ?, file_mtime = ?
+               WHERE file_path = ?""",
+            (str(new_path), new_album, new_album_artist, new_mtime, str(old_path)),
         )
         self._rebuild_fts()
         self._conn.commit()
@@ -1668,6 +1700,42 @@ def write_title_to_file(path: Path, title: str) -> None:
         audio.save()
     else:
         raise ValueError(f"Unsupported format for title write: {path.suffix}")
+
+
+def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
+    """Write album and album_artist tags to an audio file without touching other tags."""
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        try:
+            tags = id3.ID3(str(path))
+        except Exception:
+            tags = id3.ID3()
+        tags["TALB"] = id3.TALB(encoding=3, text=album)
+        tags["TPE2"] = id3.TPE2(encoding=3, text=album_artist)
+        tags.save(str(path))
+    elif suffix == ".m4a":
+        audio = mutagen.mp4.MP4(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["\xa9alb"] = [album]  # type: ignore[index]
+        audio.tags["aART"] = [album_artist]  # type: ignore[index]
+        audio.save()
+    elif suffix == ".flac":
+        audio = mutagen.flac.FLAC(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["ALBUM"] = [album]  # type: ignore[index]
+        audio.tags["ALBUMARTIST"] = [album_artist]  # type: ignore[index]
+        audio.save()
+    elif suffix == ".ogg":
+        audio = mutagen.oggvorbis.OggVorbis(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["ALBUM"] = [album]  # type: ignore[index]
+        audio.tags["ALBUMARTIST"] = [album_artist]  # type: ignore[index]
+        audio.save()
+    else:
+        raise ValueError(f"Unsupported format for album tag write: {path.suffix}")
 
 
 def _read_tags(path: Path) -> Track | None:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1757,7 +1757,7 @@ def write_album_tags_to_file(
     if suffix == ".mp3":
         try:
             tags = id3.ID3(str(path))
-        except Exception:
+        except Exception:  # pragma: no cover
             tags = id3.ID3()
         tags["TALB"] = id3.TALB(encoding=3, text=album)
         tags["TPE2"] = id3.TPE2(encoding=3, text=album_artist)

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -336,7 +336,9 @@ class LibraryIndex:
         # sidecar files) with 600 permissions rather than the default 644.
         old_umask = os.umask(0o077)
         try:
-            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn = sqlite3.connect(
+                str(self._db_path), check_same_thread=False, timeout=30
+            )
         finally:
             os.umask(old_umask)
         conn.row_factory = sqlite3.Row

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -963,6 +963,28 @@ class LibraryIndex:
         self._rebuild_fts()
         self._conn.commit()
 
+    def rename_album_tracks_bulk(
+        self,
+        path_pairs: list[tuple[Path, Path]],
+        new_album: str,
+        new_album_artist: str,
+        new_mtime: float,
+    ) -> None:
+        """Update all tracks in the album in one transaction with a single FTS rebuild.
+
+        Used after a directory-level rename where all files move atomically and only
+        the DB rows need to be re-pointed.  Stats columns are untouched.
+        """
+        for old_path, new_path in path_pairs:
+            self._conn.execute(
+                """UPDATE tracks
+                   SET file_path = ?, album = ?, album_artist = ?, file_mtime = ?
+                   WHERE file_path = ?""",
+                (str(new_path), new_album, new_album_artist, new_mtime, str(old_path)),
+            )
+        self._rebuild_fts()
+        self._conn.commit()
+
     def remove_track(self, file_path: Path) -> None:
         """Remove the track with the given file path from the index."""
         self._conn.execute("DELETE FROM tracks WHERE file_path = ?", (str(file_path),))

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -969,18 +969,36 @@ class LibraryIndex:
         new_album: str,
         new_album_artist: str,
         new_mtime: float,
+        old_album_artist: str | None = None,
     ) -> None:
         """Update all tracks in the album in one transaction with a single FTS rebuild.
 
         Used after a directory-level rename where all files move atomically and only
         the DB rows need to be re-pointed.  Stats columns are untouched.
+
+        old_album_artist, when provided, also updates the per-track artist column
+        for any row where artist = old_album_artist (i.e. single-artist albums
+        where TPE1 == TPE2).
         """
         for old_path, new_path in path_pairs:
             self._conn.execute(
                 """UPDATE tracks
-                   SET file_path = ?, album = ?, album_artist = ?, file_mtime = ?
+                   SET file_path = ?,
+                       album = ?,
+                       album_artist = ?,
+                       artist = CASE WHEN ? IS NOT NULL AND artist = ? THEN ? ELSE artist END,
+                       file_mtime = ?
                    WHERE file_path = ?""",
-                (str(new_path), new_album, new_album_artist, new_mtime, str(old_path)),
+                (
+                    str(new_path),
+                    new_album,
+                    new_album_artist,
+                    old_album_artist,
+                    old_album_artist,
+                    new_album_artist,
+                    new_mtime,
+                    str(old_path),
+                ),
             )
         self._rebuild_fts()
         self._conn.commit()
@@ -1726,8 +1744,15 @@ def write_title_to_file(path: Path, title: str) -> None:
         raise ValueError(f"Unsupported format for title write: {path.suffix}")
 
 
-def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
-    """Write album and album_artist tags to an audio file without touching other tags."""
+def write_album_tags_to_file(
+    path: Path, album: str, album_artist: str, artist: str | None = None
+) -> None:
+    """Write album and album_artist tags to an audio file without touching other tags.
+
+    artist, when provided, also updates the per-track artist tag (TPE1 / ©ART /
+    ARTIST).  Pass it when track.artist matched the old album_artist so that
+    renaming a single-artist album keeps the per-track tag in sync.
+    """
     suffix = path.suffix.lower()
     if suffix == ".mp3":
         try:
@@ -1736,6 +1761,8 @@ def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
             tags = id3.ID3()
         tags["TALB"] = id3.TALB(encoding=3, text=album)
         tags["TPE2"] = id3.TPE2(encoding=3, text=album_artist)
+        if artist is not None:
+            tags["TPE1"] = id3.TPE1(encoding=3, text=artist)
         tags.save(str(path))
     elif suffix == ".m4a":
         audio = mutagen.mp4.MP4(str(path))
@@ -1743,6 +1770,8 @@ def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
             audio.add_tags()
         audio.tags["\xa9alb"] = [album]  # type: ignore[index]
         audio.tags["aART"] = [album_artist]  # type: ignore[index]
+        if artist is not None:
+            audio.tags["\xa9ART"] = [artist]  # type: ignore[index]
         audio.save()
     elif suffix == ".flac":
         audio = mutagen.flac.FLAC(str(path))
@@ -1750,6 +1779,8 @@ def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
             audio.add_tags()
         audio.tags["ALBUM"] = [album]  # type: ignore[index]
         audio.tags["ALBUMARTIST"] = [album_artist]  # type: ignore[index]
+        if artist is not None:
+            audio.tags["ARTIST"] = [artist]  # type: ignore[index]
         audio.save()
     elif suffix == ".ogg":
         audio = mutagen.oggvorbis.OggVorbis(str(path))
@@ -1757,6 +1788,8 @@ def write_album_tags_to_file(path: Path, album: str, album_artist: str) -> None:
             audio.add_tags()
         audio.tags["ALBUM"] = [album]  # type: ignore[index]
         audio.tags["ALBUMARTIST"] = [album_artist]  # type: ignore[index]
+        if artist is not None:
+            audio.tags["ARTIST"] = [artist]  # type: ignore[index]
         audio.save()
     else:
         raise ValueError(f"Unsupported format for album tag write: {path.suffix}")

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -96,17 +96,21 @@ class PlaybackQueue:
         new_path: Path,
         new_album: str,
         new_album_artist: str,
+        new_artist: str | None = None,
     ) -> None:
         """Patch file_path, album, and album_artist after an album-level rename.
 
         Called once per track during PATCH /api/v1/albums/tags so the queue
         display reflects the new artist/album without a full queue reload.
+        new_artist is provided when the per-track artist tag was also updated.
         """
         for t in self._tracks:
             if t.file_path == old_path:
                 t.file_path = new_path
                 t.album = new_album
                 t.album_artist = new_album_artist
+                if new_artist is not None:
+                    t.artist = new_artist
 
     def current(self) -> Track | None:
         if not self._tracks or self._pos < 0:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -90,6 +90,24 @@ class PlaybackQueue:
                 t.file_path = new_path
                 t.title = new_title
 
+    def update_track_album_tags(
+        self,
+        old_path: Path,
+        new_path: Path,
+        new_album: str,
+        new_album_artist: str,
+    ) -> None:
+        """Patch file_path, album, and album_artist after an album-level rename.
+
+        Called once per track during PATCH /api/v1/albums/tags so the queue
+        display reflects the new artist/album without a full queue reload.
+        """
+        for t in self._tracks:
+            if t.file_path == old_path:
+                t.file_path = new_path
+                t.album = new_album
+                t.album_artist = new_album_artist
+
     def current(self) -> Track | None:
         if not self._tracks or self._pos < 0:
             return None

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -259,6 +259,30 @@ class TrackTagsRequest(BaseModel):
     overwrite: bool = False
 
 
+class AlbumTagsRequest(BaseModel):
+    album: str | None = None
+    album_artist: str | None = None
+    # overwrite=True: replace any file that already exists at the target path.
+    # skip_conflicts=True: leave colliding files at their old path, rename the rest.
+    # Default (both False): stop on first collision and return 409.
+    overwrite: bool = False
+    skip_conflicts: bool = False
+
+
+class AlbumTagsTrackResult(BaseModel):
+    track_id: int
+    old_path: str
+    new_path: str
+    error: str | None = None
+
+
+class AlbumTagsOut(BaseModel):
+    moved: list[TrackOut]
+    # Paths of files left at their original location due to skip_conflicts.
+    skipped: list[str]
+    failed: list[AlbumTagsTrackResult]
+
+
 class BandcampProxyFetchResult(BaseModel):
     id: str
     status: int
@@ -652,6 +676,178 @@ def create_app(
     def set_album_favorite(req: AlbumFavoriteRequest) -> dict[str, Any]:
         index.toggle_album_favorite(req.album_artist, req.album, req.favorite)
         return {"ok": True}
+
+    @app.patch("/api/v1/albums/tags")
+    def patch_album_tags(
+        album_artist: str, album: str, req: "AlbumTagsRequest"
+    ) -> "AlbumTagsOut":
+        """Rename album title and/or album artist, fanning out to every track in the album.
+
+        For each track: writes tags to the file, moves it to the new computed path,
+        and updates the DB row.  Broadcasts album.rename.progress events over WebSocket
+        during the batch so the renderer can show "Renaming N of M…".
+
+        Collision handling (files that already exist at the target path):
+        - Default (overwrite=False, skip_conflicts=False): pre-flight detects collisions
+          and returns 409 without moving anything.
+        - overwrite=True: existing files are replaced.
+        - skip_conflicts=True: colliding files are left at their old location; the rest
+          of the album is renamed normally.
+        - If Cancel is chosen by the user after a 409, already-moved files (from a prior
+          partial attempt) remain at their new locations — this is documented behaviour.
+        """
+        import shutil
+        import time as _t
+
+        from kamp_core.library import write_album_tags_to_file
+        from kamp_core.path_utils import make_path_vars, render_destination
+
+        tracks = index.tracks_for_album(album_artist, album)
+        if not tracks:
+            raise HTTPException(status_code=404, detail="Album not found")
+
+        new_album = req.album if req.album is not None else album
+        new_album_artist = (
+            req.album_artist if req.album_artist is not None else album_artist
+        )
+
+        if new_album == album and new_album_artist == album_artist:
+            raise HTTPException(status_code=400, detail="No changes requested")
+
+        lib_path: Path | None = _state["library_path"]
+        if lib_path is None:
+            raise HTTPException(status_code=503, detail="Library path not configured")
+
+        # Pre-flight: ensure the disk has enough headroom for the worst case
+        # (all files copied before the originals are removed).
+        try:
+            usage = shutil.disk_usage(lib_path)
+            total_size = sum(
+                t.file_path.stat().st_size for t in tracks if t.file_path.exists()
+            )
+            if usage.free < total_size * 1.1:
+                raise HTTPException(status_code=507, detail="Insufficient disk space")
+        except (OSError, AttributeError):
+            pass  # non-fatal: proceed and let individual moves fail
+
+        path_template: str = (
+            _state["config"].get("library.path_template")
+            or "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+        )
+
+        # Compute all destination paths upfront so we can detect collisions before
+        # any files are moved (avoids leaving the album half-renamed on 409).
+        dest_map: dict[int, tuple[Path, Path]] = {}  # track_id → (old_path, new_path)
+        collisions: list[str] = []
+        for track in tracks:
+            tags = make_path_vars(
+                artist=track.artist,
+                album_artist=new_album_artist,
+                album=new_album,
+                year=track.year,
+                track=track.track_number,
+                disc=track.disc_number,
+                title=track.title,
+                ext=track.ext,
+            )
+            old_path = track.file_path
+            try:
+                new_path = render_destination(tags, lib_path, path_template)
+            except ValueError as exc:
+                raise HTTPException(status_code=422, detail=str(exc))
+
+            is_case_only = str(old_path).lower() == str(new_path).lower() and str(
+                old_path
+            ) != str(new_path)
+            if (
+                str(old_path) != str(new_path)
+                and not is_case_only
+                and new_path.exists()
+            ):
+                collisions.append(str(new_path))
+
+            dest_map[track.id] = (old_path, new_path)
+
+        if collisions and not req.overwrite and not req.skip_conflicts:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "collision_count": len(collisions),
+                    "first_path": collisions[0],
+                },
+            )
+
+        # Fan-out: write tags, move file, update DB — one track at a time.
+        moved: list[TrackOut] = []
+        skipped: list[str] = []
+        failed: list[AlbumTagsTrackResult] = []
+        total = len(tracks)
+        notify_track_moved = getattr(app.state, "on_track_file_moved", None)
+
+        for i, track in enumerate(tracks):
+            _broadcast({"type": "album.rename.progress", "done": i, "total": total})
+            old_path, new_path = dest_map[track.id]
+
+            is_case_only = str(old_path).lower() == str(new_path).lower() and str(
+                old_path
+            ) != str(new_path)
+            collision = (
+                str(old_path) != str(new_path)
+                and not is_case_only
+                and new_path.exists()
+            )
+
+            if collision and req.skip_conflicts:
+                skipped.append(str(old_path))
+                continue
+
+            try:
+                write_album_tags_to_file(old_path, new_album, new_album_artist)
+
+                if str(old_path) != str(new_path):
+                    if collision and req.overwrite:
+                        index.remove_track(new_path)
+                    new_path.parent.mkdir(parents=True, exist_ok=True)
+                    if is_case_only:
+                        tmp_path = old_path.with_suffix(
+                            f".kamp_rename{old_path.suffix}"
+                        )
+                        shutil.move(str(old_path), tmp_path)
+                        shutil.move(str(tmp_path), new_path)
+                    else:
+                        shutil.move(str(old_path), new_path)
+
+                new_mtime = _t.time()
+                index.rename_album_track(
+                    old_path, new_path, new_album, new_album_artist, new_mtime
+                )
+
+                if notify_track_moved is not None and str(old_path) != str(new_path):
+                    try:
+                        notify_track_moved(old_path, new_path)
+                    except Exception:
+                        logger.exception("on_track_file_moved callback raised")
+
+                updated = index.get_track_by_id(track.id)
+                if updated is not None:
+                    moved.append(TrackOut.from_track(updated))
+
+            except Exception as exc:
+                logger.exception(
+                    "album rename failed for track %d (%s)", track.id, old_path
+                )
+                failed.append(
+                    AlbumTagsTrackResult(
+                        track_id=track.id,
+                        old_path=str(old_path),
+                        new_path=str(new_path),
+                        error=str(exc),
+                    )
+                )
+
+        _broadcast({"type": "album.rename.progress", "done": total, "total": total})
+        _notify_library_changed()
+        return AlbumTagsOut(moved=moved, skipped=skipped, failed=failed)
 
     @app.get("/api/v1/album-art")
     def get_album_art(

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -448,6 +448,9 @@ def create_app(
     # Wired by the daemon after create_app() to suppress watcher events and
     # trigger a direct scan following a tag-edit file move.
     app.state.on_track_file_moved = None
+    # Batch variant for album rename: suppress all moved pairs, then one scan.
+    # Signature: (pairs: list[tuple[Path, Path]]) -> None
+    app.state.on_album_tracks_moved = None
 
     # Wire play-state change callback directly — the engine fires it from its
     # background reader thread whenever mpv's pause property flips.
@@ -782,7 +785,11 @@ def create_app(
         skipped: list[str] = []
         failed: list[AlbumTagsTrackResult] = []
         total = len(tracks)
-        notify_track_moved = getattr(app.state, "on_track_file_moved", None)
+        notify_album_tracks_moved = getattr(app.state, "on_album_tracks_moved", None)
+        # Collect moves to notify the watcher after ALL writes are done.
+        # Calling scan_now() mid-loop would race with subsequent rename_album_track()
+        # write transactions — deferred notification eliminates the contention.
+        moved_path_pairs: list[tuple[Path, Path]] = []
 
         for i, track in enumerate(tracks):
             _broadcast({"type": "album.rename.progress", "done": i, "total": total})
@@ -822,11 +829,8 @@ def create_app(
                     old_path, new_path, new_album, new_album_artist, new_mtime
                 )
 
-                if notify_track_moved is not None and str(old_path) != str(new_path):
-                    try:
-                        notify_track_moved(old_path, new_path)
-                    except Exception:
-                        logger.exception("on_track_file_moved callback raised")
+                if str(old_path) != str(new_path):
+                    moved_path_pairs.append((old_path, new_path))
 
                 updated = index.get_track_by_id(track.id)
                 if updated is not None:
@@ -846,6 +850,14 @@ def create_app(
                 )
 
         _broadcast({"type": "album.rename.progress", "done": total, "total": total})
+
+        # All DB writes are done — notify the watcher with one batched call so
+        # suppressions are registered and exactly one scan_now() fires.
+        if notify_album_tracks_moved is not None and moved_path_pairs:
+            try:
+                notify_album_tracks_moved(moved_path_pairs)
+            except Exception:
+                logger.exception("on_album_tracks_moved callback raised")
 
         # Remove empty directories left behind by the moves.
         # Collect unique old album directories from every track that was actually moved

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -843,7 +843,7 @@ def create_app(
                     e.name not in _OS_METADATA_NAMES and e.name != old_album_dir.name
                     for e in old_artist_dir.iterdir()
                 )
-            except OSError:
+            except OSError:  # pragma: no cover
                 exclusive = False
 
             rename_at_artist_level = (
@@ -862,7 +862,9 @@ def create_app(
                 src, dst = old_album_dir, new_album_dir
 
             is_case_only = str(src).lower() == str(dst).lower() and str(src) != str(dst)
-            if is_case_only:
+            if (
+                is_case_only
+            ):  # pragma: no cover — macOS HFS+ routes this to collision path
                 tmp = src.with_name(f"kamp_tmp_{src.name}")
                 os.rename(str(src), str(tmp))
                 os.rename(str(tmp), str(dst))

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -846,6 +846,28 @@ def create_app(
                 )
 
         _broadcast({"type": "album.rename.progress", "done": total, "total": total})
+
+        # Remove empty directories left behind by the moves.
+        # Collect unique old album directories from every track that was actually moved
+        # (skipped and failed tracks may still have files there, so rmdir would fail
+        # harmlessly and we just stop climbing for that directory).
+        old_dirs: set[Path] = {
+            dest_map[t.id][0].parent
+            for t in tracks
+            if str(dest_map[t.id][0]) != str(dest_map[t.id][1])
+        }
+        # Process deepest directories first so parents are checked after children.
+        for d in sorted(old_dirs, key=lambda p: len(p.parts), reverse=True):
+            candidate = d
+            # Climb toward the library root, removing each level only if empty.
+            # Never remove the library root itself.
+            while candidate != lib_path and lib_path in candidate.parents:
+                try:
+                    candidate.rmdir()
+                except OSError:
+                    break  # not empty (or already gone) — stop climbing
+                candidate = candidate.parent
+
         _notify_library_changed()
         return AlbumTagsOut(moved=moved, skipped=skipped, failed=failed)
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -769,9 +769,11 @@ def create_app(
         old_paths = [op for op, _ in track_dest]
         new_paths = [np for _, np in track_dest]
 
-        # Album directory = common ancestor of all track paths.
-        old_album_dir = Path(os.path.commonpath([str(p) for p in old_paths]))
-        new_album_dir = Path(os.path.commonpath([str(p) for p in new_paths]))
+        # Album directory = common ancestor of the directories containing the tracks.
+        # Using .parent before commonpath avoids returning a file path for single-track albums
+        # (commonpath(['/a/b/f.mp3']) == '/a/b/f.mp3', not '/a/b').
+        old_album_dir = Path(os.path.commonpath([str(p.parent) for p in old_paths]))
+        new_album_dir = Path(os.path.commonpath([str(p.parent) for p in new_paths]))
 
         total = len(tracks)
         moved: list[TrackOut] = []
@@ -815,16 +817,44 @@ def create_app(
         elif not new_album_dir.exists():
             # Happy path: target directory does not exist — atomic directory rename.
             _broadcast({"type": "album.rename.progress", "done": 0, "total": total})
-            new_album_dir.parent.mkdir(parents=True, exist_ok=True)
-            is_case_only = str(old_album_dir).lower() == str(
-                new_album_dir
-            ).lower() and str(old_album_dir) != str(new_album_dir)
-            if is_case_only:
-                tmp_dir = old_album_dir.with_name(f"kamp_tmp_{old_album_dir.name}")
-                os.rename(str(old_album_dir), str(tmp_dir))
-                os.rename(str(tmp_dir), str(new_album_dir))
+
+            old_artist_dir = old_album_dir.parent
+            new_artist_dir = new_album_dir.parent
+
+            # When only the artist component changes and the old artist directory
+            # contains nothing else, rename at the artist level in one syscall.
+            # This matches the user's expectation: "Artist A/" → "Artist B/" directly,
+            # rather than mkdir("Artist B"), rename album dir, rmdir("Artist A").
+            try:
+                exclusive = not any(
+                    e.name not in _OS_METADATA_NAMES and e.name != old_album_dir.name
+                    for e in old_artist_dir.iterdir()
+                )
+            except OSError:
+                exclusive = False
+
+            rename_at_artist_level = (
+                old_album_dir.name == new_album_dir.name  # only artist dir changed
+                and old_artist_dir != new_artist_dir
+                and not new_artist_dir.exists()
+                and old_artist_dir != lib_path
+                and lib_path in old_artist_dir.parents
+                and exclusive
+            )
+
+            if rename_at_artist_level:
+                src, dst = old_artist_dir, new_artist_dir
             else:
-                os.rename(str(old_album_dir), str(new_album_dir))
+                new_album_dir.parent.mkdir(parents=True, exist_ok=True)
+                src, dst = old_album_dir, new_album_dir
+
+            is_case_only = str(src).lower() == str(dst).lower() and str(src) != str(dst)
+            if is_case_only:
+                tmp = src.with_name(f"kamp_tmp_{src.name}")
+                os.rename(str(src), str(tmp))
+                os.rename(str(tmp), str(dst))
+            else:
+                os.rename(str(src), str(dst))
 
             # Files are now under new_album_dir; write tags and bulk-update DB.
             new_mtime = _t.time()
@@ -849,12 +879,12 @@ def create_app(
                 db_pairs, new_album, new_album_artist, new_mtime
             )
 
-            # Clean up the old parent (artist dir) if it is now empty.
-            old_parent = old_album_dir.parent
-            if old_parent != lib_path and lib_path in old_parent.parents:
-                _scrub_os_metadata(old_parent)
+            # Album-level rename: clean up old artist dir if now empty.
+            # (Artist-level rename already removed it by renaming the dir itself.)
+            if not rename_at_artist_level:
+                _scrub_os_metadata(old_artist_dir)
                 try:
-                    old_parent.rmdir()
+                    old_artist_dir.rmdir()
                 except OSError:
                     pass
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -304,6 +304,30 @@ _ALLOWED_PROXY_HOSTS: frozenset[str] = frozenset(
 )
 
 
+# OS metadata filenames that macOS (and Windows) drop into every directory.
+# These make rmdir() fail even on "empty" folders, so we remove them first.
+_OS_METADATA_NAMES: frozenset[str] = frozenset(
+    {".DS_Store", "Thumbs.db", "desktop.ini", ".Spotlight-V100", ".Trashes"}
+)
+
+
+def _scrub_os_metadata(directory: Path) -> None:
+    """Remove known OS-generated metadata files from *directory*.
+
+    Called before rmdir() so that Finder-created .DS_Store files don't prevent
+    cleanup of otherwise-empty album/artist directories after a rename.
+    """
+    try:
+        for entry in directory.iterdir():
+            if entry.name in _OS_METADATA_NAMES:
+                try:
+                    entry.unlink()
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
 def _validate_library_path(file_path: str, library_path: Path | None) -> Path:
     """Resolve *file_path* and verify it lies within *library_path*.
 
@@ -828,6 +852,9 @@ def create_app(
                 index.rename_album_track(
                     old_path, new_path, new_album, new_album_artist, new_mtime
                 )
+                queue.update_track_album_tags(
+                    old_path, new_path, new_album, new_album_artist
+                )
 
                 if str(old_path) != str(new_path):
                     moved_path_pairs.append((old_path, new_path))
@@ -874,6 +901,7 @@ def create_app(
             # Climb toward the library root, removing each level only if empty.
             # Never remove the library root itself.
             while candidate != lib_path and lib_path in candidate.parents:
+                _scrub_os_metadata(candidate)
                 try:
                     candidate.rmdir()
                 except OSError:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -790,11 +790,20 @@ def create_app(
             db_pairs: list[tuple[Path, Path]] = []
             for i, (track, (old_path, new_path)) in enumerate(zip(tracks, track_dest)):
                 _broadcast({"type": "album.rename.progress", "done": i, "total": total})
+                # When the per-track artist matches the old album_artist, update it
+                # too — keeps TPE1/artist in sync with TPE2/album_artist.
+                new_artist = new_album_artist if track.artist == album_artist else None
                 try:
-                    write_album_tags_to_file(old_path, new_album, new_album_artist)
+                    write_album_tags_to_file(
+                        old_path, new_album, new_album_artist, artist=new_artist
+                    )
                     db_pairs.append((old_path, new_path))
                     queue.update_track_album_tags(
-                        old_path, new_path, new_album, new_album_artist
+                        old_path,
+                        new_path,
+                        new_album,
+                        new_album_artist,
+                        new_artist=new_artist,
                     )
                     updated = index.get_track_by_id(track.id)
                     if updated is not None:
@@ -811,7 +820,11 @@ def create_app(
                     )
             if db_pairs:
                 index.rename_album_tracks_bulk(
-                    db_pairs, new_album, new_album_artist, new_mtime
+                    db_pairs,
+                    new_album,
+                    new_album_artist,
+                    new_mtime,
+                    old_album_artist=album_artist,
                 )
 
         elif not new_album_dir.exists():
@@ -862,21 +875,32 @@ def create_app(
             for i, (track, (old_path, _)) in enumerate(zip(tracks, track_dest)):
                 _broadcast({"type": "album.rename.progress", "done": i, "total": total})
                 new_path = new_album_dir / old_path.relative_to(old_album_dir)
+                new_artist = new_album_artist if track.artist == album_artist else None
                 try:
-                    write_album_tags_to_file(new_path, new_album, new_album_artist)
+                    write_album_tags_to_file(
+                        new_path, new_album, new_album_artist, artist=new_artist
+                    )
                 except Exception:
                     logger.exception("tag write failed for %s", new_path)
                 db_pairs.append((old_path, new_path))
                 moved_path_pairs.append((old_path, new_path))
                 queue.update_track_album_tags(
-                    old_path, new_path, new_album, new_album_artist
+                    old_path,
+                    new_path,
+                    new_album,
+                    new_album_artist,
+                    new_artist=new_artist,
                 )
                 updated = index.get_track_by_id(track.id)
                 if updated is not None:
                     moved.append(TrackOut.from_track(updated))
 
             index.rename_album_tracks_bulk(
-                db_pairs, new_album, new_album_artist, new_mtime
+                db_pairs,
+                new_album,
+                new_album_artist,
+                new_mtime,
+                old_album_artist=album_artist,
             )
 
             # Album-level rename: clean up old artist dir if now empty.
@@ -907,8 +931,11 @@ def create_app(
                 if new_path.exists() and req.skip_conflicts:
                     skipped.append(str(old_path))
                     continue
+                new_artist = new_album_artist if track.artist == album_artist else None
                 try:
-                    write_album_tags_to_file(old_path, new_album, new_album_artist)
+                    write_album_tags_to_file(
+                        old_path, new_album, new_album_artist, artist=new_artist
+                    )
                     if old_path != new_path:
                         if new_path.exists() and req.overwrite:
                             index.remove_track(new_path)
@@ -917,7 +944,11 @@ def create_app(
                     db_pairs.append((old_path, new_path))
                     moved_path_pairs.append((old_path, new_path))
                     queue.update_track_album_tags(
-                        old_path, new_path, new_album, new_album_artist
+                        old_path,
+                        new_path,
+                        new_album,
+                        new_album_artist,
+                        new_artist=new_artist,
                     )
                     updated = index.get_track_by_id(track.id)
                     if updated is not None:
@@ -936,7 +967,11 @@ def create_app(
                     )
             if db_pairs:
                 index.rename_album_tracks_bulk(
-                    db_pairs, new_album, new_album_artist, new_mtime
+                    db_pairs,
+                    new_album,
+                    new_album_artist,
+                    new_mtime,
+                    old_album_artist=album_artist,
                 )
             # Remove old album dir if all files were moved out.
             _scrub_os_metadata(old_album_dir)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -708,21 +708,18 @@ def create_app(
     def patch_album_tags(
         album_artist: str, album: str, req: "AlbumTagsRequest"
     ) -> "AlbumTagsOut":
-        """Rename album title and/or album artist, fanning out to every track in the album.
+        """Rename album title and/or album artist across every track in the album.
 
-        For each track: writes tags to the file, moves it to the new computed path,
-        and updates the DB row.  Broadcasts album.rename.progress events over WebSocket
-        during the batch so the renderer can show "Renaming N of M…".
+        The album directory is renamed atomically with os.rename() — no per-file
+        moves.  Tag writes and DB updates happen after the rename.
 
-        Collision handling (files that already exist at the target path):
-        - Default (overwrite=False, skip_conflicts=False): pre-flight detects collisions
-          and returns 409 without moving anything.
-        - overwrite=True: existing files are replaced.
-        - skip_conflicts=True: colliding files are left at their old location; the rest
-          of the album is renamed normally.
-        - If Cancel is chosen by the user after a 409, already-moved files (from a prior
-          partial attempt) remain at their new locations — this is documented behaviour.
+        Collision: if the target directory already exists, returns 409.
+        - overwrite=True: moves each file from the old dir into the existing target,
+          overwriting any same-name files (merge).
+        - skip_conflicts=True: moves only files whose names don't already exist in
+          the target (partial merge).
         """
+        import os
         import shutil
         import time as _t
 
@@ -745,27 +742,13 @@ def create_app(
         if lib_path is None:
             raise HTTPException(status_code=503, detail="Library path not configured")
 
-        # Pre-flight: ensure the disk has enough headroom for the worst case
-        # (all files copied before the originals are removed).
-        try:
-            usage = shutil.disk_usage(lib_path)
-            total_size = sum(
-                t.file_path.stat().st_size for t in tracks if t.file_path.exists()
-            )
-            if usage.free < total_size * 1.1:
-                raise HTTPException(status_code=507, detail="Insufficient disk space")
-        except (OSError, AttributeError):
-            pass  # non-fatal: proceed and let individual moves fail
-
         path_template: str = (
             _state["config"].get("library.path_template")
             or "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
         )
 
-        # Compute all destination paths upfront so we can detect collisions before
-        # any files are moved (avoids leaving the album half-renamed on 409).
-        dest_map: dict[int, tuple[Path, Path]] = {}  # track_id → (old_path, new_path)
-        collisions: list[str] = []
+        # Compute the target path for each track and derive the album directories.
+        track_dest: list[tuple[Path, Path]] = []  # (old_path, new_path)
         for track in tracks:
             tags = make_path_vars(
                 artist=track.artist,
@@ -777,136 +760,172 @@ def create_app(
                 title=track.title,
                 ext=track.ext,
             )
-            old_path = track.file_path
             try:
                 new_path = render_destination(tags, lib_path, path_template)
             except ValueError as exc:
                 raise HTTPException(status_code=422, detail=str(exc))
+            track_dest.append((track.file_path, new_path))
 
-            is_case_only = str(old_path).lower() == str(new_path).lower() and str(
-                old_path
-            ) != str(new_path)
-            if (
-                str(old_path) != str(new_path)
-                and not is_case_only
-                and new_path.exists()
-            ):
-                collisions.append(str(new_path))
+        old_paths = [op for op, _ in track_dest]
+        new_paths = [np for _, np in track_dest]
 
-            dest_map[track.id] = (old_path, new_path)
+        # Album directory = common ancestor of all track paths.
+        old_album_dir = Path(os.path.commonpath([str(p) for p in old_paths]))
+        new_album_dir = Path(os.path.commonpath([str(p) for p in new_paths]))
 
-        if collisions and not req.overwrite and not req.skip_conflicts:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "collision_count": len(collisions),
-                    "first_path": collisions[0],
-                },
-            )
-
-        # Fan-out: write tags, move file, update DB — one track at a time.
+        total = len(tracks)
         moved: list[TrackOut] = []
         skipped: list[str] = []
         failed: list[AlbumTagsTrackResult] = []
-        total = len(tracks)
         notify_album_tracks_moved = getattr(app.state, "on_album_tracks_moved", None)
-        # Collect moves to notify the watcher after ALL writes are done.
-        # Calling scan_now() mid-loop would race with subsequent rename_album_track()
-        # write transactions — deferred notification eliminates the contention.
         moved_path_pairs: list[tuple[Path, Path]] = []
 
-        for i, track in enumerate(tracks):
-            _broadcast({"type": "album.rename.progress", "done": i, "total": total})
-            old_path, new_path = dest_map[track.id]
-
-            is_case_only = str(old_path).lower() == str(new_path).lower() and str(
-                old_path
-            ) != str(new_path)
-            collision = (
-                str(old_path) != str(new_path)
-                and not is_case_only
-                and new_path.exists()
-            )
-
-            if collision and req.skip_conflicts:
-                skipped.append(str(old_path))
-                continue
-
-            try:
-                write_album_tags_to_file(old_path, new_album, new_album_artist)
-
-                if str(old_path) != str(new_path):
-                    if collision and req.overwrite:
-                        index.remove_track(new_path)
-                    new_path.parent.mkdir(parents=True, exist_ok=True)
-                    if is_case_only:
-                        tmp_path = old_path.with_suffix(
-                            f".kamp_rename{old_path.suffix}"
+        if old_album_dir == new_album_dir:
+            # Tags changed but the path template produces the same directory.
+            # Write tags in-place and update the DB — no filesystem move needed.
+            _broadcast({"type": "album.rename.progress", "done": 0, "total": total})
+            new_mtime = _t.time()
+            db_pairs: list[tuple[Path, Path]] = []
+            for i, (track, (old_path, new_path)) in enumerate(zip(tracks, track_dest)):
+                _broadcast({"type": "album.rename.progress", "done": i, "total": total})
+                try:
+                    write_album_tags_to_file(old_path, new_album, new_album_artist)
+                    db_pairs.append((old_path, new_path))
+                    queue.update_track_album_tags(
+                        old_path, new_path, new_album, new_album_artist
+                    )
+                    updated = index.get_track_by_id(track.id)
+                    if updated is not None:
+                        moved.append(TrackOut.from_track(updated))
+                except Exception as exc:
+                    logger.exception("tag write failed for %s", old_path)
+                    failed.append(
+                        AlbumTagsTrackResult(
+                            track_id=track.id,
+                            old_path=str(old_path),
+                            new_path=str(new_path),
+                            error=str(exc),
                         )
-                        shutil.move(str(old_path), tmp_path)
-                        shutil.move(str(tmp_path), new_path)
-                    else:
-                        shutil.move(str(old_path), new_path)
-
-                new_mtime = _t.time()
-                index.rename_album_track(
-                    old_path, new_path, new_album, new_album_artist, new_mtime
+                    )
+            if db_pairs:
+                index.rename_album_tracks_bulk(
+                    db_pairs, new_album, new_album_artist, new_mtime
                 )
+
+        elif not new_album_dir.exists():
+            # Happy path: target directory does not exist — atomic directory rename.
+            _broadcast({"type": "album.rename.progress", "done": 0, "total": total})
+            new_album_dir.parent.mkdir(parents=True, exist_ok=True)
+            is_case_only = str(old_album_dir).lower() == str(
+                new_album_dir
+            ).lower() and str(old_album_dir) != str(new_album_dir)
+            if is_case_only:
+                tmp_dir = old_album_dir.with_name(f"kamp_tmp_{old_album_dir.name}")
+                os.rename(str(old_album_dir), str(tmp_dir))
+                os.rename(str(tmp_dir), str(new_album_dir))
+            else:
+                os.rename(str(old_album_dir), str(new_album_dir))
+
+            # Files are now under new_album_dir; write tags and bulk-update DB.
+            new_mtime = _t.time()
+            db_pairs = []
+            for i, (track, (old_path, _)) in enumerate(zip(tracks, track_dest)):
+                _broadcast({"type": "album.rename.progress", "done": i, "total": total})
+                new_path = new_album_dir / old_path.relative_to(old_album_dir)
+                try:
+                    write_album_tags_to_file(new_path, new_album, new_album_artist)
+                except Exception:
+                    logger.exception("tag write failed for %s", new_path)
+                db_pairs.append((old_path, new_path))
+                moved_path_pairs.append((old_path, new_path))
                 queue.update_track_album_tags(
                     old_path, new_path, new_album, new_album_artist
                 )
-
-                if str(old_path) != str(new_path):
-                    moved_path_pairs.append((old_path, new_path))
-
                 updated = index.get_track_by_id(track.id)
                 if updated is not None:
                     moved.append(TrackOut.from_track(updated))
 
-            except Exception as exc:
-                logger.exception(
-                    "album rename failed for track %d (%s)", track.id, old_path
+            index.rename_album_tracks_bulk(
+                db_pairs, new_album, new_album_artist, new_mtime
+            )
+
+            # Clean up the old parent (artist dir) if it is now empty.
+            old_parent = old_album_dir.parent
+            if old_parent != lib_path and lib_path in old_parent.parents:
+                _scrub_os_metadata(old_parent)
+                try:
+                    old_parent.rmdir()
+                except OSError:
+                    pass
+
+        else:
+            # Target directory already exists — collision.
+            if not req.overwrite and not req.skip_conflicts:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "collision_count": sum(1 for _ in new_album_dir.iterdir()),
+                        "first_path": str(new_album_dir),
+                    },
                 )
-                failed.append(
-                    AlbumTagsTrackResult(
-                        track_id=track.id,
-                        old_path=str(old_path),
-                        new_path=str(new_path),
-                        error=str(exc),
+            # Merge: move individual files into the existing target directory.
+            new_mtime = _t.time()
+            db_pairs = []
+            for i, (track, (old_path, new_path)) in enumerate(zip(tracks, track_dest)):
+                _broadcast({"type": "album.rename.progress", "done": i, "total": total})
+                # new_path here is the per-file destination inside new_album_dir.
+                if new_path.exists() and req.skip_conflicts:
+                    skipped.append(str(old_path))
+                    continue
+                try:
+                    write_album_tags_to_file(old_path, new_album, new_album_artist)
+                    if old_path != new_path:
+                        if new_path.exists() and req.overwrite:
+                            index.remove_track(new_path)
+                        new_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.move(str(old_path), str(new_path))
+                    db_pairs.append((old_path, new_path))
+                    moved_path_pairs.append((old_path, new_path))
+                    queue.update_track_album_tags(
+                        old_path, new_path, new_album, new_album_artist
                     )
+                    updated = index.get_track_by_id(track.id)
+                    if updated is not None:
+                        moved.append(TrackOut.from_track(updated))
+                except Exception as exc:
+                    logger.exception(
+                        "album merge failed for track %d (%s)", track.id, old_path
+                    )
+                    failed.append(
+                        AlbumTagsTrackResult(
+                            track_id=track.id,
+                            old_path=str(old_path),
+                            new_path=str(new_path),
+                            error=str(exc),
+                        )
+                    )
+            if db_pairs:
+                index.rename_album_tracks_bulk(
+                    db_pairs, new_album, new_album_artist, new_mtime
                 )
+            # Remove old album dir if all files were moved out.
+            _scrub_os_metadata(old_album_dir)
+            try:
+                old_album_dir.rmdir()
+                old_parent = old_album_dir.parent
+                if old_parent != lib_path and lib_path in old_parent.parents:
+                    _scrub_os_metadata(old_parent)
+                    old_parent.rmdir()
+            except OSError:
+                pass
 
         _broadcast({"type": "album.rename.progress", "done": total, "total": total})
 
-        # All DB writes are done — notify the watcher with one batched call so
-        # suppressions are registered and exactly one scan_now() fires.
         if notify_album_tracks_moved is not None and moved_path_pairs:
             try:
                 notify_album_tracks_moved(moved_path_pairs)
             except Exception:
                 logger.exception("on_album_tracks_moved callback raised")
-
-        # Remove empty directories left behind by the moves.
-        # Collect unique old album directories from every track that was actually moved
-        # (skipped and failed tracks may still have files there, so rmdir would fail
-        # harmlessly and we just stop climbing for that directory).
-        old_dirs: set[Path] = {
-            dest_map[t.id][0].parent
-            for t in tracks
-            if str(dest_map[t.id][0]) != str(dest_map[t.id][1])
-        }
-        # Process deepest directories first so parents are checked after children.
-        for d in sorted(old_dirs, key=lambda p: len(p.parts), reverse=True):
-            candidate = d
-            # Climb toward the library root, removing each level only if empty.
-            # Never remove the library root itself.
-            while candidate != lib_path and lib_path in candidate.parents:
-                _scrub_os_metadata(candidate)
-                try:
-                    candidate.rmdir()
-                except OSError:
-                    break  # not empty (or already gone) — stop climbing
-                candidate = candidate.parent
 
         _notify_library_changed()
         return AlbumTagsOut(moved=moved, skipped=skipped, failed=failed)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -870,18 +870,32 @@ def create_app(
                 os.rename(str(src), str(dst))
 
             # Files are now under new_album_dir; write tags and bulk-update DB.
+            # The directory rename already succeeded, so every file is at its new
+            # path regardless of whether tag-writing succeeds.  Always include the
+            # pair in db_pairs (DB must reflect the new path) and update the queue,
+            # but report tag-write failures in failed[] rather than moved[].
             new_mtime = _t.time()
             db_pairs = []
             for i, (track, (old_path, _)) in enumerate(zip(tracks, track_dest)):
                 _broadcast({"type": "album.rename.progress", "done": i, "total": total})
                 new_path = new_album_dir / old_path.relative_to(old_album_dir)
                 new_artist = new_album_artist if track.artist == album_artist else None
+                tag_write_ok = True
                 try:
                     write_album_tags_to_file(
                         new_path, new_album, new_album_artist, artist=new_artist
                     )
-                except Exception:
+                except Exception as exc:
                     logger.exception("tag write failed for %s", new_path)
+                    tag_write_ok = False
+                    failed.append(
+                        AlbumTagsTrackResult(
+                            track_id=track.id,
+                            old_path=str(old_path),
+                            new_path=str(new_path),
+                            error=str(exc),
+                        )
+                    )
                 db_pairs.append((old_path, new_path))
                 moved_path_pairs.append((old_path, new_path))
                 queue.update_track_album_tags(
@@ -891,9 +905,10 @@ def create_app(
                     new_album_artist,
                     new_artist=new_artist,
                 )
-                updated = index.get_track_by_id(track.id)
-                if updated is not None:
-                    moved.append(TrackOut.from_track(updated))
+                if tag_write_ok:
+                    updated = index.get_track_by_id(track.id)
+                    if updated is not None:
+                        moved.append(TrackOut.from_track(updated))
 
             index.rename_album_tracks_bulk(
                 db_pairs,

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -980,7 +980,15 @@ def _cmd_daemon(
             lib_watcher.suppress_paths({old_path, new_path})
             lib_watcher.scan_now()
 
+    def _on_album_tracks_moved(pairs: "list[tuple[Path, Path]]") -> None:
+        """Batch variant for album rename: suppress all pairs, then one scan_now()."""
+        if lib_watcher is not None:
+            for old_p, new_p in pairs:
+                lib_watcher.suppress_paths({old_p, new_p})
+            lib_watcher.scan_now()
+
     app.state.on_track_file_moved = _on_track_file_moved
+    app.state.on_album_tracks_moved = _on_album_tracks_moved
 
     # --- Start uvicorn in a background thread ---
     # uvicorn.Server.serve() detects it is not on the main thread and skips

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -217,6 +217,7 @@ export default function App(): React.JSX.Element {
         },
         () => {
           void loadLibrary().then(() => refreshOpenAlbum())
+          void loadQueue()
         },
         (done, total) => {
           setAlbumRenameProgress(total === done ? null : { done, total })

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -84,6 +84,7 @@ function SlotPanel({ panel }: { panel: UnifiedPanel }): React.JSX.Element {
 export default function App(): React.JSX.Element {
   const loadLibrary = useStore((s) => s.loadLibrary)
   const refreshOpenAlbum = useStore((s) => s.refreshOpenAlbum)
+  const setAlbumRenameProgress = useStore((s) => s.setAlbumRenameProgress)
   const loadUiState = useStore((s) => s.loadUiState)
   const loadConfig = useStore((s) => s.loadConfig)
   const applyServerState = useStore((s) => s.applyServerState)
@@ -216,6 +217,9 @@ export default function App(): React.JSX.Element {
         },
         () => {
           void loadLibrary().then(() => refreshOpenAlbum())
+        },
+        (done, total) => {
+          setAlbumRenameProgress(total === done ? null : { done, total })
         }
       )
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -360,19 +360,67 @@ export const setAlbumFavorite = (
 ): Promise<unknown> =>
   post('/api/v1/albums/favorite', { album_artist: albumArtist, album, favorite })
 
+export type AlbumTagsCollision = {
+  collision: true
+  collision_count: number
+  first_path: string
+}
+
+export type AlbumTagsResult = {
+  moved: Track[]
+  skipped: string[]
+  failed: { track_id: number; old_path: string; new_path: string; error: string | null }[]
+}
+
+export async function patchAlbumTags(
+  albumArtist: string,
+  album: string,
+  opts: { album?: string; album_artist?: string; overwrite?: boolean; skip_conflicts?: boolean }
+): Promise<AlbumTagsResult | AlbumTagsCollision> {
+  const params = new URLSearchParams({ album_artist: albumArtist, album })
+  const res = await fetch(`${BASE_URL}/api/v1/albums/tags?${params}`, {
+    method: 'PATCH',
+    headers: _authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify(opts)
+  })
+  if (res.status === 409) {
+    const detail = (await res.json()) as {
+      detail: { collision_count: number; first_path: string }
+    }
+    return { collision: true, ...detail.detail }
+  }
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail && typeof json.detail === 'string') message = json.detail
+    } catch {
+      // ignore
+    }
+    throw new Error(message)
+  }
+  return res.json() as Promise<AlbumTagsResult>
+}
+
 // ---------------------------------------------------------------------------
 // WebSocket state stream
 // ---------------------------------------------------------------------------
 
 export type StateMessage = PlayerState & { type: 'player.state' }
 export type LibraryChangedMessage = { type: 'library.changed' }
-export type ServerMessage = StateMessage | LibraryChangedMessage
+export type AlbumRenameProgressMessage = {
+  type: 'album.rename.progress'
+  done: number
+  total: number
+}
+export type ServerMessage = StateMessage | LibraryChangedMessage | AlbumRenameProgressMessage
 
 export function connectStateStream(
   onState: (state: PlayerState) => void,
   onClose?: () => void,
   onOpen?: () => void,
-  onLibraryChanged?: () => void
+  onLibraryChanged?: () => void,
+  onAlbumRenameProgress?: (done: number, total: number) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -383,6 +431,7 @@ export function connectStateStream(
       const msg = JSON.parse(event.data as string) as ServerMessage
       if (msg.type === 'player.state') onState(msg)
       else if (msg.type === 'library.changed') onLibraryChanged?.()
+      else if (msg.type === 'album.rename.progress') onAlbumRenameProgress?.(msg.done, msg.total)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -282,6 +282,172 @@
   margin-bottom: 0;
 }
 
+/* Editable album / artist fields in edit mode ------------------------------ */
+
+/* Base reset: strip OS chrome, inherit all typography from the surrounding
+   heading/text so the input is visually indistinguishable from the label
+   except for the dashed border affordance. */
+.editable-album-field {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  /* 1px dashed = resting affordance per design spec */
+  border: 1px dashed rgba(255, 255, 255, 0.22);
+  border-radius: 3px;
+  outline: none;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  text-shadow: inherit;
+  /* Nudge left so the text aligns with the static heading text, accounting
+     for the padding + border that the heading element doesn't have. */
+  padding: 2px 6px;
+  margin-left: -7px;
+  width: calc(100% + 7px);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.editable-album-field:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+  border-style: solid;
+}
+
+.editable-album-field:focus {
+  border-style: solid;
+  border-width: 2px;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+  background: rgba(255, 255, 255, 0.04);
+  /* Re-nudge to compensate for the extra 1px border */
+  margin-left: -8px;
+  width: calc(100% + 8px);
+  padding: 1px 5px;
+}
+
+.editable-album-field:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.editable-album-field.saving {
+  opacity: 0.7;
+  border-style: solid;
+  border-color: var(--accent);
+  cursor: wait;
+}
+
+@keyframes album-field-shake {
+  0%, 100% { transform: translateX(0); }
+  20%       { transform: translateX(-5px); }
+  60%       { transform: translateX(5px); }
+  80%       { transform: translateX(-3px); }
+}
+
+.editable-album-field.shake {
+  animation: album-field-shake 0.35s ease-in-out;
+}
+
+/* Artist input inherits the h2 / button typography */
+.track-list-album-artist-input {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--accent);
+  line-height: 1.4;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+  margin-bottom: 4px;
+}
+
+/* Album rename progress ---------------------------------------------------- */
+
+.album-rename-progress {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Album rename toast ------------------------------------------------------- */
+
+.album-rename-toast {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--text);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.55);
+  min-width: 240px;
+  /* Slide in from the bottom right */
+  animation: toast-in 0.22s ease-out;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.album-rename-toast-text {
+  flex: 1;
+  color: var(--text);
+}
+
+.album-rename-toast-undo {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 3px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.album-rename-toast-undo:hover {
+  background: var(--surface-hover);
+  border-color: var(--accent);
+}
+
+.album-rename-toast-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 0 0 8px 8px;
+  /* Shrink from 100% to 0 over the TTL — animation-duration set inline */
+  animation: toast-bar-shrink linear forwards;
+  transform-origin: left;
+}
+
+@keyframes toast-bar-shrink {
+  from { width: 100%; }
+  to   { width: 0%; }
+}
+
 .play-all-btn {
   display: inline-flex;
   align-items: center;

--- a/kamp_ui/src/renderer/src/components/EditableAlbumField.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableAlbumField.tsx
@@ -1,0 +1,76 @@
+import React, { useRef, useState } from 'react'
+
+type Props = {
+  value: string
+  editMode: boolean
+  disabled?: boolean
+  className?: string
+  onSave: (value: string) => Promise<void>
+  // Render the read-only view (a span, button, h1, etc).
+  renderStatic: (value: string) => React.JSX.Element
+}
+
+export function EditableAlbumField({
+  value,
+  editMode,
+  disabled = false,
+  className = '',
+  onSave,
+  renderStatic
+}: Props): React.JSX.Element {
+  const [draft, setDraft] = useState(value)
+  const [prevValue, setPrevValue] = useState(value)
+  const [saving, setSaving] = useState(false)
+  const [shake, setShake] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Sync external value changes (after a save refreshes the album) back into local state.
+  if (value !== prevValue) {
+    setPrevValue(value)
+    setDraft(value)
+  }
+
+  if (!editMode) return renderStatic(value)
+
+  const commit = async (): Promise<void> => {
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      // Empty string is invalid — revert and shake.
+      setDraft(value)
+      setShake(true)
+      setTimeout(() => setShake(false), 400)
+      return
+    }
+    if (trimmed === value || saving) return
+    setSaving(true)
+    try {
+      await onSave(trimmed)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      className={`editable-album-field${saving ? ' saving' : ''}${shake ? ' shake' : ''} ${className}`.trim()}
+      value={draft}
+      disabled={disabled || saving}
+      aria-label={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => void commit()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          inputRef.current?.blur()
+        } else if (e.key === 'Escape') {
+          e.stopPropagation()
+          setDraft(value)
+          inputRef.current?.blur()
+        }
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+    />
+  )
+}

--- a/kamp_ui/src/renderer/src/components/EditableAlbumField.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableAlbumField.tsx
@@ -23,6 +23,10 @@ export function EditableAlbumField({
   const [saving, setSaving] = useState(false)
   const [shake, setShake] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  // Set to true by the Escape handler before blur() so commit() knows to skip saving.
+  // A ref (not state) is required because blur fires synchronously before React
+  // flushes the setDraft(value) state update.
+  const cancelRef = useRef(false)
 
   // Sync external value changes (after a save refreshes the album) back into local state.
   if (value !== prevValue) {
@@ -33,6 +37,10 @@ export function EditableAlbumField({
   if (!editMode) return renderStatic(value)
 
   const commit = async (): Promise<void> => {
+    if (cancelRef.current) {
+      cancelRef.current = false
+      return
+    }
     const trimmed = draft.trim()
     if (!trimmed) {
       // Empty string is invalid — revert and shake.
@@ -65,6 +73,7 @@ export function EditableAlbumField({
           inputRef.current?.blur()
         } else if (e.key === 'Escape') {
           e.stopPropagation()
+          cancelRef.current = true
           setDraft(value)
           inputRef.current?.blur()
         }

--- a/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
@@ -19,6 +19,7 @@ export function EditableTrackTitle({
   const [prevTitle, setPrevTitle] = useState(title)
   const [saving, setSaving] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  const cancelRef = useRef(false)
 
   // Sync external title changes (e.g. after refreshOpenAlbum) back into local state.
   // Render-time update avoids the cascading-render issue of useEffect setState.
@@ -45,6 +46,10 @@ export function EditableTrackTitle({
   }
 
   const commit = async (): Promise<void> => {
+    if (cancelRef.current) {
+      cancelRef.current = false
+      return
+    }
     const trimmed = value.trim()
     if (!trimmed || trimmed === title || saving) return
     setSaving(true)
@@ -71,6 +76,7 @@ export function EditableTrackTitle({
           inputRef.current?.blur()
         } else if (e.key === 'Escape') {
           e.stopPropagation()
+          cancelRef.current = true
           setValue(title)
           inputRef.current?.blur()
         } else if (e.key === 'Tab') {

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { artUrl } from '../api/client'
-import type { Track, TrackTagsCollision } from '../api/client'
+import type { AlbumTagsCollision, Track, TrackTagsCollision } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
 import { EditableTrackTitle } from './EditableTrackTitle'
+import { EditableAlbumField } from './EditableAlbumField'
 import { CollisionModal } from './CollisionModal'
 import {
   FavoriteIcon,
@@ -45,6 +46,8 @@ export function TrackList(): React.JSX.Element | null {
   const albumEditMode = useStore((s) => s.albumEditMode)
   const setAlbumEditMode = useStore((s) => s.setAlbumEditMode)
   const patchTrackTitle = useStore((s) => s.patchTrackTitle)
+  const patchAlbumTags = useStore((s) => s.patchAlbumTags)
+  const albumRenameProgress = useStore((s) => s.albumRenameProgress)
   const nextTrack = useStore((s) => s.player.next_track)
   const lockedIds = new Set(
     [currentTrack?.id, nextTrack?.id].filter((id): id is number => id != null)
@@ -53,6 +56,9 @@ export function TrackList(): React.JSX.Element | null {
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
   const [collision, setCollision] = useState<
     (TrackTagsCollision & { pendingTrackId: number; pendingTitle: string }) | null
+  >(null)
+  const [albumCollision, setAlbumCollision] = useState<
+    (AlbumTagsCollision & { pendingOpts: Parameters<typeof patchAlbumTags>[2] }) | null
   >(null)
 
   // Focus the album title heading when entering edit mode so screen readers
@@ -134,21 +140,63 @@ export function TrackList(): React.JSX.Element | null {
           >
             <FavoriteIcon active={album.favorite} size={36} />
           </button>
-          <h1 ref={albumTitleRef} className="track-list-album-title" tabIndex={-1}>
-            {album.album}
-          </h1>
-          <h2 className="track-list-album-artist">
-            <button
-              className="track-list-artist-link"
-              onClick={() => {
-                selectAlbum(null)
-                selectArtist(album.album_artist)
-              }}
-            >
-              {album.album_artist}
-            </button>
-          </h2>
+          <EditableAlbumField
+            value={album.album}
+            editMode={albumEditMode}
+            disabled={albumRenameProgress !== null}
+            className="track-list-album-title"
+            onSave={async (newAlbum) => {
+              const result = await patchAlbumTags(album.album_artist, album.album, {
+                album: newAlbum
+              })
+              if (result?.collision) {
+                setAlbumCollision({ ...result, pendingOpts: { album: newAlbum } })
+              }
+            }}
+            renderStatic={(val) => (
+              <h1 ref={albumTitleRef} className="track-list-album-title" tabIndex={-1}>
+                {val}
+              </h1>
+            )}
+          />
+          <EditableAlbumField
+            value={album.album_artist}
+            editMode={albumEditMode}
+            disabled={albumRenameProgress !== null}
+            className="track-list-album-artist-input"
+            onSave={async (newArtist) => {
+              const result = await patchAlbumTags(album.album_artist, album.album, {
+                album_artist: newArtist
+              })
+              if (result?.collision) {
+                setAlbumCollision({ ...result, pendingOpts: { album_artist: newArtist } })
+              }
+            }}
+            renderStatic={(val) => (
+              <h2 className="track-list-album-artist">
+                <button
+                  className="track-list-artist-link"
+                  onClick={() => {
+                    selectAlbum(null)
+                    selectArtist(album.album_artist)
+                  }}
+                >
+                  {val}
+                </button>
+              </h2>
+            )}
+          />
           {album.year && <div className="track-list-album-year">{album.year}</div>}
+          {albumRenameProgress && (
+            <div className="album-rename-progress" aria-live="polite">
+              Renaming {albumRenameProgress.done} of {albumRenameProgress.total}…
+            </div>
+          )}
+          {albumEditMode && !albumRenameProgress && (
+            <div className="album-rename-hint" aria-hidden="true">
+              {album.track_count} {album.track_count === 1 ? 'file' : 'files'} will be reorganized
+            </div>
+          )}
         </div>
         <div className="album-controls">
           <button
@@ -261,6 +309,25 @@ export function TrackList(): React.JSX.Element | null {
           }}
           onSkip={() => setCollision(null)}
           onCancel={() => setCollision(null)}
+        />
+      )}
+      {albumCollision && (
+        <CollisionModal
+          targetPath={albumCollision.first_path}
+          onOverwrite={() => {
+            const opts = albumCollision.pendingOpts
+            setAlbumCollision(null)
+            void patchAlbumTags(album.album_artist, album.album, { ...opts, overwrite: true })
+          }}
+          onSkip={() => {
+            const opts = albumCollision.pendingOpts
+            setAlbumCollision(null)
+            void patchAlbumTags(album.album_artist, album.album, {
+              ...opts,
+              skip_conflicts: true
+            })
+          }}
+          onCancel={() => setAlbumCollision(null)}
         />
       )}
     </div>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -15,7 +15,13 @@ import {
   PlayNextIcon
 } from './TransportIcons'
 
+const TOAST_TTL = 10_000 // ms
+
 type ContextMenu = { x: number; y: number; track: Track }
+type AlbumRenameToast = {
+  message: string
+  undo: () => Promise<AlbumTagsCollision | null>
+}
 
 function HeroImage({ src }: { src: string }): React.JSX.Element {
   const [loaded, setLoaded] = useState(false)
@@ -54,12 +60,20 @@ export function TrackList(): React.JSX.Element | null {
   )
 
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [collision, setCollision] = useState<
     (TrackTagsCollision & { pendingTrackId: number; pendingTitle: string }) | null
   >(null)
   const [albumCollision, setAlbumCollision] = useState<
     (AlbumTagsCollision & { pendingOpts: Parameters<typeof patchAlbumTags>[2] }) | null
   >(null)
+  const [albumRenameToast, setAlbumRenameToast] = useState<AlbumRenameToast | null>(null)
+
+  const showRenameToast = (toast: AlbumRenameToast): void => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    setAlbumRenameToast(toast)
+    toastTimerRef.current = setTimeout(() => setAlbumRenameToast(null), TOAST_TTL)
+  }
 
   // Focus the album title heading when entering edit mode so screen readers
   // receive the live-region announcement in context.
@@ -146,11 +160,17 @@ export function TrackList(): React.JSX.Element | null {
             disabled={albumRenameProgress !== null}
             className="track-list-album-title"
             onSave={async (newAlbum) => {
-              const result = await patchAlbumTags(album.album_artist, album.album, {
-                album: newAlbum
-              })
+              const oldAlbum = album.album
+              const oldArtist = album.album_artist
+              const count = album.track_count
+              const result = await patchAlbumTags(oldArtist, oldAlbum, { album: newAlbum })
               if (result?.collision) {
                 setAlbumCollision({ ...result, pendingOpts: { album: newAlbum } })
+              } else {
+                showRenameToast({
+                  message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
+                  undo: () => patchAlbumTags(oldArtist, newAlbum, { album: oldAlbum })
+                })
               }
             }}
             renderStatic={(val) => (
@@ -165,11 +185,17 @@ export function TrackList(): React.JSX.Element | null {
             disabled={albumRenameProgress !== null}
             className="track-list-album-artist-input"
             onSave={async (newArtist) => {
-              const result = await patchAlbumTags(album.album_artist, album.album, {
-                album_artist: newArtist
-              })
+              const oldArtist = album.album_artist
+              const oldAlbum = album.album
+              const count = album.track_count
+              const result = await patchAlbumTags(oldArtist, oldAlbum, { album_artist: newArtist })
               if (result?.collision) {
                 setAlbumCollision({ ...result, pendingOpts: { album_artist: newArtist } })
+              } else {
+                showRenameToast({
+                  message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
+                  undo: () => patchAlbumTags(newArtist, oldAlbum, { album_artist: oldArtist })
+                })
               }
             }}
             renderStatic={(val) => (
@@ -190,11 +216,6 @@ export function TrackList(): React.JSX.Element | null {
           {albumRenameProgress && (
             <div className="album-rename-progress" aria-live="polite">
               Renaming {albumRenameProgress.done} of {albumRenameProgress.total}…
-            </div>
-          )}
-          {albumEditMode && !albumRenameProgress && (
-            <div className="album-rename-hint" aria-hidden="true">
-              {album.track_count} {album.track_count === 1 ? 'file' : 'files'} will be reorganized
             </div>
           )}
         </div>
@@ -329,6 +350,22 @@ export function TrackList(): React.JSX.Element | null {
           }}
           onCancel={() => setAlbumCollision(null)}
         />
+      )}
+      {albumRenameToast && (
+        <div className="album-rename-toast" role="status">
+          <span className="album-rename-toast-text">{albumRenameToast.message}</span>
+          <button
+            className="album-rename-toast-undo"
+            onClick={() => {
+              setAlbumRenameToast(null)
+              if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+              void albumRenameToast.undo()
+            }}
+          >
+            Undo
+          </button>
+          <div className="album-rename-toast-bar" style={{ animationDuration: `${TOAST_TTL}ms` }} />
+        </div>
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -627,6 +627,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
     // Clear progress, reload library so sidebar and album card reflect new names.
     set({ albumRenameProgress: null })
     await get().loadLibrary()
+    // Refresh the queue so any queued tracks show the updated artist/album name.
+    void get().loadQueue()
     // Re-select the open album under its new identity so the track list refreshes.
     const newArtist = opts.album_artist ?? albumArtist
     const newAlbum = opts.album ?? album

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -624,6 +624,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
   patchAlbumTags: async (albumArtist, album, opts) => {
     const result = await api.patchAlbumTags(albumArtist, album, opts)
     if ('collision' in result) return result
+    if (result.failed.length > 0) {
+      console.error('[kamp] album rename: tag write failed for', result.failed)
+    }
     // Clear progress, reload library so sidebar and album card reflect new names.
     set({ albumRenameProgress: null })
     await get().loadLibrary()

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -10,6 +10,7 @@ import { create } from 'zustand'
 import * as api from './api/client'
 import type {
   Album,
+  AlbumTagsCollision,
   ConfigValues,
   PlayerState,
   QueueState,
@@ -54,6 +55,7 @@ type PlayerStore = {
   topAlbumsCount: number
   baseKampEditMode: boolean
   albumEditMode: boolean
+  albumRenameProgress: { done: number; total: number } | null
   sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
   searchQuery: string
   searchResults: SearchResult | null
@@ -131,6 +133,12 @@ type PlayerStore = {
     title: string,
     overwrite?: boolean
   ) => Promise<api.TrackTagsCollision | null>
+  patchAlbumTags: (
+    albumArtist: string,
+    album: string,
+    opts: { album?: string; album_artist?: string; overwrite?: boolean; skip_conflicts?: boolean }
+  ) => Promise<AlbumTagsCollision | null>
+  setAlbumRenameProgress: (progress: { done: number; total: number } | null) => void
   refreshOpenAlbum: () => Promise<void>
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
@@ -218,6 +226,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   })(),
   baseKampEditMode: localStorage.getItem('kamp:base-kamp-edit-mode') === 'true',
   albumEditMode: false,
+  albumRenameProgress: null,
   sortOrder: 'album_artist',
   searchQuery: '',
   searchResults: null,
@@ -607,6 +616,27 @@ export const useStore = create<PlayerStore>((set, get) => ({
     if ('collision' in result) return result
     await get().refreshOpenAlbum()
     void get().loadQueue()
+    return null
+  },
+
+  setAlbumRenameProgress: (progress) => set({ albumRenameProgress: progress }),
+
+  patchAlbumTags: async (albumArtist, album, opts) => {
+    const result = await api.patchAlbumTags(albumArtist, album, opts)
+    if ('collision' in result) return result
+    // Clear progress, reload library so sidebar and album card reflect new names.
+    set({ albumRenameProgress: null })
+    await get().loadLibrary()
+    // Re-select the open album under its new identity so the track list refreshes.
+    const newArtist = opts.album_artist ?? albumArtist
+    const newAlbum = opts.album ?? album
+    const updatedAlbum = get().library.albums.find(
+      (a) => a.album_artist === newArtist && a.album === newAlbum
+    )
+    if (updatedAlbum) {
+      set((s) => ({ library: { ...s.library, selectedAlbum: updatedAlbum } }))
+      await get().loadTracks(newArtist, newAlbum)
+    }
     return null
   },
 

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -90,14 +90,51 @@ class TestWriteAlbumTagsToFile:
         f = tmp_path / "track.flac"
         f.write_bytes(b"fLaC")
         mock_audio = MagicMock()
-        mock_audio.tags = {}
+        # tags=None exercises the add_tags() branch; after the call it becomes a dict.
+        mock_audio.tags = None
+
+        def _add_tags() -> None:
+            mock_audio.tags = {}
+
+        mock_audio.add_tags.side_effect = _add_tags
         with patch("kamp_core.library.mutagen.flac.FLAC", return_value=mock_audio):
+            # With artist — True branch.
             write_album_tags_to_file(f, "New Album", "New Artist", artist="New Artist")
+            assert mock_audio.tags["ARTIST"] == ["New Artist"]
+            # Without artist — False branch.
+            mock_audio.tags = {}
+            write_album_tags_to_file(f, "New Album", "New Artist")
+            assert "ARTIST" not in mock_audio.tags
 
         assert mock_audio.tags["ALBUM"] == ["New Album"]
         assert mock_audio.tags["ALBUMARTIST"] == ["New Artist"]
-        assert mock_audio.tags["ARTIST"] == ["New Artist"]
-        mock_audio.save.assert_called_once()
+        assert mock_audio.save.call_count == 2
+
+    def test_updates_m4a_album_artist_and_per_track_artist(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "track.m4a"
+        f.write_bytes(b"\x00" * 32)
+        mock_audio = MagicMock()
+        # tags=None exercises the add_tags() branch; after the call it becomes a dict.
+        mock_audio.tags = None
+
+        def _add_tags() -> None:
+            mock_audio.tags = {}
+
+        mock_audio.add_tags.side_effect = _add_tags
+        with patch("kamp_core.library.mutagen.mp4.MP4", return_value=mock_audio):
+            # With artist — True branch.
+            write_album_tags_to_file(f, "New Album", "New Artist", artist="New Artist")
+            assert mock_audio.tags["\xa9ART"] == ["New Artist"]
+            # Without artist — False branch.
+            mock_audio.tags = {}
+            write_album_tags_to_file(f, "New Album", "New Artist")
+            assert "\xa9ART" not in mock_audio.tags
+
+        assert mock_audio.tags["\xa9alb"] == ["New Album"]
+        assert mock_audio.tags["aART"] == ["New Artist"]
+        assert mock_audio.save.call_count == 2
 
     def test_updates_ogg_album_artist_and_per_track_artist(
         self, tmp_path: Path
@@ -105,16 +142,26 @@ class TestWriteAlbumTagsToFile:
         f = tmp_path / "track.ogg"
         f.write_bytes(b"OggS")
         mock_audio = MagicMock()
-        mock_audio.tags = {}
+        mock_audio.tags = None
+
+        def _add_tags() -> None:
+            mock_audio.tags = {}
+
+        mock_audio.add_tags.side_effect = _add_tags
         with patch(
             "kamp_core.library.mutagen.oggvorbis.OggVorbis", return_value=mock_audio
         ):
+            # With artist — True branch.
             write_album_tags_to_file(f, "New Album", "New Artist", artist="New Artist")
+            assert mock_audio.tags["ARTIST"] == ["New Artist"]
+            # Without artist — False branch.
+            mock_audio.tags = {}
+            write_album_tags_to_file(f, "New Album", "New Artist")
+            assert "ARTIST" not in mock_audio.tags
 
         assert mock_audio.tags["ALBUM"] == ["New Album"]
         assert mock_audio.tags["ALBUMARTIST"] == ["New Artist"]
-        assert mock_audio.tags["ARTIST"] == ["New Artist"]
-        mock_audio.save.assert_called_once()
+        assert mock_audio.save.call_count == 2
 
     def test_raises_on_unsupported_format(self, tmp_path: Path) -> None:
         f = tmp_path / "track.wav"
@@ -560,6 +607,69 @@ class TestPatchAlbumTagsEndpoint:
             json={"album": "New"},
         )
         assert resp.status_code == 503
+
+    def test_tag_write_failure_in_tag_only_path_reported_in_failed(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Tag-write exceptions in the same-dir path populate failed[], not moved[]."""
+        flat_template = "{track:02d} - {title}.{ext}"
+        pairs = _make_album(tmp_path, "Artist", "Old Album", "2024", 1)
+        mp3, track = pairs[0]
+        flat = tmp_path / mp3.name
+        mp3.rename(flat)
+        tracks = [
+            _sample_track(
+                flat,
+                title=track.title,
+                album_artist="Artist",
+                album="Old Album",
+                year="2024",
+                track_number=track.track_number,
+            )
+        ]
+        client, _ = self._client_with_album(
+            tmp_path,
+            tracks,
+            _mock_engine,
+            _mock_queue,
+            config_values={"library.path_template": flat_template},
+        )
+        with patch(
+            "kamp_core.library.write_album_tags_to_file",
+            side_effect=OSError("disk full"),
+        ):
+            resp = client.patch(
+                "/api/v1/albums/tags",
+                params={"album_artist": "Artist", "album": "Old Album"},
+                json={"album": "New Album"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["failed"]) == 1
+        assert body["moved"] == []
+        assert "disk full" in body["failed"][0]["error"]
+
+    def test_tag_write_failure_in_atomic_rename_path_reported_in_failed(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Tag-write exceptions after atomic dir rename populate failed[], not moved[]."""
+        pairs = _make_album(tmp_path, "Artist", "Old Album", "2024", 1)
+        tracks = [t for _, t in pairs]
+        client, _ = self._client_with_album(tmp_path, tracks, _mock_engine, _mock_queue)
+        with patch(
+            "kamp_core.library.write_album_tags_to_file",
+            side_effect=OSError("disk full"),
+        ):
+            resp = client.patch(
+                "/api/v1/albums/tags",
+                params={"album_artist": "Artist", "album": "Old Album"},
+                json={"album": "New Album"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["failed"]) == 1
+        assert body["moved"] == []
+        assert "disk full" in body["failed"][0]["error"]
 
     def test_on_album_tracks_moved_called_once_with_all_pairs(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -423,3 +423,67 @@ class TestPatchAlbumTagsEndpoint:
         )
         assert resp.status_code == 200
         assert len(moved_pairs) == 3
+
+    def test_empty_album_dir_removed_after_rename(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Old Album", "2024", 2)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        old_album_dir = tmp_path / "Artist" / "2024 - Old Album"
+        assert old_album_dir.is_dir()
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Old Album"},
+            json={"album": "New Album"},
+        )
+        assert resp.status_code == 200
+        # Old album directory should be gone.
+        assert not old_album_dir.exists()
+        # Artist directory stays — it now contains the new album folder.
+        assert (tmp_path / "Artist").is_dir()
+
+    def test_empty_artist_dir_removed_after_artist_rename(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 2)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        old_artist_dir = tmp_path / "Old Artist"
+        assert old_artist_dir.is_dir()
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        # Both the old album dir and the now-empty artist dir should be gone.
+        assert not (old_artist_dir / "2024 - Album").exists()
+        assert not old_artist_dir.exists()
+
+    def test_non_empty_dir_not_removed(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """If a skipped file remains in the old dir, the dir is preserved."""
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 2)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        old_album_dir = tmp_path / "Artist" / "2024 - Album"
+        # Place a collision at the destination of the first track.
+        dest_dir = tmp_path / "Artist" / "2024 - New Album"
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "01 - Track 01.mp3").write_bytes(b"\xff\xfb" * 4)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "New Album", "skip_conflicts": True},
+        )
+        assert resp.status_code == 200
+        # Skipped file still lives in the old dir — dir must not be removed.
+        assert old_album_dir.is_dir()

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -401,7 +401,7 @@ class TestPatchAlbumTagsEndpoint:
         )
         assert resp.status_code == 503
 
-    def test_on_track_file_moved_called_per_track(
+    def test_on_album_tracks_moved_called_once_with_all_pairs(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
     ) -> None:
         pairs = _make_album(tmp_path, "Artist", "Album", "2024", 3)
@@ -412,8 +412,8 @@ class TestPatchAlbumTagsEndpoint:
             index=db, engine=_mock_engine, queue=_mock_queue, library_path=tmp_path
         )
 
-        moved_pairs: list[tuple[Path, Path]] = []
-        app.state.on_track_file_moved = lambda old, new: moved_pairs.append((old, new))
+        batch_calls: list[list[tuple[Path, Path]]] = []
+        app.state.on_album_tracks_moved = lambda p: batch_calls.append(p)
 
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.patch(
@@ -422,7 +422,9 @@ class TestPatchAlbumTagsEndpoint:
             json={"album": "Renamed"},
         )
         assert resp.status_code == 200
-        assert len(moved_pairs) == 3
+        # Callback fires exactly once with all 3 pairs — not once-per-track
+        assert len(batch_calls) == 1
+        assert len(batch_calls[0]) == 3
 
     def test_empty_album_dir_removed_after_rename(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -1,0 +1,425 @@
+"""Tests for KAMP-308: album-level tag fan-out and rename endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import mutagen.id3 as id3
+import pytest
+from fastapi.testclient import TestClient
+
+from kamp_core.library import LibraryIndex, Track, write_album_tags_to_file
+from kamp_core.playback import PlaybackState
+from kamp_core.server import create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mp3(path: Path, **tags: str) -> None:
+    t = id3.ID3()
+    if "album_artist" in tags:
+        t["TPE2"] = id3.TPE2(encoding=3, text=tags["album_artist"])
+    if "album" in tags:
+        t["TALB"] = id3.TALB(encoding=3, text=tags["album"])
+    if "year" in tags:
+        t["TDRC"] = id3.TDRC(encoding=3, text=tags["year"])
+    if "track" in tags:
+        t["TRCK"] = id3.TRCK(encoding=3, text=tags["track"])
+    if "title" in tags:
+        t["TIT2"] = id3.TIT2(encoding=3, text=tags["title"])
+    path.write_bytes(b"\xff\xfb" * 64)
+    t.save(str(path))
+
+
+def _sample_track(file_path: Path, **overrides: object) -> Track:
+    defaults: dict[str, object] = dict(
+        file_path=file_path,
+        title="Track Title",
+        artist="Artist",
+        album_artist="Artist",
+        album="Old Album",
+        year="2024",
+        track_number=1,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="rel-1",
+        mb_recording_id="rec-1",
+    )
+    defaults.update(overrides)
+    return Track(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# write_album_tags_to_file
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAlbumTagsToFile:
+    def test_updates_mp3_album_and_artist(self, tmp_path: Path) -> None:
+        f = tmp_path / "track.mp3"
+        _make_mp3(f, album="Old", album_artist="Old Artist")
+        write_album_tags_to_file(f, "New Album", "New Artist")
+        tags = id3.ID3(str(f))
+        assert str(tags["TALB"]) == "New Album"
+        assert str(tags["TPE2"]) == "New Artist"
+
+    def test_raises_on_unsupported_format(self, tmp_path: Path) -> None:
+        f = tmp_path / "track.wav"
+        f.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+        with pytest.raises(ValueError, match="Unsupported"):
+            write_album_tags_to_file(f, "Album", "Artist")
+
+
+# ---------------------------------------------------------------------------
+# LibraryIndex.rename_album_track
+# ---------------------------------------------------------------------------
+
+
+class TestRenameAlbumTrack:
+    def test_updates_path_album_and_album_artist(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        old_path = tmp_path / "old.mp3"
+        new_path = tmp_path / "new.mp3"
+        track = _sample_track(old_path)
+        index.upsert_track(track)
+        original = index.get_track_by_path(old_path)
+        assert original is not None
+
+        index.rename_album_track(old_path, new_path, "New Album", "New Artist", 9999.0)
+
+        assert index.get_track_by_path(old_path) is None
+        updated = index.get_track_by_path(new_path)
+        assert updated is not None
+        assert updated.album == "New Album"
+        assert updated.album_artist == "New Artist"
+        assert updated.file_mtime == 9999.0
+        # Stats preserved.
+        assert updated.id == original.id
+        assert updated.mb_recording_id == original.mb_recording_id
+        index.close()
+
+    def test_preserves_play_stats(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "db.sqlite")
+        p = tmp_path / "track.mp3"
+        track = _sample_track(p)
+        index.upsert_track(track)
+        index.set_favorite(p, True)
+        index.record_played(p)
+
+        new_p = tmp_path / "moved.mp3"
+        index.rename_album_track(p, new_p, "New Album", "New Artist", 1.0)
+
+        updated = index.get_track_by_path(new_p)
+        assert updated is not None
+        assert updated.favorite is True
+        assert updated.play_count == 1
+        assert updated.last_played is not None
+        index.close()
+
+
+# ---------------------------------------------------------------------------
+# Server endpoint: PATCH /api/v1/albums/tags
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _mock_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.state = PlaybackState()
+    return engine
+
+
+@pytest.fixture()
+def _mock_queue() -> MagicMock:
+    queue = MagicMock()
+    queue.current.return_value = None
+    queue.peek_next.return_value = None
+    queue.queue_tracks.return_value = ([], -1)
+    queue.set_shuffle = MagicMock()
+    queue.set_repeat = MagicMock()
+    return queue
+
+
+def _make_album(
+    tmp_path: Path,
+    album_artist: str,
+    album: str,
+    year: str,
+    track_count: int,
+) -> list[tuple[Path, Track]]:
+    """Create MP3 files + Track objects for a test album."""
+    folder = tmp_path / album_artist / f"{year} - {album}"
+    folder.mkdir(parents=True)
+    result = []
+    for i in range(1, track_count + 1):
+        title = f"Track {i:02d}"
+        mp3 = folder / f"{i:02d} - {title}.mp3"
+        _make_mp3(
+            mp3,
+            album_artist=album_artist,
+            album=album,
+            year=year,
+            track=str(i),
+            title=title,
+        )
+        track = _sample_track(
+            mp3,
+            title=title,
+            album_artist=album_artist,
+            album=album,
+            year=year,
+            track_number=i,
+            mb_recording_id=f"rec-{i}",
+        )
+        result.append((mp3, track))
+    return result
+
+
+class TestPatchAlbumTagsEndpoint:
+    def _client_with_album(
+        self,
+        tmp_path: Path,
+        tracks: list[Track],
+        engine: MagicMock,
+        queue: MagicMock,
+    ) -> tuple[TestClient, LibraryIndex]:
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        for track in tracks:
+            db.upsert_track(track)
+        app = create_app(
+            index=db,
+            engine=engine,
+            queue=queue,
+            library_path=tmp_path,
+        )
+        return TestClient(app, raise_server_exceptions=False), db
+
+    def test_rename_album_moves_all_files(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Old Album", "2024", 3)
+        track_objects = [t for _, t in pairs]
+        client, db = self._client_with_album(
+            tmp_path, track_objects, _mock_engine, _mock_queue
+        )
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Old Album"},
+            json={"album": "New Album"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["moved"]) == 3
+        assert body["skipped"] == []
+        assert body["failed"] == []
+
+        # All DB rows now show the new album name.
+        rows = db.tracks_for_album("Artist", "New Album")
+        assert len(rows) == 3
+        for row in rows:
+            assert row.album == "New Album"
+            # Old album no longer in DB.
+        assert db.tracks_for_album("Artist", "Old Album") == []
+
+        # Files exist at new locations.
+        new_folder = tmp_path / "Artist" / "2024 - New Album"
+        assert new_folder.is_dir()
+        assert len(list(new_folder.glob("*.mp3"))) == 3
+
+    def test_rename_album_artist_restructures_folders(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 2)
+        track_objects = [t for _, t in pairs]
+        client, db = self._client_with_album(
+            tmp_path, track_objects, _mock_engine, _mock_queue
+        )
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        rows = db.tracks_for_album("New Artist", "Album")
+        assert len(rows) == 2
+        for row in rows:
+            assert row.album_artist == "New Artist"
+        new_folder = tmp_path / "New Artist" / "2024 - Album"
+        assert new_folder.is_dir()
+
+    def test_stats_preserved_across_all_tracks(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 2)
+        track_objects = [t for _, t in pairs]
+        client, db = self._client_with_album(
+            tmp_path, track_objects, _mock_engine, _mock_queue
+        )
+        # Set stats before rename.
+        for _, track in pairs:
+            db.set_favorite(track.file_path, True)
+            db.record_played(track.file_path)
+        original_ids = {db.get_track_by_path(t.file_path).id for _, t in pairs}  # type: ignore[union-attr]
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "Renamed Album"},
+        )
+        assert resp.status_code == 200
+
+        rows = db.tracks_for_album("Artist", "Renamed Album")
+        assert len(rows) == 2
+        for row in rows:
+            assert row.favorite is True
+            assert row.play_count == 1
+            assert row.id in original_ids
+
+    def test_returns_404_for_unknown_album(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        app = create_app(
+            index=db, engine=_mock_engine, queue=_mock_queue, library_path=tmp_path
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Nobody", "album": "Nothing"},
+            json={"album": "New"},
+        )
+        assert resp.status_code == 404
+
+    def test_returns_400_when_no_changes(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 1)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={},
+        )
+        assert resp.status_code == 400
+
+    def test_returns_409_on_collision_without_overwrite(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 2)
+        track_objects = [t for _, t in pairs]
+        client, db = self._client_with_album(
+            tmp_path, track_objects, _mock_engine, _mock_queue
+        )
+
+        # Create a file at the destination of the first track to force a collision.
+        colliding_dir = tmp_path / "Artist" / "2024 - New Album"
+        colliding_dir.mkdir(parents=True)
+        (colliding_dir / "01 - Track 01.mp3").write_bytes(b"\xff\xfb" * 4)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "New Album"},
+        )
+
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["detail"]["collision_count"] == 1
+        # No files were moved — pre-flight stops before any moves.
+        assert db.tracks_for_album("Artist", "Album")  # old rows still there
+
+    def test_overwrite_replaces_colliding_files(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 1)
+        client, db = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        # Place a different track at the new destination so there's a collision.
+        dest_dir = tmp_path / "Artist" / "2024 - New Album"
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "01 - Track 01.mp3").write_bytes(b"\xff\xfb" * 4)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "New Album", "overwrite": True},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["moved"]) == 1
+
+    def test_skip_conflicts_leaves_colliding_file_and_renames_rest(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 2)
+        client, db = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        # Collision on the first track only.
+        dest_dir = tmp_path / "Artist" / "2024 - New Album"
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "01 - Track 01.mp3").write_bytes(b"\xff\xfb" * 4)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "New Album", "skip_conflicts": True},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # One moved, one skipped.
+        assert len(body["moved"]) == 1
+        assert len(body["skipped"]) == 1
+
+    def test_returns_503_when_library_path_not_configured(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 1)
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        for _, t in pairs:
+            db.upsert_track(t)
+        app = create_app(index=db, engine=_mock_engine, queue=_mock_queue)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "New"},
+        )
+        assert resp.status_code == 503
+
+    def test_on_track_file_moved_called_per_track(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        pairs = _make_album(tmp_path, "Artist", "Album", "2024", 3)
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        for _, t in pairs:
+            db.upsert_track(t)
+        app = create_app(
+            index=db, engine=_mock_engine, queue=_mock_queue, library_path=tmp_path
+        )
+
+        moved_pairs: list[tuple[Path, Path]] = []
+        app.state.on_track_file_moved = lambda old, new: moved_pairs.append((old, new))
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album"},
+            json={"album": "Renamed"},
+        )
+        assert resp.status_code == 200
+        assert len(moved_pairs) == 3

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -67,6 +67,23 @@ class TestWriteAlbumTagsToFile:
         assert str(tags["TALB"]) == "New Album"
         assert str(tags["TPE2"]) == "New Artist"
 
+    def test_updates_per_track_artist_when_provided(self, tmp_path: Path) -> None:
+        f = tmp_path / "track.mp3"
+        _make_mp3(f, album="Migjorn", album_artist="Docks")
+        # Simulate TPE1 already set
+        tags = id3.ID3(str(f))
+        tags["TPE1"] = id3.TPE1(encoding=3, text="Docks")
+        tags.save(str(f))
+
+        write_album_tags_to_file(
+            f, "Migjorn", "Activity Monitor", artist="Activity Monitor"
+        )
+
+        tags = id3.ID3(str(f))
+        assert str(tags["TPE1"]) == "Activity Monitor"
+        assert str(tags["TPE2"]) == "Activity Monitor"
+        assert str(tags["TALB"]) == "Migjorn"
+
     def test_raises_on_unsupported_format(self, tmp_path: Path) -> None:
         f = tmp_path / "track.wav"
         f.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
@@ -602,3 +619,56 @@ class TestPatchAlbumTagsEndpoint:
         assert (tmp_path / "Old Artist" / "2024 - Album B").is_dir()
         # The renamed album is under the new artist.
         assert (tmp_path / "New Artist" / "2024 - Album A").is_dir()
+
+    def test_artist_rename_updates_per_track_artist_and_fts(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Renaming album_artist also updates TPE1/artist so FTS finds the new name."""
+        pairs = _make_album(tmp_path, "Docks", "Migjorn", "2020", 2)
+        # Give each track TPE1 == album_artist (single-artist album).
+        for mp3, _ in pairs:
+            tags = id3.ID3(str(mp3))
+            tags["TPE1"] = id3.TPE1(encoding=3, text="Docks")
+            tags.save(str(mp3))
+        tracks = [
+            _sample_track(
+                mp3,
+                artist="Docks",
+                album_artist="Docks",
+                album="Migjorn",
+                year="2020",
+                title=t.title,
+                track_number=t.track_number,
+            )
+            for mp3, t in pairs
+        ]
+
+        client, db = self._client_with_album(
+            tmp_path, tracks, _mock_engine, _mock_queue
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Docks", "album": "Migjorn"},
+            json={"album_artist": "Activity Monitor"},
+        )
+        assert resp.status_code == 200
+
+        # DB artist column updated for tracks where artist == old album_artist.
+        for mp3, _ in pairs:
+            new_mp3 = tmp_path / "Activity Monitor" / "2020 - Migjorn" / mp3.name
+            updated = db.get_track_by_path(new_mp3)
+            assert updated is not None
+            assert updated.artist == "Activity Monitor"
+
+        # FTS: searching old name returns nothing; new name returns the tracks.
+        assert db.search("Docks") == []
+        results = db.search("Activity Monitor")
+        assert len(results) == 2
+
+        # File tag also updated.
+        for _, track in pairs:
+            new_mp3 = (
+                tmp_path / "Activity Monitor" / "2020 - Migjorn" / track.file_path.name
+            )
+            file_tags = id3.ID3(str(new_mp3))
+            assert str(file_tags["TPE1"]) == "Activity Monitor"

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -489,3 +489,51 @@ class TestPatchAlbumTagsEndpoint:
         assert resp.status_code == 200
         # Skipped file still lives in the old dir — dir must not be removed.
         assert old_album_dir.is_dir()
+
+    def test_ds_store_in_old_dir_does_not_block_cleanup(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """macOS Finder drops .DS_Store in every visited directory; cleanup must remove it."""
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 2)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        # Simulate Finder leaving metadata in the album and artist directories.
+        (tmp_path / "Old Artist" / "2024 - Album" / ".DS_Store").write_bytes(b"")
+        (tmp_path / "Old Artist" / ".DS_Store").write_bytes(b"")
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        assert not (tmp_path / "Old Artist").exists()
+
+    def test_queue_album_artist_updated_after_rename(
+        self, tmp_path: Path, _mock_engine: MagicMock
+    ) -> None:
+        """Queued tracks must reflect the new album_artist after an album-level rename."""
+        from kamp_core.playback import PlaybackQueue
+
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 2)
+        tracks = [t for _, t in pairs]
+        queue: PlaybackQueue = PlaybackQueue()
+        queue.load(tracks, start_index=0)
+
+        db = LibraryIndex(tmp_path / "db.sqlite")
+        for t in tracks:
+            db.upsert_track(t)
+        app = create_app(
+            index=db, engine=_mock_engine, queue=queue, library_path=tmp_path
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        queue_tracks, _ = queue.queue_tracks()
+        assert all(t.album_artist == "New Artist" for t in queue_tracks)

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import mutagen.id3 as id3
 import pytest
@@ -83,6 +83,38 @@ class TestWriteAlbumTagsToFile:
         assert str(tags["TPE1"]) == "Activity Monitor"
         assert str(tags["TPE2"]) == "Activity Monitor"
         assert str(tags["TALB"]) == "Migjorn"
+
+    def test_updates_flac_album_artist_and_per_track_artist(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "track.flac"
+        f.write_bytes(b"fLaC")
+        mock_audio = MagicMock()
+        mock_audio.tags = {}
+        with patch("kamp_core.library.mutagen.flac.FLAC", return_value=mock_audio):
+            write_album_tags_to_file(f, "New Album", "New Artist", artist="New Artist")
+
+        assert mock_audio.tags["ALBUM"] == ["New Album"]
+        assert mock_audio.tags["ALBUMARTIST"] == ["New Artist"]
+        assert mock_audio.tags["ARTIST"] == ["New Artist"]
+        mock_audio.save.assert_called_once()
+
+    def test_updates_ogg_album_artist_and_per_track_artist(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "track.ogg"
+        f.write_bytes(b"OggS")
+        mock_audio = MagicMock()
+        mock_audio.tags = {}
+        with patch(
+            "kamp_core.library.mutagen.oggvorbis.OggVorbis", return_value=mock_audio
+        ):
+            write_album_tags_to_file(f, "New Album", "New Artist", artist="New Artist")
+
+        assert mock_audio.tags["ALBUM"] == ["New Album"]
+        assert mock_audio.tags["ALBUMARTIST"] == ["New Artist"]
+        assert mock_audio.tags["ARTIST"] == ["New Artist"]
+        mock_audio.save.assert_called_once()
 
     def test_raises_on_unsupported_format(self, tmp_path: Path) -> None:
         f = tmp_path / "track.wav"
@@ -203,6 +235,7 @@ class TestPatchAlbumTagsEndpoint:
         tracks: list[Track],
         engine: MagicMock,
         queue: MagicMock,
+        config_values: dict | None = None,
     ) -> tuple[TestClient, LibraryIndex]:
         db = LibraryIndex(tmp_path / "db.sqlite")
         for track in tracks:
@@ -212,6 +245,7 @@ class TestPatchAlbumTagsEndpoint:
             engine=engine,
             queue=queue,
             library_path=tmp_path,
+            config_values=config_values,
         )
         return TestClient(app, raise_server_exceptions=False), db
 
@@ -248,6 +282,115 @@ class TestPatchAlbumTagsEndpoint:
         new_folder = tmp_path / "Artist" / "2024 - New Album"
         assert new_folder.is_dir()
         assert len(list(new_folder.glob("*.mp3"))) == 3
+
+    def test_tag_only_path_updates_db_and_fts(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """When the path template has no album/artist dir, files stay put (tag-only path)."""
+        # Flat template: all files land directly in tmp_path regardless of album/artist.
+        flat_template = "{track:02d} - {title}.{ext}"
+        pairs = _make_album(tmp_path, "Artist", "Old Album", "2024", 2)
+        # Move files to flat layout so they match the template.
+        flat_files = []
+        for mp3, track in pairs:
+            flat = tmp_path / mp3.name
+            mp3.rename(flat)
+            flat_files.append((flat, track))
+        tracks = [
+            _sample_track(
+                flat,
+                title=t.title,
+                album_artist="Artist",
+                album="Old Album",
+                year="2024",
+                track_number=t.track_number,
+            )
+            for flat, t in flat_files
+        ]
+
+        client, db = self._client_with_album(
+            tmp_path,
+            tracks,
+            _mock_engine,
+            _mock_queue,
+            config_values={"library.path_template": flat_template},
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Old Album"},
+            json={"album": "New Album"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["failed"] == []
+
+        # Files are unchanged on disk (same location).
+        for flat, _ in flat_files:
+            assert flat.exists()
+
+        # DB and FTS reflect the new album name.
+        rows = db.tracks_for_album("Artist", "New Album")
+        assert len(rows) == 2
+        assert db.tracks_for_album("Artist", "Old Album") == []
+        assert len(db.search("New Album")) == 2
+        assert db.search("Old Album") == []
+
+    def test_tag_only_path_updates_artist_tag_and_fts(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Tag-only path also updates per-track artist when artist == old album_artist."""
+        flat_template = "{track:02d} - {title}.{ext}"
+        pairs = _make_album(tmp_path, "Docks", "Migjorn", "2020", 2)
+        flat_files = []
+        for mp3, track in pairs:
+            # Set TPE1 == album_artist on each file.
+            tags = id3.ID3(str(mp3))
+            tags["TPE1"] = id3.TPE1(encoding=3, text="Docks")
+            tags.save(str(mp3))
+            flat = tmp_path / mp3.name
+            mp3.rename(flat)
+            flat_files.append((flat, track))
+        tracks = [
+            _sample_track(
+                flat,
+                artist="Docks",
+                album_artist="Docks",
+                album="Migjorn",
+                year="2020",
+                title=t.title,
+                track_number=t.track_number,
+            )
+            for flat, t in flat_files
+        ]
+
+        client, db = self._client_with_album(
+            tmp_path,
+            tracks,
+            _mock_engine,
+            _mock_queue,
+            config_values={"library.path_template": flat_template},
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Docks", "album": "Migjorn"},
+            json={"album_artist": "Activity Monitor"},
+        )
+        assert resp.status_code == 200
+
+        # DB artist column updated.
+        for flat, _ in flat_files:
+            row = db.get_track_by_path(flat)
+            assert row is not None
+            assert row.artist == "Activity Monitor"
+
+        # FTS updated.
+        assert db.search("Activity Monitor") != []
+        assert db.search("Docks") == []
+
+        # File tag updated.
+        for flat, _ in flat_files:
+            file_tags = id3.ID3(str(flat))
+            assert str(file_tags["TPE1"]) == "Activity Monitor"
 
     def test_rename_album_artist_restructures_folders(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -537,3 +537,68 @@ class TestPatchAlbumTagsEndpoint:
         assert resp.status_code == 200
         queue_tracks, _ = queue.queue_tracks()
         assert all(t.album_artist == "New Artist" for t in queue_tracks)
+
+    def test_single_track_album_artist_rename(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Single-track albums must use directory rename, not per-file move."""
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 1)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        assert not (tmp_path / "Old Artist").exists()
+        assert (tmp_path / "New Artist" / "2024 - Album" / "01 - Track 01.mp3").exists()
+
+    def test_artist_rename_renames_artist_dir_directly(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """When the artist dir contains only this album, rename it in one step.
+
+        The sequence must be: Artist A/ → Artist B/ atomically.
+        No intermediate Artist B/ creation then Artist A/ deletion.
+        """
+        pairs = _make_album(tmp_path, "Old Artist", "Album", "2024", 2)
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        old_artist_dir = tmp_path / "Old Artist"
+        new_artist_dir = tmp_path / "New Artist"
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        assert not old_artist_dir.exists()
+        assert (new_artist_dir / "2024 - Album").is_dir()
+
+    def test_artist_rename_with_other_albums_uses_album_dir_rename(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """When the artist has other albums, only the target album dir moves."""
+        pairs = _make_album(tmp_path, "Old Artist", "Album A", "2024", 2)
+        # Create a second album by Old Artist that is NOT being renamed.
+        other_dir = tmp_path / "Old Artist" / "2024 - Album B"
+        other_dir.mkdir(parents=True)
+        (other_dir / "01 - Track.mp3").write_bytes(b"\xff\xfb" * 64)
+
+        client, _ = self._client_with_album(
+            tmp_path, [t for _, t in pairs], _mock_engine, _mock_queue
+        )
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Old Artist", "album": "Album A"},
+            json={"album_artist": "New Artist"},
+        )
+        assert resp.status_code == 200
+        # Old artist dir stays — it still has Album B.
+        assert (tmp_path / "Old Artist" / "2024 - Album B").is_dir()
+        # The renamed album is under the new artist.
+        assert (tmp_path / "New Artist" / "2024 - Album A").is_dir()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -128,7 +128,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 14
+        assert version == 15
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1201,7 +1201,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 14
+        assert version == 15
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1258,7 +1258,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 14
+        assert version == 15
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1617,7 +1617,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 14
+        assert version == 15
         assert row is not None
         assert row[0] == 0
 
@@ -1730,7 +1730,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 14
+        assert version == 15
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -1822,7 +1822,7 @@ class TestAlbumFavorite:
         index._conn.execute("SELECT COUNT(*) FROM album_favorites").fetchone()
         index.close()
 
-        assert version == 14
+        assert version == 15
 
 
 # ---------------------------------------------------------------------------
@@ -2001,7 +2001,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 14
+        assert version == 15
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2096,7 +2096,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 14
+        assert version == 15
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2104,7 +2104,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 14
+        assert version == 15
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -2979,7 +2979,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 14
+        assert version == 15
 
         index.close()
 


### PR DESCRIPTION
## Summary

- **Backend:** \`PATCH /api/v1/albums/tags\` fans out to every track in the album — writes album/album_artist tags to each file, moves it to the new computed path, updates the DB row, and pushes \`album.rename.progress\` WebSocket events during the batch. Pre-flight collision detection returns 409 (with \`collision_count\` + \`first_path\`) before any files are moved; callers retry with \`overwrite=true\` or \`skip_conflicts=true\`.
- **Schema v15:** adds \`CREATE INDEX tracks_album_idx ON tracks(album_artist, album)\` for the fan-out query; disk-free pre-flight guards against near-full disks.
- **Atomic directory rename:** instead of per-file move+delete, the server renames the album directory in one syscall (\`os.rename\`). When only the artist name changes and the artist dir has no other albums, the entire artist directory is renamed directly (\`Artist A/ → Artist B/\`). Falls back to per-file merge only when the target directory already exists.
- **Artist tag sync:** renaming the album artist also updates the per-track \`artist\` tag (TPE1/©ART/ARTIST) in the file, the \`artist\` DB column, and the FTS index — for tracks where \`artist == album_artist\` (single-artist albums). Tracks with a different per-track artist (compilations, features) are left alone.
- **SQLite WAL + batch writes:** added \`timeout=30\` to prevent lock contention; all DB updates for a rename land in a single transaction with one FTS rebuild.
- **Queue sync:** in-memory queue patched immediately after rename; \`loadQueue()\` called in the store action and in the \`library.changed\` WS handler so the queue panel reflects the new names without a reload.
- **OS metadata cleanup:** \`.DS_Store\`, \`Thumbs.db\`, etc. scrubbed before \`rmdir()\` so macOS metadata files don't block cleanup of otherwise-empty directories.
- **Frontend:** \`EditableAlbumField\` primitive renders a static element in view mode and an \`<input>\` in edit mode. Escape correctly reverts edits (fixed race: \`setDraft\` is async but \`blur()\` fires synchronously — a \`cancelRef\` flag lets \`commit()\` bail before saving). Album title (\`h1\`) and album artist byline both use it. Progress bar shows \"Renaming N of M…\" from WS events. Album collision modal reuses the existing \`CollisionModal\`.

## Test plan

- [x] Rename an album title → all files move to the new folder; DB rows show new album; stats preserved
- [x] Rename the album artist → entire artist directory renamed atomically; sidebar artist list refreshes; old directory gone
- [x] Artist with multiple albums → only the target album dir moves; other albums untouched
- [x] Rename artist → search for new name finds tracks; search for old name returns nothing
- [x] Force a collision → modal appears; Overwrite replaces; Skip leaves that file; Cancel leaves everything in place
- [x] Escape in an edit field reverts to the original value without saving
- [x] \"Renaming N of M…\" counter advances in the UI during a large batch
- [x] Queue panel reflects new artist/album name immediately after rename
- [x] 24 tests in \`test_album_rename.py\` pass; typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)