### PR TITLE
feat(KAMP-383): integrate remote tracks into AlbumInfo, scanner guard, and queue state

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -14,7 +14,7 @@ import time as _time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import keyring
 import keyring.errors
@@ -356,6 +356,14 @@ class AlbumInfo:
     favorite: bool = False
     # True when any track in this album is individually favorited (KAMP-294).
     has_favorite_track: bool = False
+    # 'local' when all tracks are local, the source value when all are the same
+    # remote source, or 'mixed' when both local and remote tracks are present.
+    source: str = "local"
+    # True when any track in this album has source != 'local'.
+    has_remote_tracks: bool = False
+    # True when this local album is also in bandcamp_collection with mode='local'
+    # (i.e. the user owns it on Bandcamp but has it downloaded locally).
+    in_bandcamp_collection: bool = False
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -1561,7 +1569,8 @@ class LibraryIndex:
             SELECT album_artist, album, year, track_count, has_art,
                    missing_album, file_path, art_version,
                    sort_date_added, sort_last_played, sort_play_count_avg,
-                   is_favorite, has_favorite_track
+                   is_favorite, has_favorite_track,
+                   album_source, has_remote_tracks, in_bandcamp_collection
             FROM (
                 SELECT t.album_artist, t.album, t.year, COUNT(*) AS track_count,
                        MAX(t.embedded_art) AS has_art,
@@ -1571,10 +1580,19 @@ class LibraryIndex:
                        MAX(t.file_mtime) AS art_version,
                        CAST(SUM(t.play_count) AS REAL) / COUNT(*) AS sort_play_count_avg,
                        MAX(CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END) AS is_favorite,
-                       MAX(t.favorite) AS has_favorite_track
+                       MAX(t.favorite) AS has_favorite_track,
+                       CASE WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                            ELSE MIN(t.source) END AS album_source,
+                       MAX(CASE WHEN t.source != 'local' THEN 1 ELSE 0 END) AS has_remote_tracks,
+                       MAX(CASE WHEN bc.sale_item_id IS NOT NULL THEN 1 ELSE 0 END)
+                           AS in_bandcamp_collection
                 FROM tracks t
                 LEFT JOIN album_favorites af
                     ON af.album_artist = t.album_artist AND af.album = t.album
+                LEFT JOIN bandcamp_collection bc
+                    ON bc.band_name = t.album_artist COLLATE NOCASE
+                    AND bc.item_title = t.album COLLATE NOCASE
+                    AND bc.mode = 'local'
                 WHERE t.album != ''
                 GROUP BY t.album_artist, t.album
                 UNION ALL
@@ -1586,7 +1604,10 @@ class LibraryIndex:
                        t.file_mtime AS art_version,
                        CAST(t.play_count AS REAL) AS sort_play_count_avg,
                        CASE WHEN af.album_artist IS NOT NULL THEN 1 ELSE 0 END AS is_favorite,
-                       t.favorite AS has_favorite_track
+                       t.favorite AS has_favorite_track,
+                       t.source AS album_source,
+                       CASE WHEN t.source != 'local' THEN 1 ELSE 0 END AS has_remote_tracks,
+                       0 AS in_bandcamp_collection
                 FROM tracks t
                 LEFT JOIN album_favorites af
                     ON af.album_artist = t.album_artist AND af.album = t.title
@@ -1609,6 +1630,9 @@ class LibraryIndex:
                 play_count_avg=r["sort_play_count_avg"] or 0.0,
                 favorite=bool(r["is_favorite"]),
                 has_favorite_track=bool(r["has_favorite_track"]),
+                source=r["album_source"],
+                has_remote_tracks=bool(r["has_remote_tracks"]),
+                in_bandcamp_collection=bool(r["in_bandcamp_collection"]),
             )
             for r in rows
         ]
@@ -1633,19 +1657,37 @@ class LibraryIndex:
         return [_row_to_track(r) for r in rows]
 
     def indexed_paths(self) -> set[Path]:
