### PR TITLE
feat(KAMP-393): custom version tag for tester builds + version in preferences

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -3,6 +3,10 @@ name: Build App
 on:
   workflow_dispatch:
     inputs:
+      version_tag:
+        description: 'Optional suffix appended to the version (e.g. -beta, -bandcamp-streaming). Leave blank for a normal build.'
+        type: string
+        default: ''
       debug_macos:
         description: 'SSH into macOS 14 ARM runner with built bundle (tmate)'
         type: boolean
@@ -464,6 +468,18 @@ jobs:
         run: npm ci
         working-directory: kamp_ui
 
+      - name: Patch version tag
+        if: inputs.version_tag != ''
+        run: |
+          python3 -c "
+          import json, pathlib
+          p = pathlib.Path('kamp_ui/package.json')
+          d = json.loads(p.read_text())
+          d['version'] += '${{ inputs.version_tag }}'
+          p.write_text(json.dumps(d, indent=2) + '\n')
+          "
+          echo "→ Version: $(python3 -c "import json; print(json.load(open('kamp_ui/package.json'))['version'])")"
+
       - name: Build DMG
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -686,6 +702,15 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
         working-directory: kamp_ui
+
+      - name: Patch version tag
+        if: inputs.version_tag != ''
+        shell: pwsh
+        run: |
+          $pkg = Get-Content kamp_ui\package.json | ConvertFrom-Json
+          $pkg.version += '${{ inputs.version_tag }}'
+          $pkg | ConvertTo-Json -Depth 10 | Set-Content kamp_ui\package.json
+          Write-Host "-> Version: $($pkg.version)"
 
       - name: Build NSIS installer
         # Azure Trusted Signing — AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET are read

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -6,6 +6,7 @@ declare global {
     electron: ElectronAPI
     api: {
       isPackaged: boolean
+      appVersion: string
       openDirectory: () => Promise<string | null>
       onOpenPreferences: (callback: () => void) => () => void
       bandcamp: {

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -9,6 +9,15 @@ import { buildKampAPI, onBandcampSyncStatus, onPipelineStage } from './kampAPI'
 // directly from the filesystem. The .asar extension in __dirname is definitive.
 const isPackaged: boolean = __dirname.includes('.asar')
 
+// Read the app version from package.json at preload init time. __dirname in
+// the compiled preload is always two levels below the package root (out/preload/),
+// so ../../package.json resolves correctly in both dev and packaged modes.
+const appVersion: string = (
+  JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf8')) as {
+    version: string
+  }
+).version
+
 function _kampTokenFilePath(): string {
   if (process.platform === 'win32') {
     return join(process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'), 'kamp', '.token')
@@ -27,6 +36,7 @@ function _readKampToken(): string | null {
 // Custom APIs for renderer
 const api = {
   isPackaged,
+  appVersion,
   openDirectory: (): Promise<string | null> => ipcRenderer.invoke('open-directory'),
   onOpenPreferences: (callback: () => void): (() => void) => {
     const handler = (): void => callback()

--- a/kamp_ui/src/renderer/src/assets/preferences.css
+++ b/kamp_ui/src/renderer/src/assets/preferences.css
@@ -70,6 +70,15 @@
   scrollbar-color: var(--border) transparent;
 }
 
+.prefs-status-rail {
+  padding: 6px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: left;
+}
+
 .prefs-section {
   margin-top: 24px;
 }

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1302,6 +1302,9 @@ export function PreferencesDialog({
             />
           )}
         </div>
+
+        {/* Status rail */}
+        <div className="prefs-status-rail">v{window.api.appVersion}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds a `version_tag` input to the `build-app` workflow dispatch (e.g. `-beta`, `-bandcamp-streaming`). When set, the suffix is appended to the `package.json` version before electron-builder runs, so installer filenames and the Electron app version reflect the tag. Release-triggered builds are unaffected.
- Exposes the app version in the renderer via the preload (read synchronously from `package.json` at init, same pattern as `isPackaged`) and displays it in a status rail at the bottom-left of the Preferences dialog.

## Test plan

- [ ] Trigger `build-app` via workflow_dispatch with `version_tag = -beta`; confirm DMGs are named `kamp-1.x.x-beta-arm64.dmg` / `kamp-1.x.x-beta-x64.dmg`
- [ ] Trigger with `version_tag` left blank; confirm artifact names are unchanged
- [ ] Open Preferences and confirm the version string (e.g. `v1.21.0`) appears in the bottom-left status rail on all three tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)