### PR TITLE
feat(KAMP-408): serialize Bandcamp album downloads to prevent rate limiting

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -90,7 +90,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 22
+_SCHEMA_VERSION = 23
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -227,6 +227,15 @@ CREATE TABLE IF NOT EXISTS bandcamp_collection (
     mode           TEXT NOT NULL DEFAULT 'local',
     synced_at      REAL,
     added_at       REAL NOT NULL DEFAULT 0
+);
+
+-- Serialized album download queue (KAMP-408).
+-- UNIQUE on sale_item_id prevents double-enqueue; INSERT OR IGNORE is idempotent.
+-- queued_at is a Unix timestamp used for FIFO replay order on restart.
+CREATE TABLE IF NOT EXISTS download_queue (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sale_item_id TEXT    NOT NULL UNIQUE,
+    queued_at    REAL    NOT NULL DEFAULT (unixepoch())
 );
 """
 
@@ -799,6 +808,19 @@ class LibraryIndex:
             self._conn.execute("UPDATE schema_version SET version = 22")
             self._conn.commit()
             version = 22
+
+        if version == 22:
+            # v22 → v23: download_queue table for serialized album downloads (KAMP-408).
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS download_queue (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sale_item_id TEXT    NOT NULL UNIQUE,
+                    queued_at    REAL    NOT NULL DEFAULT (unixepoch())
+                )
+            """)
+            self._conn.execute("UPDATE schema_version SET version = 23")
+            self._conn.commit()
+            version = 23
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -1491,6 +1513,39 @@ class LibraryIndex:
             "SELECT id, track_id FROM deferred_ops ORDER BY id ASC"
         ).fetchall()
         return [{"op_id": r["id"], "track_id": r["track_id"]} for r in rows]
