### PR TITLE
feat(KAMP-260): replace native title= with custom tooltip system

### DIFF
--- a/kamp_ui/src/renderer/src/assets/tooltip.css
+++ b/kamp_ui/src/renderer/src/assets/tooltip.css
@@ -1,0 +1,63 @@
+.kamp-tooltip {
+  position: fixed;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  border-radius: 5px;
+  padding: 5px 9px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  z-index: 9000;
+  white-space: nowrap;
+}
+
+/* Default (above): centered horizontally, floated above the target */
+.kamp-tooltip[data-direction="above"] {
+  transform: translateX(-50%) translateY(calc(-100% - 8px));
+}
+
+/* Below: used when target is near the top of the window */
+.kamp-tooltip[data-direction="below"] {
+  transform: translateX(-50%) translateY(8px);
+}
+
+@keyframes tooltip-in-above {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(calc(-100% - 4px));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(calc(-100% - 8px));
+  }
+}
+
+@keyframes tooltip-in-below {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(8px);
+  }
+}
+
+@keyframes tooltip-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.kamp-tooltip[data-phase="visible"][data-direction="above"] {
+  animation: tooltip-in-above 150ms ease-out;
+}
+
+.kamp-tooltip[data-phase="visible"][data-direction="below"] {
+  animation: tooltip-in-below 150ms ease-out;
+}
+
+/* forwards: holds at opacity 0 until the portal node is removed from DOM */
+.kamp-tooltip[data-phase="fading"] {
+  animation: tooltip-out 300ms ease-in forwards;
+}

--- a/kamp_ui/src/renderer/src/components/AlbumArtModal.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumArtModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import type { Album, ItunesArtCandidate } from '../api/client'
+import { useTooltip } from '../hooks/useTooltip'
 import { applyAlbumArt, applyAlbumArtLocal, searchAlbumArt } from '../api/client'
 import '../assets/album-art-modal.css'
 
