### PR TITLE
feat(KAMP-427): transport title/artist/album as nav links

### DIFF
--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -67,6 +67,17 @@
   transition: transform 6s linear 0.5s;
 }
 
+/* Button-reset so .track-title/.track-artist/.track-album render as plain text. */
+.track-field button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
 .track-idle {
   color: var(--text-dim);
   font-style: italic;

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -13,9 +13,6 @@ export function NowPlayingView(): React.JSX.Element {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
   const deferredOps = useStore((s) => s.deferredOps)
   const albums = useStore((s) => s.library.albums)
-  const selectAlbum = useStore((s) => s.selectAlbum)
-  const selectArtist = useStore((s) => s.selectArtist)
-  const setActiveView = useStore((s) => s.setActiveView)
   const showFlashToast = useStore((s) => s.showFlashToast)
   const tooltip = useTooltip()
 
@@ -33,18 +30,6 @@ export function NowPlayingView(): React.JSX.Element {
         (a) => a.album === current_track.album && a.album_artist === current_track.album_artist
       )
     : undefined
-
-  function goToAlbum(): void {
-    if (!currentAlbum) return
-    void setActiveView('library')
-    void selectAlbum(currentAlbum)
-  }
-
-  function goToArtist(): void {
-    if (!current_track) return
-    void setActiveView('library')
-    selectArtist(current_track.album_artist)
-  }
 
   return (
     <div className="now-playing">
@@ -102,13 +87,6 @@ export function NowPlayingView(): React.JSX.Element {
             />
           )}
         </div>
-        <button className="now-playing-artist now-playing-link" onClick={goToArtist}>
-          {current_track.artist}
-        </button>
-        <button className="now-playing-album now-playing-link" onClick={goToAlbum}>
-          {current_track.album}
-          {current_track.year ? ` · ${current_track.year}` : ''}
-        </button>
       </div>
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -32,8 +32,34 @@ export function TransportBar(): React.JSX.Element {
   const setRepeat = useStore((s) => s.setRepeat)
   const shuffle = queue?.shuffle ?? false
   const repeat = queue?.repeat ?? false
+  const albums = useStore((s) => s.library.albums)
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
 
   const { playing, position, duration, volume, current_track } = player
+
+  const currentAlbum = current_track
+    ? albums.find(
+        (a) => a.album === current_track.album && a.album_artist === current_track.album_artist
+      )
+    : undefined
+
+  function goToNowPlaying(): void {
+    void setActiveView('now-playing')
+  }
+
+  function goToArtist(): void {
+    if (!current_track) return
+    void setActiveView('library')
+    selectArtist(current_track.album_artist)
+  }
+
+  function goToAlbum(): void {
+    if (!currentAlbum) return
+    void setActiveView('library')
+    void selectAlbum(currentAlbum)
+  }
   // Local scrub position: holds the seek-bar value while the pointer is down so
   // that React's controlled-input re-render (which would reset value to the
   // server position) can't fire a spurious second onChange and double-seek.
@@ -71,13 +97,19 @@ export function TransportBar(): React.JSX.Element {
         {current_track ? (
           <>
             <div className="track-field">
-              <span className="track-title">{current_track.title}</span>
+              <button className="track-title" onClick={goToNowPlaying}>
+                {current_track.title}
+              </button>
             </div>
             <div className="track-field">
-              <span className="track-artist">{current_track.artist}</span>
+              <button className="track-artist" onClick={goToArtist}>
+                {current_track.artist}
+              </button>
             </div>
             <div className="track-field">
-              <span className="track-album">{current_track.album}</span>
+              <button className="track-album" onClick={goToAlbum}>
+                {current_track.album}
+              </button>
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Summary

- Transport title, artist, and album are now `<button>` elements: title → Now Playing, artist → library artist filter (album_artist), album → library album page
- Navigation logic mirrors the existing `goToArtist`/`goToAlbum` pattern from `NowPlayingView.tsx`
- `transport.css` adds a button-reset rule so the elements still render as plain text; existing marquee-on-hover animation is preserved (CSS selectors target class names, not tag)
- `NowPlayingView.tsx` artist and album buttons removed (redundant); `goToArtist`/`goToAlbum` functions and their store slices removed; `currentAlbum` kept for Bandcamp copy-link context menu

## Test plan

- [ ] Click artist in transport → library switches to artist filter for the playing track's album_artist
- [ ] Click album in transport → library switches to library view and opens the album page
- [ ] Click track title in transport → navigates to Now Playing view
- [ ] Hover over any transport text → marquee scroll animation still fires
- [ ] Cursor is `pointer` on all three transport text elements
- [ ] Now Playing view no longer shows artist/album buttons
- [ ] Bandcamp copy-link context menu in Now Playing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)