### PR TITLE
feat(KAMP-328): Cold Boot Calibration — VU sweep, oscilloscope sine, INIT stamp

### DIFF
--- a/kamp_ui/src/renderer/src/assets/stereo-rack.css
+++ b/kamp_ui/src/renderer/src/assets/stereo-rack.css
@@ -208,6 +208,14 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* Cold boot INIT overlay — shown in place of track-scroll-inner during calibration */
+.track-init-overlay {
+  display: none; /* toggled imperatively */
+  align-items: center;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.85);
+}
+
 /* Right cluster */
 .track-right {
   display: flex;

--- a/kamp_ui/src/renderer/src/components/modules/Oscilloscope.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/Oscilloscope.tsx
@@ -23,6 +23,9 @@ const DB_RANGE = 60
 const PAUSE_DECAY_MS = 800
 const PAUSE_DECAY_TARGET = -120
 
+// Duration of the cold boot VU sweep — oscilloscope uses clean sine for this window.
+const COLD_BOOT_VU_MS = 800
+
 // Target scroll rate in pixels per second.
 const SCROLL_PX_PER_SEC = 240
 
@@ -55,7 +58,7 @@ function resizeBuffer(prev: Float32Array | null, newW: number): Float32Array {
 // ---------------------------------------------------------------------------
 
 export function Oscilloscope(): React.JSX.Element {
-  const { registerDraw, unregisterDraw, isPaused, trackMeta } = useStereoRack()
+  const { registerDraw, unregisterDraw, isPaused, trackMeta, coldBootRef } = useStereoRack()
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
@@ -128,6 +131,8 @@ export function Oscilloscope(): React.JSX.Element {
   // Register the per-frame draw callback with the rAF loop.
   useEffect(() => {
     let lastLiveLevel = DB_MIN
+    // Tracks previous cold boot active state so we can reset phase on entry.
+    let coldBootWasActive = false
 
     registerDraw('oscilloscope', (leftDb, rightDb, timestamp) => {
       const ctx = ctxRef.current
@@ -140,6 +145,15 @@ export function Oscilloscope(): React.JSX.Element {
         bufferRef.current = resizeBuffer(bufferRef.current, w)
       }
       const buf = bufferRef.current
+
+      // --- Cold boot sine override ---
+      const cbStart = coldBootRef.current.startTs
+      const inColdBoot = cbStart !== null && cbStart >= 0 && timestamp - cbStart < COLD_BOOT_VU_MS
+      // Reset phase to 0 on the first cold boot frame for a clean sine sweep.
+      if (inColdBoot && !coldBootWasActive) {
+        phaseRef.current = 0
+      }
+      coldBootWasActive = inColdBoot
 
       // --- Effective level ---
       let levelDb: number
@@ -173,20 +187,29 @@ export function Oscilloscope(): React.JSX.Element {
       const frac = pixelAccumRef.current
 
       if (steps > 0) {
-        const seed = seedRef.current
-        // Phase advance per pixel — seeded ±20% for per-track character.
-        const phasePerStep = 2 * Math.PI * CYCLES_PER_PX * (0.8 + ((seed & 0xf) / 0xf) * 0.4)
-        const p0 = ((seed & 0xff) / 255) * Math.PI * 2
-        const p1 = (((seed >> 8) & 0xff) / 255) * Math.PI * 2
-
         buf.copyWithin(0, steps)
-
         let ph = phaseRef.current
-        for (let i = 0; i < steps; i++) {
-          ph += phasePerStep
-          buf[w - steps + i] =
-            (0.6 * Math.sin(ph) + 0.3 * Math.sin(2 * ph + p0) + 0.1 * Math.sin(3 * ph + p1)) * amp
+
+        if (inColdBoot) {
+          // Clean sine: exactly 1 cycle per 60px, no seed variation or harmonics.
+          const phasePerStep = 2 * Math.PI * CYCLES_PER_PX
+          for (let i = 0; i < steps; i++) {
+            ph += phasePerStep
+            buf[w - steps + i] = Math.sin(ph) * amp
+          }
+        } else {
+          const seed = seedRef.current
+          // Phase advance per pixel — seeded ±20% for per-track character.
+          const phasePerStep = 2 * Math.PI * CYCLES_PER_PX * (0.8 + ((seed & 0xf) / 0xf) * 0.4)
+          const p0 = ((seed & 0xff) / 255) * Math.PI * 2
+          const p1 = (((seed >> 8) & 0xff) / 255) * Math.PI * 2
+          for (let i = 0; i < steps; i++) {
+            ph += phasePerStep
+            buf[w - steps + i] =
+              (0.6 * Math.sin(ph) + 0.3 * Math.sin(2 * ph + p0) + 0.1 * Math.sin(3 * ph + p1)) * amp
+          }
         }
+
         phaseRef.current = ph
       }
 
@@ -222,7 +245,7 @@ export function Oscilloscope(): React.JSX.Element {
     })
 
     return () => unregisterDraw('oscilloscope')
-  }, [registerDraw, unregisterDraw])
+  }, [registerDraw, unregisterDraw, coldBootRef])
 
   return <canvas ref={canvasRef} className="oscilloscope" />
 }

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
@@ -5,6 +5,7 @@
  * fast-reload the module component without tripping over non-component exports.
  */
 import { createContext, useContext } from 'react'
+import type { MutableRefObject } from 'react'
 
 export type TrackMeta = {
   artist: string
@@ -16,6 +17,8 @@ export type TrackMeta = {
 
 export type WhimsyFlags = {
   coldBootDone: boolean
+  /** True while the cold-boot calibration animation is running (~2.2s). */
+  coldBoot: boolean
   konamiActive: boolean
   firstTrackOfDayShown: boolean
 }
@@ -29,6 +32,13 @@ export type StereoRackContextValue = {
   trackMeta: TrackMeta | null
   whimsyFlags: WhimsyFlags
   setWhimsyFlags: (patch: Partial<WhimsyFlags>) => void
+  /**
+   * Mutable ref tracking the cold-boot animation start timestamp.
+   * `startTs === null`  → not active
+   * `startTs === -1`    → armed, waiting for first rAF tick to stamp real ts
+   * `startTs >= 0`      → active; elapsed = current timestamp − startTs
+   */
+  coldBootRef: MutableRefObject<{ startTs: number | null }>
   /** Register a per-frame draw callback. Call from a useEffect on mount. */
   registerDraw: (id: string, fn: DrawFn) => void
   /** Unregister a draw callback. Call from the useEffect cleanup. */

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
@@ -6,6 +6,9 @@
  *  - A single rAF loop that reads levelDb/peakDb from the Zustand store via
  *    getState() and calls every registered draw function each frame.
  *  - visibilitychange wiring so the loop pauses when the tab is hidden.
+ *  - Cold boot calibration sequence (KAMP-328): on the first play event after
+ *    app launch, overrides levelDb with a 0→24→0 segment sweep for 800ms and
+ *    signals child components to run their whimsy animations.
  *
  * Per-frame mutable state (level, peak, decay accumulators, whimsy timers)
  * lives in the child components' useRefs — this shell intentionally holds none.
@@ -24,6 +27,14 @@ import { VUMeterPair } from './VUMeter'
 import { Oscilloscope } from './Oscilloscope'
 import { TrackDisplay } from './TrackDisplay'
 
+// VU sweep duration (ms): 0 → 24 → 0 segments via sin arc.
+const COLD_BOOT_VU_MS = 800
+// Total cold boot duration (ms): VU/oscilloscope end at 800ms, TrackDisplay
+// INIT display ends at ~2100ms; 2200ms gives a 100ms settling buffer.
+const COLD_BOOT_END_MS = 2200
+const DB_MIN = -60
+const DB_RANGE = 60
+
 // displayStyle is required by ModuleProps but unused — StereoRack has a fixed layout.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.Element {
@@ -39,15 +50,81 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
     drawsRef.current.delete(id)
   }, [])
 
-  // rAF loop — reads store state directly each frame (no subscription needed;
-  // getState() is synchronous and always returns the latest snapshot).
   const rafIdRef = useRef<number>(0)
 
+  // Discrete playback state — changes are infrequent so React state is fine here.
+  const player = useStore((s) => s.player)
+  const isPlaying = player.playing
+  const isPaused = !player.playing && player.current_track !== null
+
+  const trackMeta = useMemo((): TrackMeta | null => {
+    const t = player.current_track
+    if (!t) return null
+    return {
+      artist: t.artist || t.album_artist,
+      title: t.title,
+      year: t.year,
+      format: t.ext.replace(/^\./, '').toUpperCase(),
+      duration: player.duration
+    }
+  }, [player.current_track, player.duration])
+
+  // Whimsy flags — updated discretely by delight-layer tasks (KAMP-321+).
+  const [whimsyFlags, setWhimsyFlagsState] = useState<WhimsyFlags>({
+    coldBootDone: false,
+    coldBoot: false,
+    konamiActive: false,
+    firstTrackOfDayShown: false
+  })
+
+  const setWhimsyFlags = useCallback((patch: Partial<WhimsyFlags>) => {
+    setWhimsyFlagsState((prev) => ({ ...prev, ...patch }))
+  }, [])
+
+  // Cold boot calibration sequence (KAMP-328).
+  // startTs === null   → not active
+  // startTs === -1     → armed; first rAF tick stamps the real timestamp
+  // startTs >= 0       → active; elapsed = timestamp − startTs
+  const coldBootRef = useRef<{ startTs: number | null }>({ startTs: null })
+
+  // Stable ref to setWhimsyFlags — lets the rAF closure call it without
+  // being a dependency (avoids re-creating the loop on each render).
+  const setWhimsyFlagsRef = useRef(setWhimsyFlags)
+  useEffect(() => {
+    setWhimsyFlagsRef.current = setWhimsyFlags
+  }, [setWhimsyFlags])
+
+  // rAF loop — reads store state directly each frame (no subscription needed;
+  // getState() is synchronous and always returns the latest snapshot).
   useEffect(() => {
     const frame = (timestamp: number): void => {
+      // Stamp the real start timestamp on the first frame after arming.
+      if (coldBootRef.current.startTs === -1) {
+        coldBootRef.current = { startTs: timestamp }
+      }
+
       const { leftDb, rightDb } = useStore.getState()
-      const level = leftDb ?? -Infinity
-      const peak = rightDb ?? -Infinity
+      let level = leftDb ?? -Infinity
+      let peak = rightDb ?? -Infinity
+
+      const cbStart = coldBootRef.current.startTs
+      if (cbStart !== null) {
+        const elapsed = timestamp - cbStart
+        if (elapsed < COLD_BOOT_VU_MS) {
+          // Sin arc maps [0, 800ms] → segment count [0, 24, 0].
+          // Reverse-mapped to dBFS so VU draw fn produces the correct count.
+          const t = elapsed / COLD_BOOT_VU_MS
+          const sweepLevel = DB_MIN + Math.sin(t * Math.PI) * DB_RANGE
+          level = sweepLevel
+          peak = sweepLevel
+        } else if (elapsed >= COLD_BOOT_END_MS) {
+          coldBootRef.current = { startTs: null }
+          setWhimsyFlagsRef.current({ coldBoot: false, coldBootDone: true })
+        }
+        // Between COLD_BOOT_VU_MS and COLD_BOOT_END_MS: real audio resumes for
+        // VU/oscilloscope while TrackDisplay holds the INIT stamp.
+      }
+
       drawsRef.current.forEach((draw) => draw(level, peak, timestamp))
       rafIdRef.current = requestAnimationFrame(frame)
     }
@@ -70,33 +147,22 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
     }
   }, [])
 
-  // Discrete playback state — changes are infrequent so React state is fine here.
-  const player = useStore((s) => s.player)
-  const isPlaying = player.playing
-  const isPaused = !player.playing && player.current_track !== null
-
-  const trackMeta = useMemo((): TrackMeta | null => {
-    const t = player.current_track
-    if (!t) return null
-    return {
-      artist: t.artist || t.album_artist,
-      title: t.title,
-      year: t.year,
-      format: t.ext.replace(/^\./, '').toUpperCase(),
-      duration: player.duration
-    }
-  }, [player.current_track, player.duration])
-
-  // Whimsy flags — updated discretely by delight-layer tasks (KAMP-321+).
-  const [whimsyFlags, setWhimsyFlagsState] = useState<WhimsyFlags>({
-    coldBootDone: false,
-    konamiActive: false,
-    firstTrackOfDayShown: false
-  })
-
-  const setWhimsyFlags = useCallback((patch: Partial<WhimsyFlags>) => {
-    setWhimsyFlagsState((prev) => ({ ...prev, ...patch }))
-  }, [])
+  // Arm the cold boot sequence on the first play event after app launch.
+  // Subscribes to the store directly (not via isPlaying) so setState is called
+  // from a subscription callback rather than synchronously in the effect body.
+  // localStorage gate ensures it fires once per app lifetime, not per session.
+  useEffect(() => {
+    let triggered = false
+    const unsub = useStore.subscribe((state) => {
+      if (triggered || !state.player.playing) return
+      if (localStorage.getItem('stereo-rack:coldBootSeen')) return
+      triggered = true
+      localStorage.setItem('stereo-rack:coldBootSeen', '1')
+      coldBootRef.current = { startTs: -1 }
+      setWhimsyFlags({ coldBoot: true })
+    })
+    return unsub
+  }, [setWhimsyFlags])
 
   const contextValue = useMemo<StereoRackContextValue>(
     () => ({
@@ -105,10 +171,20 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
       trackMeta,
       whimsyFlags,
       setWhimsyFlags,
+      coldBootRef,
       registerDraw,
       unregisterDraw
     }),
-    [isPlaying, isPaused, trackMeta, whimsyFlags, setWhimsyFlags, registerDraw, unregisterDraw]
+    [
+      isPlaying,
+      isPaused,
+      trackMeta,
+      whimsyFlags,
+      setWhimsyFlags,
+      coldBootRef,
+      registerDraw,
+      unregisterDraw
+    ]
   )
 
   return (

--- a/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
@@ -38,18 +38,29 @@ const END_HOLD_MS = 1000
 // Gap between the two text copies. Must stay in sync with .track-gap width in CSS.
 const MARQUEE_GAP_PX = 60
 
+// Cold boot blink sequence: 2 off/on cycles at 150ms each = 600ms total.
+const COLD_BOOT_BLINK_MS = 150
+
 type TrackLeftProps = {
   artist: string
   title: string
   // Freeze scrolling when whimsy replaces left-cluster content (wired in KAMP-321).
   whimsyActive?: boolean
+  // Triggers cold-boot blink + INIT stamp animation (KAMP-328).
+  coldBoot?: boolean
 }
 
-function TrackLeft({ artist, title, whimsyActive = false }: TrackLeftProps): React.JSX.Element {
+function TrackLeft({
+  artist,
+  title,
+  whimsyActive = false,
+  coldBoot = false
+}: TrackLeftProps): React.JSX.Element {
   const containerRef = useRef<HTMLSpanElement | null>(null)
   const scrollRef = useRef<HTMLSpanElement | null>(null)
   const ellipsisRef = useRef<HTMLSpanElement | null>(null)
   const copyBRef = useRef<HTMLSpanElement | null>(null)
+  const initOverlayRef = useRef<HTMLSpanElement | null>(null)
 
   const phaseRef = useRef<ScrollPhase>('idle')
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -58,6 +69,10 @@ function TrackLeft({ artist, title, whimsyActive = false }: TrackLeftProps): Rea
   // Actual rendered width of one copy — measured from scrollWidth with copy B hidden.
   // Stored so the phase-2 transitionend handler can compute the exact target.
   const textWidthRef = useRef<number>(0)
+
+  // Cold boot timer and "was active" gate to prevent double-start on re-renders.
+  const coldBootTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const coldBootWasActiveRef = useRef(false)
 
   const cancel = useCallback((): void => {
     clearTimeout(timerRef.current)
@@ -192,6 +207,63 @@ function TrackLeft({ artist, title, whimsyActive = false }: TrackLeftProps): Rea
     if (whimsyActive) cancel()
   }, [whimsyActive, cancel])
 
+  // Cold boot: blink twice then show INIT HH:MM for ~1.6s.
+  // Sequence driven by the frame loop; we just react to the flag transitions.
+  useEffect(() => {
+    if (coldBoot) {
+      coldBootWasActiveRef.current = true
+      cancel()
+
+      const scrollEl = scrollRef.current
+      const initEl = initOverlayRef.current
+      if (!scrollEl) return
+
+      // 2 off/on blink cycles (4 × 150ms = 600ms), then INIT display.
+      scrollEl.style.opacity = '0'
+      coldBootTimerRef.current = setTimeout(() => {
+        scrollEl.style.opacity = '1'
+        coldBootTimerRef.current = setTimeout(() => {
+          scrollEl.style.opacity = '0'
+          coldBootTimerRef.current = setTimeout(() => {
+            scrollEl.style.opacity = '1'
+            coldBootTimerRef.current = setTimeout(() => {
+              // INIT phase: swap scroll inner for overlay text.
+              scrollEl.style.display = 'none'
+              scrollEl.style.opacity = '1' // reset for restore
+              if (initEl) {
+                const now = new Date()
+                const hh = now.getHours().toString().padStart(2, '0')
+                const mm = now.getMinutes().toString().padStart(2, '0')
+                initEl.textContent = `INIT ${hh}:${mm}`
+                initEl.style.display = 'inline-flex'
+              }
+              // Holds until coldBoot transitions to false (frame loop at ~2200ms).
+            }, COLD_BOOT_BLINK_MS)
+          }, COLD_BOOT_BLINK_MS)
+        }, COLD_BOOT_BLINK_MS)
+      }, COLD_BOOT_BLINK_MS)
+    } else if (coldBootWasActiveRef.current) {
+      // Cold boot ended — restore scroll inner and restart scroll machine.
+      coldBootWasActiveRef.current = false
+      clearTimeout(coldBootTimerRef.current)
+      coldBootTimerRef.current = undefined
+      const scrollEl = scrollRef.current
+      const initEl = initOverlayRef.current
+      if (initEl) {
+        initEl.style.display = 'none'
+        initEl.textContent = ''
+      }
+      if (scrollEl) {
+        scrollEl.style.display = ''
+        scrollEl.style.opacity = '1'
+      }
+      start()
+    }
+  }, [coldBoot, cancel, start])
+
+  // Cleanup cold boot timers on unmount.
+  useEffect(() => () => clearTimeout(coldBootTimerRef.current), [])
+
   const content = (withEllipsis: boolean): React.JSX.Element =>
     artist ? (
       <>
@@ -218,6 +290,7 @@ function TrackLeft({ artist, title, whimsyActive = false }: TrackLeftProps): Rea
           {content(false)}
         </span>
       </span>
+      <span ref={initOverlayRef} className="track-init-overlay" style={{ display: 'none' }} />
     </span>
   )
 }
@@ -245,14 +318,18 @@ function TrackRight({ position, duration, year, format }: TrackRightProps): Reac
 // ---------------------------------------------------------------------------
 
 export function TrackDisplay(): React.JSX.Element {
-  const { isPlaying, trackMeta } = useStereoRack()
+  const { isPlaying, trackMeta, whimsyFlags } = useStereoRack()
   const position = useStore((s) => s.player.position)
 
   return (
     <div className={`track-display${isPlaying ? '' : ' is-idle'}`}>
       {trackMeta && (
         <>
-          <TrackLeft artist={trackMeta.artist} title={trackMeta.title} />
+          <TrackLeft
+            artist={trackMeta.artist}
+            title={trackMeta.title}
+            coldBoot={whimsyFlags.coldBoot}
+          />
           <TrackRight
             position={position}
             duration={trackMeta.duration}


### PR DESCRIPTION
## Summary

- On first `play` event after app launch, checks `localStorage: stereo-rack:coldBootSeen` — if absent, fires the calibration sequence and sets the key (never repeats until key is cleared)
- VU bars sweep 0→24→0 segments over 800ms via a sin arc (`DB_MIN + sin(t·��)·DB_RANGE`), overriding real `levelDb` in the rAF loop
- Oscilloscope simultaneously draws a clean `sin(x)` (phase reset to 0, no harmonics, no seed variation) for the 800ms window, then hands off to normal parametric rendering
- Track display blinks twice (4×150ms) then shows `INIT HH:MM` for ~1.6s; returns to normal scroll when the frame loop sends `coldBoot: false` at 2200ms

## Architecture

- `coldBootRef` (mutable ref) threaded through `StereoRackContext` so the oscilloscope's rAF draw closure can check it without React state re-renders
- Frame loop owns the lifecycle: arms on first play event (via `useStore.subscribe`), stamps the real rAF timestamp on the next tick, ends at 2200ms
- TrackDisplay blink/INIT animation uses imperative DOM manipulation (same pattern as the scroll state machine), driven by `whimsyFlags.coldBoot` transitions

## Test plan

- [ ] Clear `localStorage` key (`stereo-rack:coldBootSeen`), reload app, play a track — observe VU sweep, clean oscilloscope sine, and INIT stamp
- [ ] Verify sequence runs only once per app lifetime (reload without clearing key — no animation)
- [ ] Confirm normal playback is unaffected after the sequence completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)