### PR TITLE
feat(KAMP-460): criteria SQL query engine for magic playlists

### DIFF
--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -1,0 +1,169 @@
+"""Translate MagicCriteria into a parameterized SQLite WHERE fragment."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kamp_core.library import Condition, Group, MagicCriteria
+
+# ---------------------------------------------------------------------------
+# Field registry
+# ---------------------------------------------------------------------------
+
+# Maps field name → (sql_column_expr, value_type).
+# value_type controls coercion and, for "year", special CAST wrapping on
+# numeric operators.
+_FIELD_MAP: dict[str, tuple[str, str]] = {
+    "track.favorite": ("tracks.favorite", "bool"),
+    "album.favorite": ("albums.favorite", "bool"),
+    "track.play_count": ("tracks.play_count", "int"),
+    # NULL last_played treated as 0 so numeric comparisons work on unplayed tracks.
+    "track.last_played": ("COALESCE(tracks.last_played, 0)", "float"),
+    "track.date_added": ("tracks.date_added", "float"),
+    # year is TEXT in the DB; numeric ops use CAST so "2023" compares correctly.
+    "track.year": ("tracks.year", "year"),
+    "track.genre": ("tracks.genre", "text"),
+    "track.artist": ("tracks.artist", "text"),
+    "track.album": ("tracks.album", "text"),
+    "track.source": ("tracks.source", "text"),
+}
+
+# Fields whose SQL expression references the albums table.
+_ALBUM_FIELDS: frozenset[str] = frozenset({"album.favorite"})
+
+# Operators that need a numeric (CAST) column expression for "year".
+_NUMERIC_OPS: frozenset[str] = frozenset({"gt", "lt", "gte", "lte"})
+
+# ---------------------------------------------------------------------------
+# Value coercion
+# ---------------------------------------------------------------------------
+
+
+def _coerce(value: str, vtype: str) -> Any:
+    """Convert the wire string *value* to the Python type expected by SQLite."""
+    if vtype == "bool":
+        return 1 if value.lower() == "true" else 0
+    if vtype == "int":
+        return int(value)
+    if vtype == "float":
+        return float(value)
+    # "text" and "year" pass through as-is; year CAST happens in SQL.
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Condition → SQL fragment
+# ---------------------------------------------------------------------------
+
+_OP_MAP: dict[str, str] = {
+    "is": "= ?",
+    "is_not": "!= ?",
+    "gt": "> ?",
+    "lt": "< ?",
+    "gte": ">= ?",
+    "lte": "<= ?",
+    "contains": "LIKE ?",
+    "not_contains": "NOT LIKE ?",
+}
+
+
+def _condition_sql(cond: "Condition") -> tuple[str, list[Any], bool]:
+    """Return ``(sql_fragment, params, needs_album_join)`` for a single condition."""
+    field = cond.field
+    op = cond.op
+    value = cond.value
+
+    # in_playlist is a special subquery field.
+    if field == "in_playlist":
+        playlist_id = int(value)
+        subquery = (
+            "EXISTS (SELECT 1 FROM playlist_tracks"
+            " WHERE playlist_id = ? AND track_id = tracks.id)"
+        )
+        if op == "is_not":
+            subquery = "NOT " + subquery
+        return subquery, [playlist_id], False
+
+    if field not in _FIELD_MAP:
+        raise ValueError(f"Unknown magic playlist field: {field!r}")
+
+    col_expr, vtype = _FIELD_MAP[field]
+    needs_join = field in _ALBUM_FIELDS
+
+    if op not in _OP_MAP:
+        raise ValueError(f"Unknown magic playlist operator: {op!r}")
+
+    # For year with numeric operators, wrap the column in CAST so SQLite
+    # compares integers rather than string-collation order.
+    if vtype == "year" and op in _NUMERIC_OPS:
+        col_expr = f"CAST({col_expr} AS INTEGER)"
+
+    param: Any
+    if op == "contains":
+        param = f"%{value}%"
+    elif op == "not_contains":
+        param = f"%{value}%"
+    else:
+        param = _coerce(value, vtype)
+
+    sql_op = _OP_MAP[op]
+    fragment = f"{col_expr} {sql_op}"
+    return fragment, [param], needs_join
+
+
+# ---------------------------------------------------------------------------
+# Group → SQL fragment
+# ---------------------------------------------------------------------------
+
+
+def _group_sql(group: "Group") -> tuple[str, list[Any], bool]:
+    """Return ``(sql_fragment, params, needs_album_join)`` for a condition group."""
+    if not group.conditions:
+        return "1", [], False
+
+    joiner = " AND " if group.match == "all" else " OR "
+    parts: list[str] = []
+    params: list[Any] = []
+    needs_join = False
+
+    for cond in group.conditions:
+        frag, p, nj = _condition_sql(cond)
+        parts.append(frag)
+        params.extend(p)
+        needs_join = needs_join or nj
+
+    block = f"({joiner.join(parts)})"
+    if group.negate:
+        block = f"NOT {block}"
+    return block, params, needs_join
+
+
+# ---------------------------------------------------------------------------
+# MagicCriteria → full WHERE fragment
+# ---------------------------------------------------------------------------
+
+
+def build_query(criteria: "MagicCriteria") -> tuple[str, list[Any], bool]:
+    """Translate *criteria* into a parameterized SQLite WHERE fragment.
+
+    Returns ``(where_fragment, params, needs_album_join)``.  The caller is
+    responsible for composing the full SELECT and adding a LEFT JOIN on albums
+    when ``needs_album_join`` is True.  An empty criteria (no groups) returns
+    ``("1", [], False)`` so the caller always gets a valid SQL fragment.
+    """
+    if not criteria.groups:
+        return "1", [], False
+
+    joiner = " AND " if criteria.match == "all" else " OR "
+    parts: list[str] = []
+    params: list[Any] = []
+    needs_join = False
+
+    for group in criteria.groups:
+        frag, p, nj = _group_sql(group)
+        parts.append(frag)
+        params.extend(p)
+        needs_join = needs_join or nj
+
+    return joiner.join(parts), params, needs_join

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3429,6 +3429,30 @@ class LibraryIndex:
             raise ValueError(f"playlist {playlist_id} is not a magic playlist")
         self._conn.commit()
 
+    def evaluate_magic_playlist(self, playlist_id: int) -> list[int]:
+        """Return track IDs matching the magic playlist criteria.
+
+        Returns an empty list when the playlist does not exist or has no
+        criteria row.  A LEFT JOIN on albums is added only when the criteria
+        reference album-level fields so the common case avoids the extra join.
+        """
+        # Lazy import avoids a circular dependency: criteria.py imports the
+        # dataclasses (MagicCriteria etc.) defined in this module.
+        from kamp_core.criteria import build_query
+
+        criteria = self.get_magic_playlist_criteria(playlist_id)
+        if criteria is None:
+            return []
+        where_fragment, params, needs_album_join = build_query(criteria)
+        album_join = (
+            "LEFT JOIN albums ON albums.id = tracks.album_id"
+            if needs_album_join
+            else ""
+        )
+        sql = f"SELECT tracks.id FROM tracks {album_join} WHERE {where_fragment} ORDER BY tracks.id"
+        rows = self._conn.execute(sql, params).fetchall()
+        return [r[0] for r in rows]
+
 
 # Track fields that extensions are permitted to write via apply_metadata_update.
 # Excludes internal columns (embedded_art, play_count, last_played, etc.) so

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -1,0 +1,310 @@
+"""Unit tests for kamp_core.criteria.build_query."""
+
+from __future__ import annotations
+
+import pytest
+
+from kamp_core.criteria import build_query
+from kamp_core.library import Condition, Group, MagicCriteria
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _criteria(*groups: Group, match: str = "all") -> MagicCriteria:
+    return MagicCriteria(groups=list(groups), match=match)
+
+
+def _group(*conditions: Condition, match: str = "all", negate: bool = False) -> Group:
+    return Group(conditions=list(conditions), match=match, negate=negate)
+
+
+def _cond(field: str, op: str, value: str) -> Condition:
+    return Condition(field=field, op=op, value=value)
+
+
+# ---------------------------------------------------------------------------
+# Empty criteria / empty group
+# ---------------------------------------------------------------------------
+
+
+def test_empty_criteria_returns_passthrough() -> None:
+    frag, params, join = build_query(MagicCriteria(groups=[], match="all"))
+    assert frag == "1"
+    assert params == []
+    assert join is False
+
+
+def test_empty_group_returns_passthrough() -> None:
+    frag, params, join = build_query(_criteria(_group()))
+    assert frag == "1"
+    assert params == []
+    assert join is False
+
+
+# ---------------------------------------------------------------------------
+# Bool coercion
+# ---------------------------------------------------------------------------
+
+
+def test_track_favorite_true() -> None:
+    frag, params, join = build_query(
+        _criteria(_group(_cond("track.favorite", "is", "true")))
+    )
+    assert "tracks.favorite" in frag
+    assert params == [1]
+    assert join is False
+
+
+def test_track_favorite_false() -> None:
+    frag, params, join = build_query(
+        _criteria(_group(_cond("track.favorite", "is", "false")))
+    )
+    assert params == [0]
+
+
+def test_album_favorite_sets_join_flag() -> None:
+    frag, params, join = build_query(
+        _criteria(_group(_cond("album.favorite", "is", "true")))
+    )
+    assert "albums.favorite" in frag
+    assert params == [1]
+    assert join is True
+
+
+# ---------------------------------------------------------------------------
+# Numeric fields
+# ---------------------------------------------------------------------------
+
+
+def test_track_play_count_gt() -> None:
+    frag, params, join = build_query(
+        _criteria(_group(_cond("track.play_count", "gt", "5")))
+    )
+    assert "tracks.play_count" in frag
+    assert "> ?" in frag
+    assert params == [5]
+
+
+def test_track_play_count_lte() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.play_count", "lte", "10")))
+    )
+    assert "<= ?" in frag
+    assert params == [10]
+
+
+def test_track_last_played_uses_coalesce() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.last_played", "gt", "1000000.0")))
+    )
+    assert "COALESCE(tracks.last_played, 0)" in frag
+    assert params == [1000000.0]
+
+
+def test_track_date_added_gte() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.date_added", "gte", "1700000000.0")))
+    )
+    assert "tracks.date_added" in frag
+    assert ">= ?" in frag
+    assert params == [1700000000.0]
+
+
+# ---------------------------------------------------------------------------
+# Year field — TEXT column with CAST for numeric ops
+# ---------------------------------------------------------------------------
+
+
+def test_track_year_gt_uses_cast() -> None:
+    frag, params, _ = build_query(_criteria(_group(_cond("track.year", "gt", "2010"))))
+    assert "CAST(tracks.year AS INTEGER)" in frag
+    assert "> ?" in frag
+    assert params == ["2010"]
+
+
+def test_track_year_lt_uses_cast() -> None:
+    frag, params, _ = build_query(_criteria(_group(_cond("track.year", "lt", "2000"))))
+    assert "CAST(tracks.year AS INTEGER)" in frag
+
+
+def test_track_year_is_does_not_cast() -> None:
+    frag, params, _ = build_query(_criteria(_group(_cond("track.year", "is", "2020"))))
+    assert "CAST" not in frag
+    assert "tracks.year" in frag
+    assert "= ?" in frag
+    assert params == ["2020"]
+
+
+# ---------------------------------------------------------------------------
+# Text fields — is / is_not / contains / not_contains
+# ---------------------------------------------------------------------------
+
+
+def test_track_artist_is() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.artist", "is", "Weezer")))
+    )
+    assert "tracks.artist" in frag
+    assert "= ?" in frag
+    assert params == ["Weezer"]
+
+
+def test_track_artist_is_not() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.artist", "is_not", "Nickelback")))
+    )
+    assert "!= ?" in frag
+    assert params == ["Nickelback"]
+
+
+def test_track_genre_contains_wraps_value() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.genre", "contains", "Rock")))
+    )
+    assert "LIKE ?" in frag
+    assert params == ["%Rock%"]
+
+
+def test_track_genre_not_contains() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.genre", "not_contains", "Pop")))
+    )
+    assert "NOT LIKE ?" in frag
+    assert params == ["%Pop%"]
+
+
+def test_track_album_contains() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.album", "contains", "Blue")))
+    )
+    assert "tracks.album" in frag
+    assert params == ["%Blue%"]
+
+
+def test_track_source_is() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.source", "is", "bandcamp")))
+    )
+    assert "tracks.source" in frag
+    assert params == ["bandcamp"]
+
+
+# ---------------------------------------------------------------------------
+# in_playlist special field
+# ---------------------------------------------------------------------------
+
+
+def test_in_playlist_is() -> None:
+    frag, params, join = build_query(_criteria(_group(_cond("in_playlist", "is", "7"))))
+    assert "EXISTS" in frag
+    assert "NOT EXISTS" not in frag
+    assert "playlist_tracks" in frag
+    assert params == [7]
+    assert join is False
+
+
+def test_in_playlist_is_not() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("in_playlist", "is_not", "3")))
+    )
+    assert "NOT EXISTS" in frag
+    assert params == [3]
+
+
+# ---------------------------------------------------------------------------
+# Group composition — AND / OR / negate
+# ---------------------------------------------------------------------------
+
+
+def test_group_match_all_uses_and() -> None:
+    g = _group(
+        _cond("track.artist", "is", "A"),
+        _cond("track.genre", "is", "B"),
+        match="all",
+    )
+    frag, _, _ = build_query(_criteria(g))
+    assert " AND " in frag
+
+
+def test_group_match_any_uses_or() -> None:
+    g = _group(
+        _cond("track.artist", "is", "A"),
+        _cond("track.genre", "is", "B"),
+        match="any",
+    )
+    frag, _, _ = build_query(_criteria(g))
+    assert " OR " in frag
+
+
+def test_group_negate_wraps_in_not() -> None:
+    g = _group(_cond("track.favorite", "is", "true"), negate=True)
+    frag, _, _ = build_query(_criteria(g))
+    assert frag.startswith("NOT (")
+
+
+# ---------------------------------------------------------------------------
+# MagicCriteria top-level composition
+# ---------------------------------------------------------------------------
+
+
+def test_criteria_match_all_joins_groups_with_and() -> None:
+    g1 = _group(_cond("track.artist", "is", "X"))
+    g2 = _group(_cond("track.genre", "is", "Y"))
+    frag, params, _ = build_query(_criteria(g1, g2, match="all"))
+    assert " AND " in frag
+    assert params == ["X", "Y"]
+
+
+def test_criteria_match_any_joins_groups_with_or() -> None:
+    g1 = _group(_cond("track.artist", "is", "X"))
+    g2 = _group(_cond("track.genre", "is", "Y"))
+    frag, params, _ = build_query(_criteria(g1, g2, match="any"))
+    assert " OR " in frag
+
+
+def test_needs_album_join_propagates_through_groups() -> None:
+    g1 = _group(_cond("track.artist", "is", "X"))
+    g2 = _group(_cond("album.favorite", "is", "true"))
+    _, _, join = build_query(_criteria(g1, g2))
+    assert join is True
+
+
+def test_needs_album_join_false_when_no_album_fields() -> None:
+    g = _group(_cond("track.artist", "is", "X"))
+    _, _, join = build_query(_criteria(g))
+    assert join is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-condition params order
+# ---------------------------------------------------------------------------
+
+
+def test_params_are_ordered_correctly() -> None:
+    g = _group(
+        _cond("track.artist", "is", "Alvvays"),
+        _cond("track.year", "gt", "2010"),
+        match="all",
+    )
+    _, params, _ = build_query(_criteria(g))
+    assert params[0] == "Alvvays"
+    assert params[1] == "2010"
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_field_raises() -> None:
+    g = _group(_cond("track.nonsense", "is", "x"))
+    with pytest.raises(ValueError, match="Unknown magic playlist field"):
+        build_query(_criteria(g))
+
+
+def test_unknown_operator_raises() -> None:
+    g = _group(_cond("track.artist", "between", "A"))
+    with pytest.raises(ValueError, match="Unknown magic playlist operator"):
+        build_query(_criteria(g))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7939,3 +7939,272 @@ class TestMagicPlaylists:
 
         assert version == 33
         assert fetched == criteria
+
+    # ------------------------------------------------------------------
+    # evaluate_magic_playlist integration
+    # ------------------------------------------------------------------
+
+    def _seeded_index(self, tmp_path: Path) -> tuple["LibraryIndex", int, int]:
+        """Return (index, track_id_a, track_id_b) with two distinct tracks."""
+        from kamp_core.library import Track
+
+        index = LibraryIndex(tmp_path / "library.db")
+        track_a = Track(
+            file_path=tmp_path / "a.mp3",
+            title="Song A",
+            artist="Alvvays",
+            album_artist="Alvvays",
+            album="Antisocialites",
+            year="2017",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="Indie",
+            favorite=True,
+            play_count=5,
+            source="local",
+        )
+        track_b = Track(
+            file_path=tmp_path / "b.mp3",
+            title="Song B",
+            artist="Weezer",
+            album_artist="Weezer",
+            album="Blue Album",
+            year="1994",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="Rock",
+            favorite=False,
+            play_count=0,
+            source="local",
+        )
+        index.upsert_many([track_a, track_b])
+        # favorite and play_count are runtime fields not written by upsert_many;
+        # set them directly so the evaluate tests can filter on them.
+        index._conn.execute(
+            "UPDATE tracks SET favorite = 1, play_count = 5 WHERE file_path = ?",
+            (str(tmp_path / "a.mp3"),),
+        )
+        index._conn.commit()
+        row_a = index._conn.execute(
+            "SELECT id FROM tracks WHERE file_path = ?", (str(tmp_path / "a.mp3"),)
+        ).fetchone()
+        row_b = index._conn.execute(
+            "SELECT id FROM tracks WHERE file_path = ?", (str(tmp_path / "b.mp3"),)
+        ).fetchone()
+        return index, row_a["id"], row_b["id"]
+
+    def test_evaluate_returns_empty_for_nonexistent_playlist(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.evaluate_magic_playlist(9999)
+        index.close()
+        assert result == []
+
+    def test_evaluate_returns_empty_for_static_playlist(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pl = index.create_playlist("Static")
+        result = index.evaluate_magic_playlist(pl["id"])
+        index.close()
+        assert result == []
+
+    def test_evaluate_filters_by_artist(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Alvvays Only", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]
+
+    def test_evaluate_filters_by_favorite(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.favorite", op="is", value="true")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Favorites", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]
+
+    def test_evaluate_filters_by_genre_contains(self, tmp_path: Path) -> None:
+        index, id_a, id_b = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.genre", op="contains", value="Indie")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Indie", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]
+
+    def test_evaluate_play_count_gt(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.play_count", op="gt", value="2")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Played", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]
+
+    def test_evaluate_year_lt(self, tmp_path: Path) -> None:
+        index, _, id_b = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[Condition(field="track.year", op="lt", value="2000")],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Old Stuff", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_b]
+
+    def test_evaluate_no_results(self, tmp_path: Path) -> None:
+        index, _, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Nobody Famous")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Empty Result", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == []
+
+    def test_evaluate_all_results_with_empty_criteria(self, tmp_path: Path) -> None:
+        index, id_a, id_b = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(groups=[], match="all")
+        pid = index.create_magic_playlist("Everything", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert sorted(result) == sorted([id_a, id_b])
+
+    def test_evaluate_match_any_combines_artists(self, tmp_path: Path) -> None:
+        index, id_a, id_b = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays"),
+                        Condition(field="track.artist", op="is", value="Weezer"),
+                    ],
+                    match="any",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Both Artists", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert sorted(result) == sorted([id_a, id_b])
+
+    def test_evaluate_negated_group_excludes_match(self, tmp_path: Path) -> None:
+        index, _, id_b = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays")
+                    ],
+                    match="all",
+                    negate=True,
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Not Alvvays", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_b]
+
+    def test_evaluate_album_favorite_uses_join(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        # Mark Alvvays album as favorite.
+        index.toggle_album_favorite("Alvvays", "Antisocialites", True)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="album.favorite", op="is", value="true")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Fav Albums", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]
+
+    def test_evaluate_in_playlist(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        # Create a static playlist containing only track A.
+        static = index.create_playlist("Static")
+        index.add_track_to_playlist(static["id"], str(tmp_path / "a.mp3"))
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="in_playlist", op="is", value=str(static["id"]))
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("In Static", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [id_a]


### PR DESCRIPTION
## Summary

- New `kamp_core/criteria.py` module with `build_query(criteria: MagicCriteria) -> tuple[str, list[Any], bool]`
- Translates `MagicCriteria` → parameterized SQLite WHERE fragment + bound params + `needs_album_join` flag
- Supported fields: `track.favorite`, `album.favorite`, `track.play_count`, `track.last_played` (NULL=0 via COALESCE), `track.date_added`, `track.year` (CAST for numeric ops), `track.genre`, `track.artist`, `track.album`, `track.source`, `in_playlist` (EXISTS subquery)
- Supported operators: `is`, `is_not`, `gt`, `lt`, `gte`, `lte`, `contains`, `not_contains`
- Group/criteria composition: `match="all"` → AND, `match="any"` → OR, `negate=True` → `NOT(...)`
- Lazy import in `evaluate_magic_playlist` avoids circular dependency between `criteria.py` and `library.py`
- `LibraryIndex.evaluate_magic_playlist(playlist_id) -> list[int]` wraps `build_query` and composes the full SELECT

## Test plan

- [ ] 30 unit tests in `tests/test_criteria.py` covering every field, operator, edge case (empty criteria, unknown field/op errors, bool coercion, CAST wrapping, EXISTS subquery, param ordering)
- [ ] 13 integration tests added to `TestMagicPlaylists` in `tests/test_library.py` covering all evaluate paths against a real SQLite DB
- [ ] Full suite: 1960 passed, 9 skipped, 93.28% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)