@@ -48,13 +49,14 @@ function ArtThumbnail({
   onClick: () => void
 }): React.JSX.Element {
   const [imgState, setImgState] = useState<'loading' | 'loaded' | 'error'>('loading')
+  const tooltip = useTooltip()
 
   return (
     <button
       className={`art-thumb${selected ? ' art-thumb--selected' : ''}`}
       type="button"
       onClick={onClick}
-      title={`${candidate.artist} — ${candidate.title}`}
+      {...tooltip(`${candidate.artist} — ${candidate.title}`)}
     >
       <div className="art-thumb__img-wrap">
         {imgState === 'loading' && <div className="art-thumb__skeleton" />}

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import type { Track } from '../api/client'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { TagIcon, ChevronIcon } from './TransportIcons'
 
 interface AlbumMetaPanelProps {
@@ -42,6 +44,7 @@ function MetaField({
   onChange,
   onBlur
 }: MetaFieldProps): React.JSX.Element {
+  const tooltip = useTooltip()
   const isMixed = value === '(mixed)'
   const showInput = editMode && !readOnly && !isMixed
 
@@ -64,7 +67,7 @@ function MetaField({
         {readOnly && value && (
           <button
             className="meta-field-copy-btn"
-            title="Copy to clipboard"
+            {...tooltip(TOOLTIPS.META_COPY)}
             aria-label={`Copy ${label}`}
             onClick={() => void navigator.clipboard.writeText(value)}
           >

--- a/kamp_ui/src/renderer/src/components/BandcampButton.tsx
+++ b/kamp_ui/src/renderer/src/components/BandcampButton.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { useMenuBounds } from '../hooks/useMenuBounds'
 
 export function BandcampButton(): React.JSX.Element | null {
@@ -8,6 +10,7 @@ export function BandcampButton(): React.JSX.Element | null {
   const [syncState, setSyncState] = useState<'idle' | 'syncing'>('idle')
   const [menuOpen, setMenuOpen] = useState(false)
   const anchorRef = useRef<HTMLDivElement>(null)
+  const tooltip = useTooltip()
   const menuRef = useRef<HTMLDivElement>(null)
   useMenuBounds(menuRef, menuOpen)
 
@@ -44,7 +47,7 @@ export function BandcampButton(): React.JSX.Element | null {
         className={`bandcamp-btn${syncState === 'syncing' ? ' bandcamp-btn--syncing' : ''}`}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
-        title={syncState === 'syncing' ? 'Bandcamp sync in progress…' : 'Sync Bandcamp library'}
+        {...tooltip(syncState === 'syncing' ? TOOLTIPS.BANDCAMP_SYNCING : TOOLTIPS.BANDCAMP_SYNC)}
       >
         {/* Bandcamp logo: parallelogram shape */}
         <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { MODULE_REGISTRY } from './modules/registry'
 import type { ModuleRegistration } from './modules/registry'
 import { ContextMenu } from './ContextMenu'
@@ -18,6 +20,7 @@ export function BaseKampView(): React.JSX.Element {
   const [menu, setMenu] = useState<Menu | null>(null)
   const [dragId, setDragId] = useState<string | null>(null)
   const [dragOverId, setDragOverId] = useState<string | null>(null)
+  const tooltip = useTooltip()
 
   const modules = moduleOrder
     .filter((id) => !hiddenModules.includes(id))
@@ -64,7 +67,7 @@ export function BaseKampView(): React.JSX.Element {
         <button
           className={`base-kamp-gear${editMode ? ' active' : ''}`}
           onClick={toggleEditMode}
-          title={editMode ? 'Done' : 'Customize'}
+          {...tooltip(editMode ? TOOLTIPS.PANEL_VIEW_DONE : TOOLTIPS.PANEL_VIEW_CUSTOMIZE)}
         >
           ⚙
         </button>
@@ -92,7 +95,7 @@ export function BaseKampView(): React.JSX.Element {
               <>
                 <button
                   className="base-kamp-drag-handle"
-                  title="Drag to reorder, right-click for options"
+                  {...tooltip(TOOLTIPS.PANEL_MODULE_DRAG)}
                   draggable
                   onDragStart={(e) => {
                     setDragId(mod.id)
@@ -119,7 +122,7 @@ export function BaseKampView(): React.JSX.Element {
                 </button>
                 <button
                   className="base-kamp-remove-btn"
-                  title="Remove Module"
+                  {...tooltip(TOOLTIPS.PANEL_MODULE_REMOVE)}
                   onClick={() => hideModule(mod.id)}
                 >
                   <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">

--- a/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
+++ b/kamp_ui/src/renderer/src/components/EditableTrackTitle.tsx
@@ -1,4 +1,6 @@
 import React, { useRef, useState } from 'react'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 
 type Props = {
   trackId: number
@@ -20,6 +22,7 @@ export function EditableTrackTitle({
   const [saving, setSaving] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const cancelRef = useRef(false)
+  const tooltip = useTooltip()
 
   // Sync external title changes (e.g. after refreshOpenAlbum) back into local state.
   // Render-time update avoids the cascading-render issue of useEffect setState.
@@ -31,7 +34,7 @@ export function EditableTrackTitle({
   const pip = deferred ? (
     <span
       className="deferred-op-pip"
-      title="Will reorganize when playback ends"
+      {...tooltip(TOOLTIPS.META_WILL_REORGANIZE)}
       aria-label="Pending rename"
     />
   ) : null

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { artUrl } from '../api/client'
 
 export function NowPlayingView(): React.JSX.Element {
@@ -11,6 +13,7 @@ export function NowPlayingView(): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const selectArtist = useStore((s) => s.selectArtist)
   const setActiveView = useStore((s) => s.setActiveView)
+  const tooltip = useTooltip()
 
   if (!current_track) {
     return (
@@ -57,7 +60,7 @@ export function NowPlayingView(): React.JSX.Element {
           {current_track.id in deferredOps && (
             <span
               className="deferred-op-pip"
-              title="Will reorganize when playback ends"
+              {...tooltip(TOOLTIPS.META_WILL_REORGANIZE)}
               aria-label="Pending rename"
             />
           )}

--- a/kamp_ui/src/renderer/src/components/PanelPicker.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelPicker.tsx
@@ -5,6 +5,8 @@
 
 import React, { useEffect, useRef, useState } from 'react'
 import { isPanelCompatibleWithSlot } from '../hooks/usePanelLayout'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import type { PanelLayoutApi, UnifiedPanel } from '../hooks/usePanelLayout'
 import type { SlotId } from '../../../shared/kampAPI'
 
@@ -27,6 +29,7 @@ function PanelRow({
   onHide: () => void
 }): React.JSX.Element {
   const slots: SlotId[] = ['main', 'left', 'right', 'bottom']
+  const tooltip = useTooltip()
 
   return (
     <div className="panel-picker-row">
@@ -37,7 +40,7 @@ function PanelRow({
           return (
             <button
               key={slot}
-              title={compatible ? SLOT_LABELS[slot] : `${SLOT_LABELS[slot]} (incompatible)`}
+              {...tooltip(compatible ? SLOT_LABELS[slot] : `${SLOT_LABELS[slot]} (incompatible)`)}
               className={
                 'panel-picker-slot-btn' +
                 (currentSlot === slot ? ' active' : '') +
@@ -71,6 +74,7 @@ function slotIcon(slot: SlotId): string {
 export function PanelPicker({ layout }: { layout: PanelLayoutApi }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const tooltip = useTooltip()
 
   // Close when clicking outside
   useEffect(() => {
@@ -97,7 +101,7 @@ export function PanelPicker({ layout }: { layout: PanelLayoutApi }): React.JSX.E
     <div className="panel-picker-anchor" ref={ref}>
       <button
         className={'panel-picker-trigger' + (open ? ' active' : '')}
-        title="Manage panels"
+        {...tooltip(TOOLTIPS.PANEL_PICKER_MANAGE)}
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="true"

--- a/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
+++ b/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
+import { useTooltip } from '../hooks/useTooltip'
 
 export function PipelineIndicator(): React.JSX.Element | null {
   const [stage, setStage] = useState('')
+  const tooltip = useTooltip()
 
   useEffect(() => {
     return window.api.pipeline.onStage(setStage)
@@ -10,7 +12,7 @@ export function PipelineIndicator(): React.JSX.Element | null {
   return (
     <div
       className={`pipeline-indicator${stage ? ' pipeline-indicator--active' : ''}`}
-      title={stage || 'Idle'}
+      {...tooltip(stage || 'Idle')}
     >
       {/* Approximates SF Symbol "music.note.list": a note head + stem + three horizontal lines */}
       <svg viewBox="0 0 20 20" width="20" height="20" fill="currentColor" aria-hidden="true">

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { QueueContextMenu } from './QueueContextMenu'
 import { FavoriteIcon } from './TransportIcons'
 import type { Track } from '../api/client'
@@ -29,6 +31,7 @@ export function QueuePanel(): React.JSX.Element {
   const listRef = useRef<HTMLOListElement>(null)
   const hasMounted = useRef(false)
   const [menu, setMenu] = useState<ContextMenu | null>(null)
+  const tooltip = useTooltip()
 
   const tracks = queue?.tracks ?? []
   const position = queue?.position ?? -1
@@ -115,7 +118,11 @@ export function QueuePanel(): React.JSX.Element {
     <aside className="queue-panel">
       <div className="queue-panel-header">
         <span className="queue-panel-label">QUEUE</span>
-        <button className="queue-close-btn" onClick={toggleQueuePanel} title="Close queue">
+        <button
+          className="queue-close-btn"
+          onClick={toggleQueuePanel}
+          {...tooltip(TOOLTIPS.QUEUE_CLOSE)}
+        >
           ✕
         </button>
       </div>

--- a/kamp_ui/src/renderer/src/components/SearchBar.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchBar.tsx
@@ -1,9 +1,12 @@
 import { forwardRef } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 
 export const SearchBar = forwardRef<HTMLInputElement>(function SearchBar(_, ref) {
   const query = useStore((s) => s.searchQuery)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
+  const tooltip = useTooltip()
 
   return (
     <div className="search-bar">
@@ -21,6 +24,7 @@ export const SearchBar = forwardRef<HTMLInputElement>(function SearchBar(_, ref)
         <button
           className="search-clear"
           onClick={() => void setSearchQuery('')}
+          {...tooltip(TOOLTIPS.SEARCH_CLEAR)}
           aria-label="Clear search"
         >
           ✕

--- a/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
+++ b/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { TooltipContext } from '../hooks/useTooltip'
+
+const SHOW_DELAY_MS = 500
+const VISIBLE_MS = 2000
+// Rescind window: hot-switching is active for this long after the tooltip begins fading.
+// The CSS fade animation is 300ms (tooltip.css); this timer controls when the portal
+// is removed from the DOM, keeping it available for hot-switch detection.
+const RESCIND_MS = 1500
+const MARGIN = 8
+
+// Threshold below which a target is considered "near the top of the window"
+// and the tooltip should appear below rather than above.
+const TOP_THRESHOLD = 50
+
+type Phase = 'visible' | 'fading'
+
+interface TooltipDisplay {
+  text: string
+  x: number
+  y: number
+  above: boolean
+  phase: Phase
+}
+
+export function TooltipProvider({ children }: { children: React.ReactNode }): React.ReactElement {
+  const [display, setDisplay] = useState<TooltipDisplay | null>(null)
+  const portalRef = useRef<HTMLDivElement>(null)
+
+  // Phase tracked in a ref so timer callbacks always read the current value.
+  const phaseRef = useRef<'hidden' | 'delay' | 'visible' | 'fading'>('hidden')
+  // The element currently showing a tooltip — receives aria-describedby while visible.
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const beginFade = useCallback(() => {
+    phaseRef.current = 'fading'
+    setDisplay((prev) => (prev ? { ...prev, phase: 'fading' } : null))
+    fadeTimerRef.current = setTimeout(() => {
+      if (targetRef.current) {
+        targetRef.current.removeAttribute('aria-describedby')
+        targetRef.current = null
+      }
+      phaseRef.current = 'hidden'
+      setDisplay(null)
+    }, RESCIND_MS)
+  }, [])
+
+  const arm = useCallback(
+    (text: string, target: HTMLElement) => {
+      clearTimeout(showTimerRef.current)
+      clearTimeout(hideTimerRef.current)
+      clearTimeout(fadeTimerRef.current)
+
+      const rect = target.getBoundingClientRect()
+      const above = rect.top > TOP_THRESHOLD
+      const x = rect.left + rect.width / 2
+      const y = above ? rect.top : rect.bottom
+
+      const show = (): void => {
+        if (targetRef.current) targetRef.current.removeAttribute('aria-describedby')
+        targetRef.current = target
+        target.setAttribute('aria-describedby', 'kamp-tooltip')
+        phaseRef.current = 'visible'
+        setDisplay({ text, x, y, above, phase: 'visible' })
+        hideTimerRef.current = setTimeout(beginFade, VISIBLE_MS)
+      }
+
+      // Hot-switch: during the rescind window, skip the show delay.
+      if (phaseRef.current === 'fading') {
+        show()
+        return
+      }
+
+      phaseRef.current = 'delay'
+      showTimerRef.current = setTimeout(show, SHOW_DELAY_MS)
+    },
+    [beginFade]
+  )
+
+  // mouseleave only cancels the pending show timer; a visible tooltip times out
+  // on its own (the 2000ms visible period is not hover-dependent).
+  const disarm = useCallback(() => {
+    clearTimeout(showTimerRef.current)
+    if (phaseRef.current === 'delay') phaseRef.current = 'hidden'
+  }, [])
+
+  // Clamp the tooltip horizontally so it never overflows the viewport edges.
+  useLayoutEffect(() => {
+    if (!display || !portalRef.current) return
+    const el = portalRef.current
+    const rect = el.getBoundingClientRect()
+    if (rect.left < MARGIN) {
+      el.style.left = `${display.x + (MARGIN - rect.left)}px`
+    } else if (rect.right > window.innerWidth - MARGIN) {
+      el.style.left = `${display.x - (rect.right - (window.innerWidth - MARGIN))}px`
+    }
+  }, [display])
+
+  return (
+    <TooltipContext.Provider value={{ arm, disarm }}>
+      {children}
+      {display &&
+        createPortal(
+          <div
+            ref={portalRef}
+            role="tooltip"
+            id="kamp-tooltip"
+            className="kamp-tooltip"
+            data-phase={display.phase}
+            data-direction={display.above ? 'above' : 'below'}
+            style={{ left: display.x, top: display.y }}
+          >
+            {display.text}
+          </div>,
+          document.body
+        )}
+    </TooltipContext.Provider>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import { artUrl, fetchMusicBrainzCandidates, patchTrackMeta } from '../api/client'
 import type {
   AlbumTagsCollision,
@@ -89,6 +91,7 @@ export function TrackList(): React.JSX.Element | null {
   const [albumRenameToast, setAlbumRenameToast] = useState<AlbumRenameToast | null>(null)
   const [mbState, setMbState] = useState<MBFetchState>({ status: 'idle' })
   const [artSearchOpen, setArtSearchOpen] = useState(false)
+  const tooltip = useTooltip()
 
   // Reset MB state when navigating to a different album (derived state from props).
   // Using the render-time pattern avoids a setState-in-effect lint violation.
@@ -245,7 +248,7 @@ export function TrackList(): React.JSX.Element | null {
         <button
           className={`breadcrumb-edit-btn mb-pill${mbState.status === 'loading' ? ' mb-pill--loading' : mbState.status === 'error' ? ' mb-pill--error' : ''}`}
           disabled={mbState.status === 'loading'}
-          title={mbState.status === 'error' ? mbState.message : 'Fetch from MusicBrainz'}
+          {...tooltip(mbState.status === 'error' ? mbState.message : TOOLTIPS.LIBRARY_FETCH_MB)}
           onClick={handleFetchMB}
           type="button"
         >
@@ -277,7 +280,7 @@ export function TrackList(): React.JSX.Element | null {
       {albumEditMode && (
         <button
           className="breadcrumb-edit-btn mb-pill mb-pill--second"
-          title="Fetch album art"
+          {...tooltip(TOOLTIPS.LIBRARY_FETCH_ART)}
           onClick={() => setArtSearchOpen(true)}
           type="button"
         >
@@ -295,6 +298,9 @@ export function TrackList(): React.JSX.Element | null {
         <div className="track-list-identity-text">
           <button
             className={`track-list-album-fav-btn favorite-btn${album.favorite ? ' active' : ''}`}
+            {...tooltip(
+              album.favorite ? TOOLTIPS.ALBUM_FAVORITE_REMOVE : TOOLTIPS.ALBUM_FAVORITE_ADD
+            )}
             aria-label={album.favorite ? 'Remove from favorites' : 'Add to favorites'}
             aria-pressed={album.favorite}
             onClick={() => setAlbumFavorite(album.album_artist, album.album, !album.favorite)}
@@ -369,7 +375,7 @@ export function TrackList(): React.JSX.Element | null {
         <div className="album-controls">
           <button
             className="album-secondary-btn"
-            title="Add to queue"
+            {...tooltip(TOOLTIPS.LIBRARY_ADD_TO_QUEUE)}
             aria-label="Add album to queue"
             onClick={() => void addAlbumToQueue(album.album_artist, album.album, album.file_path)}
           >
@@ -377,7 +383,7 @@ export function TrackList(): React.JSX.Element | null {
           </button>
           <button
             className="album-secondary-btn"
-            title="Play next"
+            {...tooltip(TOOLTIPS.LIBRARY_PLAY_NEXT)}
             aria-label="Play album next"
             onClick={() => void playAlbumNext(album.album_artist, album.album, album.file_path)}
           >

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState } from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
 import {
   FavoriteIcon,
   NextIcon,
@@ -42,6 +44,7 @@ export function TransportBar(): React.JSX.Element {
   // server position) can't fire a spurious second onChange and double-seek.
   const [scrubPos, setScrubPos] = useState<number | null>(null)
   const pointerDown = useRef(false)
+  const tooltip = useTooltip()
   const displayPosition = scrubPos !== null ? scrubPos : position
 
   // Force-clear scrub state when the track changes. Without this, a pointerup
@@ -91,28 +94,47 @@ export function TransportBar(): React.JSX.Element {
         className={`transport-btn favorite-btn${current_track?.favorite ? ' active' : ''}`}
         onClick={() => current_track && void setFavorite(current_track, !current_track.favorite)}
         disabled={!current_track}
-        title={current_track?.favorite ? 'Remove from favorites' : 'Add to favorites'}
+        {...tooltip(
+          current_track?.favorite
+            ? TOOLTIPS.TRANSPORT_FAVORITE_REMOVE
+            : TOOLTIPS.TRANSPORT_FAVORITE_ADD
+        )}
         aria-pressed={current_track?.favorite ?? false}
       >
         <FavoriteIcon active={current_track?.favorite ?? false} />
       </button>
 
       <div className="transport-controls">
-        <button className="transport-btn" onClick={prev} title="Previous (←)" aria-label="Previous">
+        <button
+          className="transport-btn"
+          onClick={prev}
+          {...tooltip(TOOLTIPS.TRANSPORT_PREV)}
+          aria-label="Previous"
+        >
           <PrevIcon />
         </button>
         <button
           className="transport-btn primary"
           onClick={togglePlayPause}
-          title={playing ? 'Pause (Space)' : 'Play (Space)'}
+          {...tooltip(playing ? TOOLTIPS.TRANSPORT_PAUSE : TOOLTIPS.TRANSPORT_PLAY)}
           aria-label={playing ? 'Pause' : 'Play'}
         >
           {playing ? <PauseIcon /> : <PlayIcon />}
         </button>
-        <button className="transport-btn" onClick={stop} title="Stop" aria-label="Stop">
+        <button
+          className="transport-btn"
+          onClick={stop}
+          {...tooltip(TOOLTIPS.TRANSPORT_STOP)}
+          aria-label="Stop"
+        >
           <StopIcon />
         </button>
-        <button className="transport-btn" onClick={next} title="Next (→)" aria-label="Next">
+        <button
+          className="transport-btn"
+          onClick={next}
+          {...tooltip(TOOLTIPS.TRANSPORT_NEXT)}
+          aria-label="Next"
+        >
           <NextIcon />
         </button>
       </div>
@@ -170,7 +192,7 @@ export function TransportBar(): React.JSX.Element {
         <button
           className={`transport-btn${shuffle ? ' active' : ''}`}
           onClick={() => void setShuffle(!shuffle)}
-          title="Shuffle"
+          {...tooltip(TOOLTIPS.TRANSPORT_SHUFFLE)}
           aria-label="Shuffle"
           aria-pressed={shuffle}
         >
@@ -179,7 +201,7 @@ export function TransportBar(): React.JSX.Element {
         <button
           className={`transport-btn${repeat ? ' active' : ''}`}
           onClick={() => void setRepeat(!repeat)}
-          title="Repeat"
+          {...tooltip(TOOLTIPS.TRANSPORT_REPEAT)}
           aria-label="Repeat"
           aria-pressed={repeat}
         >
@@ -188,7 +210,7 @@ export function TransportBar(): React.JSX.Element {
       </div>
 
       <div className="transport-volume">
-        <span className="volume-icon" title="Volume" aria-hidden="true">
+        <span className="volume-icon" aria-hidden="true">
           <VolumeIcon />
         </span>
         <input
@@ -206,7 +228,7 @@ export function TransportBar(): React.JSX.Element {
       <button
         className={`transport-btn queue-toggle-btn${queueVisible ? ' active' : ''}`}
         onClick={toggleQueuePanel}
-        title="Queue (Q)"
+        {...tooltip(TOOLTIPS.TRANSPORT_QUEUE)}
         aria-label="Queue"
         aria-pressed={queueVisible}
       >

--- a/kamp_ui/src/renderer/src/hooks/useTooltip.ts
+++ b/kamp_ui/src/renderer/src/hooks/useTooltip.ts
@@ -1,0 +1,37 @@
+import { createContext, useCallback, useContext } from 'react'
+import type React from 'react'
+
+export interface TooltipContextValue {
+  arm: (text: string, target: HTMLElement) => void
+  disarm: () => void
+}
+
+export const TooltipContext = createContext<TooltipContextValue>({
+  arm: () => {},
+  disarm: () => {}
+})
+
+/**
+ * Returns a function that, given a tooltip string, produces onMouseEnter /
+ * onMouseLeave props for any interactive element.
+ *
+ * Usage:
+ *   const tooltip = useTooltip()
+ *   <button {...tooltip(TOOLTIPS.TRANSPORT_PLAY)} onClick={...} />
+ *
+ * For dynamic text, pass the computed string directly:
+ *   <button {...tooltip(playing ? TOOLTIPS.TRANSPORT_PAUSE : TOOLTIPS.TRANSPORT_PLAY)} />
+ */
+export function useTooltip(): (text: string) => {
+  onMouseEnter: (e: React.MouseEvent<HTMLElement>) => void
+  onMouseLeave: () => void
+} {
+  const { arm, disarm } = useContext(TooltipContext)
+  return useCallback(
+    (text: string) => ({
+      onMouseEnter: (e: React.MouseEvent<HTMLElement>) => arm(text, e.currentTarget),
+      onMouseLeave: disarm
+    }),
+    [arm, disarm]
+  )
+}

--- a/kamp_ui/src/renderer/src/main.tsx
+++ b/kamp_ui/src/renderer/src/main.tsx
@@ -1,8 +1,10 @@
 import './assets/main.css'
+import './assets/tooltip.css'
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { TooltipProvider } from './components/TooltipProvider'
 import { theme } from '../../shared/theme'
 
 // Apply shared design tokens as CSS custom properties so the stylesheet can
@@ -16,6 +18,8 @@ document.documentElement.dataset.platform = window.electron.process.platform
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <TooltipProvider>
+      <App />
+    </TooltipProvider>
   </StrictMode>
 )

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -1,0 +1,44 @@
+export const TOOLTIPS = {
+  // Transport controls
+  TRANSPORT_PLAY: 'Play (Space)',
+  TRANSPORT_PAUSE: 'Pause (Space)',
+  TRANSPORT_STOP: 'Stop',
+  TRANSPORT_PREV: 'Previous (←)',
+  TRANSPORT_NEXT: 'Next (→)',
+  TRANSPORT_SHUFFLE: 'Shuffle',
+  TRANSPORT_REPEAT: 'Repeat',
+  TRANSPORT_QUEUE: 'Queue (Q)',
+  TRANSPORT_FAVORITE_ADD: 'Add to favorites',
+  TRANSPORT_FAVORITE_REMOVE: 'Remove from favorites',
+
+  // Library / track list actions
+  LIBRARY_FETCH_MB: 'Fetch from MusicBrainz',
+  LIBRARY_FETCH_ART: 'Fetch album art',
+  LIBRARY_ADD_TO_QUEUE: 'Add to queue',
+  LIBRARY_PLAY_NEXT: 'Play next',
+
+  // Queue panel
+  QUEUE_CLOSE: 'Close queue',
+
+  // Panel management
+  PANEL_PICKER_MANAGE: 'Manage panels',
+  PANEL_MODULE_DRAG: 'Drag to reorder, right-click for options',
+  PANEL_MODULE_REMOVE: 'Remove module',
+  PANEL_VIEW_CUSTOMIZE: 'Customize',
+  PANEL_VIEW_DONE: 'Done',
+
+  // Metadata
+  META_COPY: 'Copy to clipboard',
+  META_WILL_REORGANIZE: 'Will reorganize when playback ends',
+
+  // Bandcamp
+  BANDCAMP_SYNC: 'Sync Bandcamp library',
+  BANDCAMP_SYNCING: 'Bandcamp sync in progress…',
+
+  // Search
+  SEARCH_CLEAR: 'Clear search',
+
+  // Track / album favorites
+  ALBUM_FAVORITE_ADD: 'Add to favorites',
+  ALBUM_FAVORITE_REMOVE: 'Remove from favorites'
+} as const

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -12,7 +12,7 @@ export const TOOLTIPS = {
   TRANSPORT_FAVORITE_REMOVE: 'Remove from favorites',
 
   // Library / track list actions
-  LIBRARY_FETCH_MB: 'Fetch from MusicBrainz',
+  LIBRARY_FETCH_MB: 'Fetch tags from MusicBrainz',
   LIBRARY_FETCH_ART: 'Fetch album art',
   LIBRARY_ADD_TO_QUEUE: 'Add to queue',
   LIBRARY_PLAY_NEXT: 'Play next',


### PR DESCRIPTION
## Summary

- Replaces all 27 action `title=` attributes across 13 components with a custom tooltip system; overflow-truncation `title=` uses (track title on `<td>`, span) intentionally preserved
- New `TooltipProvider` implements a 4-phase state machine (delay → visible → fading → hidden) with portal to `document.body` to escape `overflow: hidden` containers, hot-switching during the 1500ms rescind window, and viewport-edge clamping
- New `tooltipStrings.ts` flat string catalog enables future i18n; `useTooltip()` hook gives consumers a one-spread API: `<button {...tooltip(TOOLTIPS.TRANSPORT_PLAY)} />`

## New files

- `tooltipStrings.ts` — 27-entry string catalog with namespace prefixes
- `TooltipProvider.tsx` — React Context provider + state machine + `createPortal` node
- `useTooltip.ts` — consumer hook (also owns `TooltipContext` to satisfy `react-refresh/only-export-components`)
- `tooltip.css` — styles, directional keyframes (above/below), fade-in/fade-out animations

## Timing

| Phase | Duration |
|-------|----------|
| Show delay | 500ms |
| Visible | 2000ms |
| Rescind window (hot-switch active) | 1500ms |
| CSS fade-out | 300ms |

## Test plan

- [ ] Hover a transport button — tooltip appears after ~500ms
- [ ] Let tooltip show — disappears after ~2000ms + 300ms fade
- [ ] During fade, hover a different button — immediate hot-switch, no 500ms delay
- [ ] Narrow the window — rightmost-button tooltip should not overflow the viewport edge
- [ ] Hover a top-nav / panel-picker button — tooltip appears **below** rather than above
- [ ] SearchBar clear button and TrackList album-favorite button now show tooltips (were missing before)
- [ ] `rg 'title=' kamp_ui/src/renderer/src/components/ -g '*.tsx'` returns only the three intentional overflow-truncation uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)