### PR TITLE
feat(KAMP-423): show pre-order status on streaming albums

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -90,7 +90,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 24
+_SCHEMA_VERSION = 25
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -121,7 +121,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     source               TEXT    NOT NULL DEFAULT 'local',
     stream_url           TEXT,
     stream_url_expires_at REAL,
-    album_id             INTEGER REFERENCES albums(id)
+    album_id             INTEGER REFERENCES albums(id),
+    is_available         INTEGER NOT NULL DEFAULT 1
 );
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
@@ -344,6 +345,8 @@ class Track:
     source: str = field(default="local", compare=False)
     stream_url: str | None = field(default=None, compare=False)
     stream_url_expires_at: float | None = field(default=None, compare=False)
+    # False for pre-order tracks whose CDN file has not yet been released.
+    is_available: bool = field(default=True, compare=False)
     # Runtime flag; not persisted to DB. False for stub tracks created during
     # queue restore when the DB row is missing (e.g. after a DB wipe).
     reachable: bool = field(default=True, compare=False)
@@ -391,6 +394,8 @@ class AlbumInfo:
     in_bandcamp_collection: bool = False
     # Bandcamp sale_item_id — stored on the albums row since KAMP-418.
     sale_item_id: str | None = None
+    # True when the album is a Bandcamp pre-order (some tracks not yet released).
+    is_preorder: bool = False
     # Stable integer PK of the albums row; 0 for missing-album virtual entries.
     album_id: int = field(default=0, compare=False)
 
@@ -970,7 +975,20 @@ class LibraryIndex:
                 self._conn.execute("DROP TABLE album_favorites")
             self._conn.execute("UPDATE schema_version SET version = 24")
             self._conn.commit()
