### PR TITLE
feat(KAMP-382): remote track schema — source, stream_url, playback_uri

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -90,7 +90,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 19
+_SCHEMA_VERSION = 20
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -116,8 +116,11 @@ CREATE TABLE IF NOT EXISTS tracks (
     favorite         INTEGER NOT NULL DEFAULT 0,
     play_count       INTEGER NOT NULL DEFAULT 0,
     file_mtime       REAL,    -- st_mtime at last scan; NULL until v6 migration backfill
-    genre            TEXT    NOT NULL DEFAULT '',
-    label            TEXT    NOT NULL DEFAULT ''
+    genre                TEXT    NOT NULL DEFAULT '',
+    label                TEXT    NOT NULL DEFAULT '',
+    source               TEXT    NOT NULL DEFAULT 'local',
+    stream_url           TEXT,
+    stream_url_expires_at REAL
 );
 
 -- FTS5 virtual table for full-text search across track metadata.
@@ -314,6 +317,18 @@ class Track:
     favorite: bool = field(default=False, compare=False)
     play_count: int = field(default=0, compare=False)
     file_mtime: float | None = field(default=None, compare=False)
+    source: str = field(default="local", compare=False)
+    stream_url: str | None = field(default=None, compare=False)
+    stream_url_expires_at: float | None = field(default=None, compare=False)
+
+    @property
+    def is_remote(self) -> bool:
+        return self.source != "local"
+
+    @property
+    def playback_uri(self) -> str:
+        """URL or file-path string to pass to mpv for playback."""
+        return self.stream_url or str(self.file_path)
 
 
 @dataclass
@@ -714,6 +729,28 @@ class LibraryIndex:
             self._conn.execute("UPDATE schema_version SET version = 19")
             self._conn.commit()
 
