### PR TITLE
feat(KAMP-231): MusicBrainz candidate navigation

### DIFF
--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -23,6 +23,10 @@
 .mb-modal {
   width: min(680px, 92vw);
   max-height: 80vh;
+  /* Grid lets the body row take whatever space the actual header/footer leave,
+     without a hardcoded magic number that breaks when header height changes. */
+  display: grid;
+  grid-template-rows: auto 1fr auto;
 }
 
 /* Header */
@@ -94,11 +98,9 @@
   text-align: center;
 }
 
-/* Body — scrollable. Max-height reserves space for header (~57px) + footer (~57px).
-   flex: 1 1 auto would need an explicit parent height; max-height is simpler here. */
 .mb-modal__body {
   overflow-y: auto;
-  max-height: calc(80vh - 114px);
+  min-height: 0; /* grid 1fr rows shrink to scroll rather than overflow */
   padding: 0 20px;
 }
 

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -77,9 +77,12 @@
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
-  padding: 2px 5px;
+  width: 24px;
+  padding: 2px 0;
+  text-align: center;
   border-radius: 4px;
   transition: color 0.1s, background 0.1s;
+  flex-shrink: 0;
 }
 
 .mb-modal__nav-btn:hover:not(:disabled) {
@@ -88,15 +91,16 @@
 }
 
 .mb-modal__nav-btn:disabled {
-  opacity: 0.25;
+  opacity: 0.35;
   cursor: default;
 }
 
 .mb-modal__nav-count {
   font-size: 11px;
   color: var(--text-dim);
-  min-width: 28px;
+  width: 44px;
   text-align: center;
+  flex-shrink: 0;
 }
 
 .mb-modal__body {

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -42,6 +42,13 @@
   margin: 0;
 }
 
+.mb-modal__header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .mb-modal__release-type {
   font-size: 11px;
   font-weight: 500;
@@ -49,6 +56,42 @@
   background: var(--surface-hover);
   border-radius: 10px;
   padding: 2px 8px;
+}
+
+/* Candidate navigation */
+.mb-modal__nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.mb-modal__nav-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: 4px;
+  transition: color 0.1s, background 0.1s;
+}
+
+.mb-modal__nav-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.mb-modal__nav-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.mb-modal__nav-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  min-width: 28px;
+  text-align: center;
 }
 
 /* Body — scrollable. Max-height reserves space for header (~57px) + footer (~57px).

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -22,6 +22,7 @@
 
 .mb-modal {
   width: min(680px, 92vw);
+  height: 80vh;
   max-height: 80vh;
   /* Grid lets the body row take whatever space the actual header/footer leave,
      without a hardcoded magic number that breaks when header height changes. */

