### PR TITLE
fix(KAMP-396): resolve stream URL on EOF auto-advance for remote tracks

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -44,6 +44,76 @@ from kamp_core.library import LibraryIndex, LibraryScanner, Track, extract_art
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
 # ---------------------------------------------------------------------------
+# Playback URI resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_playback_uri(
+    track: Track,
+    index: LibraryIndex,
+    refresh_stream_url: Callable[[str, int], tuple[str, float] | None] | None,
+) -> str:
+    """Return the URL or path string to pass to mpv for *track*.
+
+    For local tracks returns str(track.file_path). For remote tracks checks
+    stream URL expiry and attempts a refresh via the refresh_stream_url
+    callback before returning track.playback_uri.
+    """
+    if not track.is_remote:
+        return track.playback_uri
+
+    import time as _t
+
+    needs_refresh = (
+        track.stream_url_expires_at is None
+        or track.stream_url_expires_at < _t.time() + 60
+    )
+    if needs_refresh and refresh_stream_url is not None:
+        _fp = str(track.file_path)
+        # Parse sale_item_id and track_number from bandcamp://sale_id/track_num.
+        # Path() mutates the URI differently per platform:
+        #   POSIX: bandcamp:// → bandcamp:/ (double-slash collapse)
+        #   Windows: bandcamp:// → bandcamp:\\ (backslash normalisation)
+        # Split on "bandcamp:" and strip all leading slashes/backslashes to
+        # get the raw "sale_id/track_num" segment, then reconstruct canonical
+        # "bandcamp://sale_id/track_num" for DB lookups.
+        _after_scheme = _fp.split("bandcamp:", 1)
+        _canonical_fp: str | None = None
+        _rest: str | None = None
+        if len(_after_scheme) == 2:
+            _rest = _after_scheme[1].lstrip("/\\").replace("\\", "/")
+            _canonical_fp = "bandcamp://" + _rest
+        if _canonical_fp is not None and _rest is not None:
+            parts = _rest.split("/", 1)
+            if len(parts) == 2:
+                sale_item_id, track_num_str = parts
+                try:
+                    track_num = int(track_num_str)
+                except ValueError:
+                    track_num = 0
+                item = index.get_collection_item(sale_item_id)
+                album_url = (item or {}).get("album_url", "")
+                if album_url:
+                    result = refresh_stream_url(album_url, track_num)
+                    if result is not None:
+                        new_url, expires_at = result
+                        index.update_stream_url(_canonical_fp, new_url, expires_at)
+                        return new_url
+                    else:
+                        logger.warning(
+                            "Stream URL refresh failed for %s — using existing URI",
+                            _canonical_fp,
+                        )
+                else:
+                    logger.warning(
+                        "No album_url for %s — cannot refresh stream URL; "
+                        "run kamp sync to populate.",
+                        _canonical_fp,
+                    )
+    return track.playback_uri
+
+
+# ---------------------------------------------------------------------------
 # Request / response models
 # ---------------------------------------------------------------------------
 
