### PR TITLE
feat(KAMP-394): suppress new-arrival glow on initial Bandcamp sync

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1144,6 +1144,27 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def update_remote_track_date_added(
+        self, sale_item_id: str, date_added: float
+    ) -> None:
+        """Set date_added on remote tracks for *sale_item_id* if it is later than *date_added*.
+
+        Corrects tracks whose date_added was recorded as the sync timestamp rather than
+        the actual purchase date.  The MIN-wins rule mirrors upsert_collection_item so
+        that an earlier purchase date can never be overwritten by a later sync.
+        """
+        self._conn.execute(
+            "UPDATE tracks SET date_added = ? "
+            "WHERE (file_path LIKE ? OR file_path LIKE ?) AND date_added > ?",
+            (
+                date_added,
+                f"bandcamp://{sale_item_id}/%",
+                f"bandcamp:\\{sale_item_id}\\%",
+                date_added,
+            ),
+        )
+        self._conn.commit()
+
     def set_track_source_for_item(self, sale_item_id: str, source: str) -> int:
         """Set source on every track whose file_path belongs to *sale_item_id*.
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1127,7 +1127,8 @@ class LibraryIndex:
                 tralbum_id = excluded.tralbum_id,
                 album_url  = excluded.album_url,
                 mode       = excluded.mode,
-                synced_at  = COALESCE(excluded.synced_at, synced_at)
+                synced_at  = COALESCE(excluded.synced_at, synced_at),
+                added_at   = MIN(added_at, COALESCE(excluded.added_at, added_at))
             """,
             (
                 sale_item_id,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -454,6 +454,12 @@ def sync_collection_stream(
         )
         album_count += 1
 
+        # Correct date_added for existing remote tracks so the purchase date —
+        # not the sync timestamp — drives the new-arrival highlight.
+        purchased_ts = _parse_purchased(item.get("purchased"))
+        if purchased_ts is not None:
+            index.update_remote_track_date_added(str(sid), purchased_ts)
+
         # Fetch track metadata only for albums not yet in the tracks table.
         # This keeps incremental syncs fast while still populating new albums.
         if album_url and not index.has_remote_album_tracks(str(sid)):
@@ -462,7 +468,12 @@ def sync_collection_stream(
             fetch_index += 1
             try:
                 tracks = fetch_album_tracks(
-                    album_url, int(sid), band_name, item_title, session
+                    album_url,
+                    int(sid),
+                    band_name,
+                    item_title,
+                    session,
+                    date_added=purchased_ts,
                 )
                 if tracks:
                     index.upsert_many(tracks)
@@ -968,6 +979,7 @@ def fetch_album_tracks(
     band_name: str,
     item_title: str,
     session: "_AnySession",
+    date_added: float | None = None,
 ) -> "list[Track]":
     """Fetch track metadata from a Bandcamp album page without downloading CDN URLs.
 
@@ -1016,7 +1028,7 @@ def fetch_album_tracks(
                 mb_release_id="",
                 mb_recording_id="",
                 source="bandcamp",
-                date_added=time.time(),
+                date_added=date_added if date_added is not None else time.time(),
             )
         )
     return result

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -25,6 +25,7 @@ to obtain the direct download URL without any JavaScript execution.
 
 from __future__ import annotations
 
+import email.utils
 import html as html_lib
 import json
 import logging
@@ -217,6 +218,19 @@ class NeedsLoginError(Exception):
     """
 
 
+def _parse_purchased(s: str | None) -> float | None:
+    """Parse a Bandcamp 'purchased' GMT string to a Unix timestamp.
+
+    Returns None on any parse failure so callers fall back to time.time().
+    """
+    if not s:
+        return None
+    try:
+        return email.utils.parsedate_to_datetime(s).timestamp()
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
@@ -255,6 +269,7 @@ def mark_collection_synced(
             album_url=str(item.get("item_url", "")),
             tralbum_id=str(item.get("tralbum_id", "")),
             synced_at=now,
+            added_at=0,
         )
 
     logger.info(
@@ -315,6 +330,7 @@ def sync_new_purchases(
                 album_url=str(item.get("item_url", "")),
                 tralbum_id=str(item.get("tralbum_id", "")),
                 synced_at=None,  # COALESCE preserves existing synced_at
+                added_at=_parse_purchased(item.get("purchased")),
             )
 
     if not new_items:
@@ -356,6 +372,7 @@ def sync_new_purchases(
                 album_url=str(item.get("item_url", "")),
                 tralbum_id=str(item.get("tralbum_id", "")),
                 synced_at=time.time(),
+                added_at=_parse_purchased(item.get("purchased")),
             )
             logger.info("Downloaded: %s", path.name)
         except Exception as exc:
@@ -433,6 +450,7 @@ def sync_collection_stream(
             album_url=album_url,
             tralbum_id=str(item.get("tralbum_id", "")),
             synced_at=time.time(),
+            added_at=_parse_purchased(item.get("purchased")),
         )
         album_count += 1
 

--- a/scripts/probe_sold_at.py
+++ b/scripts/probe_sold_at.py
@@ -4,6 +4,7 @@ field names present in the first item, plus the value of any date-like fields.
 Run from the repo root:
     poetry run python scripts/probe_sold_at.py
 """
+
 import json
 import time
 from pathlib import Path
@@ -23,7 +24,12 @@ def main() -> None:
         raise SystemExit("No Bandcamp session found — log in via the kamp app first.")
 
     cookies_list = session_data.get("cookies", [])
-    cookies = {c["name"]: c["value"] for c in cookies_list if "bandcamp.com" in c.get("domain", "")}
+    cookies = {
+        c["name"]: c["value"]
+        for c in cookies_list
+        if c.get("domain", "") == "bandcamp.com"
+        or c.get("domain", "").endswith(".bandcamp.com")
+    }
 
     fan_url = "https://bandcamp.com/api/fan/2/collection_summary"
     r = requests.get(fan_url, cookies=cookies, timeout=10)
@@ -50,7 +56,14 @@ def main() -> None:
     for k, v in sorted(item.items()):
         print(f"  {k!r}: {v!r}")
 
-    date_fields = {k: v for k, v in item.items() if any(w in k.lower() for w in ("date", "sold", "time", "added", "stamp", "purchased"))}
+    date_fields = {
+        k: v
+        for k, v in item.items()
+        if any(
+            w in k.lower()
+            for w in ("date", "sold", "time", "added", "stamp", "purchased")
+        )
+    }
     print(f"\nDate-like fields: {json.dumps(date_fields, indent=2)}")
 
     print(f"\nlast_token from response: {result.get('last_token', '(none)')!r}")

--- a/scripts/probe_sold_at.py
+++ b/scripts/probe_sold_at.py
@@ -1,0 +1,60 @@
+"""One-shot probe: fetch one page from the Bandcamp fancollection API and print all
+field names present in the first item, plus the value of any date-like fields.
+
+Run from the repo root:
+    poetry run python scripts/probe_sold_at.py
+"""
+import json
+import time
+from pathlib import Path
+
+import requests
+
+from kamp_core.library import LibraryIndex
+
+DB_PATH = Path("~/.local/share/kamp/library.db").expanduser()
+COLLECTION_URL = "https://bandcamp.com/api/fancollection/1/collection_items"
+
+
+def main() -> None:
+    index = LibraryIndex(DB_PATH)
+    session_data = index.get_session("bandcamp")
+    if not session_data:
+        raise SystemExit("No Bandcamp session found — log in via the kamp app first.")
+
+    cookies_list = session_data.get("cookies", [])
+    cookies = {c["name"]: c["value"] for c in cookies_list if "bandcamp.com" in c.get("domain", "")}
+
+    fan_url = "https://bandcamp.com/api/fan/2/collection_summary"
+    r = requests.get(fan_url, cookies=cookies, timeout=10)
+    r.raise_for_status()
+    fan_id = r.json()["fan_id"]
+    print(f"fan_id: {fan_id}")
+
+    payload = {
+        "fan_id": fan_id,
+        "count": 2,
+        "older_than_token": f"{int(time.time())}:0:a::",
+    }
+    r2 = requests.post(COLLECTION_URL, json=payload, cookies=cookies, timeout=30)
+    r2.raise_for_status()
+    result = r2.json()
+
+    items = result.get("items", [])
+    if not items:
+        print("No items returned.")
+        return
+
+    item = items[0]
+    print(f"\nAll fields in first item ({len(items)} returned):")
+    for k, v in sorted(item.items()):
+        print(f"  {k!r}: {v!r}")
+
+    date_fields = {k: v for k, v in item.items() if any(w in k.lower() for w in ("date", "sold", "time", "added", "stamp", "purchased"))}
+    print(f"\nDate-like fields: {json.dumps(date_fields, indent=2)}")
+
+    print(f"\nlast_token from response: {result.get('last_token', '(none)')!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2392,6 +2392,26 @@ class TestSyncCollectionStream:
         assert call_kwargs["added_at"] == _parse_purchased(purchased_str)
         assert call_kwargs["added_at"] is not None
 
+    def test_calls_update_remote_track_date_added(self, tmp_path: Path) -> None:
+        """sync_collection_stream corrects existing remote tracks' date_added."""
+        purchased_str = "10 Jun 2023 08:00:00 GMT"
+        items = [_item(1, purchased=purchased_str)]
+        _result, index = self._run(tmp_path, items)
+
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        index.update_remote_track_date_added.assert_called_once_with(
+            "1", _parse_purchased(purchased_str)
+        )
+
+    def test_skips_update_when_purchased_missing(self, tmp_path: Path) -> None:
+        """Items without a purchased field don't call update_remote_track_date_added."""
+        item = _item(1)
+        item.pop("purchased")
+        _result, index = self._run(tmp_path, [item])
+
+        index.update_remote_track_date_added.assert_not_called()
+
 
 class TestStreamSyncArtPrefetch:
     """Art prefetch behaviour in sync_collection_stream."""
@@ -2521,8 +2541,8 @@ class TestFetchAlbumTracks:
         )
         assert all(t.stream_url is None for t in result)
 
-    def test_date_added_is_set(self) -> None:
-        """date_added is set to the current time so tracks sort correctly by date added."""
+    def test_date_added_defaults_to_current_time(self) -> None:
+        """Without an explicit date_added, tracks default to the current time."""
         before = time.time()
         html = _stream_album_page_html()
         result = fetch_album_tracks(
@@ -2531,6 +2551,19 @@ class TestFetchAlbumTracks:
         after = time.time()
         assert all(t.date_added is not None for t in result)
         assert all(before <= t.date_added <= after for t in result)  # type: ignore[operator]
+
+    def test_date_added_uses_provided_value(self) -> None:
+        """A caller-supplied date_added is used verbatim on every track."""
+        html = _stream_album_page_html()
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y",
+            1,
+            "B",
+            "A",
+            self._make_session(html),
+            date_added=12345.0,
+        )
+        assert all(t.date_added == 12345.0 for t in result)
 
     def test_file_path_contains_sale_item_id_and_track_num(self) -> None:
         tracks = [{"title": "T", "track_num": 3, "artist": None}]

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -84,6 +84,7 @@ def _item(
     title: str = "Album",
     item_url: str = "",
     tralbum_id: int = 0,
+    purchased: str = "01 Jan 2024 00:00:00 GMT",
 ) -> dict[str, Any]:
     return {
         "sale_item_type": "p",
@@ -93,6 +94,7 @@ def _item(
         "item_url": item_url
         or f"https://{band.lower().replace(' ', '')}.bandcamp.com/album/{title.lower().replace(' ', '-')}",
         "tralbum_id": tralbum_id or sale_item_id * 10,
+        "purchased": purchased,
     }
 
 
@@ -780,6 +782,65 @@ class TestSyncNewPurchases:
         )
         assert call_kwargs["tralbum_id"] == "42"
         assert call_kwargs["synced_at"] is None  # preserved via COALESCE
+
+    def test_passes_purchased_as_added_at_on_download(self, tmp_path: Path) -> None:
+        """Downloaded items get added_at set to the parsed purchase timestamp."""
+        purchased_str = "15 Mar 2025 10:00:00 GMT"
+        items = [_item(1, purchased=purchased_str)]
+        watch_folder = tmp_path / "watch"
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+
+        zip_path = watch_folder / "1.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.write_bytes(b"PK\x03\x04")
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session",
+                return_value=_make_requests_mock(items),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._download_item",
+                return_value=zip_path,
+            ),
+        ):
+            sync_new_purchases(_bc_config(tmp_path), watch_folder, index)
+
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        expected = _parse_purchased(purchased_str)
+        assert call_kwargs["added_at"] == expected
+        assert call_kwargs["added_at"] is not None
+
+    def test_passes_purchased_as_added_at_on_refresh(self, tmp_path: Path) -> None:
+        """Existing items refreshed during sync get added_at from the purchase date."""
+        purchased_str = "20 Feb 2023 12:00:00 GMT"
+        items = [_item(1, purchased=purchased_str)]
+        index = MagicMock()
+        index.get_collection_state.return_value = {"1": "local"}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session",
+                return_value=_make_requests_mock(items),
+            ),
+        ):
+            sync_new_purchases(_bc_config(tmp_path), tmp_path / "watch", index)
+
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        assert call_kwargs["added_at"] == _parse_purchased(purchased_str)
 
 
 # ---------------------------------------------------------------------------
