### PR TITLE
feat(KAMP-390): Bandcamp collection mode — stream vs. download

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1115,6 +1115,18 @@ class LibraryIndex:
         ).fetchall()
         return [dict(r) for r in rows]
 
+    def has_remote_album_tracks(self, sale_item_id: str) -> bool:
+        """Return True if the tracks table already has entries for this remote album.
+
+        Checks both POSIX (bandcamp:/id/) and Windows (bandcamp:\\id\\) path forms so
+        incremental stream syncs can skip album-page fetches for existing albums.
+        """
+        row = self._conn.execute(
+            "SELECT 1 FROM tracks WHERE file_path LIKE ? OR file_path LIKE ? LIMIT 1",
+            (f"bandcamp:/{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
+        ).fetchone()
+        return row is not None
+
     def reset_collection_sync_state(self) -> None:
         """Set synced_at = NULL for all rows so the next sync re-downloads everything."""
         self._conn.execute("UPDATE bandcamp_collection SET synced_at = NULL")

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -852,6 +852,9 @@ def _cmd_daemon(
         "bandcamp.poll_interval_minutes": (
             config.bandcamp.poll_interval_minutes if config.bandcamp else None
         ),
+        "bandcamp.collection_mode": (
+            config.bandcamp.collection_mode if config.bandcamp else None
+        ),
         "lastfm.username": config.lastfm.username if config.lastfm else None,
     }
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1084,6 +1084,7 @@ def _cmd_daemon(
     _sync_all_trigger_ref[0] = core.syncer.sync_all_purchases
 
     core.syncer.status_callback = app.state.notify_bandcamp_sync_status
+    core.syncer.on_tracks_indexed = app.state.notify_library_changed
     core.watcher.stage_callback = app.state.notify_pipeline_stage
 
     # After each album finishes processing, run a library rescan directly on a

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -41,7 +41,7 @@ import requests as _requests
 from .config import BandcampConfig, token_path
 
 if TYPE_CHECKING:
-    from kamp_core.library import LibraryIndex
+    from kamp_core.library import LibraryIndex, Track
 
 logger = logging.getLogger(__name__)
 
@@ -374,11 +374,15 @@ def sync_collection_stream(
     watch_dir: Path,
     index: "LibraryIndex",
     status_callback: Callable[[str], None] | None = None,
-) -> int:
+) -> tuple[int, int]:
     """Index all Bandcamp purchases as remote rows — no ZIP download.
 
-    Re-upserts every item unconditionally so that re-sync and first-sync are
-    identical. Returns the count of items indexed.
+    For each album, upserts a bandcamp_collection row and fetches the album
+    page to create individual track records in the tracks table.  Albums that
+    already have tracks in the DB are skipped (their collection row is still
+    refreshed) so that incremental syncs remain fast.
+
+    Returns (album_count, track_count).
     """
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
@@ -389,28 +393,67 @@ def sync_collection_stream(
     logger.info("Fetched fan_id=%s for user %r", fan_id, username)
 
     collection = _fetch_collection(fan_id, session, index)
-    count = 0
+    album_count = 0
+    track_count = 0
+    fetch_index = 0  # throttle counter for album-page requests
     for item in collection:
         sid = item.get("sale_item_id")
         if sid is None:
             continue
+
+        band_name = str(item.get("band_name", ""))
+        item_title = str(item.get("item_title", ""))
+        album_url = str(item.get("item_url", ""))
+
         if status_callback:
-            status_callback(
-                f"{item.get('item_title', '?')} by {item.get('band_name', '?')}"
-            )
+            status_callback(f"{item_title} by {band_name}")
+
         index.upsert_collection_item(
             str(sid),
             mode="remote",
             item_type=str(item.get("sale_item_type", "p")),
-            band_name=str(item.get("band_name", "")),
-            item_title=str(item.get("item_title", "")),
-            album_url=str(item.get("item_url", "")),
+            band_name=band_name,
+            item_title=item_title,
+            album_url=album_url,
             tralbum_id=str(item.get("tralbum_id", "")),
             synced_at=time.time(),
         )
-        count += 1
-    logger.info("Stream sync complete: %d purchase(s) indexed as remote.", count)
-    return count
+        album_count += 1
+
+        # Fetch track metadata only for albums not yet in the tracks table.
+        # This keeps incremental syncs fast while still populating new albums.
+        if album_url and not index.has_remote_album_tracks(str(sid)):
+            if fetch_index > 0:
+                time.sleep(0.5)
+            fetch_index += 1
+            try:
+                tracks = fetch_album_tracks(
+                    album_url, int(sid), band_name, item_title, session
+                )
+                if tracks:
+                    index.upsert_many(tracks)
+                    track_count += len(tracks)
+                    logger.debug(
+                        "Indexed %d track(s) for %r by %r",
+                        len(tracks),
+                        item_title,
+                        band_name,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "fetch_album_tracks: skipping tracks for %r by %r (%s): %s",
+                    item_title,
+                    band_name,
+                    album_url,
+                    exc,
+                )
+
+    logger.info(
+        "Stream sync complete: %d album(s), %d track(s) indexed as remote.",
+        album_count,
+        track_count,
+    )
+    return album_count, track_count
 
 
 # ---------------------------------------------------------------------------
@@ -800,6 +843,65 @@ def fetch_stream_url(
         f"fetch_stream_url: track_num={track_number} not found in {album_url} "
         f"(tracks present: {[t.get('track_num') for t in tracks]})"
     )
+
+
+def fetch_album_tracks(
+    album_url: str,
+    sale_item_id: int,
+    band_name: str,
+    item_title: str,
+    session: "_AnySession",
+) -> "list[Track]":
+    """Fetch track metadata from a Bandcamp album page without downloading CDN URLs.
+
+    Returns a list of Track objects (source='remote', no stream_url) ready to
+    upsert into the tracks table.  CDN stream URLs are fetched on demand at
+    play time by _resolve_playback().
+
+    Raises BandcampAPIError if the page cannot be parsed.
+    """
+    from kamp_core.library import Track
+
+    resp = session.get(album_url, timeout=30)
+    resp.raise_for_status()
+
+    match = re.search(r'data-tralbum="([^"]+)"', resp.text)
+    if not match:
+        raise BandcampAPIError(f"fetch_album_tracks: no data-tralbum in {album_url}")
+
+    tralbum: dict[str, Any] = json.loads(html_lib.unescape(match.group(1)))
+    trackinfo: list[dict[str, Any]] = tralbum.get("trackinfo") or []
+
+    # Extract year from the release date string (e.g. "01 Jan 2020 00:00:00 GMT").
+    release_date = tralbum.get("album_release_date") or ""
+    year_match = re.search(r"\b(19|20)\d{2}\b", str(release_date))
+    year_str = year_match.group(0) if year_match else ""
+
+    result: list[Track] = []
+    for t in trackinfo:
+        track_num = t.get("track_num")
+        if not track_num:
+            continue
+        # Per-track artist field is set on compilations/splits; fall back to band_name.
+        artist = t.get("artist") or band_name
+        result.append(
+            Track(
+                file_path=Path(f"bandcamp://{sale_item_id}/{track_num}"),
+                title=t.get("title") or "",
+                artist=artist,
+                album_artist=band_name,
+                album=item_title,
+                year=year_str,
+                track_number=int(track_num),
+                disc_number=1,
+                ext="mp3",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+                source="remote",
+            )
+        )
+    return result
 
 
 def refresh_stream_url(

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -907,6 +907,7 @@ def fetch_album_tracks(
                 mb_release_id="",
                 mb_recording_id="",
                 source="remote",
+                date_added=time.time(),
             )
         )
     return result

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -393,12 +393,20 @@ def sync_collection_stream(
     logger.info("Fetched fan_id=%s for user %r", fan_id, username)
 
     collection = _fetch_collection(fan_id, session, index)
+    # Load existing state so we never overwrite a locally-downloaded album
+    # (mode='local') with mode='remote'.  Local albums were processed by the
+    # download pipeline and already have their tracks in the tracks table.
+    existing_state = index.get_collection_state()
     album_count = 0
     track_count = 0
     fetch_index = 0  # throttle counter for album-page requests
     for item in collection:
         sid = item.get("sale_item_id")
         if sid is None:
+            continue
+
+        # Skip albums the user already has locally — do not demote to remote.
+        if existing_state.get(str(sid)) == "local":
             continue
 
         band_name = str(item.get("band_name", ""))

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -369,6 +369,50 @@ def sync_new_purchases(
     return downloaded
 
 
+def sync_collection_stream(
+    bc_config: BandcampConfig,
+    watch_dir: Path,
+    index: "LibraryIndex",
+    status_callback: Callable[[str], None] | None = None,
+) -> int:
+    """Index all Bandcamp purchases as remote rows — no ZIP download.
+
+    Re-upserts every item unconditionally so that re-sync and first-sync are
+    identical. Returns the count of items indexed.
+    """
+    session_data = _ensure_session(bc_config, index)
+    session = _make_requests_session(session_data)
+    fan_id, username = _get_fan_info(session)
+    if not username:
+        username = _username_from_logout_cookie(session_data.get("cookies", []))
+    _store_username_in_session(username, session_data, index)
+    logger.info("Fetched fan_id=%s for user %r", fan_id, username)
+
+    collection = _fetch_collection(fan_id, session, index)
+    count = 0
+    for item in collection:
+        sid = item.get("sale_item_id")
+        if sid is None:
+            continue
+        if status_callback:
+            status_callback(
+                f"{item.get('item_title', '?')} by {item.get('band_name', '?')}"
+            )
+        index.upsert_collection_item(
+            str(sid),
+            mode="remote",
+            item_type=str(item.get("sale_item_type", "p")),
+            band_name=str(item.get("band_name", "")),
+            item_title=str(item.get("item_title", "")),
+            album_url=str(item.get("item_url", "")),
+            tralbum_id=str(item.get("tralbum_id", "")),
+            synced_at=time.time(),
+        )
+        count += 1
+    logger.info("Stream sync complete: %d purchase(s) indexed as remote.", count)
+    return count
+
+
 # ---------------------------------------------------------------------------
 # Session management
 # ---------------------------------------------------------------------------

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -73,6 +73,7 @@ class LastfmConfig:
 class BandcampConfig:
     format: str  # e.g. "mp3-v0", "mp3-320", "flac"
     poll_interval_minutes: int  # 0 = manual only
+    collection_mode: str = "download"  # "stream" | "download"
 
 
 def _prompt(label: str, default: str) -> str:
@@ -94,6 +95,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",
+    "bandcamp.collection_mode": "download",
     "ui.active_view": "home",
     "ui.sort_order": "album_artist",
     "ui.queue_panel_open": "0",
@@ -111,6 +113,7 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "library.path_template": str,
     "bandcamp.format": str,
     "bandcamp.poll_interval_minutes": int,
+    "bandcamp.collection_mode": str,
     "ui.active_view": str,
     "ui.sort_order": str,
     "ui.queue_panel_open": int,
@@ -172,6 +175,7 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
     "bandcamp.format": frozenset(
         {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
     ),
+    "bandcamp.collection_mode": frozenset({"stream", "download"}),
     "ui.active_view": frozenset({"library", "now-playing", "home"}),
     "ui.sort_order": frozenset({"album_artist", "album", "date_added", "last_played"}),
 }
@@ -321,6 +325,7 @@ class Config:
             bandcamp=BandcampConfig(
                 format=_get("bandcamp.format"),
                 poll_interval_minutes=_int("bandcamp.poll_interval_minutes"),
+                collection_mode=_get("bandcamp.collection_mode"),
             ),
             lastfm=lastfm,
             ui=UiConfig(

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -55,13 +55,13 @@ def _sync_worker(
             if bc_config.collection_mode == "stream":
                 from .bandcamp import sync_collection_stream
 
-                sync_collection_stream(
+                album_count, track_count = sync_collection_stream(
                     bc_config=bc_config,
                     watch_dir=watch_dir,
                     index=index,
                     status_callback=lambda msg: status_q.put(msg),
                 )
-                result_q.put(("ok", []))
+                result_q.put(("ok_stream", (album_count, track_count)))
             else:
                 from .bandcamp import sync_new_purchases
 
@@ -327,13 +327,26 @@ class Syncer:
         if status == "error":
             raise RuntimeError(f"Bandcamp sync failed: {value}")
 
-        paths = value or []
-        if paths:
-            logger.info(
-                "Sync complete: %d file(s) downloaded to watch folder.", len(paths)
-            )
+        if status == "ok_stream":
+            album_count, track_count = value
+            if track_count:
+                logger.info(
+                    "Sync complete: %d album(s), %d track(s) indexed as remote.",
+                    album_count,
+                    track_count,
+                )
+            else:
+                logger.info(
+                    "Sync complete: %d album(s) already up to date.", album_count
+                )
         else:
-            logger.info("Sync complete: nothing new.")
+            paths = value or []
+            if paths:
+                logger.info(
+                    "Sync complete: %d file(s) downloaded to watch folder.", len(paths)
+                )
+            else:
+                logger.info("Sync complete: nothing new.")
         # Clear the status display in the menu bar (applies to both automatic
         # and manual syncs — an empty string signals "no active sync").
         if self.status_callback is not None:

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -50,17 +50,28 @@ def _sync_worker(
     try:
         from kamp_core.library import LibraryIndex
 
-        from .bandcamp import sync_new_purchases
-
         index = LibraryIndex(db_path)
         try:
-            paths = sync_new_purchases(
-                bc_config=bc_config,
-                watch_dir=watch_dir,
-                index=index,
-                status_callback=lambda msg: status_q.put(msg),
-            )
-            result_q.put(("ok", paths))
+            if bc_config.collection_mode == "stream":
+                from .bandcamp import sync_collection_stream
+
+                sync_collection_stream(
+                    bc_config=bc_config,
+                    watch_dir=watch_dir,
+                    index=index,
+                    status_callback=lambda msg: status_q.put(msg),
+                )
+                result_q.put(("ok", []))
+            else:
+                from .bandcamp import sync_new_purchases
+
+                paths = sync_new_purchases(
+                    bc_config=bc_config,
+                    watch_dir=watch_dir,
+                    index=index,
+                    status_callback=lambda msg: status_q.put(msg),
+                )
+                result_q.put(("ok", paths))
         finally:
             index.close()
     except Exception as exc:  # noqa: BLE001
@@ -246,11 +257,12 @@ class Syncer:
 
         db_path = _state_dir() / "library.db"
 
-        if not skip_auto_mark:
-            # First-run detection: if bandcamp_collection has no rows, mark
-            # the entire existing collection as synced before downloading.
-            # This prevents re-downloading everything on first run when the
-            # user already has their Bandcamp purchases locally.
+        if not skip_auto_mark and bc.collection_mode != "stream":
+            # First-run detection for download mode: if bandcamp_collection has
+            # no rows, mark the entire existing collection as synced before
+            # downloading to avoid re-downloading a library the user already has.
+            # Skipped in stream mode (stream sync indexes everything as remote
+            # directly; auto-mark would incorrectly set items to mode='local').
             # Use --download-all (skip_auto_mark=True) to bypass.
             from kamp_core.library import LibraryIndex as _LI
 
@@ -328,7 +340,20 @@ class Syncer:
             self.status_callback("")
 
     def sync_all_purchases(self) -> None:
-        """Reset sync state and re-download the entire Bandcamp collection."""
+        """Re-sync or re-download the entire Bandcamp collection.
+
+        In stream mode: re-indexes all purchases as remote (no state reset needed;
+        stream sync is unconditional).  In download mode: resets sync state so the
+        next sync re-downloads everything.
+        """
+        bc = self._config.bandcamp
+        if bc and bc.collection_mode == "stream":
+            logger.info(
+                "Bandcamp re-sync (stream): re-indexing all purchases as remote."
+            )
+            self.sync_once(skip_auto_mark=True)
+            return
+
         from kamp_core.library import LibraryIndex as _LI
 
         db_path = _state_dir() / "library.db"

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -167,6 +167,7 @@ class Syncer:
         self._thread: threading.Thread | None = None
         self.status_callback: Callable[[str], None] | None = None
         self.error_callback: Callable[[str, str, str], None] | None = None
+        self.on_tracks_indexed: Callable[[], None] | None = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -335,6 +336,8 @@ class Syncer:
                     album_count,
                     track_count,
                 )
+                if self.on_tracks_indexed is not None:
+                    self.on_tracks_indexed()
             else:
                 logger.info(
                     "Sync complete: %d album(s) already up to date.", album_count

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -231,6 +231,7 @@ export type ConfigValues = {
   'bandcamp.username': string | null
   'bandcamp.format': string | null
   'bandcamp.poll_interval_minutes': number | null
+  'bandcamp.collection_mode': string | null
   'lastfm.username': string | null
 }
 

--- a/kamp_ui/src/renderer/src/assets/onboarding.css
+++ b/kamp_ui/src/renderer/src/assets/onboarding.css
@@ -278,6 +278,36 @@
   text-decoration: underline;
 }
 
+/* Stream / Download mode selector */
+.onboarding-mode-selector {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.onboarding-mode-btn {
+  background: var(--surface-2, var(--surface));
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+
+.onboarding-mode-btn:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.onboarding-mode-btn--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
 /* Almost Done rotating text */
 .onboarding-almost-done-text {
   font-size: 24px;

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -130,12 +130,13 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   const setWatchFolderPath = useStore((s) => s.setWatchFolderPath)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const loadConfig = useStore((s) => s.loadConfig)
+  const setConfigValue = useStore((s) => s.setConfigValue)
 
   const [step, setStep] = useState<OnboardingStep>('welcome')
   const [vinylPhase, setVinylPhase] = useState<VinylPhase>('rising')
   const [cardError, setCardError] = useState<string | null>(null)
   const [bandcampBusy, setBandcampBusy] = useState(false)
-  const [bandcampDownloadAll, setBandcampDownloadAll] = useState(false)
+  const [collectionMode, setCollectionMode] = useState<'stream' | 'download'>('stream')
   const [lastfmUsername, setLastfmUsername] = useState('')
   const [lastfmPassword, setLastfmPassword] = useState('')
   const [lastfmBusy, setLastfmBusy] = useState(false)
@@ -290,11 +291,12 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
     setBandcampBusy(true)
     setCardError(null)
     try {
+      await setConfigValue('bandcamp.collection_mode', collectionMode)
       const result = await window.api.bandcamp.beginLogin()
       if (result.ok) {
         await loadConfig()
-        if (bandcampDownloadAll) {
-          window.api.bandcamp.triggerSyncAll().catch(console.error)
+        if (collectionMode === 'stream') {
+          window.api.bandcamp.triggerSync().catch(console.error)
         }
         changeStep('lastfm')
       } else {
@@ -367,8 +369,6 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 <p className="onboarding-card-body">
                   <strong>kamp</strong> will keep an eye on your watch folder to auto-tag and add
                   files to your library.
-                  <br />
-                  This is also where Kamp will download new files, if you sign into Bandcamp.
                 </p>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
               </>
@@ -376,6 +376,27 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
 
             {step === 'bandcamp' && (
               <>
+                <div className="onboarding-mode-selector">
+                  <button
+                    type="button"
+                    className={`onboarding-mode-btn${collectionMode === 'stream' ? ' onboarding-mode-btn--active' : ''}`}
+                    onClick={() => setCollectionMode('stream')}
+                  >
+                    Stream
+                  </button>
+                  <button
+                    type="button"
+                    className={`onboarding-mode-btn${collectionMode === 'download' ? ' onboarding-mode-btn--active' : ''}`}
+                    onClick={() => setCollectionMode('download')}
+                  >
+                    Download
+                  </button>
+                </div>
+                <p className="onboarding-card-body">
+                  {collectionMode === 'stream'
+                    ? 'Your Bandcamp purchases stream directly. No downloads needed. Applies to new purchases synced going forward.'
+                    : 'Purchases are downloaded to your library folder for offline playback. Applies to new purchases synced going forward. Existing downloads remain in your library.'}
+                </p>
                 <button
                   className="onboarding-primary-btn"
                   onClick={handleBandcampLogin}
@@ -383,18 +404,6 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 >
                   {bandcampBusy ? 'Logging in…' : 'Log in to Bandcamp'}
                 </button>
-                <p className="onboarding-card-body">
-                  If you have a Bandcamp account, <strong>kamp</strong> can download your purchases
-                  and put them into your library
-                </p>
-                <label className="onboarding-toggle">
-                  <input
-                    type="checkbox"
-                    checked={bandcampDownloadAll}
-                    onChange={(e) => setBandcampDownloadAll(e.target.checked)}
-                  />
-                  Download all my existing purchases
-                </label>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
                 <button className="onboarding-skip-btn" onClick={() => changeStep('lastfm')}>
                   Skip

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -171,13 +171,15 @@ function SelectRow({
   configKey,
   options,
   initialValue,
-  onSave
+  onSave,
+  hint
 }: {
   label: string
   configKey: string
   options: string[]
   initialValue: string
   onSave: (key: string, value: string) => Promise<void>
+  hint?: string
 }): React.JSX.Element {
   const [localValue, setLocalValue] = useState(initialValue || options[0])
   const [saved, setSaved] = useState(false)
@@ -215,6 +217,7 @@ function SelectRow({
           </option>
         ))}
       </select>
+      {hint && <p className="prefs-hint">{hint}</p>}
       {error && (
         <p className="prefs-hint" style={{ color: 'var(--error)' }}>
           {error}
@@ -664,11 +667,13 @@ function ExtensionsPanel({
 function BandcampSection({
   isConnected,
   connectedUsername,
+  collectionMode,
   onConnected,
   onDisconnected
 }: {
   isConnected: boolean
   connectedUsername: string | null
+  collectionMode: string
   onConnected: () => void
   onDisconnected: () => void
 }): React.JSX.Element {
@@ -763,7 +768,9 @@ function BandcampSection({
       {isConnected && (
         <div className="prefs-row">
           <div className="prefs-row-header">
-            <span className="prefs-label">Re-download</span>
+            <span className="prefs-label">
+              {collectionMode === 'stream' ? 'Re-sync' : 'Re-download'}
+            </span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <button
@@ -771,9 +778,17 @@ function BandcampSection({
               onClick={() => void handleSyncAll()}
               disabled={syncAllBusy}
             >
-              {syncAllBusy ? 'Starting…' : 'Re-download all purchases'}
+              {syncAllBusy
+                ? 'Starting…'
+                : collectionMode === 'stream'
+                  ? 'Re-sync purchase list'
+                  : 'Re-download all purchases'}
             </button>
-            <span className="prefs-hint">Clears sync history and re-downloads everything.</span>
+            <span className="prefs-hint">
+              {collectionMode === 'stream'
+                ? 'Re-indexes your entire purchase list as remote tracks.'
+                : 'Clears sync history and re-downloads everything.'}
+            </span>
           </div>
         </div>
       )}
@@ -991,7 +1006,7 @@ export function PreferencesDialog({
   const configLoading =
     configValues === null && (activeTab === 'general' || activeTab === 'services')
 
-  const hasBandcamp = configValues !== null && configValues['bandcamp.format'] !== null
+  const hasBandcamp = configValues !== null && configValues['bandcamp.connected'] === true
 
   const str = (key: keyof NonNullable<typeof configValues>): string => {
     if (!configValues) return ''
@@ -1215,13 +1230,30 @@ export function PreferencesDialog({
                   {hasBandcamp && (
                     <div className="prefs-section">
                       <div className="prefs-section-label">Bandcamp</div>
-                      <SelectRow
-                        label="Download format"
-                        configKey="bandcamp.format"
-                        options={BANDCAMP_FORMATS}
-                        initialValue={str('bandcamp.format')}
-                        onSave={handleSave}
+                      <BandcampSection
+                        isConnected={configValues?.['bandcamp.connected'] ?? false}
+                        connectedUsername={configValues?.['bandcamp.username'] ?? null}
+                        collectionMode={str('bandcamp.collection_mode')}
+                        onConnected={() => void loadConfig()}
+                        onDisconnected={() => void loadConfig()}
                       />
+                      <SelectRow
+                        label="Collection mode"
+                        configKey="bandcamp.collection_mode"
+                        options={['stream', 'download']}
+                        initialValue={str('bandcamp.collection_mode')}
+                        onSave={handleSave}
+                        hint="Applies to new purchases synced going forward. Existing downloads remain in your library."
+                      />
+                      {str('bandcamp.collection_mode') !== 'stream' && (
+                        <SelectRow
+                          label="Download format"
+                          configKey="bandcamp.format"
+                          options={BANDCAMP_FORMATS}
+                          initialValue={str('bandcamp.format')}
+                          onSave={handleSave}
+                        />
+                      )}
                       <InputRow
                         label="Poll interval"
                         configKey="bandcamp.poll_interval_minutes"
@@ -1230,12 +1262,6 @@ export function PreferencesDialog({
                         initialValue={str('bandcamp.poll_interval_minutes')}
                         hint="0 = manual only"
                         onSave={handleSave}
-                      />
-                      <BandcampSection
-                        isConnected={configValues?.['bandcamp.connected'] ?? false}
-                        connectedUsername={configValues?.['bandcamp.username'] ?? null}
-                        onConnected={() => void loadConfig()}
-                        onDisconnected={() => void loadConfig()}
                       />
                     </div>
                   )}

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2021,12 +2021,13 @@ class TestSyncCollectionStream:
         *,
         already_have_tracks: bool = True,
         fake_tracks: list[Any] | None = None,
+        existing_state: dict[str, str] | None = None,
     ) -> tuple[tuple[int, int], MagicMock]:
         watch_folder = tmp_path / "watch"
         config = _bc_config(tmp_path)
         mock_session = _make_requests_mock(items)
         index = MagicMock()
-        index.get_collection_state.return_value = {}
+        index.get_collection_state.return_value = existing_state or {}
         # By default pretend tracks already exist so fetch_album_tracks is skipped.
         index.has_remote_album_tracks.return_value = already_have_tracks
 
@@ -2098,6 +2099,23 @@ class TestSyncCollectionStream:
         (_counts, _), index = self._run(tmp_path, items, already_have_tracks=True)
         index.upsert_collection_item.assert_called_once()
         assert index.upsert_collection_item.call_args[1]["mode"] == "remote"
+
+    def test_skips_local_mode_items(self, tmp_path: Path) -> None:
+        """Items already mode='local' are not overwritten with mode='remote'."""
+        items = [
+            _item(1, "Downloaded Band", "Downloaded Album"),
+            _item(2, "New Band", "New Album"),
+        ]
+        # Item 1 was already downloaded; item 2 is new.
+        (album_count, _), index = self._run(
+            tmp_path,
+            items,
+            existing_state={"1": "local"},
+        )
+        assert album_count == 1  # only the new item counted
+        calls = index.upsert_collection_item.call_args_list
+        assert len(calls) == 1
+        assert calls[0][0][0] == "2"  # only item 2 upserted
 
     def test_no_files_downloaded(self, tmp_path: Path) -> None:
         """Stream sync must not touch the watch folder."""

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2197,6 +2197,17 @@ class TestFetchAlbumTracks:
         )
         assert all(t.stream_url is None for t in result)
 
+    def test_date_added_is_set(self) -> None:
+        """date_added is set to the current time so tracks sort correctly by date added."""
+        before = time.time()
+        html = _stream_album_page_html()
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        after = time.time()
+        assert all(t.date_added is not None for t in result)
+        assert all(before <= t.date_added <= after for t in result)  # type: ignore[operator]
+
     def test_file_path_contains_sale_item_id_and_track_num(self) -> None:
         tracks = [{"title": "T", "track_num": 3, "artist": None}]
         html = _stream_album_page_html(tracks=tracks)

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -32,6 +32,7 @@ from kamp_daemon.bandcamp import (
     _username_from_logout_cookie,
     _validate_session,
     fetch_album_art_bytes,
+    fetch_album_tracks,
     fetch_stream_url,
     mark_collection_synced,
     refresh_stream_url,
@@ -92,6 +93,24 @@ def _item(
         or f"https://{band.lower().replace(' ', '')}.bandcamp.com/album/{title.lower().replace(' ', '-')}",
         "tralbum_id": tralbum_id or sale_item_id * 10,
     }
+
+
+def _stream_album_page_html(
+    tracks: list[dict[str, Any]] | None = None,
+    release_date: str = "01 Jan 2020 00:00:00 GMT",
+) -> str:
+    """Build fake album page HTML with data-tralbum for fetch_album_tracks tests."""
+    import html as _html
+    import json as _json
+
+    if tracks is None:
+        tracks = [
+            {"title": f"Track {i}", "track_num": i, "artist": None, "duration": 200.0}
+            for i in range(1, 4)
+        ]
+    tralbum = {"trackinfo": tracks, "album_release_date": release_date}
+    encoded = _html.escape(_json.dumps(tralbum), quote=True)
+    return f'<html><body data-tralbum="{encoded}"></body></html>'
 
 
 def _collection_page_html(items: list[dict[str, Any]]) -> str:
@@ -1993,17 +2012,25 @@ class TestRefreshStreamUrl:
 
 
 class TestSyncCollectionStream:
+    """Tests for sync_collection_stream — album-level collection indexing."""
+
     def _run(
         self,
         tmp_path: Path,
         items: list[dict[str, Any]],
-    ) -> tuple[int, MagicMock]:
+        *,
+        already_have_tracks: bool = True,
+        fake_tracks: list[Any] | None = None,
+    ) -> tuple[tuple[int, int], MagicMock]:
         watch_folder = tmp_path / "watch"
         config = _bc_config(tmp_path)
         mock_session = _make_requests_mock(items)
         index = MagicMock()
         index.get_collection_state.return_value = {}
+        # By default pretend tracks already exist so fetch_album_tracks is skipped.
+        index.has_remote_album_tracks.return_value = already_have_tracks
 
+        fake_tracks = fake_tracks or []
         with (
             patch(
                 "kamp_daemon.bandcamp._ensure_session",
@@ -2012,45 +2039,63 @@ class TestSyncCollectionStream:
             patch(
                 "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
             ),
+            patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=fake_tracks),
         ):
-            count = sync_collection_stream(config, watch_folder, index)
+            result = sync_collection_stream(config, watch_folder, index)
 
-        return count, index
+        return result, index
 
     def test_upserts_all_items_as_remote(self, tmp_path: Path) -> None:
         items = [_item(1, "Artist A", "Album 1"), _item(2, "Artist B", "Album 2")]
-        count, index = self._run(tmp_path, items)
-        assert count == 2
+        (album_count, _track_count), index = self._run(tmp_path, items)
+        assert album_count == 2
         calls = index.upsert_collection_item.call_args_list
         assert len(calls) == 2
         assert all(c[1]["mode"] == "remote" for c in calls)
 
-    def test_returns_count(self, tmp_path: Path) -> None:
+    def test_returns_album_count(self, tmp_path: Path) -> None:
         items = [_item(10), _item(20), _item(30)]
-        count, _ = self._run(tmp_path, items)
-        assert count == 3
+        (album_count, _), _ = self._run(tmp_path, items)
+        assert album_count == 3
+
+    def test_fetches_tracks_for_new_albums(self, tmp_path: Path) -> None:
+        """Albums not yet in tracks table trigger a fetch_album_tracks call."""
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        fake_track = Track(
+            file_path=_Path("bandcamp://1/1"),
+            title="T",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            year="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="remote",
+        )
+        items = [_item(1)]
+        (album_count, track_count), index = self._run(
+            tmp_path, items, already_have_tracks=False, fake_tracks=[fake_track]
+        )
+        assert album_count == 1
+        assert track_count == 1
+        index.upsert_many.assert_called_once()
+
+    def test_skips_track_fetch_for_existing_albums(self, tmp_path: Path) -> None:
+        """Albums already in tracks table do not trigger fetch_album_tracks."""
+        items = [_item(1), _item(2)]
+        (_counts, _), index = self._run(tmp_path, items, already_have_tracks=True)
+        index.upsert_many.assert_not_called()
 
     def test_re_upserts_already_remote_item(self, tmp_path: Path) -> None:
-        """Idempotent: an item already mode='remote' is re-upserted without error."""
-        watch_folder = tmp_path / "watch"
-        config = _bc_config(tmp_path)
+        """Idempotent: collection row is always refreshed even if tracks exist."""
         items = [_item(99)]
-        mock_session = _make_requests_mock(items)
-        index = MagicMock()
-        index.get_collection_state.return_value = {"99": "remote"}
-
-        with (
-            patch(
-                "kamp_daemon.bandcamp._ensure_session",
-                return_value=_make_session_data(),
-            ),
-            patch(
-                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
-            ),
-        ):
-            count = sync_collection_stream(config, watch_folder, index)
-
-        assert count == 1
+        (_counts, _), index = self._run(tmp_path, items, already_have_tracks=True)
         index.upsert_collection_item.assert_called_once()
         assert index.upsert_collection_item.call_args[1]["mode"] == "remote"
 
@@ -2059,3 +2104,128 @@ class TestSyncCollectionStream:
         items = [_item(5), _item(6)]
         self._run(tmp_path, items)
         assert not (tmp_path / "watch").exists()
+
+    def test_warns_and_continues_on_fetch_error(self, tmp_path: Path) -> None:
+        """A failed fetch_album_tracks is logged as a warning; other albums continue."""
+        items = [_item(1), _item(2)]
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+        index.has_remote_album_tracks.return_value = False
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+            patch(
+                "kamp_daemon.bandcamp.fetch_album_tracks",
+                side_effect=BandcampAPIError("rate limited"),
+            ),
+        ):
+            album_count, track_count = sync_collection_stream(
+                config, watch_folder, index
+            )
+
+        assert album_count == 2  # both albums counted in bandcamp_collection
+        assert track_count == 0  # no tracks indexed (fetch failed)
+
+
+class TestFetchAlbumTracks:
+    """Tests for fetch_album_tracks — parses data-tralbum into Track objects."""
+
+    def _make_session(self, html: str) -> MagicMock:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.text = html
+        resp.raise_for_status = MagicMock()
+        session.get.return_value = resp
+        return session
+
+    def test_returns_tracks_for_each_trackinfo_entry(self) -> None:
+        tracks = [
+            {"title": "Song One", "track_num": 1, "artist": None, "duration": 200.0},
+            {"title": "Song Two", "track_num": 2, "artist": None, "duration": 180.0},
+        ]
+        html = _stream_album_page_html(tracks=tracks)
+        session = self._make_session(html)
+
+        result = fetch_album_tracks(
+            "https://band.bandcamp.com/album/x", 12345, "Band", "Album", session
+        )
+
+        assert len(result) == 2
+        assert result[0].title == "Song One"
+        assert result[0].track_number == 1
+        assert result[1].title == "Song Two"
+        assert result[1].track_number == 2
+
+    def test_source_is_remote(self) -> None:
+        html = _stream_album_page_html()
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert all(t.source == "remote" for t in result)
+
+    def test_no_stream_url(self) -> None:
+        html = _stream_album_page_html()
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert all(t.stream_url is None for t in result)
+
+    def test_file_path_contains_sale_item_id_and_track_num(self) -> None:
+        tracks = [{"title": "T", "track_num": 3, "artist": None}]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 999, "B", "A", self._make_session(html)
+        )
+        assert len(result) == 1
+        assert "999" in str(result[0].file_path)
+        assert "3" in str(result[0].file_path)
+
+    def test_year_extracted_from_release_date(self) -> None:
+        html = _stream_album_page_html(release_date="15 Mar 2018 00:00:00 GMT")
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert all(t.year == "2018" for t in result)
+
+    def test_per_track_artist_used_when_present(self) -> None:
+        tracks = [{"title": "T", "track_num": 1, "artist": "Guest Artist"}]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "Band", "A", self._make_session(html)
+        )
+        assert result[0].artist == "Guest Artist"
+        assert result[0].album_artist == "Band"
+
+    def test_falls_back_to_band_name_when_no_per_track_artist(self) -> None:
+        tracks = [{"title": "T", "track_num": 1, "artist": None}]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "Band", "A", self._make_session(html)
+        )
+        assert result[0].artist == "Band"
+
+    def test_raises_on_missing_data_tralbum(self) -> None:
+        session = self._make_session("<html><body>no tralbum here</body></html>")
+        with pytest.raises(BandcampAPIError, match="no data-tralbum"):
+            fetch_album_tracks("https://x.bandcamp.com/album/y", 1, "B", "A", session)
+
+    def test_skips_tracks_without_track_num(self) -> None:
+        tracks = [
+            {"title": "Good", "track_num": 1, "artist": None},
+            {"title": "Hidden", "track_num": None, "artist": None},
+        ]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert len(result) == 1
+        assert result[0].title == "Good"

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -35,6 +35,7 @@ from kamp_daemon.bandcamp import (
     fetch_stream_url,
     mark_collection_synced,
     refresh_stream_url,
+    sync_collection_stream,
     sync_new_purchases,
 )
 from kamp_daemon.config import BandcampConfig
@@ -1989,3 +1990,72 @@ class TestRefreshStreamUrl:
             result = refresh_stream_url(self._album_url, 99, self._session_data)
 
         assert result is None
+
+
+class TestSyncCollectionStream:
+    def _run(
+        self,
+        tmp_path: Path,
+        items: list[dict[str, Any]],
+    ) -> tuple[int, MagicMock]:
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+        ):
+            count = sync_collection_stream(config, watch_folder, index)
+
+        return count, index
+
+    def test_upserts_all_items_as_remote(self, tmp_path: Path) -> None:
+        items = [_item(1, "Artist A", "Album 1"), _item(2, "Artist B", "Album 2")]
+        count, index = self._run(tmp_path, items)
+        assert count == 2
+        calls = index.upsert_collection_item.call_args_list
+        assert len(calls) == 2
+        assert all(c[1]["mode"] == "remote" for c in calls)
+
+    def test_returns_count(self, tmp_path: Path) -> None:
+        items = [_item(10), _item(20), _item(30)]
+        count, _ = self._run(tmp_path, items)
+        assert count == 3
+
+    def test_re_upserts_already_remote_item(self, tmp_path: Path) -> None:
+        """Idempotent: an item already mode='remote' is re-upserted without error."""
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        items = [_item(99)]
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {"99": "remote"}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+        ):
+            count = sync_collection_stream(config, watch_folder, index)
+
+        assert count == 1
+        index.upsert_collection_item.assert_called_once()
+        assert index.upsert_collection_item.call_args[1]["mode"] == "remote"
+
+    def test_no_files_downloaded(self, tmp_path: Path) -> None:
+        """Stream sync must not touch the watch folder."""
+        items = [_item(5), _item(6)]
+        self._run(tmp_path, items)
+        assert not (tmp_path / "watch").exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -345,3 +345,20 @@ class TestConfigSet:
         Config.write_defaults(db)
         config_set(db, "paths.watch_folder", "~/Music/staging")
         assert db.get_setting("paths.watch_folder") == "~/Music/staging"
+
+    def test_collection_mode_valid_values_accepted(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        config_set(db, "bandcamp.collection_mode", "stream")
+        assert db.get_setting("bandcamp.collection_mode") == "stream"
+        config_set(db, "bandcamp.collection_mode", "download")
+        assert db.get_setting("bandcamp.collection_mode") == "download"
+
+    def test_collection_mode_invalid_value_raises(self, db: LibraryIndex) -> None:
+        with pytest.raises(ValueError, match="Invalid value 'offline'"):
+            config_set(db, "bandcamp.collection_mode", "offline")
+
+    def test_collection_mode_default_is_download(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        config = Config.load(db)
+        assert config.bandcamp is not None
+        assert config.bandcamp.collection_mode == "download"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -727,7 +727,7 @@ class TestStreamMode:
         """sync_once() in stream mode does not call mark_synced() on first run."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=2),
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(2, 10)),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
             patch.object(syncer, "mark_synced") as mock_mark,
@@ -741,7 +741,7 @@ class TestStreamMode:
         """sync_all_purchases() in stream mode does not reset the collection state."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=0),
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(0, 0)),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
         ):
@@ -756,10 +756,38 @@ class TestStreamMode:
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
             patch(
-                "kamp_daemon.bandcamp.sync_collection_stream", return_value=3
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(3, 15)
             ) as mock_stream,
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
         ):
             syncer.sync_once()
         mock_stream.assert_called_once()
+
+    def test_sync_once_stream_logs_track_count(self, tmp_path: Path) -> None:
+        """sync_once() in stream mode logs album and track counts when tracks indexed."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42)),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+            patch("kamp_daemon.syncer.logger") as mock_log,
+        ):
+            syncer.sync_once()
+        info_msgs = " ".join(str(c) for c in mock_log.info.call_args_list)
+        assert "42" in info_msgs
+
+    def test_sync_once_stream_logs_up_to_date_when_no_new_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        """sync_once() in stream mode logs 'up to date' when track_count == 0."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0)),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+            patch("kamp_daemon.syncer.logger") as mock_log,
+        ):
+            syncer.sync_once()
+        info_msgs = " ".join(str(c) for c in mock_log.info.call_args_list)
+        assert "up to date" in info_msgs

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -777,6 +777,34 @@ class TestStreamMode:
         info_msgs = " ".join(str(c) for c in mock_log.info.call_args_list)
         assert "42" in info_msgs
 
+    def test_on_tracks_indexed_called_when_tracks_written(self, tmp_path: Path) -> None:
+        """on_tracks_indexed fires when stream sync indexes new tracks."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        fired: list[bool] = []
+        syncer.on_tracks_indexed = lambda: fired.append(True)
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42)),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+        assert fired == [True]
+
+    def test_on_tracks_indexed_not_called_when_no_new_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        """on_tracks_indexed does not fire when track_count == 0."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        fired: list[bool] = []
+        syncer.on_tracks_indexed = lambda: fired.append(True)
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0)),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+        assert fired == []
+
     def test_sync_once_stream_logs_up_to_date_when_no_new_tracks(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -703,3 +703,63 @@ class TestLogout:
         """logout() does not raise when art_cache does not exist."""
         with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
             logout()  # art_cache dir is absent — must not raise
+
+
+class TestStreamMode:
+    def _make_stream_config(self, tmp_path: Path, poll_interval: int = 0) -> Config:
+        return Config(
+            paths=PathsConfig(
+                watch_folder=tmp_path / "watch", library=tmp_path / "library"
+            ),
+            musicbrainz=MusicBrainzConfig(),
+            artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
+            library=LibraryConfig(
+                path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
+            ),
+            bandcamp=BandcampConfig(
+                format="mp3-v0",
+                poll_interval_minutes=poll_interval,
+                collection_mode="stream",
+            ),
+        )
+
+    def test_sync_once_stream_mode_skips_auto_mark(self, tmp_path: Path) -> None:
+        """sync_once() in stream mode does not call mark_synced() on first run."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=2),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+            patch.object(syncer, "mark_synced") as mock_mark,
+        ):
+            syncer.sync_once()
+        mock_mark.assert_not_called()
+
+    def test_sync_all_purchases_stream_mode_skips_state_reset(
+        self, tmp_path: Path
+    ) -> None:
+        """sync_all_purchases() in stream mode does not reset the collection state."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        with (
+            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=0),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            from kamp_core.library import LibraryIndex as _LI
+
+            with patch.object(_LI, "reset_collection_sync_state") as mock_reset:
+                syncer.sync_all_purchases()
+        mock_reset.assert_not_called()
+
+    def test_sync_once_stream_mode_uses_stream_worker(self, tmp_path: Path) -> None:
+        """sync_once() in stream mode calls sync_collection_stream, not sync_new_purchases."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        with (
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=3
+            ) as mock_stream,
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+        mock_stream.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds `bandcamp.collection_mode` config key (`"stream" | "download"`); existing users default to `"download"` (no behavior change)
- Onboarding Bandcamp card: replaces the "Download all" checkbox with a Stream/Download mode selector; saves the choice before login; auto-triggers a metadata-only sync for stream mode
- Preferences → Services: `hasBandcamp` gate now checks `bandcamp.connected` (stream-mode users who never set a format now see the section); adds Collection mode selector; Download format row hidden in stream mode; Re-sync/Re-download button copy adapts to mode
- New `sync_collection_stream()` in `bandcamp.py`: upserts all collection items as `mode="remote"` without downloading ZIPs; unconditional re-upsert makes re-sync work without a state reset
- Syncer branches on `collection_mode`: stream mode skips the first-run auto-mark (which would incorrectly set items to `mode="local"`) and skips `reset_collection_sync_state` in `sync_all_purchases`

## Test plan

- [ ] New user → onboarding → choose Stream → login → daemon log shows "Stream sync complete: N purchase(s) indexed as remote"; no ZIPs in watch folder
- [ ] New user → onboarding → choose Download → login → no auto-sync; Re-download in Prefs triggers existing download behavior
- [ ] Existing user (no `collection_mode` in DB) → Preferences → Services → shows Download as current mode
- [ ] Preferences → Collection mode = Stream → Download format row disappears
- [ ] Preferences → Collection mode = Download → Download format row reappears
- [ ] Stream user → "Re-sync purchase list" → metadata-only sync fires; no ZIPs
- [ ] Download user → "Re-download all purchases" → current behavior unchanged
- [ ] `GET /api/v1/config` includes `"bandcamp.collection_mode"`
- [ ] Watch-folder onboarding card no longer contains the "also download" sentence
- [ ] Stream user who never set a download format still sees Bandcamp section in Preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)