### PR TITLE
feat(KAMP-230): MusicBrainz fetch & compare in album edit mode

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1234,8 +1234,9 @@ class LibraryIndex:
         genre: str | None = None,
         label: str | None = None,
         year: str | None = None,
+        mb_release_id: str | None = None,
     ) -> list[Track]:
-        """Write genre, label, and/or year to every track in *album*.
+        """Write genre, label, year, and/or mb_release_id to every track in *album*.
 
         Returns the updated Track objects.  Only the provided (non-None) fields
         are changed; the others are left as-is in the database.
@@ -1251,6 +1252,9 @@ class LibraryIndex:
         if year is not None:
             sets.append("year = ?")
             params.append(year)
+        if mb_release_id is not None:
+            sets.append("mb_release_id = ?")
+            params.append(mb_release_id)
         if not sets:
             return self.tracks_for_album(album_artist, album)
         params.extend([album_artist, album])
@@ -1261,6 +1265,23 @@ class LibraryIndex:
         )
         self._conn.commit()
         return self.tracks_for_album(album_artist, album)
+
+    def update_track_mb_recording_id(
+        self, track_id: int, mb_recording_id: str
+    ) -> Track | None:
+        """Write mb_recording_id to a single track in the database.
+
+        Returns the updated Track, or None if the track_id is not found.
+        """
+        self._conn.execute(
+            "UPDATE tracks SET mb_recording_id = ? WHERE id = ?",
+            (mb_recording_id, track_id),
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            "SELECT * FROM tracks WHERE id = ?", (track_id,)
+        ).fetchone()
+        return _row_to_track(row) if row else None
 
     def toggle_album_favorite(
         self, album_artist: str, album: str, favorite: bool
@@ -2056,8 +2077,9 @@ def write_meta_tags_to_file(
     genre: str | None = None,
     label: str | None = None,
     year: str | None = None,
+    mb_release_id: str | None = None,
 ) -> None:
-    """Write genre, label, and/or year tags to an audio file without moving it.
+    """Write genre, label, year, and/or mb_release_id to an audio file without moving it.
 
     Only the fields that are not None are written; the others are left
     unchanged on disk.  This is a tag-only operation — no file rename occurs.
@@ -2074,6 +2096,10 @@ def write_meta_tags_to_file(
             tags["TPUB"] = id3.TPUB(encoding=3, text=label)
         if year is not None:
             tags["TDRC"] = id3.TDRC(encoding=3, text=year)
+        if mb_release_id is not None:
+            tags["TXXX:MusicBrainz Release Id"] = id3.TXXX(
+                encoding=3, desc="MusicBrainz Release Id", text=mb_release_id
+            )
         tags.save(str(path))
     elif suffix == ".m4a":
         audio = mutagen.mp4.MP4(str(path))
@@ -2087,6 +2113,10 @@ def write_meta_tags_to_file(
             ]
         if year is not None:
             audio.tags["\xa9day"] = [year]  # type: ignore[index]
+        if mb_release_id is not None:
+            audio.tags["----:com.apple.iTunes:MusicBrainz Release Id"] = [  # type: ignore[index]
+                mutagen.mp4.MP4FreeForm(mb_release_id.encode())
+            ]
         audio.save()
     elif suffix == ".flac":
         audio = mutagen.flac.FLAC(str(path))
@@ -2098,6 +2128,8 @@ def write_meta_tags_to_file(
             audio.tags["LABEL"] = [label]  # type: ignore[index]
         if year is not None:
             audio.tags["DATE"] = [year]  # type: ignore[index]
+        if mb_release_id is not None:
+            audio.tags["MUSICBRAINZ_ALBUMID"] = [mb_release_id]  # type: ignore[index]
         audio.save()
     elif suffix == ".ogg":
         audio = mutagen.oggvorbis.OggVorbis(str(path))
@@ -2109,9 +2141,50 @@ def write_meta_tags_to_file(
             audio.tags["LABEL"] = [label]  # type: ignore[index]
         if year is not None:
             audio.tags["DATE"] = [year]  # type: ignore[index]
+        if mb_release_id is not None:
+            audio.tags["MUSICBRAINZ_ALBUMID"] = [mb_release_id]  # type: ignore[index]
         audio.save()
     else:
         raise ValueError(f"Unsupported format for meta tag write: {path.suffix}")
+
+
+def write_track_mbid_to_file(path: Path, *, mb_recording_id: str) -> None:
+    """Write a MusicBrainz recording ID to an audio file without moving it.
+
+    Tag-only operation — no file rename occurs.
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        try:
+            tags = id3.ID3(str(path))
+        except Exception:
+            tags = id3.ID3()
+        tags["TXXX:MusicBrainz Track Id"] = id3.TXXX(
+            encoding=3, desc="MusicBrainz Track Id", text=mb_recording_id
+        )
+        tags.save(str(path))
+    elif suffix == ".m4a":
+        audio = mutagen.mp4.MP4(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["----:com.apple.iTunes:MusicBrainz Track Id"] = [  # type: ignore[index]
+            mutagen.mp4.MP4FreeForm(mb_recording_id.encode())
+        ]
+        audio.save()
+    elif suffix == ".flac":
+        audio = mutagen.flac.FLAC(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["MUSICBRAINZ_TRACKID"] = [mb_recording_id]  # type: ignore[index]
+        audio.save()
+    elif suffix == ".ogg":
+        audio = mutagen.oggvorbis.OggVorbis(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags["MUSICBRAINZ_TRACKID"] = [mb_recording_id]  # type: ignore[index]
+        audio.save()
+    else:
+        raise ValueError(f"Unsupported format for MBID tag write: {path.suffix}")
 
 
 def _read_tags(path: Path) -> Track | None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -263,6 +263,10 @@ class TrackTagsRequest(BaseModel):
     overwrite: bool = False
 
 
+class TrackMetaRequest(BaseModel):
+    mb_recording_id: str
+
+
 class AlbumTagsRequest(BaseModel):
     album: str | None = None
     album_artist: str | None = None
@@ -300,10 +304,34 @@ class AlbumMetaRequest(BaseModel):
     genre: str | None = None
     label: str | None = None
     year: str | None = None
+    mb_release_id: str | None = None
 
 
 class AlbumMetaOut(BaseModel):
     tracks: list[TrackOut]
+
+
+class MusicBrainzTrackOut(BaseModel):
+    track_number: int
+    disc_number: int
+    title: str
+    recording_mbid: str
+
+
+class MusicBrainzReleaseOut(BaseModel):
+    mbid: str
+    release_group_mbid: str
+    title: str
+    album_artist: str
+    year: str
+    label: str
+    release_type: str
+    tracks: list[MusicBrainzTrackOut]
+
+
+class MusicBrainzLookupOut(BaseModel):
+    # Ranked best-first. KAMP-230 always uses candidates[0]; KAMP-231 adds a picker.
+    candidates: list[MusicBrainzReleaseOut]
 
 
 class BandcampProxyFetchResult(BaseModel):
@@ -401,6 +429,7 @@ def create_app(
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
     dev_mode: bool = False,
     auth_token: str | None = None,
+    mb_lookup_fn: Callable[..., Any] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -761,6 +790,36 @@ def create_app(
 
         _notify_library_changed()
         updated = index.get_track_by_id(track_id)
+        return TrackOut.from_track(updated)  # type: ignore[arg-type]
+
+    @app.patch("/api/v1/tracks/{track_id}/meta")
+    def patch_track_meta(track_id: int, req: "TrackMetaRequest") -> "TrackOut":
+        """Write a MusicBrainz recording ID to a track without renaming the file.
+
+        Tag-only operation — no file move occurs.  Returns 404 if the track is
+        not in the library.
+        """
+        from kamp_core.library import write_track_mbid_to_file
+
+        track = index.get_track_by_id(track_id)
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+
+        try:
+            write_track_mbid_to_file(
+                track.file_path, mb_recording_id=req.mb_recording_id
+            )
+        except Exception as exc:
+            logger.exception(
+                "MBID tag write failed for track %d (%s)", track.id, track.file_path
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to write MBID to {track.file_path}: {exc}",
+            ) from exc
+
+        updated = index.update_track_mb_recording_id(track_id, req.mb_recording_id)
+        _notify_library_changed()
         return TrackOut.from_track(updated)  # type: ignore[arg-type]
 
     @app.get("/api/v1/deferred-ops")
@@ -1290,7 +1349,12 @@ def create_app(
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
 
-        if req.genre is None and req.label is None and req.year is None:
+        if (
+            req.genre is None
+            and req.label is None
+            and req.year is None
+            and req.mb_release_id is None
+        ):
             raise HTTPException(status_code=400, detail="No changes requested")
 
         for track in tracks:
@@ -1300,6 +1364,7 @@ def create_app(
                     genre=req.genre,
                     label=req.label,
                     year=req.year,
+                    mb_release_id=req.mb_release_id,
                 )
             except Exception as exc:
                 logger.exception(
@@ -1316,9 +1381,68 @@ def create_app(
             genre=req.genre,
             label=req.label,
             year=req.year,
+            mb_release_id=req.mb_release_id,
         )
         _notify_library_changed()
         return AlbumMetaOut(tracks=[TrackOut.from_track(t) for t in updated])
+
+    @app.get("/api/v1/albums/musicbrainz", response_model=MusicBrainzLookupOut)
+    async def get_album_musicbrainz(
+        album_artist: str, album: str
+    ) -> MusicBrainzLookupOut:
+        """Fetch ranked MusicBrainz release candidates for an album.
+
+        Uses the same tier-1 (per-track recording votes) + tier-2 (album-level
+        search) strategy as the import pipeline.  Returns up to 5 candidates
+        sorted best-first.  The frontend uses candidates[0] for KAMP-230;
+        KAMP-231 will add a picker that steps through the full list.
+
+        Returns 404 if no tracks are found or if MusicBrainz has no match.
+        Returns 503 if mb_lookup_fn was not wired up at server construction.
+        """
+        if mb_lookup_fn is None:
+            raise HTTPException(
+                status_code=503, detail="MusicBrainz lookup not available"
+            )
+
+        tracks = index.tracks_for_album(album_artist, album)
+        if not tracks:
+            raise HTTPException(status_code=404, detail="Album not found")
+
+        tuples = [(t.artist, t.title, t.album) for t in tracks]
+        try:
+            from kamp_daemon.tagger import TaggingError
+
+            releases = await asyncio.get_event_loop().run_in_executor(
+                None, mb_lookup_fn, tuples
+            )
+        except Exception as exc:
+            # TaggingError and network failures both surface as 404 with the
+            # human-readable message so the frontend can show "No match found".
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        def _to_release_out(r: Any) -> MusicBrainzReleaseOut:
+            sorted_tracks = sorted(r.tracks.values(), key=lambda t: (t.disc, t.number))
+            return MusicBrainzReleaseOut(
+                mbid=r.mbid,
+                release_group_mbid=r.release_group_mbid,
+                title=r.title,
+                album_artist=r.album_artist,
+                year=r.year,
+                label=r.label,
+                release_type=r.release_type,
+                tracks=[
+                    MusicBrainzTrackOut(
+                        track_number=t.number,
+                        disc_number=t.disc,
+                        title=t.title,
+                        recording_mbid=t.recording_mbid,
+                    )
+                    for t in sorted_tracks
+                ],
+            )
+
+        return MusicBrainzLookupOut(candidates=[_to_release_out(r) for r in releases])
 
     @app.get("/api/v1/album-art")
     def get_album_art(

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -569,6 +569,7 @@ def _cmd_daemon(
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
     from kamp_core.server import create_app
     from kamp_daemon.config import config_set as _config_set
+    from kamp_daemon.tagger import lookup_releases_from_tracks
 
     _logger = logging.getLogger(__name__)
     pkg_version = _get_version()
@@ -902,6 +903,7 @@ def _cmd_daemon(
         on_bandcamp_sync_all_trigger=_on_bandcamp_sync_all_trigger,
         dev_mode=bool(os.environ.get("KAMP_DEV")),
         auth_token=_auth_token,
+        mb_lookup_fn=lookup_releases_from_tracks,
     )
 
     # Wrap the existing on_track_end callback to also push track.changed events.

--- a/kamp_daemon/tagger.py
+++ b/kamp_daemon/tagger.py
@@ -888,6 +888,93 @@ def lookup_release_from_tracks(
     return _search_release(artist, album)
 
 
+_MAX_MB_CANDIDATES = 5
+
+
+def lookup_releases_from_tracks(
+    tracks: list[tuple[str, str, str]],
+) -> list[ReleaseInfo]:
+    """Return up to _MAX_MB_CANDIDATES MusicBrainz releases ranked best-first.
+
+    Uses the same tier-1 (per-track recording votes) + tier-2 (album-level
+    search) strategy as lookup_release_from_tracks, but returns all parseable
+    candidates instead of stopping at the first.  Designed for the comparison
+    UI where the user selects from multiple possible matches.
+
+    Args:
+        tracks: Sequence of (artist, title, album) strings, one per track.
+
+    Returns:
+        Non-empty list of ReleaseInfo sorted best-first.
+
+    Raises:
+        TaggingError: If no release can be found at all.
+    """
+    if not tracks:
+        raise TaggingError("No tracks provided for MusicBrainz lookup")
+
+    # Tier 1: per-track recording votes — collect top-N voted MBIDs
+    votes: Counter[str] = Counter()
+    for artist, title, album in tracks:
+        if not title:
+            continue
+        result = _mb_call(
+            musicbrainzngs.search_recordings,
+            recording=title,
+            artist=artist,
+            release=album,
+            limit=3,
+        )
+        recordings = result.get("recording-list", [])
+        if not recordings:
+            continue
+        top = recordings[0]
+        for rel in top.get("release-list", []):
+            rel_id = rel.get("id", "")
+            if rel_id:
+                votes[rel_id] += 1
+
+    seen_mbids: set[str] = set()
+    releases: list[ReleaseInfo] = []
+
+    if votes:
+        logger.debug(
+            "lookup_releases_from_tracks: top votes=%s",
+            dict(votes.most_common(_MAX_MB_CANDIDATES)),
+        )
+        for mbid, _ in votes.most_common(_MAX_MB_CANDIDATES):
+            if len(releases) >= _MAX_MB_CANDIDATES:
+                break
+            try:
+                detail = _mb_call(
+                    musicbrainzngs.get_release_by_id,
+                    mbid,
+                    includes=["artists", "recordings", "release-groups", "labels"],
+                )
+                releases.append(_parse_release(detail["release"]))
+                seen_mbids.add(mbid)
+            except (ValueError, KeyError, TaggingError):
+                continue
+
+    # Supplement with tier-2 (album-level) search when tier-1 left us short
+    if len(releases) < _MAX_MB_CANDIDATES:
+        artist, _, album = tracks[0]
+        for r in _search_releases(artist, album):
+            if r.mbid not in seen_mbids:
+                releases.append(r)
+                seen_mbids.add(r.mbid)
+                if len(releases) >= _MAX_MB_CANDIDATES:
+                    break
+
+    if not releases:
+        artist, _, album = tracks[0]
+        raise TaggingError(
+            f"No MusicBrainz results for artist={artist!r} album={album!r}"
+        )
+
+    return releases
+
+
 def _mb_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Call a musicbrainzngs function, retrying on transient errors with exponential backoff."""
     delay = 1.0
@@ -912,18 +999,36 @@ def _mb_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
 
 
 def _search_release(artist: str, album: str) -> ReleaseInfo:
+    """Return the single best-matching release. Delegates to _search_releases."""
+    results = _search_releases(artist, album)
+    if results:
+        return results[0]
+    raise TaggingError(
+        f"No parseable MusicBrainz release for artist={artist!r} album={album!r}"
+    )
+
+
+def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
+    """Return up to _MAX_MB_CANDIDATES parseable releases for artist + album.
+
+    Performs one search_releases call (retrying with cleaned name when the
+    first attempt returns nothing), then fetches full details for each
+    candidate in preference order (highest score, earliest date).  Returns an
+    empty list rather than raising so callers can decide how to handle zero
+    results.
+    """
     logger.debug("MusicBrainz search: artist=%r release=%r", artist, album)
     result = _mb_call(
         musicbrainzngs.search_releases,
         artist=artist,
         release=album,
-        limit=5,
+        limit=_MAX_MB_CANDIDATES,
     )
 
-    releases: list[dict[str, Any]] = result.get("release-list", [])
-    logger.debug("MusicBrainz returned %d result(s)", len(releases))
+    raw_releases: list[dict[str, Any]] = result.get("release-list", [])
+    logger.debug("MusicBrainz returned %d result(s)", len(raw_releases))
 
-    if not releases:
+    if not raw_releases:
         # Retry once with any iTunes edition suffix stripped from the album name
         # (e.g. "Abbey Road (Super Deluxe Edition)" → "Abbey Road").
         cleaned = _EDITION_RE.sub("", album).strip()
@@ -935,14 +1040,12 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
                 musicbrainzngs.search_releases,
                 artist=artist,
                 release=cleaned,
-                limit=5,
+                limit=_MAX_MB_CANDIDATES,
             )
-            releases = result.get("release-list", [])
+            raw_releases = result.get("release-list", [])
 
-    if not releases:
-        raise TaggingError(
-            f"No MusicBrainz results for artist={artist!r} album={album!r}"
-        )
+    if not raw_releases:
+        return []
 
     # Sort candidates: highest score first; break ties by earliest release date so
     # original/digital releases (e.g. 2020-03-27) beat later vinyl reissues (2021-04-30).
@@ -951,14 +1054,14 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
         date = r.get("date", "") or "9999"
         return (-score, date)
 
-    candidates = sorted(releases, key=_sort_key)
+    sorted_raw = sorted(raw_releases, key=_sort_key)
 
-    # search_releases returns minimal data (no full date, no track listings).
-    # Fetch the full release to get accurate year and track info.  Try each
-    # candidate in preference order; skip releases whose metadata cannot be
-    # parsed (e.g. vinyl with non-numeric track numbers like "A1").
-    last_err: Exception = TaggingError("no candidates")
-    for candidate in candidates:
+    # Fetch full release details (search_releases returns minimal data).
+    # Skip releases whose metadata cannot be parsed (e.g. vinyl "A1" track nums).
+    releases: list[ReleaseInfo] = []
+    for candidate in sorted_raw:
+        if len(releases) >= _MAX_MB_CANDIDATES:
+            break
         candidate_mbid: str = candidate["id"]
         logger.debug("Fetching full release details for %s", candidate_mbid)
         detail = _mb_call(
@@ -967,15 +1070,12 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
             includes=["artists", "recordings", "release-groups", "labels"],
         )
         try:
-            return _parse_release(detail["release"])
+            releases.append(_parse_release(detail["release"]))
         except (ValueError, KeyError) as exc:
             logger.debug("Skipping release %s: %s", candidate_mbid, exc)
-            last_err = exc
             continue
 
-    raise TaggingError(
-        f"No parseable MusicBrainz release for artist={artist!r} album={album!r}: {last_err}"
-    )
+    return releases
 
 
 def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -415,10 +415,75 @@ export type AlbumMetaResult = {
 export const patchAlbumMeta = (
   albumArtist: string,
   album: string,
-  opts: { genre?: string; label?: string; year?: string }
+  opts: { genre?: string; label?: string; year?: string; mb_release_id?: string }
 ): Promise<AlbumMetaResult> => {
   const params = new URLSearchParams({ album_artist: albumArtist, album })
   return patch(`/api/v1/albums/meta?${params}`, opts)
+}
+
+// ---------------------------------------------------------------------------
+// MusicBrainz lookup (KAMP-230)
+// ---------------------------------------------------------------------------
+
+export type MusicBrainzTrack = {
+  track_number: number
+  disc_number: number
+  title: string
+  recording_mbid: string
+}
+
+export type MusicBrainzRelease = {
+  mbid: string
+  release_group_mbid: string
+  title: string
+  album_artist: string
+  year: string
+  label: string
+  release_type: string
+  tracks: MusicBrainzTrack[]
+}
+
+export async function fetchMusicBrainzCandidates(
+  albumArtist: string,
+  album: string,
+  signal: AbortSignal
+): Promise<MusicBrainzRelease[]> {
+  const params = new URLSearchParams({ album_artist: albumArtist, album })
+  const res = await fetch(`${BASE_URL}/api/v1/albums/musicbrainz?${params}`, {
+    headers: _authHeaders(),
+    signal
+  })
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail && typeof json.detail === 'string') message = json.detail
+    } catch {
+      // ignore
+    }
+    throw new Error(message)
+  }
+  const data = (await res.json()) as { candidates: MusicBrainzRelease[] }
+  return data.candidates
+}
+
+export async function patchTrackMeta(trackId: number, mbRecordingId: string): Promise<Track> {
+  const res = await fetch(`${BASE_URL}/api/v1/tracks/${trackId}/meta`, {
+    method: 'PATCH',
+    headers: _authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ mb_recording_id: mbRecordingId })
+  })
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail && typeof json.detail === 'string') message = json.detail
+    } catch {
+      // ignore
+    }
+    throw new Error(message)
+  }
+  return res.json() as Promise<Track>
 }
 
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -20,3 +20,4 @@
 @import './modules.css';       /* overrides .album-card; must follow album-card.css */
 @import './stereo-rack.css';
 @import './animations.css';