@@ -1872,6 +1933,60 @@ class TestMarkCollectionSyncedStoresAlbumUrl:
 
 
 # ---------------------------------------------------------------------------
+# _parse_purchased
+# ---------------------------------------------------------------------------
+
+
+class TestParsePurchased:
+    def test_parses_gmt_string(self) -> None:
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        ts = _parse_purchased("01 Jan 2024 00:00:00 GMT")
+        assert ts is not None
+        assert abs(ts - 1704067200.0) < 2  # 2024-01-01 UTC
+
+    def test_returns_none_for_none(self) -> None:
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        assert _parse_purchased(None) is None
+
+    def test_returns_none_for_garbage(self) -> None:
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        assert _parse_purchased("not a date") is None
+
+
+# ---------------------------------------------------------------------------
+# mark_collection_synced — added_at suppression
+# ---------------------------------------------------------------------------
+
+
+class TestMarkCollectionSyncedAddedAt:
+    """mark_collection_synced must pass added_at=0 so items never appear as new arrivals."""
+
+    def test_passes_added_at_zero(self, tmp_path: Path) -> None:
+        config = _bc_config(tmp_path)
+        items = [_item(1, purchased="01 Jan 2024 00:00:00 GMT")]
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+        ):
+            mark_collection_synced(config, index)
+
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        assert call_kwargs["added_at"] == 0
+
+
+# ---------------------------------------------------------------------------
 # fetch_album_art_bytes
 # ---------------------------------------------------------------------------
 
