### PR TITLE
feat(KAMP-358): resizable album page hero via Liner Notes drag handle

### DIFF
--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -17,11 +17,13 @@
 }
 
 /* Hero: full-width art. No overflow clipping — the image intentionally
-   bleeds past the hero boundary into the track list zone. */
+   bleeds past the hero boundary into the track list zone.
+   Height driven by --hero-height-pct (set inline from TrackList state);
+   no CSS transition — height changes during live drag or instant reset. */
 .track-list-hero {
   position: relative;
   flex-shrink: 0;
-  height: 45vh;
+  height: calc(var(--hero-height-pct, 45) * 1vh);
   background: linear-gradient(160deg, var(--surface) 0%, var(--bg) 100%);
 }
 
@@ -46,7 +48,9 @@
 }
 
 /* Overlay is a sibling of the hero (not inside it) so the gradient spans
-   the hero + part of the track list. Uses literal #141414 (= --bg) because
+   the hero + part of the track list. Stop positions scale with the hero via
+   --hero-height-pct so the same opacity profile lands at the hero boundary
+   regardless of resize position. Uses literal #141414 (= --bg) because
    CSS gradient interpolates custom properties through transparent-black,
    causing a gray band artifact. */
 .track-list-hero-overlay {
@@ -60,11 +64,11 @@
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    transparent 15%,
-    rgba(20, 20, 20, 0.45) 45%,
-    rgba(20, 20, 20, 0.8) 63%,
-    rgba(20, 20, 20, 0.95) 75%,
-    #141414 85%
+    transparent       calc(var(--hero-height-pct, 45) / 45 * 15%),
+    rgba(20, 20, 20, 0.45) calc(var(--hero-height-pct, 45) / 45 * 45%),
+    rgba(20, 20, 20, 0.8)  calc(var(--hero-height-pct, 45) / 45 * 63%),
+    rgba(20, 20, 20, 0.95) calc(var(--hero-height-pct, 45) / 45 * 75%),
+    #141414                calc(var(--hero-height-pct, 45) / 45 * 85%)
   );
 }
 
