### PR TITLE
feat(KAMP-294): library sort dropdown, sticky filter rail, and favorites filtering

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -322,6 +322,8 @@ class AlbumInfo:
     play_count_avg: float = 0.0
     # True when the user has favorited this album (KAMP-293).
     favorite: bool = False
+    # True when any track in this album is individually favorited (KAMP-294).
+    has_favorite_track: bool = False
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -1366,7 +1368,7 @@ class LibraryIndex:
             SELECT album_artist, album, year, track_count, has_art,
                    missing_album, file_path, art_version,
                    sort_date_added, sort_last_played, sort_play_count_avg,
-                   is_favorite
+                   is_favorite, has_favorite_track
             FROM (
                 SELECT t.album_artist, t.album, t.year, COUNT(*) AS track_count,
                        MAX(t.embedded_art) AS has_art,
@@ -1375,7 +1377,8 @@ class LibraryIndex:
                        MAX(t.last_played) AS sort_last_played,
                        MAX(t.file_mtime) AS art_version,
                        CAST(SUM(t.play_count) AS REAL) / COUNT(*) AS sort_play_count_avg,
-                       MAX(CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END) AS is_favorite
+                       MAX(CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END) AS is_favorite,
+                       MAX(t.favorite) AS has_favorite_track
                 FROM tracks t
                 LEFT JOIN album_favorites af
                     ON af.album_artist = t.album_artist AND af.album = t.album
@@ -1389,7 +1392,8 @@ class LibraryIndex:
                        t.last_played AS sort_last_played,
                        t.file_mtime AS art_version,
                        CAST(t.play_count AS REAL) AS sort_play_count_avg,
-                       CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END AS is_favorite
+                       CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END AS is_favorite,
+                       t.favorite AS has_favorite_track
                 FROM tracks t
                 LEFT JOIN album_favorites af
                     ON af.album_artist = t.album_artist AND af.album = t.title
@@ -1411,6 +1415,7 @@ class LibraryIndex:
                 last_played_at=r["sort_last_played"],
                 play_count_avg=r["sort_play_count_avg"] or 0.0,
                 favorite=bool(r["is_favorite"]),
+                has_favorite_track=bool(r["has_favorite_track"]),
             )
             for r in rows
         ]

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -111,6 +111,8 @@ class AlbumOut(BaseModel):
     play_count_avg: float = 0.0
     # True when the user has favorited this album (KAMP-293).
     favorite: bool = False
+    # True when any track in this album is individually favorited (KAMP-294).
+    has_favorite_track: bool = False
 
 
 class PlayerStateOut(BaseModel):
@@ -669,6 +671,7 @@ def create_app(
                 last_played_at=a.last_played_at,
                 play_count_avg=a.play_count_avg,
                 favorite=a.favorite,
+                has_favorite_track=a.has_favorite_track,
             )
             for a in index.albums(sort=sort)
         ]
