### PR TITLE
feat(KAMP-273): add bonus dynamic and static strings for onboarding

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -482,6 +482,8 @@ def create_app(
             "current_file": None,
             "current_artist": None,
             "top_artist": None,
+            "num_albums": 0,
+            "num_artists": 0,
         },
         "ui_active_view": ui_active_view,
         "ui_sort_order": ui_sort_order,
@@ -1844,8 +1846,9 @@ def create_app(
         if _state["library_path"] is None:
             raise HTTPException(status_code=503, detail="Library path not configured")
 
-        # Running artist frequency map, accumulated across all on_progress calls.
+        # Running artist frequency map and unique album set, accumulated across all on_progress calls.
         artist_counts: dict[str, int] = {}
+        albums_seen: set[tuple[str, str]] = set()
 
         def _on_progress(current: int, total: int, track: Track | None) -> None:
             current_file: str | None = None
@@ -1857,6 +1860,8 @@ def create_app(
                     artist_counts[current_artist] = (
                         artist_counts.get(current_artist, 0) + 1
                     )
+                if track.album.strip():
+                    albums_seen.add((track.album_artist, track.album))
             top_artist = (
                 max(artist_counts, key=lambda a: artist_counts[a])
                 if artist_counts
@@ -1869,6 +1874,8 @@ def create_app(
                 "current_file": current_file,
                 "current_artist": current_artist,
                 "top_artist": top_artist,
+                "num_albums": len(albums_seen),
+                "num_artists": len(artist_counts),
             }
 
         _state["scan_progress"] = {
@@ -1878,6 +1885,8 @@ def create_app(
             "current_file": None,
             "current_artist": None,
             "top_artist": None,
+            "num_albums": 0,
+            "num_artists": 0,
         }
         try:
             result = LibraryScanner(index).scan(
@@ -1891,6 +1900,8 @@ def create_app(
                 "current_file": None,
                 "current_artist": None,
                 "top_artist": None,
+                "num_albums": 0,
+                "num_artists": 0,
             }
 
         return ScanResult(

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -208,6 +208,8 @@ export type ScanProgress = {
   current_file?: string | null
   current_artist?: string | null
   top_artist?: string | null
+  num_albums?: number | null
+  num_artists?: number | null
 }
 
 export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -14,32 +14,83 @@ const STEP_TITLES: Record<OnboardingStep, string> = {
   'almost-done': 'Almost Done'
 }
 
-const STATIC_STRINGS = [
-  'Almost done…',
-  'Just a little bit longer…',
+// Movement 1: shown sequentially, each exactly once, before anything else.
+const USAGE_TIPS = [
   "In the Library, press 'A' to show or hide the Artist panel",
   "The 'Now Playing' tab shows off your album art",
   "Press 'Q' at any time to show or hide the Queue panel",
-  'Good things are worth waiting for…',
-  'What are you gonna listen to first?'
+  'Drag albums from the Library straight into the Queue.',
+  'Right click albums to favorite them or slot them in the queue.',
+  'Base Kamp is configurable. Make it yours with the gear icon.',
+  'A ten dollar digital album sale is worth 3000 streams to an artist. Your support matters.',
 ]
 
-function buildDynamicStrings(progress: ScanProgress | null): string[] {
+// Movement 2 filler: general waiting strings mixed into the random pool after tips are done.
+const FILLER_STRINGS = [
+  'Almost done…',
+  'Just a little bit longer…',
+  'Good things are worth waiting for…',
+  'What are you gonna listen to first?',
+]
+
+// Movement 3 stingers: combined with a stat root each time a finalizing string is shown.
+const FINALIZING_STINGERS = [
+  ' waiting to be adored.',
+  '… so far…',
+  ' and counting.',
+  ". I'm not even kidding.",
+  ', every one a keeper.',
+  '. Seriously.',
+  ', all of them skip-proof.',
+  ', each one deserving of praise.',
+  ". You've got a lot of listening ahead of you.",
+  ". That's a lot.",
+  ' ready for a spin.',
+  ". We're almost done here.",
+  ' waiting for the needle to drop.',
+  ' currently charming your hard drive.',
+  ', all thriller, no filler.',
+  ' about to melt your face.',
+  ' waiting for your love.',
+  ' ready to rock the party.',
+  ". Calm down. We're nearly there.",
+  ". It's a love affair.",
+  ". This is so going to be worth it when we're done.",
+]
+
+type DynamicString = { id: string; text: string }
+
+function buildDynamicStrings(progress: ScanProgress | null): DynamicString[] {
   if (!progress?.active) return []
-  const strings: string[] = []
+  const out: DynamicString[] = []
+  const add = (id: string, text: string): void => { out.push({ id, text }) }
   if (progress.current_file && progress.current_artist)
-    strings.push(`My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
-  if (progress.top_artist) strings.push(`${progress.top_artist}? Exquisite taste.`)
+    add('fav-song', `My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
   if (progress.current_artist)
-    strings.push(`Ooooh, I haven't heard ${progress.current_artist} in ages!`)
+    add('exquisite-taste', `${progress.current_artist}? Exquisite taste.`)
+  if (progress.current_artist)
+    add('havent-heard', `Ooooh, I haven't heard ${progress.current_artist} in ages!`)
   if (progress.current_artist && progress.current_file)
-    strings.push(`${progress.current_artist}'s "${progress.current_file}"? Killer song.`)
+    add('killer-song', `${progress.current_artist}'s "${progress.current_file}"? Killer song.`)
   if (progress.current_artist)
-    strings.push(`I'd sell my left kidney to see ${progress.current_artist} live…`)
+    add('left-kidney', `I'd sell my left kidney to see ${progress.current_artist} live…`)
   if (progress.current_artist)
-    strings.push(
-      `Nobody will say it out loud, but ${progress.current_artist} is totally underrated.`
-    )
+    add('underrated', `Nobody will say it out loud, but ${progress.current_artist} is totally underrated.`)
+  if (progress.top_artist)
+    add('carrying', `${progress.top_artist} has been carrying this library for a while now, huh.`)
+  if (progress.current_artist)
+    add('tiny-venue', `If ${progress.current_artist} played a tiny venue tomorrow, you'd already have a ticket.`)
+  return out
+}
+
+function buildFinalizingStrings(progress: ScanProgress | null): string[] {
+  if (!progress?.active) return []
+  const stinger = (): string =>
+    FINALIZING_STINGERS[Math.floor(Math.random() * FINALIZING_STINGERS.length)]
+  const strings: string[] = []
+  if (progress.num_albums) strings.push(`${progress.num_albums} albums${stinger()}`)
+  if (progress.current > 0) strings.push(`${progress.current} songs${stinger()}`)
+  if (progress.num_artists) strings.push(`${progress.num_artists} artists${stinger()}`)
   return strings
 }
 
@@ -80,7 +131,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const [lastfmUsername, setLastfmUsername] = useState('')
   const [lastfmPassword, setLastfmPassword] = useState('')
   const [lastfmBusy, setLastfmBusy] = useState(false)
-  const [currentString, setCurrentString] = useState(STATIC_STRINGS[0])
+  const [currentString, setCurrentString] = useState(USAGE_TIPS[0])
   const [stringVisible, setStringVisible] = useState(true)
   const [showAllSet, setShowAllSet] = useState(false)
   // Fade transition state for content changes
@@ -137,26 +188,51 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
 
   // Keep refs so the rotation interval can read the latest values without
   // needing them as dependencies (which would restart the interval on every poll tick).
-  const dynamicStringsRef = useRef<string[]>([])
-  const stringPosRef = useRef(0)
+  const dynamicStringsRef = useRef<DynamicString[]>([])
+  const scanProgressRef = useRef<typeof scanProgress>(null)
+  // USAGE_TIPS[0] is the initial displayed value, so start at 1.
+  const tipIndexRef = useRef(1)
+  // Dynamic strings are one-shots; track shown template IDs so they never repeat.
+  const shownDynamicRef = useRef<Set<string>>(new Set())
   useEffect(() => {
     dynamicStringsRef.current = buildDynamicStrings(scanProgress)
+    scanProgressRef.current = scanProgress
   }, [scanProgress])
 
-  // Rotate the 'Almost done' strings every 4s with a fade.
-  // The next string is snapshotted during the fade-out so live scanProgress
-  // updates between rotations never mutate the currently visible string.
+  // Rotate the 'Almost done' strings every 3s with a fade.
+  // Movement 1: USAGE_TIPS play sequentially, each once.
+  // Movement 2: dynamic strings are one-shots keyed by template ID; popped once shown.
+  // Movement 3: finalizing strings cycle continuously (fresh random stinger each rotation).
+  // FILLER_STRINGS are a last resort when no dynamic or finalizing strings are available yet.
   useEffect(() => {
     if (step !== 'almost-done') return
     const t = setInterval(() => {
       setStringVisible(false)
       setTimeout(() => {
-        const pool = [...STATIC_STRINGS, ...dynamicStringsRef.current]
-        stringPosRef.current = (stringPosRef.current + 1) % pool.length
-        setCurrentString(pool[stringPosRef.current])
+        let next: string
+        if (tipIndexRef.current < USAGE_TIPS.length) {
+          next = USAGE_TIPS[tipIndexRef.current]
+          tipIndexRef.current++
+        } else {
+          const unseenDynamic = dynamicStringsRef.current.filter(
+            (s) => !shownDynamicRef.current.has(s.id)
+          )
+          // Rebuild finalizing strings here so each rotation gets a fresh random stinger.
+          const finalizing = buildFinalizingStrings(scanProgressRef.current)
+          if (unseenDynamic.length > 0 || finalizing.length > 0) {
+            const dynTexts = unseenDynamic.map((s) => s.text)
+            const pool = [...dynTexts, ...finalizing]
+            const idx = Math.floor(Math.random() * pool.length)
+            next = pool[idx]
+            if (idx < dynTexts.length) shownDynamicRef.current.add(unseenDynamic[idx].id)
+          } else {
+            next = FILLER_STRINGS[Math.floor(Math.random() * FILLER_STRINGS.length)]
+          }
+        }
+        setCurrentString(next)
         setStringVisible(true)
       }, 350)
-    }, 3000)
+    }, 5000)
     return () => clearInterval(t)
   }, [step])
 

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -22,7 +22,7 @@ const USAGE_TIPS = [
   'Drag albums from the Library straight into the Queue.',
   'Right click albums to favorite them or slot them in the queue.',
   'Base Kamp is configurable. Make it yours with the gear icon.',
-  'A ten dollar digital album sale is worth 3000 streams to an artist. Your support matters.',
+  'A ten dollar digital album sale is worth 3000 streams to an artist. Your support matters.'
 ]
 
 // Movement 2 filler: general waiting strings mixed into the random pool after tips are done.
@@ -30,7 +30,7 @@ const FILLER_STRINGS = [
   'Almost done…',
   'Just a little bit longer…',
   'Good things are worth waiting for…',
-  'What are you gonna listen to first?',
+  'What are you gonna listen to first?'
 ]
 
 // Movement 3 stingers: combined with a stat root each time a finalizing string is shown.
@@ -55,7 +55,7 @@ const FINALIZING_STINGERS = [
   ' ready to rock the party.',
   ". Calm down. We're nearly there.",
   ". It's a love affair.",
-  ". This is so going to be worth it when we're done.",
+  ". This is so going to be worth it when we're done."
 ]
 
 type DynamicString = { id: string; text: string }
@@ -63,7 +63,9 @@ type DynamicString = { id: string; text: string }
 function buildDynamicStrings(progress: ScanProgress | null): DynamicString[] {
   if (!progress?.active) return []
   const out: DynamicString[] = []
-  const add = (id: string, text: string): void => { out.push({ id, text }) }
+  const add = (id: string, text: string): void => {
+    out.push({ id, text })
+  }
   if (progress.current_file && progress.current_artist)
     add('fav-song', `My favorite song is ${progress.current_file} by ${progress.current_artist}…`)
   if (progress.current_artist)
@@ -75,11 +77,17 @@ function buildDynamicStrings(progress: ScanProgress | null): DynamicString[] {
   if (progress.current_artist)
     add('left-kidney', `I'd sell my left kidney to see ${progress.current_artist} live…`)
   if (progress.current_artist)
-    add('underrated', `Nobody will say it out loud, but ${progress.current_artist} is totally underrated.`)
+    add(
+      'underrated',
+      `Nobody will say it out loud, but ${progress.current_artist} is totally underrated.`
+    )
   if (progress.top_artist)
     add('carrying', `${progress.top_artist} has been carrying this library for a while now, huh.`)
   if (progress.current_artist)
-    add('tiny-venue', `If ${progress.current_artist} played a tiny venue tomorrow, you'd already have a ticket.`)
+    add(
+      'tiny-venue',
+      `If ${progress.current_artist} played a tiny venue tomorrow, you'd already have a ticket.`
+    )
   return out
 }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -694,6 +694,8 @@ class TestScanProgressEndpoint:
         assert data["active"] is False
         assert data["current"] == 0
         assert data["total"] == 0
+        assert data["num_albums"] == 0
+        assert data["num_artists"] == 0
 
     def test_progress_callback_updates_state(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -771,6 +773,8 @@ class TestScanProgressEndpoint:
         assert data["current_file"] == "Tha"
         assert data["current_artist"] == "Aphex Twin"
         assert data["top_artist"] == "Aphex Twin"
+        assert data["num_artists"] == 1
+        assert data["num_albums"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Restructures the 'almost-done' scan screen into three movements: sequential usage tips (fire once), dynamic one-shot strings keyed by template ID (not string content), and finalizing strings that cycle continuously with a fresh random stinger each rotation
- Adds 4 new usage tips, 5 new dynamic string templates, and 21 stinger variants for the finalizing strings
- Adds `num_albums` and `num_artists` to the scan progress API (tracked incrementally during the scan)
- Uses `progress.current` (songs scanned so far, always incrementing) rather than `progress.total` (fixed ceiling) for the songs finalizing string

## Test plan

- [ ] Run `poetry run pytest tests/test_server.py::TestScanProgressEndpoint -v --no-cov` — all pass
- [ ] Run `poetry run pytest tests/ -v` — full suite ≥94% coverage
- [ ] Trigger a fresh onboarding scan and confirm: tips play sequentially first, dynamic strings appear once each, finalizing strings cycle with changing stingers and live-updating counts throughout the scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)