### PR TITLE
fix(KAMP-338): gate artist panel render on library view

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -545,7 +545,7 @@ export default function App(): React.JSX.Element {
   const isPanelVisible = (p: UnifiedPanel | undefined): boolean => {
     if (!p) return false
     if (p.id === 'kamp.queue') return queueVisible
-    if (p.id === 'kamp.artist-list') return artistPanelVisible
+    if (p.id === 'kamp.artist-list') return activeView === 'library' && artistPanelVisible
     return true
   }
 


### PR DESCRIPTION
## Summary

- Artist panel is a Library-only component; it should never render in Base Kamp
- Adds `activeView === 'library'` guard to `isPanelVisible()` in App.tsx
- Root cause: store init uses `!== 'false'` default (correct — panel visible on first Library visit), but there was no rendering-level gate preventing it from showing in non-Library views when the key is absent

## Test plan

- [ ] Remove `kamp:artist-panel-visible` from DevTools → Application → Local Storage
- [ ] Navigate to Base Kamp → artist panel must NOT be visible
- [ ] Navigate to Library → artist panel must be visible by default
- [ ] Toggle panel off, navigate to Base Kamp, return to Library → panel stays hidden
- [ ] Toggle panel on, navigate to Base Kamp, restart → panel visible in Library, not in Base Kamp

🤖 Generated with [Claude Code](https://claude.ai/claude-code)