### PR TITLE
fix: resolve bundled mpv from sys._MEIPASS when KAMP_MPV_BIN is absent

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1314,13 +1314,23 @@ def _resolve_mpv_binary() -> str:
     """Return the absolute path to the mpv binary.
 
     The .app bundle sets KAMP_MPV_BIN to the bundled binary path; check that
-    first. For launchd (macOS minimal PATH) or an Electron-spawned daemon on
-    Windows (stale parent-shell PATH), fall back to platform-typical install
-    locations before relying on PATH.
+    first. When running as a frozen PyInstaller bundle without KAMP_MPV_BIN
+    (e.g. a launchd service that pre-dates the env-var injection), derive the
+    path from sys._MEIPASS: _internal/ → ../  → ../../mpv[/mpv.exe]. For
+    launchd (macOS minimal PATH) or an Electron-spawned daemon on Windows
+    (stale parent-shell PATH), fall back to platform-typical install locations
+    before relying on PATH.
     """
     env_path = os.environ.get("KAMP_MPV_BIN")
     if env_path and Path(env_path).exists():
         return env_path
+    # Frozen bundle without KAMP_MPV_BIN: infer from _internal/ layout.
+    # Contents/Resources/kamp/_internal/ → ../../ → Contents/Resources/mpv
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        name = Path("mpv", "mpv.exe") if sys.platform == "win32" else Path("mpv")
+        bundled = Path(sys._MEIPASS).parent.parent / name
+        if bundled.exists():
+            return str(bundled)
     fallback_paths = _WIN_MPV_PATHS if sys.platform == "win32" else _HOMEBREW_MPV_PATHS
     for path in fallback_paths:
         if Path(path).exists():

--- a/tests/test_resolve_mpv_binary.py
+++ b/tests/test_resolve_mpv_binary.py
@@ -1,5 +1,6 @@
 """Tests for _resolve_mpv_binary() in kamp_daemon.__main__."""
 
+import sys
 from unittest.mock import patch
 
 from kamp_daemon.__main__ import _resolve_mpv_binary
@@ -41,6 +42,48 @@ def test_env_var_not_set_falls_back_to_platform_paths(tmp_path):
         patch("kamp_daemon.__main__._WIN_MPV_PATHS", [str(fallback_mpv)]),
     ):
         assert _resolve_mpv_binary() == str(fallback_mpv)
+
+
+def test_frozen_bundle_without_env_var_uses_meipass(tmp_path):
+    """Frozen bundle without KAMP_MPV_BIN derives mpv from _internal/ layout.
+
+    This covers launchd services started before KAMP_MPV_BIN was injected by
+    Electron — the daemon must still find the bundled mpv sibling.
+    """
+    # Simulate Contents/Resources/kamp/_internal/ layout:
+    internal = tmp_path / "kamp" / "_internal"
+    internal.mkdir(parents=True)
+    bundled_mpv = tmp_path / "mpv"
+    bundled_mpv.touch()
+
+    without_kamp_mpv_bin = {
+        k: v for k, v in __import__("os").environ.items() if k != "KAMP_MPV_BIN"
+    }
+    with (
+        patch.dict("os.environ", without_kamp_mpv_bin, clear=True),
+        patch.object(sys, "frozen", True, create=True),
+        patch.object(sys, "_MEIPASS", str(internal), create=True),
+        patch("kamp_daemon.__main__._HOMEBREW_MPV_PATHS", []),
+        patch("kamp_daemon.__main__._WIN_MPV_PATHS", []),
+    ):
+        assert _resolve_mpv_binary() == str(bundled_mpv)
+
+
+def test_frozen_bundle_env_var_still_takes_priority(tmp_path):
+    """KAMP_MPV_BIN env var beats the frozen-bundle path when it exists."""
+    internal = tmp_path / "kamp" / "_internal"
+    internal.mkdir(parents=True)
+    bundled_mpv = tmp_path / "mpv"
+    bundled_mpv.touch()
+    explicit_mpv = tmp_path / "explicit_mpv"
+    explicit_mpv.touch()
+
+    with (
+        patch.dict("os.environ", {"KAMP_MPV_BIN": str(explicit_mpv)}),
+        patch.object(sys, "frozen", True, create=True),
+        patch.object(sys, "_MEIPASS", str(internal), create=True),
+    ):
+        assert _resolve_mpv_binary() == str(explicit_mpv)
 
 
 def test_windows_uses_win_paths_not_homebrew(tmp_path):


### PR DESCRIPTION
## Summary

- `_resolve_mpv_binary()` now has a self-healing fallback for frozen PyInstaller bundles: when `KAMP_MPV_BIN` is not in the environment, it derives the mpv path from `sys._MEIPASS` (`_internal/../../mpv`) rather than falling through to the bare string `"mpv"` and crashing.
- This covers any scenario where the daemon is started without Electron injecting the env var.
- 2 new tests cover the frozen-bundle path and confirm `KAMP_MPV_BIN` still takes priority.

## Test plan

- [ ] `poetry run pytest tests/test_resolve_mpv_binary.py -v --no-cov` — 6 tests pass
- [ ] If user with the crash confirms: `launchctl list | grep kamp` shows a registered service, and `ls /Applications/Kamp.app/Contents/Resources/mpv` exists — this fix would have resolved their crash

Relates to KAMP-349 (launchd removal tracked as follow-up tech debt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)