### PR TITLE
feat(KAMP-403): remote search — source filter in SearchView + SourceControl in toolbar

### DIFF
--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../store'
 import { artUrl } from '../api/client'
 import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
+import { SourceControl } from './SourceControl'
 import { FilterControl } from './FilterControl'
 import { AlbumContextMenu } from './AlbumContextMenu'
 import { TrackContextMenu } from './TrackContextMenu'
@@ -128,6 +129,9 @@ export function SearchView(): React.JSX.Element {
   const [albumMenu, setAlbumMenu] = useState<AlbumMenu | null>(null)
   const [trackMenu, setTrackMenu] = useState<TrackMenu | null>(null)
 
+  const QUALITATIVE_FILTERS = ['favorite_album', 'has_favorite_track', 'unplayed', 'top_albums']
+  const hasQualitativeFilter = QUALITATIVE_FILTERS.some((f) => libraryFilter.includes(f))
+
   const top100Keys =
     libraryFilter.includes('top_albums') && allAlbums.length > 0
       ? new Set(
@@ -139,40 +143,46 @@ export function SearchView(): React.JSX.Element {
       : null
 
   const rawAlbums = results?.albums ?? []
-  const visibleAlbums =
-    libraryFilter.length > 0
-      ? rawAlbums.filter(
-          (a) =>
-            (libraryFilter.includes('favorite_album') && a.favorite) ||
-            (libraryFilter.includes('has_favorite_track') && a.has_favorite_track) ||
-            (libraryFilter.includes('unplayed') && a.last_played_at === null) ||
-            (libraryFilter.includes('top_albums') &&
-              top100Keys!.has(`${a.album_artist}\0${a.album}`))
-        )
-      : rawAlbums
+  let visibleAlbums = rawAlbums
+  if (hasQualitativeFilter) {
+    visibleAlbums = visibleAlbums.filter(
+      (a) =>
+        (libraryFilter.includes('favorite_album') && a.favorite) ||
+        (libraryFilter.includes('has_favorite_track') && a.has_favorite_track) ||
+        (libraryFilter.includes('unplayed') && a.last_played_at === null) ||
+        (libraryFilter.includes('top_albums') && top100Keys!.has(`${a.album_artist}\0${a.album}`))
+    )
+  }
+  // Source filters are AND-type: they narrow the result set independently.
+  if (libraryFilter.includes('remote_only')) visibleAlbums = visibleAlbums.filter((a) => a.source !== 'local')
+  if (libraryFilter.includes('local_only')) visibleAlbums = visibleAlbums.filter((a) => a.source === 'local')
 
   const albumMap = new Map<string, Album>()
   allAlbums.forEach((a) => albumMap.set(`${a.album_artist}\0${a.album}`, a))
 
   const rawTracks = results?.tracks ?? []
-  const visibleTracks =
-    libraryFilter.length > 0
-      ? rawTracks.filter((t) => {
-          const key = `${t.album_artist}\0${t.album}`
-          const album = t.album ? albumMap.get(key) : undefined
-          return (
-            (libraryFilter.includes('favorite_album') && album?.favorite === true) ||
-            (libraryFilter.includes('has_favorite_track') && t.favorite) ||
-            (libraryFilter.includes('unplayed') && t.play_count === 0) ||
-            (libraryFilter.includes('top_albums') && album !== undefined && top100Keys!.has(key))
-          )
-        })
-      : rawTracks
+  let visibleTracks = rawTracks
+  if (hasQualitativeFilter) {
+    visibleTracks = visibleTracks.filter((t) => {
+      const key = `${t.album_artist}\0${t.album}`
+      const album = t.album ? albumMap.get(key) : undefined
+      return (
+        (libraryFilter.includes('favorite_album') && album?.favorite === true) ||
+        (libraryFilter.includes('has_favorite_track') && t.favorite) ||
+        (libraryFilter.includes('unplayed') && t.play_count === 0) ||
+        (libraryFilter.includes('top_albums') && album !== undefined && top100Keys!.has(key))
+      )
+    })
+  }
+  // Source filters are AND-type: they narrow the result set independently.
+  if (libraryFilter.includes('remote_only')) visibleTracks = visibleTracks.filter((t) => t.source !== 'local')
+  if (libraryFilter.includes('local_only')) visibleTracks = visibleTracks.filter((t) => t.source === 'local')
 
   return (
     <div className="search-view">
       <div className="search-view-toolbar">
         <SortControl />
+        <SourceControl />
         <FilterControl />
       </div>
       <div className="search-view-content">

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -154,8 +154,10 @@ export function SearchView(): React.JSX.Element {
     )
   }
   // Source filters are AND-type: they narrow the result set independently.
-  if (libraryFilter.includes('remote_only')) visibleAlbums = visibleAlbums.filter((a) => a.source !== 'local')
-  if (libraryFilter.includes('local_only')) visibleAlbums = visibleAlbums.filter((a) => a.source === 'local')
+  if (libraryFilter.includes('remote_only'))
+    visibleAlbums = visibleAlbums.filter((a) => a.source !== 'local')
+  if (libraryFilter.includes('local_only'))
+    visibleAlbums = visibleAlbums.filter((a) => a.source === 'local')
 
   const albumMap = new Map<string, Album>()
   allAlbums.forEach((a) => albumMap.set(`${a.album_artist}\0${a.album}`, a))
@@ -175,8 +177,10 @@ export function SearchView(): React.JSX.Element {
     })
   }
   // Source filters are AND-type: they narrow the result set independently.
-  if (libraryFilter.includes('remote_only')) visibleTracks = visibleTracks.filter((t) => t.source !== 'local')
-  if (libraryFilter.includes('local_only')) visibleTracks = visibleTracks.filter((t) => t.source === 'local')
+  if (libraryFilter.includes('remote_only'))
+    visibleTracks = visibleTracks.filter((t) => t.source !== 'local')
+  if (libraryFilter.includes('local_only'))
+    visibleTracks = visibleTracks.filter((t) => t.source === 'local')
 
   return (
     <div className="search-view">

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1555,6 +1555,25 @@ class TestSearchEndpoint:
         assert [a["album"] for a in data["albums"]] == ["Amnesiac", "Kid A"]
         mock_index.albums.assert_called_once_with(sort="album")
 
+    def test_remote_track_appears_in_results(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(1, album="The Moon Rang Like a Bell", artist="Hundred Waters")
+        t.source = "bandcamp"
+        t.file_path = Path("bandcamp://12345/01.mp3")
+        remote_album = _album("Hundred Waters", "The Moon Rang Like a Bell")
+        remote_album.source = "bandcamp"
+        mock_index.search.return_value = [t]
+        mock_index.albums.return_value = [remote_album]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=hundred+waters")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["tracks"]) == 1
+        assert data["tracks"][0]["source"] == "bandcamp"
+        assert len(data["albums"]) == 1
+        assert data["albums"][0]["source"] == "bandcamp"
+
 
 # ---------------------------------------------------------------------------
 # UI state endpoints


### PR DESCRIPTION
## Summary

- **Root cause**: `SearchView.tsx` applied a single OR-based qualitative filter (`favorite_album`, `has_favorite_track`, `unplayed`, `top_albums`). When only a source chip was active (`libraryFilter = ['remote_only']`), every album and track failed the predicate → zero results.
- **Fix**: Refactored to the same two-phase approach as `AlbumGrid.tsx` — qualitative filter guarded by `hasQualitativeFilter`, then `remote_only`/`local_only` applied as independent AND conditions on both albums and tracks.
- **SourceControl** added to the search toolbar so users can toggle source chips without leaving the search view.
- **Backend test** added: remote track with `source='bandcamp'` appears in `/api/v1/search` results.

## Test plan

- [ ] With "Streaming" chip active, search for an artist/album/track that only exists in the remote library — results appear
- [ ] Source dropdown visible in search toolbar; selecting "Streaming" / "Local only" filters search results live
- [ ] With "Streaming" chip active, searching a local-only term returns no results
- [ ] With no chip active, remote results still appear
- [ ] With "Local" chip active, only local results appear
- [ ] Click a remote album result → navigates to library view and selects the album
- [ ] Double-click a remote track result → plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)