### PR TITLE
feat(KAMP-454): go to album / go to artist in track context menu

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -222,21 +222,6 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
               Download this album
             </button>
           )}
-          <ContextMenuSubmenu label="Add to Playlist">
-            {playlists.map((pl) => (
-              <button
-                key={pl.id}
-                className="track-context-menu-item"
-                onClick={() => handleAddToPlaylist(pl.id)}
-              >
-                {truncateTitle(pl.title)}
-              </button>
-            ))}
-            {playlists.length > 0 && <div className="track-context-menu-divider" />}
-            <button className="track-context-menu-item" onClick={handleNewPlaylist}>
-              New Playlist
-            </button>
-          </ContextMenuSubmenu>
           {album.source === 'local' && (
             <button
               className="track-context-menu-item"
@@ -253,6 +238,21 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
               {revealInFinderLabel()}
             </button>
           )}
+          <ContextMenuSubmenu label="Add to Playlist">
+            {playlists.map((pl) => (
+              <button
+                key={pl.id}
+                className="track-context-menu-item"
+                onClick={() => handleAddToPlaylist(pl.id)}
+              >
+                {truncateTitle(pl.title)}
+              </button>
+            ))}
+            {playlists.length > 0 && <div className="track-context-menu-divider" />}
+            <button className="track-context-menu-item" onClick={handleNewPlaylist}>
+              New Playlist
+            </button>
+          </ContextMenuSubmenu>
         </ContextMenu>
       )}
       {duplicateModal && (

--- a/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
@@ -3,7 +3,6 @@ import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { FavoriteIcon, PlayNextIcon, QueueAddIcon } from './TransportIcons'
 import type { Playlist } from '../api/client'
-import { truncateTitle } from '../utils/truncateTitle'
 
 interface Props {
   x: number
@@ -14,7 +13,6 @@ interface Props {
 
 export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.JSX.Element {
   const deletePlaylist = useStore((s) => s.deletePlaylist)
-  const renamePlaylist = useStore((s) => s.renamePlaylist)
   const setPlaylistFavorite = useStore((s) => s.setPlaylistFavorite)
   const playNext = useStore((s) => s.playNext)
   const addToQueue = useStore((s) => s.addToQueue)
@@ -76,22 +74,9 @@ export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.J
       <div className="track-context-menu-divider" />
       <button
         className="track-context-menu-item"
-        onClick={() => {
-          const newTitle = window.prompt('Rename playlist', playlist.title)
-          const trimmed = newTitle?.trim()
-          if (trimmed && trimmed !== playlist.title) {
-            void renamePlaylist(playlist.id, trimmed)
-          }
-          onClose()
-        }}
-      >
-        Rename Playlist
-      </button>
-      <button
-        className="track-context-menu-item"
         style={{ color: 'var(--danger, #e05)' }}
         onClick={() => {
-          if (window.confirm(`Delete playlist "${truncateTitle(playlist.title, 40)}"?`)) {
+          if (window.confirm(`Delete playlist "${playlist.title}"?`)) {
             void deletePlaylist(playlist.id)
           }
           onClose()

--- a/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { FavoriteIcon, PlayNextIcon, QueueAddIcon } from './TransportIcons'
 import type { Playlist } from '../api/client'
+import { truncateTitle } from '../utils/truncateTitle'
 
 interface Props {
   x: number
@@ -13,6 +14,7 @@ interface Props {
 
 export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.JSX.Element {
   const deletePlaylist = useStore((s) => s.deletePlaylist)
+  const renamePlaylist = useStore((s) => s.renamePlaylist)
   const setPlaylistFavorite = useStore((s) => s.setPlaylistFavorite)
   const playNext = useStore((s) => s.playNext)
   const addToQueue = useStore((s) => s.addToQueue)
@@ -74,9 +76,22 @@ export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.J
       <div className="track-context-menu-divider" />
       <button
         className="track-context-menu-item"
+        onClick={() => {
+          const newTitle = window.prompt('Rename playlist', playlist.title)
+          const trimmed = newTitle?.trim()
+          if (trimmed && trimmed !== playlist.title) {
+            void renamePlaylist(playlist.id, trimmed)
+          }
+          onClose()
+        }}
+      >
+        Rename Playlist
+      </button>
+      <button
+        className="track-context-menu-item"
         style={{ color: 'var(--danger, #e05)' }}
         onClick={() => {
-          if (window.confirm(`Delete playlist "${playlist.title}"?`)) {
+          if (window.confirm(`Delete playlist "${truncateTitle(playlist.title, 40)}"?`)) {
             void deletePlaylist(playlist.id)
           }
           onClose()

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -178,6 +178,7 @@ export function QueueContextMenu({
                 className="track-context-menu-item"
                 onClick={() => {
                   void setActiveView('library')
+                  setCollectionType('albums')
                   selectArtist(track.album_artist)
                   onClose()
                 }}

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -233,6 +233,7 @@ export function TrackContextMenu({
                 className="track-context-menu-item"
                 onClick={() => {
                   void setActiveView('library')
+                  setCollectionType('albums')
                   selectArtist(track.album_artist)
                   onClose()
                 }}

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -252,6 +252,17 @@ export function TrackContextMenu({
               </button>
             </>
           )}
+          {track.source === 'local' && (
+            <button
+              className="track-context-menu-item"
+              onClick={() => {
+                window.api.showItemInFolder(track.file_path)
+                onClose()
+              }}
+            >
+              {revealInFinderLabel()}
+            </button>
+          )}
           <ContextMenuSubmenu label="Add to Playlist">
             {playlists.map((pl) => (
               <button
@@ -280,17 +291,6 @@ export function TrackContextMenu({
                 Remove from Playlist
               </button>
             </>
-          )}
-          {track.source === 'local' && (
-            <button
-              className="track-context-menu-item"
-              onClick={() => {
-                window.api.showItemInFolder(track.file_path)
-                onClose()
-              }}
-            >
-              {revealInFinderLabel()}
-            </button>
           )}
         </ContextMenu>
       )}

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -3,7 +3,13 @@ import { useStore } from '../store'
 import { ContextMenu } from './ContextMenu'
 import { ContextMenuSubmenu } from './ContextMenuSubmenu'
 import { revealInFinderLabel } from '../hooks/platformLabel'
-import { FavoriteIcon, PlayNextIcon, QueueAddIcon } from './TransportIcons'
+import {
+  FavoriteIcon,
+  GoToAlbumIcon,
+  GoToArtistIcon,
+  PlayNextIcon,
+  QueueAddIcon
+} from './TransportIcons'
 import type { Track } from '../api/client'
 import { getPlaylistTracks } from '../api/client'
 import { truncateTitle } from '../utils/truncateTitle'
@@ -45,6 +51,10 @@ export function TrackContextMenu({
   const createPlaylist = useStore((s) => s.createPlaylist)
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const setCollectionType = useStore((s) => s.setCollectionType)
+  const albums = useStore((s) => s.library.albums)
+  const selectAlbum = useStore((s) => s.selectAlbum)
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
 
   const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
 
@@ -178,6 +188,69 @@ export function TrackContextMenu({
             </span>
             {allFavorited ? 'Remove from Favorites' : 'Add to Favorites'}
           </button>
+          {targets.length === 1 && (
+            <>
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  const found = albums.find(
+                    (a) => a.album_artist === track.album_artist && a.album === track.album
+                  ) ?? {
+                    album_artist: track.album_artist,
+                    album: track.album,
+                    year: '',
+                    track_count: 0,
+                    has_art: false,
+                    missing_album: false,
+                    file_path: '',
+                    art_version: null,
+                    added_at: null,
+                    last_played_at: null,
+                    play_count_avg: 0,
+                    favorite: false,
+                    has_favorite_track: false,
+                    source: 'local',
+                    has_remote_tracks: false
+                  }
+                  void setActiveView('library')
+                  void selectAlbum(found)
+                  onClose()
+                }}
+              >
+                <span
+                  style={{
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                    flexShrink: 0,
+                    display: 'inline-flex'
+                  }}
+                >
+                  <GoToAlbumIcon size={12} />
+                </span>
+                Go to Album
+              </button>
+              <button
+                className="track-context-menu-item"
+                onClick={() => {
+                  void setActiveView('library')
+                  selectArtist(track.album_artist)
+                  onClose()
+                }}
+              >
+                <span
+                  style={{
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                    flexShrink: 0,
+                    display: 'inline-flex'
+                  }}
+                >
+                  <GoToArtistIcon size={12} />
+                </span>
+                Go to Artist
+              </button>
+            </>
+          )}
           <ContextMenuSubmenu label="Add to Playlist">
             {playlists.map((pl) => (
               <button


### PR DESCRIPTION
## Summary

- Adds "Go to Album" and "Go to Artist" items to `TrackContextMenu`
- Items are hidden when multiple tracks are selected (single-track only, per spec)
- Copies the established pattern from `QueueContextMenu` verbatim

## Test plan

- [ ] Right-click a single track in a playlist → "Go to Album" and "Go to Artist" appear
- [ ] Click "Go to Album" → library navigates to the album; menu closes
- [ ] Click "Go to Artist" → library navigates to the artist; menu closes
- [ ] Right-click with multiple tracks selected → items do not appear
- [ ] Same behavior in the main library track list (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)