### PR TITLE
feat(KAMP-347): add Discord link to Preferences About section

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -897,6 +897,10 @@ app.whenReady().then(async () => {
     shell.showItemInFolder(filePath)
   })
 
+  ipcMain.on('shell:open-external', (_event, url: string) => {
+    void shell.openExternal(url)
+  })
+
   ipcMain.handle('update:dismiss', (_event, version: string) => {
     writeUpdateState({ dismissedVersion: version })
   })

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -23,6 +23,7 @@ declare global {
       dismissUpdate: (version: string) => Promise<void>
       getApiToken: () => string | null
       showItemInFolder: (filePath: string) => void
+      openExternal: (url: string) => void
     }
     KampAPI: KampAPI
   }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -80,7 +80,8 @@ const api = {
   // Re-reads from disk so Electron picks up a fresh token after daemon restart.
   getApiToken: (): string | null => _readKampToken(),
   showItemInFolder: (filePath: string): void =>
-    ipcRenderer.send('shell:show-item-in-folder', filePath)
+    ipcRenderer.send('shell:show-item-in-folder', filePath),
+  openExternal: (url: string): void => ipcRenderer.send('shell:open-external', url)
 }
 
 const kampAPI = buildKampAPI()

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -21,6 +21,7 @@ const RESTART_KEYS = new Set([
 ])
 
 const BANDCAMP_FORMATS = ['mp3-v0', 'mp3-320', 'flac', 'aac-hi', 'vorbis', 'alac', 'wav']
+const DISCORD_INVITE_URL = 'https://discord.gg/VRkRnmAcNj'
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -1194,7 +1195,7 @@ export function PreferencesDialog({
                     <div className="prefs-row">
                       <button
                         className="prefs-choose-btn"
-                        onClick={() => window.api.openExternal('https://discord.gg/VRkRnmAcNj')}
+                        onClick={() => window.api.openExternal(DISCORD_INVITE_URL)}
                       >
                         Join Discord
                       </button>

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1198,9 +1198,7 @@ export function PreferencesDialog({
                       >
                         Join Discord
                       </button>
-                      <p className="prefs-hint">
-                        Give feedback and connect with other Kamp users.
-                      </p>
+                      <p className="prefs-hint">Give feedback and connect with other Kamp users.</p>
                     </div>
                   </div>
                 </>

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1187,6 +1187,22 @@ export function PreferencesDialog({
                       onSave={handleArtworkSave}
                     />
                   </div>
+
+                  {/* ABOUT */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">About</div>
+                    <div className="prefs-row">
+                      <button
+                        className="prefs-choose-btn"
+                        onClick={() => window.api.openExternal('https://discord.gg/VRkRnmAcNj')}
+                      >
+                        Join Discord
+                      </button>
+                      <p className="prefs-hint">
+                        Give feedback and connect with other Kamp users.
+                      </p>
+                    </div>
+                  </div>
                 </>
               )}
             </>


### PR DESCRIPTION
## Summary

- Wires `shell:open-external` IPC handler (main) and exposes `window.api.openExternal()` via preload
- Adds an **About** section at the bottom of the General tab in Preferences with a **Join Discord** button that opens `https://discord.gg/VRkRnmAcNj` in the browser

## Test plan

- [ ] Open Preferences → General → scroll to the bottom
- [ ] Confirm an About section is present with a "Join Discord" button and hint text
- [ ] Click "Join Discord" — browser opens `https://discord.gg/VRkRnmAcNj`
- [ ] Typecheck and lint pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)