### PR TITLE
feat(KAMP-421): set poll_interval_minutes to 15 when onboarding in stream mode

### DIFF
--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -309,6 +309,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
       if (result.ok) {
         await loadConfig()
         if (collectionMode === 'stream') {
+          await setConfigValue('bandcamp.poll_interval_minutes', '15')
           window.api.bandcamp.triggerSync().catch(console.error)
         }
         changeStep('lastfm')


### PR DESCRIPTION
## Summary

Streaming users completing onboarding received the default `poll_interval_minutes = 0` (manual sync only). They had to manually navigate to Preferences to enable background syncs — an unnecessary friction point for a streaming-first workflow.

Add one `setConfigValue('bandcamp.poll_interval_minutes', '15')` call inside the `result.ok` block of `handleBandcampLogin`, conditioned on `collectionMode === 'stream'`. Download mode is unaffected. Users can still adjust the interval at any time via Preferences.

## Test plan

- [x] Fresh onboarding in Stream mode → Bandcamp login succeeds → open Preferences → "Sync every" shows 15 minutes
- [x] Fresh onboarding in Download mode → Bandcamp login succeeds → open Preferences → "Sync every" shows 0 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)