### PR TITLE
fix(KAMP-419): propagate track mutations to albums entity; catch rename collision

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1335,6 +1335,7 @@ class LibraryIndex:
         Corrects tracks whose date_added was recorded as the sync timestamp rather than
         the actual purchase date.  The MIN-wins rule mirrors upsert_collection_item so
         that an earlier purchase date can never be overwritten by a later sync.
+        Also propagates the corrected date to the parent albums row via sale_item_id.
         """
         self._conn.execute(
             "UPDATE tracks SET date_added = ? "
@@ -1346,17 +1347,43 @@ class LibraryIndex:
                 date_added,
             ),
         )
+        # Propagate to the albums row. MIN-wins: only update when new value is earlier.
+        self._conn.execute(
+            "UPDATE albums SET date_added = ?"
+            " WHERE sale_item_id = ?"
+            " AND (date_added IS NULL OR date_added > ?)",
+            (date_added, sale_item_id, date_added),
+        )
         self._conn.commit()
 
     def set_track_source_for_item(self, sale_item_id: str, source: str) -> int:
         """Set source on every track whose file_path belongs to *sale_item_id*.
 
         Matches canonical bandcamp:// (POSIX) and Windows bandcamp:\\ path forms.
-        Returns the number of rows updated.
+        Returns the number of rows updated. Also refreshes albums.source so the
+        album entity stays consistent without waiting for the next full rescan.
         """
         cur = self._conn.execute(
             "UPDATE tracks SET source = ? WHERE file_path LIKE ? OR file_path LIKE ?",
             (source, f"bandcamp://{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
+        )
+        # Refresh albums.source via the sale_item_id FK. Remote tracks may not have
+        # album_id populated yet, so join through albums.sale_item_id instead.
+        self._conn.execute(
+            """
+            UPDATE albums SET source = (
+                SELECT CASE
+                    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+                         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
+                    THEN 'local'
+                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                    ELSE MIN(t.source)
+                END
+                FROM tracks t WHERE t.album_id = albums.id
+            )
+            WHERE sale_item_id = ?
+            """,
+            (sale_item_id,),
         )
         self._conn.commit()
         return cur.rowcount

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1636,6 +1636,23 @@ class LibraryIndex:
                     """,
                     album_ids,
                 )
+                # Backfill sale_item_id from bandcamp_collection for albums that were
+                # just inserted without it. This covers the streaming-sync order where
+                # upsert_collection_item fires before upsert_many, so the UPDATE inside
+                # upsert_collection_item is a no-op (no albums row yet at that point).
+                self._conn.execute(
+                    f"""
+                    UPDATE albums SET sale_item_id = (
+                        SELECT bc.sale_item_id FROM bandcamp_collection bc
+                        WHERE bc.band_name  = albums.album_artist COLLATE NOCASE
+                          AND bc.item_title = albums.album        COLLATE NOCASE
+                        LIMIT 1
+                    )
+                    WHERE id IN ({id_placeholders})
+                      AND sale_item_id IS NULL
+                    """,
+                    album_ids,
+                )
 
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1731,35 +1731,39 @@ class LibraryIndex:
             ).fetchone()
             album_id = r["album_id"] if r else None
 
-        for old_path, new_path in path_pairs:
-            self._conn.execute(
-                """UPDATE tracks
-                   SET file_path = ?,
-                       album = ?,
-                       album_artist = ?,
-                       artist = CASE WHEN ? IS NOT NULL AND artist = ? THEN ? ELSE artist END,
-                       file_mtime = ?
-                   WHERE file_path = ?""",
-                (
-                    str(new_path),
-                    new_album,
-                    new_album_artist,
-                    old_album_artist,
-                    old_album_artist,
-                    new_album_artist,
-                    new_mtime,
-                    str(old_path),
-                ),
-            )
-        # Update the albums row. The UNIQUE (album_artist, album) COLLATE NOCASE
-        # constraint raises IntegrityError if the new name already exists.
-        if album_id is not None:
-            self._conn.execute(
-                "UPDATE albums SET album_artist = ?, album = ? WHERE id = ?",
-                (new_album_artist, new_album, album_id),
-            )
-        self._rebuild_fts()
-        self._conn.commit()
+        try:
+            for old_path, new_path in path_pairs:
+                self._conn.execute(
+                    """UPDATE tracks
+                       SET file_path = ?,
+                           album = ?,
+                           album_artist = ?,
+                           artist = CASE WHEN ? IS NOT NULL AND artist = ? THEN ? ELSE artist END,
+                           file_mtime = ?
+                       WHERE file_path = ?""",
+                    (
+                        str(new_path),
+                        new_album,
+                        new_album_artist,
+                        old_album_artist,
+                        old_album_artist,
+                        new_album_artist,
+                        new_mtime,
+                        str(old_path),
+                    ),
+                )
+            # Update the albums row. The UNIQUE (album_artist, album) COLLATE NOCASE
+            # constraint raises IntegrityError if the new name already exists.
+            if album_id is not None:
+                self._conn.execute(
+                    "UPDATE albums SET album_artist = ?, album = ? WHERE id = ?",
+                    (new_album_artist, new_album, album_id),
+                )
+            self._rebuild_fts()
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
 
     # ------------------------------------------------------------------
     # Deferred ops (KAMP-309)
