### PR TITLE
feat(KAMP-399): track and album duration display

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 27
+_SCHEMA_VERSION = 28
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -1024,7 +1024,18 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 27")
             self._conn.commit()
-            version = 27  # noqa: F841
+            version = 27
+
+        if version == 27:
+            # v27 → v28: null file_mtime for local tracks so the next scan
+            # re-reads them and populates the duration column added in v27 (KAMP-399).
+            self._conn.execute(
+                "UPDATE tracks SET file_mtime = NULL"
+                " WHERE source = 'local' AND duration = 0"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 28")
+            self._conn.commit()
+            version = 28  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -37,6 +37,7 @@ else:
 
 import mutagen.flac
 import mutagen.id3 as id3
+import mutagen.mp3
 import mutagen.mp4
 import mutagen.oggvorbis
 
@@ -90,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 26
+_SCHEMA_VERSION = 27
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -122,7 +123,8 @@ CREATE TABLE IF NOT EXISTS tracks (
     stream_url           TEXT,
     stream_url_expires_at REAL,
     album_id             INTEGER REFERENCES albums(id),
-    is_available         INTEGER NOT NULL DEFAULT 1
+    is_available         INTEGER NOT NULL DEFAULT 1,
+    duration             REAL    NOT NULL DEFAULT 0
 );
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
@@ -348,6 +350,7 @@ class Track:
     stream_url_expires_at: float | None = field(default=None, compare=False)
     # False for pre-order tracks whose CDN file has not yet been released.
     is_available: bool = field(default=True, compare=False)
+    duration: float = field(default=0.0, compare=False)
     # Runtime flag; not persisted to DB. False for stub tracks created during
     # queue restore when the DB row is missing (e.g. after a DB wipe).
     reachable: bool = field(default=True, compare=False)
@@ -1008,7 +1011,20 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 26")
             self._conn.commit()
-            version = 26  # noqa: F841
+            version = 26
+
+        if version == 26:
+            # v26 → v27: add duration to tracks for per-track and album total display (KAMP-399).
+            existing = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if "duration" not in existing:
+                self._conn.execute(
+                    "ALTER TABLE tracks ADD COLUMN duration REAL NOT NULL DEFAULT 0"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 27")
+            self._conn.commit()
+            version = 27  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -1608,8 +1624,8 @@ class LibraryIndex:
                  track_number, disc_number, ext, embedded_art,
                  mb_release_id, mb_recording_id, date_added, file_mtime,
                  genre, label, source, stream_url, stream_url_expires_at,
-                 is_available)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 is_available, duration)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 title                 = excluded.title,
                 artist                = excluded.artist,
@@ -1628,7 +1644,8 @@ class LibraryIndex:
                 source                = excluded.source,
                 stream_url            = excluded.stream_url,
                 stream_url_expires_at = excluded.stream_url_expires_at,
