### PR TITLE
feat(KAMP-398): keep Bandcamp icon in status rail after logout

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2353,6 +2353,7 @@ def create_app(
             if session:
                 _state["config"]["bandcamp.connected"] = True
                 _state["config"]["bandcamp.username"] = session.get("username")
+                _state["config"]["bandcamp.ever_connected"] = True
         _broadcast({"type": "bandcamp.login-complete"})
         return {"ok": True}
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -803,6 +803,7 @@ def _cmd_daemon(
     def _on_bandcamp_login_complete(payload: dict[str, object]) -> None:
         session_data: dict[str, Any] = dict(payload)
         index.set_session("bandcamp", session_data)
+        index.set_setting("bandcamp.ever_connected", "true")
         _logger.info("Bandcamp session saved from Electron login flow.")
         # Extract username immediately so the UI can show "Connected as {username}".
         # Primary source: the logout cookie (URL-encoded JSON, always present after
@@ -884,6 +885,7 @@ def _cmd_daemon(
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")
     _bc_username: str | None = _bc_session.get("username") if _bc_session else None
+    _bc_ever_connected = index.get_setting("bandcamp.ever_connected") == "true"
     _config_values: dict[str, object] = {
         "paths.watch_folder": (
             str(config.paths.watch_folder) if config.paths.watch_folder else None
@@ -895,6 +897,7 @@ def _cmd_daemon(
         "library.path_template": config.library.path_template,
         "bandcamp.connected": _bc_session is not None,
         "bandcamp.username": _bc_username,
+        "bandcamp.ever_connected": _bc_ever_connected,
         "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
         "bandcamp.poll_interval_minutes": (
             config.bandcamp.poll_interval_minutes if config.bandcamp else None

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -237,6 +237,7 @@ export type ConfigValues = {
   'library.path_template': string | null
   'bandcamp.connected': boolean | null
   'bandcamp.username': string | null
+  'bandcamp.ever_connected': boolean | null
   'bandcamp.format': string | null
   'bandcamp.poll_interval_minutes': number | null
   'bandcamp.collection_mode': string | null

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -228,6 +228,12 @@ html[data-platform='win32'] .view-tabs {
   animation: bandcamp-pulse 1.4s ease-in-out infinite;
 }
 
+.bandcamp-btn--disconnected svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
 .pipeline-indicator {
   display: flex;
   align-items: center;

--- a/kamp_ui/src/renderer/src/components/BandcampButton.tsx
+++ b/kamp_ui/src/renderer/src/components/BandcampButton.tsx
@@ -7,6 +7,7 @@ import { useMenuBounds } from '../hooks/useMenuBounds'
 export function BandcampButton(): React.JSX.Element | null {
   const configValues = useStore((s) => s.configValues)
   const openPrefs = useStore((s) => s.openPrefs)
+  const loadConfig = useStore((s) => s.loadConfig)
   const [syncState, setSyncState] = useState<'idle' | 'syncing'>('idle')
   const [menuOpen, setMenuOpen] = useState(false)
   const anchorRef = useRef<HTMLDivElement>(null)
@@ -40,7 +41,12 @@ export function BandcampButton(): React.JSX.Element | null {
       <div className="bandcamp-btn-anchor">
         <button
           className="bandcamp-btn bandcamp-btn--disconnected"
-          onClick={() => window.api.bandcamp.beginLogin().catch(console.error)}
+          onClick={() =>
+            window.api.bandcamp
+              .beginLogin()
+              .then(({ ok }) => { if (ok) loadConfig() })
+              .catch(console.error)
+          }
           {...tooltip(TOOLTIPS.BANDCAMP_RECONNECT)}
         >
           <svg viewBox="0 0 24 24" width="20" height="20">

--- a/kamp_ui/src/renderer/src/components/BandcampButton.tsx
+++ b/kamp_ui/src/renderer/src/components/BandcampButton.tsx
@@ -30,7 +30,26 @@ export function BandcampButton(): React.JSX.Element | null {
     return () => document.removeEventListener('mousedown', handler)
   }, [menuOpen])
 
-  if (!configValues?.['bandcamp.connected']) return null
+  const connected = configValues?.['bandcamp.connected'] ?? false
+  const everConnected = configValues?.['bandcamp.ever_connected'] ?? false
+
+  if (!connected && !everConnected) return null
+
+  if (!connected) {
+    return (
+      <div className="bandcamp-btn-anchor">
+        <button
+          className="bandcamp-btn bandcamp-btn--disconnected"
+          onClick={() => window.api.bandcamp.beginLogin().catch(console.error)}
+          {...tooltip(TOOLTIPS.BANDCAMP_RECONNECT)}
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20">
+            <path d="M0 18.75l7.437-13.5H24L16.563 18.75z" />
+          </svg>
+        </button>
+      </div>
+    )
+  }
 
   const handleClick = (): void => {
     window.api.bandcamp.triggerSync().catch(console.error)

--- a/kamp_ui/src/renderer/src/components/BandcampButton.tsx
+++ b/kamp_ui/src/renderer/src/components/BandcampButton.tsx
@@ -44,7 +44,9 @@ export function BandcampButton(): React.JSX.Element | null {
           onClick={() =>
             window.api.bandcamp
               .beginLogin()
-              .then(({ ok }) => { if (ok) loadConfig() })
+              .then(({ ok }) => {
+                if (ok) loadConfig()
+              })
               .catch(console.error)
           }
           {...tooltip(TOOLTIPS.BANDCAMP_RECONNECT)}

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -34,6 +34,7 @@ export const TOOLTIPS = {
   // Bandcamp
   BANDCAMP_SYNC: 'Sync Bandcamp library',
   BANDCAMP_SYNCING: 'Bandcamp sync in progress…',
+  BANDCAMP_RECONNECT: 'Log in to Bandcamp',
 
   // Search
   SEARCH_CLEAR: 'Clear search',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2127,7 +2127,11 @@ class TestBandcampStatus:
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            config_values={"bandcamp.connected": True, "bandcamp.username": "johndoe"},
+            config_values={
+                "bandcamp.connected": True,
+                "bandcamp.username": "johndoe",
+                "bandcamp.ever_connected": True,
+            },
             on_bandcamp_disconnect=lambda: None,
         )
         c = TestClient(app)
@@ -2135,6 +2139,7 @@ class TestBandcampStatus:
         data = c.get("/api/v1/config").json()
         assert data["bandcamp.connected"] is False
         assert data["bandcamp.username"] is None
+        assert data["bandcamp.ever_connected"] is True
 
     def test_login_complete_sets_bandcamp_connected(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2146,7 +2151,11 @@ class TestBandcampStatus:
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            config_values={"bandcamp.connected": False, "bandcamp.username": None},
+            config_values={
+                "bandcamp.connected": False,
+                "bandcamp.username": None,
+                "bandcamp.ever_connected": False,
+            },
             on_bandcamp_login_complete=lambda payload: None,
             get_bandcamp_session=lambda: session,
         )
@@ -2157,6 +2166,7 @@ class TestBandcampStatus:
         )
         data = c.get("/api/v1/config").json()
         assert data["bandcamp.connected"] is True
+        assert data["bandcamp.ever_connected"] is True
 
     def test_login_complete_sets_username_when_available(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2167,7 +2177,11 @@ class TestBandcampStatus:
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            config_values={"bandcamp.connected": False, "bandcamp.username": None},
+            config_values={
+                "bandcamp.connected": False,
+                "bandcamp.username": None,
+                "bandcamp.ever_connected": False,
+            },
             on_bandcamp_login_complete=lambda payload: None,
             get_bandcamp_session=lambda: session,
         )
@@ -2179,6 +2193,7 @@ class TestBandcampStatus:
         data = c.get("/api/v1/config").json()
         assert data["bandcamp.connected"] is True
         assert data["bandcamp.username"] == "johndoe"
+        assert data["bandcamp.ever_connected"] is True
 
     def test_login_complete_accepts_full_electron_cookie_shape(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

- Persists a `bandcamp.ever_connected` flag to the `settings` DB table on first login — survives explicit logouts so "never connected" can be distinguished from "disconnected"
- When disconnected but ever-connected: renders an outline Bandcamp icon in the status rail; clicking it opens the Bandcamp login window directly via `beginLogin()`
- After successful login, calls `loadConfig()` so the UI transitions from outline to filled icon immediately without a restart
- Connected state: existing filled icon + sync behavior is unchanged; disconnect does not clear the `ever_connected` flag

## Test plan

- [x] Fresh daemon (no prior session) → no icon in status rail
- [x] Log in via Preferences > Services → filled icon appears
- [x] Quit and restart daemon → filled icon still present
- [x] Log out via Preferences > Services → outline icon appears
- [x] Hover outline icon → tooltip reads "Log in to Bandcamp"
- [x] Click outline icon → login window opens; on success icon becomes filled immediately (no restart required)
- [x] Sync still works from filled icon; context menu still opens

Closes KAMP-398

🤖 Generated with [Claude Code](https://claude.com/claude-code)