### PR TITLE
fix(KAMP-407,KAMP-409): restore bandcamp:// URIs in TrackOut and record methods

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1544,7 +1544,7 @@ class LibraryIndex:
 
         self._conn.execute(
             "UPDATE tracks SET last_played = ? WHERE file_path = ?",
-            (time.time(), str(file_path)),
+            (time.time(), _canonical_track_key(file_path)),
         )
         self._conn.commit()
 
@@ -1556,7 +1556,7 @@ class LibraryIndex:
         """
         self._conn.execute(
             "UPDATE tracks SET play_count = play_count + 1 WHERE file_path = ?",
-            (str(file_path),),
+            (_canonical_track_key(file_path),),
         )
         self._conn.commit()
 
@@ -1572,6 +1572,43 @@ class LibraryIndex:
             (int(favorite), key),
         )
         self._conn.commit()
+
+    def inherit_remote_favorites(self, new_tracks: "list[Track]") -> None:
+        """Copy the favorite flag from a matching remote bandcamp:// row to each
+        newly-added local track, if the remote version was favorited.
+
+        Called by LibraryScanner after upserting newly-scanned local files so
+        that favorites set on streaming tracks are not lost when an album is
+        downloaded.  Matches by (album_artist, album, track_number, disc_number).
+        Only updates rows where the local track has favorite=0 to avoid clearing
+        a flag the user explicitly set on the local file.
+        """
+        for t in new_tracks:
+            self._conn.execute(
+                """
+                UPDATE tracks SET favorite = 1
+                WHERE file_path = ?
+                  AND favorite = 0
+                  AND EXISTS (
+                      SELECT 1 FROM tracks r
+                      WHERE r.album_artist = ?
+                        AND r.album = ?
+                        AND r.track_number = ?
+                        AND r.disc_number = ?
+                        AND r.file_path LIKE 'bandcamp://%'
+                        AND r.favorite = 1
+                  )
+                """,
+                (
+                    str(t.file_path),
+                    t.album_artist,
+                    t.album,
+                    t.track_number,
+                    t.disc_number,
+                ),
+            )
+        if new_tracks:
+            self._conn.commit()
 
     def update_album_meta(
         self,
@@ -2874,6 +2911,8 @@ class LibraryScanner:
         self._index.upsert_many(upsert_subset)
 
         newly_added = [t for t in upsert_subset if t.file_path in to_add]
+        if newly_added:
+            self._index.inherit_remote_favorites(newly_added)
         added = len(newly_added) + len(reconciled_new_paths)
         updated = len([t for t in upsert_subset if t.file_path in to_update])
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -40,7 +40,13 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-from kamp_core.library import LibraryIndex, LibraryScanner, Track, extract_art
+from kamp_core.library import (
+    LibraryIndex,
+    LibraryScanner,
+    Track,
+    _canonical_track_key,
+    extract_art,
+)
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
 # ---------------------------------------------------------------------------
@@ -150,7 +156,7 @@ class TrackOut(BaseModel):
             year=t.year,
             track_number=t.track_number,
             disc_number=t.disc_number,
-            file_path=str(t.file_path),
+            file_path=_canonical_track_key(t.file_path),
             ext=t.ext,
             embedded_art=t.embedded_art,
             mb_release_id=t.mb_release_id,

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1028,6 +1028,57 @@ class TestLibraryScanner:
         assert len(tracks) == 1
         assert tracks[0].embedded_art is False
 
+    def test_scan_inherits_favorite_from_remote_track(self, tmp_path: Path) -> None:
+        """A newly-scanned local file inherits the favorite flag from a matching
+        bandcamp:// row (same album_artist, album, track_number, disc_number).
+        This preserves favorites set on streaming tracks after an album download.
+        """
+        lib = tmp_path / "music"
+        lib.mkdir()
+
+        index = LibraryIndex(tmp_path / "library.db")
+        # Seed a remote track that has been favorited.
+        remote_uri = "bandcamp://999/3"
+        index.upsert_many(
+            [
+                Track(
+                    file_path=Path(remote_uri),
+                    title="Remote",
+                    artist="The Artist",
+                    album_artist="The Artist",
+                    album="Great Album",
+                    year="2020",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+        index.set_favorite(remote_uri, True)
+
+        # Scan in a local file with matching album metadata.
+        _make_mp3(
+            lib / "01.mp3",
+            artist="The Artist",
+            album_artist="The Artist",
+            album="Great Album",
+            year="2020",
+            title="Remote",
+            track="1",
+            disc="1",
+        )
+        LibraryScanner(index).scan(lib)
+
+        local_track = index.get_track_by_path(lib / "01.mp3")
+        index.close()
+
+        assert local_track is not None
+        assert local_track.favorite is True
+
 
 # ---------------------------------------------------------------------------
 # Tag reader helpers
@@ -1699,6 +1750,37 @@ class TestRecordPlayed:
         assert track is not None
         assert track.play_count == 2
 
+    def test_record_played_remote_track(self, tmp_path: Path) -> None:
+        """record_played must work for bandcamp:// URIs (POSIX Path collapses // to /)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        remote_uri = "bandcamp://999/3"
+        index.upsert_many(
+            [
+                Track(
+                    file_path=Path(remote_uri),
+                    title="Remote",
+                    artist="A",
+                    album_artist="A",
+                    album="B",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+
+        index.record_played(Path(remote_uri))
+
+        track = index.get_track_by_path(remote_uri)
+        index.close()
+        assert track is not None
+        assert track.play_count == 1
+
     def test_migration_v4_to_v5_adds_play_count_column(self, tmp_path: Path) -> None:
         """Existing v4 databases gain the play_count column on open."""
         import sqlite3 as _sqlite3
@@ -1819,6 +1901,42 @@ class TestRecordTrackStarted:
         index = LibraryIndex(tmp_path / "library.db")
         index.record_track_started(tmp_path / "ghost.mp3")  # must not raise
         index.close()
+
+    def test_record_track_started_remote_track(self, tmp_path: Path) -> None:
+        """record_track_started must work for bandcamp:// URIs."""
+        import time
+
+        index = LibraryIndex(tmp_path / "library.db")
+        remote_uri = "bandcamp://999/3"
+        index.upsert_many(
+            [
+                Track(
+                    file_path=Path(remote_uri),
+                    title="Remote",
+                    artist="A",
+                    album_artist="A",
+                    album="B",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+
+        before = time.time()
+        index.record_track_started(Path(remote_uri))
+        after = time.time()
+
+        track = index.get_track_by_path(remote_uri)
+        index.close()
+        assert track is not None
+        assert track.last_played is not None
+        assert before <= track.last_played <= after
 
     def test_last_played_sort_reflects_record_track_started(
         self, tmp_path: Path

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 
 from kamp_core.library import AlbumInfo, Track
 from kamp_core.playback import PlaybackState
-from kamp_core.server import create_app, resolve_playback_uri
+from kamp_core.server import TrackOut, create_app, resolve_playback_uri
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1717,6 +1717,41 @@ class TestFavoriteEndpoint:
         )
         assert "play_count" in track
         assert track["play_count"] == 0
+
+    def test_track_out_preserves_remote_uri_double_slash(self) -> None:
+        # Path("bandcamp://999/3") on POSIX collapses // to /.  TrackOut must
+        # reconstruct the canonical double-slash form so clients can round-trip
+        # the URI back to the server correctly.
+        t = _track(1)
+        t.file_path = Path("bandcamp://999/3")
+        out = TrackOut.from_track(t)
+        assert out.file_path == "bandcamp://999/3"
+
+    def test_set_favorite_remote_track(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        remote_uri = "bandcamp://999/3"
+        mock_index.get_track_by_path.return_value = _track(1)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite",
+            json={"file_path": remote_uri, "favorite": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        mock_index.set_favorite.assert_called_once_with(remote_uri, True)
+        mock_queue.update_favorite.assert_called_once_with(remote_uri, True)
+
+    def test_set_favorite_remote_track_returns_404_when_not_found(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_track_by_path.return_value = None
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite",
+            json={"file_path": "bandcamp://999/3", "favorite": True},
+        )
+        assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `str(Path("bandcamp://x"))` on POSIX collapses `//` to `/`, so SQL `WHERE file_path = ?` matched 0 rows for remote tracks — silently breaking favorites, play count, and last-played for all Bandcamp streaming tracks.
- **Fix 1** (`server.py`): `TrackOut.from_track` now uses `_canonical_track_key(t.file_path)` instead of `str(t.file_path)`, so the client always receives and round-trips the correct `bandcamp://` URI.
- **Fix 2 + 3** (`library.py`): `record_track_started` and `record_played` use `_canonical_track_key(file_path)` in their SQL bindings.
- **Fix 4** (`library.py`): New `LibraryIndex.inherit_remote_favorites()` method — called by `LibraryScanner.scan()` after upserting newly-added local files — copies the `favorite` flag from any matching `bandcamp://` row (matched by album + track_number + disc_number), so favorites set on streaming tracks survive an album download.

## Test plan

- [ ] \`test_track_out_preserves_remote_uri_double_slash\` — \`TrackOut.from_track\` returns canonical \`bandcamp://\` URI
- [ ] \`test_set_favorite_remote_track\` — POST \`/api/v1/tracks/favorite\` with \`bandcamp://\` URI returns 200
- [ ] \`test_record_played_remote_track\` — \`play_count\` increments for remote track
- [ ] \`test_record_track_started_remote_track\` — \`last_played\` is set for remote track
- [ ] \`test_scan_inherits_favorite_from_remote_track\` — scan picks up \`favorite=True\` from matching remote row

Full suite: 1699 passed, coverage 93.22 %.

Closes KAMP-407, KAMP-409

🤖 Generated with [Claude Code](https://claude.ai/claude-code)