### PR TITLE
fix(KAMP-412): dedup c-typed collection items shadowed by a p-typed entry

### DIFF
--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -817,7 +817,13 @@ def _extract_pagedata(html: str, url: str) -> dict[str, Any]:
 def _fetch_collection(
     fan_id: int, session: _AnySession, index: "LibraryIndex"
 ) -> list[dict[str, Any]]:
-    """Fetch all collection items (visible + hidden), deduplicated by sale_item_id."""
+    """Fetch all collection items (visible + hidden), deduplicated by sale_item_id.
+
+    A second pass deduplicates by (band_name, item_title): when the same album
+    appears under two sale_item_ids (e.g. item_type=p for the purchase and
+    item_type=c for a pre-order/compilation entry), the p-typed entry is kept
+    and the c-typed entry is dropped to prevent duplicate tracks in the DB.
+    """
     seen: set[int] = set()
     items: list[dict[str, Any]] = []
     for endpoint in (_COLLECTION_URL, _HIDDEN_URL):
@@ -826,7 +832,22 @@ def _fetch_collection(
             if item_id not in seen:
                 seen.add(item_id)
                 items.append(item)
-    return items
+
+    # Drop c-typed items that have a p-typed counterpart with the same (band, title).
+    # This prevents duplicate tracks when Bandcamp returns the same album under two
+    # sale_item_ids (one per item_type).  Two p-typed items with the same title are
+    # kept as-is (they may be distinct editions or repurchases).
+    p_titles: set[tuple[str, str]] = {
+        (str(i.get("band_name", "")), str(i.get("item_title", "")))
+        for i in items
+        if i.get("sale_item_type") == "p"
+    }
+    return [
+        i
+        for i in items
+        if i.get("sale_item_type") != "c"
+        or (str(i.get("band_name", "")), str(i.get("item_title", ""))) not in p_titles
+    ]
 
 
 def _paginate(

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -1250,8 +1250,8 @@ class TestPaginate:
 class TestFetchCollection:
     def test_deduplicates_items_across_collection_and_hidden(self) -> None:
         """Items appearing in both collection and hidden endpoints are returned once."""
-        shared = _item(99)
-        unique_hidden = _item(100)
+        shared = _item(99, title="Album A")
+        unique_hidden = _item(100, title="Album B")
 
         session = MagicMock()
 
@@ -1274,6 +1274,25 @@ class TestFetchCollection:
         ids = [r["sale_item_id"] for r in result]
         assert ids.count(99) == 1
         assert 100 in ids
+
+    def test_deduplicates_p_and_c_same_title(self) -> None:
+        """When two items share (band_name, item_title), the p-typed entry wins."""
+        p_item = _item(293211292, band="Derya Yıldırım", title="Dost 1 & 2")
+        c_item = {
+            **_item(626315711, band="Derya Yıldırım", title="Dost 1 & 2"),
+            "sale_item_type": "c",
+        }
+
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"items": [p_item, c_item], "last_token": ""}
+        session.post.return_value = resp
+
+        result = _fetch_collection(12345, session, MagicMock())
+        ids = [r["sale_item_id"] for r in result]
+        assert ids == [293211292]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Bandcamp occasionally returns the same album under two `sale_item_id` values: one with `item_type=p` (the canonical purchase) and one with `item_type=c` (unknown provenance — pre-order or compilation entry). `_fetch_collection` already deduped by `sale_item_id` but had no cross-ID awareness.
- Add a second pass in `_fetch_collection`: drop any `c`-typed item whose `(band_name, item_title)` collides with an existing `p`-typed entry. Two `p`-typed entries for the same title are intentionally preserved (may be distinct editions or repurchases).
- Fix the existing `test_deduplicates_items_across_collection_and_hidden` test to use distinct album titles (the items were always meant to be distinct albums; shared defaults masked the semantic correctness of the new dedup).
- Add `test_deduplicates_p_and_c_same_title` to `TestFetchCollection` covering the repro case from the issue.

## Test plan

- [ ] Resync Bandcamp collection — "Dost 1 & 2" by Derya Yıldırım & Grup Şimşek should appear once with no duplicate tracks
- [ ] Confirm `sale_item_id` 293211292 (the `p` entry) is retained; 626315711 (the `c` entry) is excluded
- [ ] Confirm no other albums are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)