--- a/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
@@ -15,10 +15,11 @@ type SelectionState = {
 export type MBApplyPayload = {
   album: Record<FieldId, 'local' | 'mb'>
   tracks: Record<TrackKey, 'local' | 'mb'>
+  release: MusicBrainzRelease
 }
 
 type Props = {
-  release: MusicBrainzRelease
+  candidates: MusicBrainzRelease[]
   localTracks: Track[]
   onApply: (payload: MBApplyPayload) => void
   onClose: () => void
@@ -97,17 +98,19 @@ const FIELD_LABELS: Record<FieldId, string> = {
 }
 
 export function MusicBrainzModal({
-  release,
+  candidates,
   localTracks,
   onApply,
   onClose
 }: Props): React.JSX.Element {
   const localAlbum = localTracks[0]
 
+  const [candidateIndex, setCandidateIndex] = useState(0)
+  const release = candidates[candidateIndex]
+
   const [sel, setSel] = useState<SelectionState>(() => defaultSelection(release, localTracks))
 
-  // Reset selection when the release prop changes (KAMP-231 candidate switch).
-  // Uses the "derived state from props" render-time pattern to avoid an effect.
+  // Reset selection when the active candidate changes (render-time derived state pattern).
   const [prevRelease, setPrevRelease] = useState(release)
   if (release !== prevRelease) {
     setPrevRelease(release)
@@ -168,9 +171,36 @@ export function MusicBrainzModal({
           <h2 id="mb-modal-title" className="mb-modal__title">
             MusicBrainz — {release.title}
           </h2>
-          {release.release_type && (
-            <span className="mb-modal__release-type">{release.release_type}</span>
-          )}
+          <div className="mb-modal__header-right">
+            {candidates.length > 1 && (
+              <div className="mb-modal__nav" role="group" aria-label="Switch candidate">
+                <button
+                  className="mb-modal__nav-btn"
+                  type="button"
+                  aria-label="Previous candidate"
+                  disabled={candidateIndex === 0}
+                  onClick={() => setCandidateIndex((i) => i - 1)}
+                >
+                  ‹
+                </button>
+                <span className="mb-modal__nav-count">
+                  {candidateIndex + 1} / {candidates.length}
+                </span>
+                <button
+                  className="mb-modal__nav-btn"
+                  type="button"
+                  aria-label="Next candidate"
+                  disabled={candidateIndex === candidates.length - 1}
+                  onClick={() => setCandidateIndex((i) => i + 1)}
+                >
+                  ›
+                </button>
+              </div>
+            )}
+            {release.release_type && (
+              <span className="mb-modal__release-type">{release.release_type}</span>
+            )}
+          </div>
         </div>
 
         {/* Body */}
@@ -255,7 +285,7 @@ export function MusicBrainzModal({
           <button
             className="mb-modal__btn mb-modal__btn--accent"
             type="button"
-            onClick={() => onApply({ album: sel.album, tracks: sel.tracks })}
+            onClick={() => onApply({ album: sel.album, tracks: sel.tracks, release })}
           >
             Apply selected
           </button>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -139,9 +139,7 @@ export function TrackList(): React.JSX.Element | null {
     if (!album) return
     setMbState({ status: 'idle' })
 
-    const mbRelease =
-      (mbState as Extract<MBFetchState, { status: 'ready' }>).candidates?.[0] ?? null
-    if (!mbRelease) return
+    const mbRelease = payload.release
 
     // 1. Album meta (year, label, mb_release_id)
     const metaOpts: { year?: string; label?: string; mb_release_id?: string } = {
@@ -462,7 +460,7 @@ export function TrackList(): React.JSX.Element | null {
       )}
       {mbState.status === 'ready' && (
         <MusicBrainzModal
-          release={mbState.candidates[0]}
+          candidates={mbState.candidates}
           localTracks={tracks}
           onApply={(payload) => void handleMBApply(payload)}
           onClose={() => setMbState({ status: 'idle' })}


### PR DESCRIPTION
## Summary

- When multiple MB releases are returned, the modal header shows `‹ N / total ›` controls so the user can step through candidates without closing and reopening
- Selection state resets to defaults whenever a new candidate is shown
- The apply payload carries the selected `release` so the correct MBID is always written regardless of which candidate was chosen
- Modal uses CSS grid (`auto 1fr auto`) instead of a hardcoded `calc(80vh - 114px)` body height — no longer breaks when the header grows
- Fixed `height: 80vh` (matching the preferences dialog pattern) prevents the centered modal from shifting position as candidates with different track counts are compared, which was causing accidental backdrop dismissal
- Nav buttons and count span have fixed widths so the layout is stable as digit count changes; disabled arrows show at 35% opacity (dimmed, not gone)

## Test plan

- [ ] Open an album in edit mode, click MusicBrainz pill
- [ ] If multiple candidates returned: `‹ 1 / N ›` appears in header; `‹` is disabled at first candidate, `›` at last — both remain visible throughout
- [ ] Stepping through candidates resets field selections to their defaults for each new release
- [ ] Modal does not shift/resize when switching between a full album and a single-track candidate
- [ ] Apply writes the correct release MBID for whichever candidate was selected, not always the first
- [ ] Single-candidate result: no nav controls shown, modal unchanged from KAMP-230 behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)