### PR TITLE
fix(KAMP-448): use track_id FK in playlist_tracks instead of file_path

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 29
+_SCHEMA_VERSION = 30
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -272,7 +272,7 @@ CREATE TABLE IF NOT EXISTS playlists (
 CREATE TABLE IF NOT EXISTS playlist_tracks (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
-    file_path   TEXT    NOT NULL,
+    track_id    INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     position    INTEGER NOT NULL
 );
 """
@@ -1086,7 +1086,40 @@ class LibraryIndex:
                 """)
             self._conn.execute("UPDATE schema_version SET version = 29")
             self._conn.commit()
-            version = 29  # noqa: F841
+            version = 29
+
+        if version == 29:
+            # v29 → v30: replace file_path with track_id FK in playlist_tracks (KAMP-448).
+            # SQLite doesn't support DROP COLUMN on older engines, so use rename/recreate.
+            # Rows whose file_path no longer maps to a track are dropped — they were
+            # already orphaned.
+            # Guard: _DDL may have already created playlist_tracks with track_id on
+            # fresh installs that upgrade through v28→v29 in the same session, in which
+            # case the rename/recreate is not needed.
+            existing_cols = {
+                r[1]
+                for r in self._conn.execute(
+                    "PRAGMA table_info(playlist_tracks)"
+                ).fetchall()
+            }
+            if "file_path" in existing_cols:
+                self._conn.executescript("""
+                    ALTER TABLE playlist_tracks RENAME TO playlist_tracks_old;
+                    CREATE TABLE playlist_tracks (
+                        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                        playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+                        track_id    INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+                        position    INTEGER NOT NULL
+                    );
+                    INSERT INTO playlist_tracks (id, playlist_id, track_id, position)
+                        SELECT pt.id, pt.playlist_id, t.id, pt.position
+                        FROM playlist_tracks_old pt
+                        JOIN tracks t ON t.file_path = pt.file_path;
+                    DROP TABLE playlist_tracks_old;
+                """)
+            self._conn.execute("UPDATE schema_version SET version = 30")
+            self._conn.commit()
+            version = 30  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -2501,7 +2534,7 @@ class LibraryIndex:
             """
             SELECT t.*
             FROM playlist_tracks pt
-            JOIN tracks t ON t.file_path = pt.file_path
+            JOIN tracks t ON t.id = pt.track_id
             WHERE pt.playlist_id = ?
             ORDER BY pt.position ASC
             """,
@@ -2960,7 +2993,7 @@ class LibraryIndex:
                    t.mb_release_id, t.mb_recording_id, t.genre, t.label,
                    t.favorite, t.play_count, t.last_played, t.source, t.is_available, t.duration
             FROM playlist_tracks pt
-            JOIN tracks t ON t.file_path = pt.file_path
+            JOIN tracks t ON t.id = pt.track_id
             WHERE pt.playlist_id = ?
             ORDER BY pt.position ASC
             """,
@@ -3002,18 +3035,19 @@ class LibraryIndex:
         """
         import time as _time
 
-        exists = self._conn.execute(
-            "SELECT 1 FROM tracks WHERE file_path = ?", (file_path,)
+        row = self._conn.execute(
+            "SELECT id FROM tracks WHERE file_path = ?", (file_path,)
         ).fetchone()
-        if not exists:
+        if not row:
             return
+        track_id = row["id"]
         next_pos = self._conn.execute(
             "SELECT COALESCE(MAX(position) + 1, 0) FROM playlist_tracks WHERE playlist_id = ?",
             (playlist_id,),
         ).fetchone()[0]
         self._conn.execute(
-            "INSERT INTO playlist_tracks (playlist_id, file_path, position) VALUES (?, ?, ?)",
-            (playlist_id, file_path, next_pos),
+            "INSERT INTO playlist_tracks (playlist_id, track_id, position) VALUES (?, ?, ?)",
+            (playlist_id, track_id, next_pos),
         )
         self._conn.execute(
             "UPDATE playlists SET updated_at = ? WHERE id = ?",

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 29
+        assert version == 30
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1454,7 +1454,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1511,7 +1511,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1924,7 +1924,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert row is not None
         assert row[0] == 0
 
@@ -2178,7 +2178,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2274,7 +2274,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2455,7 +2455,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2550,7 +2550,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 29
+        assert version == 30
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2558,7 +2558,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 29
+        assert version == 30
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3435,7 +3435,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 29
+        assert version == 30
 
         index.close()
 
@@ -4120,7 +4120,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 29
+        assert version == 30
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4155,7 +4155,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 29
+        assert version == 30
         index.close()
 
 
@@ -4603,7 +4603,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 29
+        assert version == 30
 
 
 class TestRemoteTrackSchema:
@@ -4937,7 +4937,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4998,7 +4998,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5665,7 +5665,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5780,7 +5780,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5858,7 +5858,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6064,7 +6064,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6413,7 +6413,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6510,7 +6510,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6625,7 +6625,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -6974,6 +6974,24 @@ class TestPlaylists:
 
         assert count == 0
 
+    def test_track_survives_move(self, tmp_path: Path) -> None:
+        """A track that moves on disk must still appear in playlists (KAMP-448)."""
+        index = self._index(tmp_path)
+        pl = index.create_playlist("Mix")
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "a.mp3"))
+
+        index.move_track(
+            tmp_path / "a.mp3",
+            tmp_path / "a_moved.mp3",
+            "A Song",
+            1.0,
+        )
+        tracks = index.get_playlist_tracks(pl["id"])
+        index.close()
+
+        assert len(tracks) == 1
+        assert tracks[0]["file_path"] == str(tmp_path / "a_moved.mp3")
+
     # ------------------------------------------------------------------
     # migration v28 → v29
     # ------------------------------------------------------------------
