### PR TITLE
feat(KAMP-339): clear search when navigating to a view tab

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -487,6 +487,7 @@ export default function App(): React.JSX.Element {
 
   // Activate a main-slot panel tab.
   const activateMain = (panel: UnifiedPanel): void => {
+    void setSearchQuery('')
     if (panel.kind === 'builtin' && panel.id === 'kamp.base-kamp') {
       void setActiveView('home')
       setActiveExtPanel(null)


### PR DESCRIPTION
## Summary

- Clicking any view tab while search results are showing now clears the search query and navigates to the selected tab
- One-line fix in `activateMain`: call `setSearchQuery('')` before processing the tab switch

## Test plan

- [ ] Search for something, then click Now Playing — search clears, Now Playing opens
- [ ] Search for something, then click Library — search clears, Library opens
- [ ] Search for something, then click Base Kamp — search clears, home view opens
- [ ] Tab switch with no active search — behaves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)