### PR TITLE
feat(KAMP-320): StereoRackModule shell — context, rAF loop, Zustand level subscription

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -90,6 +90,7 @@ export default function App(): React.JSX.Element {
   const loadConfig = useStore((s) => s.loadConfig)
   const applyServerState = useStore((s) => s.applyServerState)
   const setServerStatus = useStore((s) => s.setServerStatus)
+  const setAudioLevel = useStore((s) => s.setAudioLevel)
   const serverStatus = useStore((s) => s.serverStatus)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const activeView = useStore((s) => s.activeView)
@@ -233,7 +234,8 @@ export default function App(): React.JSX.Element {
         (trackId) => {
           clearDeferredOp(trackId)
           void refreshOpenAlbum()
-        }
+        },
+        setAudioLevel
       )
     }
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -437,11 +437,17 @@ export type DeferredOpCompletedMessage = {
   op_id: number
   track_id: number
 }
+export type AudioLevelMessage = {
+  type: 'audio.level'
+  level_db: number
+  peak_db: number
+}
 export type ServerMessage =
   | StateMessage
   | LibraryChangedMessage
   | AlbumRenameProgressMessage
   | DeferredOpCompletedMessage
+  | AudioLevelMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -457,7 +463,8 @@ export function connectStateStream(
   onOpen?: () => void,
   onLibraryChanged?: () => void,
   onAlbumRenameProgress?: (done: number, total: number) => void,
-  onDeferredOpCompleted?: (trackId: number, opId: number) => void
+  onDeferredOpCompleted?: (trackId: number, opId: number) => void,
+  onAudioLevel?: (levelDb: number, peakDb: number) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -471,6 +478,7 @@ export function connectStateStream(
       else if (msg.type === 'album.rename.progress') onAlbumRenameProgress?.(msg.done, msg.total)
       else if (msg.type === 'deferred_op.completed')
         onDeferredOpCompleted?.(msg.track_id, msg.op_id)
+      else if (msg.type === 'audio.level') onAudioLevel?.(msg.level_db, msg.peak_db)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -179,7 +179,7 @@ export function QueuePanel(): React.JSX.Element {
             const isUnplayed = position >= 0 && idx > position
             return (
               <li
-                key={track.id}
+                key={idx}
                 ref={isCurrent ? activeRef : null}
                 className={`queue-track-row${isCurrent ? ' current' : ''}${isPlayed ? ' played' : ''}`}
                 draggable={!isCurrent}

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
@@ -1,0 +1,44 @@
+/**
+ * StereoRackContext — types, context, and useStereoRack hook.
+ *
+ * Kept in a separate file from StereoRackModule so react-refresh can
+ * fast-reload the module component without tripping over non-component exports.
+ */
+import { createContext, useContext } from 'react'
+
+export type TrackMeta = {
+  artist: string
+  title: string
+  year: string
+  format: string
+  duration: number
+}
+
+export type WhimsyFlags = {
+  coldBootDone: boolean
+  konamiActive: boolean
+  firstTrackOfDayShown: boolean
+}
+
+/** Called by the rAF loop each frame — child components register one of these. */
+export type DrawFn = (levelDb: number, peakDb: number) => void
+
+export type StereoRackContextValue = {
+  isPlaying: boolean
+  isPaused: boolean
+  trackMeta: TrackMeta | null
+  whimsyFlags: WhimsyFlags
+  setWhimsyFlags: (patch: Partial<WhimsyFlags>) => void
+  /** Register a per-frame draw callback. Call from a useEffect on mount. */
+  registerDraw: (id: string, fn: DrawFn) => void
+  /** Unregister a draw callback. Call from the useEffect cleanup. */
+  unregisterDraw: (id: string) => void
+}
+
+export const StereoRackContext = createContext<StereoRackContextValue | null>(null)
+
+export function useStereoRack(): StereoRackContextValue {
+  const ctx = useContext(StereoRackContext)
+  if (!ctx) throw new Error('useStereoRack must be used inside StereoRackModule')
+  return ctx
+}

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
@@ -1,0 +1,118 @@
+/**
+ * StereoRackModule — shell for the KAMP-318 visualizer.
+ *
+ * Owns:
+ *  - StereoRackContext provider (discrete playback state + imperative draw registry)
+ *  - A single rAF loop that reads levelDb/peakDb from the Zustand store via
+ *    getState() and calls every registered draw function each frame.
+ *  - visibilitychange wiring so the loop pauses when the tab is hidden.
+ *
+ * Per-frame mutable state (level, peak, decay accumulators, whimsy timers)
+ * lives in the child components' useRefs — this shell intentionally holds none.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useStore } from '../../store'
+import type { ModuleProps } from './registry'
+import {
+  StereoRackContext,
+  type StereoRackContextValue,
+  type TrackMeta,
+  type WhimsyFlags,
+  type DrawFn
+} from './StereoRackContext'
+
+// displayStyle is required by ModuleProps but unused — StereoRack has a fixed layout.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.Element {
+  // Draw registry — child components register imperative draw callbacks here.
+  // Map keyed by a stable id string supplied by the child.
+  const drawsRef = useRef<Map<string, DrawFn>>(new Map())
+
+  const registerDraw = useCallback((id: string, fn: DrawFn) => {
+    drawsRef.current.set(id, fn)
+  }, [])
+
+  const unregisterDraw = useCallback((id: string) => {
+    drawsRef.current.delete(id)
+  }, [])
+
+  // rAF loop — reads store state directly each frame (no subscription needed;
+  // getState() is synchronous and always returns the latest snapshot).
+  const rafIdRef = useRef<number>(0)
+
+  useEffect(() => {
+    const frame = (): void => {
+      const { levelDb, peakDb } = useStore.getState()
+      const level = levelDb ?? -Infinity
+      const peak = peakDb ?? -Infinity
+      drawsRef.current.forEach((draw) => draw(level, peak))
+      rafIdRef.current = requestAnimationFrame(frame)
+    }
+
+    rafIdRef.current = requestAnimationFrame(frame)
+
+    const onVisibilityChange = (): void => {
+      if (document.hidden) {
+        cancelAnimationFrame(rafIdRef.current)
+      } else {
+        rafIdRef.current = requestAnimationFrame(frame)
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      cancelAnimationFrame(rafIdRef.current)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  // Discrete playback state — changes are infrequent so React state is fine here.
+  const player = useStore((s) => s.player)
+  const isPlaying = player.playing
+  const isPaused = !player.playing && player.current_track !== null
+
+  const trackMeta = useMemo((): TrackMeta | null => {
+    const t = player.current_track
+    if (!t) return null
+    return {
+      artist: t.artist || t.album_artist,
+      title: t.title,
+      year: t.year,
+      format: t.ext.replace(/^\./, '').toUpperCase(),
+      duration: player.duration
+    }
+  }, [player.current_track, player.duration])
+
+  // Whimsy flags — updated discretely by delight-layer tasks (KAMP-321+).
+  const [whimsyFlags, setWhimsyFlagsState] = useState<WhimsyFlags>({
+    coldBootDone: false,
+    konamiActive: false,
+    firstTrackOfDayShown: false
+  })
+
+  const setWhimsyFlags = useCallback((patch: Partial<WhimsyFlags>) => {
+    setWhimsyFlagsState((prev) => ({ ...prev, ...patch }))
+  }, [])
+
+  const contextValue = useMemo<StereoRackContextValue>(
+    () => ({
+      isPlaying,
+      isPaused,
+      trackMeta,
+      whimsyFlags,
+      setWhimsyFlags,
+      registerDraw,
+      unregisterDraw
+    }),
+    [isPlaying, isPaused, trackMeta, whimsyFlags, setWhimsyFlags, registerDraw, unregisterDraw]
+  )
+
+  return (
+    <StereoRackContext.Provider value={contextValue}>
+      <div className="stereo-rack-module">
+        {/* VUMeterPair, Oscilloscope, and TrackDisplay are mounted here in subsequent tasks */}
+      </div>
+    </StereoRackContext.Provider>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -2,6 +2,7 @@ import type React from 'react'
 import { NewArrivalsModule, NewArrivalsConfig } from './NewArrivalsModule'
 import { LastPlayedModule, LastPlayedConfig } from './LastPlayedModule'
 import { TopAlbumsModule, TopAlbumsConfig } from './TopAlbumsModule'
+import { StereoRackModule } from './StereoRackModule'
 
 export type DisplayStyle = 'shelf' | 'grid' | 'list'
 
@@ -34,5 +35,12 @@ export const MODULE_REGISTRY: ModuleRegistration[] = [
     title: 'Top Albums',
     component: TopAlbumsModule,
     configComponent: TopAlbumsConfig
+  },
+  {
+    // defaultVisible: false — not in the default moduleOrder, so it appears in
+    // the "add module" list rather than the active Home view on first launch.
+    id: 'kamp.stereo-rack',
+    title: 'Stereo Rack',
+    component: StereoRackModule
   }
 ]

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -39,6 +39,9 @@ type PlayerStore = {
   scanError: string | null
   scanProgress: ScanProgress | null
 
+  levelDb: number | null
+  peakDb: number | null
+
   configuredLibraryPath: string | null
   activeView: 'library' | 'now-playing' | 'home'
   moduleOrder: string[]
@@ -66,6 +69,7 @@ type PlayerStore = {
   queue: QueueState | null
 
   // Actions
+  setAudioLevel: (levelDb: number, peakDb: number) => void
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   toggleQueuePanel: () => void
   toggleArtistPanel: () => void
@@ -188,6 +192,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   lastScanResult: null,
   scanError: null,
   scanProgress: null,
+  levelDb: null,
+  peakDb: null,
   configuredLibraryPath: null,
   activeView: 'library',
   moduleOrder: (() => {
@@ -249,6 +255,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   prefsOpen: false,
   prefsInitialTab: 'general',
   deferredOps: {},
+
+  setAudioLevel: (levelDb, peakDb) => set({ levelDb, peakDb }),
 
   setServerStatus: (status) => set({ serverStatus: status }),
 


### PR DESCRIPTION
## Summary

- Adds `AudioLevelMessage` WebSocket type and wires `audio.level` events from the daemon into the Zustand store (`levelDb`, `peakDb`)
- Creates `StereoRackContext.tsx` — types (`TrackMeta`, `WhimsyFlags`, `DrawFn`), context, and `useStereoRack` hook for child components
- Creates `StereoRackModule.tsx` — context provider, single `requestAnimationFrame` loop (reads store via `getState()` each frame, zero React re-renders), `visibilitychange` pause/resume, imperative draw registry (`registerDraw`/`unregisterDraw`) that child components will use
- Registers `kamp.stereo-rack` in `MODULE_REGISTRY` — absent from default `moduleOrder` so it starts hidden (user must add it via the gear menu)
- Fixes duplicate React key warnings in `QueuePanel` when the same track appears more than once in the queue

## What this PR does NOT include

The module renders an empty div for now. VU meters, oscilloscope, and track display arrive in KAMP-321 through KAMP-325+. This PR is purely the infrastructure those components plug into.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Adding the Stereo Rack module via the Base Kamp gear menu shows it in the layout (empty, no visible content — expected)
- [x] No console errors on mount/unmount
- [x] rAF loop cleanup: paste the snippet below into the console, then remove and re-add the module several times — the rAFs/sec count should stay flat at ~60, not climb with each re-add

```js
let count = 0
const orig = window.requestAnimationFrame
window.requestAnimationFrame = (cb) => { count++; return orig(cb) }
setInterval(() => { console.log('rAFs/sec:', count); count = 0 }, 1000)
```

Closes KAMP-320

🤖 Generated with [Claude Code](https://claude.com/claude-code)