### PR TITLE
fix: prevent hero image from being draggable on album page

### DIFF
--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -45,6 +45,7 @@ function HeroImage({ src }: { src: string }): React.JSX.Element {
       className={`track-list-hero-img${loaded ? ' loaded' : ''}`}
       src={src}
       alt=""
+      draggable={false}
       onLoad={() => setLoaded(true)}
       onError={() => setLoaded(false)}
     />


### PR DESCRIPTION
## Summary
- Adds `draggable={false}` to the `<img>` in `HeroImage` in `TrackList.tsx`
- Prevents the ghost-drag behavior when clicking and dragging the album art hero

## Test plan
- [x] Navigate to an album page
- [x] Click and drag the hero image — no ghost image should appear

Closes KAMP-354

🤖 Generated with [Claude Code](https://claude.com/claude-code)