-                is_available          = excluded.is_available
+                is_available          = excluded.is_available,
+                duration              = excluded.duration
                 -- date_added intentionally omitted: preserve original scan date on re-scan
                 -- last_played intentionally omitted: managed exclusively by record_played()
             """,
@@ -2834,6 +2851,7 @@ def _track_to_params(
     str | None,
     float | None,
     int,
+    float,
 ]:
     return (
         _canonical_track_key(t.file_path),
@@ -2856,6 +2874,7 @@ def _track_to_params(
         t.stream_url,
         t.stream_url_expires_at,
         int(t.is_available),
+        t.duration,
     )
 
 
@@ -2901,6 +2920,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         stream_url=row["stream_url"],
         stream_url_expires_at=row["stream_url_expires_at"],
         is_available=bool(row["is_available"]),
+        duration=row["duration"],
     )
 
 
@@ -2973,6 +2993,13 @@ def _read_mp3_tags(path: Path) -> Track:
     except Exception:
         tags = id3.ID3()
 
+    # mutagen.mp3.MP3 parses the MPEG stream (required for duration); kept
+    # separate from the ID3 read above to avoid raising on fake test files.
+    try:
+        duration = mutagen.mp3.MP3(str(path)).info.length
+    except Exception:
+        duration = 0.0
+
     def _str(frame_key: str) -> str:
         frame = tags.get(frame_key)
         if not frame:
@@ -2998,15 +3025,22 @@ def _read_mp3_tags(path: Path) -> Track:
         mb_recording_id=_str("TXXX:MusicBrainz Track Id"),
         genre=_str("TCON"),
         label=_str("TPUB"),
+        duration=duration,
     )
 
 
 def _read_m4a_tags(path: Path) -> Track:
+    audio = None
     try:
         audio = mutagen.mp4.MP4(str(path))
         tags = audio.tags or {}
     except Exception:
         tags = {}
+
+    try:
+        duration = float(audio.info.length) if audio is not None else 0.0
+    except Exception:
+        duration = 0.0
 
     def _s(key: str) -> str:
         vals = tags.get(key)
@@ -3038,11 +3072,13 @@ def _read_m4a_tags(path: Path) -> Track:
         mb_recording_id=_s("----:com.apple.iTunes:MusicBrainz Track Id"),
         genre=_s("\xa9gen"),
         label=_s("----:com.apple.iTunes:LABEL"),
+        duration=duration,
     )
 
 
 def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
     """Read tags from a FLAC or OGG Vorbis file."""
+    audio = None
     try:
         if is_flac:
             audio = mutagen.flac.FLAC(str(path))
@@ -3059,6 +3095,11 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
     except Exception:
         tags = {}
         pictures = []
+
+    try:
+        duration = float(audio.info.length) if audio is not None else 0.0
+    except Exception:
+        duration = 0.0
 
     def _s(key: str) -> str:
         vals = tags.get(key)
@@ -3081,6 +3122,7 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
         mb_recording_id=_s("MUSICBRAINZ_TRACKID"),
         genre=_s("GENRE"),
         label=_s("LABEL") or _s("ORGANIZATION"),
+        duration=duration,
     )
 
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -146,6 +146,7 @@ class TrackOut(BaseModel):
     source: str
     reachable: bool = True
     is_available: bool = True
+    duration: float = 0.0
 
     @classmethod
     def from_track(cls, t: Track) -> "TrackOut":
@@ -170,6 +171,7 @@ class TrackOut(BaseModel):
             source=t.source,
             reachable=t.reachable,
             is_available=t.is_available,
+            duration=t.duration,
         )
 
 

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1118,6 +1118,7 @@ def fetch_album_tracks(
                 source="bandcamp",
                 date_added=date_added if date_added is not None else time.time(),
                 is_available=is_available,
+                duration=float(t.get("duration") or 0.0),
             )
         )
     return result

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -27,6 +27,7 @@ export type Track = {
   source: string
   reachable: boolean
   is_available: boolean
+  duration: number
 }
 
 export type Album = {

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -643,7 +643,7 @@
 
 .track-row {
   display: grid;
-  grid-template-columns: 12px 32px 1fr auto;
+  grid-template-columns: 12px 32px 1fr auto auto;
   align-items: center;
   gap: 12px;
   padding: 8px 6px;
@@ -754,6 +754,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 160px;
+}
+
+.track-row-duration {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  min-width: 36px;
+  text-align: right;
 }
 
 .track-row-cloud {

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -30,6 +30,7 @@ import {
   WarnIcon
 } from './TransportIcons'
 import { downloadAlbum } from '../api/client'
+import { formatTime } from '../utils/formatTime'
 
 const TOAST_TTL = 10_000 // ms
 
@@ -298,6 +299,8 @@ export function TrackList(): React.JSX.Element | null {
   const isCurrentAlbum =
     currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
+  const totalDuration = tracks.reduce((sum, t) => sum + (t.duration || 0), 0)
+
   return (
     <div
       className={`track-list-view${albumEditMode ? ' track-list-view--edit' : ''}${isResizing ? ' track-list-view--resizing' : ''}`}
@@ -488,7 +491,13 @@ export function TrackList(): React.JSX.Element | null {
               </h2>
             )}
           />
-          {album.year && <div className="track-list-album-year">{album.year}</div>}
+          {(album.year || totalDuration > 0) && (
+            <div className="track-list-album-year">
+              {[album.year, totalDuration > 0 ? formatTime(totalDuration) : '']
+                .filter(Boolean)
+                .join(' · ')}
+            </div>
+          )}
           {albumRenameProgress && (
             <div className="album-rename-progress" aria-live="polite">
               Renaming {albumRenameProgress.done} of {albumRenameProgress.total}…
@@ -644,6 +653,9 @@ export function TrackList(): React.JSX.Element | null {
                   />
                 </span>
                 <span className="track-row-artist">{track.artist}</span>
+                <span className="track-row-duration">
+                  {track.duration > 0 ? formatTime(track.duration) : '—'}
+                </span>
               </li>
             )
           })}

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -14,12 +14,7 @@ import {
   StopIcon,
   VolumeIcon
 } from './TransportIcons'
-
-function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = Math.floor(seconds % 60)
-  return `${m}:${s.toString().padStart(2, '0')}`
-}
+import { formatTime } from '../utils/formatTime'
 
 export function TransportBar(): React.JSX.Element {
   const player = useStore((s) => s.player)

--- a/kamp_ui/src/renderer/src/utils/formatTime.ts
+++ b/kamp_ui/src/renderer/src/utils/formatTime.ts
@@ -1,0 +1,5 @@
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2744,8 +2744,10 @@ class TestFetchAlbumTracks:
         assert len(result) == 2
         assert result[0].title == "Song One"
         assert result[0].track_number == 1
+        assert result[0].duration == 200.0
         assert result[1].title == "Song Two"
         assert result[1].track_number == 2
+        assert result[1].duration == 180.0
 
     def test_source_is_bandcamp(self) -> None:
         html = _stream_album_page_html()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -916,6 +916,70 @@ class TestLibraryScanner:
         assert tracks[0].artist == "OGG Artist"
         assert tracks[0].ext == "ogg"
 
+    def test_read_mp3_duration(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3", title="Song")
+
+        mock_mp3 = MagicMock()
+        mock_mp3.info.length = 180.0
+
+        with patch("kamp_core.library.mutagen.mp3.MP3", return_value=mock_mp3):
+            index = LibraryIndex(tmp_path / "library.db")
+            LibraryScanner(index).scan(lib)
+            tracks = index.all_tracks()
+            index.close()
+
+        assert tracks[0].duration == 180.0
+
+    def test_read_mp3_duration_graceful_on_error(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3", title="Song")
+
+        with patch("kamp_core.library.mutagen.mp3.MP3", side_effect=Exception("bad")):
+            index = LibraryIndex(tmp_path / "library.db")
+            LibraryScanner(index).scan(lib)
+            tracks = index.all_tracks()
+            index.close()
+
+        assert tracks[0].duration == 0.0
+
+    def test_read_m4a_duration(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        (lib / "01.m4a").write_bytes(b"\x00" * 32)
+
+        mock_audio = MagicMock()
+        mock_audio.tags = {"\xa9nam": ["Track"]}
+        mock_audio.info.length = 240.0
+
+        with patch("kamp_core.library.mutagen.mp4.MP4", return_value=mock_audio):
+            index = LibraryIndex(tmp_path / "library.db")
+            LibraryScanner(index).scan(lib)
+            tracks = index.all_tracks()
+            index.close()
+
+        assert tracks[0].duration == 240.0
+
+    def test_read_flac_duration(self, tmp_path: Path) -> None:
+        lib = tmp_path / "music"
+        lib.mkdir()
+        (lib / "01.flac").write_bytes(b"fLaC")
+
+        mock_audio = MagicMock()
+        mock_audio.tags = {"TITLE": ["Track"]}
+        mock_audio.pictures = []
+        mock_audio.info.length = 300.0
+
+        with patch("kamp_core.library.mutagen.flac.FLAC", return_value=mock_audio):
+            index = LibraryIndex(tmp_path / "library.db")
+            LibraryScanner(index).scan(lib)
+            tracks = index.all_tracks()
+            index.close()
+
+        assert tracks[0].duration == 300.0
+
     def test_scan_nonexistent_directory(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         result = LibraryScanner(index).scan(tmp_path / "does_not_exist")
@@ -6301,6 +6365,103 @@ class TestMigrationV26:
         index = LibraryIndex(db_path)
         row = index._conn.execute(
             "SELECT num_streamable_tracks FROM bandcamp_collection WHERE sale_item_id = '1'"
+        ).fetchone()
+        index.close()
+
+        assert row is not None
+        assert row[0] == 0
+
+
+class TestMigrationV27:
+    """v26 → v27: duration column on tracks (KAMP-399)."""
+
+    def _build_v26_db(self, db_path: Path) -> None:
+        import sqlite3 as _sqlite3
+
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (26)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
+            " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
+            " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
+            " stream_url_expires_at REAL, album_id INTEGER,"
+            " is_available INTEGER NOT NULL DEFAULT 1)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " album_artist TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " album TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " year TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', genre TEXT NOT NULL DEFAULT '',"
+            " label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local',"
+            " sale_item_id TEXT, favorite INTEGER NOT NULL DEFAULT 0,"
+            " date_added REAL, last_played_at REAL, play_count_avg REAL NOT NULL DEFAULT 0,"
+            " art_version REAL, UNIQUE (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY,"
+            " item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '',"
+            " item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '',"
+            " album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local',"
+            " synced_at REAL, added_at REAL NOT NULL DEFAULT 0,"
+            " num_streamable_tracks INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY,"
+            " session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE,"
+            " payload_json TEXT NOT NULL, created_at REAL NOT NULL,"
+            " attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE download_queue (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE, queued_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, title) VALUES ('local/song.mp3', 'Old Song')"
+        )
+        conn.commit()
+        conn.close()
+
+    def test_migration_adds_duration_column(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v26_db(db_path)
+        index = LibraryIndex(db_path)
+        cols = {
+            r[1] for r in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        index.close()
+
+        assert version == 27
+        assert "duration" in cols
+
+    def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v26_db(db_path)
+        index = LibraryIndex(db_path)
+        row = index._conn.execute(
+            "SELECT duration FROM tracks WHERE file_path = 'local/song.mp3'"
         ).fetchone()
         index.close()
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 27
+        assert version == 28
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1454,7 +1454,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1511,7 +1511,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1898,7 +1898,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert row is not None
         assert row[0] == 0
 
@@ -2152,7 +2152,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2248,7 +2248,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2429,7 +2429,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2524,7 +2524,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 27
+        assert version == 28
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2532,7 +2532,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 27
+        assert version == 28
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3409,7 +3409,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 27
+        assert version == 28
 
         index.close()
 
@@ -4094,7 +4094,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 27
+        assert version == 28
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4129,7 +4129,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 27
+        assert version == 28
         index.close()
 
 
@@ -4577,7 +4577,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 27
+        assert version == 28
 
 
 class TestRemoteTrackSchema:
@@ -4880,7 +4880,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4941,7 +4941,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 27
+        assert version == 28
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5608,7 +5608,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5723,7 +5723,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5801,7 +5801,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6007,7 +6007,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6356,7 +6356,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6453,7 +6453,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 27
+        assert version == 28
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6467,6 +6467,111 @@ class TestMigrationV27:
 
         assert row is not None
         assert row[0] == 0
+
+
+class TestMigrationV28:
+    """v27 → v28: null file_mtime for local zero-duration tracks to force rescan (KAMP-399)."""
+
+    def _build_v27_db(self, db_path: Path) -> None:
+        import sqlite3 as _sqlite3
+
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (27)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
+            " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
+            " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
+            " stream_url_expires_at REAL, album_id INTEGER,"
+            " is_available INTEGER NOT NULL DEFAULT 1,"
+            " duration REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " album_artist TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " album TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " year TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', genre TEXT NOT NULL DEFAULT '',"
+            " label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local',"
+            " sale_item_id TEXT, favorite INTEGER NOT NULL DEFAULT 0,"
+            " date_added REAL, last_played_at REAL, play_count_avg REAL NOT NULL DEFAULT 0,"
+            " art_version REAL, UNIQUE (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY,"
+            " item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '',"
+            " item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '',"
+            " album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local',"
+            " synced_at REAL, added_at REAL NOT NULL DEFAULT 0,"
+            " num_streamable_tracks INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY,"
+            " session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE,"
+            " payload_json TEXT NOT NULL, created_at REAL NOT NULL,"
+            " attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE download_queue (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE, queued_at REAL NOT NULL DEFAULT 0)"
+        )
+        # local track with zero duration and a stored mtime (simulate post-v27 state)
+        conn.execute(
+            "INSERT INTO tracks (file_path, title, source, file_mtime, duration)"
+            " VALUES ('local/a.mp3', 'A', 'local', 1000.0, 0)"
+        )
+        # local track that already has duration — mtime must NOT be nulled
+        conn.execute(
+            "INSERT INTO tracks (file_path, title, source, file_mtime, duration)"
+            " VALUES ('local/b.mp3', 'B', 'local', 2000.0, 180.0)"
+        )
+        # bandcamp track with zero duration — should not be touched
+        conn.execute(
+            "INSERT INTO tracks (file_path, title, source, file_mtime, duration)"
+            " VALUES ('bandcamp://1/1', 'C', 'bandcamp', 3000.0, 0)"
+        )
+        conn.commit()
+        conn.close()
+
+    def test_migration_nulls_mtime_for_zero_duration_local_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "library.db"
+        self._build_v27_db(db_path)
+        index = LibraryIndex(db_path)
+        rows = {
+            r[0]: r[1]
+            for r in index._conn.execute(
+                "SELECT file_path, file_mtime FROM tracks"
+            ).fetchall()
+        }
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        index.close()
+
+        assert version == 28
+        assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
+        assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
+        assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
 
 
 class TestNumStreamableTracks:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 26
+        assert version == 27
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1454,7 +1454,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1511,7 +1511,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1898,7 +1898,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert row is not None
         assert row[0] == 0
 
@@ -2152,7 +2152,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2248,7 +2248,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2429,7 +2429,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2524,7 +2524,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 26
+        assert version == 27
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2532,7 +2532,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 26
+        assert version == 27
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3409,7 +3409,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 26
+        assert version == 27
 
         index.close()
 
@@ -4094,7 +4094,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 26
+        assert version == 27
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4129,7 +4129,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 26
+        assert version == 27
         index.close()
 
 
@@ -4577,7 +4577,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 26
+        assert version == 27
 
 
 class TestRemoteTrackSchema:
@@ -4880,7 +4880,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4941,7 +4941,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 26
+        assert version == 27
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5608,7 +5608,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5723,7 +5723,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5801,7 +5801,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6007,7 +6007,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6356,7 +6356,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 26
+        assert version == 27
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- DB migration v26→v27 adds `duration REAL NOT NULL DEFAULT 0` to `tracks`
- All three tag readers (`_read_mp3_tags`, `_read_m4a_tags`, `_read_vorbis_tags`) now extract `audio.info.length`; MP3 uses a separate `mutagen.mp3.MP3` call since `id3.ID3` doesn't expose stream metadata
- `fetch_album_tracks` extracts `duration` from Bandcamp's `trackinfo` JSON (already present in the API response)
- `TrackOut` and the TypeScript `Track` type gain a `duration` field
- `TrackList.tsx` renders per-track durations in each row (`—` for zero) and total album duration alongside year in the identity block
- `formatTime` extracted from `TransportBar.tsx` to a shared `utils/formatTime.ts`

## Test plan

- [x] Rescan a local album; confirm track rows show correct lengths (cross-check against `ffprobe`)
- [x] Confirm album identity block shows `<year> · <total>` (e.g. `2019 · 42:31`)
- [x] Pre-migration rows (no rescan) show `—` not `0:00`
- [x] Open a Bandcamp streaming album; confirm track durations appear from Bandcamp data
- [x] Confirm transport bar still works (formatTime extraction did not regress it)
- [x] Album with no year shows duration alone (no leading `·`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)