@@ -2264,6 +2379,18 @@ class TestSyncCollectionStream:
             )
 
         assert fired == []
+
+    def test_passes_purchased_as_added_at(self, tmp_path: Path) -> None:
+        """sync_collection_stream passes the parsed purchase date as added_at."""
+        purchased_str = "10 Jun 2023 08:00:00 GMT"
+        items = [_item(1, purchased=purchased_str)]
+        _result, index = self._run(tmp_path, items)
+
+        call_kwargs = index.upsert_collection_item.call_args[1]
+        from kamp_daemon.bandcamp import _parse_purchased
+
+        assert call_kwargs["added_at"] == _parse_purchased(purchased_str)
+        assert call_kwargs["added_at"] is not None
 
 
 class TestStreamSyncArtPrefetch:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4108,6 +4108,63 @@ class TestBandcampCollection:
 
         assert row["added_at"] == 0.0
 
+    def test_update_remote_track_date_added_corrects_wrong_timestamp(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(Path("bandcamp://42/1"))
+        track.date_added = 9_999_999.0  # wrong sync-time timestamp
+        index.upsert_many([track])
+
+        index.update_remote_track_date_added("42", 100.0)
+
+        row = index._conn.execute(
+            "SELECT date_added FROM tracks WHERE file_path = 'bandcamp://42/1'"
+        ).fetchone()
+        index.close()
+
+        assert row["date_added"] == 100.0
+
+    def test_update_remote_track_date_added_does_not_overwrite_earlier_value(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(Path("bandcamp://43/1"))
+        track.date_added = 50.0  # already correct (earlier than new value)
+        index.upsert_many([track])
+
+        index.update_remote_track_date_added("43", 999_999.0)
+
+        row = index._conn.execute(
+            "SELECT date_added FROM tracks WHERE file_path = 'bandcamp://43/1'"
+        ).fetchone()
+        index.close()
+
+        assert row["date_added"] == 50.0
+
+    def test_update_remote_track_date_added_ignores_other_items(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(Path("bandcamp://10/1"))
+        t1.date_added = 9_999_999.0
+        t2 = _sample_track(Path("bandcamp://99/1"))
+        t2.date_added = 9_999_999.0
+        index.upsert_many([t1, t2])
+
+        index.update_remote_track_date_added("10", 1.0)
+
+        r1 = index._conn.execute(
+            "SELECT date_added FROM tracks WHERE file_path = 'bandcamp://10/1'"
+        ).fetchone()
+        r2 = index._conn.execute(
+            "SELECT date_added FROM tracks WHERE file_path = 'bandcamp://99/1'"
+        ).fetchone()
+        index.close()
+
+        assert r1["date_added"] == 1.0
+        assert r2["date_added"] == 9_999_999.0
+
     def test_get_remote_collection_filters_by_mode(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_collection_item("1", mode="local")

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4080,6 +4080,34 @@ class TestBandcampCollection:
 
         assert row["added_at"] == 500.0
 
+    def test_upsert_updates_added_at_when_new_value_is_earlier(
+        self, tmp_path: Path
+    ) -> None:
+        """ON CONFLICT takes MIN — a smaller added_at (real purchase date) replaces a
+        larger one (wrong sync-time timestamp), so existing users are self-correcting.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("8", mode="local", added_at=1_000_000.0)
+        index.upsert_collection_item("8", mode="local", added_at=100.0)
+        row = index._conn.execute(
+            "SELECT added_at FROM bandcamp_collection WHERE sale_item_id = '8'"
+        ).fetchone()
+        index.close()
+
+        assert row["added_at"] == 100.0
+
+    def test_upsert_preserves_zero_added_at_on_conflict(self, tmp_path: Path) -> None:
+        """added_at=0 (from mark_collection_synced) must survive subsequent syncs."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("9", mode="local", added_at=0.0)
+        index.upsert_collection_item("9", mode="local", added_at=9_999_999.0)
+        row = index._conn.execute(
+            "SELECT added_at FROM bandcamp_collection WHERE sale_item_id = '9'"
+        ).fetchone()
+        index.close()
+
+        assert row["added_at"] == 0.0
+
     def test_get_remote_collection_filters_by_mode(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_collection_item("1", mode="local")


### PR DESCRIPTION
## Summary

- On first sync, every album got `added_at = time.time()` (the sync moment), which falls inside the 5-day highlight window — causing the entire library to glow with new-arrival highlighting
- The Bandcamp `fancollection` API returns a `purchased` field (RFC 2822 date string) per item containing the actual purchase date (confirmed via live API probe)
- `mark_collection_synced` (the "I already have downloads" onboarding path) now passes `added_at=0` — permanently suppressed, since the user explicitly said they already own everything
- `sync_collection_stream` and `sync_new_purchases` now parse `purchased` → Unix timestamp via a new `_parse_purchased()` helper and pass it as `added_at`
- `upsert_collection_item` ON CONFLICT clause updated to `MIN(added_at, new_value)` — existing users with wrong sync-time timestamps are silently self-correcting on their next sync, no migration needed

## Test plan

- [ ] `TestParsePurchased` — helper parses valid GMT strings, returns None for None/garbage
- [ ] `TestMarkCollectionSyncedAddedAt` — asserts `added_at=0` passed through
- [ ] `TestSyncNewPurchases.test_passes_purchased_as_added_at_on_download` — download path passes purchase timestamp
- [ ] `TestSyncNewPurchases.test_passes_purchased_as_added_at_on_refresh` — refresh loop passes purchase timestamp
- [ ] `TestSyncCollectionStream.test_passes_purchased_as_added_at` — stream path passes purchase timestamp
- [ ] `TestBandcampCollection.test_upsert_updates_added_at_when_new_value_is_earlier` — MIN correction works
- [ ] `TestBandcampCollection.test_upsert_preserves_zero_added_at_on_conflict` — `added_at=0` survives subsequent syncs
- [ ] Manual: fresh stream sync shows no albums glowing; a row manually backdated to `time.time()` in SQLite glows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)