### PR TITLE
feat(KAMP-442): search returns playlists by name and via track/artist results

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 31
+_SCHEMA_VERSION = 32
 
 _DDL = """\
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -265,6 +265,12 @@ CREATE TABLE IF NOT EXISTS playlists (
     created_at     REAL    NOT NULL,
     updated_at     REAL    NOT NULL,
     last_played_at REAL
+);
+
+-- FTS5 index for playlist name search (KAMP-442). Non-content table; manually synced.
+CREATE VIRTUAL TABLE IF NOT EXISTS playlists_fts USING fts5(
+    title,
+    tokenize = 'unicode61'
 );
 
 -- Ordered track membership in a playlist (KAMP-441).
@@ -1137,7 +1143,21 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 31")
             self._conn.commit()
-            version = 31  # noqa: F841
+            version = 31
+
+        if version == 31:
+            # v31 → v32: add playlists_fts FTS5 table for playlist name search (KAMP-442).
+            self._conn.execute("""
+                CREATE VIRTUAL TABLE IF NOT EXISTS playlists_fts USING fts5(
+                    title, tokenize = 'unicode61'
+                )
+            """)
+            self._conn.execute(
+                "INSERT INTO playlists_fts(rowid, title) SELECT id, title FROM playlists"
+            )
+            self._conn.execute("UPDATE schema_version SET version = 32")
+            self._conn.commit()
+            version = 32  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -1145,6 +1165,10 @@ class LibraryIndex:
         self._conn.execute(
             "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album) "
             "SELECT id, title, artist, album_artist, album FROM tracks"
+        )
+        self._conn.execute("DELETE FROM playlists_fts")
+        self._conn.execute(
+            "INSERT INTO playlists_fts(rowid, title) SELECT id, title FROM playlists"
         )
 
     # ------------------------------------------------------------------
@@ -2633,6 +2657,77 @@ class LibraryIndex:
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
+    # Source expression reused by both playlist search methods.  Matches the
+    # album source computation: 'mixed' when both local and non-local tracks are
+    # present; otherwise the sole source value, defaulting to 'local' if empty.
+    _PLAYLIST_SOURCE_EXPR = """
+        CASE
+            WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+             AND COUNT(CASE WHEN t.source != 'local' THEN 1 END) > 0
+            THEN 'mixed'
+            WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+            THEN 'local'
+            WHEN COUNT(t.id) = 0 THEN 'local'
+            ELSE MIN(t.source)
+        END
+    """
+
+    def search_playlists(self, query: str) -> list[dict[str, Any]]:
+        """Full-text search over playlist titles.
+
+        Returns playlists ranked by relevance, each with a computed ``source``
+        field ('local', 'bandcamp', or 'mixed'). Returns an empty list when
+        *query* is blank.
+        """
+        fts_expr = _make_fts_query(query)
+        if not fts_expr:
+            return []
+        rows = self._conn.execute(
+            f"""
+            SELECT p.id, p.title, p.favorite, p.created_at, p.updated_at,
+                   p.last_played_at,
+                   COUNT(pt.id) AS track_count,
+                   {self._PLAYLIST_SOURCE_EXPR} AS source
+            FROM playlists_fts f
+            JOIN playlists p ON f.rowid = p.id
+            LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+            LEFT JOIN tracks t ON t.id = pt.track_id
+            WHERE playlists_fts MATCH ?
+            GROUP BY p.id
+            ORDER BY p.favorite DESC, f.rank
+            """,
+            (fts_expr,),
+        ).fetchall()
+        return [_playlist_row_to_dict(r) for r in rows]
+
+    def playlists_for_tracks(self, track_ids: list[int]) -> list[dict[str, Any]]:
+        """Return deduplicated playlists that contain any of the given track IDs.
+
+        Each result includes a computed ``source`` field. Returns an empty list
+        when *track_ids* is empty.
+        """
+        if not track_ids:
+            return []
+        placeholders = ",".join("?" * len(track_ids))
+        rows = self._conn.execute(
+            f"""
+            SELECT p.id, p.title, p.favorite, p.created_at, p.updated_at,
+                   p.last_played_at,
+                   COUNT(DISTINCT pt_all.id) AS track_count,
+                   {self._PLAYLIST_SOURCE_EXPR} AS source
+            FROM playlist_tracks pt_match
+            JOIN playlists p ON p.id = pt_match.playlist_id
+            -- Count all tracks in the playlist (not just the matched ones).
+            LEFT JOIN playlist_tracks pt_all ON pt_all.playlist_id = p.id
+            LEFT JOIN tracks t ON t.id = pt_all.track_id
+            WHERE pt_match.track_id IN ({placeholders})
+            GROUP BY p.id
+            ORDER BY p.favorite DESC, p.title COLLATE NOCASE
+            """,
+            track_ids,
+        ).fetchall()
+        return [_playlist_row_to_dict(r) for r in rows]
+
     def save_player_state(self, track_path: "str | Path", position: float) -> None:
         """Persist the current track path and playback position."""
         self._conn.execute(
@@ -2941,9 +3036,13 @@ class LibraryIndex:
             "INSERT INTO playlists (title, favorite, created_at, updated_at) VALUES (?, 0, ?, ?)",
             (title, now, now),
         )
+        new_id = cur.lastrowid
+        self._conn.execute(
+            "INSERT INTO playlists_fts(rowid, title) VALUES (?, ?)", (new_id, title)
+        )
         self._conn.commit()
         return {
-            "id": cur.lastrowid,
+            "id": new_id,
             "title": title,
             "favorite": False,
             "track_count": 0,
@@ -3159,10 +3258,16 @@ class LibraryIndex:
             "UPDATE playlists SET title = ?, updated_at = ? WHERE id = ?",
             (title, _time.time(), playlist_id),
         )
+        self._conn.execute("DELETE FROM playlists_fts WHERE rowid = ?", (playlist_id,))
+        self._conn.execute(
+            "INSERT INTO playlists_fts(rowid, title) VALUES (?, ?)",
+            (playlist_id, title),
+        )
         self._conn.commit()
 
     def delete_playlist(self, playlist_id: int) -> None:
         """Delete *playlist_id* and all its playlist_tracks rows (via CASCADE)."""
+        self._conn.execute("DELETE FROM playlists_fts WHERE rowid = ?", (playlist_id,))
         self._conn.execute("DELETE FROM playlists WHERE id = ?", (playlist_id,))
         self._conn.commit()
 
@@ -3301,6 +3406,19 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         is_available=bool(row["is_available"]),
         duration=row["duration"],
     )
+
+
+def _playlist_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "favorite": bool(row["favorite"]),
+        "track_count": row["track_count"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "last_played_at": row["last_played_at"],
+        "source": row["source"],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -363,6 +363,7 @@ class AlbumFavoriteRequest(BaseModel):
 class SearchOut(BaseModel):
     albums: list[AlbumOut]
     tracks: list[TrackOut]
+    playlists: list[PlaylistSearchOut] = []
 
 
 class QueueOut(BaseModel):
@@ -545,6 +546,10 @@ class PlaylistOut(BaseModel):
     created_at: float
     updated_at: float
     last_played_at: float | None = None
+
+
+class PlaylistSearchOut(PlaylistOut):
+    source: str = "local"
 
 
 class PlaylistTrackOut(BaseModel):
@@ -2308,8 +2313,22 @@ def create_app(
             or (a.missing_album and a.file_path in fts_paths)
         ]
         albums.sort(key=lambda a: not a.favorite)
+
+        # Merge playlist-name matches with playlists containing matched tracks,
+        # deduplicating by id so a playlist that matches both facets appears once.
+        name_playlists = index.search_playlists(q)
+        track_playlists = index.playlists_for_tracks([t.id for t in fts_tracks])
+        seen_ids: set[int] = set()
+        playlists: list[PlaylistSearchOut] = []
+        for raw in name_playlists + track_playlists:
+            if raw["id"] not in seen_ids:
+                seen_ids.add(raw["id"])
+                playlists.append(PlaylistSearchOut(**raw))
+
         return SearchOut(
-            albums=albums, tracks=[TrackOut.from_track(t) for t in fts_tracks]
+            albums=albums,
+            tracks=[TrackOut.from_track(t) for t in fts_tracks],
+            playlists=playlists,
         )
 
     @app.post("/api/v1/library/scan", response_model=ScanResult)

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -215,9 +215,12 @@ export const getTracksForAlbum = (
   return get(filePath ? `${base}&file_path=${encodeURIComponent(filePath)}` : base)
 }
 
+export type PlaylistSearchResult = Playlist & { source: string }
+
 export type SearchResult = {
   albums: Album[]
   tracks: Track[]
+  playlists: PlaylistSearchResult[]
 }
 
 export const search = (q: string, sort = 'album_artist'): Promise<SearchResult> =>

--- a/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
@@ -7,7 +7,13 @@ import { FavoriteIcon } from './TransportIcons'
 
 type MenuPos = { x: number; y: number }
 
-export function PlaylistCard({ playlist }: { playlist: Playlist }): React.JSX.Element {
+export function PlaylistCard({
+  playlist,
+  onAfterSelect
+}: {
+  playlist: Playlist
+  onAfterSelect?: () => void
+}): React.JSX.Element {
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const setCollectionType = useStore((s) => s.setCollectionType)
   const [menu, setMenu] = useState<MenuPos | null>(null)
@@ -17,6 +23,7 @@ export function PlaylistCard({ playlist }: { playlist: Playlist }): React.JSX.El
     if (menu) return
     setCollectionType('playlists')
     void selectPlaylist(playlist)
+    onAfterSelect?.()
   }
 
   return (

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react'
 import { useStore } from '../store'
-import type { Album, Track } from '../api/client'
+import type { Album, PlaylistSearchResult, Track } from '../api/client'
 import { SortControl } from './SortControl'
 import { SourceControl } from './SourceControl'
 import { FilterControl } from './FilterControl'
 import { AlbumCard } from './AlbumCard'
+import { PlaylistCard } from './PlaylistCard'
 import { TrackContextMenu } from './TrackContextMenu'
 import { FavoriteIcon } from './TransportIcons'
 
@@ -130,6 +131,20 @@ export function SearchView(): React.JSX.Element {
   if (libraryFilter.includes('local_only'))
     visibleTracks = visibleTracks.filter((t) => t.source === 'local')
 
+  const rawPlaylists: PlaylistSearchResult[] = results?.playlists ?? []
+  let visiblePlaylists = rawPlaylists
+  if (hasQualitativeFilter) {
+    visiblePlaylists = visiblePlaylists.filter(
+      (pl) =>
+        (libraryFilter.includes('favorite_album') && pl.favorite) ||
+        (libraryFilter.includes('unplayed') && pl.last_played_at === null)
+    )
+  }
+  if (libraryFilter.includes('remote_only'))
+    visiblePlaylists = visiblePlaylists.filter((pl) => pl.source !== 'local')
+  if (libraryFilter.includes('local_only'))
+    visiblePlaylists = visiblePlaylists.filter((pl) => pl.source === 'local')
+
   return (
     <div className="search-view">
       <div className="search-view-toolbar">
@@ -146,7 +161,7 @@ export function SearchView(): React.JSX.Element {
       <div className="search-view-content">
         {!results ? (
           <div className="search-empty">Searching…</div>
-        ) : !visibleAlbums.length && !visibleTracks.length ? (
+        ) : !visibleAlbums.length && !visibleTracks.length && !visiblePlaylists.length ? (
           <div className="search-empty">No results for &ldquo;{query}&rdquo;</div>
         ) : (
           <>
@@ -160,6 +175,16 @@ export function SearchView(): React.JSX.Element {
                       album={album}
                       onAfterSelect={() => void setSearchQuery('')}
                     />
+                  ))}
+                </div>
+              </section>
+            )}
+            {visiblePlaylists.length > 0 && (
+              <section className="search-section">
+                <h2 className="search-section-title">Playlists</h2>
+                <div className="search-album-grid">
+                  {visiblePlaylists.map((pl) => (
+                    <PlaylistCard key={pl.id} playlist={pl} />
                   ))}
                 </div>
               </section>

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -184,7 +184,11 @@ export function SearchView(): React.JSX.Element {
                 <h2 className="search-section-title">Playlists</h2>
                 <div className="search-album-grid">
                   {visiblePlaylists.map((pl) => (
-                    <PlaylistCard key={pl.id} playlist={pl} />
+                    <PlaylistCard
+                      key={pl.id}
+                      playlist={pl}
+                      onAfterSelect={() => void setSearchQuery('')}
+                    />
                   ))}
                 </div>
               </section>

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,7 +129,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 31
+        assert version == 32
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1454,7 +1454,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1511,7 +1511,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1924,7 +1924,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert row is not None
         assert row[0] == 0
 
@@ -2178,7 +2178,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2274,7 +2274,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2455,7 +2455,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2550,7 +2550,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 31
+        assert version == 32
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2558,7 +2558,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 31
+        assert version == 32
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3435,7 +3435,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 31
+        assert version == 32
 
         index.close()
 
@@ -4120,7 +4120,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 31
+        assert version == 32
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4155,7 +4155,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 31
+        assert version == 32
         index.close()
 
 
@@ -4603,7 +4603,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 31
+        assert version == 32
 
 
 class TestRemoteTrackSchema:
@@ -4937,7 +4937,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -4998,7 +4998,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5665,7 +5665,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5780,7 +5780,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5858,7 +5858,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6064,7 +6064,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6413,7 +6413,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6510,7 +6510,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6625,7 +6625,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7114,7 +7114,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7229,7 +7229,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -7327,5 +7327,289 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 31
+        assert version == 32
         assert "last_played_at" in columns
+
+    # ------------------------------------------------------------------
+    # migration v31 → v32
+    # ------------------------------------------------------------------
+
+    def test_migration_v31_creates_playlists_fts(self, tmp_path: Path) -> None:
+        """Opening a v31 DB triggers the v32 migration: playlists_fts created."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (31)")
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0, disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
+            " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
+            " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
+            " stream_url_expires_at REAL, album_id INTEGER,"
+            " is_available INTEGER NOT NULL DEFAULT 1,"
+            " duration REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE VIRTUAL TABLE tracks_fts USING fts5(title, artist, album_artist, album)"
+        )
+        conn.execute(
+            "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " album_artist TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " album TEXT NOT NULL DEFAULT '' COLLATE NOCASE,"
+            " year TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '', genre TEXT NOT NULL DEFAULT '',"
+            " label TEXT NOT NULL DEFAULT '', source TEXT NOT NULL DEFAULT 'local',"
+            " sale_item_id TEXT, favorite INTEGER NOT NULL DEFAULT 0,"
+            " date_added REAL, last_played_at REAL, play_count_avg REAL NOT NULL DEFAULT 0,"
+            " art_version REAL, UNIQUE (album_artist, album))"
+        )
+        conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT NOT NULL PRIMARY KEY,"
+            " item_type TEXT NOT NULL DEFAULT 'p', band_name TEXT NOT NULL DEFAULT '',"
+            " item_title TEXT NOT NULL DEFAULT '', tralbum_id TEXT NOT NULL DEFAULT '',"
+            " album_url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT 'local',"
+            " synced_at REAL, added_at REAL NOT NULL DEFAULT 0,"
+            " num_streamable_tracks INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE settings (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE sessions (service TEXT NOT NULL PRIMARY KEY,"
+            " session_json TEXT, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE deferred_ops (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " op_type TEXT NOT NULL, track_id INTEGER NOT NULL UNIQUE,"
+            " payload_json TEXT NOT NULL, created_at REAL NOT NULL,"
+            " attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE download_queue (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE, queued_at REAL NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " title TEXT NOT NULL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " created_at REAL NOT NULL, updated_at REAL NOT NULL,"
+            " last_played_at REAL)"
+        )
+        conn.execute(
+            "CREATE TABLE playlist_tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,"
+            " track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,"
+            " position INTEGER NOT NULL)"
+        )
+        import time as _time
+
+        conn.execute(
+            "INSERT INTO playlists (title, favorite, created_at, updated_at)"
+            " VALUES ('Existing Playlist', 0, ?, ?)",
+            (_time.time(), _time.time()),
+        )
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        # The migrated FTS table should contain the pre-existing playlist.
+        results = index.search_playlists("Existing Playlist")
+        index.close()
+
+        assert version == 32
+        assert len(results) == 1
+        assert results[0]["title"] == "Existing Playlist"
+
+    # ------------------------------------------------------------------
+    # search_playlists
+    # ------------------------------------------------------------------
+
+    def test_search_playlists_empty_query_returns_empty(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.create_playlist("Chill Mix")
+        assert index.search_playlists("") == []
+        assert index.search_playlists("   ") == []
+        index.close()
+
+    def test_search_playlists_by_exact_name(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.create_playlist("Road Trip")
+        index.create_playlist("Late Night")
+        results = index.search_playlists("Road Trip")
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["title"] == "Road Trip"
+
+    def test_search_playlists_partial_match(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.create_playlist("Morning Coffee")
+        index.create_playlist("Evening Wind-Down")
+        results = index.search_playlists("morning")
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["title"] == "Morning Coffee"
+
+    def test_search_playlists_result_has_source_local_for_empty_playlist(
+        self, tmp_path: Path
+    ) -> None:
+        index = self._index(tmp_path)
+        index.create_playlist("Empty Playlist")
+        results = index.search_playlists("Empty")
+        index.close()
+
+        assert results[0]["source"] == "local"
+
+    def test_search_playlists_source_computed_from_tracks(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        local_track = _sample_track(tmp_path / "local.mp3")
+        remote_track = Track(
+            file_path=tmp_path / "remote.mp3",
+            title="Remote Song",
+            artist="Remote Artist",
+            album_artist="Remote Artist",
+            album="Remote Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        index.upsert_many([local_track, remote_track])
+
+        pl_local = index.create_playlist("Local Only")
+        index.add_track_to_playlist(pl_local["id"], str(local_track.file_path))
+        results_local = index.search_playlists("Local Only")
+
+        pl_remote = index.create_playlist("Remote Only")
+        index.add_track_to_playlist(pl_remote["id"], str(remote_track.file_path))
+        results_remote = index.search_playlists("Remote Only")
+
+        pl_mixed = index.create_playlist("Mixed")
+        index.add_track_to_playlist(pl_mixed["id"], str(local_track.file_path))
+        index.add_track_to_playlist(pl_mixed["id"], str(remote_track.file_path))
+        results_mixed = index.search_playlists("Mixed")
+        index.close()
+
+        assert results_local[0]["source"] == "local"
+        assert results_remote[0]["source"] == "bandcamp"
+        assert results_mixed[0]["source"] == "mixed"
+
+    def test_search_playlists_fts_updated_on_rename(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        pl = index.create_playlist("Old Name")
+        index.rename_playlist(pl["id"], "New Name")
+
+        assert index.search_playlists("Old Name") == []
+        results = index.search_playlists("New Name")
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["title"] == "New Name"
+
+    def test_search_playlists_fts_cleared_on_delete(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        pl = index.create_playlist("Gone")
+        index.delete_playlist(pl["id"])
+        results = index.search_playlists("Gone")
+        index.close()
+
+        assert results == []
+
+    # ------------------------------------------------------------------
+    # playlists_for_tracks
+    # ------------------------------------------------------------------
+
+    def test_playlists_for_tracks_empty_list_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        index = self._index(tmp_path)
+        index.create_playlist("Mix")
+        assert index.playlists_for_tracks([]) == []
+        index.close()
+
+    def test_playlists_for_tracks_basic(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        pl = index.create_playlist("My Faves")
+        track = index.get_track_by_path(str(tmp_path / "a.mp3"))
+        assert track is not None
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "a.mp3"))
+
+        results = index.playlists_for_tracks([track.id])
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["id"] == pl["id"]
+        assert results[0]["title"] == "My Faves"
+
+    def test_playlists_for_tracks_deduplicated(self, tmp_path: Path) -> None:
+        """Multiple tracks from the same playlist must produce one result row."""
+        index = LibraryIndex(tmp_path / "library.db")
+        tracks = [_sample_track(tmp_path / f"{i}.mp3") for i in range(3)]
+        index.upsert_many(tracks)
+        pl = index.create_playlist("Triple")
+        ids = []
+        for t in tracks:
+            row = index.get_track_by_path(str(t.file_path))
+            assert row is not None
+            ids.append(row.id)
+            index.add_track_to_playlist(pl["id"], str(t.file_path))
+
+        results = index.playlists_for_tracks(ids)
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["title"] == "Triple"
+
+    def test_playlists_for_tracks_excludes_unrelated_playlists(
+        self, tmp_path: Path
+    ) -> None:
+        index = self._index(tmp_path)
+        pl_a = index.create_playlist("Has Track")
+        index.create_playlist("Empty")
+        track = index.get_track_by_path(str(tmp_path / "a.mp3"))
+        assert track is not None
+        index.add_track_to_playlist(pl_a["id"], str(tmp_path / "a.mp3"))
+
+        results = index.playlists_for_tracks([track.id])
+        index.close()
+
+        assert len(results) == 1
+        assert results[0]["id"] == pl_a["id"]
+
+    def test_playlists_for_tracks_track_count_reflects_full_playlist(
+        self, tmp_path: Path
+    ) -> None:
+        """track_count in results must count all tracks in the playlist, not
+        just the ones in the search input."""
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "t1.mp3")
+        t2 = _sample_track(tmp_path / "t2.mp3")
+        index.upsert_many([t1, t2])
+        pl = index.create_playlist("Two Tracks")
+        row1 = index.get_track_by_path(str(t1.file_path))
+        row2 = index.get_track_by_path(str(t2.file_path))
+        assert row1 is not None and row2 is not None
+        index.add_track_to_playlist(pl["id"], str(t1.file_path))
+        index.add_track_to_playlist(pl["id"], str(t2.file_path))
+
+        # Only pass one track id; track_count must still be 2.
+        results = index.playlists_for_tracks([row1.id])
+        index.close()
+
+        assert results[0]["track_count"] == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -52,6 +52,8 @@ def mock_index() -> MagicMock:
     index.albums.return_value = []
     index.artists.return_value = []
     index.tracks_for_album.return_value = []
+    index.search_playlists.return_value = []
+    index.playlists_for_tracks.return_value = []
     return index
 
 
@@ -1561,7 +1563,7 @@ class TestSearchEndpoint:
         res = TestClient(app).get("/api/v1/search?q=")
         assert res.status_code == 200
         data = res.json()
-        assert data == {"albums": [], "tracks": []}
+        assert data == {"albums": [], "tracks": [], "playlists": []}
 
     def test_returns_matching_tracks_and_albums(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -1635,6 +1637,90 @@ class TestSearchEndpoint:
         assert data["tracks"][0]["source"] == "bandcamp"
         assert len(data["albums"]) == 1
         assert data["albums"][0]["source"] == "bandcamp"
+
+    def test_search_response_includes_playlists_key(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.search.return_value = []
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=anything")
+        assert "playlists" in res.json()
+
+    def test_search_returns_playlist_name_match(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.search.return_value = []
+        mock_index.search_playlists.return_value = [
+            {
+                "id": 1,
+                "title": "Road Trip",
+                "favorite": False,
+                "track_count": 5,
+                "created_at": 1000.0,
+                "updated_at": 1001.0,
+                "last_played_at": None,
+                "source": "local",
+            }
+        ]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=road")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["playlists"]) == 1
+        assert data["playlists"][0]["title"] == "Road Trip"
+        assert data["playlists"][0]["source"] == "local"
+
+    def test_search_returns_playlists_containing_matched_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        t = _track(1, album="Kid A", artist="Radiohead")
+        mock_index.search.return_value = [t]
+        mock_index.albums.return_value = []
+        mock_index.playlists_for_tracks.return_value = [
+            {
+                "id": 7,
+                "title": "Chill Mix",
+                "favorite": True,
+                "track_count": 10,
+                "created_at": 2000.0,
+                "updated_at": 2001.0,
+                "last_played_at": None,
+                "source": "bandcamp",
+            }
+        ]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=radiohead")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["playlists"]) == 1
+        assert data["playlists"][0]["id"] == 7
+        assert data["playlists"][0]["source"] == "bandcamp"
+        mock_index.playlists_for_tracks.assert_called_once_with([t.id])
+
+    def test_search_playlists_deduplication(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """A playlist matching both by name and by track-membership appears once."""
+        t = _track(1, album="Kid A", artist="Radiohead")
+        mock_index.search.return_value = [t]
+        mock_index.albums.return_value = []
+        shared = {
+            "id": 3,
+            "title": "Radiohead Playlist",
+            "favorite": False,
+            "track_count": 2,
+            "created_at": 3000.0,
+            "updated_at": 3001.0,
+            "last_played_at": None,
+            "source": "local",
+        }
+        mock_index.search_playlists.return_value = [shared]
+        mock_index.playlists_for_tracks.return_value = [shared]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=radiohead")
+        data = res.json()
+        assert len(data["playlists"]) == 1
+        assert data["playlists"][0]["id"] == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `playlists_fts` FTS5 virtual table (schema v31→v32) with maintenance in `create_playlist`, `rename_playlist`, `delete_playlist`, and `_rebuild_fts`
- Adds `search_playlists()` (name FTS) and `playlists_for_tracks()` (track-membership JOIN) to `LibraryIndex`, each returning a computed `source` field (local/bandcamp/mixed)
- Extends `SearchOut` with a `playlists` field; `search_library()` merges and deduplicates both result sets by playlist id
- Adds `PlaylistSearchResult` type to `client.ts`; `SearchView` gains a Playlists section with source, favorite, and unplayed filtering using the existing `PlaylistCard` component

## Test plan

- [ ] Search for a playlist name → "Playlists" section appears with matching card
- [ ] Click a playlist result → navigates to PlaylistView
- [ ] Search for an artist/song → playlists containing matching tracks appear
- [ ] 5 tracks from same artist in one playlist → playlist appears once (deduplication)
- [ ] Playlist matching both by name and track-membership appears once
- [ ] `remote_only` filter: playlist with only local tracks excluded
- [ ] `local_only` filter: playlist with only remote tracks excluded
- [ ] Rename playlist → old name no longer matches; new name does
- [ ] Delete playlist → no longer appears in search

🤖 Generated with [Claude Code](https://claude.com/claude-code)