-            version = 24  # noqa: F841
+            version = 24
+
+        if version == 24:
+            # v24 → v25: add is_available to tracks for pre-order support (KAMP-423).
+            existing = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if "is_available" not in existing:
+                self._conn.execute(
+                    "ALTER TABLE tracks ADD COLUMN is_available INTEGER NOT NULL DEFAULT 1"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 25")
+            self._conn.commit()
+            version = 25  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -1557,8 +1575,9 @@ class LibraryIndex:
                 (file_path, title, artist, album_artist, album, year,
                  track_number, disc_number, ext, embedded_art,
                  mb_release_id, mb_recording_id, date_added, file_mtime,
-                 genre, label, source, stream_url, stream_url_expires_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 genre, label, source, stream_url, stream_url_expires_at,
+                 is_available)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 title                 = excluded.title,
                 artist                = excluded.artist,
@@ -1576,7 +1595,8 @@ class LibraryIndex:
                 label                 = excluded.label,
                 source                = excluded.source,
                 stream_url            = excluded.stream_url,
-                stream_url_expires_at = excluded.stream_url_expires_at
+                stream_url_expires_at = excluded.stream_url_expires_at,
+                is_available          = excluded.is_available
                 -- date_added intentionally omitted: preserve original scan date on re-scan
                 -- last_played intentionally omitted: managed exclusively by record_played()
             """,
@@ -2185,11 +2205,12 @@ class LibraryIndex:
                 END                 AS track_count,
                 MAX(t.favorite)     AS has_favorite_track,
                 -- in_bandcamp_collection: True only when mode='local' (user downloaded it).
-                CASE WHEN bc.sale_item_id IS NOT NULL THEN 1 ELSE 0 END AS in_bc
+                CASE WHEN bc.mode = 'local' THEN 1 ELSE 0 END AS in_bc,
+                -- is_preorder: True when the album is a Bandcamp pre-order (KAMP-423).
+                CASE WHEN bc.mode = 'preorder' THEN 1 ELSE 0 END AS is_preorder
             FROM albums a
             LEFT JOIN tracks t ON t.album_id = a.id
-            LEFT JOIN bandcamp_collection bc
-                ON bc.sale_item_id = a.sale_item_id AND bc.mode = 'local'
+            LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id
             GROUP BY a.id
             UNION ALL
             -- Missing-album tracks: each track with album='' appears as its own
@@ -2211,7 +2232,8 @@ class LibraryIndex:
                 t.file_path,
                 1                   AS track_count,
                 t.favorite          AS has_favorite_track,
-                0                   AS in_bc
+                0                   AS in_bc,
+                0                   AS is_preorder
             FROM tracks t
             WHERE t.album = ''
             ORDER BY {order_by}
@@ -2235,6 +2257,7 @@ class LibraryIndex:
                 source=r["album_source"],
                 has_remote_tracks=r["album_source"] != "local",
                 in_bandcamp_collection=bool(r["in_bc"]),
+                is_preorder=bool(r["is_preorder"]),
                 sale_item_id=r["sale_item_id"],
             )
             for r in rows
@@ -2723,6 +2746,7 @@ def _track_to_params(
     str,
     str | None,
     float | None,
+    int,
 ]:
     return (
         _canonical_track_key(t.file_path),
@@ -2744,6 +2768,7 @@ def _track_to_params(
         t.source,
         t.stream_url,
         t.stream_url_expires_at,
+        int(t.is_available),
     )
 
 
@@ -2788,6 +2813,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         source=row["source"],
         stream_url=row["stream_url"],
         stream_url_expires_at=row["stream_url_expires_at"],
+        is_available=bool(row["is_available"]),
     )
 
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -145,6 +145,7 @@ class TrackOut(BaseModel):
     play_count: int
     source: str
     reachable: bool = True
+    is_available: bool = True
 
     @classmethod
     def from_track(cls, t: Track) -> "TrackOut":
@@ -168,6 +169,7 @@ class TrackOut(BaseModel):
             play_count=t.play_count,
             source=t.source,
             reachable=t.reachable,
+            is_available=t.is_available,
         )
 
 
@@ -200,6 +202,8 @@ class AlbumOut(BaseModel):
     has_remote_tracks: bool = False
     # Bandcamp sale_item_id parsed from constituent track file paths; None for local albums.
     sale_item_id: str | None = None
+    # True when the album is a Bandcamp pre-order (some tracks not yet released).
+    is_preorder: bool = False
 
 
 class PlayerStateOut(BaseModel):
@@ -846,6 +850,7 @@ def create_app(
                 source=a.source,
                 has_remote_tracks=a.has_remote_tracks,
                 sale_item_id=a.sale_item_id,
+                is_preorder=a.is_preorder,
             )
             for a in index.albums(sort=sort)
         ]
@@ -1867,6 +1872,7 @@ def create_app(
                     source=a.source,
                     has_remote_tracks=a.has_remote_tracks,
                     sale_item_id=a.sale_item_id,
+                    is_preorder=a.is_preorder,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -1992,6 +1998,7 @@ def create_app(
                     source=a.source,
                     has_remote_tracks=a.has_remote_tracks,
                     sale_item_id=a.sale_item_id,
+                    is_preorder=a.is_preorder,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -2146,6 +2153,7 @@ def create_app(
                 source=a.source,
                 has_remote_tracks=a.has_remote_tracks,
                 sale_item_id=a.sale_item_id,
+                is_preorder=a.is_preorder,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys
@@ -2571,7 +2579,35 @@ def create_app(
             track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
-            tracks = index.tracks_for_album(req.album_artist, req.album)
+            all_tracks = index.tracks_for_album(req.album_artist, req.album)
+            # Map start_index from the full list to the available subset before filtering.
+            requested = (
+                all_tracks[req.track_index]
+                if req.track_index < len(all_tracks)
+                else None
+            )
+            tracks = [t for t in all_tracks if t.is_available]
+            if requested and requested.is_available:
+                req = PlayRequest(
+                    album_artist=req.album_artist,
+                    album=req.album,
+                    track_index=next(
+                        (
+                            i
+                            for i, t in enumerate(tracks)
+                            if t.file_path == requested.file_path
+                        ),
+                        0,
+                    ),
+                    file_path=req.file_path,
+                )
+            else:
+                req = PlayRequest(
+                    album_artist=req.album_artist,
+                    album=req.album,
+                    track_index=0,
+                    file_path=req.file_path,
+                )
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.load(tracks, start_index=req.track_index)
@@ -2721,7 +2757,11 @@ def create_app(
             track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
-            tracks = index.tracks_for_album(req.album_artist, req.album)
+            tracks = [
+                t
+                for t in index.tracks_for_album(req.album_artist, req.album)
+                if t.is_available
+            ]
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         was_stopped = queue.current() is None
@@ -2742,7 +2782,11 @@ def create_app(
             track = index.get_track_by_path(p)
             tracks = [track] if track else []
         else:
-            tracks = index.tracks_for_album(req.album_artist, req.album)
+            tracks = [
+                t
+                for t in index.tracks_for_album(req.album_artist, req.album)
+                if t.is_available
+            ]
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         was_stopped = queue.current() is None
@@ -2762,7 +2806,11 @@ def create_app(
             track = index.get_track_by_path(Path(req.file_path))
             tracks = [track] if track else []
         else:
-            tracks = index.tracks_for_album(req.album_artist, req.album)
+            tracks = [
+                t
+                for t in index.tracks_for_album(req.album_artist, req.album)
+                if t.is_available
+            ]
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
         queue.insert_album_at(tracks, req.index)

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -437,13 +437,17 @@ def sync_collection_stream(
         band_name = str(item.get("band_name", ""))
         item_title = str(item.get("item_title", ""))
         album_url = str(item.get("item_url", ""))
+        current_mode = existing_state.get(str(sid))
+        is_preorder_already = current_mode == "preorder"
 
         if status_callback:
             status_callback(f"{item_title} by {band_name}")
 
+        # Preserve 'preorder' mode through the upsert; corrected after track re-inspection.
+        upsert_mode = "preorder" if is_preorder_already else "remote"
         index.upsert_collection_item(
             str(sid),
-            mode="remote",
+            mode=upsert_mode,
             item_type=str(item.get("sale_item_type", "p")),
             band_name=band_name,
             item_title=item_title,
@@ -460,9 +464,11 @@ def sync_collection_stream(
         if purchased_ts is not None:
             index.update_remote_track_date_added(str(sid), purchased_ts)
 
-        # Fetch track metadata only for albums not yet in the tracks table.
-        # This keeps incremental syncs fast while still populating new albums.
-        if album_url and not index.has_remote_album_tracks(str(sid)):
+        # Fetch track metadata for new albums or pre-order albums (always re-inspect
+        # pre-orders so newly released tracks and full-release transitions are caught).
+        if album_url and (
+            is_preorder_already or not index.has_remote_album_tracks(str(sid))
+        ):
             if fetch_index > 0:
                 time.sleep(0.5)
             fetch_index += 1
@@ -486,6 +492,13 @@ def sync_collection_stream(
                     )
                     if batch_indexed_callback:
                         batch_indexed_callback()
+                    # Update pre-order mode based on current track availability.
+                    has_unavailable = any(not t.is_available for t in tracks)
+                    if has_unavailable:
+                        index.set_collection_item_mode(str(sid), "preorder")
+                    elif is_preorder_already:
+                        # All tracks are now released — graduate to normal remote.
+                        index.set_collection_item_mode(str(sid), "remote")
             except Exception as exc:
                 logger.warning(
                     "fetch_album_tracks: skipping tracks for %r by %r (%s): %s",
@@ -1034,6 +1047,8 @@ def fetch_album_tracks(
             continue
         # Per-track artist field is set on compilations/splits; fall back to band_name.
         artist = t.get("artist") or band_name
+        # file=null (or absent) means the track hasn't been released yet (pre-order).
+        is_available = bool(t.get("file"))
         result.append(
             Track(
                 file_path=Path(f"bandcamp://{sale_item_id}/{track_num}"),
@@ -1050,6 +1065,7 @@ def fetch_album_tracks(
                 mb_recording_id="",
                 source="bandcamp",
                 date_added=date_added if date_added is not None else time.time(),
+                is_available=is_available,
             )
         )
     return result

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -26,6 +26,7 @@ export type Track = {
   play_count: number
   source: string
   reachable: boolean
+  is_available: boolean
 }
 
 export type Album = {
@@ -56,6 +57,8 @@ export type Album = {
   has_remote_tracks: boolean
   // Bandcamp sale_item_id parsed from constituent track file paths; undefined for local albums.
   sale_item_id?: string
+  // True when this album is a Bandcamp pre-order (some tracks not yet released).
+  is_preorder?: boolean
 }
 
 export type PlayerState = {

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -201,3 +201,21 @@
   font-size: 10px;
   opacity: 0.8;
 }
+
+/* Pre-order banner — anchored to bottom of album art area (KAMP-423) */
+.album-preorder-banner {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: lowercase;
+  background: rgba(124, 134, 225, 0.88);
+  color: #fff;
+  padding: 3px 0;
+  pointer-events: none;
+  z-index: 2;
+}

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -125,6 +125,24 @@
   color: #ffffff;
 }
 
+/* Pre-order badge inline with album title (KAMP-423) */
+.album-preorder-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(124, 134, 225, 0.25);
+  color: #7c86e1;
+  vertical-align: middle;
+  pointer-events: none;
+  border: 1px solid rgba(124, 134, 225, 0.4);
+}
+
 /* Edit / Done toggle — separate pill, absolutely positioned at the right of
    the hero row. Ghost in resting state; filled accent chip when active. */
 .breadcrumb-edit-btn {
@@ -769,6 +787,22 @@
 .track-row--offline .track-row-title {
   font-style: italic;
   opacity: 0.42;
+}
+
+/* Pre-order unavailable tracks (KAMP-423) ---------------------------------- */
+
+.track-row--preorder-unavailable {
+  cursor: not-allowed;
+}
+
+.track-row--preorder-unavailable .track-row-num,
+.track-row--preorder-unavailable .track-row-artist {
+  opacity: 0.35;
+}
+
+.track-row--preorder-unavailable .track-row-title {
+  font-style: italic;
+  opacity: 0.35;
 }
 
 /* Now Playing view --------------------------------------------------------- */

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -304,6 +304,11 @@ export function AlbumCard({
             </div>
           </div>
         )}
+        {album.is_preorder && (
+          <div className="album-preorder-banner" aria-label="Pre-Order">
+            pre-order
+          </div>
+        )}
         {isNew && highlightStyle === 'shiny' && <span className="shiny-sweep" aria-hidden="true" />}
         {isNew && highlightStyle === 'boring' && (
           <span className="boring-hover" aria-hidden="true">

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -363,22 +363,26 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
 
         {step === 'library' && (
           <div className="onboarding-library">
-            <div className="onboarding-heading">Let&apos;s set up your library</div>
+            <div className="onboarding-heading">let&apos;s set up your library</div>
             <button className="onboarding-primary-btn" onClick={handleChooseLibrary}>
-              Choose Library Folder
+              choose library folder
             </button>
+            <p className="onboarding-card-body">
+              <strong>kamp</strong> will scan any files in this folder and add them to its 
+              library. if you use kamp to download music, it will end up here.
+            </p>
             {cardError && <div className="onboarding-error">{cardError}</div>}
           </div>
         )}
 
         {(step === 'watch-folder' || step === 'bandcamp' || step === 'lastfm') && (
           <div className="onboarding-card">
-            <div className="onboarding-card-heading">While we&apos;re waiting&hellip;</div>
+            <div className="onboarding-card-heading">while we&apos;re waiting&hellip;</div>
 
             {step === 'watch-folder' && (
               <>
                 <button className="onboarding-primary-btn" onClick={handleChooseWatchFolder}>
-                  Choose Watch Folder
+                  choose watch folder
                 </button>
                 <p className="onboarding-card-body">
                   <strong>kamp</strong> will keep an eye on your watch folder to auto-tag and add
@@ -396,20 +400,20 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                     className={`onboarding-mode-btn${collectionMode === 'stream' ? ' onboarding-mode-btn--active' : ''}`}
                     onClick={() => setCollectionMode('stream')}
                   >
-                    Stream
+                    stream
                   </button>
                   <button
                     type="button"
                     className={`onboarding-mode-btn${collectionMode === 'download' ? ' onboarding-mode-btn--active' : ''}`}
                     onClick={() => setCollectionMode('download')}
                   >
-                    Download
+                    download
                   </button>
                 </div>
                 <p className="onboarding-card-body">
                   {collectionMode === 'stream'
-                    ? 'Your Bandcamp purchases stream directly. No downloads needed. Applies to new purchases synced going forward.'
-                    : 'Purchases are downloaded to your library folder for offline playback. Applies to new purchases synced going forward. Existing downloads remain in your library.'}
+                    ? "you are a busy music fan with a solid network connection. stream your bandcamp purchases, no downloads needed. albums can be downloaded individually for offline listening."
+                    : "you are a connoisseur and curator with a big hard drive. purchases are downloaded to your library folder for offline playback. pre-orders stream until they are released."}
                 </p>
                 <button
                   className="onboarding-primary-btn"
@@ -430,7 +434,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 <input
                   className="prefs-input"
                   type="text"
-                  placeholder="Last.fm username"
+                  placeholder="last.fm username"
                   value={lastfmUsername}
                   autoComplete="username"
                   onChange={(e) => setLastfmUsername(e.target.value)}
@@ -439,7 +443,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 <input
                   className="prefs-input"
                   type="password"
-                  placeholder="Password"
+                  placeholder="password"
                   value={lastfmPassword}
                   autoComplete="current-password"
                   onChange={(e) => setLastfmPassword(e.target.value)}
@@ -450,14 +454,14 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                   onClick={handleLastfmLogin}
                   disabled={lastfmBusy}
                 >
-                  {lastfmBusy ? 'Connecting…' : 'Connect Last.fm'}
+                  {lastfmBusy ? 'connecting…' : 'Connect Last.fm'}
                 </button>
                 <p className="onboarding-card-body">
-                  Connect your <strong>Last.fm</strong> account to save your listening history.
+                  connect your <strong>last.fm</strong> account to save and share your listening history.
                 </p>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
                 <button className="onboarding-skip-btn" onClick={advancePastCards}>
-                  Skip
+                  skip
                 </button>
               </>
             )}

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -420,11 +420,11 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                   onClick={handleBandcampLogin}
                   disabled={bandcampBusy}
                 >
-                  {bandcampBusy ? 'Logging in…' : 'Log in to Bandcamp'}
+                  {bandcampBusy ? 'logging in…' : 'log in to bandcamp'}
                 </button>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
                 <button className="onboarding-skip-btn" onClick={() => changeStep('lastfm')}>
-                  Skip
+                  skip
                 </button>
               </>
             )}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -339,6 +339,9 @@ export function TrackList(): React.JSX.Element | null {
           ›
         </span>
         <span>{album.album}</span>
+        {album.is_preorder && (
+          <span className="album-preorder-badge" aria-label="Pre-Order">Pre-Order</span>
+        )}
       </nav>
 
       {/* Edit toggle — suppressed for bandcamp-only albums (no local files to edit) */}
@@ -564,13 +567,14 @@ export function TrackList(): React.JSX.Element | null {
             const isCurrent = currentTrack?.id === track.id
             const isRemoteTrack = track.source !== 'local'
             const isTrackOffline = isRemoteTrack && !connected
+            const isPreorderUnavailable = track.is_available === false
             return (
               <li
                 key={track.id}
-                className={`track-row${isCurrent ? ' current' : ''}${isTrackOffline ? ' track-row--offline' : ''}`}
+                className={`track-row${isCurrent ? ' current' : ''}${isTrackOffline ? ' track-row--offline' : ''}${isPreorderUnavailable ? ' track-row--preorder-unavailable' : ''}`}
                 tabIndex={0}
                 onDoubleClick={() => {
-                  if (isTrackOffline) return
+                  if (isTrackOffline || isPreorderUnavailable) return
                   if (isCurrent) {
                     togglePlayPause()
                   } else {
@@ -579,7 +583,7 @@ export function TrackList(): React.JSX.Element | null {
                 }}
                 onKeyDown={(e) => {
                   if (e.key !== 'Enter') return
-                  if (isTrackOffline) return
+                  if (isTrackOffline || isPreorderUnavailable) return
                   if (isCurrent) togglePlayPause()
                   else playTrack(album.album_artist, album.album, i, album.file_path)
                 }}

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2635,6 +2635,210 @@ class TestFetchAlbumTracks:
         assert len(result) == 1
         assert result[0].title == "Good"
 
+    def test_is_available_true_when_file_present(self) -> None:
+        """Tracks with a file entry are marked available (KAMP-423)."""
+        tracks = [
+            {
+                "title": "Released",
+                "track_num": 1,
+                "artist": None,
+                "file": {"mp3-128": "https://cdn.example.com/track1.mp3"},
+            }
+        ]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert len(result) == 1
+        assert result[0].is_available is True
+
+    def test_is_available_false_when_file_is_null(self) -> None:
+        """Tracks with file=null (unreleased pre-order tracks) are unavailable (KAMP-423)."""
+        tracks = [
+            {
+                "title": "Released",
+                "track_num": 1,
+                "artist": None,
+                "file": {"mp3-128": "https://cdn.example.com/t1.mp3"},
+            },
+            {"title": "Unreleased", "track_num": 2, "artist": None, "file": None},
+        ]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert len(result) == 2
+        assert result[0].is_available is True
+        assert result[1].is_available is False
+
+    def test_is_available_false_when_file_absent(self) -> None:
+        """Tracks with no file key at all are also unavailable (KAMP-423)."""
+        tracks = [{"title": "Unreleased", "track_num": 1, "artist": None}]
+        html = _stream_album_page_html(tracks=tracks)
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        assert result[0].is_available is False
+
+    def test_all_available_when_no_file_key_by_default(self) -> None:
+        """The default _stream_album_page_html fixture omits 'file'; confirm False."""
+        html = _stream_album_page_html()
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
+        )
+        # Default fixture tracks have no 'file' key → all unavailable
+        assert all(t.is_available is False for t in result)
+
+
+class TestSyncCollectionStreamPreorder:
+    """Pre-order-aware sync behaviour in sync_collection_stream (KAMP-423)."""
+
+    def _make_track(
+        self, sale_item_id: str, track_num: int, available: bool = True
+    ) -> "Track":
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        t = Track(
+            file_path=_Path(f"bandcamp://{sale_item_id}/{track_num}"),
+            title=f"Track {track_num}",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            year="2020",
+            track_number=track_num,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        t.is_available = available
+        return t
+
+    def _run(
+        self,
+        tmp_path: Path,
+        items: list[dict[str, Any]],
+        fake_tracks: list[Any],
+        existing_state: dict[str, str] | None = None,
+        has_remote_tracks: bool = False,
+    ) -> "MagicMock":
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock(items)
+        index = MagicMock()
+        index.get_collection_state.return_value = existing_state or {}
+        index.has_remote_album_tracks.return_value = has_remote_tracks
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+            patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=fake_tracks),
+        ):
+            sync_collection_stream(config, watch_folder, index)
+
+        return index
+
+    def test_sets_preorder_mode_when_unavailable_tracks_present(
+        self, tmp_path: Path
+    ) -> None:
+        """When fetched tracks include unavailable ones, mode is set to 'preorder'."""
+        items = [_item(1)]
+        tracks = [
+            self._make_track("1", 1, available=True),
+            self._make_track("1", 2, available=False),
+        ]
+        index = self._run(tmp_path, items, tracks, has_remote_tracks=False)
+
+        index.set_collection_item_mode.assert_called_once_with("1", "preorder")
+
+    def test_does_not_call_set_mode_when_all_tracks_available_and_not_preorder(
+        self, tmp_path: Path
+    ) -> None:
+        """Fully available albums (not previously preorder) leave mode unchanged."""
+        items = [_item(1)]
+        tracks = [self._make_track("1", 1, available=True)]
+        index = self._run(tmp_path, items, tracks, has_remote_tracks=False)
+
+        index.set_collection_item_mode.assert_not_called()
+
+    def test_reverts_to_remote_when_all_tracks_become_available(
+        self, tmp_path: Path
+    ) -> None:
+        """A previously-preorder album whose tracks are all now available reverts to 'remote'."""
+        items = [_item(1)]
+        tracks = [
+            self._make_track("1", 1, available=True),
+            self._make_track("1", 2, available=True),
+        ]
+        index = self._run(
+            tmp_path,
+            items,
+            tracks,
+            existing_state={"1": "preorder"},
+            has_remote_tracks=True,
+        )
+
+        index.set_collection_item_mode.assert_called_once_with("1", "remote")
+
+    def test_preorder_album_bypasses_has_remote_tracks_short_circuit(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-order albums are always re-fetched even if tracks already exist in DB."""
+        items = [_item(1)]
+        tracks = [self._make_track("1", 1, available=False)]
+        index = self._run(
+            tmp_path,
+            items,
+            tracks,
+            existing_state={"1": "preorder"},
+            has_remote_tracks=True,  # would normally skip fetch
+        )
+
+        index.upsert_many.assert_called_once()
+
+    def test_non_preorder_album_still_skips_when_tracks_exist(
+        self, tmp_path: Path
+    ) -> None:
+        """Regular remote albums with existing tracks are still short-circuited."""
+        items = [_item(1)]
+        index = self._run(
+            tmp_path,
+            items,
+            fake_tracks=[],
+            existing_state={"1": "remote"},
+            has_remote_tracks=True,
+        )
+
+        index.upsert_many.assert_not_called()
+
+    def test_upsert_collection_item_preserves_preorder_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """When existing mode is 'preorder', upsert_collection_item is called with mode='preorder'
+        (not 'remote') so the mode survives the initial upsert before track re-inspection.
+        """
+        items = [_item(1)]
+        tracks = [self._make_track("1", 1, available=False)]
+        index = self._run(
+            tmp_path,
+            items,
+            tracks,
+            existing_state={"1": "preorder"},
+            has_remote_tracks=True,
+        )
+
+        upsert_calls = index.upsert_collection_item.call_args_list
+        assert len(upsert_calls) == 1
+        assert upsert_calls[0][1]["mode"] == "preorder"
+
 
 class TestDownloadSingleAlbum:
     """Tests for download_single_album()."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 24
+        assert version == 25
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1390,7 +1390,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1447,7 +1447,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1834,7 +1834,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert row is not None
         assert row[0] == 0
 
@@ -2088,7 +2088,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2184,7 +2184,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2365,7 +2365,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2460,7 +2460,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 24
+        assert version == 25
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2468,7 +2468,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 24
+        assert version == 25
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3345,7 +3345,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 24
+        assert version == 25
 
         index.close()
 
@@ -4030,7 +4030,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 24
+        assert version == 25
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4065,7 +4065,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 24
+        assert version == 25
         index.close()
 
 
@@ -4513,7 +4513,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 24
+        assert version == 25
 
 
 class TestRemoteTrackSchema:
@@ -4816,7 +4816,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4877,7 +4877,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 24
+        assert version == 25
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5544,7 +5544,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5659,7 +5659,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5737,7 +5737,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 24
+        assert version == 25
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -5860,3 +5860,239 @@ class TestMigrationV24:
         assert row is not None
         assert row[0] == 1
         assert albums[0].favorite is True
+
+
+class TestMigrationV25:
+    """v24 → v25: is_available column on tracks (KAMP-423)."""
+
+    def _build_v24_db(self, db_path: Path) -> None:
+        import sqlite3 as _sqlite3
+
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (24)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
+            " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
+            " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
+            " stream_url_expires_at REAL, album_id INTEGER)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " album_artist TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " album TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " year TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', genre TEXT NOT NULL DEFAULT '',"
+            " label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local',"
+            " sale_item_id TEXT, favorite INTEGER NOT NULL DEFAULT 0,"
+            " date_added REAL, last_played_at REAL, play_count_avg REAL NOT NULL DEFAULT 0,"
+            " art_version REAL, UNIQUE (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY,"
+            " item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '',"
+            " item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '',"
+            " album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local',"
+            " synced_at REAL, added_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY,"
+            " session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE,"
+            " payload_json TEXT NOT NULL, created_at REAL NOT NULL,"
+            " attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE download_queue (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE, queued_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+            " track_number, source) VALUES (?,?,?,?,?,?,?)",
+            ("bandcamp://1/1", "T1", "A", "A", "Alb", 1, "bandcamp"),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_migration_adds_is_available_column(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v24_db(db_path)
+        index = LibraryIndex(db_path)
+        cols = {
+            r[1] for r in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        index.close()
+
+        assert version == 25
+        assert "is_available" in cols
+
+    def test_migration_defaults_existing_rows_to_available(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v24_db(db_path)
+        index = LibraryIndex(db_path)
+        row = index._conn.execute("SELECT is_available FROM tracks LIMIT 1").fetchone()
+        index.close()
+
+        assert row is not None
+        assert row[0] == 1
+
+
+class TestIsAvailable:
+    """Track.is_available is persisted and read back correctly."""
+
+    def test_is_available_defaults_to_true(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "01.mp3")
+        index.upsert_many([t])
+        result = index.all_tracks()
+        index.close()
+
+        assert result[0].is_available is True
+
+    def test_is_available_false_is_persisted(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(Path("bandcamp://42/1"))
+        t.source = "bandcamp"
+        t.is_available = False
+        index.upsert_many([t])
+        result = index.all_tracks()
+        index.close()
+
+        assert result[0].is_available is False
+
+    def test_upsert_updates_is_available(self, tmp_path: Path) -> None:
+        """Re-upserting a track with is_available=True updates a previously unavailable row."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(Path("bandcamp://42/1"))
+        t.source = "bandcamp"
+        t.is_available = False
+        index.upsert_many([t])
+
+        t2 = _sample_track(Path("bandcamp://42/1"))
+        t2.source = "bandcamp"
+        t2.is_available = True
+        index.upsert_many([t2])
+
+        result = index.all_tracks()
+        index.close()
+
+        assert len(result) == 1
+        assert result[0].is_available is True
+
+
+class TestIsPreorder:
+    """AlbumInfo.is_preorder reflects bandcamp_collection.mode='preorder'."""
+
+    def _remote_track(self, sale_item_id: str, track_num: int) -> Track:
+        return Track(
+            file_path=Path(f"bandcamp://{sale_item_id}/{track_num}"),
+            title=f"Track {track_num}",
+            artist="The Artist",
+            album_artist="The Artist",
+            album="The Album",
+            year="2024",
+            track_number=track_num,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+
+    def test_is_preorder_false_by_default(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._remote_track("10", 1)])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].is_preorder is False
+
+    def test_is_preorder_true_when_mode_is_preorder(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "10",
+            mode="preorder",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        index.upsert_many([self._remote_track("10", 1)])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].is_preorder is True
+
+    def test_is_preorder_false_when_mode_is_remote(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "10",
+            mode="remote",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        index.upsert_many([self._remote_track("10", 1)])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].is_preorder is False
+
+    def test_in_bandcamp_collection_still_false_for_preorder_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """in_bandcamp_collection should remain False for mode='preorder' (not downloaded)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "10",
+            mode="preorder",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        index.upsert_many([self._remote_track("10", 1)])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].in_bandcamp_collection is False
+
+    def test_in_bandcamp_collection_still_true_for_local_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """Changing the LEFT JOIN must not break in_bandcamp_collection for mode='local'."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "10",
+            mode="local",
+            band_name="The Artist",
+            item_title="The Album",
+            synced_at=1000.0,
+        )
+        index.upsert_many([self._remote_track("10", 1)])
+        albums = index.albums()
+        index.close()
+
+        assert albums[0].in_bandcamp_collection is True
+        assert albums[0].is_preorder is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4522,3 +4522,158 @@ class TestArtEndpointRemoteAlbums:
 
         assert res.status_code == 200
         assert res.content == self._JPEG
