### PR TITLE
chore: resolve all prettier formatting warnings

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -4,7 +4,13 @@ import { getTracksForAlbum, downloadAlbum } from '../api/client'
 import type { Album } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
-import { DownloadArrowIcon, FavoriteIcon, PlayNextIcon, QueueAddIcon, ShareIcon } from './TransportIcons'
+import {
+  DownloadArrowIcon,
+  FavoriteIcon,
+  PlayNextIcon,
+  QueueAddIcon,
+  ShareIcon
+} from './TransportIcons'
 
 interface Props {
   x: number
@@ -74,7 +80,12 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
           }}
         >
           <span
-            style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+            style={{
+              marginRight: 6,
+              verticalAlign: 'middle',
+              flexShrink: 0,
+              display: 'inline-flex'
+            }}
           >
             <ShareIcon size={12} />
           </span>

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -368,8 +368,8 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
               choose library folder
             </button>
             <p className="onboarding-card-body">
-              <strong>kamp</strong> will scan any files in this folder and add them to its 
-              library. if you use kamp to download music, it will end up here.
+              <strong>kamp</strong> will scan any files in this folder and add them to its library.
+              if you use kamp to download music, it will end up here.
             </p>
             {cardError && <div className="onboarding-error">{cardError}</div>}
           </div>
@@ -412,8 +412,8 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 </div>
                 <p className="onboarding-card-body">
                   {collectionMode === 'stream'
-                    ? "you are a busy music fan with a solid network connection. stream your bandcamp purchases, no downloads needed. albums can be downloaded individually for offline listening."
-                    : "you are a connoisseur and curator with a big hard drive. purchases are downloaded to your library folder for offline playback."}
+                    ? 'you are a busy music fan with a solid network connection. stream your bandcamp purchases, no downloads needed. albums can be downloaded individually for offline listening.'
+                    : 'you are a connoisseur and curator with a big hard drive. purchases are downloaded to your library folder for offline playback.'}
                 </p>
                 <button
                   className="onboarding-primary-btn"
@@ -457,7 +457,8 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                   {lastfmBusy ? 'connecting…' : 'Connect Last.fm'}
                 </button>
                 <p className="onboarding-card-body">
-                  connect your <strong>last.fm</strong> account to save and share your listening history.
+                  connect your <strong>last.fm</strong> account to save and share your listening
+                  history.
                 </p>
                 {cardError && <div className="onboarding-error">{cardError}</div>}
                 <button className="onboarding-skip-btn" onClick={advancePastCards}>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -337,7 +337,14 @@ export function TrackList(): React.JSX.Element | null {
               setHeroMenu(null)
             }}
           >
-            <span style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}>
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
               <ShareIcon size={12} />
             </span>
             Copy Bandcamp link
@@ -371,7 +378,9 @@ export function TrackList(): React.JSX.Element | null {
         </span>
         <span>{album.album}</span>
         {album.is_preorder && (
-          <span className="album-preorder-badge" aria-label="Pre-Order">Pre-Order</span>
+          <span className="album-preorder-badge" aria-label="Pre-Order">
+            Pre-Order
+          </span>
         )}
       </nav>
 


### PR DESCRIPTION
## Summary

Auto-fixes from `eslint --fix` — no logic changes:

- `AlbumContextMenu.tsx`: multi-line import block, multi-line inline style object
- `OnboardingScreen.tsx`: string quotes, inline formatting
- `TrackList.tsx`: inline style object, Pre-Order text formatting

Lint now exits clean with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)