### PR TITLE
feat(KAMP-334): Stereo Rack polish — remove bottom pad, add to default setup

### DIFF
--- a/kamp_ui/src/renderer/src/assets/stereo-rack.css
+++ b/kamp_ui/src/renderer/src/assets/stereo-rack.css
@@ -325,6 +325,16 @@
   }
 }
 
+/* ============================================================
+   Base Kamp integration — suppress the module body min-height
+   (.base-kamp-module-body has min-height: 285px for shelf modules;
+   the stereo rack is much shorter and needs no floor.)
+   ============================================================ */
+
+.base-kamp-module-body:has(.stereo-rack-module) {
+  min-height: 0;
+}
+
 /* always: when container is narrow enough that meters would show ≤10 segments
    (oscilloscope 240px + 2×8px gap + 2×100px meters = 456px), hide meters
    and let the plasma fill the full width. */

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -212,7 +212,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   activeView: 'library',
   moduleOrder: (() => {
     const saved = localStorage.getItem('kamp:module-order')
-    return saved ? (JSON.parse(saved) as string[]) : ['kamp.new-arrivals', 'kamp.last-played']
+    return saved ? (JSON.parse(saved) as string[]) : ['kamp.stereo-rack', 'kamp.new-arrivals', 'kamp.last-played']
   })(),
   hiddenModules: (() => {
     const saved = localStorage.getItem('kamp:hidden-modules')

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -212,7 +212,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
   activeView: 'library',
   moduleOrder: (() => {
     const saved = localStorage.getItem('kamp:module-order')
-    return saved ? (JSON.parse(saved) as string[]) : ['kamp.stereo-rack', 'kamp.new-arrivals', 'kamp.last-played']
+    return saved
+      ? (JSON.parse(saved) as string[])
+      : ['kamp.stereo-rack', 'kamp.new-arrivals', 'kamp.last-played']
   })(),
   hiddenModules: (() => {
     const saved = localStorage.getItem('kamp:hidden-modules')


### PR DESCRIPTION
## Summary

- Suppress `min-height: 285px` on `.base-kamp-module-body` when it contains the stereo rack (`:has(.stereo-rack-module)`), eliminating ~100px of dead space below the track display. The min-height is sized for shelf/grid modules and inappropriate for the compact stereo rack layout.
- Add `kamp.stereo-rack` to the top of the default `moduleOrder` so fresh installs show it without manual setup.

## Test plan

- [x] Stereo rack module in Base Kamp has no excess padding below the track display
- [x] New-arrivals and last-played modules are unaffected (still have their min-height floor)
- [x] Clear `localStorage` key `kamp:module-order` and reload — stereo rack appears first in Base Kamp
- [x] Existing users with saved module order are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)