@@ -2254,6 +2258,10 @@ class LibraryIndex:
             (album_artist, album),
         ).fetchone()
         return row["id"] if row else None
+
+    def album_name_exists(self, album_artist: str, album: str) -> bool:
+        """Return True if any albums row matches (album_artist, album) case-insensitively."""
+        return self._album_id(album_artist, album) is not None
 
     def tracks_for_album(self, album_artist: str, album: str) -> list[Track]:
         """Return tracks for a given album sorted by disc then track number.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1079,6 +1079,7 @@ def create_app(
         """
         import os
         import shutil
+        import sqlite3
         import time as _t
 
         from kamp_core.library import write_album_tags_to_file
@@ -1224,13 +1225,19 @@ def create_app(
                         )
                     )
             if db_pairs:
-                index.rename_album_tracks_bulk(
-                    db_pairs,
-                    new_album,
-                    new_album_artist,
-                    new_mtime,
-                    old_album_artist=album_artist,
-                )
+                try:
+                    index.rename_album_tracks_bulk(
+                        db_pairs,
+                        new_album,
+                        new_album_artist,
+                        new_mtime,
+                        old_album_artist=album_artist,
+                    )
+                except sqlite3.IntegrityError:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Album name already exists in library",
+                    )
 
         elif not new_album_dir.exists():
             # Happy path: target directory does not exist — atomic directory rename.
@@ -1319,13 +1326,19 @@ def create_app(
                             )
                         )
                 if db_pairs:
-                    index.rename_album_tracks_bulk(
-                        db_pairs,
-                        new_album,
-                        new_album_artist,
-                        new_mtime,
-                        old_album_artist=album_artist,
-                    )
+                    try:
+                        index.rename_album_tracks_bulk(
+                            db_pairs,
+                            new_album,
+                            new_album_artist,
+                            new_mtime,
+                            old_album_artist=album_artist,
+                        )
+                    except sqlite3.IntegrityError:
+                        raise HTTPException(
+                            status_code=409,
+                            detail="Album name already exists in library",
+                        )
             else:
                 old_artist_dir = old_album_dir.parent
                 new_artist_dir = new_album_dir.parent
@@ -1415,13 +1428,19 @@ def create_app(
                         if updated is not None:
                             moved.append(TrackOut.from_track(updated))
 
-                index.rename_album_tracks_bulk(
-                    db_pairs,
-                    new_album,
-                    new_album_artist,
-                    new_mtime,
-                    old_album_artist=album_artist,
-                )
+                try:
+                    index.rename_album_tracks_bulk(
+                        db_pairs,
+                        new_album,
+                        new_album_artist,
+                        new_mtime,
+                        old_album_artist=album_artist,
+                    )
+                except sqlite3.IntegrityError:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Album name already exists in library",
+                    )
 
                 # Album-level rename: clean up old artist dir if now empty.
                 # (Artist-level rename already removed it by renaming the dir itself.)
@@ -1521,13 +1540,19 @@ def create_app(
                         )
                     )
             if db_pairs:
