### PR TITLE
feat(KAMP-387): remote/local filter chips and remote-aware context menus

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useStore } from '../store'
-import { getTracksForAlbum } from '../api/client'
+import { getTracksForAlbum, downloadAlbum } from '../api/client'
 import type { Album } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
@@ -17,6 +17,7 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
   const playAlbumNext = useStore((s) => s.playAlbumNext)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
   const setAlbumFavorite = useStore((s) => s.setAlbumFavorite)
+  const markAlbumDownloading = useStore((s) => s.markAlbumDownloading)
 
   return (
     <ContextMenu x={x} y={y} onClose={onClose}>
@@ -62,20 +63,39 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
         </span>
         {album.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
       </button>
-      <button
-        className="track-context-menu-item"
-        onClick={async () => {
-          let filePath = album.file_path
-          if (!filePath) {
+      {album.source === 'local' && (
+        <button
+          className="track-context-menu-item"
+          onClick={async () => {
+            let filePath = album.file_path
+            if (!filePath) {
+              const tracks = await getTracksForAlbum(album.album_artist, album.album)
+              filePath = tracks[0]?.file_path ?? ''
+            }
+            if (filePath) window.api.showItemInFolder(filePath)
+            onClose()
+          }}
+        >
+          {revealInFinderLabel()}
+        </button>
+      )}
+      {album.source !== 'local' && (
+        <button
+          className="track-context-menu-item track-context-menu-item--action"
+          onClick={async () => {
             const tracks = await getTracksForAlbum(album.album_artist, album.album)
-            filePath = tracks[0]?.file_path ?? ''
-          }
-          if (filePath) window.api.showItemInFolder(filePath)
-          onClose()
-        }}
-      >
-        {revealInFinderLabel()}
-      </button>
+            const saleItemId =
+              tracks[0]?.file_path.split('bandcamp:')[1]?.replace(/^\/+/, '').split('/')[0] ?? null
+            if (saleItemId) {
+              markAlbumDownloading(saleItemId)
+              void downloadAlbum(saleItemId)
+            }
+            onClose()
+          }}
+        >
+          ⬇ Download this album
+        </button>
+      )}
     </ContextMenu>
   )
 }

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -29,24 +29,33 @@ export function AlbumGrid(): React.JSX.Element {
   let visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
 
   if (libraryFilter.length > 0) {
-    // "Top Albums": top 100 by avg plays per track — same algorithm as Base Kamp Top Albums module.
-    const top100Keys =
-      libraryFilter.includes('top_albums') && albums.length > 0
-        ? new Set(
-            [...albums]
-              .sort((a, b) => b.play_count_avg - a.play_count_avg)
-              .slice(0, 100)
-              .map((a) => `${a.album_artist}\0${a.album}`)
-          )
-        : null
+    const QUALITATIVE_FILTERS = ['favorite_album', 'has_favorite_track', 'unplayed', 'top_albums']
+    const hasQualitativeFilter = QUALITATIVE_FILTERS.some((f) => libraryFilter.includes(f))
 
-    visible = visible.filter(
-      (a) =>
-        (libraryFilter.includes('favorite_album') && a.favorite) ||
-        (libraryFilter.includes('has_favorite_track') && a.has_favorite_track) ||
-        (libraryFilter.includes('unplayed') && a.last_played_at === null) ||
-        (libraryFilter.includes('top_albums') && top100Keys!.has(`${a.album_artist}\0${a.album}`))
-    )
+    if (hasQualitativeFilter) {
+      // "Top Albums": top 100 by avg plays per track — same algorithm as Base Kamp Top Albums module.
+      const top100Keys =
+        libraryFilter.includes('top_albums') && albums.length > 0
+          ? new Set(
+              [...albums]
+                .sort((a, b) => b.play_count_avg - a.play_count_avg)
+                .slice(0, 100)
+                .map((a) => `${a.album_artist}\0${a.album}`)
+            )
+          : null
+
+      visible = visible.filter(
+        (a) =>
+          (libraryFilter.includes('favorite_album') && a.favorite) ||
+          (libraryFilter.includes('has_favorite_track') && a.has_favorite_track) ||
+          (libraryFilter.includes('unplayed') && a.last_played_at === null) ||
+          (libraryFilter.includes('top_albums') && top100Keys!.has(`${a.album_artist}\0${a.album}`))
+      )
+    }
+
+    // Source filters are AND-type: they narrow the result set independently.
+    if (libraryFilter.includes('remote_only')) visible = visible.filter((a) => a.source !== 'local')
+    if (libraryFilter.includes('local_only')) visible = visible.filter((a) => a.source === 'local')
   }
 
   const emptyMessage = (): string => {

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -7,6 +7,7 @@ import { useStore } from '../store'
 import { AlbumCard } from './AlbumCard'
 import { SortControl } from './SortControl'
 import { FilterControl } from './FilterControl'
+import { SourceControl } from './SourceControl'
 
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
@@ -68,6 +69,7 @@ export function AlbumGrid(): React.JSX.Element {
     <div className="album-grid-container" ref={containerRef}>
       <div className="album-grid-toolbar">
         <SortControl />
+        <SourceControl />
         <FilterControl />
       </div>
       {visible.length === 0 ? (

--- a/kamp_ui/src/renderer/src/components/FilterControl.tsx
+++ b/kamp_ui/src/renderer/src/components/FilterControl.tsx
@@ -41,7 +41,9 @@ export function FilterControl(): React.JSX.Element {
     }
   }
 
-  const hasActive = libraryFilter.length > 0
+  const SOURCE_KEYS = ['remote_only', 'local_only']
+  const activeFilters = libraryFilter.filter((f) => !SOURCE_KEYS.includes(f))
+  const hasActive = activeFilters.length > 0
 
   return (
     <div className="filter-anchor" ref={ref}>
@@ -53,8 +55,8 @@ export function FilterControl(): React.JSX.Element {
       >
         Filter
         {hasActive && (
-          <span className="toolbar-dropdown-badge" aria-label={`${libraryFilter.length} active`}>
-            · {libraryFilter.length}
+          <span className="toolbar-dropdown-badge" aria-label={`${activeFilters.length} active`}>
+            · {activeFilters.length}
           </span>
         )}
         <span className="dropdown-chevron" aria-hidden="true">

--- a/kamp_ui/src/renderer/src/components/FilterControl.tsx
+++ b/kamp_ui/src/renderer/src/components/FilterControl.tsx
@@ -1,13 +1,21 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 
-type FilterKey = 'favorite_album' | 'has_favorite_track' | 'unplayed' | 'top_albums'
+type FilterKey =
+  | 'favorite_album'
+  | 'has_favorite_track'
+  | 'unplayed'
+  | 'top_albums'
+  | 'remote_only'
+  | 'local_only'
 
 const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
   { key: 'favorite_album', label: 'Favorite albums' },
   { key: 'has_favorite_track', label: 'Albums with favorited tracks' },
   { key: 'unplayed', label: 'Unplayed' },
-  { key: 'top_albums', label: 'Top Albums' }
+  { key: 'top_albums', label: 'Top Albums' },
+  { key: 'remote_only', label: '☁ Remote' },
+  { key: 'local_only', label: '⬇ Local only' }
 ]
 
 export function FilterControl(): React.JSX.Element {
@@ -33,11 +41,18 @@ export function FilterControl(): React.JSX.Element {
     }
   }, [open])
 
+  const MUTUAL_EXCLUSIONS: Partial<Record<FilterKey, FilterKey>> = {
+    remote_only: 'local_only',
+    local_only: 'remote_only'
+  }
+
   const toggle = (key: FilterKey): void => {
     if (libraryFilter.includes(key)) {
       setLibraryFilter(libraryFilter.filter((f) => f !== key))
     } else {
-      setLibraryFilter([...libraryFilter, key])
+      const exclude = MUTUAL_EXCLUSIONS[key]
+      const base = exclude ? libraryFilter.filter((f) => f !== exclude) : libraryFilter
+      setLibraryFilter([...base, key])
     }
   }
 

--- a/kamp_ui/src/renderer/src/components/FilterControl.tsx
+++ b/kamp_ui/src/renderer/src/components/FilterControl.tsx
@@ -74,7 +74,9 @@ export function FilterControl(): React.JSX.Element {
             <>
               <button
                 className="toolbar-dropdown-item toolbar-dropdown-clear"
-                onClick={() => setLibraryFilter([])}
+                onClick={() =>
+                  setLibraryFilter(libraryFilter.filter((f) => SOURCE_KEYS.includes(f)))
+                }
               >
                 No filter
               </button>

--- a/kamp_ui/src/renderer/src/components/SortControl.tsx
+++ b/kamp_ui/src/renderer/src/components/SortControl.tsx
@@ -42,7 +42,7 @@ export function SortControl(): React.JSX.Element {
         aria-expanded={open}
         aria-haspopup="listbox"
       >
-        {SORT_LABELS[sortOrder as SortOrder] ?? SORT_LABELS.album_artist}
+        {`Sort: ${SORT_LABELS[sortOrder as SortOrder] ?? SORT_LABELS.album_artist}`}
         <span className="dropdown-chevron" aria-hidden="true">
           ▾
         </span>

--- a/kamp_ui/src/renderer/src/components/SourceControl.tsx
+++ b/kamp_ui/src/renderer/src/components/SourceControl.tsx
@@ -52,12 +52,7 @@ export function SourceControl(): React.JSX.Element {
         aria-expanded={open}
         aria-haspopup="listbox"
       >
-        Source
-        {activeKey && (
-          <span className="toolbar-dropdown-badge" aria-label="1 active">
-            · 1
-          </span>
-        )}
+        {activeKey ? `Source: ${SOURCE_OPTIONS.find((o) => o.key === activeKey)!.label}` : 'Source'}
         <span className="dropdown-chevron" aria-hidden="true">
           ▾
         </span>

--- a/kamp_ui/src/renderer/src/components/SourceControl.tsx
+++ b/kamp_ui/src/renderer/src/components/SourceControl.tsx
@@ -1,20 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 
-type FilterKey = 'favorite_album' | 'has_favorite_track' | 'unplayed' | 'top_albums'
+type SourceKey = 'remote_only' | 'local_only'
 
-const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
-  { key: 'favorite_album', label: 'Favorite albums' },
-  { key: 'has_favorite_track', label: 'Albums with favorited tracks' },
-  { key: 'unplayed', label: 'Unplayed' },
-  { key: 'top_albums', label: 'Top Albums' }
+const SOURCE_OPTIONS: { key: SourceKey; label: string }[] = [
+  { key: 'remote_only', label: 'Streaming' },
+  { key: 'local_only', label: 'Local only' }
 ]
 
-export function FilterControl(): React.JSX.Element {
+export function SourceControl(): React.JSX.Element {
   const libraryFilter = useStore((s) => s.libraryFilter)
   const setLibraryFilter = useStore((s) => s.setLibraryFilter)
   const [open, setOpen] = useState(false)
-  // Single ref wrapping both trigger and popover so contains() check works on option clicks.
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -33,28 +30,32 @@ export function FilterControl(): React.JSX.Element {
     }
   }, [open])
 
-  const toggle = (key: FilterKey): void => {
-    if (libraryFilter.includes(key)) {
+  const activeKey = SOURCE_OPTIONS.find(({ key }) => libraryFilter.includes(key))?.key ?? null
+
+  const toggle = (key: SourceKey): void => {
+    if (activeKey === key) {
+      // deselect
       setLibraryFilter(libraryFilter.filter((f) => f !== key))
     } else {
-      setLibraryFilter([...libraryFilter, key])
+      // select this one, removing the other if present
+      const other = SOURCE_OPTIONS.find((o) => o.key !== key)!.key
+      setLibraryFilter([...libraryFilter.filter((f) => f !== other && f !== key), key])
     }
+    setOpen(false)
   }
-
-  const hasActive = libraryFilter.length > 0
 
   return (
     <div className="filter-anchor" ref={ref}>
       <button
-        className={`toolbar-dropdown-trigger${hasActive ? ' has-active' : ''}`}
+        className={`toolbar-dropdown-trigger${activeKey ? ' has-active' : ''}`}
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-haspopup="listbox"
       >
-        Filter
-        {hasActive && (
-          <span className="toolbar-dropdown-badge" aria-label={`${libraryFilter.length} active`}>
-            · {libraryFilter.length}
+        Source
+        {activeKey && (
+          <span className="toolbar-dropdown-badge" aria-label="1 active">
+            · 1
           </span>
         )}
         <span className="dropdown-chevron" aria-hidden="true">
@@ -62,25 +63,23 @@ export function FilterControl(): React.JSX.Element {
         </span>
       </button>
       {open && (
-        <div
-          className="toolbar-dropdown-popover"
-          role="listbox"
-          aria-multiselectable="true"
-          aria-label="Filter"
-        >
-          {hasActive && (
-            <>
-              <button
-                className="toolbar-dropdown-item toolbar-dropdown-clear"
-                onClick={() => setLibraryFilter([])}
-              >
-                No filter
-              </button>
-              <div className="toolbar-dropdown-divider" />
-            </>
-          )}
-          {FILTER_OPTIONS.map(({ key, label }) => {
-            const active = libraryFilter.includes(key)
+        <div className="toolbar-dropdown-popover" role="listbox" aria-label="Source">
+          <button
+            role="option"
+            aria-selected={activeKey === null}
+            className={`toolbar-dropdown-item${activeKey === null ? ' active' : ''}`}
+            onClick={() => {
+              if (activeKey) setLibraryFilter(libraryFilter.filter((f) => f !== activeKey))
+              setOpen(false)
+            }}
+          >
+            <span className="dropdown-check" aria-hidden="true">
+              {activeKey === null ? '▪' : ''}
+            </span>
+            All
+          </button>
+          {SOURCE_OPTIONS.map(({ key, label }) => {
+            const active = activeKey === key
             return (
               <button
                 key={key}


### PR DESCRIPTION
## Summary

- Adds **Remote** (`☁ Remote`) and **Local only** (`⬇ Local only`) filter chips to the FilterControl dropdown; the two are mutually exclusive with each other but compose freely with Favorites, Unplayed, and Top Albums
- Restructures `AlbumGrid` filter logic so source filters AND-narrow the result set independently (previously all filters were OR'd together, which would have hidden all albums when `remote_only` was the only active filter)
- `AlbumContextMenu`: hides "Reveal in Finder" for remote albums; adds "Download this album" action (green text) that derives the `saleItemId` from the first track's `file_path` and calls the existing download API
- `TrackContextMenu`: no change needed — no "Edit title" item exists (AC #8 vacuously satisfied)

## Test plan

- [ ] FilterControl dropdown shows Remote and Local only chips below existing filters
- [ ] Activating Remote shows only remote/mixed-source albums
- [ ] Activating Local only shows only local albums; Remote chip deselects
- [ ] Activating Remote + Favorites shows remote albums that are also favorited
- [ ] Right-click local album → Reveal in Finder visible, no Download
- [ ] Right-click remote album → Reveal in Finder absent, Download this album visible
- [ ] Click Download this album → download API fires (check daemon logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)