### PR TITLE
feat(KAMP-361): Queue Next context menu item

### DIFF
--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -18,6 +18,7 @@ interface Props {
   selectedTracks: Track[] // all selected items — used for bulk favorites
   unplayedSelectedIndices: number[] // display indices of unplayed selected tracks
   position: number // currently playing track's display index
+  onClearSelection: () => void
   onClose: () => void
 }
 
@@ -29,6 +30,7 @@ export function QueueContextMenu({
   selectedTracks,
   unplayedSelectedIndices,
   position,
+  onClearSelection,
   onClose
 }: Props): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -147,6 +149,7 @@ export function QueueContextMenu({
                   ]
                   void reorderQueue(newOrder)
                 }
+                onClearSelection()
                 onClose()
               }}
             >

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
-import { FavoriteIcon, GoToAlbumIcon, GoToArtistIcon, RemoveFromQueueIcon } from './TransportIcons'
+import {
+  FavoriteIcon,
+  GoToAlbumIcon,
+  GoToArtistIcon,
+  PlayNextIcon,
+  RemoveFromQueueIcon
+} from './TransportIcons'
 import type { Track } from '../api/client'
 
 interface Props {
@@ -11,6 +17,7 @@ interface Props {
   track?: Track // right-clicked item — used for navigation only
   selectedTracks: Track[] // all selected items — used for bulk favorites
   unplayedSelectedIndices: number[] // display indices of unplayed selected tracks
+  position: number // currently playing track's display index
   onClose: () => void
 }
 
@@ -21,6 +28,7 @@ export function QueueContextMenu({
   track,
   selectedTracks,
   unplayedSelectedIndices,
+  position,
   onClose
 }: Props): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -30,6 +38,9 @@ export function QueueContextMenu({
   const clearQueue = useStore((s) => s.clearQueue)
   const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
   const removeFromQueue = useStore((s) => s.removeFromQueue)
+  const moveQueueTrack = useStore((s) => s.moveQueueTrack)
+  const reorderQueue = useStore((s) => s.reorderQueue)
+  const queueLength = useStore((s) => s.queue?.tracks.length ?? 0)
   const setFavorites = useStore((s) => s.setFavorites)
 
   // For the favorites label: apply to all selected; label reflects majority state.
@@ -115,6 +126,41 @@ export function QueueContextMenu({
                 <FavoriteIcon active={!allFavorited} size={12} />
               </span>
               {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
+            </button>
+          )}
+          {unplayedSelectedIndices.length > 0 && position >= 0 && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                if (unplayedSelectedIndices.length === 1) {
+                  void moveQueueTrack(unplayedSelectedIndices[0], position + 1)
+                } else {
+                  const selectedSet = new Set(unplayedSelectedIndices)
+                  const nonSelected = Array.from({ length: queueLength }, (_, i) => i).filter(
+                    (i) => !selectedSet.has(i)
+                  )
+                  const insertAt = nonSelected.indexOf(position) + 1
+                  const newOrder = [
+                    ...nonSelected.slice(0, insertAt),
+                    ...unplayedSelectedIndices,
+                    ...nonSelected.slice(insertAt)
+                  ]
+                  void reorderQueue(newOrder)
+                }
+                onClose()
+              }}
+            >
+              <span
+                style={{
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                  display: 'inline-flex'
+                }}
+              >
+                <PlayNextIcon size={12} />
+              </span>
+              Queue Next
             </button>
           )}
           {unplayedSelectedIndices.length > 0 && (

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -367,6 +367,7 @@ export function QueuePanel(): React.JSX.Element {
           selectedTracks={menu.selectedTracks}
           unplayedSelectedIndices={menu.unplayedSelectedIndices}
           position={position}
+          onClearSelection={() => setSelectedIndices(new Set())}
           onClose={() => setMenu(null)}
         />
       )}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -366,6 +366,7 @@ export function QueuePanel(): React.JSX.Element {
           track={menu.track}
           selectedTracks={menu.selectedTracks}
           unplayedSelectedIndices={menu.unplayedSelectedIndices}
+          position={position}
           onClose={() => setMenu(null)}
         />
       )}


### PR DESCRIPTION
## Summary

- Adds a **Queue Next** item to the queue context menu (single and multi-select)
- Single track: calls existing `moveQueueTrack(idx, position + 1)`
- Multi-select: builds a full permutation and calls existing `reorderQueue` — no new backend or store code
- Item hidden when no session is active (`position < 0`) or no unplayed track is in context (playing/played track right-clicked)
- Reuses `PlayNextIcon` from `TransportIcons.tsx`

## Test plan

- [x] Right-click an unplayed track mid-queue → "Queue Next" appears with PlayNextIcon; clicking it moves it to position+1
- [x] Right-click the currently playing track → "Queue Next" absent
- [x] Right-click a played (greyed) track → "Queue Next" absent
- [x] Right-click with no active session → "Queue Next" absent
- [x] Multi-select two non-contiguous unplayed tracks → "Queue Next" moves both to position+1 and position+2 in queue order
- [x] Track already at position+1 → "Queue Next" present; clicking is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)