### PR TITLE
feat(KAMP-406): gapless playback for remote (Bandcamp streaming) tracks

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -983,6 +983,13 @@ class MpvPlaybackEngine:
         # Path of the track pre-appended to mpv's playlist as a gapless lookahead.
         # None means mpv's playlist has only the current track (slot 0).
         self._lookahead_path: Path | None = None
+        # CDN URL for a remote-track lookahead; mutually exclusive with
+        # _lookahead_path (a track is either local or remote, never both).
+        self._lookahead_url: str | None = None
+        # Track ID of the track registered in the lookahead slot.  Set eagerly
+        # by preload_next() — before the URL is fetched — so preload_next_url()
+        # can reject stale pre-fetch results after a queue change.
+        self._lookahead_id: int | None = None
         self._start_mpv()
 
     def _start_mpv(self) -> None:  # pragma: no cover
@@ -1167,6 +1174,8 @@ class MpvPlaybackEngine:
         logger.info("engine.play: loading %s", path)
         with self._lock:
             self._lookahead_path = None
+            self._lookahead_url = None
+            self._lookahead_id = None
             self.state.position = 0.0
             self.state.duration = 0.0
             self._send_command("loadfile", str(path), "replace")
@@ -1189,6 +1198,8 @@ class MpvPlaybackEngine:
         self._pending_seek = position if position > 0 else None
         with self._lock:
             self._lookahead_path = None
+            self._lookahead_url = None
+            self._lookahead_id = None
             self.state.position = 0.0
             self.state.duration = 0.0
             self._send_command("loadfile", str(path), "replace")
@@ -1211,21 +1222,29 @@ class MpvPlaybackEngine:
         _lookahead_path mutation, and the playlist-remove/loadfile send happen
         atomically with respect to a concurrent end-file/eof handler.
         """
-        # Remote tracks: CDN URL is resolved by _resolve_playback on EOF;
+        # Remote tracks: CDN URL is resolved asynchronously by preload_next_url();
         # passing the raw bandcamp: URI to mpv would silently fail.
         path = (
             None
             if (next_track is None or next_track.is_remote)
             else next_track.file_path
         )
+        next_id = next_track.id if next_track is not None else None
         with self._lock:
-            if path == self._lookahead_path:
+            # Idempotent: no-op when the registered lookahead track hasn't changed.
+            # For remote tracks path is always None, so _lookahead_id distinguishes
+            # "same remote track" from "different remote track in the lookahead slot."
+            if path == self._lookahead_path and next_id == self._lookahead_id:
                 return
-            if self._lookahead_path is not None:
+            if self._lookahead_path is not None or self._lookahead_url is not None:
                 self._lookahead_path = (
                     None  # clear before sending remove (see docstring)
                 )
+                self._lookahead_url = None
                 self._send_command("playlist-remove", 1)
+            # Register the incoming track eagerly so preload_next_url() can reject
+            # stale pre-fetch results that arrive after a subsequent queue change.
+            self._lookahead_id = next_id
             if path is not None:
                 # Skip the append when we're within the gapless danger window.
                 # mpv would trigger an immediate EOF transition the moment the
@@ -1240,10 +1259,34 @@ class MpvPlaybackEngine:
                 self._send_command("loadfile", str(path), "append")
                 self._lookahead_path = path
 
+    def preload_next_url(self, url: str, track_id: int) -> None:
+        """Pre-load a CDN URL into mpv's slot-1 for gapless remote-track playback.
+
+        Called from a background thread once the CDN URL for the next remote
+        track has been resolved.  Discards stale results whose track_id no
+        longer matches the registered lookahead track (i.e. the queue changed
+        while the pre-fetch was in flight).
+        """
+        with self._lock:
+            if self._lookahead_id != track_id:
+                return  # queue changed while pre-fetch was in flight
+            if url == self._lookahead_url:
+                return
+            if self._lookahead_url is not None:
+                self._lookahead_url = None
+                self._send_command("playlist-remove", 1)
+            if (
+                self.state.duration > 0
+                and self.state.position > self.state.duration - _GAPLESS_GUARD_SECS
+            ):
+                return
+            self._send_command("loadfile", url, "append")
+            self._lookahead_url = url
+
     @property
     def has_lookahead(self) -> bool:
         """True when a next-track is pre-appended to mpv's playlist."""
-        return self._lookahead_path is not None
+        return self._lookahead_path is not None or self._lookahead_url is not None
 
     def pause(self) -> None:
         self._send_command("set_property", "pause", True)
@@ -1267,11 +1310,13 @@ class MpvPlaybackEngine:
             # no gapless risk — removing the lookahead there breaks gapless at
             # the track's natural EOF without any benefit (KAMP-261 / KAMP-276).
             if (
-                self._lookahead_path is not None
+                (self._lookahead_path is not None or self._lookahead_url is not None)
                 and self.state.duration > 0
                 and position > self.state.duration - _GAPLESS_GUARD_SECS
             ):
                 self._lookahead_path = None
+                self._lookahead_url = None
+                self._lookahead_id = None
                 self._send_command("playlist-remove", 1)
         self._send_command("seek", position, "absolute")
 
