### PR TITLE
feat(KAMP-330): Dead Air — thermal noise, blinking cursor, --:-- display

### DIFF
--- a/kamp_ui/src/renderer/src/assets/stereo-rack.css
+++ b/kamp_ui/src/renderer/src/assets/stereo-rack.css
@@ -208,6 +208,14 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* Dead air cursor — blinking underscore shown when no track / idle >60s */
+.track-dead-air-cursor {
+  display: none; /* toggled imperatively */
+  align-items: center;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.50);
+}
+
 /* Cold boot INIT overlay — shown in place of track-scroll-inner during calibration */
 .track-init-overlay {
   display: none; /* toggled imperatively */

--- a/kamp_ui/src/renderer/src/components/modules/Oscilloscope.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/Oscilloscope.tsx
@@ -58,7 +58,8 @@ function resizeBuffer(prev: Float32Array | null, newW: number): Float32Array {
 // ---------------------------------------------------------------------------
 
 export function Oscilloscope(): React.JSX.Element {
-  const { registerDraw, unregisterDraw, isPaused, trackMeta, coldBootRef } = useStereoRack()
+  const { registerDraw, unregisterDraw, isPaused, trackMeta, coldBootRef, deadAirRef } =
+    useStereoRack()
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
@@ -139,6 +140,35 @@ export function Oscilloscope(): React.JSX.Element {
       if (!ctx) return
       const { w, h } = sizeRef.current
       if (w === 0 || h === 0) return
+
+      // --- Dead air: thermal noise polyline, skip ring buffer entirely ---
+      if (deadAirRef.current) {
+        ctx.clearRect(0, 0, w, h)
+        ctx.save()
+        ctx.strokeStyle = 'rgba(255,255,255,0.08)'
+        ctx.lineWidth = 1
+        ctx.setLineDash([4, 6])
+        ctx.beginPath()
+        ctx.moveTo(0, h / 2)
+        ctx.lineTo(w, h / 2)
+        ctx.stroke()
+        ctx.restore()
+
+        ctx.save()
+        ctx.strokeStyle = accentRef.current
+        ctx.lineWidth = 1.5
+        ctx.setLineDash([])
+        ctx.beginPath()
+        const midY = h / 2
+        for (let x = 0; x <= w; x++) {
+          const py = midY + (Math.random() - 0.5) * 2
+          if (x === 0) ctx.moveTo(x, py)
+          else ctx.lineTo(x, py)
+        }
+        ctx.stroke()
+        ctx.restore()
+        return
+      }
 
       // Ensure the buffer matches the current canvas width.
       if (!bufferRef.current || bufferRef.current.length !== w) {
@@ -245,7 +275,7 @@ export function Oscilloscope(): React.JSX.Element {
     })
 
     return () => unregisterDraw('oscilloscope')
-  }, [registerDraw, unregisterDraw, coldBootRef])
+  }, [registerDraw, unregisterDraw, coldBootRef, deadAirRef])
 
   return <canvas ref={canvasRef} className="oscilloscope" />
 }

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackContext.tsx
@@ -39,6 +39,13 @@ export type StereoRackContextValue = {
    * `startTs >= 0`      → active; elapsed = current timestamp − startTs
    */
   coldBootRef: MutableRefObject<{ startTs: number | null }>
+  /** True when no track is loaded or playback has been paused for >60s. */
+  isDeadAir: boolean
+  /**
+   * Mutable ref mirroring isDeadAir — read by rAF draw callbacks to avoid
+   * React state subscription overhead inside the per-frame hot path.
+   */
+  deadAirRef: MutableRefObject<boolean>
   /** Register a per-frame draw callback. Call from a useEffect on mount. */
   registerDraw: (id: string, fn: DrawFn) => void
   /** Unregister a draw callback. Call from the useEffect cleanup. */

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
@@ -9,6 +9,8 @@
  *  - Cold boot calibration sequence (KAMP-328): on the first play event after
  *    app launch, overrides levelDb with a 0→24→0 segment sweep for 800ms and
  *    signals child components to run their whimsy animations.
+ *  - Dead air detection (KAMP-330): tracks pause idle duration per rAF frame;
+ *    signals isDeadAir when no track is loaded or paused for >60s.
  *
  * Per-frame mutable state (level, peak, decay accumulators, whimsy timers)
  * lives in the child components' useRefs — this shell intentionally holds none.
@@ -34,6 +36,9 @@ const COLD_BOOT_VU_MS = 800
 const COLD_BOOT_END_MS = 2200
 const DB_MIN = -60
 const DB_RANGE = 60
+
+// Dead air activates after this many milliseconds of continuous pause.
+const DEAD_AIR_IDLE_MS = 60_000
 
 // displayStyle is required by ModuleProps but unused — StereoRack has a fixed layout.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -94,18 +99,46 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
     setWhimsyFlagsRef.current = setWhimsyFlags
   }, [setWhimsyFlags])
 
