### PR TITLE
fix(KAMP-335): start playback when add/play-next called with no track loaded

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1833,8 +1833,14 @@ def create_app(
         track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
+        was_stopped = queue.current() is None
         queue.add_to_queue(track)
-        engine.preload_next(queue.peek_next())
+        current = queue.current()
+        if was_stopped and current is not None:
+            engine.play(current.file_path)
+            _notify_track_changed()
+        else:
+            engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/play-next")
@@ -1843,8 +1849,14 @@ def create_app(
         track = index.get_track_by_path(p)
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
+        was_stopped = queue.current() is None
         queue.play_next(track)
-        engine.preload_next(queue.peek_next())
+        current = queue.current()
+        if was_stopped and current is not None:
+            engine.play(current.file_path)
+            _notify_track_changed()
+        else:
+            engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/insert")
@@ -1867,8 +1879,14 @@ def create_app(
             tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
+        was_stopped = queue.current() is None
         queue.add_album_to_queue(tracks)
-        engine.preload_next(queue.peek_next())
+        current = queue.current()
+        if was_stopped and current is not None:
+            engine.play(current.file_path)
+            _notify_track_changed()
+        else:
+            engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/play-album-next")
@@ -1881,8 +1899,14 @@ def create_app(
             tracks = index.tracks_for_album(req.album_artist, req.album)
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
+        was_stopped = queue.current() is None
         queue.play_album_next(tracks)
-        engine.preload_next(queue.peek_next())
+        current = queue.current()
+        if was_stopped and current is not None:
+            engine.play(current.file_path)
+            _notify_track_changed()
+        else:
+            engine.preload_next(queue.peek_next())
         return {"ok": True}
 
     @app.post("/api/v1/player/queue/insert-album")

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -678,8 +678,11 @@ def _cmd_daemon(
             # will fire shortly and preload_next will queue the new next track.
         else:
             engine.stop()
-            # Queue exhausted — clear saved state so restart starts fresh
-            # rather than restoring the last track a few seconds from the end.
+            # Queue exhausted — reset in-memory queue so subsequent add/play-next
+            # operations start fresh rather than appending to stale old tracks.
+            queue.clear()
+            # Clear saved state so restart starts fresh rather than restoring
+            # the last track a few seconds from the end.
             index.clear_player_state()
             index.clear_queue_state()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -969,6 +969,42 @@ class TestQueueMutationEndpoints:
         assert resp.status_code == 200
         mock_engine.play.assert_not_called()
 
+    def test_add_to_queue_starts_playback_when_stopped(
+        self,
+        client: TestClient,
+        mock_index: MagicMock,
+        mock_queue: MagicMock,
+        mock_engine: MagicMock,
+    ) -> None:
+        t = _track(1)
+        mock_index.get_track_by_path.return_value = t
+        # Three calls: was_stopped check, current after mutation, _state_snapshot in notify
+        mock_queue.current.side_effect = [None, t, t]
+        resp = client.post(
+            "/api/v1/player/queue/add", json={"file_path": str(t.file_path)}
+        )
+        assert resp.status_code == 200
+        mock_engine.play.assert_called_once_with(t.file_path)
+        mock_engine.preload_next.assert_not_called()
+
+    def test_play_next_starts_playback_when_stopped(
+        self,
+        client: TestClient,
+        mock_index: MagicMock,
+        mock_queue: MagicMock,
+        mock_engine: MagicMock,
+    ) -> None:
+        t = _track(2)
+        mock_index.get_track_by_path.return_value = t
+        # Three calls: was_stopped check, current after mutation, _state_snapshot in notify
+        mock_queue.current.side_effect = [None, t, t]
+        resp = client.post(
+            "/api/v1/player/queue/play-next", json={"file_path": str(t.file_path)}
+        )
+        assert resp.status_code == 200
+        mock_engine.play.assert_called_once_with(t.file_path)
+        mock_engine.preload_next.assert_not_called()
+
 
 class TestAlbumQueueEndpoints:
     def test_add_album_to_queue_calls_queue_method(
@@ -1036,6 +1072,44 @@ class TestAlbumQueueEndpoints:
             json={"album_artist": "X", "album": "Y", "index": 0},
         )
         assert resp.status_code == 404
+
+    def test_add_album_starts_playback_when_stopped(
+        self,
+        client: TestClient,
+        mock_index: MagicMock,
+        mock_queue: MagicMock,
+        mock_engine: MagicMock,
+    ) -> None:
+        ts = [_track(i) for i in range(3)]
+        mock_index.tracks_for_album.return_value = ts
+        # Three calls: was_stopped check, current after mutation, _state_snapshot in notify
+        mock_queue.current.side_effect = [None, ts[0], ts[0]]
+        resp = client.post(
+            "/api/v1/player/queue/add-album",
+            json={"album_artist": "Artist", "album": "Album"},
+        )
+        assert resp.status_code == 200
+        mock_engine.play.assert_called_once_with(ts[0].file_path)
+        mock_engine.preload_next.assert_not_called()
+
+    def test_play_album_next_starts_playback_when_stopped(
+        self,
+        client: TestClient,
+        mock_index: MagicMock,
+        mock_queue: MagicMock,
+        mock_engine: MagicMock,
+    ) -> None:
+        ts = [_track(i) for i in range(3)]
+        mock_index.tracks_for_album.return_value = ts
+        # Three calls: was_stopped check, current after mutation, _state_snapshot in notify
+        mock_queue.current.side_effect = [None, ts[0], ts[0]]
+        resp = client.post(
+            "/api/v1/player/queue/play-album-next",
+            json={"album_artist": "Artist", "album": "Album"},
+        )
+        assert resp.status_code == 200
+        mock_engine.play.assert_called_once_with(ts[0].file_path)
+        mock_engine.preload_next.assert_not_called()
 
 
 class TestPlayerWebSocket:


### PR DESCRIPTION
## Summary

- When the queue exhausts naturally, `_on_track_end` now calls `queue.clear()` after `engine.stop()`, dropping old tracks from memory so subsequent add/play-next operations start from a clean slate
- Four queue-mutation server endpoints (`queue_add`, `queue_play_next`, `queue_add_album`, `queue_play_album_next`) now detect the stopped condition and call `engine.play()` + `_notify_track_changed()` instead of only syncing the gapless lookahead
- Fixes transport breaking until restart, scrub bar stuck at end, no playback starting, and queue entering bad state after exhaustion

## Test plan

- [x] Play an album to completion; confirm transport stops and position resets
- [x] Right-click another album → **Add to Queue** → playback starts immediately at track 1
- [x] Right-click another album → **Play Next** → playback starts immediately at track 1
- [x] Verify normal mid-queue add/play-next still works (lookahead path, no regressions)
- [x] `poetry run pytest tests/test_server.py::TestQueueMutationEndpoints tests/test_server.py::TestAlbumQueueEndpoints -v --no-cov`

Closes KAMP-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)