### PR TITLE
fix(KAMP-422): pass pause=yes in loadfile options to prevent streaming autoplay on startup

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1209,7 +1209,13 @@ class MpvPlaybackEngine:
             self.state.position = 0.0
             self.state.duration = 0.0
             self.state.position_updated_at = time.time()
-            self._send_command("loadfile", str(path), "replace", "pause=yes")
+            # Pre-set pause so mpv inherits the paused state on loadfile.
+            # pause=yes in the loadfile options arg defers the network connection
+            # for remote URLs, preventing demux and leaving duration=0. Sending
+            # set_property pause True first is processed before loadfile, so mpv
+            # starts buffering normally but won't advance the playback clock.
+            self._send_command("set_property", "pause", True)
+            self._send_command("loadfile", str(path), "replace")
         self._send_command("set_property", "pause", True)
 
     def preload_next(self, next_track: "Track | None") -> None:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1209,7 +1209,7 @@ class MpvPlaybackEngine:
             self.state.position = 0.0
             self.state.duration = 0.0
             self.state.position_updated_at = time.time()
-            self._send_command("loadfile", str(path), "replace")
+            self._send_command("loadfile", str(path), "replace", "pause=yes")
         self._send_command("set_property", "pause", True)
 
     def preload_next(self, next_track: "Track | None") -> None:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1251,22 +1251,22 @@ class TestMpvPlaybackEngine:
     def test_load_paused_loads_and_pauses(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"))
-        send.assert_any_call(
-            "loadfile", str(Path("/music/track.mp3")), "replace", "pause=yes"
-        )
+        send.assert_any_call("loadfile", str(Path("/music/track.mp3")), "replace")
         send.assert_any_call("set_property", "pause", True)
 
-    def test_load_paused_remote_url_includes_pause_option(self) -> None:
-        # pause=yes in the loadfile options arg is atomic — prevents the race where
-        # mpv starts streaming a remote URL before the follow-up set_property lands.
+    def test_load_paused_pause_set_before_loadfile(self) -> None:
+        # pause is sent before loadfile so mpv inherits the paused state on load.
+        # pause=yes in the loadfile options arg defers network connections for remote
+        # URLs (leaving duration=0 and the play button dead); pre-setting the property
+        # allows mpv to buffer normally while still starting paused.
         engine, send = _make_engine()
         engine.load_paused("https://cdn.bandcamp.com/stream/track.mp3")
-        send.assert_any_call(
-            "loadfile",
-            "https://cdn.bandcamp.com/stream/track.mp3",
-            "replace",
-            "pause=yes",
-        )
+        calls = [c[0] for c in send.call_args_list]
+        pause_indices = [
+            i for i, c in enumerate(calls) if c == ("set_property", "pause", True)
+        ]
+        loadfile_idx = next(i for i, c in enumerate(calls) if c[0] == "loadfile")
+        assert pause_indices[0] < loadfile_idx
 
     def test_load_paused_sets_pending_seek_when_position_nonzero(self) -> None:
         engine, _ = _make_engine()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1251,8 +1251,22 @@ class TestMpvPlaybackEngine:
     def test_load_paused_loads_and_pauses(self) -> None:
         engine, send = _make_engine()
         engine.load_paused(Path("/music/track.mp3"))
-        send.assert_any_call("loadfile", str(Path("/music/track.mp3")), "replace")
+        send.assert_any_call(
+            "loadfile", str(Path("/music/track.mp3")), "replace", "pause=yes"
+        )
         send.assert_any_call("set_property", "pause", True)
+
+    def test_load_paused_remote_url_includes_pause_option(self) -> None:
+        # pause=yes in the loadfile options arg is atomic — prevents the race where
+        # mpv starts streaming a remote URL before the follow-up set_property lands.
+        engine, send = _make_engine()
+        engine.load_paused("https://cdn.bandcamp.com/stream/track.mp3")
+        send.assert_any_call(
+            "loadfile",
+            "https://cdn.bandcamp.com/stream/track.mp3",
+            "replace",
+            "pause=yes",
+        )
 
     def test_load_paused_sets_pending_seek_when_position_nonzero(self) -> None:
         engine, _ = _make_engine()


### PR DESCRIPTION
## Summary

- `load_paused()` used a two-step IPC sequence: `loadfile <url> replace` followed by `set_property pause True`. For local files the demux step buys enough time for the pause command to land. For remote HTTPS URLs (Bandcamp streaming), mpv can begin buffering/playing before the follow-up IPC round-trip arrives — causing the track to auto-play on app restart.
- Fix: pass `pause=yes` as the `loadfile` options argument (4th positional arg to the mpv IPC command), which atomically loads the file in a paused state regardless of URL type. The existing `set_property pause True` is retained as belt-and-suspenders.
- Update the existing `test_load_paused_loads_and_pauses` assertion to match the new 4-arg form; add `test_load_paused_remote_url_includes_pause_option` to cover the remote URL case explicitly.

## Test plan

- [ ] Add a streaming album to queue, start playback partway through a track, close app, reopen — queue position is restored but playback does NOT auto-start
- [ ] Press play manually after restart — playback resumes from the saved position
- [ ] Confirm local file queue behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)