+        if version < 20:
+            # v19 → v20: add source, stream_url, stream_url_expires_at to tracks
+            # so local and remote (Bandcamp stream-only) tracks coexist in one table.
+            # Guard each ALTER with a PRAGMA check: new DBs already have these columns.
+            existing = {
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if "source" not in existing:
+                self._conn.execute(
+                    "ALTER TABLE tracks ADD COLUMN source TEXT NOT NULL DEFAULT 'local'"
+                )
+            if "stream_url" not in existing:
+                self._conn.execute("ALTER TABLE tracks ADD COLUMN stream_url TEXT")
+            if "stream_url_expires_at" not in existing:
+                self._conn.execute(
+                    "ALTER TABLE tracks ADD COLUMN stream_url_expires_at REAL"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 20")
+            self._conn.commit()
+            version = 20
+
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
         self._conn.execute("DELETE FROM tracks_fts")
@@ -1074,6 +1111,24 @@ class LibraryIndex:
         self._conn.execute("DELETE FROM bandcamp_collection")
         self._conn.commit()
 
+    def get_collection_item(self, sale_item_id: str) -> dict[str, Any] | None:
+        """Return the bandcamp_collection row for *sale_item_id*, or None if absent."""
+        row = self._conn.execute(
+            "SELECT * FROM bandcamp_collection WHERE sale_item_id = ?",
+            (sale_item_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def update_stream_url(
+        self, file_path_uri: str, stream_url: str, expires_at: float
+    ) -> None:
+        """Persist a refreshed CDN stream URL and its expiry timestamp for a remote track."""
+        self._conn.execute(
+            "UPDATE tracks SET stream_url = ?, stream_url_expires_at = ? WHERE file_path = ?",
+            (stream_url, expires_at, file_path_uri),
+        )
+        self._conn.commit()
+
     # ------------------------------------------------------------------
     # Settings (application configuration)
     # ------------------------------------------------------------------
@@ -1115,23 +1170,26 @@ class LibraryIndex:
                 (file_path, title, artist, album_artist, album, year,
                  track_number, disc_number, ext, embedded_art,
                  mb_release_id, mb_recording_id, date_added, file_mtime,
-                 genre, label)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 genre, label, source, stream_url, stream_url_expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
-                title           = excluded.title,
-                artist          = excluded.artist,
-                album_artist    = excluded.album_artist,
-                album           = excluded.album,
-                year            = excluded.year,
-                track_number    = excluded.track_number,
-                disc_number     = excluded.disc_number,
-                ext             = excluded.ext,
-                embedded_art    = excluded.embedded_art,
-                mb_release_id   = excluded.mb_release_id,
-                mb_recording_id = excluded.mb_recording_id,
-                file_mtime      = excluded.file_mtime,
-                genre           = excluded.genre,
-                label           = excluded.label
+                title                 = excluded.title,
+                artist                = excluded.artist,
+                album_artist          = excluded.album_artist,
+                album                 = excluded.album,
+                year                  = excluded.year,
+                track_number          = excluded.track_number,
+                disc_number           = excluded.disc_number,
+                ext                   = excluded.ext,
+                embedded_art          = excluded.embedded_art,
+                mb_release_id         = excluded.mb_release_id,
+                mb_recording_id       = excluded.mb_recording_id,
+                file_mtime            = excluded.file_mtime,
+                genre                 = excluded.genre,
+                label                 = excluded.label,
+                source                = excluded.source,
+                stream_url            = excluded.stream_url,
+                stream_url_expires_at = excluded.stream_url_expires_at
                 -- date_added intentionally omitted: preserve original scan date on re-scan
                 -- last_played intentionally omitted: managed exclusively by record_played()
             """,
@@ -1948,6 +2006,9 @@ def _track_to_params(
     float | None,
     str,
     str,
+    str,
+    str | None,
+    float | None,
 ]:
     return (
         str(t.file_path),
@@ -1966,6 +2027,9 @@ def _track_to_params(
         t.file_mtime,
         t.genre,
         t.label,
+        t.source,
+        t.stream_url,
+        t.stream_url_expires_at,
     )
 
 
@@ -1982,6 +2046,10 @@ def _row_to_deferred_op(row: sqlite3.Row) -> DeferredOp:
 
 
 def _row_to_track(row: sqlite3.Row) -> Track:
+    # KAMP-383 note: Path("bandcamp://sale_item_id/track_num") is safe on
+    # POSIX (round-trips via str()) but corrupts on Windows (backslash
+    # normalisation). Fix Track.file_path type when remote tracks are first
+    # inserted so Windows is addressed before they reach prod.
     return Track(
         id=row["id"],
         file_path=Path(row["file_path"]),
@@ -2003,6 +2071,9 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         favorite=bool(row["favorite"]),
         play_count=row["play_count"],
         file_mtime=row["file_mtime"],
+        source=row["source"],
+        stream_url=row["stream_url"],
+        stream_url_expires_at=row["stream_url_expires_at"],
     )
 
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1084,7 +1084,7 @@ class LibraryIndex:
                 tralbum_id = excluded.tralbum_id,
                 album_url  = excluded.album_url,
                 mode       = excluded.mode,
-                synced_at  = excluded.synced_at
+                synced_at  = COALESCE(excluded.synced_at, synced_at)
             """,
             (
                 sale_item_id,

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -450,6 +450,12 @@ class LibraryIndex:
             return
 
         version = row["version"]
+        # In Python 3.12+, sqlite3 no longer implicitly commits an open
+        # transaction before DDL statements (ALTER TABLE, CREATE TABLE, etc.).
+        # The SELECT above opens an implicit deferred read transaction; commit
+        # it now so subsequent ALTER TABLE calls can acquire an exclusive write
+        # lock without hitting "database is locked".
+        self._conn.commit()
         if version < 2:
             # v1 → v2: FTS table added; backfill from existing tracks.
             self._rebuild_fts()

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1126,7 +1126,7 @@ class MpvPlaybackEngine:
     # Public interface
     # ------------------------------------------------------------------
 
-    def play(self, path: Path) -> None:
+    def play(self, path: str | Path) -> None:
         # loadfile replace clears mpv's entire playlist, including any lookahead.
         # _lookahead_path mutation and the IPC send are paired under _lock so a
         # concurrent end-file/eof handler cannot observe a stale lookahead value.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -427,7 +427,14 @@ def _validate_library_path(file_path: str, library_path: Path | None) -> Path:
     Raises HTTP 400 when a library_path is configured and the resolved path
     falls outside it — preventing path-traversal attacks from reaching any
     future code that uses the caller-supplied path directly.
+
+    Remote track URIs (bandcamp://) are rejected here; remote tracks are only
+    reachable through the queue/album flow, not by direct file_path reference.
     """
+    if file_path.startswith("bandcamp://"):
+        raise HTTPException(
+            status_code=400, detail="Remote tracks cannot be addressed by path"
+        )
     p = Path(file_path).resolve()
     if library_path is not None and not p.is_relative_to(library_path.resolve()):
         raise HTTPException(status_code=400, detail="Path outside library directory")
@@ -469,6 +476,7 @@ def create_app(
     on_bandcamp_disconnect: Callable[[], None] | None = None,
     on_bandcamp_sync_trigger: Callable[[], None] | None = None,
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
+    refresh_stream_url: Callable[[str, int], tuple[str, float] | None] | None = None,
     dev_mode: bool = False,
     auth_token: str | None = None,
     mb_lookup_fn: Callable[..., Any] | None = None,
@@ -635,6 +643,63 @@ def create_app(
         t = _threading.Timer(5.0, _fire)
         _last_played_timer[0] = t
         t.start()
+
+    def _resolve_playback(track: "Track") -> str:
+        """Return the URL or path string to pass to mpv for *track*.
+
+        For local tracks returns str(track.file_path). For remote tracks checks
+        stream URL expiry and attempts a refresh via the refresh_stream_url
+        callback before returning track.playback_uri.
+        """
+        if not track.is_remote:
+            return track.playback_uri
+
+        import time as _t
+
+        needs_refresh = (
+            track.stream_url_expires_at is None
+            or track.stream_url_expires_at < _t.time() + 60
+        )
+        if needs_refresh and refresh_stream_url is not None:
+            _fp = str(track.file_path)
+            # Parse sale_item_id and track_number from bandcamp://sale_id/track_num.
+            # Path() normalises bandcamp:// → bandcamp:/ on POSIX (// collapse);
+            # strip either prefix and reconstruct the canonical form for DB lookups.
+            _canonical_fp: str | None = None
+            _rest: str | None = None
+            for _prefix in ("bandcamp://", "bandcamp:/"):
+                if _fp.startswith(_prefix):
+                    _rest = _fp[len(_prefix) :]
+                    _canonical_fp = "bandcamp://" + _rest
+                    break
+            if _canonical_fp is not None and _rest is not None:
+                parts = _rest.split("/", 1)
+                if len(parts) == 2:
+                    sale_item_id, track_num_str = parts
+                    try:
+                        track_num = int(track_num_str)
+                    except ValueError:
+                        track_num = 0
+                    item = index.get_collection_item(sale_item_id)
+                    album_url = (item or {}).get("album_url", "")
+                    if album_url:
+                        result = refresh_stream_url(album_url, track_num)
+                        if result is not None:
+                            new_url, expires_at = result
+                            index.update_stream_url(_canonical_fp, new_url, expires_at)
+                            return new_url
+                        else:
+                            logger.warning(
+                                "Stream URL refresh failed for %s — using existing URI",
+                                _canonical_fp,
+                            )
+                    else:
+                        logger.warning(
+                            "No album_url for %s — cannot refresh stream URL; "
+                            "run kamp sync to populate.",
+                            _canonical_fp,
+                        )
+        return track.playback_uri
 
     # Wire play-state change callback directly — the engine fires it from its
     # background reader thread whenever mpv's pause property flips.
@@ -2267,7 +2332,7 @@ def create_app(
         queue.load(tracks, start_index=req.track_index)
         current = queue.current()
         if current:
-            engine.play(current.file_path)
+            engine.play(_resolve_playback(current))
             _record_track_started_immediate(current.file_path)
         _notify_track_changed()
         _drain_unlocked(old_current, old_lookahead)
@@ -2305,7 +2370,7 @@ def create_app(
         old_lookahead = queue.peek_next()
         track = queue.next()
         if track:
-            engine.play(track.file_path)
+            engine.play(_resolve_playback(track))
             _record_track_started_debounced(track.file_path)
         else:
             engine.stop()
@@ -2319,7 +2384,7 @@ def create_app(
         old_lookahead = queue.peek_next()
         track = queue.prev()
         if track:
-            engine.play(track.file_path)
+            engine.play(_resolve_playback(track))
             _record_track_started_debounced(track.file_path)
         _notify_track_changed()
         _drain_unlocked(old_current, old_lookahead)
@@ -2344,8 +2409,8 @@ def create_app(
         track = queue.skip_to(req.position)
         if track:
             engine.play(
-                track.file_path
-            )  # play() resets lookahead; file-loaded re-primes it
+                _resolve_playback(track)
+            )  # resets lookahead; file-loaded re-primes it
             _record_track_started_debounced(track.file_path)
         _notify_track_changed()
         _drain_unlocked(old_current, old_lookahead)
@@ -2361,7 +2426,7 @@ def create_app(
         queue.add_to_queue(track)
         current = queue.current()
         if was_stopped and current is not None:
-            engine.play(current.file_path)
+            engine.play(_resolve_playback(current))
             _record_track_started_immediate(current.file_path)
             _notify_track_changed()
         else:
@@ -2378,7 +2443,7 @@ def create_app(
         queue.play_next(track)
         current = queue.current()
         if was_stopped and current is not None:
-            engine.play(current.file_path)
+            engine.play(_resolve_playback(current))
             _record_track_started_immediate(current.file_path)
             _notify_track_changed()
         else:
@@ -2409,7 +2474,7 @@ def create_app(
         queue.add_album_to_queue(tracks)
         current = queue.current()
         if was_stopped and current is not None:
-            engine.play(current.file_path)
+            engine.play(_resolve_playback(current))
             _record_track_started_immediate(current.file_path)
             _notify_track_changed()
         else:
@@ -2430,7 +2495,7 @@ def create_app(
         queue.play_album_next(tracks)
         current = queue.current()
         if was_stopped and current is not None:
-            engine.play(current.file_path)
+            engine.play(_resolve_playback(current))
             _record_track_started_immediate(current.file_path)
             _notify_track_changed()
         else:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -663,15 +663,18 @@ def create_app(
         if needs_refresh and refresh_stream_url is not None:
             _fp = str(track.file_path)
             # Parse sale_item_id and track_number from bandcamp://sale_id/track_num.
-            # Path() normalises bandcamp:// → bandcamp:/ on POSIX (// collapse);
-            # strip either prefix and reconstruct the canonical form for DB lookups.
+            # Path() mutates the URI differently per platform:
+            #   POSIX: bandcamp:// → bandcamp:/ (double-slash collapse)
+            #   Windows: bandcamp:// → bandcamp:\\ (backslash normalisation)
+            # Split on "bandcamp:" and strip all leading slashes/backslashes to
+            # get the raw "sale_id/track_num" segment, then reconstruct canonical
+            # "bandcamp://sale_id/track_num" for DB lookups.
+            _after_scheme = _fp.split("bandcamp:", 1)
             _canonical_fp: str | None = None
             _rest: str | None = None
-            for _prefix in ("bandcamp://", "bandcamp:/"):
-                if _fp.startswith(_prefix):
-                    _rest = _fp[len(_prefix) :]
-                    _canonical_fp = "bandcamp://" + _rest
-                    break
+            if len(_after_scheme) == 2:
+                _rest = _after_scheme[1].lstrip("/\\").replace("\\", "/")
+                _canonical_fp = "bandcamp://" + _rest
             if _canonical_fp is not None and _rest is not None:
                 parts = _rest.split("/", 1)
                 if len(parts) == 2:

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -252,6 +252,8 @@ def mark_collection_synced(
             item_type=str(item.get("sale_item_type", "p")),
             band_name=str(item.get("band_name", "")),
             item_title=str(item.get("item_title", "")),
+            album_url=str(item.get("item_url", "")),
+            tralbum_id=str(item.get("tralbum_id", "")),
             synced_at=now,
         )
 
@@ -331,6 +333,8 @@ def sync_new_purchases(
                 item_type=str(item.get("sale_item_type", "p")),
                 band_name=str(item.get("band_name", "")),
                 item_title=str(item.get("item_title", "")),
+                album_url=str(item.get("item_url", "")),
+                tralbum_id=str(item.get("tralbum_id", "")),
                 synced_at=time.time(),
             )
             logger.info("Downloaded: %s", path.name)
@@ -685,6 +689,55 @@ def _get_download_links(
 
 
 # ---------------------------------------------------------------------------
+# Stream URL resolution
+# ---------------------------------------------------------------------------
+
+
+def fetch_stream_url(
+    album_url: str,
+    track_number: int,
+    session: "_AnySession",
+) -> tuple[str, float]:
+    """Fetch the streaming URL for *track_number* from a Bandcamp album page.
+
+    Scrapes the ``data-tralbum`` JSON attribute embedded in the album page HTML.
+    Returns ``(stream_url, expires_at)`` where ``expires_at`` is
+    ``time.time() + 86400`` (Bandcamp stream URLs are valid for ~24 hours).
+
+    Raises ``BandcampAPIError`` if the page cannot be parsed or the track is
+    not found.
+    """
+    resp = session.get(album_url, timeout=30)
+    resp.raise_for_status()
+    html = resp.text
+
+    match = re.search(r'data-tralbum="([^"]+)"', html)
+    if not match:
+        raise BandcampAPIError(
+            f"fetch_stream_url: no data-tralbum found in {album_url}"
+        )
+
+    tralbum: dict[str, Any] = json.loads(html_lib.unescape(match.group(1)))
+    tracks: list[dict[str, Any]] = tralbum.get("tracks") or []
+
+    for t in tracks:
+        if t.get("track_num") == track_number:
+            files: dict[str, Any] = t.get("file") or {}
+            url = files.get("mp3-128") or files.get("mp3-v0")
+            if not url:
+                raise BandcampAPIError(
+                    f"fetch_stream_url: no mp3 stream URL for track {track_number} "
+                    f"in {album_url}"
+                )
+            expires_at = time.time() + 86400
+            return url, expires_at
+
+    raise BandcampAPIError(
+        f"fetch_stream_url: track_num={track_number} not found in {album_url} "
+        f"(tracks present: {[t.get('track_num') for t in tracks]})"
+    )
+
+
 # Download
 # ---------------------------------------------------------------------------
 

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -297,6 +297,26 @@ def sync_new_purchases(
         and state.get(str(item["sale_item_id"])) != "remote"
     ]
 
+    # Refresh metadata (band_name, album_url, tralbum_id) for all fetched items,
+    # not just new ones.  Existing rows may have been created before KAMP-382
+    # started populating these fields; synced_at is preserved via COALESCE.
+    for item in collection:
+        sid = item.get("sale_item_id")
+        if sid is None:
+            continue
+        key = str(sid)
+        if key in state and key not in {str(i["sale_item_id"]) for i in new_items}:
+            index.upsert_collection_item(
+                key,
+                mode=state[key],
+                item_type=str(item.get("sale_item_type", "p")),
+                band_name=str(item.get("band_name", "")),
+                item_title=str(item.get("item_title", "")),
+                album_url=str(item.get("item_url", "")),
+                tralbum_id=str(item.get("tralbum_id", "")),
+                synced_at=None,  # COALESCE preserves existing synced_at
+            )
+
     if not new_items:
         logger.info("No new purchases to download.")
         return []

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -31,6 +31,7 @@ from kamp_daemon.bandcamp import (
     _session_from_cookie_file,
     _username_from_logout_cookie,
     _validate_session,
+    fetch_stream_url,
     mark_collection_synced,
     sync_new_purchases,
 )
@@ -76,12 +77,17 @@ def _item(
     sale_item_id: int,
     band: str = "Band",
     title: str = "Album",
+    item_url: str = "",
+    tralbum_id: int = 0,
 ) -> dict[str, Any]:
     return {
         "sale_item_type": "p",
         "sale_item_id": sale_item_id,
         "band_name": band,
         "item_title": title,
+        "item_url": item_url
+        or f"https://{band.lower().replace(' ', '')}.bandcamp.com/album/{title.lower().replace(' ', '-')}",
+        "tralbum_id": tralbum_id or sale_item_id * 10,
     }
 
 
@@ -1676,3 +1682,108 @@ class TestResolveCdnRedirect:
         result = _resolve_cdn_redirect(self._popplers_url, sess)
 
         assert result == self._popplers_url
+
+
+# ---------------------------------------------------------------------------
+# fetch_stream_url
+# ---------------------------------------------------------------------------
+
+
+def _album_page_html(tracks: list[dict]) -> str:
+    """Build fake Bandcamp album page HTML with data-tralbum attribute."""
+    import html as html_lib
+    import json
+
+    tralbum = {"tracks": tracks}
+    encoded = html_lib.escape(json.dumps(tralbum))
+    return f'<html><body><div data-tralbum="{encoded}"></div></body></html>'
+
+
+class TestFetchStreamUrl:
+    _album_url = "https://artist.bandcamp.com/album/my-album"
+
+    def test_returns_stream_url_for_track(self) -> None:
+        track_data = [
+            {"track_num": 1, "file": {"mp3-128": "https://cdn.example.com/1.mp3"}},
+            {"track_num": 2, "file": {"mp3-128": "https://cdn.example.com/2.mp3"}},
+        ]
+        html = _album_page_html(track_data)
+        sess = MagicMock()
+        sess.get.return_value = MagicMock(status_code=200, text=html)
+        sess.get.return_value.raise_for_status = MagicMock()
+
+        url, expires_at = fetch_stream_url(self._album_url, 2, sess)
+
+        assert url == "https://cdn.example.com/2.mp3"
+        import time
+
+        assert expires_at > time.time() + 86000
+
+    def test_falls_back_to_mp3_v0(self) -> None:
+        track_data = [
+            {"track_num": 1, "file": {"mp3-v0": "https://cdn.example.com/v0.mp3"}},
+        ]
+        html = _album_page_html(track_data)
+        sess = MagicMock()
+        sess.get.return_value = MagicMock(status_code=200, text=html)
+        sess.get.return_value.raise_for_status = MagicMock()
+
+        url, _ = fetch_stream_url(self._album_url, 1, sess)
+
+        assert url == "https://cdn.example.com/v0.mp3"
+
+    def test_raises_when_no_data_tralbum(self) -> None:
+        sess = MagicMock()
+        sess.get.return_value = MagicMock(
+            status_code=200, text="<html>no data here</html>"
+        )
+        sess.get.return_value.raise_for_status = MagicMock()
+
+        with pytest.raises(BandcampAPIError, match="no data-tralbum"):
+            fetch_stream_url(self._album_url, 1, sess)
+
+    def test_raises_when_track_not_found(self) -> None:
+        track_data = [
+            {"track_num": 1, "file": {"mp3-128": "https://cdn.example.com/1.mp3"}}
+        ]
+        html = _album_page_html(track_data)
+        sess = MagicMock()
+        sess.get.return_value = MagicMock(status_code=200, text=html)
+        sess.get.return_value.raise_for_status = MagicMock()
+
+        with pytest.raises(BandcampAPIError, match="track_num=99 not found"):
+            fetch_stream_url(self._album_url, 99, sess)
+
+
+class TestMarkCollectionSyncedStoresAlbumUrl:
+    """mark_collection_synced now passes album_url and tralbum_id from the API response."""
+
+    def test_mark_collection_synced_stores_album_url(self, tmp_path: Path) -> None:
+        config = _bc_config(tmp_path)
+        items = [
+            _item(
+                1,
+                "Artist",
+                "Album",
+                item_url="https://artist.bandcamp.com/album/album",
+                tralbum_id=100,
+            )
+        ]
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+        ):
+            mark_collection_synced(config, index)
+
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        assert call_kwargs["album_url"] == "https://artist.bandcamp.com/album/album"
+        assert call_kwargs["tralbum_id"] == "100"

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -717,6 +717,47 @@ class TestSyncNewPurchases:
 
         assert len(paths) == 1  # only item 2 downloaded
 
+    def test_refreshes_metadata_for_existing_items(self, tmp_path: Path) -> None:
+        """Existing items get band_name/album_url/tralbum_id refreshed even if not downloaded."""
+        items = [
+            _item(
+                1,
+                "The Artist",
+                "The Album",
+                item_url="https://theartist.bandcamp.com/album/the-album",
+                tralbum_id=42,
+            )
+        ]
+        paths = self._run(tmp_path, items, known_ids=["1"])
+
+        # No downloads — item was already known.
+        assert paths == []
+
+        # upsert_collection_item should have been called once for the metadata refresh.
+        index = MagicMock()
+        index.get_collection_state.return_value = {"1": "local"}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session",
+                return_value=_make_requests_mock(items),
+            ),
+        ):
+            sync_new_purchases(_bc_config(tmp_path), tmp_path / "watch", index)
+
+        index.upsert_collection_item.assert_called_once()
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        assert call_kwargs["band_name"] == "The Artist"
+        assert (
+            call_kwargs["album_url"] == "https://theartist.bandcamp.com/album/the-album"
+        )
+        assert call_kwargs["tralbum_id"] == "42"
+        assert call_kwargs["synced_at"] is None  # preserved via COALESCE
+
 
 # ---------------------------------------------------------------------------
 # mark_collection_synced

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 19
+        assert version == 20
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1336,7 +1336,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 19
+        assert version == 20
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1393,7 +1393,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 19
+        assert version == 20
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1749,7 +1749,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 19
+        assert version == 20
         assert row is not None
         assert row[0] == 0
 
@@ -1967,7 +1967,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 19
+        assert version == 20
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2059,7 +2059,7 @@ class TestAlbumFavorite:
         index._conn.execute("SELECT COUNT(*) FROM album_favorites").fetchone()
         index.close()
 
-        assert version == 19
+        assert version == 20
 
 
 # ---------------------------------------------------------------------------
@@ -2238,7 +2238,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 19
+        assert version == 20
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2333,7 +2333,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 19
+        assert version == 20
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2341,7 +2341,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 19
+        assert version == 20
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3218,7 +3218,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 19
+        assert version == 20
 
         index.close()
 
@@ -3901,7 +3901,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 19
+        assert version == 20
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -3936,7 +3936,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 19
+        assert version == 20
         index.close()
 
 
@@ -4221,4 +4221,181 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 19
+        assert version == 20
+
+
+class TestRemoteTrackSchema:
+    """Tests for Track.is_remote, Track.playback_uri, update_stream_url, get_collection_item."""
+
+    def test_track_is_remote_default_false(self, tmp_path: Path) -> None:
+        track = _sample_track(tmp_path / "song.mp3")
+        assert not track.is_remote
+
+    def test_track_is_remote_true(self, tmp_path: Path) -> None:
+        track = _sample_track(tmp_path / "song.mp3")
+        track.source = "bandcamp"
+        assert track.is_remote
+
+    def test_track_playback_uri_local(self, tmp_path: Path) -> None:
+        fp = tmp_path / "song.mp3"
+        track = _sample_track(fp)
+        assert track.playback_uri == str(fp)
+
+    def test_track_playback_uri_remote_with_stream_url(self, tmp_path: Path) -> None:
+        track = _sample_track(tmp_path / "bandcamp://123/1")
+        track.source = "bandcamp"
+        track.stream_url = "https://cdn.bandcamp.com/stream/abc.mp3"
+        assert track.playback_uri == "https://cdn.bandcamp.com/stream/abc.mp3"
+
+    def test_track_playback_uri_remote_without_stream_url(self, tmp_path: Path) -> None:
+        track = _sample_track(tmp_path / "bandcamp://123/1")
+        track.source = "bandcamp"
+        track.stream_url = None
+        # Falls back to str(file_path)
+        assert track.playback_uri == str(tmp_path / "bandcamp://123/1")
+
+    def test_upsert_remote_track_roundtrips(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(tmp_path / "bandcamp://999/2")
+        track.source = "bandcamp"
+        track.stream_url = "https://cdn.example.com/stream.mp3"
+        track.stream_url_expires_at = 9999.0
+        index.upsert_track(track)
+
+        row = index._conn.execute(
+            "SELECT source, stream_url, stream_url_expires_at FROM tracks WHERE file_path = ?",
+            (str(track.file_path),),
+        ).fetchone()
+        index.close()
+
+        assert row["source"] == "bandcamp"
+        assert row["stream_url"] == "https://cdn.example.com/stream.mp3"
+        assert row["stream_url_expires_at"] == 9999.0
+
+    def test_local_track_source_defaults_to_local(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        fp = tmp_path / "song.mp3"
+        track = _sample_track(fp)
+        index.upsert_track(track)
+
+        row = index._conn.execute(
+            "SELECT source FROM tracks WHERE file_path = ?", (str(fp),)
+        ).fetchone()
+        index.close()
+
+        assert row["source"] == "local"
+
+    def test_update_stream_url(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        fp_str = str(tmp_path / "bandcamp://555/1")
+        track = _sample_track(tmp_path / "bandcamp://555/1")
+        track.source = "bandcamp"
+        index.upsert_track(track)
+
+        index.update_stream_url(
+            fp_str, "https://new-cdn.example.com/track.mp3", 12345.0
+        )
+
+        row = index._conn.execute(
+            "SELECT stream_url, stream_url_expires_at FROM tracks WHERE file_path = ?",
+            (fp_str,),
+        ).fetchone()
+        index.close()
+
+        assert row["stream_url"] == "https://new-cdn.example.com/track.mp3"
+        assert row["stream_url_expires_at"] == 12345.0
+
+    def test_get_collection_item_found(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "42",
+            mode="remote",
+            album_url="https://artist.bandcamp.com/album/album",
+            tralbum_id="abc123",
+        )
+        item = index.get_collection_item("42")
+        index.close()
+
+        assert item is not None
+        assert item["sale_item_id"] == "42"
+        assert item["album_url"] == "https://artist.bandcamp.com/album/album"
+        assert item["tralbum_id"] == "abc123"
+        assert item["mode"] == "remote"
+
+    def test_get_collection_item_not_found(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        item = index.get_collection_item("nonexistent")
+        index.close()
+
+        assert item is None
+
+    def test_migration_v20_adds_stream_columns(self, tmp_path: Path) -> None:
+        """A v19 DB gains the three new columns on open."""
+        db_path = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (19)")
+        conn.execute("""
+            CREATE TABLE tracks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL DEFAULT '',
+                artist TEXT NOT NULL DEFAULT '',
+                album_artist TEXT NOT NULL DEFAULT '',
+                album TEXT NOT NULL DEFAULT '',
+                year TEXT NOT NULL DEFAULT '',
+                track_number INTEGER NOT NULL DEFAULT 0,
+                disc_number INTEGER NOT NULL DEFAULT 1,
+                ext TEXT NOT NULL DEFAULT '',
+                embedded_art INTEGER NOT NULL DEFAULT 0,
+                mb_release_id TEXT NOT NULL DEFAULT '',
+                mb_recording_id TEXT NOT NULL DEFAULT '',
+                date_added REAL,
+                last_played REAL,
+                favorite INTEGER NOT NULL DEFAULT 0,
+                play_count INTEGER NOT NULL DEFAULT 0,
+                file_mtime REAL,
+                genre TEXT NOT NULL DEFAULT '',
+                label TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE queue_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                tracks TEXT NOT NULL,
+                order_json TEXT NOT NULL DEFAULT '',
+                pos INTEGER NOT NULL DEFAULT -1,
+                shuffle INTEGER NOT NULL DEFAULT 0,
+                repeat INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS bandcamp_collection (
+                sale_item_id TEXT NOT NULL PRIMARY KEY,
+                item_type    TEXT NOT NULL DEFAULT 'p',
+                band_name    TEXT NOT NULL DEFAULT '',
+                item_title   TEXT NOT NULL DEFAULT '',
+                tralbum_id   TEXT NOT NULL DEFAULT '',
+                album_url    TEXT NOT NULL DEFAULT '',
+                mode         TEXT NOT NULL DEFAULT 'local',
+                synced_at    REAL,
+                added_at     REAL NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        cols = {
+            row[1]
+            for row in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
+        index.close()
+
+        assert version == 20
+        assert "source" in cols
+        assert "stream_url" in cols
+        assert "stream_url_expires_at" in cols

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -823,7 +823,7 @@ class TestPlayerPlayEndpoint:
         )
         assert response.status_code == 200
         mock_queue.load.assert_called_once_with(tracks, start_index=0)
-        mock_engine.play.assert_called_once_with(tracks[0].file_path)
+        mock_engine.play.assert_called_once_with(str(tracks[0].file_path))
 
     def test_play_returns_404_for_unknown_album(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -869,7 +869,7 @@ class TestPlayerControlEndpoints:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         assert c.post("/api/v1/player/next").status_code == 200
-        mock_engine.play.assert_called_once_with(next_track.file_path)
+        mock_engine.play.assert_called_once_with(str(next_track.file_path))
 
     def test_next_at_end_of_queue_stops(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -888,7 +888,7 @@ class TestPlayerControlEndpoints:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         assert c.post("/api/v1/player/prev").status_code == 200
-        mock_engine.play.assert_called_once_with(prev_track.file_path)
+        mock_engine.play.assert_called_once_with(str(prev_track.file_path))
 
     def test_prev_at_start_of_queue_is_noop(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -1053,7 +1053,7 @@ class TestQueueMutationEndpoints:
         resp = client.post("/api/v1/player/queue/skip-to", json={"position": 3})
         assert resp.status_code == 200
         mock_queue.skip_to.assert_called_once_with(3)
-        mock_engine.play.assert_called_once_with(t.file_path)
+        mock_engine.play.assert_called_once_with(str(t.file_path))
 
     def test_skip_to_invalid_position_does_not_play(
         self, client: TestClient, mock_engine: MagicMock, mock_queue: MagicMock
@@ -1078,7 +1078,7 @@ class TestQueueMutationEndpoints:
             "/api/v1/player/queue/add", json={"file_path": str(t.file_path)}
         )
         assert resp.status_code == 200
-        mock_engine.play.assert_called_once_with(t.file_path)
+        mock_engine.play.assert_called_once_with(str(t.file_path))
         mock_engine.preload_next.assert_not_called()
 
     def test_play_next_starts_playback_when_stopped(
@@ -1096,7 +1096,7 @@ class TestQueueMutationEndpoints:
             "/api/v1/player/queue/play-next", json={"file_path": str(t.file_path)}
         )
         assert resp.status_code == 200
-        mock_engine.play.assert_called_once_with(t.file_path)
+        mock_engine.play.assert_called_once_with(str(t.file_path))
         mock_engine.preload_next.assert_not_called()
 
 
@@ -1183,7 +1183,7 @@ class TestAlbumQueueEndpoints:
             json={"album_artist": "Artist", "album": "Album"},
         )
         assert resp.status_code == 200
-        mock_engine.play.assert_called_once_with(ts[0].file_path)
+        mock_engine.play.assert_called_once_with(str(ts[0].file_path))
         mock_engine.preload_next.assert_not_called()
 
     def test_play_album_next_starts_playback_when_stopped(
@@ -1202,7 +1202,7 @@ class TestAlbumQueueEndpoints:
             json={"album_artist": "Artist", "album": "Album"},
         )
         assert resp.status_code == 200
-        mock_engine.play.assert_called_once_with(ts[0].file_path)
+        mock_engine.play.assert_called_once_with(str(ts[0].file_path))
         mock_engine.preload_next.assert_not_called()
 
 
@@ -3453,3 +3453,129 @@ class TestApplyLocalAlbumArt:
         assert res.status_code == 200
         mock_write.assert_called_once()
         mock_index.mark_album_art_embedded.assert_called_once()
+
+
+class TestValidateLibraryPathRemoteURI:
+    """_validate_library_path rejects bandcamp:// URIs."""
+
+    def test_bandcamp_uri_returns_400(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        response = c.post(
+            "/api/v1/player/queue/add",
+            json={"file_path": "bandcamp://380008227/3"},
+        )
+        assert response.status_code == 400
+        assert "Remote tracks" in response.json()["detail"]
+
+
+class TestResolvePlaybackRemote:
+    """_resolve_playback invokes the refresh callback for expired remote track URLs."""
+
+    def test_local_track_plays_via_file_path(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        mock_queue.next.return_value = track
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+        mock_engine.play.assert_called_once_with(str(track.file_path))
+
+    def test_remote_track_uses_stream_url_when_fresh(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        import time
+
+        remote = _track(1)
+        remote.source = "bandcamp"
+        remote.stream_url = "https://cdn.example.com/stream.mp3"
+        remote.stream_url_expires_at = time.time() + 7200  # 2 hours from now
+
+        mock_queue.next.return_value = remote
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+        mock_engine.play.assert_called_once_with("https://cdn.example.com/stream.mp3")
+
+    def test_remote_track_refreshes_when_url_expired(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        remote = Track(
+            file_path=Path("bandcamp://999/3"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=3,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/old.mp3",
+            stream_url_expires_at=0.0,  # expired
+        )
+        mock_queue.next.return_value = remote
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "999",
+            "album_url": "https://artist.bandcamp.com/album/the-album",
+        }
+
+        refreshed_url = "https://cdn.example.com/new.mp3"
+        refresh_fn = MagicMock(return_value=(refreshed_url, 9999.0))
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            refresh_stream_url=refresh_fn,
+        )
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+
+        refresh_fn.assert_called_once_with(
+            "https://artist.bandcamp.com/album/the-album", 3
+        )
+        # update_stream_url receives the canonical bandcamp:// URI.
+        # Path() normalises bandcamp:// → bandcamp:/ on POSIX; _resolve_playback
+        # restores the canonical form so the DB lookup matches the stored row.
+        mock_index.update_stream_url.assert_called_once_with(
+            "bandcamp://999/3", refreshed_url, 9999.0
+        )
+        mock_engine.play.assert_called_once_with(refreshed_url)
+
+    def test_remote_track_skips_refresh_when_no_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        remote = Track(
+            file_path=Path("bandcamp://888/1"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/existing.mp3",
+            stream_url_expires_at=0.0,  # expired
+        )
+        mock_queue.next.return_value = remote
+        # No refresh_stream_url callback provided — falls back to existing URL.
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+        mock_engine.play.assert_called_once_with("https://cdn.example.com/existing.mp3")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3552,6 +3552,52 @@ class TestResolvePlaybackRemote:
         )
         mock_engine.play.assert_called_once_with(refreshed_url)
 
+    def test_remote_track_refreshes_with_windows_corrupted_path(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Windows Path normalises bandcamp:// to bandcamp:\\ — still parsed correctly."""
+        remote = Track(
+            # Simulate what str(Path("bandcamp://999/3")) yields on Windows.
+            file_path=Path("bandcamp:\\\\999\\3"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=3,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/old.mp3",
+            stream_url_expires_at=0.0,
+        )
+        mock_queue.next.return_value = remote
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "999",
+            "album_url": "https://artist.bandcamp.com/album/the-album",
+        }
+
+        refresh_fn = MagicMock(return_value=("https://cdn.example.com/new.mp3", 9999.0))
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            refresh_stream_url=refresh_fn,
+        )
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+
+        refresh_fn.assert_called_once_with(
+            "https://artist.bandcamp.com/album/the-album", 3
+        )
+        mock_index.update_stream_url.assert_called_once_with(
+            "bandcamp://999/3", "https://cdn.example.com/new.mp3", 9999.0
+        )
+
     def test_remote_track_skips_refresh_when_no_callback(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- Schema v20: adds `source`, `stream_url`, `stream_url_expires_at` columns to `tracks` table; v20 migration adds them to existing DBs via guarded `ALTER TABLE`
- `Track` dataclass gains `is_remote` and `playback_uri` properties; `engine.play()` widened to `str | Path`
- `_validate_library_path` short-circuits `bandcamp://` URIs with HTTP 400 (RC blocker #1)
- `_resolve_playback` inner helper in `server.py` handles pre-play stream URL expiry check and refresh via `refresh_stream_url` callback — keeps `kamp_core` free of `requests` dependency
- `LibraryIndex` gains `update_stream_url()` and `get_collection_item()` methods
- `bandcamp.py`: `fetch_stream_url()` scrapes album page `data-tralbum` JSON for CDN stream URLs; `mark_collection_synced` and `sync_new_purchases` now store `album_url` and `tralbum_id` from the Bandcamp API response

## Test plan

- [x] 1543 tests pass, 93.20% coverage, mypy clean, black clean
- [x] Fresh DB: `tracks` table has 3 new columns, all rows `source='local'`, NULL stream fields
- [x] Upgrade from v19: migration adds columns cleanly, existing tracks unaffected
- [x] Local track playback: `playback_uri` returns `str(file_path)`, engine receives string (no regression)
- [x] `bandcamp://` via play-by-path endpoint → HTTP 400
- [x] `kamp sync` on a configured account → `bandcamp_collection` rows now populated with `album_url` and `tralbum_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)