### PR TITLE
feat(KAMP-404): stream albums into library incrementally during first sync

### DIFF
--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -375,6 +375,7 @@ def sync_collection_stream(
     index: "LibraryIndex",
     status_callback: Callable[[str], None] | None = None,
     art_cache_dir: Path | None = None,
+    batch_indexed_callback: Callable[[], None] | None = None,
 ) -> tuple[int, int]:
     """Index all Bandcamp purchases as remote rows — no ZIP download.
 
@@ -454,6 +455,8 @@ def sync_collection_stream(
                         item_title,
                         band_name,
                     )
+                    if batch_indexed_callback:
+                        batch_indexed_callback()
             except Exception as exc:
                 logger.warning(
                     "fetch_album_tracks: skipping tracks for %r by %r (%s): %s",

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -35,6 +35,7 @@ def _sync_worker(
     bc_config: BandcampConfig,
     watch_dir: Path,
     db_path: Path,
+    notify_q: Any,
     status_q: Any,
     log_q: Any,
     result_q: Any,
@@ -61,6 +62,7 @@ def _sync_worker(
                     index=index,
                     status_callback=lambda msg: status_q.put(msg),
                     art_cache_dir=_state_dir() / "art_cache",
+                    batch_indexed_callback=lambda: notify_q.put(True),
                 )
                 result_q.put(("ok_stream", (album_count, track_count)))
             else:
@@ -327,9 +329,10 @@ class Syncer:
         if self.status_callback is not None:
             self.status_callback("Syncing\u2026")
 
+        notify_q: Any = multiprocessing.get_context("spawn").Queue()
         proc, status_q, log_q, result_q = _spawn_worker(
             _sync_worker,
-            (bc, self._config.paths.watch_folder, db_path),
+            (bc, self._config.paths.watch_folder, db_path, notify_q),
         )
 
         # Drain both queues while the subprocess runs.  log_q MUST be drained
@@ -344,6 +347,13 @@ class Syncer:
             except queue.Empty:
                 pass
             _replay_log_queue(log_q)
+            while True:
+                try:
+                    notify_q.get_nowait()
+                    if self.on_tracks_indexed is not None:
+                        self.on_tracks_indexed()
+                except queue.Empty:
+                    break
 
         # Drain any messages that arrived just before the process exited.
         while True:
@@ -351,6 +361,13 @@ class Syncer:
                 msg = status_q.get_nowait()
                 if self.status_callback is not None:
                     self.status_callback(msg)
+            except queue.Empty:
+                break
+        while True:
+            try:
+                notify_q.get_nowait()
+                if self.on_tracks_indexed is not None:
+                    self.on_tracks_indexed()
             except queue.Empty:
                 break
 

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -125,12 +125,18 @@ interface Props {
 export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JSX.Element {
   const scanStatus = useStore((s) => s.scanStatus)
   const scanProgress = useStore((s) => s.scanProgress)
+  const albums = useStore((s) => s.library.albums)
+  const configValues = useStore((s) => s.configValues)
   const setLibraryPath = useStore((s) => s.setLibraryPath)
   const scanLibrary = useStore((s) => s.scanLibrary)
   const setWatchFolderPath = useStore((s) => s.setWatchFolderPath)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const loadConfig = useStore((s) => s.loadConfig)
   const setConfigValue = useStore((s) => s.setConfigValue)
+
+  const isBandcampStreamMode =
+    configValues?.['bandcamp.connected'] === true &&
+    configValues?.['bandcamp.collection_mode'] === 'stream'
 
   const [step, setStep] = useState<OnboardingStep>('welcome')
   const [vinylPhase, setVinylPhase] = useState<VinylPhase>('rising')
@@ -178,10 +184,16 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
   // When scan completes: sink the vinyl; if past all cards, finish onboarding.
   // onComplete is accessed via ref so this effect never needs it as a dep,
   // preventing re-renders from recreating the closure and cancelling the timeout.
+  // In Bandcamp stream mode, the almost-done step waits for the first album to
+  // appear before exiting — avoids handing the user a blank library while
+  // sync_collection_stream continues in the background.
   useEffect(() => {
     if (scanStatus !== 'done' || scanDoneRef.current) return
-    scanDoneRef.current = true
     if (step === 'almost-done') {
+      // In stream mode, hold until the first library.changed broadcast delivers content.
+      // scanDoneRef is NOT set here so this effect re-runs when albums.length changes.
+      if (isBandcampStreamMode && albums.length === 0) return
+      scanDoneRef.current = true
       // Snap rotating strings to "All set!" immediately (deferred to avoid sync setState in effect).
       setTimeout(() => setShowAllSet(true), 0)
       // After the 500ms hold, sink the vinyl; then wait for sink + art-preload buffer.
@@ -191,9 +203,10 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
         setTimeout(() => onCompleteRef.current(), 1600)
       }, 500)
     } else {
+      scanDoneRef.current = true
       setTimeout(() => setVinylPhase('sinking'), 0)
     }
-  }, [scanStatus, step])
+  }, [scanStatus, step, isBandcampStreamMode, albums.length])
 
   // Keep refs so the rotation interval can read the latest values without
   // needing them as dependencies (which would restart the interval on every poll tick).

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2173,6 +2173,98 @@ class TestSyncCollectionStream:
         assert album_count == 2  # both albums counted in bandcamp_collection
         assert track_count == 0  # no tracks indexed (fetch failed)
 
+    def test_batch_indexed_callback_fires_per_new_batch(self, tmp_path: Path) -> None:
+        """batch_indexed_callback fires once per album batch that has new tracks."""
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        def _fake_track(n: int) -> Track:
+            return Track(
+                file_path=_Path(f"bandcamp://1/{n}"),
+                title=f"Track {n}",
+                artist="A",
+                album_artist="A",
+                album="Album",
+                year="2020",
+                track_number=n,
+                disc_number=1,
+                ext="mp3",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+                source="bandcamp",
+            )
+
+        items = [_item(1), _item(2), _item(3)]
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+        index.has_remote_album_tracks.return_value = False
+
+        fired: list[bool] = []
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+            patch(
+                "kamp_daemon.bandcamp.fetch_album_tracks",
+                side_effect=[
+                    [_fake_track(1)],
+                    [_fake_track(2)],
+                    [_fake_track(3)],
+                ],
+            ),
+        ):
+            sync_collection_stream(
+                config,
+                watch_folder,
+                index,
+                batch_indexed_callback=lambda: fired.append(True),
+            )
+
+        assert len(fired) == 3  # one call per album with new tracks
+
+    def test_batch_indexed_callback_not_called_when_no_new_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        """batch_indexed_callback is not called when albums already have tracks."""
+        items = [_item(1), _item(2)]
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+        # Tracks already exist — fetch_album_tracks path is skipped entirely.
+        index.has_remote_album_tracks.return_value = True
+
+        fired: list[bool] = []
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+            patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=[]),
+        ):
+            sync_collection_stream(
+                config,
+                watch_folder,
+                index,
+                batch_indexed_callback=lambda: fired.append(True),
+            )
+
+        assert fired == []
+
 
 class TestStreamSyncArtPrefetch:
     """Art prefetch behaviour in sync_collection_stream."""

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -790,6 +790,44 @@ class TestStreamMode:
             syncer.sync_once()
         assert fired == [True]
 
+    def test_on_tracks_indexed_fires_per_batch_via_notify_q(
+        self, tmp_path: Path
+    ) -> None:
+        """on_tracks_indexed fires once per album batch during streaming (via notify_q).
+
+        Simulates sync_collection_stream invoking batch_indexed_callback twice
+        (two album batches) plus the belt-and-suspenders final call at ok_stream.
+        """
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        fired: list[bool] = []
+        syncer.on_tracks_indexed = lambda: fired.append(True)
+
+        def _stream_with_two_batches(
+            bc_config: object,
+            watch_dir: object,
+            index: object,
+            status_callback: object = None,
+            art_cache_dir: object = None,
+            batch_indexed_callback: object = None,
+        ) -> tuple[int, int]:
+            if batch_indexed_callback is not None:
+                batch_indexed_callback()
+                batch_indexed_callback()
+            return (2, 4)
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream",
+                side_effect=_stream_with_two_batches,
+            ),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+
+        # 2 per-batch calls via notify_q + 1 belt-and-suspenders final call = 3
+        assert len(fired) == 3
+
     def test_on_tracks_indexed_not_called_when_no_new_tracks(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds `batch_indexed_callback` to `sync_collection_stream` — called after each album batch is written to the DB, so the parent process knows new content is available without waiting for the full sync to finish
- Threads a `notify_q` through `_sync_worker` and `Syncer.sync_once`; the drain loop calls `on_tracks_indexed()` per batch, broadcasting `library.changed` incrementally throughout the sync
- `OnboardingScreen` now gates the `almost-done` exit on `albums.length > 0` when Bandcamp stream mode is active — the user sees their first albums within seconds instead of waiting 30–60 min on a blank library

## Test plan

- [ ] `poetry run pytest tests/test_bandcamp.py tests/test_syncer.py -v --no-cov` — all 181 tests pass
- [ ] Full suite: `poetry run pytest` — 1678 passed, coverage 93.19% (above 93% threshold)
- [ ] Manual: fresh Bandcamp login in stream mode → reach almost-done → confirm screen stays up; first album appears in library grid; onboarding exits as soon as first content arrives
- [ ] Regression: local-library-only user exits onboarding normally after scan
- [ ] Regression: no-library no-Bandcamp user exits onboarding when scan finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)