-                index.rename_album_tracks_bulk(
-                    db_pairs,
-                    new_album,
-                    new_album_artist,
-                    new_mtime,
-                    old_album_artist=album_artist,
-                )
+                try:
+                    index.rename_album_tracks_bulk(
+                        db_pairs,
+                        new_album,
+                        new_album_artist,
+                        new_mtime,
+                        old_album_artist=album_artist,
+                    )
+                except sqlite3.IntegrityError:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Album name already exists in library",
+                    )
             # Remove old album dir if all files were moved out.
             _scrub_os_metadata(old_album_dir)
             try:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1097,6 +1097,17 @@ def create_app(
         if new_album == album and new_album_artist == album_artist:
             raise HTTPException(status_code=400, detail="No changes requested")
 
+        # Pre-flight: reject before any file or DB mutation if the target name
+        # already exists as a different album (e.g. a streaming-only entry).
+        # This prevents file operations from running when the DB write would
+        # fail anyway, and ensures the check fires before any transaction opens.
+        current_id = index._album_id(album_artist, album)
+        target_id = index._album_id(new_album_artist, new_album)
+        if target_id is not None and target_id != current_id:
+            raise HTTPException(
+                status_code=409, detail="Album name already exists in library"
+            )
+
         lib_path: Path | None = _state["library_path"]
         if lib_path is None:
             raise HTTPException(status_code=503, detail="Library path not configured")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -414,10 +414,15 @@ export async function patchAlbumTags(
     body: JSON.stringify(opts)
   })
   if (res.status === 409) {
-    const detail = (await res.json()) as {
-      detail: { collision_count: number; first_path: string }
+    const body = (await res.json()) as {
+      detail: { collision_count: number; first_path: string } | string
     }
-    return { collision: true, ...detail.detail }
+    // Filesystem collision (overwritable) — detail is an object with collision_count.
+    if (typeof body.detail === 'object' && body.detail !== null) {
+      return { collision: true, ...body.detail }
+    }
+    // Non-overridable conflict (e.g. album name already exists in streaming library).
+    throw new Error(typeof body.detail === 'string' ? body.detail : '409 Conflict')
   }
   if (!res.ok) {
     let message = `${res.status} ${res.statusText}`

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -45,7 +45,7 @@ function sourceIcon(source: string, size: number): React.JSX.Element {
 type ContextMenu = { x: number; y: number; track: Track }
 type AlbumRenameToast = {
   message: string
-  undo: () => Promise<AlbumTagsCollision | null>
+  undo?: () => Promise<AlbumTagsCollision | null>
 }
 
 type MBFetchState =
@@ -426,14 +426,18 @@ export function TrackList(): React.JSX.Element | null {
               const oldAlbum = album.album
               const oldArtist = album.album_artist
               const count = album.track_count
-              const result = await patchAlbumTags(oldArtist, oldAlbum, { album: newAlbum })
-              if (result?.collision) {
-                setAlbumCollision({ ...result, pendingOpts: { album: newAlbum } })
-              } else {
-                showRenameToast({
-                  message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
-                  undo: () => patchAlbumTags(oldArtist, newAlbum, { album: oldAlbum })
-                })
+              try {
+                const result = await patchAlbumTags(oldArtist, oldAlbum, { album: newAlbum })
+                if (result?.collision) {
+                  setAlbumCollision({ ...result, pendingOpts: { album: newAlbum } })
+                } else {
+                  showRenameToast({
+                    message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
+                    undo: () => patchAlbumTags(oldArtist, newAlbum, { album: oldAlbum })
+                  })
+                }
+              } catch (err) {
+                showRenameToast({ message: err instanceof Error ? err.message : 'Rename failed' })
               }
             }}
             renderStatic={(val) => (
@@ -451,14 +455,18 @@ export function TrackList(): React.JSX.Element | null {
               const oldArtist = album.album_artist
               const oldAlbum = album.album
               const count = album.track_count
-              const result = await patchAlbumTags(oldArtist, oldAlbum, { album_artist: newArtist })
-              if (result?.collision) {
-                setAlbumCollision({ ...result, pendingOpts: { album_artist: newArtist } })
-              } else {
-                showRenameToast({
-                  message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
-                  undo: () => patchAlbumTags(newArtist, oldAlbum, { album_artist: oldArtist })
-                })
+              try {
+                const result = await patchAlbumTags(oldArtist, oldAlbum, { album_artist: newArtist })
+                if (result?.collision) {
+                  setAlbumCollision({ ...result, pendingOpts: { album_artist: newArtist } })
+                } else {
+                  showRenameToast({
+                    message: `${count} ${count === 1 ? 'file' : 'files'} reorganized`,
+                    undo: () => patchAlbumTags(newArtist, oldAlbum, { album_artist: oldArtist })
+                  })
+                }
+              } catch (err) {
+                showRenameToast({ message: err instanceof Error ? err.message : 'Rename failed' })
               }
             }}
             renderStatic={(val) => (
@@ -693,16 +701,18 @@ export function TrackList(): React.JSX.Element | null {
       {albumRenameToast && (
         <div className="album-rename-toast" role="status">
           <span className="album-rename-toast-text">{albumRenameToast.message}</span>
-          <button
-            className="album-rename-toast-undo"
-            onClick={() => {
-              setAlbumRenameToast(null)
-              if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
-              void albumRenameToast.undo()
-            }}
-          >
-            Undo
-          </button>
+          {albumRenameToast.undo && (
+            <button
+              className="album-rename-toast-undo"
+              onClick={() => {
+                setAlbumRenameToast(null)
+                if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+                void albumRenameToast.undo!()
+              }}
+            >
+              Undo
+            </button>
+          )}
           <div className="album-rename-toast-bar" style={{ animationDuration: `${TOAST_TTL}ms` }} />
         </div>
       )}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -456,7 +456,9 @@ export function TrackList(): React.JSX.Element | null {
               const oldAlbum = album.album
               const count = album.track_count
               try {
-                const result = await patchAlbumTags(oldArtist, oldAlbum, { album_artist: newArtist })
+                const result = await patchAlbumTags(oldArtist, oldAlbum, {
+                  album_artist: newArtist
+                })
                 if (result?.collision) {
                   setAlbumCollision({ ...result, pendingOpts: { album_artist: newArtist } })
                 } else {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -797,7 +797,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setAlbumRenameProgress: (progress) => set({ albumRenameProgress: progress }),
 
   patchAlbumTags: async (albumArtist, album, opts) => {
-    const result = await api.patchAlbumTags(albumArtist, album, opts)
+    let result: Awaited<ReturnType<typeof api.patchAlbumTags>>
+    try {
+      result = await api.patchAlbumTags(albumArtist, album, opts)
+    } catch (err) {
+      set({ albumRenameProgress: null })
+      throw err
+    }
     if ('collision' in result) return result
     if (result.failed.length > 0) {
       console.error('[kamp] album rename: tag write failed for', result.failed)

--- a/tests/test_album_rename.py
+++ b/tests/test_album_rename.py
@@ -926,3 +926,50 @@ class TestPatchAlbumTagsEndpoint:
             )
             file_tags = id3.ID3(str(new_mp3))
             assert str(file_tags["TPE1"]) == "Activity Monitor"
+
+    def test_returns_409_when_albums_table_collision(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """Renaming to a name that already exists in the albums table (e.g. a
+        streaming-only album) returns 409 even when no filesystem collision exists."""
+        from kamp_core.library import Track as _Track
+
+        pairs = _make_album(tmp_path, "Artist", "Album A", "2024", 1)
+        track_objects = [t for _, t in pairs]
+        client, db = self._client_with_album(
+            tmp_path, track_objects, _mock_engine, _mock_queue
+        )
+
+        # Seed a remote-only album with the target name directly in the albums table.
+        # Use upsert_many with a bandcamp:// track so the albums row is created.
+        db.upsert_many(
+            [
+                _Track(
+                    file_path=__import__("pathlib").Path("bandcamp://sale-x/1"),
+                    title="T",
+                    artist="Artist",
+                    album_artist="Artist",
+                    album="Album B",
+                    year="2024",
+                    track_number=1,
+                    disc_number=1,
+                    ext="",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+
+        # No filesystem directory exists for "Album B" — only the albums table has it.
+        assert not (tmp_path / "Artist" / "2024 - Album B").exists()
+
+        resp = client.patch(
+            "/api/v1/albums/tags",
+            params={"album_artist": "Artist", "album": "Album A"},
+            json={"album": "Album B"},
+        )
+
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "Album name already exists in library"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4358,6 +4358,31 @@ class TestBandcampCollection:
         assert result[0]["sale_item_id"] == "2"
         assert result[0]["band_name"] == "Artist"
 
+    def test_upsert_many_backfills_sale_item_id_when_collection_item_upserted_first(
+        self, tmp_path: Path
+    ) -> None:
+        """upsert_collection_item before upsert_many (the streaming-sync order) still
+        links albums.sale_item_id — the backfill in upsert_many closes the gap."""
+        index = LibraryIndex(tmp_path / "library.db")
+        # Streaming sync order: collection item arrives before tracks are fetched.
+        index.upsert_collection_item(
+            "sale-stream",
+            mode="remote",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        # At this point no albums row exists yet, so the link in upsert_collection_item
+        # was a no-op. Now upsert_many inserts the remote tracks.
+        t = _sample_track(Path("bandcamp://sale-stream/1"))
+        t.source = "bandcamp"
+        index.upsert_many([t])
+        row = index._conn.execute("SELECT sale_item_id FROM albums LIMIT 1").fetchone()
+        index.close()
+
+        assert row is not None
+        assert row["sale_item_id"] == "sale-stream"
+
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_collection_item("1", mode="local", synced_at=999.0)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4291,6 +4291,59 @@ class TestBandcampCollection:
         assert r1["date_added"] == 1.0
         assert r2["date_added"] == 9_999_999.0
 
+    def test_update_remote_track_date_added_propagates_to_albums(
+        self, tmp_path: Path
+    ) -> None:
+        """albums.date_added is updated alongside tracks.date_added (MIN-wins)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(Path("bandcamp://sale-1/1"))
+        track.date_added = 9_000_000.0
+        index.upsert_many([track])
+        index.upsert_collection_item(
+            "sale-1",
+            mode="local",
+            band_name=track.album_artist,
+            item_title=track.album,
+            synced_at=1000.0,
+        )
+
+        index.update_remote_track_date_added("sale-1", 100.0)
+
+        row = index._conn.execute(
+            "SELECT date_added FROM albums WHERE sale_item_id = 'sale-1'"
+        ).fetchone()
+        index.close()
+
+        assert row is not None
+        assert row["date_added"] == pytest.approx(100.0)
+
+    def test_update_remote_track_date_added_albums_min_wins(
+        self, tmp_path: Path
+    ) -> None:
+        """albums.date_added is not overwritten when existing value is already earlier."""
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(Path("bandcamp://sale-2/1"))
+        track.date_added = 50.0
+        index.upsert_many([track])
+        index.upsert_collection_item(
+            "sale-2",
+            mode="local",
+            band_name=track.album_artist,
+            item_title=track.album,
+            synced_at=1000.0,
+        )
+
+        index.update_remote_track_date_added("sale-2", 999_999.0)
+
+        row = index._conn.execute(
+            "SELECT date_added FROM albums WHERE sale_item_id = 'sale-2'"
+        ).fetchone()
+        index.close()
+
+        # albums.date_added was already 50.0 (from upsert_many); must not be overwritten
+        assert row is not None
+        assert row["date_added"] == pytest.approx(50.0)
+
     def test_get_remote_collection_filters_by_mode(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_collection_item("1", mode="local")
@@ -4635,6 +4688,42 @@ class TestRemoteTrackSchema:
         index.close()
 
         assert updated == 0
+
+    def test_set_track_source_for_item_propagates_to_albums(
+        self, tmp_path: Path
+    ) -> None:
+        """albums.source is refreshed after set_track_source_for_item."""
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _sample_track(Path("bandcamp://sale-3/1"))
+        track.source = "bandcamp"
+        index.upsert_many([track])
+        index.upsert_collection_item(
+            "sale-3",
+            mode="local",
+            band_name=track.album_artist,
+            item_title=track.album,
+            synced_at=1000.0,
+        )
+
+        # Initially albums.source should be 'bandcamp' (only remote tracks).
+        row_before = index._conn.execute(
+            "SELECT source FROM albums WHERE sale_item_id = 'sale-3'"
+        ).fetchone()
+        assert row_before is not None
+        assert row_before["source"] == "bandcamp"
+
+        # set_track_source_for_item is called (e.g. during sync cleanup).
+        index.set_track_source_for_item("sale-3", "local")
+
+        row_after = index._conn.execute(
+            "SELECT source FROM albums WHERE sale_item_id = 'sale-3'"
+        ).fetchone()
+        index.close()
+
+        # Remote tracks now have source='local' but file_path still starts with
+        # bandcamp://, so the dedup logic produces 'local' (local wins).
+        assert row_after is not None
+        assert row_after["source"] == "local"
 
     def test_migration_v20_adds_stream_columns(self, tmp_path: Path) -> None:
         """A v19 DB gains the three new columns on open."""


### PR DESCRIPTION
## Summary

Three gaps left after KAMP-418 are closed:

- **`update_remote_track_date_added`** now propagates the corrected purchase timestamp to `albums.date_added` via `sale_item_id` (MIN-wins rule: only update when new value is earlier)
- **`set_track_source_for_item`** now refreshes `albums.source` via a correlated subquery after updating `tracks.source`, using the same dedup logic as `upsert_many`
- **`patch_album_tags`** (all 4 `rename_album_tracks_bulk` call sites) now catches `sqlite3.IntegrityError` and returns 409 — covers the new case where the target album name exists in the `albums` table as a streaming-only entry but not yet on the filesystem

The 13-endpoint `_resolve_album_id` server shim originally planned for this task was not needed — KAMP-418 baked `_album_id()` resolution directly into the library methods, making the server endpoints already correct.

## Test plan

- [x] `poetry run pytest tests/test_library.py tests/test_album_rename.py -v --no-cov` — all pass
- [x] `poetry run pytest tests/` — 93.18% coverage (above 93% threshold)
- [x] `poetry run black --check .` — clean
- [x] `poetry run mypy kamp_core/ kamp_daemon/` — no issues
- [x] Manual: trigger a Bandcamp streaming sync; verify albums sort by purchase date in Last Added view
- [x] Manual: attempt to rename a local album to the name of a streaming-only album; verify 409 returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)