### PR TITLE
feat(KAMP-325): TrackDisplay layout

### DIFF
--- a/kamp_ui/src/renderer/src/assets/stereo-rack.css
+++ b/kamp_ui/src/renderer/src/assets/stereo-rack.css
@@ -138,3 +138,77 @@
 .vu-meter.is-idle .vu-segment {
   opacity: 0.4;
 }
+
+/* ============================================================
+   Track Display
+   ============================================================ */
+
+.track-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 28px;
+  padding: 0 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 1;
+  transition: opacity 300ms ease;
+}
+
+.track-display.is-idle {
+  opacity: 0.5;
+}
+
+/* Left cluster — clipped; scroll added in KAMP-326 */
+.track-left {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.track-artist {
+  color: rgba(255, 255, 255, 0.85);
+  flex-shrink: 0;
+}
+
+.track-sep {
+  color: rgba(255, 255, 255, 0.40);
+  flex-shrink: 0;
+}
+
+.track-title {
+  color: rgba(255, 255, 255, 0.85);
+  overflow: hidden;
+}
+
+/* Right cluster */
+.track-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding-left: 12px;
+}
+
+.track-time {
+  color: rgba(255, 255, 255, 0.40);
+}
+
+.track-timesep {
+  color: rgba(255, 255, 255, 0.20);
+}
+
+.track-year {
+  color: rgba(255, 255, 255, 0.40);
+}
+
+.track-format {
+  color: color-mix(in srgb, var(--accent) 60%, transparent);
+}

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
@@ -22,6 +22,7 @@ import {
 } from './StereoRackContext'
 import { VUMeterPair } from './VUMeter'
 import { Oscilloscope } from './Oscilloscope'
+import { TrackDisplay } from './TrackDisplay'
 
 // displayStyle is required by ModuleProps but unused — StereoRack has a fixed layout.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -118,7 +119,7 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
             <Oscilloscope />
           </VUMeterPair>
         </div>
-        {/* TrackDisplay mounts here in KAMP-325 */}
+        <TrackDisplay />
       </div>
     </StereoRackContext.Provider>
   )

--- a/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { useStore } from '../../store'
+import { useStereoRack } from './StereoRackContext'
+
+function formatTime(seconds: number): string {
+  const s = Math.floor(seconds)
+  const mm = Math.floor(s / 60)
+    .toString()
+    .padStart(2, '0')
+  const ss = (s % 60).toString().padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+type TrackLeftProps = { artist: string; title: string }
+
+function TrackLeft({ artist, title }: TrackLeftProps): React.JSX.Element {
+  return (
+    <span className="track-left">
+      {artist ? (
+        <>
+          <span className="track-artist">{artist}</span>
+          <span className="track-sep"> — </span>
+          <span className="track-title">{title}</span>
+        </>
+      ) : (
+        <span className="track-title">{title}</span>
+      )}
+    </span>
+  )
+}
+
+type TrackRightProps = { position: number; duration: number; year: string; format: string }
+
+function TrackRight({ position, duration, year, format }: TrackRightProps): React.JSX.Element {
+  return (
+    <span className="track-right">
+      <span className="track-time">{formatTime(position)}</span>
+      <span className="track-timesep">/</span>
+      <span className="track-time">{formatTime(duration)}</span>
+      {year && <span className="track-year">{year}</span>}
+      {format && <span className="track-format">{format}</span>}
+    </span>
+  )
+}
+
+export function TrackDisplay(): React.JSX.Element {
+  const { isPlaying, trackMeta } = useStereoRack()
+  const position = useStore((s) => s.player.position)
+
+  return (
+    <div className={`track-display${isPlaying ? '' : ' is-idle'}`}>
+      {trackMeta && (
+        <>
+          <TrackLeft artist={trackMeta.artist} title={trackMeta.title} />
+          <TrackRight
+            position={position}
+            duration={trackMeta.duration}
+            year={trackMeta.year}
+            format={trackMeta.format}
+          />
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `TrackDisplay` component: 28px monospace strip with artist/title (left) and time/year/format (right)
- Left cluster: `ARTIST — TITLE` with dimmed em-dash separator; title-only when no artist; clipped with `overflow: hidden` (scroll state machine in KAMP-326)
- Right cluster: `MM:SS / MM:SS  YEAR  FORMAT` — time and year in secondary color, slash at 20% opacity, format badge in accent at 60%
- Idle/paused: container dims to 50% opacity with 300ms ease transition
- Position reads directly from the Zustand store (`player.position`) so only `TrackDisplay` re-renders on tick; oscilloscope and VU meters are unaffected

## Test plan
- [ ] Play a track — verify artist, title, time, year, and format badge all appear correctly
- [ ] Confirm time advances and format badge renders in accent color
- [ ] Pause — verify container dims to ~50% and position freezes
- [ ] Stop/no track — verify container dims and content is hidden
- [ ] Track with no artist — verify title-only display (no em-dash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)