@@ -1397,7 +1442,10 @@ class MpvPlaybackEngine:
                 # slow callback (e.g. Last.fm scrobble) cannot block FastAPI
                 # threads on seek/pause/resume (KAMP-284).
                 with self._lock:
-                    had_lookahead = self._lookahead_path is not None
+                    had_lookahead = (
+                        self._lookahead_path is not None
+                        or self._lookahead_url is not None
+                    )
                     if had_lookahead:
                         # When a lookahead was present, mpv already transitioned
                         # gaplessly and the finished entry sits at slot 0.
@@ -1415,6 +1463,8 @@ class MpvPlaybackEngine:
                         self.state.position = 0.0
                         self.state.duration = 0.0
                     self._lookahead_path = None
+                    self._lookahead_url = None
+                    self._lookahead_id = None
                 logger.info("eof: had_lookahead=%s firing on_track_end", had_lookahead)
                 # had_lookahead tells the callback whether mpv already advanced
                 # so it can skip calling engine.play(next_path) — calling play()

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -703,10 +703,27 @@ def _cmd_daemon(
 
     engine.on_track_end = _on_track_end
 
+    def _prefetch_remote_lookahead(nxt: Track) -> None:
+        """Resolve a CDN URL for *nxt* and wire it into mpv's slot-1 lookahead.
+
+        Runs on a daemon thread so the HTTP request (album page scrape) does not
+        block the mpv reader thread.  preload_next_url() rejects stale results
+        automatically if the queue has changed by the time the fetch completes.
+        """
+        url = resolve_playback_uri(nxt, index, _refresh_stream_url)
+        if url.startswith("https://"):
+            engine.preload_next_url(url, nxt.id)
+
     def _on_file_loaded() -> None:
         # Prime or refresh the gapless lookahead whenever a new file starts.
-        # Now Playing updates are driven by Electron WebSocket subscription.
-        engine.preload_next(queue.peek_next())
+        # For remote tracks, spawn a thread to resolve the CDN URL so the HTTP
+        # request doesn't block the mpv reader thread.
+        nxt = queue.peek_next()
+        engine.preload_next(nxt)
+        if nxt is not None and nxt.is_remote:
+            threading.Thread(
+                target=_prefetch_remote_lookahead, args=(nxt,), daemon=True
+            ).start()
 
     engine.on_file_loaded = _on_file_loaded
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1708,9 +1708,10 @@ class TestMpvPlaybackEngine:
         engine.preload_next(_track(2))
         send.assert_called_once_with("loadfile", str(_track(2).file_path), "append")
 
-    def test_preload_next_skips_remote_track(self) -> None:
-        """Remote next-tracks must never be preloaded — their bandcamp: URI
-        cannot be opened by mpv; CDN URL is resolved on EOF instead."""
+    def test_preload_next_skips_remote_track_ipc(self) -> None:
+        """preload_next must not send any IPC command for a remote next-track —
+        the bandcamp: URI cannot be opened by mpv.  CDN URL resolution happens
+        asynchronously via preload_next_url()."""
         engine, send = _make_engine()
         engine.preload_next(_remote_track())
         send.assert_not_called()
@@ -1823,6 +1824,171 @@ class TestMpvPlaybackEngine:
         engine.on_track_end = lambda _: observed.append(engine.has_lookahead)
         engine._handle_event({"event": "end-file", "reason": "eof"})
         assert observed == [False]
+
+    # ------------------------------------------------------------------
+    # preload_next_url / remote-track gapless lookahead
+    # ------------------------------------------------------------------
+
+    def test_preload_next_registers_lookahead_id_for_remote_track(self) -> None:
+        """preload_next with a remote next-track eagerly sets _lookahead_id so
+        preload_next_url() can validate its result, but does NOT send any IPC
+        command (URL resolution happens asynchronously)."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        send.assert_not_called()
+        assert engine._lookahead_path is None
+        assert engine._lookahead_url is None
+        assert engine._lookahead_id == remote.id
+
+    def test_preload_next_replaces_url_lookahead_when_switching_to_local(self) -> None:
+        """Switching the lookahead from a remote track (URL-based) to a local
+        track (path-based) must evict the old URL from mpv's slot-1."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        local = _track(3)
+
+        # Wire URL-based lookahead for the remote track.
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/a.mp3", remote.id)
+        send.reset_mock()
+
+        # Queue changes: next track is now local.  Old URL must be removed.
+        engine.preload_next(local)
+        assert send.call_args_list == [
+            call("playlist-remove", 1),
+            call("loadfile", str(local.file_path), "append"),
+        ]
+        assert engine._lookahead_url is None
+        assert engine._lookahead_path == local.file_path
+
+    def test_preload_next_clears_url_lookahead_when_queue_exhausted(self) -> None:
+        """preload_next(None) must evict a URL-based lookahead when the queue
+        runs out of tracks."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/a.mp3", remote.id)
+        send.reset_mock()
+
+        engine.preload_next(None)
+        send.assert_called_once_with("playlist-remove", 1)
+        assert engine._lookahead_url is None
+        assert engine._lookahead_id is None
+
+    def test_preload_next_url_sends_loadfile_append(self) -> None:
+        """preload_next_url must call loadfile append with the CDN URL."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        send.reset_mock()
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        send.assert_called_once_with(
+            "loadfile", "https://cdn.example.com/track.mp3", "append"
+        )
+
+    def test_preload_next_url_sets_lookahead_url(self) -> None:
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        assert engine._lookahead_url == "https://cdn.example.com/track.mp3"
+
+    def test_has_lookahead_true_after_preload_next_url(self) -> None:
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        assert engine.has_lookahead is True
+
+    def test_preload_next_url_ignored_when_track_id_mismatch(self) -> None:
+        """Stale pre-fetch results (track changed after fetch started) are silently
+        discarded based on the registered _lookahead_id."""
+        engine, send = _make_engine()
+        engine._lookahead_id = 99  # registered for track 99
+        engine.preload_next_url("https://cdn.example.com/stale.mp3", 77)  # wrong id
+        send.assert_not_called()
+        assert engine._lookahead_url is None
+
+    def test_preload_next_url_skips_append_within_guard_window(self) -> None:
+        """URL pre-fetch arriving within the gapless danger window must not be
+        appended — mpv would trigger an immediate EOF transition."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.state.duration = 180.0
+        engine.state.position = 172.0  # 8 s from end
+        send.reset_mock()
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        send.assert_not_called()
+        assert engine._lookahead_url is None
+
+    def test_preload_next_url_is_noop_for_same_url(self) -> None:
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        url = "https://cdn.example.com/track.mp3"
+        engine.preload_next_url(url, remote.id)
+        send.reset_mock()
+        engine.preload_next_url(url, remote.id)
+        send.assert_not_called()
+
+    def test_seek_into_guard_window_removes_url_lookahead(self) -> None:
+        """seek() must remove a URL-based lookahead when the target is within
+        the gapless guard window, just as it does for path-based lookaheads."""
+        engine, send = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        engine.state.duration = 180.0
+        engine.state.position = 60.0
+        send.reset_mock()
+        engine.seek(172.0)  # within guard window
+        assert engine._lookahead_url is None
+        assert engine._lookahead_path is None
+        assert engine._lookahead_id is None
+        assert send.call_args_list[0] == call("playlist-remove", 1)
+
+    def test_end_file_clears_url_lookahead(self) -> None:
+        """end-file/eof must clear _lookahead_url so has_lookahead reads False."""
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert engine._lookahead_url is None
+        assert engine._lookahead_id is None
+        assert engine.has_lookahead is False
+
+    def test_end_file_had_lookahead_true_for_url_lookahead(self) -> None:
+        """Gapless transition via URL-based lookahead: on_track_end receives
+        had_lookahead=True so the queue advances without an extra engine.play()."""
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        observed: list[bool] = []
+        engine.on_track_end = lambda had_lookahead: observed.append(had_lookahead)
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        assert observed == [True]
+
+    def test_play_clears_url_lookahead(self) -> None:
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        engine.play(Path("/music/01.mp3"))
+        assert engine._lookahead_url is None
+        assert engine._lookahead_id is None
+
+    def test_load_paused_clears_url_lookahead(self) -> None:
+        engine, _ = _make_engine()
+        remote = _remote_track()
+        engine.preload_next(remote)
+        engine.preload_next_url("https://cdn.example.com/track.mp3", remote.id)
+        engine.load_paused(Path("/music/01.mp3"))
+        assert engine._lookahead_url is None
+        assert engine._lookahead_id is None
 
     def test_handle_event_pause_with_non_bool_data_is_ignored(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- Extends `MpvPlaybackEngine` with `_lookahead_url: str | None` and `_lookahead_id: int | None` to track URL-based lookahead entries alongside the existing path-based `_lookahead_path`
- Adds `preload_next_url(url, track_id)` method that appends a CDN HTTPS URL to mpv's slot-1 under the same `_lock` contract as `preload_next()` — includes the gapless guard window check and stale-result rejection via `_lookahead_id` 
- In `kamp_daemon/__main__.py`, `_on_file_loaded` now spawns a daemon thread (`_prefetch_remote_lookahead`) that resolves the CDN URL for the next remote track via `resolve_playback_uri()` and calls `engine.preload_next_url()` — Bandcamp CDN URLs have a ~24h TTL so the pre-fetched URL will not expire before mpv uses it
- All lookahead-touching methods (`seek`, `play`, `load_paused`, `end-file/eof` handler, `preload_next`) updated to handle URL-based lookahead consistently

## Test plan

- [x] 196 playback tests pass, including 14 new tests covering: `preload_next_url` IPC behavior, guard window, stale-ID rejection, `has_lookahead` via URL, `seek()` guard with URL lookahead, EOF clearing, gapless transition (`had_lookahead=True`), `play()`/`load_paused()` clearing
- [x] Full suite: 1713 passed, coverage 93.21%
- [x] mypy clean, black clean
- [x] **Manual verification needed**: Play the Dagmar Zuniga album (`dagmarzuniga.bandcamp.com/album/...`) and confirm no audible gap between remote tracks; seek to last 10 s and confirm normal transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)