### PR TITLE
fix(KAMP-392): extrapolate progress bar position when mpv time-pos events stall

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -42,6 +42,11 @@ class PlaybackState:
     position: float = 0.0
     duration: float = 0.0
     volume: int = 100
+    # Wall-clock time of the last time-pos event from mpv. Used by
+    # _state_snapshot() to extrapolate position when events stall (e.g.
+    # after seeking near EOF of an HTTP stream: mpv drains its audio
+    # buffer while the demuxer is already at EOF and stops emitting events).
+    position_updated_at: float = field(default_factory=time.time, compare=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1178,6 +1183,7 @@ class MpvPlaybackEngine:
             self._lookahead_id = None
             self.state.position = 0.0
             self.state.duration = 0.0
+            self.state.position_updated_at = time.time()
             self._send_command("loadfile", str(path), "replace")
         # Pause-toggle is unrelated to the lookahead slot; send outside the lock.
         self._send_command("set_property", "pause", False)
@@ -1202,6 +1208,7 @@ class MpvPlaybackEngine:
             self._lookahead_id = None
             self.state.position = 0.0
             self.state.duration = 0.0
+            self.state.position_updated_at = time.time()
             self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
 
@@ -1409,6 +1416,7 @@ class MpvPlaybackEngine:
             data = event.get("data")
             if prop == "time-pos" and isinstance(data, (int, float)):
                 self.state.position = float(data)
+                self.state.position_updated_at = time.time()
             elif prop == "duration" and isinstance(data, (int, float)):
                 self.state.duration = float(data)
             elif prop == "pause" and isinstance(data, bool):
@@ -1424,6 +1432,7 @@ class MpvPlaybackEngine:
             # not fire on the new file-loaded event and block the lookahead re-arm.
             self.state.position = 0.0
             self.state.duration = 0.0
+            self.state.position_updated_at = time.time()
             if self._pending_seek is not None:
                 self.seek(self._pending_seek)
                 self._pending_seek = None
@@ -1462,6 +1471,7 @@ class MpvPlaybackEngine:
                         # the new track at 0:00 instead of a stale position.
                         self.state.position = 0.0
                         self.state.duration = 0.0
+                        self.state.position_updated_at = time.time()
                     self._lookahead_path = None
                     self._lookahead_url = None
                     self._lookahead_id = None

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -794,11 +794,27 @@ def create_app(
     )
 
     def _state_snapshot() -> PlayerStateOut:
+        import time as _t
+
         current = queue.current()
         nxt = queue.peek_next()
+        pos = engine.state.position
+        # When mpv stops emitting time-pos events (e.g. after seeking near EOF
+        # of an HTTP stream where the demuxer is at EOF but audio drains from
+        # the hardware buffer), extrapolate position from wall-clock time so the
+        # progress bar advances smoothly instead of freezing.
+        if (
+            engine.state.playing
+            and engine.state.duration > 0
+            and _t.time() - engine.state.position_updated_at > 0.3
+        ):
+            pos = min(
+                pos + (_t.time() - engine.state.position_updated_at),
+                engine.state.duration,
+            )
         return PlayerStateOut(
             playing=engine.state.playing,
-            position=engine.state.position,
+            position=pos,
             duration=engine.state.duration,
             volume=engine.state.volume,
             current_track=TrackOut.from_track(current) if current else None,

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1661,6 +1661,60 @@ class TestMpvPlaybackEngine:
         assert engine._lookahead_path is None
 
     # ------------------------------------------------------------------
+    # position_updated_at — KAMP-392 seek-freeze fix
+    # ------------------------------------------------------------------
+
+    def test_time_pos_event_updates_position_updated_at(self) -> None:
+        """Every time-pos event must refresh position_updated_at so the
+        _state_snapshot() interpolation threshold resets while mpv is emitting
+        normally."""
+        engine, _ = _make_engine()
+        before = engine.state.position_updated_at
+        engine._handle_event(
+            {"event": "property-change", "name": "time-pos", "data": 42.0}
+        )
+        assert engine.state.position_updated_at >= before
+        assert engine.state.position == pytest.approx(42.0)
+
+    def test_play_resets_position_updated_at(self) -> None:
+        """play() must reset position_updated_at so a stale timestamp from the
+        previous track's event-stall does not immediately extrapolate the new
+        track's position past 0."""
+        engine, _ = _make_engine()
+        engine.state.position_updated_at = 0.0  # simulate very stale
+        engine.play(Path("/music/01.mp3"))
+        import time
+
+        assert engine.state.position_updated_at >= time.time() - 1.0
+
+    def test_load_paused_resets_position_updated_at(self) -> None:
+        engine, _ = _make_engine()
+        engine.state.position_updated_at = 0.0
+        engine.load_paused(Path("/music/01.mp3"))
+        import time
+
+        assert engine.state.position_updated_at >= time.time() - 1.0
+
+    def test_file_loaded_resets_position_updated_at(self) -> None:
+        engine, _ = _make_engine()
+        engine.state.position_updated_at = 0.0
+        engine._handle_event({"event": "file-loaded"})
+        import time
+
+        assert engine.state.position_updated_at >= time.time() - 1.0
+
+    def test_eof_gapless_transition_resets_position_updated_at(self) -> None:
+        """When a gapless transition fires (had_lookahead=True), position_updated_at
+        must be reset so the new track's bar doesn't immediately jump forward."""
+        engine, _ = _make_engine()
+        engine.preload_next(_track(2))
+        engine.state.position_updated_at = 0.0  # simulate stale
+        engine._handle_event({"event": "end-file", "reason": "eof"})
+        import time
+
+        assert engine.state.position_updated_at >= time.time() - 1.0
+
+    # ------------------------------------------------------------------
     # preload_next near-end guard
     # ------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -806,6 +806,41 @@ class TestPlayerStateEndpoint:
         assert data["playing"] is True
         assert data["current_track"]["title"] == "Track 3"
 
+    def test_extrapolates_position_when_time_pos_events_stale(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """When no time-pos event has arrived for >300 ms while playing, the
+        snapshot must extrapolate position from wall-clock time so the progress
+        bar advances even after mpv stops emitting events (e.g. seek near EOF
+        of an HTTP stream — KAMP-392)."""
+        import time
+
+        state = PlaybackState(playing=True, position=42.0, duration=180.0)
+        state.position_updated_at = time.time() - 2.0  # simulate 2 s stale
+        mock_engine.state = state
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/player/state").json()
+        # Position must be extrapolated beyond the raw 42.0 (by ~2 s).
+        assert data["position"] > 42.0
+        assert data["position"] < 47.0  # allow 5 s slack for test execution time
+        assert data["position"] <= 180.0
+
+    def test_does_not_extrapolate_when_paused(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Extrapolation must be suppressed when paused — freezing the bar
+        is correct behaviour in that state."""
+        import time
+
+        state = PlaybackState(playing=False, position=42.0, duration=180.0)
+        state.position_updated_at = time.time() - 5.0
+        mock_engine.state = state
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/player/state").json()
+        assert data["position"] == pytest.approx(42.0)
+
 
 class TestPlayerPlayEndpoint:
     def test_play_loads_album_and_starts_playback(


### PR DESCRIPTION
## Summary

- Adds `position_updated_at: float` to `PlaybackState` (updated on every `time-pos` event, `compare=False` so equality checks are unaffected)
- `_state_snapshot()` in `server.py` extrapolates position from wall-clock elapsed time when no `time-pos` event has arrived for >300 ms while playing — the 4 Hz WS ping cycle then returns an advancing position to the UI instead of a frozen one
- Resets `position_updated_at` on every track boundary (`play()`, `load_paused()`, `file-loaded` event, gapless `end-file/eof`) to prevent stale timestamps from falsely extrapolating at the start of the next track
- Extrapolation is suppressed when `playing=False` (paused or stopped), so the bar correctly freezes while paused

## Root cause

After seeking near EOF of an HTTP stream (e.g. a Bandcamp track's last ~10 s), mpv's demuxer reaches EOF and stops emitting `time-pos` property-change events while audio drains from the hardware buffer. The engine's `state.position` is driven exclusively by those events, so it freezes at the seek target. The UI receives a frozen position on every 250 ms WS ping until `end-file` fires.

## Test plan

- [x] 4 new tests in `test_playback.py`: `position_updated_at` updated on `time-pos`, reset on `play`, `load_paused`, `file-loaded`, and gapless EOF
- [x] 2 new tests in `test_server.py`: extrapolates when stale, does not extrapolate when paused
- [x] Full suite: 1720 passed, coverage 93.22%, mypy clean, black clean
- [x] **Manual verification needed**: seek to last ~8 s of a Bandcamp streaming track and confirm the progress bar advances to the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)