@@ -1637,6 +1640,7 @@ def create_app(
                     last_played_at=a.last_played_at,
                     play_count_avg=a.play_count_avg,
                     favorite=a.favorite,
+                    has_favorite_track=a.has_favorite_track,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -1752,6 +1756,7 @@ def create_app(
                     last_played_at=a.last_played_at,
                     play_count_avg=a.play_count_avg,
                     favorite=a.favorite,
+                    has_favorite_track=a.has_favorite_track,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -1833,6 +1838,7 @@ def create_app(
                 added_at=a.added_at,
                 play_count_avg=a.play_count_avg,
                 favorite=a.favorite,
+                has_favorite_track=a.has_favorite_track,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -46,6 +46,8 @@ export type Album = {
   play_count_avg: number
   // True when the user has favorited this album (KAMP-293).
   favorite: boolean
+  // True when any track in this album is individually favorited (KAMP-294).
+  has_favorite_track: boolean
 }
 
 export type PlayerState = {
@@ -189,7 +191,7 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
 
 export type UiState = {
   active_view: 'library' | 'now-playing' | 'home'
-  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played'
+  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
   queue_panel_open: boolean
 }
 
@@ -198,7 +200,7 @@ export const setActiveViewApi = (
   view: 'library' | 'now-playing' | 'home'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
+  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/sort-order', { sort_order: sortOrder })
 export const setQueuePanelApi = (open: boolean): Promise<{ ok: boolean }> =>
   post('/api/v1/ui/queue-panel', { open })

--- a/kamp_ui/src/renderer/src/assets/album-grid.css
+++ b/kamp_ui/src/renderer/src/assets/album-grid.css
@@ -16,8 +16,9 @@
   align-items: center;
   gap: 8px;
   padding: 6px 16px;
-  /* Bleed past .main-content's 16px padding so the bar covers the full width */
-  margin: -16px -16px 0;
+  /* Bleed past .main-content's left/right padding to cover the full width.
+     Top padding is removed by layout.css when the album grid is active. */
+  margin: 0 -16px 0;
 }
 
 /* Shared toolbar dropdown styles ------------------------------------------- */

--- a/kamp_ui/src/renderer/src/assets/album-grid.css
+++ b/kamp_ui/src/renderer/src/assets/album-grid.css
@@ -7,50 +7,121 @@
 }
 
 .album-grid-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 6px 12px 4px;
+  gap: 8px;
+  padding: 6px 16px;
+  /* Bleed past .main-content's 16px padding so the bar covers the full width */
+  margin: -16px -16px 0;
 }
 
-.sort-control {
+/* Shared toolbar dropdown styles ------------------------------------------- */
+
+.sort-anchor,
+.filter-anchor {
+  position: relative;
+}
+
+.toolbar-dropdown-trigger {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 3px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+  white-space: nowrap;
+}
+
+.toolbar-dropdown-trigger:hover {
+  background: var(--surface-hover);
+}
+
+.toolbar-dropdown-trigger.has-active {
+  border-color: var(--accent-dim);
+}
+
+.toolbar-dropdown-badge {
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.dropdown-chevron {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.toolbar-dropdown-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  min-width: 160px;
+  padding: 4px;
+  z-index: 50;
+  white-space: nowrap;
+}
+
+.toolbar-dropdown-item {
   display: flex;
   align-items: center;
   gap: 6px;
-  flex-wrap: wrap;
-}
-
-.sort-label {
-  color: var(--text-dim);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-right: 2px;
-}
-
-.sort-btn {
   background: none;
-  border: 1px solid var(--border);
+  border: none;
   border-radius: 4px;
   color: var(--text-dim);
   cursor: pointer;
   font-size: 12px;
-  padding: 3px 10px;
+  padding: 5px 10px;
+  width: 100%;
+  text-align: left;
   transition:
     background 0.1s,
     color 0.1s;
 }
 
-.sort-btn:hover {
+.toolbar-dropdown-item:hover {
   background: var(--surface-hover);
   color: var(--text);
 }
 
-.sort-btn.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+.toolbar-dropdown-item.active {
+  color: var(--accent);
 }
+
+.toolbar-dropdown-item.toolbar-dropdown-clear {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.toolbar-dropdown-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.dropdown-check {
+  width: 12px;
+  flex-shrink: 0;
+  color: var(--accent);
+  font-size: 10px;
+}
+
+/* Album grid --------------------------------------------------------------- */
 
 .album-grid {
   display: grid;

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -428,6 +428,13 @@ html[data-platform='win32'] .view-tabs {
   overflow: hidden;
 }
 
+/* Library view: the sticky toolbar manages its own top edge, so remove the
+   top padding here to let it sit flush with the pane. Left/right/bottom
+   padding remain so the album grid and track list keep their margins. */
+.main-content:has(.view-pane--active .album-grid-container) {
+  padding-top: 0;
+}
+
 /* Artist panel ------------------------------------------------------------- */
 
 .artist-panel {

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -6,10 +6,12 @@ let savedScrollTop = 0
 import { useStore } from '../store'
 import { AlbumCard } from './AlbumCard'
 import { SortControl } from './SortControl'
+import { FilterControl } from './FilterControl'
 
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
+  const libraryFilter = useStore((s) => s.libraryFilter)
 
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -24,17 +26,43 @@ export function AlbumGrid(): React.JSX.Element {
     }
   }, [])
 
-  const visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
+  let visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
+
+  if (libraryFilter.length > 0) {
+    // "Top Albums": top 100 by avg plays per track — same algorithm as Base Kamp Top Albums module.
+    const top100Keys =
+      libraryFilter.includes('top_albums') && albums.length > 0
+        ? new Set(
+            [...albums]
+              .sort((a, b) => b.play_count_avg - a.play_count_avg)
+              .slice(0, 100)
+              .map((a) => `${a.album_artist}\0${a.album}`)
+          )
+        : null
+
+    visible = visible.filter(
+      (a) =>
+        (libraryFilter.includes('favorite_album') && a.favorite) ||
+        (libraryFilter.includes('has_favorite_track') && a.has_favorite_track) ||
+        (libraryFilter.includes('unplayed') && a.last_played_at === null) ||
+        (libraryFilter.includes('top_albums') && top100Keys!.has(`${a.album_artist}\0${a.album}`))
+    )
+  }
+
+  const emptyMessage = (): string => {
+    if (albums.length === 0) return 'No albums in library.'
+    if (libraryFilter.length > 0) return 'No albums match the active filter.'
+    return 'No albums for this artist.'
+  }
 
   return (
     <div className="album-grid-container" ref={containerRef}>
       <div className="album-grid-toolbar">
         <SortControl />
+        <FilterControl />
       </div>
       {visible.length === 0 ? (
-        <div className="album-grid-empty">
-          {albums.length === 0 ? 'No albums in library.' : 'No albums for this artist.'}
-        </div>
+        <div className="album-grid-empty">{emptyMessage()}</div>
       ) : (
         <div className="album-grid">
           {visible.map((album) => (

--- a/kamp_ui/src/renderer/src/components/FilterControl.tsx
+++ b/kamp_ui/src/renderer/src/components/FilterControl.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useStore } from '../store'
+
+type FilterKey = 'favorite_album' | 'has_favorite_track' | 'unplayed' | 'top_albums'
+
+const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
+  { key: 'favorite_album', label: 'Favorite albums' },
+  { key: 'has_favorite_track', label: 'Albums with favorited tracks' },
+  { key: 'unplayed', label: 'Unplayed' },
+  { key: 'top_albums', label: 'Top Albums' }
+]
+
+export function FilterControl(): React.JSX.Element {
+  const libraryFilter = useStore((s) => s.libraryFilter)
+  const setLibraryFilter = useStore((s) => s.setLibraryFilter)
+  const [open, setOpen] = useState(false)
+  // Single ref wrapping both trigger and popover so contains() check works on option clicks.
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent): void => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return (): void => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const toggle = (key: FilterKey): void => {
+    if (libraryFilter.includes(key)) {
+      setLibraryFilter(libraryFilter.filter((f) => f !== key))
+    } else {
+      setLibraryFilter([...libraryFilter, key])
+    }
+  }
+
+  const hasActive = libraryFilter.length > 0
+
+  return (
+    <div className="filter-anchor" ref={ref}>
+      <button
+        className={`toolbar-dropdown-trigger${hasActive ? ' has-active' : ''}`}
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        Filter
+        {hasActive && (
+          <span className="toolbar-dropdown-badge" aria-label={`${libraryFilter.length} active`}>
+            · {libraryFilter.length}
+          </span>
+        )}
+        <span className="dropdown-chevron" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div
+          className="toolbar-dropdown-popover"
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label="Filter"
+        >
+          {hasActive && (
+            <>
+              <button
+                className="toolbar-dropdown-item toolbar-dropdown-clear"
+                onClick={() => setLibraryFilter([])}
+              >
+                No filter
+              </button>
+              <div className="toolbar-dropdown-divider" />
+            </>
+          )}
+          {FILTER_OPTIONS.map(({ key, label }) => {
+            const active = libraryFilter.includes(key)
+            return (
+              <button
+                key={key}
+                role="option"
+                aria-selected={active}
+                className={`toolbar-dropdown-item${active ? ' active' : ''}`}
+                onClick={() => toggle(key)}
+              >
+                <span className="dropdown-check" aria-hidden="true">
+                  {active ? '▪' : ''}
+                </span>
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -42,7 +42,8 @@ export function QueueContextMenu({ x, y, trackIdx, track, onClose }: Props): Rea
                 added_at: null,
                 last_played_at: null,
                 play_count_avg: 0,
-                favorite: false
+                favorite: false,
+                has_favorite_track: false
               }
               void setActiveView('library')
               void selectAlbum(found)

--- a/kamp_ui/src/renderer/src/components/SortControl.tsx
+++ b/kamp_ui/src/renderer/src/components/SortControl.tsx
@@ -1,31 +1,73 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 
-type SortOrder = 'album_artist' | 'album' | 'date_added' | 'last_played'
+type SortOrder = 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+
+const SORT_OPTIONS: SortOrder[] = [
+  'album_artist',
+  'album',
+  'date_added',
+  'last_played',
+  'most_played'
+]
 
 const SORT_LABELS: Record<SortOrder, string> = {
   album_artist: 'Artist',
   album: 'Album',
   date_added: 'Date Added',
-  last_played: 'Last Played'
+  last_played: 'Last Played',
+  most_played: 'Most Played'
 }
 
 export function SortControl(): React.JSX.Element {
   const sortOrder = useStore((s) => s.sortOrder)
   const setSortOrder = useStore((s) => s.setSortOrder)
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: PointerEvent): void => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', handler)
+    return (): void => document.removeEventListener('pointerdown', handler)
+  }, [open])
 
   return (
-    <div className="sort-control">
-      <span className="sort-label">Sort by</span>
-      {(Object.keys(SORT_LABELS) as SortOrder[]).map((key) => (
-        <button
-          key={key}
-          className={`sort-btn${sortOrder === key ? ' active' : ''}`}
-          onClick={() => setSortOrder(key)}
-        >
-          {SORT_LABELS[key]}
-        </button>
-      ))}
+    <div className="sort-anchor" ref={ref}>
+      <button
+        className="toolbar-dropdown-trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        {SORT_LABELS[sortOrder as SortOrder] ?? SORT_LABELS.album_artist}
+        <span className="dropdown-chevron" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div className="toolbar-dropdown-popover" role="listbox" aria-label="Sort by">
+          {SORT_OPTIONS.map((key) => (
+            <button
+              key={key}
+              role="option"
+              aria-selected={sortOrder === key}
+              className={`toolbar-dropdown-item${sortOrder === key ? ' active' : ''}`}
+              onClick={() => {
+                setSortOrder(key)
+                setOpen(false)
+              }}
+            >
+              <span className="dropdown-check" aria-hidden="true">
+                {sortOrder === key ? '✓' : ''}
+              </span>
+              {SORT_LABELS[key]}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -69,7 +69,8 @@ type PlayerStore = {
   albumEditMode: boolean
   albumMetaExpanded: boolean
   albumRenameProgress: { done: number; total: number } | null
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played'
+  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+  libraryFilter: string[]
   searchQuery: string
   searchResults: SearchResult | null
   queueVisible: boolean
@@ -84,7 +85,10 @@ type PlayerStore = {
   toggleArtistPanel: () => void
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
-  setSortOrder: (sort: 'album_artist' | 'album' | 'date_added' | 'last_played') => Promise<void>
+  setSortOrder: (
+    sort: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+  ) => Promise<void>
+  setLibraryFilter: (filters: string[]) => void
   setActiveView: (view: 'library' | 'now-playing' | 'home') => Promise<void>
   setModuleOrder: (ids: string[]) => void
   hideModule: (id: string) => void
@@ -270,6 +274,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   albumMetaExpanded: localStorage.getItem('kamp:meta-expanded') === 'true',
   albumRenameProgress: null,
   sortOrder: 'album_artist',
+  libraryFilter: [],
   searchQuery: '',
   searchResults: null,
   queueVisible: false,
@@ -318,6 +323,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
     } catch {
       // Best-effort — preference is already applied locally.
     }
+  },
+
+  setLibraryFilter: (filters) => {
+    set({ libraryFilter: filters })
   },
 
   setSearchQuery: async (q) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -299,6 +299,60 @@ class TestLibraryIndex:
 
         assert albums[0].has_art is True
 
+    def test_albums_has_favorite_track_false_by_default(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_track(_sample_track(tmp_path / "1.mp3"))
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_favorite_track is False
+
+    def test_albums_has_favorite_track_true_when_any_track_favorited(
+        self, tmp_path: Path
+    ) -> None:
+        """has_favorite_track is True when at least one track in the album is favorited."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "1.mp3")
+        t1.track_number = 1
+        t2 = _sample_track(tmp_path / "2.mp3")
+        t2.track_number = 2
+        index.upsert_many([t1, t2])
+        index.set_favorite(t1.file_path, favorite=True)
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_favorite_track is True
+
+    def test_albums_has_favorite_track_false_when_no_tracks_favorited(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "1.mp3")
+        t1.track_number = 1
+        t2 = _sample_track(tmp_path / "2.mp3")
+        t2.track_number = 2
+        index.upsert_many([t1, t2])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].has_favorite_track is False
+
+    def test_missing_album_has_favorite_track_reflects_track_favorite(
+        self, tmp_path: Path
+    ) -> None:
+        """has_favorite_track on missing-album entries uses the track's own favorite flag."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "standalone.mp3")
+        t.album = ""
+        t.title = "Standalone Track"
+        index.upsert_track(t)
+        index.set_favorite(t.file_path, favorite=True)
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].missing_album is True
+        assert albums[0].has_favorite_track is True
+
     def test_missing_album_track_appears_as_own_entry(self, tmp_path: Path) -> None:
         """A track with no album tag should produce its own AlbumInfo entry."""
         index = LibraryIndex(tmp_path / "library.db")


### PR DESCRIPTION
## Summary

- **Sort dropdown**: replaces the flat button row with a custom single-select dropdown (Artist / Album / Date Added / Last Played / **Most Played** — the backend already supported it but it wasn't exposed in the UI)
- **Filter dropdown**: new multi-select `FilterControl` with four criteria — Favorite albums, Albums with favorited tracks, Unplayed, Top Albums (top 100 by avg plays/track, same algorithm as the Top Albums module). Shows a count badge when active; "No filter" row clears all; Escape closes. Union (OR) semantics when multiple filters are selected.
- **Sticky top rail**: sort and filter are always visible; the toolbar is flush with the top of the library pane using the same `:has()` pattern as the now-playing view
- **Backend**: adds `has_favorite_track: bool` to `AlbumInfo` and `AlbumOut` via `MAX(t.favorite)` in the `albums()` GROUP BY query (scalar `t.favorite` in the UNION ALL missing-album branch). 4 new tests.

## Test plan

- [x] Sort dropdown opens/closes, each option applies correctly including Most Played
- [x] Filter badge shows count when active; "No filter" row clears all
- [x] Favorite an album → "Favorite albums" filter shows only that album
- [x] Favorite a track → "Albums with favorited tracks" filter shows that album
- [x] Unplayed filter shows only albums with no play history
- [x] Top Albums filter shows roughly the most-played albums (up to 100)
- [x] Multiple filters selected together shows union (either condition)
- [x] Toolbar is flush with the top of the library pane on load and while scrolling
- [x] Artist panel filter still works in combination with the new filters
- [x] TrackList view (album detail) retains its normal top padding
- [x] SearchView sort dropdown still functions (inherited from SortControl rewrite)
- [ ] `poetry run pytest tests/test_library.py -v --no-cov` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)