### PR TITLE
fix(KAMP-449): double-clicking a playlist track starts playback from that track

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -228,6 +228,7 @@ class PlayRequest(BaseModel):
 
 class PlayPlaylistRequest(BaseModel):
     playlist_id: int
+    start_index: int = 0
 
 
 class SeekRequest(BaseModel):
@@ -2716,7 +2717,8 @@ def create_app(
             return {"ok": True}
         old_current = queue.current()
         old_lookahead = queue.peek_next()
-        queue.load(tracks, start_index=0)
+        start = max(0, min(req.start_index, len(tracks) - 1))
+        queue.load(tracks, start_index=start)
         current = queue.current()
         if current:
             engine.play(_resolve_playback(current))

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -716,8 +716,8 @@ export async function applyAlbumArtLocal(
 // Playlists (KAMP-441)
 // ---------------------------------------------------------------------------
 
-export const playPlaylist = (playlistId: number): Promise<void> =>
-  post('/api/v1/player/play-playlist', { playlist_id: playlistId })
+export const playPlaylist = (playlistId: number, startIndex = 0): Promise<void> =>
+  post('/api/v1/player/play-playlist', { playlist_id: playlistId, start_index: startIndex })
 
 export const getPlaylists = (): Promise<Playlist[]> => get('/api/v1/playlists')
 

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -391,6 +391,20 @@ export function PlaylistView(): React.JSX.Element | null {
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, i)}
+                onDoubleClick={() => {
+                  if (isOffline) return
+                  if (isCurrent) {
+                    void togglePlayPause()
+                  } else {
+                    void playPlaylist(playlist.id, i)
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key !== 'Enter') return
+                  if (isOffline) return
+                  if (isCurrent) void togglePlayPause()
+                  else void playPlaylist(playlist.id, i)
+                }}
                 onContextMenu={(e) => {
                   e.preventDefault()
                   // Right-click on an unselected row: select only that row.

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -135,7 +135,7 @@ type PlayerStore = {
   selectAlbum: (album: Album | null) => Promise<void>
   loadTracks: (albumArtist: string, album: string, filePath?: string) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
-  playPlaylist: (playlistId: number) => Promise<void>
+  playPlaylist: (playlistId: number, startIndex?: number) => Promise<void>
   loadPlaylists: () => Promise<void>
   createPlaylist: (title: string) => Promise<Playlist>
   selectPlaylist: (playlist: Playlist | null) => Promise<void>
@@ -629,8 +629,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setCollectionType: (type) => set((s) => ({ library: { ...s.library, collectionType: type } })),
 
-  playPlaylist: async (playlistId) => {
-    await api.playPlaylist(playlistId)
+  playPlaylist: async (playlistId, startIndex = 0) => {
+    await api.playPlaylist(playlistId, startIndex)
     void get().loadQueue()
   },
 


### PR DESCRIPTION
## Summary

Track rows in `PlaylistView` had no `onDoubleClick` or `onKeyDown` handlers.

- Double-clicking the current track → `togglePlayPause()`
- Double-clicking any other track → `playPlaylist(id, i)` starting from that position
- Enter key on a focused row works the same way

`PlayPlaylistRequest` gains `start_index: int = 0` (clamped to valid range) so the server starts the queue at the right track. Wired through `client.ts` and `store.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)