### PR TITLE
feat(KAMP-429): share button and hero context menu on album page

### DIFF
--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -9,6 +9,7 @@ import type {
   Track,
   TrackTagsCollision
 } from '../api/client'
+import { ContextMenu } from './ContextMenu'
 import { TrackContextMenu } from './TrackContextMenu'
 import { EditableTrackTitle } from './EditableTrackTitle'
 import { EditableAlbumField } from './EditableAlbumField'
@@ -27,6 +28,7 @@ import {
   PauseIcon,
   QueueAddIcon,
   PlayNextIcon,
+  ShareIcon,
   WarnIcon
 } from './TransportIcons'
 import { downloadAlbum } from '../api/client'
@@ -98,6 +100,7 @@ export function TrackList(): React.JSX.Element | null {
   const patchOpenAlbum = useStore((s) => s.patchOpenAlbum)
   const albumRenameProgress = useStore((s) => s.albumRenameProgress)
   const deferredOps = useStore((s) => s.deferredOps)
+  const showFlashToast = useStore((s) => s.showFlashToast)
 
   const albumTitleRef = useRef<HTMLHeadingElement>(null)
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -286,6 +289,7 @@ export function TrackList(): React.JSX.Element | null {
   }
 
   const [menu, setMenu] = useState<ContextMenu | null>(null)
+  const [heroMenu, setHeroMenu] = useState<{ x: number; y: number } | null>(null)
 
   if (!album) return null
 
@@ -307,7 +311,14 @@ export function TrackList(): React.JSX.Element | null {
       style={{ '--hero-height-pct': heroHeightPct } as React.CSSProperties}
     >
       {/* Hero: full-width art — image intentionally taller than hero to bleed into track list */}
-      <div className={`track-list-hero${album.has_art ? ' has-art' : ''}`}>
+      <div
+        className={`track-list-hero${album.has_art ? ' has-art' : ''}`}
+        onContextMenu={(e) => {
+          if (!album.album_url) return
+          e.preventDefault()
+          setHeroMenu({ x: e.clientX, y: e.clientY })
+        }}
+      >
         {album.has_art && (
           <HeroImage
             src={artUrl(album.album_artist, album.album, album.file_path, album.art_version)}
@@ -316,6 +327,23 @@ export function TrackList(): React.JSX.Element | null {
       </div>
       {/* Overlay spans the full view so the gradient covers both hero and the top of the track list */}
       <div className="track-list-hero-overlay" />
+      {heroMenu && album.album_url && (
+        <ContextMenu x={heroMenu.x} y={heroMenu.y} onClose={() => setHeroMenu(null)}>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void navigator.clipboard.writeText(album.album_url!)
+              showFlashToast(`Copied link to ${album.album}`)
+              setHeroMenu(null)
+            }}
+          >
+            <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+              <ShareIcon size={12} />
+            </span>
+            Copy Bandcamp link
+          </button>
+        </ContextMenu>
+      )}
 
       {/* Breadcrumb floats over the hero */}
       <nav className="breadcrumb" aria-label="Navigation">
@@ -520,6 +548,19 @@ export function TrackList(): React.JSX.Element | null {
                   }}
                 >
                   <DownloadArrowIcon size={16} />
+                </button>
+              )}
+              {album.album_url && (
+                <button
+                  className="album-secondary-btn"
+                  {...tooltip('Copy Bandcamp link')}
+                  aria-label="Copy Bandcamp link"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(album.album_url!)
+                    showFlashToast(`Copied link to ${album.album}`)
+                  }}
+                >
+                  <ShareIcon size={16} />
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Inline share button added to `streaming-controls` for any album with an `album_url` — sits alongside the download button, copies the Bandcamp URL to clipboard and fires a flash toast
- Right-clicking the album art hero now opens a "Copy Bandcamp link" context menu, matching the same gesture in NowPlayingView
- Both surfaces guard on `album.album_url` being truthy — local albums with no Bandcamp URL show neither
- Only `TrackList.tsx` changed; reuses `ContextMenu`, `ShareIcon`, and `showFlashToast` already present in the codebase

## Test plan

- [x] Open a Bandcamp album → share button visible in streaming controls → click → toast fires with album name → clipboard has Bandcamp URL
- [x] Right-click album art hero → context menu with "Copy Bandcamp link" → click → toast + clipboard correct → menu closes
- [x] Click outside hero context menu → dismisses without copying
- [x] Open a local album (no album_url) → no share button; right-click hero → no context menu
- [x] Download button still works alongside share button

🤖 Generated with [Claude Code](https://claude.com/claude-code)