@@ -652,64 +722,7 @@ def create_app(
         t.start()
 
     def _resolve_playback(track: "Track") -> str:
-        """Return the URL or path string to pass to mpv for *track*.
-
-        For local tracks returns str(track.file_path). For remote tracks checks
-        stream URL expiry and attempts a refresh via the refresh_stream_url
-        callback before returning track.playback_uri.
-        """
-        if not track.is_remote:
-            return track.playback_uri
-
-        import time as _t
-
-        needs_refresh = (
-            track.stream_url_expires_at is None
-            or track.stream_url_expires_at < _t.time() + 60
-        )
-        if needs_refresh and refresh_stream_url is not None:
-            _fp = str(track.file_path)
-            # Parse sale_item_id and track_number from bandcamp://sale_id/track_num.
-            # Path() mutates the URI differently per platform:
-            #   POSIX: bandcamp:// → bandcamp:/ (double-slash collapse)
-            #   Windows: bandcamp:// → bandcamp:\\ (backslash normalisation)
-            # Split on "bandcamp:" and strip all leading slashes/backslashes to
-            # get the raw "sale_id/track_num" segment, then reconstruct canonical
-            # "bandcamp://sale_id/track_num" for DB lookups.
-            _after_scheme = _fp.split("bandcamp:", 1)
-            _canonical_fp: str | None = None
-            _rest: str | None = None
-            if len(_after_scheme) == 2:
-                _rest = _after_scheme[1].lstrip("/\\").replace("\\", "/")
-                _canonical_fp = "bandcamp://" + _rest
-            if _canonical_fp is not None and _rest is not None:
-                parts = _rest.split("/", 1)
-                if len(parts) == 2:
-                    sale_item_id, track_num_str = parts
-                    try:
-                        track_num = int(track_num_str)
-                    except ValueError:
-                        track_num = 0
-                    item = index.get_collection_item(sale_item_id)
-                    album_url = (item or {}).get("album_url", "")
-                    if album_url:
-                        result = refresh_stream_url(album_url, track_num)
-                        if result is not None:
-                            new_url, expires_at = result
-                            index.update_stream_url(_canonical_fp, new_url, expires_at)
-                            return new_url
-                        else:
-                            logger.warning(
-                                "Stream URL refresh failed for %s — using existing URI",
-                                _canonical_fp,
-                            )
-                    else:
-                        logger.warning(
-                            "No album_url for %s — cannot refresh stream URL; "
-                            "run kamp sync to populate.",
-                            _canonical_fp,
-                        )
-        return track.playback_uri
+        return resolve_playback_uri(track, index, refresh_stream_url)
 
     # Wire play-state change callback directly — the engine fires it from its
     # background reader thread whenever mpv's pause property flips.

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -532,7 +532,7 @@ def _cmd_daemon(
     from kamp_core.library import LibraryIndex
     from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
-    from kamp_core.server import create_app
+    from kamp_core.server import create_app, resolve_playback_uri
     from kamp_daemon.config import config_set as _config_set
     from kamp_daemon.tagger import lookup_releases_from_tracks
 
@@ -660,7 +660,9 @@ def _cmd_daemon(
             index.record_track_started(track.file_path)
             if not had_lookahead:
                 # No gapless transition was queued — start the next track manually.
-                engine.play(track.file_path)
+                # resolve_playback_uri refreshes expired CDN stream URLs for remote
+                # tracks so mpv receives a real HTTPS URL, not a raw bandcamp: URI.
+                engine.play(resolve_playback_uri(track, index, _refresh_stream_url))
             # If had_lookahead: mpv already transitioned gaplessly.  file-loaded
             # will fire shortly and preload_next will queue the new next track.
         else:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 
 from kamp_core.library import AlbumInfo, Track
 from kamp_core.playback import PlaybackState
-from kamp_core.server import create_app
+from kamp_core.server import create_app, resolve_playback_uri
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -3739,6 +3739,94 @@ class TestResolvePlaybackRemote:
 
         c.post("/api/v1/player/next")
         mock_engine.play.assert_called_once_with("https://cdn.example.com/existing.mp3")
+
+
+# ---------------------------------------------------------------------------
+# resolve_playback_uri — module-level function (used by on_track_end auto-advance)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePlaybackUri:
+    """resolve_playback_uri is a module-level function so on_track_end can
+    call it without going through a REST endpoint.  The underlying resolution
+    logic is the same as _resolve_playback inside create_app — these tests
+    verify the function directly to guard the KAMP-396 regression (EOF
+    auto-advance passed a raw bandcamp: URI to mpv instead of a CDN URL)."""
+
+    def _remote_track(
+        self,
+        *,
+        stream_url: str | None = None,
+        stream_url_expires_at: float | None = None,
+    ) -> Track:
+        return Track(
+            file_path=Path("bandcamp://777/2"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=2,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url=stream_url,
+            stream_url_expires_at=stream_url_expires_at,
+        )
+
+    def test_local_track_returns_file_path(self) -> None:
+        index = MagicMock()
+        track = _track(1)
+        assert resolve_playback_uri(track, index, None) == str(track.file_path)
+
+    def test_remote_track_with_fresh_url_returns_stream_url(self) -> None:
+        import time
+
+        index = MagicMock()
+        track = self._remote_track(
+            stream_url="https://cdn.example.com/fresh.mp3",
+            stream_url_expires_at=time.time() + 7200,
+        )
+        assert (
+            resolve_playback_uri(track, index, None)
+            == "https://cdn.example.com/fresh.mp3"
+        )
+
+    def test_remote_track_with_expired_url_refreshes(self) -> None:
+        index = MagicMock()
+        index.get_collection_item.return_value = {
+            "album_url": "https://artist.bandcamp.com/album/x"
+        }
+        refresh_fn = MagicMock(return_value=("https://cdn.example.com/new.mp3", 9999.0))
+
+        track = self._remote_track(
+            stream_url="https://cdn.example.com/old.mp3",
+            stream_url_expires_at=0.0,
+        )
+        result = resolve_playback_uri(track, index, refresh_fn)
+
+        assert result == "https://cdn.example.com/new.mp3"
+        refresh_fn.assert_called_once_with("https://artist.bandcamp.com/album/x", 2)
+        index.update_stream_url.assert_called_once_with(
+            "bandcamp://777/2", "https://cdn.example.com/new.mp3", 9999.0
+        )
+
+    def test_remote_track_with_no_stream_url_falls_back_to_playback_uri(self) -> None:
+        """No stream_url and no refresh callback → playback_uri (raw bandcamp: URI).
+
+        This is the best we can do when no refresh is available; mpv will error
+        and the error-advance path will skip the track.  The key requirement is
+        that we do NOT pass the Path str form (e.g. bandcamp:/777/2) — we pass
+        playback_uri which returns the stream_url if set, else str(file_path).
+        """
+        index = MagicMock()
+        track = self._remote_track(stream_url=None, stream_url_expires_at=None)
+        # Without a refresh callback we fall through to playback_uri.
+        result = resolve_playback_uri(track, index, None)
+        assert result == track.playback_uri
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_on_track_end` was calling `engine.play(track.file_path)` which passed the raw `bandcamp:/sale_id/track_num` URI to mpv — mpv can't handle that scheme, so every natural EOF cascaded through the entire remaining queue with `end-file: reason=error`
- Manual next/prev already went through `_resolve_playback` via the REST endpoints; this aligns the EOF auto-advance path with the same behaviour
- Extracted the private `_resolve_playback` closure from `make_app` into a module-level `resolve_playback_uri` so `_on_track_end` in `kamp_daemon/__main__.py` can call it directly

## Test plan

- [x] All 1627 existing tests pass
- [x] New `TestResolvePlaybackUri` class directly exercises the module-level function (4 tests: local track, fresh URL, expired URL refresh, no-callback fallback)
- [x] `mypy` clean
- [x] Coverage: 93.3%

🤖 Generated with [Claude Code](https://claude.com/claude-code)