-        """Return the set of all file paths currently in the index."""
-        rows = self._conn.execute("SELECT file_path FROM tracks").fetchall()
+        """Return the set of local file paths currently in the index.
+
+        Remote tracks (source != 'local') are excluded so the scanner never
+        tries to stat a bandcamp:// URI or treats it as a missing file.
+        """
+        rows = self._conn.execute(
+            "SELECT file_path FROM tracks WHERE source = 'local'"
+        ).fetchall()
         return {Path(r["file_path"]) for r in rows}
 
     def indexed_paths_with_mtime(self) -> dict[Path, float | None]:
-        """Return a mapping of indexed file paths to their stored file_mtime."""
-        rows = self._conn.execute("SELECT file_path, file_mtime FROM tracks").fetchall()
+        """Return a mapping of local indexed file paths to their stored file_mtime.
+
+        Remote tracks (source != 'local') are excluded for the same reason as
+        indexed_paths() — their URI is not a real filesystem path.
+        """
+        rows = self._conn.execute(
+            "SELECT file_path, file_mtime FROM tracks WHERE source = 'local'"
+        ).fetchall()
         return {Path(r["file_path"]): r["file_mtime"] for r in rows}
 
-    def get_track_by_path(self, path: Path) -> "Track | None":
-        """Return the track for *path*, or None if not indexed."""
+    def get_track_by_path(self, path: "str | Path") -> "Track | None":
+        """Return the track for *path*, or None if not indexed.
+
+        Accepts both Path objects and plain strings. Strings are used directly
+        as the lookup key to avoid Path normalization corrupting remote URIs
+        (e.g. Path("bandcamp://999/3") collapses to "bandcamp:/999/3" on POSIX).
+        """
+        key = path if isinstance(path, str) else str(path)
         row = self._conn.execute(
-            "SELECT * FROM tracks WHERE file_path = ?", (str(path),)
+            "SELECT * FROM tracks WHERE file_path = ?", (key,)
         ).fetchone()
         return _row_to_track(row) if row else None
 
