### PR TITLE
feat(KAMP-443): playlist cover art

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3272,13 +3272,11 @@ class LibraryIndex:
         self._conn.commit()
 
     def set_playlist_cover(
-        self, playlist_id: int, data: bytes, mime_type: str = "image/jpeg"
+        self, playlist_id: int, data: bytes
     ) -> dict[str, Any] | None:
         """Write *data* as the cover image for *playlist_id* and bump updated_at.
 
-        Stores SVGs at <db_dir>/playlist_art/<playlist_id>.svg and all other
-        formats at <playlist_id>.jpg.  Removes the other extension if it exists
-        so only one file is present at a time.
+        Stores the file at <db_dir>/playlist_art/<playlist_id>.jpg.
         Returns the updated playlist row dict, or None if the playlist does not exist.
         """
         pl = self.get_playlist(playlist_id)
@@ -3286,10 +3284,7 @@ class LibraryIndex:
             return None
         art_dir = self._db_path.parent / "playlist_art"
         art_dir.mkdir(exist_ok=True)
-        ext = ".svg" if mime_type == "image/svg+xml" else ".jpg"
-        other_ext = ".jpg" if ext == ".svg" else ".svg"
-        (art_dir / f"{playlist_id}{other_ext}").unlink(missing_ok=True)
-        (art_dir / f"{playlist_id}{ext}").write_bytes(data)
+        (art_dir / f"{playlist_id}.jpg").write_bytes(data)
         now = _time.time()
         self._conn.execute(
             "UPDATE playlists SET updated_at = ? WHERE id = ?", (now, playlist_id)
@@ -3297,13 +3292,11 @@ class LibraryIndex:
         self._conn.commit()
         return self.get_playlist(playlist_id)
 
-    def get_playlist_cover(self, playlist_id: int) -> tuple[bytes, str] | None:
-        """Return (bytes, mime_type) for the stored cover art, or None if not set."""
-        art_dir = self._db_path.parent / "playlist_art"
-        for ext, mime in ((".svg", "image/svg+xml"), (".jpg", "image/jpeg")):
-            path = art_dir / f"{playlist_id}{ext}"
-            if path.exists():
-                return path.read_bytes(), mime
+    def get_playlist_cover(self, playlist_id: int) -> bytes | None:
+        """Return the raw bytes of the stored cover art, or None if not set."""
+        path = self._db_path.parent / "playlist_art" / f"{playlist_id}.jpg"
+        if path.exists():
+            return path.read_bytes()
         return None
 
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3271,6 +3271,34 @@ class LibraryIndex:
         self._conn.execute("DELETE FROM playlists WHERE id = ?", (playlist_id,))
         self._conn.commit()
 
+    def set_playlist_cover(
+        self, playlist_id: int, data: bytes
+    ) -> dict[str, Any] | None:
+        """Write *data* as the cover image for *playlist_id* and bump updated_at.
+
+        Stores the file at <db_dir>/playlist_art/<playlist_id>.jpg.
+        Returns the updated playlist row dict, or None if the playlist does not exist.
+        """
+        pl = self.get_playlist(playlist_id)
+        if pl is None:
+            return None
+        art_dir = self._db_path.parent / "playlist_art"
+        art_dir.mkdir(exist_ok=True)
+        (art_dir / f"{playlist_id}.jpg").write_bytes(data)
+        now = _time.time()
+        self._conn.execute(
+            "UPDATE playlists SET updated_at = ? WHERE id = ?", (now, playlist_id)
+        )
+        self._conn.commit()
+        return self.get_playlist(playlist_id)
+
+    def get_playlist_cover(self, playlist_id: int) -> bytes | None:
+        """Return the raw bytes of the stored cover art, or None if not set."""
+        path = self._db_path.parent / "playlist_art" / f"{playlist_id}.jpg"
+        if path.exists():
+            return path.read_bytes()
+        return None
+
 
 # Track fields that extensions are permitted to write via apply_metadata_update.
 # Excludes internal columns (embedded_art, play_count, last_played, etc.) so

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3272,11 +3272,13 @@ class LibraryIndex:
         self._conn.commit()
 
     def set_playlist_cover(
-        self, playlist_id: int, data: bytes
+        self, playlist_id: int, data: bytes, mime_type: str = "image/jpeg"
     ) -> dict[str, Any] | None:
         """Write *data* as the cover image for *playlist_id* and bump updated_at.
 
-        Stores the file at <db_dir>/playlist_art/<playlist_id>.jpg.
+        Stores SVGs at <db_dir>/playlist_art/<playlist_id>.svg and all other
+        formats at <playlist_id>.jpg.  Removes the other extension if it exists
+        so only one file is present at a time.
         Returns the updated playlist row dict, or None if the playlist does not exist.
         """
         pl = self.get_playlist(playlist_id)
@@ -3284,7 +3286,10 @@ class LibraryIndex:
             return None
         art_dir = self._db_path.parent / "playlist_art"
         art_dir.mkdir(exist_ok=True)
-        (art_dir / f"{playlist_id}.jpg").write_bytes(data)
+        ext = ".svg" if mime_type == "image/svg+xml" else ".jpg"
+        other_ext = ".jpg" if ext == ".svg" else ".svg"
+        (art_dir / f"{playlist_id}{other_ext}").unlink(missing_ok=True)
+        (art_dir / f"{playlist_id}{ext}").write_bytes(data)
         now = _time.time()
         self._conn.execute(
             "UPDATE playlists SET updated_at = ? WHERE id = ?", (now, playlist_id)
@@ -3292,11 +3297,13 @@ class LibraryIndex:
         self._conn.commit()
         return self.get_playlist(playlist_id)
 
-    def get_playlist_cover(self, playlist_id: int) -> bytes | None:
-        """Return the raw bytes of the stored cover art, or None if not set."""
-        path = self._db_path.parent / "playlist_art" / f"{playlist_id}.jpg"
-        if path.exists():
-            return path.read_bytes()
+    def get_playlist_cover(self, playlist_id: int) -> tuple[bytes, str] | None:
+        """Return (bytes, mime_type) for the stored cover art, or None if not set."""
+        art_dir = self._db_path.parent / "playlist_art"
+        for ext, mime in ((".svg", "image/svg+xml"), (".jpg", "image/jpeg")):
+            path = art_dir / f"{playlist_id}{ext}"
+            if path.exists():
+                return path.read_bytes(), mime
         return None
 
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3269,8 +3269,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="Playlist not found")
         cover = index.get_playlist_cover(playlist_id)
         if cover is not None:
-            data, mime = cover
-            return Response(content=data, media_type=mime)
+            return Response(content=cover, media_type="image/jpeg")
         title = pl["title"]
         display = title if len(title) <= 12 else title[:11] + "…"
         svg = _PLAYLIST_ART_TEMPLATE.replace("__TITLE__", display)
@@ -3300,16 +3299,15 @@ def create_app(
 
         image_data = await file.read()
 
-        if content_type != "image/svg+xml":
-            try:
-                validate_image_bytes(image_data)
-            except ArtworkError as exc:
-                raise HTTPException(status_code=422, detail=str(exc)) from exc
+        try:
+            validate_image_bytes(image_data)
+        except ArtworkError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
         if index.get_playlist(playlist_id) is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
 
-        updated = index.set_playlist_cover(playlist_id, image_data, content_type)
+        updated = index.set_playlist_cover(playlist_id, image_data)
         return PlaylistOut(**updated)  # type: ignore[arg-type]
 
     # -----------------------------------------------------------------------

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3267,10 +3267,48 @@ def create_app(
         pl = index.get_playlist(playlist_id)
         if pl is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
+        cover = index.get_playlist_cover(playlist_id)
+        if cover is not None:
+            return Response(content=cover, media_type="image/jpeg")
         title = pl["title"]
         display = title if len(title) <= 12 else title[:11] + "…"
         svg = _PLAYLIST_ART_TEMPLATE.replace("__TITLE__", display)
         return Response(content=svg, media_type="image/svg+xml")
+
+    @app.post("/api/v1/playlists/{playlist_id}/art", response_model=PlaylistOut)
+    async def set_playlist_art(
+        playlist_id: int,
+        file: UploadFile = File(...),
+    ) -> PlaylistOut:
+        """Upload a local image file and store it as cover art for the playlist.
+
+        Returns 404 if the playlist does not exist.
+        Returns 422 if the uploaded file is not a valid image.
+        Returns the updated PlaylistOut on success.
+        """
+        from kamp_daemon.artwork import (
+            ArtworkError,
+            validate_image_bytes,
+        )  # noqa: PLC0415
+
+        content_type = file.content_type or ""
+        if not content_type.startswith("image/"):
+            raise HTTPException(
+                status_code=422, detail="Uploaded file must be an image"
+            )
+
+        image_data = await file.read()
+
+        try:
+            validate_image_bytes(image_data)
+        except ArtworkError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        if index.get_playlist(playlist_id) is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+
+        updated = index.set_playlist_cover(playlist_id, image_data)
+        return PlaylistOut(**updated)  # type: ignore[arg-type]
 
     # -----------------------------------------------------------------------
     # WebSocket: player state stream

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3269,7 +3269,8 @@ def create_app(
             raise HTTPException(status_code=404, detail="Playlist not found")
         cover = index.get_playlist_cover(playlist_id)
         if cover is not None:
-            return Response(content=cover, media_type="image/jpeg")
+            data, mime = cover
+            return Response(content=data, media_type=mime)
         title = pl["title"]
         display = title if len(title) <= 12 else title[:11] + "…"
         svg = _PLAYLIST_ART_TEMPLATE.replace("__TITLE__", display)
@@ -3299,15 +3300,16 @@ def create_app(
 
         image_data = await file.read()
 
-        try:
-            validate_image_bytes(image_data)
-        except ArtworkError as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        if content_type != "image/svg+xml":
+            try:
+                validate_image_bytes(image_data)
+            except ArtworkError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
 
         if index.get_playlist(playlist_id) is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
 
-        updated = index.set_playlist_cover(playlist_id, image_data)
+        updated = index.set_playlist_cover(playlist_id, image_data, content_type)
         return PlaylistOut(**updated)  # type: ignore[arg-type]
 
     # -----------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -726,6 +726,24 @@ export async function applyAlbumArtLocal(
 // Playlists (KAMP-441)
 // ---------------------------------------------------------------------------
 
+export async function applyPlaylistArtLocal(
+  playlistId: number,
+  file: File
+): Promise<Playlist> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`${BASE_URL}/api/v1/playlists/${playlistId}/art`, {
+    method: 'POST',
+    headers: _authHeaders(),
+    body: form
+  })
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({ detail: res.statusText }))
+    throw new Error(detail?.detail ?? res.statusText)
+  }
+  return res.json() as Promise<Playlist>
+}
+
 export const playPlaylist = (playlistId: number, startIndex = 0): Promise<void> =>
   post('/api/v1/player/play-playlist', { playlist_id: playlistId, start_index: startIndex })
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -726,10 +726,7 @@ export async function applyAlbumArtLocal(
 // Playlists (KAMP-441)
 // ---------------------------------------------------------------------------
 
-export async function applyPlaylistArtLocal(
-  playlistId: number,
-  file: File
-): Promise<Playlist> {
+export async function applyPlaylistArtLocal(playlistId: number, file: File): Promise<Playlist> {
   const form = new FormData()
   form.append('file', file)
   const res = await fetch(`${BASE_URL}/api/v1/playlists/${playlistId}/art`, {

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -72,6 +72,37 @@
   );
 }
 
+/* Hidden native file input for playlist art upload */
+.art-upload-input {
+  display: none;
+}
+
+/* "Change art" button sits at the bottom-right of the hero */
+.hero-art-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 10px;
+  z-index: 2;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+  background: rgba(20, 20, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.track-list-hero:hover .hero-art-btn {
+  opacity: 1;
+}
+
+.hero-art-btn:hover {
+  color: var(--text);
+  background: rgba(20, 20, 20, 0.85);
+}
+
 /* Breadcrumb floats over the hero */
 .breadcrumb {
   position: absolute;

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -77,10 +77,11 @@
   display: none;
 }
 
-/* "Change art" button sits at the bottom-right of the hero */
+/* "Change art" button sits at the top-right of the hero.
+   Bottom is occupied by .track-list-identity (margin-top: -48px overlap). */
 .hero-art-btn {
   position: absolute;
-  bottom: 8px;
+  top: 10px;
   right: 10px;
   z-index: 2;
   padding: 3px 8px;

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
-import { playlistArtUrl } from '../api/client'
+import { applyPlaylistArtLocal, playlistArtUrl } from '../api/client'
 import type { PlaylistTrack } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
 import { SortControl } from './SortControl'
@@ -128,6 +128,7 @@ export function PlaylistView(): React.JSX.Element | null {
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const playNext = useStore((s) => s.playNext)
   const addToQueue = useStore((s) => s.addToQueue)
+  const patchOpenPlaylist = useStore((s) => s.patchOpenPlaylist)
   const configValues = useStore((s) => s.configValues)
   const connected = configValues?.['bandcamp.connected'] ?? false
 
@@ -143,6 +144,7 @@ export function PlaylistView(): React.JSX.Element | null {
   const [anchorIdx, setAnchorIdx] = useState<number | null>(null)
 
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const artInputRef = useRef<HTMLInputElement>(null)
   const dragFromIdx = useRef<number | null>(null)
   const didDragRef = useRef(false)
   const dragStartYRef = useRef(0)
@@ -179,6 +181,15 @@ export function PlaylistView(): React.JSX.Element | null {
     } catch {
       // ignore
     }
+  }
+
+  const handleArtFileChosen = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    applyPlaylistArtLocal(playlist.id, file)
+      .then((updated) => patchOpenPlaylist(updated))
+      .catch((err: unknown) => console.error('Failed to set playlist art:', err))
   }
 
   const handleTrackSortChange = (key: string): void => {
@@ -399,6 +410,20 @@ export function PlaylistView(): React.JSX.Element | null {
     >
       <div className="track-list-hero has-art">
         <HeroImage src={playlistArtUrl(playlist.id, playlist.updated_at)} />
+        <input
+          type="file"
+          accept="image/*"
+          ref={artInputRef}
+          className="art-upload-input"
+          onChange={handleArtFileChosen}
+        />
+        <button
+          className="hero-art-btn"
+          title="Change art"
+          onClick={() => artInputRef.current?.click()}
+        >
+          Change art
+        </button>
       </div>
       <div className="track-list-hero-overlay" />
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -151,6 +151,7 @@ type PlayerStore = {
   setPlaylistFavorite: (playlistId: number, favorite: boolean) => Promise<void>
   renamePlaylist: (playlistId: number, title: string) => Promise<void>
   deletePlaylist: (playlistId: number) => Promise<void>
+  patchOpenPlaylist: (playlist: Playlist) => void
   playAlbum: (
     albumArtist: string,
     album: string,
@@ -765,6 +766,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }
     await get().loadPlaylists()
   },
+
+  patchOpenPlaylist: (playlist) =>
+    set((s) => ({ library: { ...s.library, selectedPlaylist: playlist } })),
 
   playAlbum: async (albumArtist, album, trackIndex = 0, filePath = '') => {
     await api.playAlbum(albumArtist, album, trackIndex, filePath)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7623,7 +7623,35 @@ class TestPlaylists:
         result = index.get_playlist_cover(pl["id"])
         index.close()
 
-        assert result == fake_jpeg
+        assert result == (fake_jpeg, "image/jpeg")
+
+    def test_set_and_get_playlist_cover_svg(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("SVG Art Test")
+        svg_data = b"<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"
+
+        index.set_playlist_cover(pl["id"], svg_data, "image/svg+xml")
+        result = index.get_playlist_cover(pl["id"])
+        index.close()
+
+        assert result == (svg_data, "image/svg+xml")
+
+    def test_set_playlist_cover_replaces_previous_format(self, tmp_path: Path) -> None:
+        """Switching from JPEG to SVG removes the old .jpg file."""
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("Format Switch")
+        index.set_playlist_cover(pl["id"], b"\xff\xd8\xff" + b"\x00" * 30)
+        index.set_playlist_cover(
+            pl["id"],
+            b"<svg/>",
+            "image/svg+xml",
+        )
+        result = index.get_playlist_cover(pl["id"])
+        art_dir = (tmp_path / "library.db").parent / "playlist_art"
+        index.close()
+
+        assert result is not None and result[1] == "image/svg+xml"
+        assert not (art_dir / f"{pl['id']}.jpg").exists()
 
     def test_set_playlist_cover_bumps_updated_at(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7613,3 +7613,42 @@ class TestPlaylists:
         index.close()
 
         assert results[0]["track_count"] == 2
+
+    def test_set_and_get_playlist_cover(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("Art Test")
+        fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 60
+
+        index.set_playlist_cover(pl["id"], fake_jpeg)
+        result = index.get_playlist_cover(pl["id"])
+        index.close()
+
+        assert result == fake_jpeg
+
+    def test_set_playlist_cover_bumps_updated_at(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("Timestamp Test")
+        original_updated_at = pl["updated_at"]
+
+        updated = index.set_playlist_cover(pl["id"], b"\xff\xd8\xff" + b"\x00" * 30)
+        index.close()
+
+        assert updated is not None
+        assert updated["updated_at"] > original_updated_at
+
+    def test_get_playlist_cover_returns_none_when_absent(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("No Art")
+        result = index.get_playlist_cover(pl["id"])
+        index.close()
+
+        assert result is None
+
+    def test_set_playlist_cover_returns_none_for_unknown_id(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.set_playlist_cover(9999, b"\xff\xd8\xff" + b"\x00" * 30)
+        index.close()
+
+        assert result is None

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7623,35 +7623,7 @@ class TestPlaylists:
         result = index.get_playlist_cover(pl["id"])
         index.close()
 
-        assert result == (fake_jpeg, "image/jpeg")
-
-    def test_set_and_get_playlist_cover_svg(self, tmp_path: Path) -> None:
-        index = LibraryIndex(tmp_path / "library.db")
-        pl = index.create_playlist("SVG Art Test")
-        svg_data = b"<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"
-
-        index.set_playlist_cover(pl["id"], svg_data, "image/svg+xml")
-        result = index.get_playlist_cover(pl["id"])
-        index.close()
-
-        assert result == (svg_data, "image/svg+xml")
-
-    def test_set_playlist_cover_replaces_previous_format(self, tmp_path: Path) -> None:
-        """Switching from JPEG to SVG removes the old .jpg file."""
-        index = LibraryIndex(tmp_path / "library.db")
-        pl = index.create_playlist("Format Switch")
-        index.set_playlist_cover(pl["id"], b"\xff\xd8\xff" + b"\x00" * 30)
-        index.set_playlist_cover(
-            pl["id"],
-            b"<svg/>",
-            "image/svg+xml",
-        )
-        result = index.get_playlist_cover(pl["id"])
-        art_dir = (tmp_path / "library.db").parent / "playlist_art"
-        index.close()
-
-        assert result is not None and result[1] == "image/svg+xml"
-        assert not (art_dir / f"{pl['id']}.jpg").exists()
+        assert result == fake_jpeg
 
     def test_set_playlist_cover_bumps_updated_at(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,6 +54,7 @@ def mock_index() -> MagicMock:
     index.tracks_for_album.return_value = []
     index.search_playlists.return_value = []
     index.playlists_for_tracks.return_value = []
+    index.get_playlist_cover.return_value = None
     return index
 
 
@@ -5222,3 +5223,98 @@ class TestPlaylistEndpoints:
     ) -> None:
         mock_index.get_playlist.return_value = None
         assert client.post("/api/v1/playlists/999/played").status_code == 404
+
+
+class TestPlaylistArt:
+    def _make_jpeg_bytes(self) -> bytes:
+        import io
+
+        from PIL import Image
+
+        img = Image.new("RGB", (100, 100), color=(128, 64, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_get_art_returns_jpeg_when_cover_present(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.get_playlist_cover.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 60
+
+        resp = client.get("/api/v1/playlists/1/art")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+
+    def test_get_art_falls_back_to_svg_when_no_cover(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1, title="My Mix")
+        mock_index.get_playlist_cover.return_value = None
+
+        resp = client.get("/api/v1/playlists/1/art")
+
+        assert resp.status_code == 200
+        assert "image/svg+xml" in resp.headers["content-type"]
+        assert "My Mix" in resp.text
+
+    def test_post_art_happy_path_returns_playlist_out(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        updated = _playlist(id=1, title="Art Test")
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.set_playlist_cover.return_value = updated
+        image_bytes = self._make_jpeg_bytes()
+
+        with patch("kamp_daemon.artwork.validate_image_bytes"):
+            resp = client.post(
+                "/api/v1/playlists/1/art",
+                files={"file": ("cover.jpg", image_bytes, "image/jpeg")},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Art Test"
+        mock_index.set_playlist_cover.assert_called_once_with(1, image_bytes)
+
+    def test_post_art_404_when_playlist_not_found(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = None
+        image_bytes = self._make_jpeg_bytes()
+
+        with patch("kamp_daemon.artwork.validate_image_bytes"):
+            resp = client.post(
+                "/api/v1/playlists/999/art",
+                files={"file": ("cover.jpg", image_bytes, "image/jpeg")},
+            )
+
+        assert resp.status_code == 404
+
+    def test_post_art_422_for_non_image_content_type(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        resp = client.post(
+            "/api/v1/playlists/1/art",
+            files={"file": ("notes.txt", b"hello world", "text/plain")},
+        )
+        assert resp.status_code == 422
+
+    def test_post_art_422_for_corrupt_image(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_daemon.artwork import ArtworkError
+
+        mock_index.get_playlist.return_value = _playlist(id=1)
+
+        with patch(
+            "kamp_daemon.artwork.validate_image_bytes",
+            side_effect=ArtworkError("not a valid image"),
+        ):
+            resp = client.post(
+                "/api/v1/playlists/1/art",
+                files={"file": ("cover.jpg", b"\xff\xd8\xff not real", "image/jpeg")},
+            )
+
+        assert resp.status_code == 422

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5240,10 +5240,7 @@ class TestPlaylistArt:
         self, client: TestClient, mock_index: MagicMock
     ) -> None:
         mock_index.get_playlist.return_value = _playlist(id=1)
-        mock_index.get_playlist_cover.return_value = (
-            b"\xff\xd8\xff\xe0" + b"\x00" * 60,
-            "image/jpeg",
-        )
+        mock_index.get_playlist_cover.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 60
 
         resp = client.get("/api/v1/playlists/1/art")
 
@@ -5262,35 +5259,6 @@ class TestPlaylistArt:
         assert "image/svg+xml" in resp.headers["content-type"]
         assert "My Mix" in resp.text
 
-    def test_get_art_returns_svg_content_type_when_cover_is_svg(
-        self, client: TestClient, mock_index: MagicMock
-    ) -> None:
-        svg_bytes = b"<svg xmlns='http://www.w3.org/2000/svg'/>"
-        mock_index.get_playlist.return_value = _playlist(id=1)
-        mock_index.get_playlist_cover.return_value = (svg_bytes, "image/svg+xml")
-
-        resp = client.get("/api/v1/playlists/1/art")
-
-        assert resp.status_code == 200
-        assert "image/svg+xml" in resp.headers["content-type"]
-
-    def test_post_art_svg_skips_pil_validation(
-        self, client: TestClient, mock_index: MagicMock
-    ) -> None:
-        svg_bytes = b"<svg xmlns='http://www.w3.org/2000/svg'/>"
-        mock_index.get_playlist.return_value = _playlist(id=1)
-        mock_index.set_playlist_cover.return_value = _playlist(id=1)
-
-        resp = client.post(
-            "/api/v1/playlists/1/art",
-            files={"file": ("icon.svg", svg_bytes, "image/svg+xml")},
-        )
-
-        assert resp.status_code == 200
-        mock_index.set_playlist_cover.assert_called_once_with(
-            1, svg_bytes, "image/svg+xml"
-        )
-
     def test_post_art_happy_path_returns_playlist_out(
         self, client: TestClient, mock_index: MagicMock
     ) -> None:
@@ -5308,9 +5276,7 @@ class TestPlaylistArt:
         assert resp.status_code == 200
         body = resp.json()
         assert body["title"] == "Art Test"
-        mock_index.set_playlist_cover.assert_called_once_with(
-            1, image_bytes, "image/jpeg"
-        )
+        mock_index.set_playlist_cover.assert_called_once_with(1, image_bytes)
 
     def test_post_art_404_when_playlist_not_found(
         self, client: TestClient, mock_index: MagicMock

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5240,7 +5240,10 @@ class TestPlaylistArt:
         self, client: TestClient, mock_index: MagicMock
     ) -> None:
         mock_index.get_playlist.return_value = _playlist(id=1)
-        mock_index.get_playlist_cover.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 60
+        mock_index.get_playlist_cover.return_value = (
+            b"\xff\xd8\xff\xe0" + b"\x00" * 60,
+            "image/jpeg",
+        )
 
         resp = client.get("/api/v1/playlists/1/art")
 
@@ -5259,6 +5262,35 @@ class TestPlaylistArt:
         assert "image/svg+xml" in resp.headers["content-type"]
         assert "My Mix" in resp.text
 
+    def test_get_art_returns_svg_content_type_when_cover_is_svg(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        svg_bytes = b"<svg xmlns='http://www.w3.org/2000/svg'/>"
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.get_playlist_cover.return_value = (svg_bytes, "image/svg+xml")
+
+        resp = client.get("/api/v1/playlists/1/art")
+
+        assert resp.status_code == 200
+        assert "image/svg+xml" in resp.headers["content-type"]
+
+    def test_post_art_svg_skips_pil_validation(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        svg_bytes = b"<svg xmlns='http://www.w3.org/2000/svg'/>"
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.set_playlist_cover.return_value = _playlist(id=1)
+
+        resp = client.post(
+            "/api/v1/playlists/1/art",
+            files={"file": ("icon.svg", svg_bytes, "image/svg+xml")},
+        )
+
+        assert resp.status_code == 200
+        mock_index.set_playlist_cover.assert_called_once_with(
+            1, svg_bytes, "image/svg+xml"
+        )
+
     def test_post_art_happy_path_returns_playlist_out(
         self, client: TestClient, mock_index: MagicMock
     ) -> None:
@@ -5276,7 +5308,9 @@ class TestPlaylistArt:
         assert resp.status_code == 200
         body = resp.json()
         assert body["title"] == "Art Test"
-        mock_index.set_playlist_cover.assert_called_once_with(1, image_bytes)
+        mock_index.set_playlist_cover.assert_called_once_with(
+            1, image_bytes, "image/jpeg"
+        )
 
     def test_post_art_404_when_playlist_not_found(
         self, client: TestClient, mock_index: MagicMock


### PR DESCRIPTION
## Summary

- `LibraryIndex.set_playlist_cover` / `get_playlist_cover` store/retrieve a user-supplied image at `playlist_art/{id}.jpg` adjacent to the DB; `set_playlist_cover` bumps `updated_at` as a cache-buster
- `GET /api/v1/playlists/{id}/art` serves the stored JPEG when present, falls back to the SVG placeholder
- New `POST /api/v1/playlists/{id}/art` endpoint validates the upload (422 for non-image or corrupt bytes, 404 if playlist missing) and returns the updated `PlaylistOut`
- `applyPlaylistArtLocal` in `client.ts`, `patchOpenPlaylist` store action, and a hover-reveal "Change art" button in the PlaylistView hero wired together end-to-end

## Test plan

- [ ] Open a playlist in PlaylistView — hero shows SVG placeholder, "Change art" button appears on hover
- [ ] Click "Change art", select a JPEG — art updates in the hero immediately without page reload
- [ ] Select a PNG — also works (stored as JPEG)
- [ ] Navigate away and back — custom art persists
- [ ] PlaylistCard in the sidebar reflects the same custom art
- [ ] Restart the app — art survives (loaded from `playlist_art/{id}.jpg`)
- [ ] Upload art for two playlists independently — no cross-contamination
- [ ] `GET /api/v1/playlists/{id}/art` on a no-art playlist → SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)