### PR TITLE
feat(KAMP-363): resizable artist panel

### DIFF
--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -438,12 +438,32 @@ html[data-platform='win32'] .view-tabs {
 /* Artist panel ------------------------------------------------------------- */
 
 .artist-panel {
-  width: var(--panel-w);
+  min-width: 200px;
   flex-shrink: 0;
+  position: relative;
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.artist-resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 6px;
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 10;
+}
+
+.artist-panel--resizing {
+  cursor: ew-resize;
+  user-select: none;
+}
+
+.artist-panel--resizing .artist-list li:hover {
+  background: none;
 }
 
 .panel-header {

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -1,13 +1,85 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+
+const ARTIST_WIDTH_KEY = 'kamp:artist-panel-width'
+const ARTIST_WIDTH_DEFAULT = 200
 
 export function ArtistPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
   const selected = useStore((s) => s.library.selectedArtist)
   const selectArtist = useStore((s) => s.selectArtist)
+  const [panelWidth, setPanelWidth] = useState<number>(() => {
+    const saved = parseFloat(localStorage.getItem(ARTIST_WIDTH_KEY) ?? '')
+    const max = window.innerWidth * 0.33
+    return isNaN(saved)
+      ? ARTIST_WIDTH_DEFAULT
+      : Math.min(max, Math.max(ARTIST_WIDTH_DEFAULT, saved))
+  })
+  const [isResizing, setIsResizing] = useState(false)
+  const dragStartXRef = useRef(0)
+  const widthAtDragStartRef = useRef(ARTIST_WIDTH_DEFAULT)
+  const didDragRef = useRef(false)
+
+  // Clamp width to 33% when the window shrinks.
+  useEffect(() => {
+    const onWindowResize = (): void => {
+      const max = window.innerWidth * 0.33
+      setPanelWidth((w) => {
+        if (w > max) {
+          localStorage.setItem(ARTIST_WIDTH_KEY, String(Math.round(max)))
+          return max
+        }
+        return w
+      })
+    }
+    window.addEventListener('resize', onWindowResize)
+    return () => window.removeEventListener('resize', onWindowResize)
+  }, [])
+
+  function handleResizeMouseDown(e: React.MouseEvent): void {
+    e.preventDefault()
+    didDragRef.current = false
+    dragStartXRef.current = e.clientX
+    widthAtDragStartRef.current = panelWidth
+    setIsResizing(true)
+
+    const onMove = (ev: MouseEvent): void => {
+      // Dragging right (larger clientX) widens the panel.
+      const delta = ev.clientX - dragStartXRef.current
+      if (Math.abs(delta) > 4) didDragRef.current = true
+      if (!didDragRef.current) return
+      const max = window.innerWidth * 0.33
+      setPanelWidth(
+        Math.min(max, Math.max(ARTIST_WIDTH_DEFAULT, widthAtDragStartRef.current + delta))
+      )
+    }
+
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      setIsResizing(false)
+      if (didDragRef.current) {
+        setPanelWidth((w) => {
+          localStorage.setItem(ARTIST_WIDTH_KEY, String(Math.round(w)))
+          return w
+        })
+      }
+    }
+
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }
+
+  function handleResizeDoubleClick(): void {
+    setPanelWidth(ARTIST_WIDTH_DEFAULT)
+    localStorage.setItem(ARTIST_WIDTH_KEY, String(ARTIST_WIDTH_DEFAULT))
+  }
 
   return (
-    <aside className="artist-panel">
+    <aside
+      className={`artist-panel${isResizing ? ' artist-panel--resizing' : ''}`}
+      style={{ width: panelWidth }}
+    >
       <div className="panel-header">Artists</div>
       <ul className="artist-list">
         <li
@@ -30,6 +102,11 @@ export function ArtistPanel(): React.JSX.Element {
           </li>
         ))}
       </ul>
+      <div
+        className="artist-resize-handle"
+        onMouseDown={handleResizeMouseDown}
+        onDoubleClick={handleResizeDoubleClick}
+      />
     </aside>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a 6px drag handle at the right edge of the artist panel (`ew-resize` cursor)
- Dragging widens the panel from 200px up to 33% of the window width
- Double-clicking the handle resets to the 200px default
- Width persists in `localStorage` (`kamp:artist-panel-width`) across restarts
- Window resize listener clamps the saved width if the window shrinks below the threshold

## Test plan

- [x] Drag right border rightward — panel widens, main content shrinks accordingly
- [x] Width bounded: floor 200px, ceiling 33% of window width
- [x] Cursor is `ew-resize` on hover and stays correct during fast drag
- [x] No text selection during drag
- [x] Double-click handle → snaps to 200px
- [x] Reload → panel restores last dragged width
- [x] Shrink window so saved width > 33% → panel clamps automatically
- [ ] Artist selection, keyboard nav, and "All Artists" row unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)