### PR TITLE
feat(KAMP-384): expose source and has_remote_tracks on Album and Track API responses

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -136,6 +136,7 @@ class TrackOut(BaseModel):
     label: str
     favorite: bool
     play_count: int
+    source: str
 
     @classmethod
     def from_track(cls, t: Track) -> "TrackOut":
@@ -157,6 +158,7 @@ class TrackOut(BaseModel):
             label=t.label,
             favorite=t.favorite,
             play_count=t.play_count,
+            source=t.source,
         )
 
 
@@ -183,6 +185,10 @@ class AlbumOut(BaseModel):
     favorite: bool = False
     # True when any track in this album is individually favorited (KAMP-294).
     has_favorite_track: bool = False
+    # 'local' | 'bandcamp' | 'mixed' — derived from constituent track sources.
+    source: str = "local"
+    # True when any track in this album has source != 'local'.
+    has_remote_tracks: bool = False
 
 
 class PlayerStateOut(BaseModel):
@@ -798,6 +804,8 @@ def create_app(
                 play_count_avg=a.play_count_avg,
                 favorite=a.favorite,
                 has_favorite_track=a.has_favorite_track,
+                source=a.source,
+                has_remote_tracks=a.has_remote_tracks,
             )
             for a in index.albums(sort=sort)
         ]
@@ -1780,6 +1788,8 @@ def create_app(
                     play_count_avg=a.play_count_avg,
                     favorite=a.favorite,
                     has_favorite_track=a.has_favorite_track,
+                    source=a.source,
+                    has_remote_tracks=a.has_remote_tracks,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -1902,6 +1912,8 @@ def create_app(
                     play_count_avg=a.play_count_avg,
                     favorite=a.favorite,
                     has_favorite_track=a.has_favorite_track,
+                    source=a.source,
+                    has_remote_tracks=a.has_remote_tracks,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -2038,6 +2050,8 @@ def create_app(
                 play_count_avg=a.play_count_avg,
                 favorite=a.favorite,
                 has_favorite_track=a.has_favorite_track,
+                source=a.source,
+                has_remote_tracks=a.has_remote_tracks,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -24,6 +24,7 @@ export type Track = {
   label: string
   favorite: boolean
   play_count: number
+  source: string
 }
 
 export type Album = {
@@ -48,6 +49,10 @@ export type Album = {
   favorite: boolean
   // True when any track in this album is individually favorited (KAMP-294).
   has_favorite_track: boolean
+  // 'local' | 'bandcamp' | 'mixed' — derived from constituent track sources.
+  source: 'local' | 'bandcamp' | 'mixed'
+  // True when any track in this album has source !== 'local'.
+  has_remote_tracks: boolean
 }
 
 export type PlayerState = {

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -70,7 +70,9 @@ export function QueueContextMenu({
                 last_played_at: null,
                 play_count_avg: 0,
                 favorite: false,
-                has_favorite_track: false
+                has_favorite_track: false,
+                source: 'local',
+                has_remote_tracks: false
               }
               void setActiveView('library')
               void selectAlbum(found)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3014,6 +3014,40 @@ class TestPatchAlbumMetaEndpoint:
         assert t["genre"] == "Reggae"
         assert t["label"] == "Trojan"
 
+    def test_track_out_includes_source(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        track = _track(1)
+        track.source = "bandcamp"
+        mock_index.tracks_for_album.return_value = [track]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).get(
+            "/api/v1/tracks",
+            params={"album_artist": track.album_artist, "album": track.album},
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]["source"] == "bandcamp"
+
+    def test_album_out_includes_source_and_has_remote_tracks(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        album = _album("Tycho", "Dive")
+        album.source = "bandcamp"
+        album.has_remote_tracks = True
+        mock_index.albums.return_value = [album]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        data = TestClient(app).get("/api/v1/albums").json()
+        assert data[0]["source"] == "bandcamp"
+        assert data[0]["has_remote_tracks"] is True
+
 
 # ---------------------------------------------------------------------------
 # iTunes art search / apply (KAMP-341)


### PR DESCRIPTION
## Summary

- Adds `source: str` to `TrackOut` and wires it through `from_track` — all track-bearing endpoints now include provenance (`local`, `bandcamp`, etc.)
- Adds `source: str` and `has_remote_tracks: bool` to `AlbumOut`; updates all 4 construction sites (get_albums, apply_album_art, apply_album_art_local, search_library)
- Updates `Track` and `Album` TypeScript types in `client.ts` with the new fields
- Fixes `QueueContextMenu.tsx` Album object literal to include the new required fields

## Test plan

- [ ] `poetry run pytest tests/test_server.py -v --no-cov` — all 247 pass
- [ ] Full suite `poetry run pytest` — 1635 passed, 93.31% coverage
- [ ] TypeScript typecheck + ESLint pass (pre-commit hook)
- [ ] Manual: start server, check Network tab in UI — album/track JSON includes `source` and `has_remote_tracks`
- [ ] Manual: local albums show `source: "local"`, `has_remote_tracks: false`
- [ ] Manual: player state and search responses include `source` on tracks/albums

Closes KAMP-384

🤖 Generated with [Claude Code](https://claude.com/claude-code)