+  // Dead air state (KAMP-330): no track loaded OR paused for >60s.
+  const [isDeadAir, setIsDeadAir] = useState(false)
+  const deadAirRef = useRef(false)
+  const setDeadAirRef = useRef(setIsDeadAir)
+  useEffect(() => {
+    setDeadAirRef.current = setIsDeadAir
+  }, [])
+
   // rAF loop — reads store state directly each frame (no subscription needed;
   // getState() is synchronous and always returns the latest snapshot).
   useEffect(() => {
+    // Pause idle tracking — local to this closure, no React state involved.
+    let pauseStartTs = -1
+    let idleElapsedMs = 0
+
     const frame = (timestamp: number): void => {
       // Stamp the real start timestamp on the first frame after arming.
       if (coldBootRef.current.startTs === -1) {
         coldBootRef.current = { startTs: timestamp }
       }
 
-      const { leftDb, rightDb } = useStore.getState()
+      const { leftDb, rightDb, player } = useStore.getState()
       let level = leftDb ?? -Infinity
       let peak = rightDb ?? -Infinity
+
+      // --- Dead air idle tracking ---
+      const paused = !player.playing && player.current_track !== null
+      const noTrack = player.current_track === null
+      if (paused) {
+        if (pauseStartTs < 0) pauseStartTs = timestamp
+        idleElapsedMs = timestamp - pauseStartTs
+      } else {
+        pauseStartTs = -1
+        idleElapsedMs = 0
+      }
+      const shouldBeDeadAir = noTrack || idleElapsedMs > DEAD_AIR_IDLE_MS
+      if (shouldBeDeadAir !== deadAirRef.current) {
+        deadAirRef.current = shouldBeDeadAir
+        setDeadAirRef.current(shouldBeDeadAir)
+      }
 
       const cbStart = coldBootRef.current.startTs
       if (cbStart !== null) {
@@ -172,6 +205,8 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
       whimsyFlags,
       setWhimsyFlags,
       coldBootRef,
+      isDeadAir,
+      deadAirRef,
       registerDraw,
       unregisterDraw
     }),
@@ -182,6 +217,8 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
       whimsyFlags,
       setWhimsyFlags,
       coldBootRef,
+      isDeadAir,
+      deadAirRef,
       registerDraw,
       unregisterDraw
     ]

--- a/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
@@ -41,6 +41,10 @@ const MARQUEE_GAP_PX = 60
 // Cold boot blink sequence: 2 off/on cycles at 150ms each = 600ms total.
 const COLD_BOOT_BLINK_MS = 150
 
+// Dead air cursor: visible 600ms, hidden 400ms.
+const CURSOR_ON_MS = 600
+const CURSOR_OFF_MS = 400
+
 type TrackLeftProps = {
   artist: string
   title: string
@@ -48,19 +52,23 @@ type TrackLeftProps = {
   whimsyActive?: boolean
   // Triggers cold-boot blink + INIT stamp animation (KAMP-328).
   coldBoot?: boolean
+  // Replaces content with blinking underscore cursor (KAMP-330).
+  isDeadAir?: boolean
 }
 
 function TrackLeft({
   artist,
   title,
   whimsyActive = false,
-  coldBoot = false
+  coldBoot = false,
+  isDeadAir = false
 }: TrackLeftProps): React.JSX.Element {
   const containerRef = useRef<HTMLSpanElement | null>(null)
   const scrollRef = useRef<HTMLSpanElement | null>(null)
   const ellipsisRef = useRef<HTMLSpanElement | null>(null)
   const copyBRef = useRef<HTMLSpanElement | null>(null)
   const initOverlayRef = useRef<HTMLSpanElement | null>(null)
+  const cursorRef = useRef<HTMLSpanElement | null>(null)
 
   const phaseRef = useRef<ScrollPhase>('idle')
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -73,6 +81,10 @@ function TrackLeft({
   // Cold boot timer and "was active" gate to prevent double-start on re-renders.
   const coldBootTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const coldBootWasActiveRef = useRef(false)
+
+  // Dead air cursor timer (alternating timeouts, stored as setInterval ref per spec).
+  const cursorTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const deadAirWasActiveRef = useRef(false)
 
   const cancel = useCallback((): void => {
     clearTimeout(timerRef.current)
@@ -261,8 +273,52 @@ function TrackLeft({
     }
   }, [coldBoot, cancel, start])
 
-  // Cleanup cold boot timers on unmount.
-  useEffect(() => () => clearTimeout(coldBootTimerRef.current), [])
+  // Dead air: show blinking underscore cursor, hide normal content.
+  // Cursor blinks 600ms on / 400ms off via alternating timeouts (setInterval ref).
+  useEffect(() => {
+    if (isDeadAir) {
+      deadAirWasActiveRef.current = true
+      cancel()
+      const scrollEl = scrollRef.current
+      const cursorEl = cursorRef.current
+      if (scrollEl) scrollEl.style.display = 'none'
+      if (!cursorEl) return
+
+      cursorEl.style.display = 'inline-flex'
+      cursorEl.textContent = '_'
+
+      const blink = (visible: boolean): void => {
+        if (cursorEl) cursorEl.textContent = visible ? '_' : ''
+        cursorTimerRef.current = setTimeout(
+          () => blink(!visible),
+          visible ? CURSOR_ON_MS : CURSOR_OFF_MS
+        )
+      }
+      cursorTimerRef.current = setTimeout(() => blink(false), CURSOR_ON_MS)
+    } else if (deadAirWasActiveRef.current) {
+      // Dead air ended — restore scroll inner and restart scroll machine.
+      deadAirWasActiveRef.current = false
+      clearTimeout(cursorTimerRef.current)
+      cursorTimerRef.current = undefined
+      const scrollEl = scrollRef.current
+      const cursorEl = cursorRef.current
+      if (cursorEl) {
+        cursorEl.style.display = 'none'
+        cursorEl.textContent = ''
+      }
+      if (scrollEl) scrollEl.style.display = ''
+      start()
+    }
+  }, [isDeadAir, cancel, start])
+
+  // Cleanup timers on unmount.
+  useEffect(
+    () => () => {
+      clearTimeout(coldBootTimerRef.current)
+      clearTimeout(cursorTimerRef.current)
+    },
+    []
+  )
 
   const content = (withEllipsis: boolean): React.JSX.Element =>
     artist ? (
@@ -291,6 +347,7 @@ function TrackLeft({
         </span>
       </span>
       <span ref={initOverlayRef} className="track-init-overlay" style={{ display: 'none' }} />
+      <span ref={cursorRef} className="track-dead-air-cursor" style={{ display: 'none' }} />
     </span>
   )
 }
@@ -299,9 +356,31 @@ function TrackLeft({
 // TrackRight
 // ---------------------------------------------------------------------------
 
-type TrackRightProps = { position: number; duration: number; year: string; format: string }
+type TrackRightProps = {
+  position: number
+  duration: number
+  year: string
+  format: string
+  isDeadAir?: boolean
+}
 
-function TrackRight({ position, duration, year, format }: TrackRightProps): React.JSX.Element {
+function TrackRight({
+  position,
+  duration,
+  year,
+  format,
+  isDeadAir = false
+}: TrackRightProps): React.JSX.Element {
+  if (isDeadAir) {
+    return (
+      <span className="track-right">
+        <span className="track-time">--:--</span>
+        <span className="track-timesep">/</span>
+        <span className="track-time">--:--</span>
+      </span>
+    )
+  }
+
   return (
     <span className="track-right">
       <span className="track-time">{formatTime(position)}</span>
@@ -318,23 +397,29 @@ function TrackRight({ position, duration, year, format }: TrackRightProps): Reac
 // ---------------------------------------------------------------------------
 
 export function TrackDisplay(): React.JSX.Element {
-  const { isPlaying, trackMeta, whimsyFlags } = useStereoRack()
+  const { isPlaying, trackMeta, whimsyFlags, isDeadAir } = useStereoRack()
   const position = useStore((s) => s.player.position)
+
+  // Show content when a track is loaded or dead air is active (dead air renders
+  // its own placeholder content — the cursor and blank time fields).
+  const showContent = isDeadAir || trackMeta !== null
 
   return (
     <div className={`track-display${isPlaying ? '' : ' is-idle'}`}>
-      {trackMeta && (
+      {showContent && (
         <>
           <TrackLeft
-            artist={trackMeta.artist}
-            title={trackMeta.title}
+            artist={trackMeta?.artist ?? ''}
+            title={trackMeta?.title ?? ''}
             coldBoot={whimsyFlags.coldBoot}
+            isDeadAir={isDeadAir}
           />
           <TrackRight
             position={position}
-            duration={trackMeta.duration}
-            year={trackMeta.year}
-            format={trackMeta.format}
+            duration={trackMeta?.duration ?? 0}
+            year={trackMeta?.year ?? ''}
+            format={trackMeta?.format ?? ''}
+            isDeadAir={isDeadAir}
           />
         </>
       )}


### PR DESCRIPTION
## Summary

- **Trigger**: `trackMeta === null` (no track loaded) OR `isPaused && idleElapsed > 60s` — tracked per rAF frame in the frame loop closure, no React state involved
- **Oscilloscope**: draws per-frame thermal noise — `(Math.random() - 0.5) * 2` px jitter polyline around the zero-line, bypassing the ring buffer entirely; exits back to normal waveform within 1 rAF frame
- **Track display left**: blinking underscore cursor — `_` visible 600ms / hidden 400ms via alternating `setTimeout`s (imperative DOM write, no React state); scroll machine is cancelled on entry and restarted on exit
- **Track display right**: `--:-- / --:--` with year and format badge hidden
- **VU meters**: no changes needed — by the time 60s idle elapses the 18 dB/s decay has already driven segments to zero, and with no track loaded `levelDb` is `-Infinity` → 0 segments from mount

## Architecture

- `isDeadAir: boolean` (React state) + `deadAirRef: MutableRefObject<boolean>` (mutable, for rAF hot path) threaded through `StereoRackContext`
- Idle tracking runs inside the rAF frame closure with local `let pauseStartTs / idleElapsedMs` — updates `deadAirRef` synchronously and queues a React state update only on transition (not every frame)
- `TrackDisplay` renders `TrackLeft`/`TrackRight` whenever `isDeadAir || trackMeta !== null`, so the cursor is visible even when no track is loaded

## Test plan

- [x] Load the app with no track — verify thermal noise, blinking cursor, `--:-- / --:--` immediately
- [ ] Play a track, pause, wait >60s — verify dead air activates
- [ ] Resume playback or load a new track — verify instant return to normal within one frame
- [ ] Verify cold boot (KAMP-328) and dead air do not interfere (cold boot fires on play, dead air deactivates on play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)