### PR TITLE
fix(KAMP-341): post-review corrections to album art fetch

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -351,8 +351,8 @@ class ItunesSearchOut(BaseModel):
 class ItunesApplyRequest(BaseModel):
     album_artist: str
     album: str
-    # Full-res mzstatic URL built by the frontend from artwork_url_template.
-    artwork_url: str
+    # mzstatic URL template with "{size}" placeholder; server resolves to min_dimension.
+    artwork_url_template: str
 
 
 class BandcampProxyFetchResult(BaseModel):
@@ -1529,7 +1529,7 @@ def create_app(
         )
 
         # SSRF guard — only mzstatic.com URLs are permitted.
-        parsed = urlparse(body.artwork_url)
+        parsed = urlparse(body.artwork_url_template)
         if not (
             parsed.scheme in ("http", "https")
             and parsed.netloc
@@ -1537,7 +1537,7 @@ def create_app(
         ):
             raise HTTPException(
                 status_code=400,
-                detail="artwork_url must be an https://….mzstatic.com URL",
+                detail="artwork_url_template must be an https://….mzstatic.com URL",
             )
 
         tracks = index.tracks_for_album(body.album_artist, body.album)
@@ -1562,9 +1562,15 @@ def create_app(
         min_dim: int = int(config.get("artwork.min_dimension", 500))
         max_b: int = int(config.get("artwork.max_bytes", 5_000_000))
 
+        # Resolve template to the user's configured minimum dimension so we always
+        # request exactly the quality they require (Apple CDN resizes on demand).
+        artwork_url = body.artwork_url_template.replace(
+            "{size}", f"{min_dim}x{min_dim}bb"
+        )
+
         try:
             image_bytes = await asyncio.get_event_loop().run_in_executor(
-                None, fetch_itunes_image, body.artwork_url, min_dim, max_b
+                None, fetch_itunes_image, artwork_url, min_dim, max_b
             )
         except ArtworkError as exc:
             msg = str(exc)

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -595,12 +595,12 @@ export async function searchAlbumArt(
 export async function applyAlbumArt(
   albumArtist: string,
   album: string,
-  artworkUrl: string
+  artworkUrlTemplate: string
 ): Promise<Album> {
   const res = await fetch(`${BASE_URL}/api/v1/albums/art/apply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-    body: JSON.stringify({ album_artist: albumArtist, album, artwork_url: artworkUrl })
+    body: JSON.stringify({ album_artist: albumArtist, album, artwork_url_template: artworkUrlTemplate })
   })
   if (!res.ok) {
     const detail = await res.json().catch(() => ({ detail: res.statusText }))

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -600,7 +600,11 @@ export async function applyAlbumArt(
   const res = await fetch(`${BASE_URL}/api/v1/albums/art/apply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ..._authHeaders() },
-    body: JSON.stringify({ album_artist: albumArtist, album, artwork_url_template: artworkUrlTemplate })
+    body: JSON.stringify({
+      album_artist: albumArtist,
+      album,
+      artwork_url_template: artworkUrlTemplate
+    })
   })
   if (!res.ok) {
     const detail = await res.json().catch(() => ({ detail: res.statusText }))

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -182,6 +182,11 @@
   overflow: hidden; /* clips progress bar at rounded corners */
 }
 
+/* Third pill slot — stacked below MusicBrainz pill */
+.mb-pill--second {
+  top: 80px; /* MusicBrainz pill top:46px + ~27px height + 7px gap */
+}
+
 .mb-pill--loading {
   opacity: 0.85;
   cursor: default;

--- a/kamp_ui/src/renderer/src/components/ItunesArtModal.tsx
+++ b/kamp_ui/src/renderer/src/components/ItunesArtModal.tsx
@@ -25,9 +25,6 @@ type Props = {
   onApplied: (updatedAlbum: Album) => void
 }
 
-function resolveArtUrl(template: string, size: string): string {
-  return template.replace('{size}', size)
-}
 
 function ArtThumbnail({
   candidate,
@@ -107,9 +104,8 @@ export function ItunesArtModal({
   ): Promise<void> => {
     setState({ kind: 'applying', candidates, selectedIndex })
     const candidate = candidates[selectedIndex]
-    const artworkUrl = resolveArtUrl(candidate.artwork_url_template, '600x600bb')
     try {
-      const updatedAlbum = await applyAlbumArt(albumArtist, album, artworkUrl)
+      const updatedAlbum = await applyAlbumArt(albumArtist, album, candidate.artwork_url_template)
       onApplied(updatedAlbum)
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Apply failed'

--- a/kamp_ui/src/renderer/src/components/ItunesArtModal.tsx
+++ b/kamp_ui/src/renderer/src/components/ItunesArtModal.tsx
@@ -25,7 +25,6 @@ type Props = {
   onApplied: (updatedAlbum: Album) => void
 }
 
-
 function ArtThumbnail({
   candidate,
   selected,

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -72,6 +72,7 @@ export function TrackList(): React.JSX.Element | null {
   const patchTrackTitle = useStore((s) => s.patchTrackTitle)
   const patchAlbumTags = useStore((s) => s.patchAlbumTags)
   const refreshOpenAlbum = useStore((s) => s.refreshOpenAlbum)
+  const patchOpenAlbum = useStore((s) => s.patchOpenAlbum)
   const albumRenameProgress = useStore((s) => s.albumRenameProgress)
   const deferredOps = useStore((s) => s.deferredOps)
 
@@ -274,7 +275,7 @@ export function TrackList(): React.JSX.Element | null {
       {/* iTunes album art fetch pill — only visible in edit mode */}
       {albumEditMode && (
         <button
-          className="breadcrumb-edit-btn mb-pill"
+          className="breadcrumb-edit-btn mb-pill mb-pill--second"
           title="Fetch album art"
           onClick={() => setArtSearchOpen(true)}
           type="button"
@@ -487,9 +488,9 @@ export function TrackList(): React.JSX.Element | null {
           album={album.album}
           hasExistingArt={album.has_art}
           onClose={() => setArtSearchOpen(false)}
-          onApplied={() => {
+          onApplied={(updatedAlbum) => {
             setArtSearchOpen(false)
-            void refreshOpenAlbum()
+            patchOpenAlbum(updatedAlbum)
           }}
         />
       )}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -522,8 +522,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }
   },
 
-  patchOpenAlbum: (album) =>
-    set((s) => ({ library: { ...s.library, selectedAlbum: album } })),
+  patchOpenAlbum: (album) => set((s) => ({ library: { ...s.library, selectedAlbum: album } })),
 
   selectArtist: (artist) =>
     set((s) => ({ library: { ...s.library, selectedArtist: artist, selectedAlbum: null } })),

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -165,6 +165,7 @@ type PlayerStore = {
   clearDeferredOp: (trackId: number) => void
   setAlbumRenameProgress: (progress: { done: number; total: number } | null) => void
   refreshOpenAlbum: () => Promise<void>
+  patchOpenAlbum: (album: Album) => void
   scanLibrary: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
   setWatchFolderPath: (path: string) => Promise<void>
@@ -520,6 +521,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
       // Best-effort — stale track list is better than a broken UI.
     }
   },
+
+  patchOpenAlbum: (album) =>
+    set((s) => ({ library: { ...s.library, selectedAlbum: album } })),
 
   selectArtist: (artist) =>
     set((s) => ({ library: { ...s.library, selectedArtist: artist, selectedAlbum: null } })),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2938,9 +2938,9 @@ _ITUNES_CANDIDATE = {
     ),
 }
 
-_MZSTATIC_URL = (
+_MZSTATIC_TEMPLATE = (
     "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/49/f7/8b/"
-    "49f78bb0/cover.jpg/600x600bb.jpg"
+    "49f78bb0/cover.jpg/{size}.jpg"
 )
 
 
@@ -3040,7 +3040,7 @@ class TestItunesArtApplyEndpoint:
         return {
             "album_artist": "Joan Jett",
             "album": "Up Your Alley",
-            "artwork_url": _MZSTATIC_URL,
+            "artwork_url_template": _MZSTATIC_TEMPLATE,
         }
 
     def _make_jpeg_bytes(self, w: int = 600, h: int = 600) -> bytes:
@@ -3094,7 +3094,10 @@ class TestItunesArtApplyEndpoint:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
 
-        payload = {**self._valid_payload(), "artwork_url": "https://evil.com/art.jpg"}
+        payload = {
+            **self._valid_payload(),
+            "artwork_url_template": "https://evil.com/art.jpg",
+        }
         res = c.post("/api/v1/albums/art/apply", json=payload)
         assert res.status_code == 400
 
@@ -3107,7 +3110,7 @@ class TestItunesArtApplyEndpoint:
 
         payload = {
             **self._valid_payload(),
-            "artwork_url": "file:///etc/passwd",
+            "artwork_url_template": "file:///etc/passwd",
         }
         res = c.post("/api/v1/albums/art/apply", json=payload)
         assert res.status_code == 400
@@ -3118,7 +3121,7 @@ class TestItunesArtApplyEndpoint:
             json={
                 "album_artist": "Ghost",
                 "album": "Nobody",
-                "artwork_url": _MZSTATIC_URL,
+                "artwork_url_template": _MZSTATIC_TEMPLATE,
             },
         )
         assert res.status_code == 404


### PR DESCRIPTION
Follow-up fixes identified during smoke testing of #430.

## Changes

- **Server resolves artwork URL from template using `artwork.min_dimension` config** — the apply endpoint now substitutes `{size}` with `{min_dim}x{min_dim}bb` itself, so the fetched image always matches the user's quality setting. Previously the frontend hardcoded `600x600bb`, causing apply to fail for users with `artwork.min_dimension = 1000` (the default).
- **Frontend passes the raw template** — `resolveArtUrl` removed from the modal; `applyAlbumArt` now takes `artwork_url_template` instead of a resolved URL.
- **Fix pill overlap** — Fetch Album Art pill was stacked on top of MusicBrainz pill (both `top: 46px`). Added `.mb-pill--second` to offset the third slot to `top: 80px`.
- **Immediate hero image update** — `onApplied` now calls `patchOpenAlbum(updatedAlbum)` to write `has_art` and `art_version` into `selectedAlbum` synchronously. Previously `refreshOpenAlbum` only refreshed tracks, leaving the hero stale until the next `library.changed` WebSocket event.

## Test plan

- [x] Apply album art with `artwork.min_dimension = 1000` → succeeds (previously 422)
- [x] Apply art → hero image updates immediately without navigating away
- [x] Edit mode shows MusicBrainz pill and Fetch Album Art pill as distinct stacked buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)