### PR TITLE
feat(KAMP-355): remove single or selected tracks from queue

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -389,6 +389,33 @@ class PlaybackQueue:
         if current_track_idx is not None:
             self._pos = self._order.index(current_track_idx)
 
+    def remove_at(self, display_indices: list[int]) -> None:
+        """Remove tracks at the given display positions.
+
+        Only indices strictly after _pos (unplayed tracks) are removed.
+        Current and past tracks are silently skipped, as are out-of-range
+        values. _pos is never adjusted because only later entries are removed.
+        """
+        n = len(self._order)
+        to_remove = sorted(
+            {i for i in display_indices if i > self._pos and 0 <= i < n},
+            reverse=True,
+        )
+        if not to_remove:
+            return
+        removed_slots: set[int] = set()
+        for disp_idx in to_remove:
+            removed_slots.add(self._order[disp_idx])
+            self._order.pop(disp_idx)
+        old_to_new: dict[int, int] = {}
+        new_tracks: list[Track] = []
+        for old_slot, track in enumerate(self._tracks):
+            if old_slot not in removed_slots:
+                old_to_new[old_slot] = len(new_tracks)
+                new_tracks.append(track)
+        self._tracks = new_tracks
+        self._order = [old_to_new[i] for i in self._order]
+
     def _shuffled_order(self, anchor_idx: int) -> None:
         """Shuffle _order placing anchor_idx first; maximises artist diversity.
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -250,6 +250,10 @@ class InsertAlbumQueueRequest(BaseModel):
     file_path: str = ""  # non-empty for missing-album tracks
 
 
+class RemoveFromQueueRequest(BaseModel):
+    indices: list[int]
+
+
 class SkipToRequest(BaseModel):
     position: int
 
@@ -2423,6 +2427,12 @@ def create_app(
             queue.reorder(req.order)
         except (IndexError, ValueError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        engine.preload_next(queue.peek_next())
+        return {"ok": True}
+
+    @app.post("/api/v1/player/queue/remove")
+    def queue_remove(req: RemoveFromQueueRequest) -> dict[str, Any]:
+        queue.remove_at(req.indices)
         engine.preload_next(queue.peek_next())
         return {"ok": True}
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -327,6 +327,8 @@ export const skipToQueueTrack = (position: number): Promise<unknown> =>
 export const clearQueue = (): Promise<unknown> => post('/api/v1/player/queue/clear', {})
 export const clearRemainingQueue = (position: number): Promise<unknown> =>
   post('/api/v1/player/queue/clear-remaining', { position })
+export const removeFromQueue = (indices: number[]): Promise<unknown> =>
+  post('/api/v1/player/queue/remove', { indices })
 export const setTrackFavorite = (track: Track, favorite: boolean): Promise<unknown> =>
   post('/api/v1/tracks/favorite', { file_path: track.file_path, favorite })
 

--- a/kamp_ui/src/renderer/src/components/ContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/ContextMenu.tsx
@@ -13,13 +13,20 @@ export function ContextMenu({ x, y, onClose, children }: Props): React.JSX.Eleme
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const handler = (e: MouseEvent): void => {
+    const onMouseDown = (e: MouseEvent): void => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         onClose()
       }
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
   }, [onClose])
 
   useMenuBounds(ref, true)

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
-import { FavoriteIcon, GoToAlbumIcon, GoToArtistIcon } from './TransportIcons'
+import { FavoriteIcon, GoToAlbumIcon, GoToArtistIcon, RemoveFromQueueIcon } from './TransportIcons'
 import type { Track } from '../api/client'
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
   trackIdx: number | null
   track?: Track // right-clicked item — used for navigation only
   selectedTracks: Track[] // all selected items — used for bulk favorites
+  unplayedSelectedIndices: number[] // display indices of unplayed selected tracks
   onClose: () => void
 }
 
@@ -19,6 +20,7 @@ export function QueueContextMenu({
   trackIdx,
   track,
   selectedTracks,
+  unplayedSelectedIndices,
   onClose
 }: Props): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -27,6 +29,7 @@ export function QueueContextMenu({
   const setActiveView = useStore((s) => s.setActiveView)
   const clearQueue = useStore((s) => s.clearQueue)
   const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
+  const removeFromQueue = useStore((s) => s.removeFromQueue)
   const setFavorites = useStore((s) => s.setFavorites)
 
   // For the favorites label: apply to all selected; label reflects majority state.
@@ -112,6 +115,27 @@ export function QueueContextMenu({
                 <FavoriteIcon active={!allFavorited} size={12} />
               </span>
               {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
+            </button>
+          )}
+          {unplayedSelectedIndices.length > 0 && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void removeFromQueue(unplayedSelectedIndices)
+                onClose()
+              }}
+            >
+              <span
+                style={{
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                  display: 'inline-flex'
+                }}
+              >
+                <RemoveFromQueueIcon size={12} />
+              </span>
+              Remove from Queue
             </button>
           )}
           <div className="track-context-menu-divider" />

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -28,6 +28,7 @@ type ContextMenu = {
   trackIdx: number | null
   track?: Track
   selectedTracks: Track[]
+  unplayedSelectedIndices: number[]
 }
 
 export function QueuePanel(): React.JSX.Element {
@@ -232,7 +233,13 @@ export function QueuePanel(): React.JSX.Element {
           className="queue-track-list"
           onContextMenu={(e) => {
             e.preventDefault()
-            setMenu({ x: e.clientX, y: e.clientY, trackIdx: null, selectedTracks: [] })
+            setMenu({
+              x: e.clientX,
+              y: e.clientY,
+              trackIdx: null,
+              selectedTracks: [],
+              unplayedSelectedIndices: []
+            })
           }}
           onDragOver={(e) => {
             if (!isQueueDrop(e.dataTransfer.types)) return
@@ -327,15 +334,16 @@ export function QueuePanel(): React.JSX.Element {
                     setSelectedIndices(nextIndices)
                     setAnchorIdx(idx)
                   }
-                  const selectedTracks = [...nextIndices]
-                    .sort((a, b) => a - b)
-                    .map((i) => tracks[i])
+                  const sortedIndices = [...nextIndices].sort((a, b) => a - b)
+                  const selectedTracks = sortedIndices.map((i) => tracks[i])
+                  const unplayedSelectedIndices = sortedIndices.filter((i) => i > position)
                   setMenu({
                     x: e.clientX,
                     y: e.clientY,
                     trackIdx: isUnplayed ? idx : null,
                     track,
-                    selectedTracks
+                    selectedTracks,
+                    unplayedSelectedIndices
                   })
                 }}
               >
@@ -357,6 +365,7 @@ export function QueuePanel(): React.JSX.Element {
           trackIdx={menu.trackIdx}
           track={menu.track}
           selectedTracks={menu.selectedTracks}
+          unplayedSelectedIndices={menu.unplayedSelectedIndices}
           onClose={() => setMenu(null)}
         />
       )}

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -183,6 +183,25 @@ export function RepeatIcon({ size = 20 }: IconProps): React.JSX.Element {
   )
 }
 
+export function RemoveFromQueueIcon({ size = 16 }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M8.46447 15.5355L15.5355 8.46446" />
+      <path d="M8.46447 8.46447L15.5355 15.5355" />
+    </svg>
+  )
+}
+
 export function FavoriteIcon({ active, size = 16 }: FavoriteIconProps): React.JSX.Element {
   return (
     <svg

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -154,6 +154,7 @@ type PlayerStore = {
   skipToQueueTrack: (position: number) => Promise<void>
   clearQueue: () => Promise<void>
   clearRemainingQueue: (position: number) => Promise<void>
+  removeFromQueue: (indices: number[]) => Promise<void>
   setFavorite: (track: Track, favorite: boolean) => Promise<void>
   setFavorites: (tracks: Track[], favorite: boolean) => Promise<void>
   setAlbumFavorite: (albumArtist: string, album: string, favorite: boolean) => Promise<void>
@@ -661,6 +662,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   clearRemainingQueue: async (position) => {
     await api.clearRemainingQueue(position)
+    void get().loadQueue()
+  },
+
+  removeFromQueue: async (indices) => {
+    await api.removeFromQueue(indices)
     void get().loadQueue()
   },
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -730,6 +730,108 @@ class TestPlaybackQueue:
         _, pos = q.queue_tracks()
         assert pos == 4  # shifted forward by 2
 
+    # ------------------------------------------------------------------
+    # remove_at
+    # ------------------------------------------------------------------
+
+    def test_remove_at_removes_single_unplayed_track(self) -> None:
+        # T0 T1 T2* T3 T4 — playing T2, remove T3
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(5)]
+        q.load(tracks, start_index=2)
+        q.remove_at([3])
+        ordered, pos = q.queue_tracks()
+        assert len(ordered) == 4
+        assert ordered[pos] == tracks[2]
+        assert tracks[3] not in ordered
+        assert tracks[4] in ordered
+
+    def test_remove_at_removes_multiple_unplayed_tracks(self) -> None:
+        # T0 T1 T2* T3 T4 T5 — playing T2, remove T3 and T5
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(6)]
+        q.load(tracks, start_index=2)
+        q.remove_at([3, 5])
+        ordered, pos = q.queue_tracks()
+        assert len(ordered) == 4
+        assert ordered[pos] == tracks[2]
+        assert tracks[3] not in ordered
+        assert tracks[4] in ordered
+        assert tracks[5] not in ordered
+
+    def test_remove_at_ignores_current_track_index(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(4)]
+        q.load(tracks, start_index=1)  # pos=1
+        q.remove_at([1])  # attempt to remove current — no-op
+        ordered, pos = q.queue_tracks()
+        assert len(ordered) == 4
+        assert ordered[pos] == tracks[1]
+
+    def test_remove_at_ignores_past_track_indices(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(5)]
+        q.load(tracks, start_index=2)  # pos=2; T0 and T1 are past
+        q.remove_at([0, 1])
+        ordered, _ = q.queue_tracks()
+        assert len(ordered) == 5  # nothing removed
+
+    def test_remove_at_mixed_removes_only_future_tracks(self) -> None:
+        # Selection spans past, current, and future; only future are removed
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(6)]
+        q.load(tracks, start_index=2)  # T0 T1 past, T2 current, T3 T4 T5 future
+        q.remove_at([0, 1, 2, 3, 4])  # 0/1/2 ignored; 3 and 4 removed
+        ordered, pos = q.queue_tracks()
+        assert len(ordered) == 4  # T0 T1 T2 T5 remain
+        assert ordered[pos] == tracks[2]
+        assert tracks[3] not in ordered
+        assert tracks[4] not in ordered
+        assert tracks[5] in ordered
+
+    def test_remove_at_out_of_range_index_is_ignored(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks, start_index=0)
+        q.remove_at([99, -1])
+        ordered, _ = q.queue_tracks()
+        assert len(ordered) == 3
+
+    def test_remove_at_empty_list_is_noop(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(3)]
+        q.load(tracks)
+        q.remove_at([])
+        ordered, _ = q.queue_tracks()
+        assert len(ordered) == 3
+
+    def test_remove_at_does_not_adjust_pos(self) -> None:
+        # Removing tracks after current must not change _pos
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(5)]
+        q.load(tracks, start_index=2)
+        q.remove_at([3, 4])
+        _, pos = q.queue_tracks()
+        assert pos == 2  # current track is still at display index 2
+
+    def test_remove_at_all_future_tracks(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(4)]
+        q.load(tracks, start_index=1)
+        q.remove_at([2, 3])
+        ordered, pos = q.queue_tracks()
+        assert len(ordered) == 2  # past + current only
+        assert ordered[pos] == tracks[1]
+        assert q.next() is None
+
+    def test_remove_at_preserves_shuffle_flag(self) -> None:
+        q = PlaybackQueue()
+        tracks = [_track(i) for i in range(5)]
+        q.load(tracks, start_index=0)
+        q.set_shuffle(True)
+        q.remove_at([len(q.queue_tracks()[0]) - 1])  # remove last in display order
+        assert q.shuffle is True
+
 
 # ---------------------------------------------------------------------------
 # IPC transport (Unix socket / Windows named pipe)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1038,6 +1038,13 @@ class TestQueueMutationEndpoints:
         assert resp.status_code == 200
         mock_queue.clear_remaining.assert_called_once_with(4)
 
+    def test_remove_from_queue_calls_remove_at_with_indices(
+        self, client: TestClient, mock_queue: MagicMock
+    ) -> None:
+        resp = client.post("/api/v1/player/queue/remove", json={"indices": [2, 4]})
+        assert resp.status_code == 200
+        mock_queue.remove_at.assert_called_once_with([2, 4])
+
     def test_skip_to_calls_engine_play(
         self, client: TestClient, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds `Queue.remove_at(display_indices)` to `playback.py` — silently skips past/current tracks (indices ≤ `_pos`), removes in reverse to avoid index drift, compacts `_tracks` via `old_to_new` map
- New `POST /api/v1/player/queue/remove` endpoint in `server.py`
- `removeFromQueue` action wired through `client.ts` → `store.ts`
- `RemoveFromQueueIcon` (X, strokeWidth 1.5 per ticket) in `TransportIcons.tsx`
- "Remove from Queue" menu item in `QueueContextMenu.tsx`, shown only when `unplayedSelectedIndices.length > 0`
- `QueuePanel.tsx` computes `unplayedSelectedIndices` (indices strictly after current position) and passes them to the context menu
- Escape key dismissal added to `ContextMenu.tsx` (applies to all context menus in the app)

## Test plan

- [ ] 10 new `Queue.remove_at` unit tests in `test_playback.py` (single removal, multi, past/current ignored, mixed, out-of-range, empty, pos unchanged, all-future, shuffle preserved)
- [ ] 1 new server integration test in `test_server.py`
- [ ] TypeScript + mypy clean; 1512 tests pass; coverage 93.31%
- [ ] Manual verification per Reality Checker test plan (see PR comment or KAMP-355)

🤖 Generated with [Claude Code](https://claude.com/claude-code)