@@ -1688,7 +1730,7 @@ class LibraryIndex:
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
-    def save_player_state(self, track_path: Path, position: float) -> None:
+    def save_player_state(self, track_path: "str | Path", position: float) -> None:
         """Persist the current track path and playback position."""
         self._conn.execute(
             """
@@ -1706,16 +1748,20 @@ class LibraryIndex:
         self._conn.execute("DELETE FROM player_state WHERE id = 1")
         self._conn.commit()
 
-    def load_player_state(self) -> "tuple[Path, float] | None":
-        """Return (track_path, position) from the last session, or None."""
+    def load_player_state(self) -> "tuple[str, float] | None":
+        """Return (track_path, position) from the last session, or None.
+
+        Returns the raw string stored in the DB — callers must not wrap it in
+        Path() since it may be a remote URI (bandcamp://) that Path normalizes.
+        """
         row = self._conn.execute(
             "SELECT track_path, position FROM player_state WHERE id = 1"
         ).fetchone()
-        return (Path(row["track_path"]), row["position"]) if row else None
+        return (row["track_path"], row["position"]) if row else None
 
     def save_queue_state(
         self,
-        tracks: list[Path],
+        tracks: "Sequence[Path | str]",
         order: list[int],
         pos: int,
         shuffle: bool,
@@ -1743,8 +1789,12 @@ class LibraryIndex:
 
     def load_queue_state(
         self,
-    ) -> "tuple[list[Path], list[int], int, bool, bool] | None":
-        """Return (tracks_in_original_order, order, pos, shuffle, repeat) or None."""
+    ) -> "tuple[list[str], list[int], int, bool, bool] | None":
+        """Return (tracks_in_original_order, order, pos, shuffle, repeat) or None.
+
+        Tracks are returned as raw strings (not Path objects) so remote URIs
+        (bandcamp://) are not corrupted by Path normalization.
+        """
         import json
 
         row = self._conn.execute(
@@ -1752,7 +1802,7 @@ class LibraryIndex:
         ).fetchone()
         if not row:
             return None
-        paths = [Path(p) for p in json.loads(row["tracks"])]
+        paths: list[str] = list(json.loads(row["tracks"]))
         raw_order = row["order_json"]
         order: list[int] = (
             json.loads(raw_order) if raw_order else list(range(len(paths)))

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -230,14 +230,15 @@ class PlaybackQueue:
         """
         return [self._tracks[i] for i in self._order], self._pos
 
-    def get_state(self) -> tuple[list[Path], list[int], int, bool, bool]:
+    def get_state(self) -> tuple[list[str], list[int], int, bool, bool]:
         """Return (original_paths, order, pos, shuffle, repeat) for persistence.
 
         *original_paths* is _tracks in load order; *order* is the index
         permutation (_order) so the shuffled sequence can be faithfully
         restored and toggling shuffle off recovers the true original order.
+        Paths are returned as strings to match load_queue_state()'s list[str].
         """
-        original_paths = [t.file_path for t in self._tracks]
+        original_paths = [str(t.file_path) for t in self._tracks]
         return original_paths, list(self._order), self._pos, self._shuffle, self._repeat
 
     @property

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1701,20 +1701,26 @@ def create_app(
             status = 422 if "below minimum" in msg else 502
             raise HTTPException(status_code=status, detail=msg) from exc
 
+        local_tracks = [t for t in tracks if not t.is_remote]
+        if not local_tracks:
+            raise HTTPException(
+                status_code=400, detail="Cannot embed art in remote-only album"
+            )
+
         if save_format == "cover-file":
-            album_dir = tracks[0].file_path.parent
+            album_dir = local_tracks[0].file_path.parent
             try:
                 await asyncio.get_event_loop().run_in_executor(
                     None, write_cover_file, image_bytes, "image/jpeg", album_dir
                 )
                 index.mark_album_art_embedded(
-                    body.album_artist, body.album, [t.file_path for t in tracks]
+                    body.album_artist, body.album, [t.file_path for t in local_tracks]
                 )
             except Exception:
                 logger.exception("Failed to write cover file to %s", album_dir)
         else:
             successful_paths: list[Path] = []
-            for track in tracks:
+            for track in local_tracks:
                 try:
                     await asyncio.get_event_loop().run_in_executor(
                         None, _embed, track.file_path, image_bytes
@@ -1819,20 +1825,26 @@ def create_app(
             image_bytes = _compress_to_max_bytes(img, min_dim, max_b)
             cover_mime = "image/jpeg"  # _compress_to_max_bytes always outputs JPEG
 
+        local_tracks = [t for t in tracks if not t.is_remote]
+        if not local_tracks:
+            raise HTTPException(
+                status_code=400, detail="Cannot embed art in remote-only album"
+            )
+
         if save_format == "cover-file":
-            album_dir = tracks[0].file_path.parent
+            album_dir = local_tracks[0].file_path.parent
             try:
                 await asyncio.get_event_loop().run_in_executor(
                     None, write_cover_file, image_bytes, cover_mime, album_dir
                 )
                 index.mark_album_art_embedded(
-                    album_artist, album, [t.file_path for t in tracks]
+                    album_artist, album, [t.file_path for t in local_tracks]
                 )
             except Exception:
                 logger.exception("Failed to write cover file to %s", album_dir)
         else:
             successful_paths: list[Path] = []
-            for track in tracks:
+            for track in local_tracks:
                 try:
                     await asyncio.get_event_loop().run_in_executor(
                         None, _embed, track.file_path, image_bytes
@@ -1889,6 +1901,8 @@ def create_app(
 
         def _embedded_response() -> Response | None:
             for track in tracks:
+                if track.is_remote:
+                    continue  # remote tracks have no local file to extract art from
                 if track.embedded_art:
                     result = extract_art(track.file_path)
                     if result:
@@ -1901,9 +1915,10 @@ def create_app(
             return None
 
         def _cover_file_response() -> Response | None:
-            if not tracks:
+            local_tracks = [t for t in tracks if not t.is_remote]
+            if not local_tracks:
                 return None
-            result = read_cover_file(tracks[0].file_path.parent)
+            result = read_cover_file(local_tracks[0].file_path.parent)
             if result:
                 data, mime = result
                 return Response(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -495,7 +495,8 @@ class TestLibraryIndex:
 
         assert result is not None
         path, position = result
-        assert path == tmp_path / "track.mp3"
+        assert isinstance(path, str)
+        assert path == str(tmp_path / "track.mp3")
         assert position == 42.5
 
     def test_load_player_state_returns_none_when_empty(self, tmp_path: Path) -> None:
@@ -523,7 +524,8 @@ class TestLibraryIndex:
 
         assert result is not None
         path, position = result
-        assert path == tmp_path / "second.mp3"
+        assert isinstance(path, str)
+        assert path == str(tmp_path / "second.mp3")
         assert position == 99.0
 
     def test_save_and_load_queue_state(self, tmp_path: Path) -> None:
@@ -537,7 +539,8 @@ class TestLibraryIndex:
 
         assert result is not None
         paths, order, pos, shuffle, repeat = result
-        assert paths == tracks
+        assert all(isinstance(p, str) for p in paths)
+        assert paths == [str(t) for t in tracks]
         assert order == [2, 0, 1]
         assert pos == 1
         assert shuffle is True
@@ -567,7 +570,7 @@ class TestLibraryIndex:
 
         assert result is not None
         paths, order, pos, shuffle, repeat = result
-        assert paths == [tmp_path / "b.mp3", tmp_path / "c.mp3"]
+        assert paths == [str(tmp_path / "b.mp3"), str(tmp_path / "c.mp3")]
         assert order == [1, 0]
         assert pos == 1
         assert shuffle is True
@@ -4399,3 +4402,317 @@ class TestRemoteTrackSchema:
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
+
+
+# ---------------------------------------------------------------------------
+# AlbumInfo remote fields — source, has_remote_tracks, in_bandcamp_collection
+# ---------------------------------------------------------------------------
+
+
+class TestAlbumInfoRemoteFields:
+    """albums() computes source, has_remote_tracks, and in_bandcamp_collection."""
+
+    def _insert_track(
+        self,
+        index: "LibraryIndex",
+        tmp_path: Path,
+        name: str,
+        album: str = "The Album",
+        album_artist: str = "The Artist",
+        source: str = "local",
+    ) -> None:
+        track = Track(
+            file_path=tmp_path / name,
+            title=name,
+            artist=album_artist,
+            album_artist=album_artist,
+            album=album,
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source=source,
+        )
+        index.upsert_many([track])
+
+    def test_all_local_album_has_local_source(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(index, tmp_path, "t1.mp3", source="local")
+        self._insert_track(index, tmp_path, "t2.mp3", source="local")
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].source == "local"
+        assert albums[0].has_remote_tracks is False
+
+    def test_all_remote_album_has_remote_source(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(index, tmp_path, "bandcamp://999/1", source="bandcamp")
+        self._insert_track(index, tmp_path, "bandcamp://999/2", source="bandcamp")
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].source == "bandcamp"
+        assert albums[0].has_remote_tracks is True
+
+    def test_mixed_album_has_mixed_source(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(index, tmp_path, "t1.mp3", source="local")
+        self._insert_track(index, tmp_path, "bandcamp://999/2", source="bandcamp")
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].source == "mixed"
+        assert albums[0].has_remote_tracks is True
+
+    def test_in_bandcamp_collection_true(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(
+            index, tmp_path, "t1.mp3", album_artist="The Artist", album="The Album"
+        )
+        index.upsert_collection_item(
+            "sale-1",
+            mode="local",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].in_bandcamp_collection is True
+
+    def test_in_bandcamp_collection_false_when_no_bc_entry(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(index, tmp_path, "t1.mp3")
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].in_bandcamp_collection is False
+
+    def test_in_bandcamp_collection_false_when_mode_is_not_local(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(
+            index, tmp_path, "t1.mp3", album_artist="The Artist", album="The Album"
+        )
+        index.upsert_collection_item(
+            "sale-1",
+            mode="remote",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].in_bandcamp_collection is False
+
+    def test_bc_join_does_not_affect_track_count(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        self._insert_track(
+            index, tmp_path, "t1.mp3", album_artist="The Artist", album="The Album"
+        )
+        self._insert_track(
+            index, tmp_path, "t2.mp3", album_artist="The Artist", album="The Album"
+        )
+        index.upsert_collection_item(
+            "sale-1",
+            mode="local",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        albums = index.albums()
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].track_count == 2
+        assert albums[0].in_bandcamp_collection is True
+
+
+# ---------------------------------------------------------------------------
+# indexed_paths / indexed_paths_with_mtime remote exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestIndexedPathsExcludesRemote:
+    def test_indexed_paths_excludes_remote_tracks(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        local = Track(
+            file_path=tmp_path / "local.mp3",
+            title="Local",
+            artist="A",
+            album_artist="A",
+            album="B",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="local",
+        )
+        remote = Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Remote",
+            artist="A",
+            album_artist="A",
+            album="B",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        index.upsert_many([local, remote])
+        paths = index.indexed_paths()
+        index.close()
+
+        assert tmp_path / "local.mp3" in paths
+        assert not any("bandcamp" in str(p) for p in paths)
+
+    def test_indexed_paths_with_mtime_excludes_remote_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        local = Track(
+            file_path=tmp_path / "local.mp3",
+            title="Local",
+            artist="A",
+            album_artist="A",
+            album="B",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="local",
+        )
+        remote = Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Remote",
+            artist="A",
+            album_artist="A",
+            album="B",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        index.upsert_many([local, remote])
+        mtime_map = index.indexed_paths_with_mtime()
+        index.close()
+
+        assert tmp_path / "local.mp3" in mtime_map
+        assert not any("bandcamp" in str(p) for p in mtime_map)
+
+
+# ---------------------------------------------------------------------------
+# Queue/player state — str round-trip and get_track_by_path str acceptance
+# ---------------------------------------------------------------------------
+
+
+class TestQueuePlayerStateStr:
+    def test_load_player_state_returns_str(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_player_state(tmp_path / "track.mp3", 10.0)
+        result = index.load_player_state()
+        index.close()
+
+        assert result is not None
+        path, _ = result
+        assert isinstance(path, str)
+
+    def test_load_player_state_preserves_remote_uri(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_player_state("bandcamp://999/3", 22.5)
+        result = index.load_player_state()
+        index.close()
+
+        assert result is not None
+        path, position = result
+        assert path == "bandcamp://999/3"
+        assert position == 22.5
+
+    def test_load_queue_state_returns_list_of_str(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_queue_state(
+            [tmp_path / "a.mp3", tmp_path / "b.mp3"],
+            order=[0, 1],
+            pos=0,
+            shuffle=False,
+            repeat=False,
+        )
+        result = index.load_queue_state()
+        index.close()
+
+        assert result is not None
+        paths, _, _, _, _ = result
+        assert all(isinstance(p, str) for p in paths)
+
+    def test_load_queue_state_preserves_remote_uri(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.save_queue_state(
+            ["bandcamp://999/1", "bandcamp://999/2"],
+            order=[0, 1],
+            pos=0,
+            shuffle=False,
+            repeat=False,
+        )
+        result = index.load_queue_state()
+        index.close()
+
+        assert result is not None
+        paths, _, _, _, _ = result
+        assert paths == ["bandcamp://999/1", "bandcamp://999/2"]
+
+    def test_get_track_by_path_accepts_str(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([_sample_track(tmp_path / "song.mp3")])
+        track = index.get_track_by_path(str(tmp_path / "song.mp3"))
+        index.close()
+
+        assert track is not None
+        assert track.title == "A Song"
+
+    def test_get_track_by_path_str_avoids_uri_normalization(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        # Insert with the canonical URI directly via SQL to bypass Path normalization.
+        canonical = "bandcamp://999/3"
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album, year, "
+            "track_number, disc_number, ext, embedded_art, mb_release_id, mb_recording_id, "
+            "source) VALUES (?, 'Remote', 'A', 'A', 'B', '2024', 1, 1, 'mp3', 0, '', '', 'bandcamp')",
+            (canonical,),
+        )
+        index._conn.commit()
+        track = index.get_track_by_path(canonical)
+        index.close()
+
+        assert track is not None
+        assert track.title == "Remote"

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -378,7 +378,7 @@ class TestPlaybackQueue:
         tracks = [_track(i) for i in range(3)]
         q.load(tracks)
         paths, order, pos, shuffle, repeat = q.get_state()
-        assert paths == [t.file_path for t in tracks]
+        assert paths == [str(t.file_path) for t in tracks]
         assert order == [0, 1, 2]
         assert pos == 0
         assert shuffle is False
@@ -391,7 +391,7 @@ class TestPlaybackQueue:
         q.set_shuffle(True)
         paths, order, pos, shuffle, repeat = q.get_state()
         # paths must be in ORIGINAL load order, not shuffled
-        assert paths == [t.file_path for t in tracks]
+        assert paths == [str(t.file_path) for t in tracks]
         # order[0] must be the original index of the currently playing track (0)
         assert order[0] == 0
         assert set(order) == {0, 1, 2, 3, 4}
@@ -446,7 +446,7 @@ class TestPlaybackQueue:
         # Simulate save/restore (what happens across a quit/restart).
         paths, order, pos, shuffle, repeat = q.get_state()
         q2 = PlaybackQueue()
-        resolved = [next(t for t in tracks if t.file_path == p) for p in paths]
+        resolved = [next(t for t in tracks if str(t.file_path) == p) for p in paths]
         q2.restore(resolved, order=order, pos=pos, shuffle=shuffle, repeat=repeat)
 
         assert q2.current() == before_toggle

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3625,3 +3625,125 @@ class TestResolvePlaybackRemote:
 
         c.post("/api/v1/player/next")
         mock_engine.play.assert_called_once_with("https://cdn.example.com/existing.mp3")
+
+
+# ---------------------------------------------------------------------------
+# Art endpoint guards for remote tracks
+# ---------------------------------------------------------------------------
+
+
+class TestArtEndpointRemoteGuards:
+    """Art read and write endpoints skip or reject remote-only tracks."""
+
+    def _make_remote_track(self) -> Track:
+        return Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Remote Song",
+            artist="The Artist",
+            album_artist="The Artist",
+            album="The Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=True,  # True but is_remote, so extract_art must not be called
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+
+    def test_art_endpoint_skips_extract_art_for_remote_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """embedded_art=True on a remote track must not trigger extract_art."""
+        remote = self._make_remote_track()
+        mock_index.tracks_for_album.return_value = [remote]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        with patch("kamp_core.server.extract_art") as mock_extract:
+            res = c.get(
+                "/api/v1/albums/art",
+                params={"album_artist": "The Artist", "album": "The Album"},
+            )
+
+        mock_extract.assert_not_called()
+        assert res.status_code == 404  # no local art found → 404
+
+    def test_art_endpoint_cover_file_returns_404_for_remote_only_album(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """_cover_file_response skips .parent when all tracks are remote.
+
+        read_cover_file is a lazy import inside the art handler — it is never
+        reached when local_tracks is empty, so no patch is needed.
+        """
+        remote = self._make_remote_track()
+        mock_index.tracks_for_album.return_value = [remote]
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            config_values={"artwork.save_format": "cover-file"},
+        )
+        c = TestClient(app)
+
+        res = c.get(
+            "/api/v1/albums/art",
+            params={"album_artist": "The Artist", "album": "The Album"},
+        )
+
+        # No local tracks → _cover_file_response returns None without touching
+        # .file_path.parent; _embedded_response also returns None (no local art).
+        assert res.status_code == 404
+
+    def test_itunes_art_apply_returns_400_for_remote_only_album(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """POST /api/v1/albums/art/apply returns 400 when all tracks are remote."""
+        remote = self._make_remote_track()
+        mock_index.tracks_for_album.return_value = [remote]
+        mock_index.albums.return_value = []
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        image_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # minimal JPEG header
+
+        with patch("kamp_daemon.artwork.fetch_itunes_image", return_value=image_bytes):
+            res = c.post(
+                "/api/v1/albums/art/apply",
+                json={
+                    "album_artist": "The Artist",
+                    "album": "The Album",
+                    "artwork_url_template": "https://example.mzstatic.com/image/{size}.jpg",
+                },
+            )
+
+        assert res.status_code == 400
+        assert "remote-only" in res.json()["detail"]
+
+    def test_upload_art_returns_400_for_remote_only_album(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """POST /api/v1/albums/art/apply-local returns 400 when all tracks are remote."""
+        remote = self._make_remote_track()
+        mock_index.tracks_for_album.return_value = [remote]
+        mock_index.albums.return_value = []
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        import io
+        from PIL import Image as _Image
+
+        buf = io.BytesIO()
+        _Image.new("RGB", (600, 600)).save(buf, format="JPEG")
+        image_bytes = buf.getvalue()
+
+        res = c.post(
+            "/api/v1/albums/art/apply-local",
+            data={"album_artist": "The Artist", "album": "The Album"},
+            files={"file": ("cover.jpg", image_bytes, "image/jpeg")},
+        )
+
+        assert res.status_code == 400
+        assert "remote-only" in res.json()["detail"]


### PR DESCRIPTION
## Summary

- `AlbumInfo` gains `source` (`'local'`/`'bandcamp'`/`'mixed'`), `has_remote_tracks`, and `in_bandcamp_collection` fields; `albums()` SQL computes them via `GROUP BY` aggregate expressions and a `LEFT JOIN bandcamp_collection`
- **Scanner data-loss fix:** `indexed_paths()` and `indexed_paths_with_mtime()` add `WHERE source = 'local'` so remote `bandcamp://` URIs never appear in `removed_paths` and get deleted on every local scan
- `load_player_state()` and `load_queue_state()` return `str` instead of `Path` to avoid POSIX `Path` normalization corrupting remote URIs (`bandcamp://` → `bandcamp:/`)
- `get_track_by_path()` widened to `str | Path`, passing strings directly to the SQL lookup (no `Path()` wrapping) so remote track lookups from a restored queue work correctly
- `PlaybackQueue.get_state()` returns `list[str]` to match `load_queue_state()`
- Art endpoints guard against remote tracks: `extract_art` is skipped, cover-file lookup returns `None` for remote-only albums, iTunes/upload art endpoints return 400

## Test plan

- [ ] 1564 tests pass, 93.18% coverage, mypy clean, black clean (CI)
- [ ] Fresh DB: local library scan completes without removing tracks
- [ ] Insert synthetic `bandcamp://` row in SQLite; trigger scan; confirm row survives
- [ ] `GET /api/v1/albums` response includes `source`, `has_remote_tracks`, `in_bandcamp_collection` fields
- [ ] Local album with matching `bandcamp_collection` row (mode=`'local'`) shows `in_bandcamp_collection: true`
- [ ] Play a local track; stop; restart daemon; queue/player state restores without crash
- [ ] Art endpoint works for local albums; returns 400 for a remote-only album

🤖 Generated with [Claude Code](https://claude.com/claude-code)