### PR TITLE
fix(KAMP-415): replace SearchAlbumCard with canonical AlbumCard in search results

### DIFF
--- a/kamp_ui/src/renderer/src/assets/search.css
+++ b/kamp_ui/src/renderer/src/assets/search.css
@@ -112,67 +112,6 @@
   gap: 12px;
 }
 
-.search-album-card {
-  cursor: pointer;
-  border-radius: 6px;
-  overflow: hidden;
-  background: var(--surface);
-  transition: background 0.15s;
-}
-
-.search-album-card:hover {
-  background: var(--surface-hover);
-}
-
-.search-album-art {
-  width: 100%;
-  aspect-ratio: 1;
-  background: var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.search-album-art img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-.search-album-art.has-art img {
-  opacity: 1;
-}
-
-.search-album-info {
-  padding: 8px;
-  position: relative;
-}
-
-.search-album-title {
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.search-album-artist {
-  font-size: 11px;
-  color: var(--text-dim);
-  margin-top: 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.search-album-year {
-  font-size: 11px;
-  color: var(--text-dim);
-  margin-top: 1px;
-}
 
 .search-track-list {
   display: flex;

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -48,7 +48,13 @@ const STATIC_BORDER_FRAMES = [
   'conic-gradient(from 180deg, #444 0deg, #888 80deg, #111 160deg, #777 220deg, #333 290deg, #444 360deg)'
 ]
 
-export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
+export function AlbumCard({
+  album,
+  onAfterSelect
+}: {
+  album: Album
+  onAfterSelect?: () => void
+}): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)
@@ -221,6 +227,7 @@ export function AlbumCard({ album }: { album: Album }): React.JSX.Element {
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
     void selectAlbum(album)
+    onAfterSelect?.()
   }
 
   const cardClass = [

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -1,78 +1,14 @@
 import React, { useState } from 'react'
 import { useStore } from '../store'
-import { artUrl } from '../api/client'
 import type { Album, Track } from '../api/client'
 import { SortControl } from './SortControl'
 import { SourceControl } from './SourceControl'
 import { FilterControl } from './FilterControl'
-import { AlbumContextMenu } from './AlbumContextMenu'
+import { AlbumCard } from './AlbumCard'
 import { TrackContextMenu } from './TrackContextMenu'
 import { FavoriteIcon } from './TransportIcons'
 
-type AlbumMenu = { x: number; y: number; album: Album }
 type TrackMenu = { x: number; y: number; track: Track }
-
-function SearchAlbumCard({
-  album,
-  onContextMenu
-}: {
-  album: Album
-  onContextMenu: (e: React.MouseEvent, album: Album) => void
-}): React.JSX.Element {
-  const selectAlbum = useStore((s) => s.selectAlbum)
-  const setSearchQuery = useStore((s) => s.setSearchQuery)
-  const setActiveView = useStore((s) => s.setActiveView)
-  const [artLoaded, setArtLoaded] = useState(false)
-
-  const handleClick = (): void => {
-    void setActiveView('library')
-    void selectAlbum(album)
-    void setSearchQuery('')
-  }
-
-  return (
-    <div
-      className="search-album-card"
-      tabIndex={0}
-      draggable
-      onClick={handleClick}
-      onKeyDown={(e) => e.key === 'Enter' && handleClick()}
-      onContextMenu={(e) => onContextMenu(e, album)}
-      onDragStart={(e) => {
-        e.dataTransfer.setData(
-          'text/kamp-album',
-          JSON.stringify({
-            album_artist: album.album_artist,
-            album: album.album,
-            file_path: album.file_path
-          })
-        )
-        e.dataTransfer.effectAllowed = 'copy'
-      }}
-    >
-      <div className={`search-album-art${artLoaded ? ' has-art' : ''}`}>
-        {album.has_art && (
-          <img
-            src={artUrl(album.album_artist, album.album, album.file_path, album.art_version)}
-            alt=""
-            onLoad={() => setArtLoaded(true)}
-            onError={() => setArtLoaded(false)}
-          />
-        )}
-      </div>
-      <div className="search-album-info">
-        <div className="search-album-title">{album.album}</div>
-        <div className="search-album-artist">{album.album_artist}</div>
-        <div className="search-album-year">{album.year}</div>
-        {album.favorite && (
-          <div className="album-fav-badge">
-            <FavoriteIcon active size={14} />
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
 
 function SearchTrackRow({
   track,
@@ -123,10 +59,10 @@ function SearchTrackRow({
 export function SearchView(): React.JSX.Element {
   const results = useStore((s) => s.searchResults)
   const query = useStore((s) => s.searchQuery)
+  const setSearchQuery = useStore((s) => s.setSearchQuery)
   const libraryFilter = useStore((s) => s.libraryFilter)
   const allAlbums = useStore((s) => s.library.albums)
 
-  const [albumMenu, setAlbumMenu] = useState<AlbumMenu | null>(null)
   const [trackMenu, setTrackMenu] = useState<TrackMenu | null>(null)
 
   const QUALITATIVE_FILTERS = ['favorite_album', 'has_favorite_track', 'unplayed', 'top_albums']
@@ -201,14 +137,10 @@ export function SearchView(): React.JSX.Element {
                 <h2 className="search-section-title">Albums</h2>
                 <div className="search-album-grid">
                   {visibleAlbums.map((album) => (
-                    <SearchAlbumCard
+                    <AlbumCard
                       key={`${album.album_artist}\0${album.album}`}
                       album={album}
-                      onContextMenu={(e, a) => {
-                        e.preventDefault()
-                        setTrackMenu(null)
-                        setAlbumMenu({ x: e.clientX, y: e.clientY, album: a })
-                      }}
+                      onAfterSelect={() => void setSearchQuery('')}
                     />
                   ))}
                 </div>
@@ -224,7 +156,6 @@ export function SearchView(): React.JSX.Element {
                       track={track}
                       onContextMenu={(e, t) => {
                         e.preventDefault()
-                        setAlbumMenu(null)
                         setTrackMenu({ x: e.clientX, y: e.clientY, track: t })
                       }}
                     />
@@ -235,15 +166,6 @@ export function SearchView(): React.JSX.Element {
           </>
         )}
       </div>
-
-      {albumMenu && (
-        <AlbumContextMenu
-          x={albumMenu.x}
-          y={albumMenu.y}
-          album={albumMenu.album}
-          onClose={() => setAlbumMenu(null)}
-        />
-      )}
 
       {trackMenu && (
         <TrackContextMenu


### PR DESCRIPTION
## Summary

- `SearchAlbumCard` in `SearchView.tsx` was a bespoke lightweight component that never received feature parity with `AlbumCard` — it was missing the streaming source badge, offline overlay, now-playing indicator, download/queue state, and new-arrival highlights
- Replace `SearchAlbumCard` entirely with `AlbumCard`, passing `onAfterSelect` to clear the search query on click (preserving existing navigation behaviour)
- Remove the now-dead `.search-album-*` CSS selectors from `search.css`

## Test plan

- [ ] All-streaming library: search for an album → Bandcamp source badge appears in the search result card
- [ ] Click a search result → navigates to library view, selects the album, clears the search query
- [ ] Local album in search results → no source badge shown
- [ ] Right-click a search result album → context menu appears
- [ ] Library and Base Kamp module album cards unchanged (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)