+@import './musicbrainz-modal.css';

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -76,7 +76,7 @@
 /* Comparison row */
 .mb-cmp-row {
   display: grid;
-  grid-template-columns: 72px 1fr auto;
+  grid-template-columns: 72px auto 1fr;
   align-items: start;
   gap: 0 12px;
   padding: 7px 0;

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -1,0 +1,218 @@
+/* MusicBrainz comparison modal (KAMP-230) ---------------------------------- */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.mb-modal {
+  width: min(680px, 92vw);
+  max-height: 80vh;
+}
+
+/* Header */
+.mb-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.mb-modal__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.mb-modal__release-type {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  background: var(--surface-hover);
+  border-radius: 10px;
+  padding: 2px 8px;
+}
+
+/* Body — scrollable. Max-height reserves space for header (~57px) + footer (~57px).
+   flex: 1 1 auto would need an explicit parent height; max-height is simpler here. */
+.mb-modal__body {
+  overflow-y: auto;
+  max-height: calc(80vh - 114px);
+  padding: 0 20px;
+}
+
+/* Section headings */
+.mb-modal__section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding: 14px 0 6px;
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 1;
+}
+
+/* Comparison row */
+.mb-cmp-row {
+  display: grid;
+  grid-template-columns: 72px 1fr auto;
+  align-items: start;
+  gap: 0 12px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.mb-cmp-row:last-child {
+  border-bottom: none;
+}
+
+/* Field label */
+.mb-cmp-row__label {
+  font-size: 11px;
+  color: var(--text-dim);
+  padding-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Values column — stacked local on top, MB below */
+.mb-cmp-row__values {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mb-cmp-row__local {
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mb-cmp-row__local--overridden {
+  text-decoration: line-through;
+}
+
+.mb-cmp-row__mb {
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mb-cmp-row__mb--diff {
+  color: var(--mb-warning);
+}
+
+.mb-cmp-row__mb--same {
+  color: var(--mb-safe);
+}
+
+/* Toggle pill */
+.mb-toggle {
+  display: inline-flex;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.mb-toggle__btn {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 8px;
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  border: none;
+  transition: background 0.1s, color 0.1s;
+  white-space: nowrap;
+}
+
+.mb-toggle__btn--active {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.mb-toggle__btn:first-child {
+  border-right: 1px solid var(--border);
+}
+
+/* Unmatched track row */
+.mb-cmp-row--unmatched .mb-cmp-row__label,
+.mb-cmp-row--unmatched .mb-cmp-row__local {
+  opacity: 0.45;
+}
+
+.mb-cmp-row--unmatched .mb-cmp-row__mb--no-match {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-dim);
+  opacity: 0.55;
+}
+
+/* Footer */
+.mb-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.mb-modal__btn {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 16px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: filter 0.1s, opacity 0.1s;
+}
+
+.mb-modal__btn--ghost {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+.mb-modal__btn--ghost:hover {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.mb-modal__btn--accent {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: var(--text-on-accent);
+}
+
+.mb-modal__btn--accent:hover {
+  filter: brightness(1.1);
+}

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -119,7 +119,6 @@
 
 .mb-cmp-row__mb {
   font-size: 12px;
-  font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -136,23 +135,27 @@
 /* Toggle pill */
 .mb-toggle {
   display: inline-flex;
-  border-radius: 12px;
+  flex-direction: column;
+  border-radius: 8px;
   border: 1px solid var(--border);
   overflow: hidden;
   flex-shrink: 0;
   align-self: center;
+  width: 44px;
 }
 
 .mb-toggle__btn {
   font-size: 10px;
   font-weight: 600;
-  padding: 3px 8px;
+  padding: 5px 4px;
+  min-height: 24px;
   background: none;
   color: var(--text-dim);
   cursor: pointer;
   border: none;
   transition: background 0.1s, color 0.1s;
   white-space: nowrap;
+  text-align: center;
 }
 
 .mb-toggle__btn--active {
@@ -161,7 +164,7 @@
 }
 
 .mb-toggle__btn:first-child {
-  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 
 /* Unmatched track row */

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -101,12 +101,12 @@
 .mb-cmp-row__values {
   display: flex;
   flex-direction: column;
-  gap: 2px;
   min-width: 0;
 }
 
 .mb-cmp-row__local {
   font-size: 12px;
+  line-height: 24px;
   color: var(--text-dim);
   white-space: nowrap;
   overflow: hidden;
@@ -119,6 +119,7 @@
 
 .mb-cmp-row__mb {
   font-size: 12px;
+  line-height: 24px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -140,7 +141,7 @@
   border: 1px solid var(--border);
   overflow: hidden;
   flex-shrink: 0;
-  align-self: center;
+  align-self: start;
   width: 44px;
 }
 

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -176,6 +176,65 @@
   }
 }
 
+/* MusicBrainz pill — stacked directly below the Edit/Done pill */
+.mb-pill {
+  top: 46px; /* Edit pill is top:12px + ~27px height + 7px gap */
+  overflow: hidden; /* clips progress bar at rounded corners */
+}
+
+.mb-pill--loading {
+  opacity: 0.85;
+  cursor: default;
+}
+
+.mb-pill--error {
+  color: var(--error);
+  border-color: var(--error);
+  opacity: 0.8;
+}
+
+/* Daisy-chain blinking dots */
+.mb-pill__dots {
+  display: inline-flex;
+  gap: 1px;
+  margin-left: 1px;
+}
+
+.mb-pill__dots span {
+  animation: mb-dot-blink 1.2s ease-in-out infinite;
+  opacity: 0;
+}
+
+.mb-pill__dots span:nth-child(1) { animation-delay: 0s; }
+.mb-pill__dots span:nth-child(2) { animation-delay: 0.2s; }
+.mb-pill__dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes mb-dot-blink {
+  0%, 80%, 100% { opacity: 0; }
+  40%            { opacity: 1; }
+}
+
+/* Progress bar — fills from left to ~90% over the estimated lookup duration */
+.mb-pill__progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+  width: 0;
+  animation: mb-progress-fill linear forwards;
+}
+
+@keyframes mb-progress-fill {
+  from { width: 0; }
+  to   { width: 90%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mb-pill__dots span { animation: none; opacity: 1; }
+  .mb-pill__progress  { animation: none; width: 30%; }
+}
+
 
 /* Visually hidden, readable by screen readers */
 .sr-only {

--- a/kamp_ui/src/renderer/src/assets/variables.css
+++ b/kamp_ui/src/renderer/src/assets/variables.css
@@ -9,6 +9,10 @@
   --accent: #7c86e1;
   --accent-dim: #252b5c;
   --error: #e06c75;
+  --mb-warning: #e8a838;
+  --mb-warning-bg: rgba(232, 168, 56, 0.10);
+  --mb-safe: #4ec9a0;
+  --mb-safe-bg: rgba(78, 201, 160, 0.08);
   --text-on-accent: #000;
   --transport-h: 88px;
   --panel-w: 200px;

--- a/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
@@ -1,0 +1,267 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import type { MusicBrainzRelease, Track } from '../api/client'
+
+// Fields that can be toggled between local and MB values.
+type FieldId = 'title' | 'album_artist' | 'year' | 'label'
+
+// Per-track selection key: "disc-track"
+type TrackKey = string
+
+type SelectionState = {
+  album: Record<FieldId, 'local' | 'mb'>
+  tracks: Record<TrackKey, 'local' | 'mb'>
+}
+
+export type MBApplyPayload = {
+  album: Record<FieldId, 'local' | 'mb'>
+  tracks: Record<TrackKey, 'local' | 'mb'>
+}
+
+type Props = {
+  release: MusicBrainzRelease
+  localTracks: Track[]
+  onApply: (payload: MBApplyPayload) => void
+  onClose: () => void
+}
+
+function trackKey(disc: number, num: number): TrackKey {
+  return `${disc}-${num}`
+}
+
+// Look up the MB track that matches a local track, with disc-normalisation
+// fallback (disc=0 vs disc=1 mismatch is common).
+function findMBTrack(
+  release: MusicBrainzRelease,
+  local: Track
+): (typeof release.tracks)[number] | undefined {
+  const byKey = (d: number, n: number): (typeof release.tracks)[number] | undefined =>
+    release.tracks.find((t) => t.disc_number === d && t.track_number === n)
+  return (
+    byKey(local.disc_number, local.track_number) ??
+    byKey(local.disc_number + 1, local.track_number) ??
+    byKey(local.disc_number - 1, local.track_number)
+  )
+}
+
+function defaultSelection(release: MusicBrainzRelease, localTracks: Track[]): SelectionState {
+  const album: Record<FieldId, 'local' | 'mb'> = {
+    title: release.title !== localTracks[0]?.album ? 'mb' : 'local',
+    album_artist: release.album_artist !== localTracks[0]?.album_artist ? 'mb' : 'local',
+    year: release.year !== localTracks[0]?.year ? 'mb' : 'local',
+    label: release.label !== localTracks[0]?.label ? 'mb' : 'local'
+  }
+
+  const tracks: Record<TrackKey, 'local' | 'mb'> = {}
+  for (const local of localTracks) {
+    const mb = findMBTrack(release, local)
+    if (!mb) continue
+    const key = trackKey(local.disc_number, local.track_number)
+    tracks[key] = mb.title !== local.title ? 'mb' : 'local'
+  }
+
+  return { album, tracks }
+}
+
+function Toggle({
+  side,
+  onChange
+}: {
+  side: 'local' | 'mb'
+  onChange: (v: 'local' | 'mb') => void
+}): React.JSX.Element {
+  return (
+    <div className="mb-toggle" role="group" aria-label="Choose value">
+      <button
+        className={`mb-toggle__btn${side === 'local' ? ' mb-toggle__btn--active' : ''}`}
+        onClick={() => onChange('local')}
+        type="button"
+      >
+        Local
+      </button>
+      <button
+        className={`mb-toggle__btn${side === 'mb' ? ' mb-toggle__btn--active' : ''}`}
+        onClick={() => onChange('mb')}
+        type="button"
+      >
+        MB
+      </button>
+    </div>
+  )
+}
+
+const FIELD_LABELS: Record<FieldId, string> = {
+  title: 'Album',
+  album_artist: 'Artist',
+  year: 'Year',
+  label: 'Label'
+}
+
+export function MusicBrainzModal({
+  release,
+  localTracks,
+  onApply,
+  onClose
+}: Props): React.JSX.Element {
+  const localAlbum = localTracks[0]
+
+  const [sel, setSel] = useState<SelectionState>(() => defaultSelection(release, localTracks))
+
+  // Reset selection when the release prop changes (KAMP-231 candidate switch).
+  // Uses the "derived state from props" render-time pattern to avoid an effect.
+  const [prevRelease, setPrevRelease] = useState(release)
+  if (release !== prevRelease) {
+    setPrevRelease(release)
+    setSel(defaultSelection(release, localTracks))
+  }
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const setAlbumField = (field: FieldId, v: 'local' | 'mb'): void =>
+    setSel((s) => ({ ...s, album: { ...s.album, [field]: v } }))
+
+  const setTrackField = (key: TrackKey, v: 'local' | 'mb'): void =>
+    setSel((s) => ({ ...s, tracks: { ...s.tracks, [key]: v } }))
+
+  const albumFieldRows: Array<{ field: FieldId; localVal: string; mbVal: string }> = useMemo(
+    () => [
+      {
+        field: 'title',
+        localVal: localAlbum?.album ?? '',
+        mbVal: release.title
+      },
+      {
+        field: 'album_artist',
+        localVal: localAlbum?.album_artist ?? '',
+        mbVal: release.album_artist
+      },
+      {
+        field: 'year',
+        localVal: localAlbum?.year ?? '',
+        mbVal: release.year
+      },
+      {
+        field: 'label',
+        localVal: localAlbum?.label ?? '',
+        mbVal: release.label
+      }
+    ],
+    [release, localAlbum]
+  )
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="modal mb-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mb-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="mb-modal__header">
+          <h2 id="mb-modal-title" className="mb-modal__title">
+            MusicBrainz — {release.title}
+          </h2>
+          {release.release_type && (
+            <span className="mb-modal__release-type">{release.release_type}</span>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="mb-modal__body">
+          {/* Album-level fields */}
+          <div className="mb-modal__section-label">Album</div>
+          {albumFieldRows.map(({ field, localVal, mbVal }) => {
+            const isDiff = localVal !== mbVal
+            const chosen = sel.album[field]
+            return (
+              <div key={field} className="mb-cmp-row">
+                <span className="mb-cmp-row__label">{FIELD_LABELS[field]}</span>
+                <div className="mb-cmp-row__values">
+                  <span
+                    className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
+                  >
+                    {localVal || <em style={{ opacity: 0.4 }}>empty</em>}
+                  </span>
+                  <span
+                    className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
+                  >
+                    {mbVal || <em style={{ opacity: 0.4 }}>empty</em>}
+                  </span>
+                </div>
+                <Toggle side={sel.album[field]} onChange={(v) => setAlbumField(field, v)} />
+              </div>
+            )
+          })}
+
+          {/* Track-level titles */}
+          <div className="mb-modal__section-label">Tracks</div>
+          {localTracks.map((local) => {
+            const mb = findMBTrack(release, local)
+            const key = trackKey(local.disc_number, local.track_number)
+
+            if (!mb) {
+              return (
+                <div key={local.id} className="mb-cmp-row mb-cmp-row--unmatched">
+                  <span className="mb-cmp-row__label">
+                    {local.disc_number > 1 ? `${local.disc_number}-` : ''}
+                    {local.track_number}
+                  </span>
+                  <div className="mb-cmp-row__values">
+                    <span className="mb-cmp-row__local">{local.title}</span>
+                    <span className="mb-cmp-row__mb--no-match">no MB match</span>
+                  </div>
+                  {/* No toggle — nothing to apply */}
+                </div>
+              )
+            }
+
+            const isDiff = local.title !== mb.title
+            const chosen = sel.tracks[key] ?? 'local'
+            return (
+              <div key={local.id} className="mb-cmp-row">
+                <span className="mb-cmp-row__label">
+                  {local.disc_number > 1 ? `${local.disc_number}-` : ''}
+                  {local.track_number}
+                </span>
+                <div className="mb-cmp-row__values">
+                  <span
+                    className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
+                  >
+                    {local.title}
+                  </span>
+                  <span
+                    className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
+                  >
+                    {mb.title}
+                  </span>
+                </div>
+                <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="mb-modal__footer">
+          <button className="mb-modal__btn mb-modal__btn--ghost" type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="mb-modal__btn mb-modal__btn--accent"
+            type="button"
+            onClick={() => onApply({ album: sel.album, tracks: sel.tracks })}
+          >
+            Apply selected
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
@@ -183,6 +183,7 @@ export function MusicBrainzModal({
             return (
               <div key={field} className="mb-cmp-row">
                 <span className="mb-cmp-row__label">{FIELD_LABELS[field]}</span>
+                <Toggle side={sel.album[field]} onChange={(v) => setAlbumField(field, v)} />
                 <div className="mb-cmp-row__values">
                   <span
                     className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
@@ -195,7 +196,6 @@ export function MusicBrainzModal({
                     {mbVal || <em style={{ opacity: 0.4 }}>empty</em>}
                   </span>
                 </div>
-                <Toggle side={sel.album[field]} onChange={(v) => setAlbumField(field, v)} />
               </div>
             )
           })}
@@ -213,11 +213,10 @@ export function MusicBrainzModal({
                     {local.disc_number > 1 ? `${local.disc_number}-` : ''}
                     {local.track_number}
                   </span>
-                  <div className="mb-cmp-row__values">
+                  <div className="mb-cmp-row__values" style={{ gridColumn: '2 / -1' }}>
                     <span className="mb-cmp-row__local">{local.title}</span>
                     <span className="mb-cmp-row__mb--no-match">no MB match</span>
                   </div>
-                  {/* No toggle — nothing to apply */}
                 </div>
               )
             }
@@ -230,6 +229,7 @@ export function MusicBrainzModal({
                   {local.disc_number > 1 ? `${local.disc_number}-` : ''}
                   {local.track_number}
                 </span>
+                <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
                 <div className="mb-cmp-row__values">
                   <span
                     className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
@@ -242,7 +242,6 @@ export function MusicBrainzModal({
                     {mb.title}
                   </span>
                 </div>
-                <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
               </div>
             )
           })}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
-import { artUrl } from '../api/client'
-import type { AlbumTagsCollision, Track, TrackTagsCollision } from '../api/client'
+import { artUrl, fetchMusicBrainzCandidates, patchTrackMeta } from '../api/client'
+import type {
+  AlbumTagsCollision,
+  MusicBrainzRelease,
+  Track,
+  TrackTagsCollision
+} from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
 import { EditableTrackTitle } from './EditableTrackTitle'
 import { EditableAlbumField } from './EditableAlbumField'
 import { CollisionModal } from './CollisionModal'
 import { AlbumMetaPanel } from './AlbumMetaPanel'
+import { MusicBrainzModal } from './MusicBrainzModal'
+import type { MBApplyPayload } from './MusicBrainzModal'
 import {
   FavoriteIcon,
   PencilIcon,
@@ -23,6 +30,12 @@ type AlbumRenameToast = {
   message: string
   undo: () => Promise<AlbumTagsCollision | null>
 }
+
+type MBFetchState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; candidates: MusicBrainzRelease[] }
+  | { status: 'error'; message: string }
 
 function HeroImage({ src }: { src: string }): React.JSX.Element {
   const [loaded, setLoaded] = useState(false)
@@ -57,11 +70,13 @@ export function TrackList(): React.JSX.Element | null {
   const patchAlbumMeta = useStore((s) => s.patchAlbumMeta)
   const patchTrackTitle = useStore((s) => s.patchTrackTitle)
   const patchAlbumTags = useStore((s) => s.patchAlbumTags)
+  const refreshOpenAlbum = useStore((s) => s.refreshOpenAlbum)
   const albumRenameProgress = useStore((s) => s.albumRenameProgress)
   const deferredOps = useStore((s) => s.deferredOps)
 
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mbAbortRef = useRef<AbortController | null>(null)
   const [collision, setCollision] = useState<
     (TrackTagsCollision & { pendingTrackId: number; pendingTitle: string }) | null
   >(null)
@@ -69,6 +84,16 @@ export function TrackList(): React.JSX.Element | null {
     (AlbumTagsCollision & { pendingOpts: Parameters<typeof patchAlbumTags>[2] }) | null
   >(null)
   const [albumRenameToast, setAlbumRenameToast] = useState<AlbumRenameToast | null>(null)
+  const [mbState, setMbState] = useState<MBFetchState>({ status: 'idle' })
+
+  // Reset MB state when navigating to a different album (derived state from props).
+  // Using the render-time pattern avoids a setState-in-effect lint violation.
+  const albumKey = album ? `${album.album_artist}\0${album.album}` : null
+  const [prevAlbumKey, setPrevAlbumKey] = useState<string | null>(albumKey)
+  if (albumKey !== prevAlbumKey) {
+    setPrevAlbumKey(albumKey)
+    setMbState({ status: 'idle' })
+  }
 
   const showRenameToast = (toast: AlbumRenameToast): void => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
@@ -81,6 +106,79 @@ export function TrackList(): React.JSX.Element | null {
   useEffect(() => {
     if (albumEditMode) albumTitleRef.current?.focus()
   }, [albumEditMode])
+
+  // Abort any in-flight MB request when the album changes or on unmount.
+  useEffect(() => {
+    return () => {
+      mbAbortRef.current?.abort()
+      mbAbortRef.current = null
+    }
+  }, [albumKey])
+
+  const handleFetchMB = (): void => {
+    if (!album) return
+    mbAbortRef.current?.abort()
+    const ctrl = new AbortController()
+    mbAbortRef.current = ctrl
+    setMbState({ status: 'loading' })
+    fetchMusicBrainzCandidates(album.album_artist, album.album, ctrl.signal).then(
+      (candidates) => {
+        if (!ctrl.signal.aborted) setMbState({ status: 'ready', candidates })
+      },
+      (err: unknown) => {
+        if (ctrl.signal.aborted) return
+        const msg = err instanceof Error ? err.message : 'MusicBrainz lookup failed'
+        setMbState({ status: 'error', message: msg })
+        // Auto-reset error display after 4 s so the pill returns to idle.
+        setTimeout(() => setMbState({ status: 'idle' }), 4_000)
+      }
+    )
+  }
+
+  const handleMBApply = async (payload: MBApplyPayload): Promise<void> => {
+    if (!album) return
+    setMbState({ status: 'idle' })
+
+    const mbRelease =
+      (mbState as Extract<MBFetchState, { status: 'ready' }>).candidates?.[0] ?? null
+    if (!mbRelease) return
+
+    // 1. Album meta (year, label, mb_release_id)
+    const metaOpts: { year?: string; label?: string; mb_release_id?: string } = {
+      mb_release_id: mbRelease.mbid
+    }
+    if (payload.album.year === 'mb' && mbRelease.year) metaOpts.year = mbRelease.year
+    if (payload.album.label === 'mb' && mbRelease.label) metaOpts.label = mbRelease.label
+    await patchAlbumMeta(album.album_artist, album.album, metaOpts)
+
+    // 2. Album tags (title, album_artist)
+    const tagOpts: { album?: string; album_artist?: string } = {}
+    if (payload.album.title === 'mb') tagOpts.album = mbRelease.title
+    if (payload.album.album_artist === 'mb') tagOpts.album_artist = mbRelease.album_artist
+    if (tagOpts.album || tagOpts.album_artist) {
+      await patchAlbumTags(album.album_artist, album.album, tagOpts)
+    }
+
+    // 3. Track titles (sequential) + recording MBIDs (parallel)
+    const mbTrackMap = new Map(
+      mbRelease.tracks.map((t) => [`${t.disc_number}-${t.track_number}`, t])
+    )
+    const mbidPromises: Promise<unknown>[] = []
+    for (const local of tracks) {
+      const key = `${local.disc_number}-${local.track_number}`
+      const mbTrack = mbTrackMap.get(key)
+      if (!mbTrack) continue
+      if (payload.tracks[key] === 'mb' && local.title !== mbTrack.title) {
+        await patchTrackTitle(local.id, mbTrack.title)
+      }
+      if (mbTrack.recording_mbid && local.mb_recording_id !== mbTrack.recording_mbid) {
+        mbidPromises.push(patchTrackMeta(local.id, mbTrack.recording_mbid))
+      }
+    }
+    if (mbidPromises.length > 0) await Promise.allSettled(mbidPromises)
+
+    await refreshOpenAlbum()
+  }
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
 
@@ -138,6 +236,39 @@ export function TrackList(): React.JSX.Element | null {
         <PencilIcon size={11} />
         {albumEditMode ? 'Done' : 'Edit tags'}
       </button>
+
+      {/* MusicBrainz fetch pill — only visible in edit mode, stacked below Edit/Done */}
+      {albumEditMode && (
+        <button
+          className={`breadcrumb-edit-btn mb-pill${mbState.status === 'loading' ? ' mb-pill--loading' : mbState.status === 'error' ? ' mb-pill--error' : ''}`}
+          disabled={mbState.status === 'loading'}
+          title={mbState.status === 'error' ? mbState.message : 'Fetch from MusicBrainz'}
+          onClick={handleFetchMB}
+          type="button"
+        >
+          {mbState.status === 'loading' ? (
+            <>
+              Searching
+              <span className="mb-pill__dots" aria-hidden="true">
+                <span>.</span>
+                <span>.</span>
+                <span>.</span>
+              </span>
+            </>
+          ) : mbState.status === 'error' ? (
+            'No match'
+          ) : (
+            'MusicBrainz'
+          )}
+          {mbState.status === 'loading' && (
+            <span
+              className="mb-pill__progress"
+              aria-hidden="true"
+              style={{ animationDuration: `${tracks.length * 1.2}s` }}
+            />
+          )}
+        </button>
+      )}
 
       {/* Screen-reader announcement for edit-mode transitions */}
       <div aria-live="polite" className="sr-only">
@@ -328,6 +459,14 @@ export function TrackList(): React.JSX.Element | null {
 
       {menu && (
         <TrackContextMenu x={menu.x} y={menu.y} track={menu.track} onClose={() => setMenu(null)} />
+      )}
+      {mbState.status === 'ready' && (
+        <MusicBrainzModal
+          release={mbState.candidates[0]}
+          localTracks={tracks}
+          onApply={(payload) => void handleMBApply(payload)}
+          onClose={() => setMbState({ status: 'idle' })}
+        />
       )}
       {collision && (
         <CollisionModal

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -264,7 +264,7 @@ export function TrackList(): React.JSX.Element | null {
             <span
               className="mb-pill__progress"
               aria-hidden="true"
-              style={{ animationDuration: `${tracks.length * 1.2}s` }}
+              style={{ animationDuration: `${tracks.length * 1.5}s` }}
             />
           )}
         </button>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -107,7 +107,7 @@ type PlayerStore = {
   patchAlbumMeta: (
     albumArtist: string,
     album: string,
-    opts: { genre?: string; label?: string; year?: string }
+    opts: { genre?: string; label?: string; year?: string; mb_release_id?: string }
   ) => Promise<void>
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>

--- a/tests/test_mb_lookup_endpoint.py
+++ b/tests/test_mb_lookup_endpoint.py
@@ -1,0 +1,394 @@
+"""Tests for the MusicBrainz lookup, track-meta, and extended album-meta endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kamp_core.library import Track
+from kamp_core.playback import PlaybackState
+from kamp_core.server import create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _track(n: int, title: str = "") -> Track:
+    return Track(
+        file_path=Path(f"/music/{n:02d}.mp3"),
+        title=title or f"Track {n}",
+        artist="Band",
+        album_artist="Band",
+        album="Record",
+        year="2020",
+        track_number=n,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+    )
+
+
+def _fake_release(mbid: str = "release-1") -> MagicMock:
+    """Return a minimal ReleaseInfo-shaped mock."""
+    track = MagicMock()
+    track.number = 1
+    track.disc = 1
+    track.title = "MB Track 1"
+    track.recording_mbid = "rec-1"
+
+    r = MagicMock()
+    r.mbid = mbid
+    r.release_group_mbid = "rg-1"
+    r.title = "MB Record"
+    r.album_artist = "MB Band"
+    r.year = "2021"
+    r.label = "MB Label"
+    r.release_type = "Album"
+    r.tracks = {"1-1": track}
+    return r
+
+
+@pytest.fixture()
+def mock_index() -> MagicMock:
+    index = MagicMock()
+    index.albums.return_value = []
+    index.tracks_for_album.return_value = []
+    return index
+
+
+@pytest.fixture()
+def mock_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.state = PlaybackState()
+    return engine
+
+
+@pytest.fixture()
+def mock_queue() -> MagicMock:
+    queue = MagicMock()
+    queue.current.return_value = None
+    queue.peek_next.return_value = None
+    return queue
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/albums/musicbrainz
+# ---------------------------------------------------------------------------
+
+
+class TestGetAlbumMusicBrainz:
+    """GET /api/v1/albums/musicbrainz returns ranked MB candidates."""
+
+    def test_happy_path_returns_candidates(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        tracks = [_track(1), _track(2)]
+        mock_index.tracks_for_album.return_value = tracks
+        release = _fake_release()
+        lookup_fn = MagicMock(return_value=[release])
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_lookup_fn=lookup_fn,
+        )
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["candidates"]) == 1
+        c = data["candidates"][0]
+        assert c["mbid"] == "release-1"
+        assert c["title"] == "MB Record"
+        assert c["album_artist"] == "MB Band"
+        assert c["year"] == "2021"
+        assert c["label"] == "MB Label"
+        assert c["release_type"] == "Album"
+        assert len(c["tracks"]) == 1
+        assert c["tracks"][0]["title"] == "MB Track 1"
+        assert c["tracks"][0]["recording_mbid"] == "rec-1"
+
+        # Verify the lookup received the correct (artist, title, album) tuples
+        lookup_fn.assert_called_once_with(
+            [("Band", "Track 1", "Record"), ("Band", "Track 2", "Record")]
+        )
+
+    def test_returns_multiple_candidates(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        releases = [_fake_release("r1"), _fake_release("r2")]
+        releases[1].title = "MB Record (Deluxe)"
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_lookup_fn=MagicMock(return_value=releases),
+        )
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["candidates"]) == 2
+        assert resp.json()["candidates"][1]["mbid"] == "r2"
+
+    def test_returns_404_when_album_not_found(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = []
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_lookup_fn=MagicMock(),
+        )
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Ghost", "album": "Void"},
+        )
+        assert resp.status_code == 404
+
+    def test_returns_404_when_mb_lookup_raises(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        lookup_fn = MagicMock(side_effect=Exception("No MusicBrainz results"))
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_lookup_fn=lookup_fn,
+        )
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Unknown", "album": "Untitled"},
+        )
+        assert resp.status_code == 404
+        assert "No MusicBrainz results" in resp.json()["detail"]
+
+    def test_returns_503_when_lookup_fn_not_wired(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+
+        app = create_app(
+            index=mock_index, engine=mock_engine, queue=mock_queue
+        )  # no mb_lookup_fn
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+        assert resp.status_code == 503
+
+    def test_tracks_sorted_by_disc_then_number(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        t1, t2, t3 = MagicMock(), MagicMock(), MagicMock()
+        t1.number, t1.disc, t1.title, t1.recording_mbid = 2, 1, "Second", "rec-2"
+        t2.number, t2.disc, t2.title, t2.recording_mbid = 1, 2, "Disc2T1", "rec-3"
+        t3.number, t3.disc, t3.title, t3.recording_mbid = 1, 1, "First", "rec-1"
+        release = _fake_release()
+        release.tracks = {"1-2": t1, "2-1": t2, "1-1": t3}
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_lookup_fn=MagicMock(return_value=[release]),
+        )
+        resp = TestClient(app).get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+        titles = [t["title"] for t in resp.json()["candidates"][0]["tracks"]]
+        assert titles == ["First", "Second", "Disc2T1"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/v1/albums/meta — mb_release_id extension (KAMP-230)
+# ---------------------------------------------------------------------------
+
+
+class TestPatchAlbumMetaMbReleaseId:
+    def _make_track(self, n: int = 1) -> Track:
+        return Track(
+            file_path=Path(f"/music/{n:02d}.mp3"),
+            title=f"Track {n}",
+            artist="Band",
+            album_artist="Band",
+            album="Record",
+            year="2020",
+            track_number=n,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+
+    def test_mb_release_id_written_to_file_and_db(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        track = self._make_track()
+        updated = Track(**{**track.__dict__, "mb_release_id": "new-mbid"})
+        mock_index.tracks_for_album.return_value = [track]
+        mock_index.update_album_meta.return_value = [updated]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch("kamp_core.library.write_meta_tags_to_file") as mock_write:
+            resp = TestClient(app).patch(
+                "/api/v1/albums/meta",
+                params={"album_artist": "Band", "album": "Record"},
+                json={"mb_release_id": "new-mbid"},
+            )
+
+        assert resp.status_code == 200
+        mock_write.assert_called_once_with(
+            track.file_path,
+            genre=None,
+            label=None,
+            year=None,
+            mb_release_id="new-mbid",
+        )
+        mock_index.update_album_meta.assert_called_once_with(
+            "Band",
+            "Record",
+            genre=None,
+            label=None,
+            year=None,
+            mb_release_id="new-mbid",
+        )
+
+    def test_returns_400_when_only_mb_release_id_absent_alongside_other_nones(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [self._make_track()]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/albums/meta",
+            params={"album_artist": "Band", "album": "Record"},
+            json={},
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/v1/tracks/{track_id}/meta (KAMP-230)
+# ---------------------------------------------------------------------------
+
+
+class TestPatchTrackMeta:
+    def _make_track(self) -> Track:
+        return Track(
+            file_path=Path("/music/01.mp3"),
+            title="Track 1",
+            artist="Band",
+            album_artist="Band",
+            album="Record",
+            year="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            id=42,
+        )
+
+    def test_writes_mbid_to_file_and_db(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        track = self._make_track()
+        updated = Track(**{**track.__dict__, "mb_recording_id": "rec-new"})
+        mock_index.get_track_by_id.return_value = track
+        mock_index.update_track_mb_recording_id.return_value = updated
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch("kamp_core.library.write_track_mbid_to_file") as mock_write:
+            resp = TestClient(app).patch(
+                "/api/v1/tracks/42/meta",
+                json={"mb_recording_id": "rec-new"},
+            )
+
+        assert resp.status_code == 200
+        mock_write.assert_called_once_with(track.file_path, mb_recording_id="rec-new")
+        mock_index.update_track_mb_recording_id.assert_called_once_with(42, "rec-new")
+        assert resp.json()["mb_recording_id"] == "rec-new"
+
+    def test_returns_404_for_unknown_track(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_track_by_id.return_value = None
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/tracks/999/meta",
+            json={"mb_recording_id": "rec-1"},
+        )
+        assert resp.status_code == 404
+
+    def test_returns_500_when_file_write_fails(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_track_by_id.return_value = self._make_track()
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch(
+            "kamp_core.library.write_track_mbid_to_file",
+            side_effect=OSError("permission denied"),
+        ):
+            resp = TestClient(app).patch(
+                "/api/v1/tracks/42/meta",
+                json={"mb_recording_id": "rec-1"},
+            )
+        assert resp.status_code == 500

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2828,7 +2828,7 @@ class TestPatchAlbumMetaEndpoint:
 
         assert resp.status_code == 200
         mock_index.update_album_meta.assert_called_once_with(
-            "Artist", "Record", genre=None, label="ECM", year="1975"
+            "Artist", "Record", genre=None, label="ECM", year="1975", mb_release_id=None
         )
 
     def test_returns_404_for_unknown_album(

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -27,6 +27,7 @@ from kamp_daemon.tagger import (
     _write_tags,
     configure_musicbrainz,
     is_tagged,
+    lookup_releases_from_tracks,
     read_release_mbids,
     read_track_metadata_from_file,
     tag_directory,
@@ -173,7 +174,7 @@ class TestTagDirectory:
         _make_mp3(mp3)
 
         with patch("musicbrainzngs.search_releases", return_value={"release-list": []}):
-            with pytest.raises(TaggingError, match="No MusicBrainz results"):
+            with pytest.raises(TaggingError, match="No parseable MusicBrainz release"):
                 tag_directory(tmp_path, [mp3])
 
     def test_mp3_tags_written(self, tmp_path: Path) -> None:
@@ -241,8 +242,10 @@ class TestTagDirectory:
             ) as mock_get:
                 tag_directory(tmp_path, [mp3])
 
-        # The winning MBID ("high") must be passed to get_release_by_id
-        assert mock_get.call_args[0][0] == "high"
+        # The highest-scoring MBID ("high") must be fetched first.
+        # _search_releases fetches all candidates in score order, so check
+        # the first call rather than the last.
+        assert mock_get.call_args_list[0][0][0] == "high"
 
     def test_tie_breaks_by_earliest_date(self, tmp_path: Path) -> None:
         """When scores are equal, the earlier-dated release is preferred over a
@@ -511,7 +514,7 @@ class TestEditionSuffixRetry:
         empty: dict[str, Any] = {"release-list": []}
 
         with patch("musicbrainzngs.search_releases", return_value=empty):
-            with pytest.raises(TaggingError, match="No MusicBrainz results"):
+            with pytest.raises(TaggingError, match="No parseable MusicBrainz release"):
                 tag_directory(tmp_path, [mp3])
 
 
@@ -2070,3 +2073,82 @@ class TestWriteTagsFromTrackMetadata:
 
         assert "DATE" not in mock_audio.tags
         assert "MUSICBRAINZ_ALBUMID" not in mock_audio.tags
+
+
+# ---------------------------------------------------------------------------
+# lookup_releases_from_tracks (KAMP-230)
+# ---------------------------------------------------------------------------
+
+RECORDING_HIT: dict[str, Any] = {
+    "recording-list": [
+        {
+            "id": "rec-1",
+            "title": "First Track",
+            "release-list": [{"id": "abc-123"}, {"id": "other-123"}],
+        }
+    ]
+}
+
+
+class TestLookupReleasesFromTracks:
+    def test_raises_on_empty_input(self) -> None:
+        with pytest.raises(TaggingError, match="No tracks provided"):
+            lookup_releases_from_tracks([])
+
+    def test_happy_path_tier1_vote(self) -> None:
+        """Tier-1 path: recording votes resolve to a release."""
+        tracks = [("Cool Artist", "First Track", "Great Album")]
+        empty_releases: dict[str, Any] = {"release-list": []}
+        with patch("musicbrainzngs.search_recordings", return_value=RECORDING_HIT):
+            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    releases = lookup_releases_from_tracks(tracks)
+
+        assert len(releases) >= 1
+        assert releases[0].mbid == "abc-123"
+        assert releases[0].title == "Great Album"
+
+    def test_falls_back_to_tier2_when_no_votes(self) -> None:
+        """When no recording results, falls back to album-level search."""
+        tracks = [("Cool Artist", "First Track", "Great Album")]
+        empty_recordings: dict[str, Any] = {"recording-list": []}
+        with patch("musicbrainzngs.search_recordings", return_value=empty_recordings):
+            with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    releases = lookup_releases_from_tracks(tracks)
+
+        assert len(releases) >= 1
+        assert releases[0].mbid == "abc-123"
+
+    def test_raises_when_all_paths_fail(self) -> None:
+        """Raises TaggingError when both tier-1 and tier-2 find nothing."""
+        tracks = [("Unknown", "???", "???")]
+        empty_recordings: dict[str, Any] = {"recording-list": []}
+        empty_releases: dict[str, Any] = {"release-list": []}
+        with patch("musicbrainzngs.search_recordings", return_value=empty_recordings):
+            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
+                with pytest.raises(TaggingError, match="No MusicBrainz results"):
+                    lookup_releases_from_tracks(tracks)
+
+    def test_skips_tracks_without_title(self) -> None:
+        """Tracks with empty title strings do not make recording API calls."""
+        tracks = [("Artist", "", "Album"), ("Artist", "Real Title", "Album")]
+        empty_releases: dict[str, Any] = {"release-list": []}
+        with patch(
+            "musicbrainzngs.search_recordings", return_value=RECORDING_HIT
+        ) as mock_rec:
+            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
+                with patch(
+                    "musicbrainzngs.get_release_by_id",
+                    return_value=SAMPLE_RELEASE_DETAIL,
+                ):
+                    lookup_releases_from_tracks(tracks)
+
+        # Only one call — the empty-title track is skipped.
+        assert mock_rec.call_count == 1


### PR DESCRIPTION
## Summary

- Adds a **MusicBrainz pill** in album edit mode (stacked below Edit/Done) that fetches the best-matching release from MusicBrainz on demand
- While searching, the pill shows daisy-chain blinking dots and a progress bar that fills at the per-track rate-limited pace (~1.2s/track)
- On success, a **comparison modal** opens showing local vs MB values for title, artist, year, label, and all track titles — differences highlighted amber, matches teal
- Each field has a Local/MB toggle defaulting to MB on differences; "Apply selected" writes only the chosen fields plus MusicBrainz IDs (mb_release_id, mb_recording_id) to files and DB
- Candidates array is stored in state (not just the winner) so KAMP-231 can add a release picker without a new API call

## Backend changes

- `lookup_releases_from_tracks()` in `tagger.py` — multi-candidate version using tier-1 per-track recording votes + tier-2 album-level search fallback; existing `lookup_release_from_tracks()` delegates to it
- `GET /api/v1/albums/musicbrainz` — returns `{ candidates: MusicBrainzReleaseOut[] }` sorted best-first; `mb_lookup_fn` is DI-injected via `create_app()` to keep the dependency direction clean
- `PATCH /api/v1/albums/meta` extended with `mb_release_id`
- `PATCH /api/v1/tracks/{id}/meta` added for `mb_recording_id` writes
- `write_meta_tags_to_file()` / `write_track_mbid_to_file()` write MusicBrainz IDs to MP3 (TXXX), M4A (iTunes atom), FLAC/OGG (Vorbis comment)

## Test plan

- [x] Open an album in edit mode → MusicBrainz pill appears below Edit/Done
- [x] Click pill → dots animate + progress bar fills at the expected rate; pill is disabled during search
- [x] Modal opens with amber/teal diff highlighting; toggle pills default to MB on differences
- [x] Apply with all MB fields selected → verify tags written to files and visible after album refresh
- [x] Apply with some fields set to Local → verify those fields are unchanged
- [x] Navigate away mid-search → confirm no stale modal on the new album (AbortController cancels the fetch)
- [ ] Album with no MB match → pill shows "No match" briefly then resets
- [x] `poetry run pytest` passes at ≥94% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)