### PR TITLE
feat(KAMP-453): warn before adding duplicate tracks to a playlist

### DIFF
--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -1,4 +1,4 @@
-/* MusicBrainz comparison modal (KAMP-230) ---------------------------------- */
+/* Shared modal primitives -------------------------------------------------- */
 
 .modal-backdrop {
   position: fixed;
@@ -19,6 +19,71 @@
   flex-direction: column;
   overflow: hidden;
 }
+
+/* Compact confirmation modal (CollisionModal, DuplicatePlaylistTrackModal) */
+.collision-modal {
+  width: min(420px, 90vw);
+  padding: 24px;
+  gap: 16px;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.modal-body {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.modal-btn {
+  padding: 6px 14px;
+  font-size: 12px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: var(--surface-raised, var(--surface));
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.modal-btn:hover {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.modal-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.modal-btn--primary:hover {
+  filter: brightness(1.1);
+}
+
+.modal-btn--destructive {
+  background: none;
+  border-color: var(--danger, #c0392b);
+  color: var(--danger, #c0392b);
+}
+
+.modal-btn--destructive:hover {
+  background: rgba(192, 57, 43, 0.12);
+}
+
+/* MusicBrainz comparison modal (KAMP-230) ---------------------------------- */
 
 .mb-modal {
   width: min(680px, 92vw);

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
-import { getTracksForAlbum, downloadAlbum } from '../api/client'
+import { getTracksForAlbum, downloadAlbum, getPlaylistTracks } from '../api/client'
 import type { Album } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { ContextMenuSubmenu } from './ContextMenuSubmenu'
@@ -13,12 +13,20 @@ import {
   QueueAddIcon,
   ShareIcon
 } from './TransportIcons'
+import { DuplicatePlaylistTrackModal } from './DuplicatePlaylistTrackModal'
 
 interface Props {
   x: number
   y: number
   album: Album
   onClose: () => void
+}
+
+type DuplicateModalState = {
+  playlistId: number
+  playlistName: string
+  allPaths: string[]
+  uniquePaths: string[]
 }
 
 export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Element {
@@ -34,20 +42,58 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
   const setCollectionType = useStore((s) => s.setCollectionType)
   const setActiveView = useStore((s) => s.setActiveView)
 
+  const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
+
   // Fetch tracks client-side so the full file_path list is available.
   // This handles missing-album tracks (keyed by file_path, not album_artist+album)
   // and avoids the server-side tracks_for_album path which has no file_path fallback.
-  const addAlbumTracksToPlaylist = async (playlistId: number): Promise<void> => {
-    const tracks = await getTracksForAlbum(album.album_artist, album.album, album.file_path)
-    for (const t of tracks) {
-      await addTrackToPlaylist(playlistId, t.file_path)
-    }
+  const handleAddToPlaylist = (playlistId: number): void => {
+    const pl = playlists.find((p) => p.id === playlistId)
+    void (async () => {
+      const albumTracks = await getTracksForAlbum(album.album_artist, album.album, album.file_path)
+      const allPaths = albumTracks.map((t) => t.file_path)
+      const existing = await getPlaylistTracks(playlistId)
+      const existingSet = new Set(existing.map((t) => t.file_path))
+      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
+      if (uniquePaths.length === allPaths.length) {
+        for (const fp of allPaths) await addTrackToPlaylist(playlistId, fp)
+        if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+        onClose()
+      } else {
+        setDuplicateModal({
+          playlistId,
+          playlistName: pl?.title ?? '',
+          allPaths,
+          uniquePaths
+        })
+      }
+    })()
   }
 
-  const handleAddToPlaylist = (playlistId: number): void => {
-    void addAlbumTracksToPlaylist(playlistId)
-    const pl = playlists.find((p) => p.id === playlistId)
-    if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+  const handleDuplicateConfirmAll = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, allPaths, playlistName } = duplicateModal
+    void (async () => {
+      for (const fp of allPaths) await addTrackToPlaylist(playlistId, fp)
+      showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    })()
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateConfirmUnique = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, uniquePaths, playlistName } = duplicateModal
+    void (async () => {
+      for (const fp of uniquePaths) await addTrackToPlaylist(playlistId, fp)
+      showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    })()
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateCancel = (): void => {
+    setDuplicateModal(null)
     onClose()
   }
 
@@ -58,134 +104,166 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
       void setActiveView('library')
       setCollectionType('playlists')
       await selectPlaylist(pl)
-      await addAlbumTracksToPlaylist(pl.id)
+      const albumTracks = await getTracksForAlbum(album.album_artist, album.album, album.file_path)
+      for (const t of albumTracks) {
+        await addTrackToPlaylist(pl.id, t.file_path)
+      }
     })()
   }
 
   return (
-    <ContextMenu x={x} y={y} onClose={onClose}>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          void playAlbumNext(album.album_artist, album.album, album.file_path)
-          onClose()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <PlayNextIcon size={12} />
-        </span>
-        Play Next
-      </button>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          void addAlbumToQueue(album.album_artist, album.album, album.file_path)
-          onClose()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <QueueAddIcon size={12} />
-        </span>
-        Add to Queue
-      </button>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          void setAlbumFavorite(album.album_artist, album.album, !album.favorite)
-          onClose()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <FavoriteIcon active={!album.favorite} size={12} />
-        </span>
-        {album.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
-      </button>
-      {album.album_url && (
-        <button
-          className="track-context-menu-item"
-          onClick={() => {
-            void navigator.clipboard.writeText(album.album_url!)
-            showFlashToast(`Copied link to ${album.album}`)
-            onClose()
-          }}
-        >
-          <span
-            style={{
-              marginRight: 6,
-              verticalAlign: 'middle',
-              flexShrink: 0,
-              display: 'inline-flex'
-            }}
-          >
-            <ShareIcon size={12} />
-          </span>
-          Copy Bandcamp link
-        </button>
-      )}
-      {album.source !== 'local' && (
-        <button
-          className="track-context-menu-item track-context-menu-item--action"
-          onClick={async () => {
-            const tracks = await getTracksForAlbum(album.album_artist, album.album)
-            const saleItemId =
-              tracks[0]?.file_path.split('bandcamp:')[1]?.replace(/^\/+/, '').split('/')[0] ?? null
-            if (saleItemId) {
-              markAlbumDownloading(saleItemId)
-              void downloadAlbum(saleItemId)
-            }
-            onClose()
-          }}
-        >
-          <span
-            style={{
-              marginRight: 6,
-              verticalAlign: 'middle',
-              flexShrink: 0,
-              display: 'inline-flex'
-            }}
-          >
-            <DownloadArrowIcon size={12} />
-          </span>
-          Download this album
-        </button>
-      )}
-      <ContextMenuSubmenu label="Add to Playlist">
-        {playlists.map((pl) => (
+    <>
+      {!duplicateModal && (
+        <ContextMenu x={x} y={y} onClose={onClose}>
           <button
-            key={pl.id}
             className="track-context-menu-item"
-            onClick={() => handleAddToPlaylist(pl.id)}
+            onClick={() => {
+              void playAlbumNext(album.album_artist, album.album, album.file_path)
+              onClose()
+            }}
           >
-            {truncateTitle(pl.title)}
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <PlayNextIcon size={12} />
+            </span>
+            Play Next
           </button>
-        ))}
-        {playlists.length > 0 && <div className="track-context-menu-divider" />}
-        <button className="track-context-menu-item" onClick={handleNewPlaylist}>
-          New Playlist
-        </button>
-      </ContextMenuSubmenu>
-      {album.source === 'local' && (
-        <button
-          className="track-context-menu-item"
-          onClick={async () => {
-            let filePath = album.file_path
-            if (!filePath) {
-              const tracks = await getTracksForAlbum(album.album_artist, album.album)
-              filePath = tracks[0]?.file_path ?? ''
-            }
-            if (filePath) window.api.showItemInFolder(filePath)
-            onClose()
-          }}
-        >
-          {revealInFinderLabel()}
-        </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void addAlbumToQueue(album.album_artist, album.album, album.file_path)
+              onClose()
+            }}
+          >
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <QueueAddIcon size={12} />
+            </span>
+            Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void setAlbumFavorite(album.album_artist, album.album, !album.favorite)
+              onClose()
+            }}
+          >
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <FavoriteIcon active={!album.favorite} size={12} />
+            </span>
+            {album.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+          </button>
+          {album.album_url && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                void navigator.clipboard.writeText(album.album_url!)
+                showFlashToast(`Copied link to ${album.album}`)
+                onClose()
+              }}
+            >
+              <span
+                style={{
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                  display: 'inline-flex'
+                }}
+              >
+                <ShareIcon size={12} />
+              </span>
+              Copy Bandcamp link
+            </button>
+          )}
+          {album.source !== 'local' && (
+            <button
+              className="track-context-menu-item track-context-menu-item--action"
+              onClick={async () => {
+                const tracks = await getTracksForAlbum(album.album_artist, album.album)
+                const saleItemId =
+                  tracks[0]?.file_path.split('bandcamp:')[1]?.replace(/^\/+/, '').split('/')[0] ??
+                  null
+                if (saleItemId) {
+                  markAlbumDownloading(saleItemId)
+                  void downloadAlbum(saleItemId)
+                }
+                onClose()
+              }}
+            >
+              <span
+                style={{
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                  display: 'inline-flex'
+                }}
+              >
+                <DownloadArrowIcon size={12} />
+              </span>
+              Download this album
+            </button>
+          )}
+          <ContextMenuSubmenu label="Add to Playlist">
+            {playlists.map((pl) => (
+              <button
+                key={pl.id}
+                className="track-context-menu-item"
+                onClick={() => handleAddToPlaylist(pl.id)}
+              >
+                {truncateTitle(pl.title)}
+              </button>
+            ))}
+            {playlists.length > 0 && <div className="track-context-menu-divider" />}
+            <button className="track-context-menu-item" onClick={handleNewPlaylist}>
+              New Playlist
+            </button>
+          </ContextMenuSubmenu>
+          {album.source === 'local' && (
+            <button
+              className="track-context-menu-item"
+              onClick={async () => {
+                let filePath = album.file_path
+                if (!filePath) {
+                  const tracks = await getTracksForAlbum(album.album_artist, album.album)
+                  filePath = tracks[0]?.file_path ?? ''
+                }
+                if (filePath) window.api.showItemInFolder(filePath)
+                onClose()
+              }}
+            >
+              {revealInFinderLabel()}
+            </button>
+          )}
+        </ContextMenu>
       )}
-    </ContextMenu>
+      {duplicateModal && (
+        <DuplicatePlaylistTrackModal
+          playlistName={duplicateModal.playlistName}
+          hasMixed={duplicateModal.uniquePaths.length > 0}
+          onAddAll={handleDuplicateConfirmAll}
+          onAddUnique={handleDuplicateConfirmUnique}
+          onCancel={handleDuplicateCancel}
+        />
+      )}
+    </>
   )
 }

--- a/kamp_ui/src/renderer/src/components/DuplicatePlaylistTrackModal.tsx
+++ b/kamp_ui/src/renderer/src/components/DuplicatePlaylistTrackModal.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react'
+import { truncateTitle } from '../utils/truncateTitle'
+
+type Props = {
+  playlistName: string
+  hasMixed: boolean
+  onAddAll: () => void
+  onAddUnique: () => void
+  onCancel: () => void
+}
+
+export function DuplicatePlaylistTrackModal({
+  playlistName,
+  hasMixed,
+  onAddAll,
+  onAddUnique,
+  onCancel
+}: Props): React.JSX.Element {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  const displayName = truncateTitle(playlistName, 40)
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="modal collision-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-playlist-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="duplicate-playlist-modal-title" className="modal-title">
+          Already in playlist
+        </h2>
+        <p className="modal-body">
+          hey! some of these songs are already in the playlist <strong>{displayName}</strong>. are
+          you sure you want to add them again?
+        </p>
+        <div className="modal-actions">
+          {hasMixed && (
+            <button className="modal-btn" onClick={onAddUnique}>
+              just the unique songs
+            </button>
+          )}
+          <button className="modal-btn modal-btn--primary" onClick={onAddAll}>
+            yeah, i&apos;m sure
+          </button>
+          <button className="modal-btn" onClick={onCancel}>
+            whoops, no
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { ContextMenuSubmenu } from './ContextMenuSubmenu'
@@ -11,6 +11,8 @@ import {
   RemoveFromQueueIcon
 } from './TransportIcons'
 import type { Track } from '../api/client'
+import { getPlaylistTracks } from '../api/client'
+import { DuplicatePlaylistTrackModal } from './DuplicatePlaylistTrackModal'
 
 interface Props {
   x: number
@@ -22,6 +24,13 @@ interface Props {
   position: number // currently playing track's display index
   onClearSelection: () => void
   onClose: () => void
+}
+
+type DuplicateModalState = {
+  playlistId: number
+  playlistName: string
+  allPaths: string[]
+  uniquePaths: string[]
 }
 
 export function QueueContextMenu({
@@ -53,14 +62,54 @@ export function QueueContextMenu({
   const setCollectionType = useStore((s) => s.setCollectionType)
   const showFlashToast = useStore((s) => s.showFlashToast)
 
+  const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
+
   // Targets for playlist operations: all selected tracks, or the right-clicked
   // track alone when there is no selection (consistent with favorites/remove).
   const playlistTargets = selectedTracks.length > 0 ? selectedTracks : track ? [track] : []
 
   const handleAddToPlaylist = (playlistId: number): void => {
-    playlistTargets.forEach((t) => void addTrackToPlaylist(playlistId, t.file_path))
     const pl = playlists.find((p) => p.id === playlistId)
-    if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+    const allPaths = playlistTargets.map((t) => t.file_path)
+    void (async () => {
+      const existing = await getPlaylistTracks(playlistId)
+      const existingSet = new Set(existing.map((t) => t.file_path))
+      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
+      if (uniquePaths.length === allPaths.length) {
+        allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+        if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+        onClose()
+      } else {
+        setDuplicateModal({
+          playlistId,
+          playlistName: pl?.title ?? '',
+          allPaths,
+          uniquePaths
+        })
+      }
+    })()
+  }
+
+  const handleDuplicateConfirmAll = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, allPaths, playlistName } = duplicateModal
+    allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateConfirmUnique = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, uniquePaths, playlistName } = duplicateModal
+    uniquePaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateCancel = (): void => {
+    setDuplicateModal(null)
     onClose()
   }
 
@@ -81,184 +130,197 @@ export function QueueContextMenu({
   const allFavorited = selectedTracks.length > 0 && selectedTracks.every((t) => t.favorite)
 
   return (
-    <ContextMenu x={x} y={y} onClose={onClose}>
-      {track && (
-        <>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              const found = albums.find(
-                (a) => a.album_artist === track.album_artist && a.album === track.album
-              ) ?? {
-                album_artist: track.album_artist,
-                album: track.album,
-                year: '',
-                track_count: 0,
-                has_art: false,
-                missing_album: false,
-                file_path: '',
-                art_version: null,
-                added_at: null,
-                last_played_at: null,
-                play_count_avg: 0,
-                favorite: false,
-                has_favorite_track: false,
-                source: 'local',
-                has_remote_tracks: false
-              }
-              void setActiveView('library')
-              void selectAlbum(found)
-              onClose()
-            }}
-          >
-            <span
-              style={{
-                marginRight: 6,
-                verticalAlign: 'middle',
-                flexShrink: 0,
-                display: 'inline-flex'
-              }}
-            >
-              <GoToAlbumIcon size={12} />
-            </span>
-            Go to Album
-          </button>
-          <button
-            className="track-context-menu-item"
-            onClick={() => {
-              void setActiveView('library')
-              selectArtist(track.album_artist)
-              onClose()
-            }}
-          >
-            <span
-              style={{
-                marginRight: 6,
-                verticalAlign: 'middle',
-                flexShrink: 0,
-                display: 'inline-flex'
-              }}
-            >
-              <GoToArtistIcon size={12} />
-            </span>
-            Go to Artist
-          </button>
-          {selectedTracks.length > 0 && (
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void setFavorites(selectedTracks, !allFavorited)
-                onClose()
-              }}
-            >
-              <span
-                style={{
-                  marginRight: 6,
-                  verticalAlign: 'middle',
-                  flexShrink: 0,
-                  display: 'inline-flex'
-                }}
-              >
-                <FavoriteIcon active={!allFavorited} size={12} />
-              </span>
-              {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
-            </button>
-          )}
-          <ContextMenuSubmenu label="Add to Playlist">
-            {playlists.map((pl) => (
+    <>
+      {!duplicateModal && (
+        <ContextMenu x={x} y={y} onClose={onClose}>
+          {track && (
+            <>
               <button
-                key={pl.id}
                 className="track-context-menu-item"
-                onClick={() => handleAddToPlaylist(pl.id)}
+                onClick={() => {
+                  const found = albums.find(
+                    (a) => a.album_artist === track.album_artist && a.album === track.album
+                  ) ?? {
+                    album_artist: track.album_artist,
+                    album: track.album,
+                    year: '',
+                    track_count: 0,
+                    has_art: false,
+                    missing_album: false,
+                    file_path: '',
+                    art_version: null,
+                    added_at: null,
+                    last_played_at: null,
+                    play_count_avg: 0,
+                    favorite: false,
+                    has_favorite_track: false,
+                    source: 'local',
+                    has_remote_tracks: false
+                  }
+                  void setActiveView('library')
+                  void selectAlbum(found)
+                  onClose()
+                }}
               >
-                {truncateTitle(pl.title)}
+                <span
+                  style={{
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                    flexShrink: 0,
+                    display: 'inline-flex'
+                  }}
+                >
+                  <GoToAlbumIcon size={12} />
+                </span>
+                Go to Album
               </button>
-            ))}
-            {playlists.length > 0 && <div className="track-context-menu-divider" />}
-            <button className="track-context-menu-item" onClick={handleNewPlaylist}>
-              New Playlist
-            </button>
-          </ContextMenuSubmenu>
-          {unplayedSelectedIndices.length > 0 && position >= 0 && (
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  void setActiveView('library')
+                  selectArtist(track.album_artist)
+                  onClose()
+                }}
+              >
+                <span
+                  style={{
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                    flexShrink: 0,
+                    display: 'inline-flex'
+                  }}
+                >
+                  <GoToArtistIcon size={12} />
+                </span>
+                Go to Artist
+              </button>
+              {selectedTracks.length > 0 && (
+                <button
+                  className="track-context-menu-item"
+                  onClick={() => {
+                    void setFavorites(selectedTracks, !allFavorited)
+                    onClose()
+                  }}
+                >
+                  <span
+                    style={{
+                      marginRight: 6,
+                      verticalAlign: 'middle',
+                      flexShrink: 0,
+                      display: 'inline-flex'
+                    }}
+                  >
+                    <FavoriteIcon active={!allFavorited} size={12} />
+                  </span>
+                  {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
+                </button>
+              )}
+              <ContextMenuSubmenu label="Add to Playlist">
+                {playlists.map((pl) => (
+                  <button
+                    key={pl.id}
+                    className="track-context-menu-item"
+                    onClick={() => handleAddToPlaylist(pl.id)}
+                  >
+                    {truncateTitle(pl.title)}
+                  </button>
+                ))}
+                {playlists.length > 0 && <div className="track-context-menu-divider" />}
+                <button className="track-context-menu-item" onClick={handleNewPlaylist}>
+                  New Playlist
+                </button>
+              </ContextMenuSubmenu>
+              {unplayedSelectedIndices.length > 0 && position >= 0 && (
+                <button
+                  className="track-context-menu-item"
+                  onClick={() => {
+                    if (unplayedSelectedIndices.length === 1) {
+                      void moveQueueTrack(unplayedSelectedIndices[0], position + 1)
+                    } else {
+                      const selectedSet = new Set(unplayedSelectedIndices)
+                      const nonSelected = Array.from({ length: queueLength }, (_, i) => i).filter(
+                        (i) => !selectedSet.has(i)
+                      )
+                      const insertAt = nonSelected.indexOf(position) + 1
+                      const newOrder = [
+                        ...nonSelected.slice(0, insertAt),
+                        ...unplayedSelectedIndices,
+                        ...nonSelected.slice(insertAt)
+                      ]
+                      void reorderQueue(newOrder)
+                    }
+                    onClearSelection()
+                    onClose()
+                  }}
+                >
+                  <span
+                    style={{
+                      marginRight: 6,
+                      verticalAlign: 'middle',
+                      flexShrink: 0,
+                      display: 'inline-flex'
+                    }}
+                  >
+                    <PlayNextIcon size={12} />
+                  </span>
+                  Queue Next
+                </button>
+              )}
+              {unplayedSelectedIndices.length > 0 && (
+                <button
+                  className="track-context-menu-item"
+                  onClick={() => {
+                    void removeFromQueue(unplayedSelectedIndices)
+                    onClose()
+                  }}
+                >
+                  <span
+                    style={{
+                      marginRight: 6,
+                      verticalAlign: 'middle',
+                      flexShrink: 0,
+                      display: 'inline-flex'
+                    }}
+                  >
+                    <RemoveFromQueueIcon size={12} />
+                  </span>
+                  Remove from Queue
+                </button>
+              )}
+              <div className="track-context-menu-divider" />
+            </>
+          )}
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              void clearQueue()
+              onClose()
+            }}
+          >
+            Clear Queue
+          </button>
+          {trackIdx !== null && (
             <button
               className="track-context-menu-item"
               onClick={() => {
-                if (unplayedSelectedIndices.length === 1) {
-                  void moveQueueTrack(unplayedSelectedIndices[0], position + 1)
-                } else {
-                  const selectedSet = new Set(unplayedSelectedIndices)
-                  const nonSelected = Array.from({ length: queueLength }, (_, i) => i).filter(
-                    (i) => !selectedSet.has(i)
-                  )
-                  const insertAt = nonSelected.indexOf(position) + 1
-                  const newOrder = [
-                    ...nonSelected.slice(0, insertAt),
-                    ...unplayedSelectedIndices,
-                    ...nonSelected.slice(insertAt)
-                  ]
-                  void reorderQueue(newOrder)
-                }
-                onClearSelection()
+                void clearRemainingQueue(trackIdx)
                 onClose()
               }}
             >
-              <span
-                style={{
-                  marginRight: 6,
-                  verticalAlign: 'middle',
-                  flexShrink: 0,
-                  display: 'inline-flex'
-                }}
-              >
-                <PlayNextIcon size={12} />
-              </span>
-              Queue Next
+              Clear Remaining
             </button>
           )}
-          {unplayedSelectedIndices.length > 0 && (
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                void removeFromQueue(unplayedSelectedIndices)
-                onClose()
-              }}
-            >
-              <span
-                style={{
-                  marginRight: 6,
-                  verticalAlign: 'middle',
-                  flexShrink: 0,
-                  display: 'inline-flex'
-                }}
-              >
-                <RemoveFromQueueIcon size={12} />
-              </span>
-              Remove from Queue
-            </button>
-          )}
-          <div className="track-context-menu-divider" />
-        </>
+        </ContextMenu>
       )}
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          void clearQueue()
-          onClose()
-        }}
-      >
-        Clear Queue
-      </button>
-      {trackIdx !== null && (
-        <button
-          className="track-context-menu-item"
-          onClick={() => {
-            void clearRemainingQueue(trackIdx)
-            onClose()
-          }}
-        >
-          Clear Remaining
-        </button>
+      {duplicateModal && (
+        <DuplicatePlaylistTrackModal
+          playlistName={duplicateModal.playlistName}
+          hasMixed={duplicateModal.uniquePaths.length > 0}
+          onAddAll={handleDuplicateConfirmAll}
+          onAddUnique={handleDuplicateConfirmUnique}
+          onCancel={handleDuplicateCancel}
+        />
       )}
-    </ContextMenu>
+    </>
   )
 }

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { ContextMenuSubmenu } from './ContextMenuSubmenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
 import { FavoriteIcon, PlayNextIcon, QueueAddIcon } from './TransportIcons'
 import type { Track } from '../api/client'
+import { getPlaylistTracks } from '../api/client'
 import { truncateTitle } from '../utils/truncateTitle'
+import { DuplicatePlaylistTrackModal } from './DuplicatePlaylistTrackModal'
 
 interface Props {
   x: number
@@ -16,6 +18,13 @@ interface Props {
   // When provided (e.g. from PlaylistView multi-select), bulk actions use this
   // list instead of the single right-clicked track.
   selectedTracks?: Track[]
+}
+
+type DuplicateModalState = {
+  playlistId: number
+  playlistName: string
+  allPaths: string[]
+  uniquePaths: string[]
 }
 
 export function TrackContextMenu({
@@ -37,14 +46,54 @@ export function TrackContextMenu({
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const setCollectionType = useStore((s) => s.setCollectionType)
 
+  const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
+
   // Bulk targets: the full selection when available, otherwise just this track.
   const targets = selectedTracks && selectedTracks.length > 0 ? selectedTracks : [track]
   const allFavorited = targets.every((t) => t.favorite)
 
   const handleAddToPlaylist = (playlistId: number): void => {
-    targets.forEach((t) => void addTrackToPlaylist(playlistId, t.file_path))
     const pl = playlists.find((p) => p.id === playlistId)
-    if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+    const allPaths = targets.map((t) => t.file_path)
+    void (async () => {
+      const existing = await getPlaylistTracks(playlistId)
+      const existingSet = new Set(existing.map((t) => t.file_path))
+      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
+      if (uniquePaths.length === allPaths.length) {
+        allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+        if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
+        onClose()
+      } else {
+        setDuplicateModal({
+          playlistId,
+          playlistName: pl?.title ?? '',
+          allPaths,
+          uniquePaths
+        })
+      }
+    })()
+  }
+
+  const handleDuplicateConfirmAll = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, allPaths, playlistName } = duplicateModal
+    allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateConfirmUnique = (): void => {
+    if (!duplicateModal) return
+    const { playlistId, uniquePaths, playlistName } = duplicateModal
+    uniquePaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
+    setDuplicateModal(null)
+    onClose()
+  }
+
+  const handleDuplicateCancel = (): void => {
+    setDuplicateModal(null)
     onClose()
   }
 
@@ -61,97 +110,125 @@ export function TrackContextMenu({
   }
 
   return (
-    <ContextMenu x={x} y={y} onClose={onClose}>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          onClose()
-          void (async () => {
-            for (let i = targets.length - 1; i >= 0; i--) await playNext(targets[i].file_path)
-          })()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <PlayNextIcon size={12} />
-        </span>
-        Play Next
-      </button>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          onClose()
-          void (async () => {
-            for (const t of targets) await addToQueue(t.file_path)
-          })()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <QueueAddIcon size={12} />
-        </span>
-        Add to Queue
-      </button>
-      <button
-        className="track-context-menu-item"
-        onClick={() => {
-          if (targets.length > 1) {
-            void setFavorites(targets, !allFavorited)
-          } else {
-            void setFavorite(track, !track.favorite)
-          }
-          onClose()
-        }}
-      >
-        <span
-          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
-        >
-          <FavoriteIcon active={!allFavorited} size={12} />
-        </span>
-        {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
-      </button>
-      <ContextMenuSubmenu label="Add to Playlist">
-        {playlists.map((pl) => (
-          <button
-            key={pl.id}
-            className="track-context-menu-item"
-            onClick={() => handleAddToPlaylist(pl.id)}
-          >
-            {truncateTitle(pl.title)}
-          </button>
-        ))}
-        {playlists.length > 0 && <div className="track-context-menu-divider" />}
-        <button className="track-context-menu-item" onClick={handleNewPlaylist}>
-          New Playlist
-        </button>
-      </ContextMenuSubmenu>
-      {onRemoveFromPlaylist && (
-        <>
-          <div className="track-context-menu-divider" />
+    <>
+      {!duplicateModal && (
+        <ContextMenu x={x} y={y} onClose={onClose}>
           <button
             className="track-context-menu-item"
             onClick={() => {
-              onRemoveFromPlaylist()
+              onClose()
+              void (async () => {
+                for (let i = targets.length - 1; i >= 0; i--) await playNext(targets[i].file_path)
+              })()
+            }}
+          >
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <PlayNextIcon size={12} />
+            </span>
+            Play Next
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              onClose()
+              void (async () => {
+                for (const t of targets) await addToQueue(t.file_path)
+              })()
+            }}
+          >
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <QueueAddIcon size={12} />
+            </span>
+            Add to Queue
+          </button>
+          <button
+            className="track-context-menu-item"
+            onClick={() => {
+              if (targets.length > 1) {
+                void setFavorites(targets, !allFavorited)
+              } else {
+                void setFavorite(track, !track.favorite)
+              }
               onClose()
             }}
           >
-            Remove from Playlist
+            <span
+              style={{
+                marginRight: 6,
+                verticalAlign: 'middle',
+                flexShrink: 0,
+                display: 'inline-flex'
+              }}
+            >
+              <FavoriteIcon active={!allFavorited} size={12} />
+            </span>
+            {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
           </button>
-        </>
+          <ContextMenuSubmenu label="Add to Playlist">
+            {playlists.map((pl) => (
+              <button
+                key={pl.id}
+                className="track-context-menu-item"
+                onClick={() => handleAddToPlaylist(pl.id)}
+              >
+                {truncateTitle(pl.title)}
+              </button>
+            ))}
+            {playlists.length > 0 && <div className="track-context-menu-divider" />}
+            <button className="track-context-menu-item" onClick={handleNewPlaylist}>
+              New Playlist
+            </button>
+          </ContextMenuSubmenu>
+          {onRemoveFromPlaylist && (
+            <>
+              <div className="track-context-menu-divider" />
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  onRemoveFromPlaylist()
+                  onClose()
+                }}
+              >
+                Remove from Playlist
+              </button>
+            </>
+          )}
+          {track.source === 'local' && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                window.api.showItemInFolder(track.file_path)
+                onClose()
+              }}
+            >
+              {revealInFinderLabel()}
+            </button>
+          )}
+        </ContextMenu>
       )}
-      {track.source === 'local' && (
-        <button
-          className="track-context-menu-item"
-          onClick={() => {
-            window.api.showItemInFolder(track.file_path)
-            onClose()
-          }}
-        >
-          {revealInFinderLabel()}
-        </button>
+      {duplicateModal && (
+        <DuplicatePlaylistTrackModal
+          playlistName={duplicateModal.playlistName}
+          hasMixed={duplicateModal.uniquePaths.length > 0}
+          onAddAll={handleDuplicateConfirmAll}
+          onAddUnique={handleDuplicateConfirmUnique}
+          onCancel={handleDuplicateCancel}
+        />
       )}
-    </ContextMenu>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- Before adding tracks via any context menu (track, album, queue), fetches the playlist's current track list and diffs the candidates against existing `file_path`s
- No duplicates: adds immediately as before, no modal
- All duplicates or mixed: context menu dismisses and a confirmation modal appears with "yeah, i'm sure" (add all), "whoops, no" (cancel), and — when at least one track is new — "just the unique songs"
- New `DuplicatePlaylistTrackModal` component following the `CollisionModal` pattern (Esc/backdrop = cancel); shared modal CSS primitives extracted to `musicbrainz-modal.css`

## Test plan

- [ ] Add a track to a playlist, right-click same track → "Add to playlist" → same playlist → modal appears; "yeah, i'm sure" adds it; "whoops, no" cancels
- [ ] Select 4 tracks (3 already in playlist, 1 new) → modal shows all three buttons; "just the unique songs" adds only the 1 new track
- [ ] All tracks new → no modal, adds immediately with toast
- [ ] Esc and backdrop click both dismiss the modal without adding
- [ ] Same flows via AlbumContextMenu and QueueContextMenu
- [ ] CollisionModal (file-move collision in TrackList) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)