### PR TITLE
fix(KAMP-391): move hideTimerRef cancel into show() to fix phantom tooltip

### DIFF
--- a/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
+++ b/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
@@ -53,8 +53,9 @@ export function TooltipProvider({ children }: { children: React.ReactNode }): Re
   const arm = useCallback(
     (text: string, target: HTMLElement) => {
       clearTimeout(showTimerRef.current)
-      clearTimeout(hideTimerRef.current)
       clearTimeout(fadeTimerRef.current)
+      // hideTimerRef is cleared inside show() so an aborted arm leaves the
+      // visible tooltip's decay timer intact (fix for KAMP-391 phantom tooltip).
 
       const rect = target.getBoundingClientRect()
       const above = rect.top > TOP_THRESHOLD
@@ -62,6 +63,7 @@ export function TooltipProvider({ children }: { children: React.ReactNode }): Re
       const y = above ? rect.top : rect.bottom
 
       const show = (): void => {
+        clearTimeout(hideTimerRef.current)
         if (targetRef.current) targetRef.current.removeAttribute('aria-describedby')
         targetRef.current = target
         target.setAttribute('aria-describedby', 'kamp-tooltip')


### PR DESCRIPTION
## Summary

`arm()` was clearing the visible tooltip's decay timer (`hideTimerRef`) before the new tooltip's show delay fired. The sequence that triggered the bug:

1. Hover element A → tooltip shows, `hideTimerRef` starts (2s decay)
2. Move to element B → `arm(B)` called → **`hideTimerRef` cleared** → 500ms show delay starts
3. Move to dead space → `disarm()` cancels B's show delay — but `hideTimerRef` is gone; nothing ever dismisses A's tooltip

Fix: move `clearTimeout(hideTimerRef.current)` from the top of `arm()` into the `show()` closure. The decay timer is now only cancelled when a new tooltip actually appears, so an aborted arm leaves the visible tooltip's natural decay intact.

## Test plan

- [x] Repro: hover Previous → move quickly to Add to Favorites (don't wait for tooltip) → move to dead space → tooltip should clear within 2s
- [x] Normal flow: hover, let tooltip show, move away — still fades after 2s
- [x] Hot-switch: hover A (shows), hover B quickly — B appears immediately, no delay
- [x] Rapid hovering: no phantom tooltips accumulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)