@@ -805,7 +809,8 @@
 /* Liner Notes panel ------------------------------------------------------- */
 
 /* Full-width toggle row between the divider and the track list.
-   Styled like a section seam — low visual weight, clearly interactive. */
+   Doubles as a vertical resize handle for the hero — heavier border-top
+   and ns-resize cursor signal the drag affordance. */
 .album-meta-toggle {
   display: flex;
   align-items: center;
@@ -815,12 +820,24 @@
   padding: 7px 20px;
   background: none;
   border: none;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  border-top: 2px solid rgba(255, 255, 255, 0.15);
   border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-  cursor: pointer;
+  cursor: ns-resize;
   color: var(--text-dim);
   position: relative;
   z-index: 2;
+}
+
+.track-list-view--resizing {
+  user-select: none;
+}
+
+.track-list-view--resizing .track-row:hover {
+  background: none;
+}
+
+.track-list-view--resizing .album-meta-toggle:hover {
+  background: none;
 }
 
 .album-meta-toggle:hover {

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -10,6 +10,8 @@ interface AlbumMetaPanelProps {
   expanded: boolean
   onToggle: () => void
   onSave: (opts: { genre?: string; label?: string; year?: string }) => Promise<void>
+  onHandleMouseDown?: (e: React.MouseEvent) => void
+  onHandleDoubleClick?: () => void
 }
 
 /**
@@ -84,7 +86,9 @@ export function AlbumMetaPanel({
   editMode,
   expanded,
   onToggle,
-  onSave
+  onSave,
+  onHandleMouseDown,
+  onHandleDoubleClick
 }: AlbumMetaPanelProps): React.JSX.Element {
   const panelRef = useRef<HTMLDivElement>(null)
 
@@ -134,6 +138,8 @@ export function AlbumMetaPanel({
         aria-expanded={expanded}
         aria-controls="album-meta-panel"
         onClick={onToggle}
+        onMouseDown={onHandleMouseDown}
+        onDoubleClick={onHandleDoubleClick}
       >
         <TagIcon size={11} />
         <span className="album-meta-toggle-label">

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -28,6 +28,10 @@ import {
 
 const TOAST_TTL = 10_000 // ms
 
+const HERO_DEFAULT = 45
+const HERO_MIN = 15
+const HERO_KEY = 'kamp:hero-height-pct'
+
 type ContextMenu = { x: number; y: number; track: Track }
 type AlbumRenameToast = {
   message: string
@@ -82,6 +86,15 @@ export function TrackList(): React.JSX.Element | null {
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const mbAbortRef = useRef<AbortController | null>(null)
+  const didDragRef = useRef(false)
+  const dragStartYRef = useRef(0)
+  const heroAtDragStartRef = useRef(HERO_DEFAULT)
+  const toggleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [heroHeightPct, setHeroHeightPct] = useState<number>(() => {
+    const saved = parseFloat(localStorage.getItem(HERO_KEY) ?? '')
+    return isNaN(saved) ? HERO_DEFAULT : Math.min(HERO_DEFAULT, Math.max(HERO_MIN, saved))
+  })
+  const [isResizing, setIsResizing] = useState(false)
   const [collision, setCollision] = useState<
     (TrackTagsCollision & { pendingTrackId: number; pendingTitle: string }) | null
   >(null)
@@ -103,6 +116,67 @@ export function TrackList(): React.JSX.Element | null {
     setArtSearchOpen(false)
   }
 
+  const handleResizeMouseDown = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    didDragRef.current = false
+    dragStartYRef.current = e.clientY
+    heroAtDragStartRef.current = heroHeightPct
+    setIsResizing(true)
+
+    const onMove = (ev: MouseEvent): void => {
+      const deltaVh = ((ev.clientY - dragStartYRef.current) / window.innerHeight) * 100
+      if (Math.abs(ev.clientY - dragStartYRef.current) > 4) didDragRef.current = true
+      if (!didDragRef.current) return
+      setHeroHeightPct(
+        Math.min(HERO_DEFAULT, Math.max(HERO_MIN, heroAtDragStartRef.current + deltaVh))
+      )
+    }
+
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      setIsResizing(false)
+      if (didDragRef.current) {
+        setHeroHeightPct((h) => {
+          localStorage.setItem(HERO_KEY, String(Math.round(h)))
+          return h
+        })
+      }
+    }
+
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }
+
+  const handleResizeReset = (): void => {
+    // Cancel any pending toggle from the first click of this double-click
+    if (toggleTimeoutRef.current) {
+      clearTimeout(toggleTimeoutRef.current)
+      toggleTimeoutRef.current = null
+    }
+    setHeroHeightPct(HERO_DEFAULT)
+    localStorage.setItem(HERO_KEY, String(HERO_DEFAULT))
+  }
+
+  const handleToggle = (): void => {
+    if (didDragRef.current) {
+      didDragRef.current = false
+      return
+    }
+    // Debounce so the second click of a double-click can cancel this toggle
+    // before it fires — double-click resets the hero without toggling the panel.
+    if (toggleTimeoutRef.current) {
+      clearTimeout(toggleTimeoutRef.current)
+      toggleTimeoutRef.current = null
+      return
+    }
+    const next = !albumMetaExpanded
+    toggleTimeoutRef.current = setTimeout(() => {
+      toggleTimeoutRef.current = null
+      setAlbumMetaExpanded(next)
+    }, 200)
+  }
+
   const showRenameToast = (toast: AlbumRenameToast): void => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
     setAlbumRenameToast(toast)
@@ -122,6 +196,15 @@ export function TrackList(): React.JSX.Element | null {
       mbAbortRef.current = null
     }
   }, [albumKey])
+
+  // Clear resizing state and pending toggle on unmount.
+  // Document mousemove/mouseup listeners clean themselves up on the next mouseup.
+  useEffect(() => {
+    return () => {
+      if (toggleTimeoutRef.current) clearTimeout(toggleTimeoutRef.current)
+      setIsResizing(false)
+    }
+  }, [])
 
   const handleFetchMB = (): void => {
     if (!album) return
@@ -194,7 +277,10 @@ export function TrackList(): React.JSX.Element | null {
     currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
   return (
-    <div className={`track-list-view${albumEditMode ? ' track-list-view--edit' : ''}`}>
+    <div
+      className={`track-list-view${albumEditMode ? ' track-list-view--edit' : ''}${isResizing ? ' track-list-view--resizing' : ''}`}
+      style={{ '--hero-height-pct': heroHeightPct } as React.CSSProperties}
+    >
       {/* Hero: full-width art — image intentionally taller than hero to bleed into track list */}
       <div className={`track-list-hero${album.has_art ? ' has-art' : ''}`}>
         {album.has_art && (
@@ -409,8 +495,10 @@ export function TrackList(): React.JSX.Element | null {
         tracks={tracks}
         editMode={albumEditMode}
         expanded={albumMetaExpanded}
-        onToggle={() => setAlbumMetaExpanded(!albumMetaExpanded)}
+        onToggle={handleToggle}
         onSave={(opts) => patchAlbumMeta(album.album_artist, album.album, opts)}
+        onHandleMouseDown={handleResizeMouseDown}
+        onHandleDoubleClick={handleResizeReset}
       />
 
       {/* Scrollable body */}


### PR DESCRIPTION
## Summary

- The Liner Notes bar becomes a vertical drag handle (`ns-resize` cursor, heavier border-top) that resizes the album hero between 15vh (min) and 45vh (default max)
- Overlay gradient stop positions scale with `--hero-height-pct` via CSS `calc()` so the same opacity profile lands at the hero boundary at any resize position
- Double-click the handle to snap back to 45vh default; single click still toggles Liner Notes open/close (debounced 200ms to absorb double-click's first click)
- Preference persists globally across all album pages and restarts via `localStorage` (`kamp:hero-height-pct`)
- Track row and Liner Notes hover highlights are suppressed during drag via `.track-list-view--resizing`

## Test plan

- [x] Hero renders at default 45vh with no visual regression
- [x] Hover Liner Notes bar: cursor is `ns-resize`, border-top is visibly heavier
- [x] Drag up: hero shrinks to 15vh floor, track list expands; overlay gradient stays correctly calibrated
- [x] Drag down: hero grows back to 45vh ceiling
- [x] No track row or Liner Notes hover highlight during drag
- [x] Release: navigate away and back — height persists; reload app — persists
- [x] Different album: same height applies (global)
- [x] Double-click bar: hero snaps to 45vh, panel open/close state unchanged
- [x] Single click: Liner Notes toggles normally (with ~200ms debounce delay)
- [x] Album without art: no crash at any hero height

🤖 Generated with [Claude Code](https://claude.com/claude-code)