@@ -7056,6 +7074,123 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 29
+        assert version == 30
         assert "playlists" in tables
         assert "playlist_tracks" in tables
+
+    # ------------------------------------------------------------------
+    # migration v29 → v30
+    # ------------------------------------------------------------------
+
+    def test_migration_v29_replaces_file_path_with_track_id(
+        self, tmp_path: Path
+    ) -> None:
+        """Opening a v29 DB triggers the v30 migration: file_path → track_id FK."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (29)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
+            " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
+            " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
+            " stream_url_expires_at REAL, album_id INTEGER,"
+            " is_available INTEGER NOT NULL DEFAULT 1,"
+            " duration REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " album_artist TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " album TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " year TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', genre TEXT NOT NULL DEFAULT '',"
+            " label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local',"
+            " sale_item_id TEXT, favorite INTEGER NOT NULL DEFAULT 0,"
+            " date_added REAL, last_played_at REAL, play_count_avg REAL NOT NULL DEFAULT 0,"
+            " art_version REAL, UNIQUE (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY,"
+            " item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '',"
+            " item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '',"
+            " album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local',"
+            " synced_at REAL, added_at REAL NOT NULL DEFAULT 0,"
+            " num_streamable_tracks INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY,"
+            " session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE,"
+            " payload_json TEXT NOT NULL, created_at REAL NOT NULL,"
+            " attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE download_queue (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE, queued_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " title TEXT NOT NULL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " created_at REAL NOT NULL, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE playlist_tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,"
+            " file_path TEXT NOT NULL, position INTEGER NOT NULL)"
+        )
+        # Seed a track and a playlist row so the data migration has something to preserve.
+        conn.execute(
+            "INSERT INTO tracks (file_path, title) VALUES ('/lib/a.mp3', 'Song A')"
+        )
+        conn.execute(
+            "INSERT INTO playlists (title, favorite, created_at, updated_at)"
+            " VALUES ('My Mix', 0, 0.0, 0.0)"
+        )
+        conn.execute(
+            "INSERT INTO playlist_tracks (playlist_id, file_path, position)"
+            " VALUES (1, '/lib/a.mp3', 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        columns = {
+            r[1]
+            for r in index._conn.execute(
+                "PRAGMA table_info(playlist_tracks)"
+            ).fetchall()
+        }
+        # Data migration: the row should survive mapped to the track's id.
+        rows = index._conn.execute("SELECT track_id FROM playlist_tracks").fetchall()
+        track_id_in_db = index._conn.execute(
+            "SELECT id FROM tracks WHERE file_path = '/lib/a.mp3'"
+        ).fetchone()[0]
+        index.close()
+
+        assert version == 30
+        assert "track_id" in columns
+        assert "file_path" not in columns
+        assert len(rows) == 1
+        assert rows[0][0] == track_id_in_db


### PR DESCRIPTION
## Summary

- `playlist_tracks` was joining on `file_path` (a loose text pointer), causing tracks to silently vanish from playlists when files moved on disk
- Replaces `file_path TEXT NOT NULL` with `track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE`
- Adds a v29→v30 schema migration that preserves existing playlist rows by joining on `file_path` at migration time; unresolvable rows are dropped (they were already orphaned)
- `add_track_to_playlist` still accepts `file_path` from callers — resolution to `track_id` happens at insert time; no API or frontend changes needed
- As a bonus, `ON DELETE CASCADE` on `track_id` means deleting a track from the library also cleans up its playlist entries

## Test plan

- [x] `test_track_survives_move` — regression test: add track to playlist, move it with `move_track()`, assert it still appears
- [x] `test_migration_v29_replaces_file_path_with_track_id` — builds a real v29 DB with `file_path` rows and verifies the migration preserves data with correct `track_id`
- [x] All 22 `TestPlaylists` tests pass
- [x] All 643 library + server tests pass
- [x] Manual: add a track to a playlist, rename the file on disk, trigger a scan, verify the track still appears in the playlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)