### PR TITLE
fix(KAMP-437): allow available streaming tracks to be dragged into queue

### DIFF
--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -646,7 +646,7 @@ export function TrackList(): React.JSX.Element | null {
                   if (isCurrent) togglePlayPause()
                   else playTrack(album.album_artist, album.album, i, album.file_path)
                 }}
-                {...(!isRemoteTrack
+                {...(!isTrackOffline && !isPreorderUnavailable
                   ? {
                       draggable: true,
                       onDragStart: (e: React.DragEvent) => {


### PR DESCRIPTION
## Summary

- The drag guard in `TrackList.tsx` was keyed on `!isRemoteTrack`, blocking all Bandcamp tracks from being draggable
- Changed to `!isTrackOffline && !isPreorderUnavailable` — available streaming tracks can now be dragged into the queue; offline and preorder-unavailable tracks remain non-draggable
- No backend changes: the queue drop handler and playback engine already accept remote `file_path` URLs

## Test plan

- [ ] Open a streaming album → drag a track to the queue → track appears and plays
- [ ] Streaming track while offline → non-draggable (unchanged)
- [ ] Preorder-unavailable track → non-draggable (unchanged)
- [ ] Local tracks drag normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)