+
+
+class TestIsAvailableField:
+    """TrackOut exposes is_available from Track (KAMP-423)."""
+
+    def test_is_available_true_by_default(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(1)
+        mock_index.tracks_for_album.return_value = [t]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/tracks?album_artist=Artist&album=Album").json()
+        assert data[0]["is_available"] is True
+
+    def test_is_available_false_for_unreleased_preorder_track(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(1)
+        t.is_available = False
+        mock_index.tracks_for_album.return_value = [t]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/tracks?album_artist=Artist&album=Album").json()
+        assert data[0]["is_available"] is False
+
+
+class TestIsPreorderField:
+    """AlbumOut exposes is_preorder from AlbumInfo (KAMP-423)."""
+
+    def test_is_preorder_false_by_default(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.albums.return_value = [_album("Artist", "Record")]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/albums").json()
+        assert data[0]["is_preorder"] is False
+
+    def test_is_preorder_true_when_album_info_flagged(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        info = _album("Artist", "Record")
+        info.is_preorder = True
+        mock_index.albums.return_value = [info]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/albums").json()
+        assert data[0]["is_preorder"] is True
+
+
+class TestPreorderUnavailableTracksExcludedFromQueue:
+    """Unavailable pre-order tracks must not enter the queue (KAMP-423)."""
+
+    def _unavailable_track(self, n: int) -> "Track":
+        t = _track(n)
+        t.is_available = False
+        return t
+
+    def test_play_album_excludes_unavailable_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        available = _track(1)
+        unavailable = self._unavailable_track(2)
+        mock_index.tracks_for_album.return_value = [available, unavailable]
+        mock_queue.current.return_value = available
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        c.post(
+            "/api/v1/player/play",
+            json={"album_artist": "A", "album": "B", "track_index": 0},
+        )
+        mock_queue.load.assert_called_once_with([available], start_index=0)
+
+    def test_play_album_404_when_all_tracks_unavailable(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [self._unavailable_track(1)]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        resp = c.post(
+            "/api/v1/player/play",
+            json={"album_artist": "A", "album": "B", "track_index": 0},
+        )
+        assert resp.status_code == 404
+
+    def test_play_album_adjusts_start_index_for_filtered_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """When track_index points past a filtered-out track, start_index shifts down."""
+        t1 = self._unavailable_track(1)
+        t2 = _track(2)  # available, originally at index 1
+        mock_index.tracks_for_album.return_value = [t1, t2]
+        mock_queue.current.return_value = t2
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        # User requests track at index 1 (t2) in the unfiltered list
+        c.post(
+            "/api/v1/player/play",
+            json={"album_artist": "A", "album": "B", "track_index": 1},
+        )
+        # After filtering t1 out, t2 is at index 0 in the available list
+        mock_queue.load.assert_called_once_with([t2], start_index=0)
+
+    def test_add_album_to_queue_excludes_unavailable_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        available = _track(1)
+        unavailable = self._unavailable_track(2)
+        mock_index.tracks_for_album.return_value = [available, unavailable]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        c.post(
+            "/api/v1/player/queue/add-album", json={"album_artist": "A", "album": "B"}
+        )
+        mock_queue.add_album_to_queue.assert_called_once_with([available])
+
+    def test_play_album_next_excludes_unavailable_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        available = _track(1)
+        unavailable = self._unavailable_track(2)
+        mock_index.tracks_for_album.return_value = [available, unavailable]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        c.post(
+            "/api/v1/player/queue/play-album-next",
+            json={"album_artist": "A", "album": "B"},
+        )
+        mock_queue.play_album_next.assert_called_once_with([available])
+
+    def test_insert_album_excludes_unavailable_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        available = _track(1)
+        unavailable = self._unavailable_track(2)
+        mock_index.tracks_for_album.return_value = [available, unavailable]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        c.post(
+            "/api/v1/player/queue/insert-album",
+            json={"album_artist": "A", "album": "B", "index": 0},
+        )
+        mock_queue.insert_album_at.assert_called_once_with([available], 0)
+
+    def test_add_album_to_queue_404_when_all_tracks_unavailable(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [self._unavailable_track(1)]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        resp = c.post(
+            "/api/v1/player/queue/add-album", json={"album_artist": "A", "album": "B"}
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Schema v25: adds `is_available` column to `tracks` (DEFAULT 1); existing rows default to available
- `fetch_album_tracks` detects `file=null` per-track to mark unreleased pre-order tracks as unavailable
- `sync_collection_stream` re-inspects pre-order albums on every sync (bypasses the `has_remote_album_tracks` short-circuit); graduates to `mode='remote'` once all tracks become available
- Server: `TrackOut.is_available` and `AlbumOut.is_preorder` exposed on API responses; unavailable tracks filtered from all queue/play endpoints
- AlbumCard: "pre-order" banner anchored to the bottom of the album art area
- TrackList: pre-order badge inline with album title; unavailable tracks are greyed out, italic, blocked from playback and excluded from queue

## Test plan

- [ ] Sync a streaming library containing a pre-order album; confirm `bandcamp_collection.mode` is set to `'preorder'` and unreleased tracks have `is_available=0`
- [ ] Album grid shows "pre-order" banner on pre-order albums; regular albums show no banner
- [ ] Album detail shows pre-order badge in the header; unavailable tracks are greyed/italic; available tracks look normal
- [ ] Double-clicking an unavailable track does nothing; available tracks play normally
- [ ] Adding a pre-order album to queue / play next / insert excludes unavailable tracks
- [ ] On next sync after all tracks release, mode reverts to `'remote'` and pre-order dressings disappear
- [ ] `poetry run pytest tests/test_library.py tests/test_bandcamp.py tests/test_server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)