+
+    # ------------------------------------------------------------------
+    # Download queue (KAMP-408)
+    # ------------------------------------------------------------------
+
+    def enqueue_download(self, sale_item_id: str) -> None:
+        """Add *sale_item_id* to the persistent download queue.
+
+        INSERT OR IGNORE makes this idempotent — re-enqueuing an already-queued
+        item is a no-op so double-clicks don't produce duplicate work.
+        """
+        self._conn.execute(
+            "INSERT OR IGNORE INTO download_queue (sale_item_id) VALUES (?)",
+            (sale_item_id,),
+        )
+        self._conn.commit()
+
+    def dequeue_download(self, sale_item_id: str) -> None:
+        """Remove *sale_item_id* from the persistent download queue after completion."""
+        self._conn.execute(
+            "DELETE FROM download_queue WHERE sale_item_id = ?", (sale_item_id,)
+        )
+        self._conn.commit()
+
+    def pending_downloads(self) -> list[str]:
+        """Return all queued sale_item_ids in FIFO order (oldest first).
+
+        Used on daemon restart to replay any downloads that survived a shutdown.
+        """
+        rows = self._conn.execute(
+            "SELECT sale_item_id FROM download_queue ORDER BY queued_at ASC, id ASC"
+        ).fetchall()
+        return [r["sale_item_id"] for r in rows]
 
     def update_track_after_album_drain(
         self,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
+import queue as _queue
 import re
 import sys
 import threading as _threading
@@ -568,7 +569,7 @@ def create_app(
     on_bandcamp_disconnect: Callable[[], None] | None = None,
     on_bandcamp_sync_trigger: Callable[[], None] | None = None,
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
-    on_album_download_trigger: Callable[[str], None] | None = None,
+    dl_queue: _queue.Queue[str] | None = None,
     refresh_stream_url: Callable[[str, int], tuple[str, float] | None] | None = None,
     art_cache_dir: Path | None = None,
     dev_mode: bool = False,
@@ -2452,21 +2453,19 @@ def create_app(
 
     @app.post("/api/v1/bandcamp/collection/{sale_item_id}/download")
     def download_collection_item(sale_item_id: str) -> dict[str, Any]:
-        """Download a single Bandcamp album to the watch folder.
+        """Enqueue a Bandcamp album for serialized download.
 
-        Immediately marks the item as 'local' in bandcamp_collection and
-        updates tracks.source, broadcasts 'downloading' to WebSocket clients,
-        then runs the actual download in a background thread.  Broadcasts
-        'done' or 'error' when the download completes.
+        Adds the item to the persistent download_queue table and the in-memory
+        dl_queue so the single-consumer worker thread in __main__ processes it.
+        Broadcasts 'queued' immediately; the worker broadcasts 'downloading' when
+        it begins and 'done'/'error' on completion.
 
         Returns 404 if the item is not in the collection.
-        Returns 503 if the album download callback is not configured.
+        Returns 503 if the download queue is not configured.
         """
-        import threading
-
         if not index.get_collection_item(sale_item_id):
             raise HTTPException(status_code=404, detail="Collection item not found")
-        if on_album_download_trigger is None:
+        if dl_queue is None:
             raise HTTPException(status_code=503, detail="Album download not configured")
 
         # Mark the collection item as targeted for local download so in_bandcamp_collection
@@ -2475,23 +2474,18 @@ def create_app(
         # the has_art=true shortcut for purely-remote albums and causes art to disappear.
         index.set_collection_item_mode(sale_item_id, "local")
 
+        # Persist first so a restart can replay the queue even if the process
+        # dies before the worker picks up the in-memory item.
+        index.enqueue_download(sale_item_id)
+        dl_queue.put(sale_item_id)
+
         _broadcast(
             {
                 "type": "bandcamp.album-download",
                 "sale_item_id": sale_item_id,
-                "state": "downloading",
+                "state": "queued",
             }
         )
-
-        def _run() -> None:
-            try:
-                on_album_download_trigger(sale_item_id)
-            except Exception:
-                _notify_album_download_status(sale_item_id, "error")
-
-        threading.Thread(
-            target=_run, daemon=True, name=f"album-dl-{sale_item_id}"
-        ).start()
         return {"ok": True}
 
     # -----------------------------------------------------------------------

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -526,7 +526,9 @@ def _cmd_daemon(
     port: int = 47483,
     library_path: Path | None = None,
 ) -> None:
+    import queue as _queue_mod
     import threading
+    import time as _time
     import uvicorn
 
     from kamp_core.library import LibraryIndex, Track
@@ -865,25 +867,6 @@ def _cmd_daemon(
             _logger.exception("Unhandled error during manual Bandcamp sync")
             app.state.notify_bandcamp_sync_status("")  # back to idle
 
-    def _on_album_download_trigger(sale_item_id: str) -> None:
-        from .syncer import NeedsLoginError
-
-        fn = _album_download_trigger_ref[0]
-        if fn is None:
-            return
-        try:
-            fn(sale_item_id)
-            app.state.notify_album_download_status(sale_item_id, "done")
-            app.state.notify_library_changed()
-        except NeedsLoginError:
-            _logger.warning("Album download: no valid session — login required.")
-            app.state.notify_album_download_status(sale_item_id, "error")
-        except Exception:
-            _logger.exception(
-                "Unhandled error during album download (%s)", sale_item_id
-            )
-            app.state.notify_album_download_status(sale_item_id, "error")
-
     def _on_bandcamp_sync_all_trigger() -> None:
         from .syncer import NeedsLoginError
 
@@ -938,6 +921,7 @@ def _cmd_daemon(
     _sync_trigger_ref: list[Any] = [None]
     _sync_all_trigger_ref: list[Any] = [None]
     _album_download_trigger_ref: list[Any] = [None]
+    _dl_queue: _queue_mod.Queue[str] = _queue_mod.Queue()
 
     def _refresh_stream_url(album_url: str, track_num: int) -> tuple[str, float] | None:
         """Fetch a fresh CDN URL for a remote track before mpv plays it."""
@@ -967,13 +951,74 @@ def _cmd_daemon(
         on_bandcamp_disconnect=_on_bandcamp_disconnect,
         on_bandcamp_sync_trigger=_on_bandcamp_sync_trigger,
         on_bandcamp_sync_all_trigger=_on_bandcamp_sync_all_trigger,
-        on_album_download_trigger=_on_album_download_trigger,
+        dl_queue=_dl_queue,
         art_cache_dir=_state_dir() / "art_cache",
         refresh_stream_url=_refresh_stream_url,
         dev_mode=bool(os.environ.get("KAMP_DEV")),
         auth_token=_auth_token,
         mb_lookup_fn=lookup_releases_from_tracks,
     )
+
+    # ---------------------------------------------------------------------------
+    # Single-consumer album download worker (KAMP-408)
+    # ---------------------------------------------------------------------------
+    # Serializes all album downloads one at a time (FIFO) so Bandcamp doesn't
+    # 429 us.  Retries rate-limited requests with an exponential back-off
+    # (5 s → 10 s → 20 s) before giving up.
+
+    def _download_worker() -> None:
+        from .syncer import NeedsLoginError
+
+        while True:
+            sale_item_id = _dl_queue.get()
+            app.state.notify_album_download_status(sale_item_id, "downloading")
+
+            fn = _album_download_trigger_ref[0]
+            if fn is None:
+                _logger.error(
+                    "Album download trigger not configured for %s", sale_item_id
+                )
+                app.state.notify_album_download_status(sale_item_id, "error")
+                index.dequeue_download(sale_item_id)
+                continue
+
+            delays = [5, 10, 20]
+            for delay in delays + [None]:
+                try:
+                    fn(sale_item_id)
+                    app.state.notify_album_download_status(sale_item_id, "done")
+                    app.state.notify_library_changed()
+                    break
+                except NeedsLoginError:
+                    _logger.warning(
+                        "Album download: no valid session for %s", sale_item_id
+                    )
+                    app.state.notify_album_download_status(sale_item_id, "error")
+                    break
+                except Exception as exc:
+                    if "429" in str(exc) and delay is not None:
+                        _logger.warning(
+                            "Album download rate-limited for %s; retrying in %ds",
+                            sale_item_id,
+                            delay,
+                        )
+                        _time.sleep(delay)
+                        continue
+                    _logger.exception("Album download failed for %s", sale_item_id)
+                    app.state.notify_album_download_status(sale_item_id, "error")
+                    break
+
+            index.dequeue_download(sale_item_id)
+
+    threading.Thread(
+        target=_download_worker, daemon=True, name="album-dl-worker"
+    ).start()
+
+    # Replay any downloads that survived a daemon restart.  These are put onto
+    # the in-memory queue so the worker picks them up in FIFO order.
+    for _pending_sid in index.pending_downloads():
+        _dl_queue.put(_pending_sid)
+        _logger.info("Replayed queued download: %s", _pending_sid)
 
     # Wrap the existing on_track_end callback to also push track.changed events.
     # Done here (after app creation) so app.state is guaranteed to be available.

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -248,6 +248,7 @@ export default function App(): React.JSX.Element {
         bumpLastPlayedVersion,
         (saleItemId, state) => {
           if (state === 'queued') {
+            useStore.getState().clearAlbumDownloading(saleItemId)
             useStore.getState().markAlbumQueued(saleItemId)
           } else if (state === 'downloading') {
             useStore.getState().clearAlbumQueued(saleItemId)

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -247,9 +247,13 @@ export default function App(): React.JSX.Element {
         setAudioLevel,
         bumpLastPlayedVersion,
         (saleItemId, state) => {
-          if (state === 'downloading') {
+          if (state === 'queued') {
+            useStore.getState().markAlbumQueued(saleItemId)
+          } else if (state === 'downloading') {
+            useStore.getState().clearAlbumQueued(saleItemId)
             useStore.getState().markAlbumDownloading(saleItemId)
           } else {
+            useStore.getState().clearAlbumQueued(saleItemId)
             useStore.getState().clearAlbumDownloading(saleItemId)
             if (state === 'done') {
               void useStore.getState().loadLibrary()

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -537,7 +537,7 @@ export type AudioLevelMessage = {
 export type AlbumDownloadMessage = {
   type: 'bandcamp.album-download'
   sale_item_id: string
-  state: 'downloading' | 'done' | 'error'
+  state: 'queued' | 'downloading' | 'done' | 'error'
 }
 export type ServerMessage =
   | StateMessage
@@ -565,7 +565,7 @@ export function connectStateStream(
   onDeferredOpCompleted?: (trackId: number, opId: number) => void,
   onAudioLevel?: (leftDb: number, rightDb: number, crestDb: number, peakDb: number) => void,
   onTrackChanged?: () => void,
-  onAlbumDownload?: (saleItemId: string, state: 'downloading' | 'done' | 'error') => void
+  onAlbumDownload?: (saleItemId: string, state: 'queued' | 'downloading' | 'done' | 'error') => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -82,6 +82,10 @@
   animation: albumArtBlurPulse 1.8s ease-in-out infinite;
 }
 
+.album-card--queued .album-art--blurred .album-art-img {
+  animation: none;
+}
+
 .now-playing-badge {
   position: absolute;
   bottom: 6px;

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -101,6 +101,12 @@
   animation: artDrift 28s linear infinite;
 }
 
+/* Suppress the drift on cards that are already animating their own state. */
+.album-card--downloading .album-art--blurred .album-art-img,
+.album-card--queued .album-art--blurred .album-art-img {
+  animation: none;
+}
+
 .now-playing-badge {
   position: absolute;
   bottom: 6px;

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -58,12 +58,23 @@
 /* Download-in-progress state ----------------------------------------------- */
 
 @keyframes albumCardDownloadPulse {
-  0%, 100% { filter: brightness(1); }
-  50%       { filter: brightness(1.2); }
+  0%, 100% { filter: blur(0px); }
+  50%       { filter: blur(1px); }
 }
 
 .album-card--downloading {
   animation: albumCardDownloadPulse 1.8s ease-in-out infinite;
+}
+
+@keyframes albumCardQueuedPulse {
+  0%, 100% { opacity: 0.55; }
+  50%       { opacity: 0.7;  }
+}
+
+/* Queued albums dim while waiting their turn; the slow pulse is calmer than
+   the brighter downloading animation to communicate "pending, not active". */
+.album-card--queued {
+  animation: albumCardQueuedPulse 3s ease-in-out infinite;
 }
 
 /* Drift of the art behind the blur — "motion behind frosted glass".

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -55,56 +55,31 @@
   transition: filter 0.5s;
 }
 
-/* Download-in-progress state ----------------------------------------------- */
-
-@keyframes albumCardDownloadPulse {
-  0%, 100% { filter: blur(0px); }
-  50%       { filter: blur(1px); }
-}
-
-.album-card--downloading {
-  animation: albumCardDownloadPulse 1.8s ease-in-out infinite;
-}
+/* Download-in-progress and queued states ------------------------------------ */
 
 @keyframes albumCardQueuedPulse {
   0%, 100% { opacity: 0.55; }
   50%       { opacity: 0.7;  }
 }
 
-/* Queued albums dim while waiting their turn; the slow pulse is calmer than
-   the brighter downloading animation to communicate "pending, not active". */
+/* Queued albums dim while waiting their turn. */
 .album-card--queued {
   animation: albumCardQueuedPulse 3s ease-in-out infinite;
 }
 
-/* Drift of the art behind the blur — "motion behind frosted glass".
-   scale > 1 ensures translate never exposes edges through overflow:hidden.
-   linear timing keeps velocity constant so there are no pauses at keyframes.
-   Ten irregular waypoints across all quadrants prevent a circular feel. */
-@keyframes artDrift {
-  0%   { transform: scale(1.13) translate(0px,   0px);  }
-  10%  { transform: scale(1.15) translate(-5px,  -8px); }
-  22%  { transform: scale(1.12) translate( 4px, -10px); }
-  35%  { transform: scale(1.16) translate(10px,  -2px); }
-  47%  { transform: scale(1.13) translate( 7px,   7px); }
-  58%  { transform: scale(1.15) translate(-1px,  10px); }
-  70%  { transform: scale(1.12) translate(-9px,   5px); }
-  80%  { transform: scale(1.16) translate(-7px,  -5px); }
-  91%  { transform: scale(1.13) translate(-2px,  -9px); }
-  100% { transform: scale(1.13) translate(0px,   0px);  }
+/* Downloading: blur on the art image pulses in and out — no card-level motion. */
+@keyframes albumArtBlurPulse {
+  0%, 100% { filter: blur(3px); }
+  50%       { filter: blur(8px); }
 }
 
 .album-art--blurred .album-art-img {
-  /* Blur applies instantly so it's in place before the drift starts. */
   filter: blur(5px);
   transition: filter 0s;
-  animation: artDrift 28s linear infinite;
 }
 
-/* Suppress the drift on cards that are already animating their own state. */
-.album-card--downloading .album-art--blurred .album-art-img,
-.album-card--queued .album-art--blurred .album-art-img {
-  animation: none;
+.album-card--downloading .album-art--blurred .album-art-img {
+  animation: albumArtBlurPulse 1.8s ease-in-out infinite;
 }
 
 .now-playing-badge {

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -61,10 +61,12 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const dismissHighlight = useStore((s) => s.dismissHighlight)
   const configValues = useStore((s) => s.configValues)
   const downloadingAlbumIds = useStore((s) => s.downloadingAlbumIds)
+  const queuedAlbumIds = useStore((s) => s.queuedAlbumIds)
   const connected = configValues?.['bandcamp.connected'] ?? false
   const isRemote = album.source !== 'local'
   const isOffline = isRemote && !connected
   const isDownloading = album.sale_item_id != null && downloadingAlbumIds.has(album.sale_item_id)
+  const isQueued = album.sale_item_id != null && queuedAlbumIds.has(album.sale_item_id)
   const [artLoaded, setArtLoaded] = useState(false)
   const [menu, setMenu] = useState<MenuPos | null>(null)
 
@@ -227,6 +229,7 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
     isRemote ? 'album-card--remote' : '',
     isOffline ? 'album-card--offline' : '',
     isDownloading ? 'album-card--downloading' : '',
+    isQueued ? 'album-card--queued' : '',
     isNew ? `album-card--highlight-${highlightStyle}` : '',
     isNew && isMounting ? 'is-mounting' : ''
   ]

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -79,6 +79,7 @@ type PlayerStore = {
   artistPanelSnapshot: boolean | null // saved visibility before entering Now Playing
   queue: QueueState | null
   downloadingAlbumIds: Set<string>
+  queuedAlbumIds: Set<string>
 
   // Actions
   setAudioLevel: (leftDb: number, rightDb: number, crestDb: number, peakDb: number) => void
@@ -101,6 +102,8 @@ type PlayerStore = {
   bumpLastPlayedVersion: () => void
   markAlbumDownloading: (saleItemId: string) => void
   clearAlbumDownloading: (saleItemId: string) => void
+  markAlbumQueued: (saleItemId: string) => void
+  clearAlbumQueued: (saleItemId: string) => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
   setHighlightEnabled: (enabled: boolean) => void
@@ -292,6 +295,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   artistPanelSnapshot: null,
   queue: null,
   downloadingAlbumIds: new Set<string>(),
+  queuedAlbumIds: new Set<string>(),
   configValues: null,
   prefsOpen: false,
   prefsInitialTab: 'general',
@@ -424,6 +428,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
       const next = new Set(s.downloadingAlbumIds)
       next.delete(saleItemId)
       return { downloadingAlbumIds: next }
+    }),
+  markAlbumQueued: (saleItemId) =>
+    set((s) => ({ queuedAlbumIds: new Set([...s.queuedAlbumIds, saleItemId]) })),
+  clearAlbumQueued: (saleItemId) =>
+    set((s) => {
+      const next = new Set(s.queuedAlbumIds)
+      next.delete(saleItemId)
+      return { queuedAlbumIds: next }
     }),
 
   setRecentlyAddedCount: (n) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 22
+        assert version == 23
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1390,7 +1390,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1447,7 +1447,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1834,7 +1834,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert row is not None
         assert row[0] == 0
 
@@ -2088,7 +2088,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2180,7 +2180,7 @@ class TestAlbumFavorite:
         index._conn.execute("SELECT COUNT(*) FROM album_favorites").fetchone()
         index.close()
 
-        assert version == 22
+        assert version == 23
 
 
 # ---------------------------------------------------------------------------
@@ -2359,7 +2359,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2454,7 +2454,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 22
+        assert version == 23
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2462,7 +2462,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 22
+        assert version == 23
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3339,7 +3339,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 22
+        assert version == 23
 
         index.close()
 
@@ -4022,7 +4022,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 22
+        assert version == 23
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4057,7 +4057,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 22
+        assert version == 23
         index.close()
 
 
@@ -4427,7 +4427,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 22
+        assert version == 23
 
 
 class TestRemoteTrackSchema:
@@ -4694,7 +4694,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4755,7 +4755,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 22
+        assert version == 23
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5436,7 +5436,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 22
+        assert version == 23
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5447,3 +5447,109 @@ class TestMigrationV22:
         assert (
             rows.get("/music/local.mp3") == "Local"
         ), "local track should be unchanged"
+
+
+class TestDownloadQueue:
+    """enqueue_download / dequeue_download / pending_downloads (KAMP-408)."""
+
+    def test_enqueue_adds_row(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("111")
+        assert index.pending_downloads() == ["111"]
+        index.close()
+
+    def test_pending_downloads_fifo_order(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        import time
+
+        for sid in ("aaa", "bbb", "ccc"):
+            index.enqueue_download(sid)
+            time.sleep(0.01)  # ensure distinct queued_at timestamps
+        assert index.pending_downloads() == ["aaa", "bbb", "ccc"]
+        index.close()
+
+    def test_dequeue_removes_row(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("111")
+        index.enqueue_download("222")
+        index.dequeue_download("111")
+        assert index.pending_downloads() == ["222"]
+        index.close()
+
+    def test_enqueue_is_idempotent(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("111")
+        index.enqueue_download("111")  # second call is a no-op
+        assert index.pending_downloads() == ["111"]
+        index.close()
+
+    def test_pending_empty_when_queue_clear(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.pending_downloads() == []
+        index.close()
+
+    def test_dequeue_nonexistent_is_noop(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.dequeue_download("nonexistent")  # must not raise
+        assert index.pending_downloads() == []
+        index.close()
+
+
+class TestMigrationV23:
+    """v22 → v23: download_queue table created on upgrade from v22."""
+
+    def test_migration_creates_download_queue_table(self, tmp_path: Path) -> None:
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        # Build a minimal v22 DB (download_queue table must not exist yet).
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (22)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY, file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '', artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '', album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '', track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1, ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0, mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '', date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0, play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL, genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local', stream_url TEXT, stream_url_expires_at REAL)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE player_state (id INTEGER PRIMARY KEY CHECK (id=1), track_path TEXT NOT NULL, position REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE queue_state (id INTEGER PRIMARY KEY CHECK (id=1), tracks TEXT NOT NULL DEFAULT '[]', order_json TEXT NOT NULL DEFAULT '', pos INTEGER NOT NULL DEFAULT -1, shuffle INTEGER NOT NULL DEFAULT 0, repeat INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE extension_audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, extension_id TEXT NOT NULL, track_mbid TEXT NOT NULL DEFAULT '', operation TEXT NOT NULL, old_value TEXT NOT NULL DEFAULT '', new_value TEXT NOT NULL DEFAULT '', timestamp REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY, session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE album_favorites (album_artist TEXT NOT NULL, album TEXT NOT NULL, PRIMARY KEY (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT, op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE, payload_json TEXT NOT NULL, created_at REAL NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY, item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '', item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '', album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local', synced_at REAL, added_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        tables = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        index.close()
+
+        assert version == 23
+        assert "download_queue" in tables

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2424,60 +2424,107 @@ class TestBandcampCollectionDownload:
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
+        import queue as _queue
+
         mock_index.get_collection_item.return_value = None
-        trigger_calls: list[str] = []
         app = create_app(
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            on_album_download_trigger=lambda sid: trigger_calls.append(sid),
+            dl_queue=_queue.Queue(),
         )
         resp = TestClient(app).post("/api/v1/bandcamp/collection/99999/download")
         assert resp.status_code == 404
-        assert trigger_calls == []
 
-    def test_returns_503_when_download_trigger_not_configured(
+    def test_returns_503_when_dl_queue_not_configured(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
         mock_index.get_collection_item.return_value = {"sale_item_id": "42"}
+        # dl_queue defaults to None → 503
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         resp = TestClient(app).post("/api/v1/bandcamp/collection/42/download")
         assert resp.status_code == 503
 
-    def test_sets_db_state_and_fires_download_trigger(
+    def test_enqueues_item_and_broadcasts_queued(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
+        import queue as _queue
+
         mock_index.get_collection_item.return_value = {
             "sale_item_id": "42",
             "mode": "remote",
         }
-        trigger_done = threading.Event()
-        trigger_calls: list[str] = []
-
-        def _trigger(sid: str) -> None:
-            trigger_calls.append(sid)
-            trigger_done.set()
+        dl_q: _queue.Queue[str] = _queue.Queue()
+        ws_messages: list[dict] = []
 
         app = create_app(
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            on_album_download_trigger=_trigger,
+            dl_queue=dl_q,
         )
         with TestClient(app) as c:
-            resp = c.post("/api/v1/bandcamp/collection/42/download")
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # consume initial state push
+                resp = c.post("/api/v1/bandcamp/collection/42/download")
+                ws_messages.append(ws.receive_json())
+
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
+        # DB enqueue and mode update must be called
         mock_index.set_collection_item_mode.assert_called_once_with("42", "local")
         mock_index.set_track_source_for_item.assert_not_called()
-        trigger_done.wait(timeout=2)
-        assert trigger_calls == ["42"]
+        mock_index.enqueue_download.assert_called_once_with("42")
+        # Item placed on the in-memory queue
+        assert dl_q.get_nowait() == "42"
+        # WS broadcast is 'queued', not 'downloading'
+        assert ws_messages[0] == {
+            "type": "bandcamp.album-download",
+            "sale_item_id": "42",
+            "state": "queued",
+        }
+
+    def test_second_download_also_broadcasts_queued(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Both items broadcast 'queued'; the worker serializes execution."""
+        import queue as _queue
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "x",
+            "mode": "remote",
+        }
+        dl_q: _queue.Queue[str] = _queue.Queue()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            dl_queue=dl_q,
+        )
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # consume initial state push
+                c.post("/api/v1/bandcamp/collection/11/download")
+                msg1 = ws.receive_json()
+                c.post("/api/v1/bandcamp/collection/22/download")
+                msg2 = ws.receive_json()
+
+        assert msg1["state"] == "queued"
+        assert msg1["sale_item_id"] == "11"
+        assert msg2["state"] == "queued"
+        assert msg2["sale_item_id"] == "22"
+        # Both items are on the queue in FIFO order
+        assert dl_q.get_nowait() == "11"
+        assert dl_q.get_nowait() == "22"
 
     def test_notify_album_download_status_exposed_on_app_state(
         self,


### PR DESCRIPTION
## Summary

- Replaces the immediate `threading.Thread` spawn per download request with a single-consumer FIFO worker thread, so only one album downloads at a time and Bandcamp can't 429 us
- Adds `download_queue` DB table (schema v22 → v23) as durable backing store; the daemon replays surviving rows on restart so queued downloads aren't silently dropped
- Worker retries rate-limited (429) requests with exponential back-off: 5 s → 10 s → 20 s, then fails the item and advances the queue
- Queued albums broadcast `state: "queued"` immediately; the worker broadcasts `downloading` when it starts, and `done`/`error` on completion
- UI: queued albums show a slow dimmed pulse (`album-card--queued`); the active-download animation is reworked from a brightness flicker to a gentle blur pulse

## Test plan

- [ ] Trigger a single album download — card shows "queued" briefly then transitions to "downloading" blur animation
- [ ] Trigger 3 album downloads rapidly — first enters "downloading", other two show the dimmed "queued" visual; downloads proceed one at a time in FIFO order
- [ ] All cards return to normal state after completion (no stuck styling)
- [ ] Start downloads, quit the app, relaunch — queue resumes from DB
- [ ] Trigger the same album download twice (double-click) — only enqueued once
- [ ] Force an error (e.g. disconnect network) — failed album clears, next queued item starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)