### PR TITLE
feat(KAMP-461): magic playlist API endpoints

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3453,6 +3453,81 @@ class LibraryIndex:
         rows = self._conn.execute(sql, params).fetchall()
         return [r[0] for r in rows]
 
+    def get_magic_playlist_tracks(self, playlist_id: int) -> list[dict[str, Any]]:
+        """Return full track dicts for a magic playlist, evaluated on the fly.
+
+        Returns the same shape as ``get_playlist_tracks`` but with
+        ``playlist_track_id=None`` and ``position=0`` since magic tracks are
+        not stored in ``playlist_tracks``.  Returns an empty list when the
+        playlist has no criteria row.
+        """
+        from kamp_core.criteria import build_query
+
+        criteria = self.get_magic_playlist_criteria(playlist_id)
+        if criteria is None:
+            return []
+        where_fragment, params, needs_album_join = build_query(criteria)
+        album_join = (
+            "LEFT JOIN albums ON albums.id = tracks.album_id"
+            if needs_album_join
+            else ""
+        )
+        sql = f"""
+            SELECT NULL AS playlist_track_id, 0 AS position,
+                   tracks.id, tracks.file_path, tracks.title, tracks.artist,
+                   tracks.album_artist, tracks.album, tracks.year,
+                   tracks.track_number, tracks.disc_number, tracks.ext,
+                   tracks.embedded_art, tracks.mb_release_id, tracks.mb_recording_id,
+                   tracks.genre, tracks.label, tracks.favorite, tracks.play_count,
+                   tracks.last_played, tracks.source, tracks.is_available, tracks.duration
+            FROM tracks {album_join}
+            WHERE {where_fragment}
+            ORDER BY tracks.id
+        """
+        rows = self._conn.execute(sql, params).fetchall()
+        return [
+            {
+                "playlist_track_id": None,
+                "position": 0,
+                "id": r["id"],
+                "file_path": r["file_path"],
+                "title": r["title"],
+                "artist": r["artist"],
+                "album_artist": r["album_artist"],
+                "album": r["album"],
+                "year": r["year"],
+                "track_number": r["track_number"],
+                "disc_number": r["disc_number"],
+                "ext": r["ext"],
+                "embedded_art": bool(r["embedded_art"]),
+                "mb_release_id": r["mb_release_id"],
+                "mb_recording_id": r["mb_recording_id"],
+                "genre": r["genre"],
+                "label": r["label"],
+                "favorite": bool(r["favorite"]),
+                "play_count": r["play_count"],
+                "last_played": r["last_played"],
+                "source": r["source"],
+                "is_available": bool(r["is_available"]),
+                "duration": r["duration"],
+            }
+            for r in rows
+        ]
+
+    def count_magic_criteria(self, criteria: "MagicCriteria") -> int:
+        """Return the number of tracks that match *criteria* without fetching them."""
+        from kamp_core.criteria import build_query
+
+        where_fragment, params, needs_album_join = build_query(criteria)
+        album_join = (
+            "LEFT JOIN albums ON albums.id = tracks.album_id"
+            if needs_album_join
+            else ""
+        )
+        sql = f"SELECT COUNT(*) FROM tracks {album_join} WHERE {where_fragment}"
+        row = self._conn.execute(sql, params).fetchone()
+        return int(row[0])
+
 
 # Track fields that extensions are permitted to write via apply_metadata_update.
 # Excludes internal columns (embedded_art, play_count, last_played, etc.) so

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 from kamp_core.library import (
     LibraryIndex,
     LibraryScanner,
+    MagicCriteria,
     Track,
     _canonical_track_key,
     extract_art,
@@ -546,6 +547,7 @@ class PlaylistOut(BaseModel):
     created_at: float
     updated_at: float
     last_played_at: float | None = None
+    criteria: dict[str, Any] | None = None
 
 
 class PlaylistSearchOut(PlaylistOut):
@@ -553,7 +555,7 @@ class PlaylistSearchOut(PlaylistOut):
 
 
 class PlaylistTrackOut(BaseModel):
-    playlist_track_id: int
+    playlist_track_id: int | None
     position: int
     id: int
     file_path: str
@@ -580,11 +582,20 @@ class PlaylistTrackOut(BaseModel):
 
 class CreatePlaylistRequest(BaseModel):
     title: str
+    criteria: dict[str, Any] | None = None
 
 
 class PatchPlaylistRequest(BaseModel):
     title: str | None = None
     favorite: bool | None = None
+
+
+class UpdateCriteriaRequest(BaseModel):
+    criteria: dict[str, Any]
+
+
+class CriteriaPreviewRequest(BaseModel):
+    criteria: dict[str, Any]
 
 
 class AddTrackToPlaylistRequest(BaseModel):
@@ -3170,23 +3181,46 @@ def create_app(
         return {"ok": True}
 
     # -----------------------------------------------------------------------
-    # Playlists (KAMP-441)
+    # Playlists (KAMP-441, KAMP-461)
     # -----------------------------------------------------------------------
+
+    def _enrich_playlist(pl: dict[str, Any]) -> dict[str, Any]:
+        """Add 'criteria' key to a playlist dict (None for static playlists)."""
+        mc = index.get_magic_playlist_criteria(pl["id"])
+        pl["criteria"] = mc.to_dict() if mc is not None else None
+        return pl
 
     @app.post("/api/v1/playlists", response_model=PlaylistOut, status_code=201)
     def create_playlist(req: CreatePlaylistRequest) -> dict[str, Any]:
-        return index.create_playlist(req.title)
+        if req.criteria is not None:
+            try:
+                mc = MagicCriteria.from_dict(req.criteria)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            new_id = index.create_magic_playlist(req.title, mc)
+            pl = index.get_playlist(new_id)
+            assert pl is not None
+        else:
+            pl = index.create_playlist(req.title)
+        return _enrich_playlist(pl)
 
     @app.get("/api/v1/playlists", response_model=list[PlaylistOut])
-    def list_playlists() -> list[dict[str, Any]]:
-        return index.get_playlists()
+    def list_playlists(type: str | None = None) -> list[dict[str, Any]]:
+        playlists = index.get_playlists()
+        result: list[dict[str, Any]] = []
+        for pl in playlists:
+            _enrich_playlist(pl)
+            if type == "simple" and pl["criteria"] is not None:
+                continue
+            result.append(pl)
+        return result
 
     @app.get("/api/v1/playlists/{playlist_id}", response_model=PlaylistOut)
     def get_playlist(playlist_id: int) -> dict[str, Any]:
         pl = index.get_playlist(playlist_id)
         if pl is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
-        return pl
+        return _enrich_playlist(pl)
 
     @app.patch("/api/v1/playlists/{playlist_id}", response_model=PlaylistOut)
     def patch_playlist(playlist_id: int, req: PatchPlaylistRequest) -> dict[str, Any]:
@@ -3199,7 +3233,7 @@ def create_app(
             index.set_playlist_favorite(playlist_id, req.favorite)
         updated = index.get_playlist(playlist_id)
         assert updated is not None
-        return updated
+        return _enrich_playlist(updated)
 
     @app.delete("/api/v1/playlists/{playlist_id}", status_code=204)
     def delete_playlist(playlist_id: int) -> Response:
@@ -3222,7 +3256,43 @@ def create_app(
     def get_playlist_tracks(playlist_id: int) -> list[dict[str, Any]]:
         if index.get_playlist(playlist_id) is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
+        if index.get_magic_playlist_criteria(playlist_id) is not None:
+            return index.get_magic_playlist_tracks(playlist_id)
         return index.get_playlist_tracks(playlist_id)
+
+    @app.put("/api/v1/playlists/{playlist_id}/criteria", response_model=PlaylistOut)
+    def update_playlist_criteria(
+        playlist_id: int, req: UpdateCriteriaRequest
+    ) -> dict[str, Any]:
+        pl = index.get_playlist(playlist_id)
+        if pl is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        try:
+            mc = MagicCriteria.from_dict(req.criteria)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        try:
+            index.update_magic_playlist_criteria(playlist_id, mc)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        updated = index.get_playlist(playlist_id)
+        assert updated is not None
+        return _enrich_playlist(updated)
+
+    @app.get("/api/v1/playlists/{playlist_id}/criteria")
+    def get_playlist_criteria(playlist_id: int) -> dict[str, Any]:
+        if index.get_playlist(playlist_id) is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        mc = index.get_magic_playlist_criteria(playlist_id)
+        return {"criteria": mc.to_dict() if mc is not None else None}
+
+    @app.post("/api/v1/criteria/preview")
+    def preview_criteria(req: CriteriaPreviewRequest) -> dict[str, Any]:
+        try:
+            mc = MagicCriteria.from_dict(req.criteria)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"count": index.count_magic_criteria(mc)}
 
     @app.post("/api/v1/playlists/{playlist_id}/tracks")
     def add_to_playlist(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8208,3 +8208,60 @@ class TestMagicPlaylists:
         result = index.evaluate_magic_playlist(pid)
         index.close()
         assert result == [id_a]
+
+    def test_get_magic_playlist_tracks_returns_full_dicts(self, tmp_path: Path) -> None:
+        index, id_a, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Smart Mix", criteria)
+        tracks = index.get_magic_playlist_tracks(pid)
+        index.close()
+
+        assert len(tracks) == 1
+        t = tracks[0]
+        assert t["id"] == id_a
+        assert t["artist"] == "Alvvays"
+        assert t["playlist_track_id"] is None
+        assert t["position"] == 0
+
+    def test_get_magic_playlist_tracks_returns_empty_for_static(
+        self, tmp_path: Path
+    ) -> None:
+        index, _, _ = self._seeded_index(tmp_path)
+        pl = index.create_playlist("Static")
+        tracks = index.get_magic_playlist_tracks(pl["id"])
+        index.close()
+        assert tracks == []
+
+    def test_count_magic_criteria_returns_match_count(self, tmp_path: Path) -> None:
+        index, _, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        count = index.count_magic_criteria(criteria)
+        index.close()
+        assert count == 1
+
+    def test_count_magic_criteria_empty_returns_all(self, tmp_path: Path) -> None:
+        index, _, _ = self._seeded_index(tmp_path)
+        criteria = MagicCriteria(groups=[], match="all")
+        count = index.count_magic_criteria(criteria)
+        index.close()
+        assert count == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,6 +55,8 @@ def mock_index() -> MagicMock:
     index.search_playlists.return_value = []
     index.playlists_for_tracks.return_value = []
     index.get_playlist_cover.return_value = None
+    # Default: no magic criteria (static playlist). Individual tests override.
+    index.get_magic_playlist_criteria.return_value = None
     return index
 
 
@@ -5235,6 +5237,249 @@ class TestPlaylistEndpoints:
     ) -> None:
         mock_index.get_playlist.return_value = None
         assert client.post("/api/v1/playlists/999/played").status_code == 404
+
+
+_SAMPLE_CRITERIA = {
+    "groups": [
+        {
+            "conditions": [{"field": "track.artist", "op": "is", "value": "Alvvays"}],
+            "match": "all",
+            "negate": False,
+        }
+    ],
+    "match": "all",
+}
+
+
+class TestMagicPlaylistEndpoints:
+    """Tests for magic playlist routes added in KAMP-461."""
+
+    # ------------------------------------------------------------------
+    # POST /api/v1/playlists — with criteria
+    # ------------------------------------------------------------------
+
+    def test_create_magic_playlist_calls_create_magic_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_core.library import MagicCriteria
+
+        mock_index.create_magic_playlist.return_value = 5
+        mock_index.get_playlist.return_value = _playlist(id=5, title="Smart Mix")
+        resp = client.post(
+            "/api/v1/playlists",
+            json={"title": "Smart Mix", "criteria": _SAMPLE_CRITERIA},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["id"] == 5
+        mock_index.create_magic_playlist.assert_called_once()
+        # criteria key is present in the response (enriched from get_magic_playlist_criteria
+        # which returns None by default in the fixture → criteria=None)
+        assert "criteria" in resp.json()
+
+    def test_create_magic_playlist_invalid_criteria_returns_400(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        resp = client.post(
+            "/api/v1/playlists", json={"title": "Bad", "criteria": {"bad": "data"}}
+        )
+        assert resp.status_code == 400
+
+    def test_create_static_playlist_unaffected(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.create_playlist.return_value = _playlist(title="Static")
+        resp = client.post("/api/v1/playlists", json={"title": "Static"})
+        assert resp.status_code == 201
+        mock_index.create_playlist.assert_called_once_with("Static")
+        mock_index.create_magic_playlist.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # GET /api/v1/playlists — criteria field + ?type=simple filter
+    # ------------------------------------------------------------------
+
+    def test_list_playlists_includes_criteria_field(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlists.return_value = [_playlist(id=1)]
+        resp = client.get("/api/v1/playlists")
+        assert resp.status_code == 200
+        assert "criteria" in resp.json()[0]
+
+    def test_list_playlists_type_simple_excludes_magic(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_core.library import Condition, Group, MagicCriteria
+
+        mock_index.get_playlists.return_value = [_playlist(id=1), _playlist(id=2)]
+        mc = MagicCriteria(
+            groups=[
+                Group(conditions=[Condition("track.artist", "is", "X")], match="all")
+            ],
+            match="all",
+        )
+        # playlist 1 is magic, playlist 2 is static
+        mock_index.get_magic_playlist_criteria.side_effect = lambda pid: (
+            mc if pid == 1 else None
+        )
+        resp = client.get("/api/v1/playlists?type=simple")
+        assert resp.status_code == 200
+        ids = [p["id"] for p in resp.json()]
+        assert 1 not in ids
+        assert 2 in ids
+
+    def test_list_playlists_no_type_includes_all(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_core.library import Condition, Group, MagicCriteria
+
+        mock_index.get_playlists.return_value = [_playlist(id=1), _playlist(id=2)]
+        mc = MagicCriteria(
+            groups=[
+                Group(conditions=[Condition("track.artist", "is", "X")], match="all")
+            ],
+            match="all",
+        )
+        mock_index.get_magic_playlist_criteria.side_effect = lambda pid: (
+            mc if pid == 1 else None
+        )
+        resp = client.get("/api/v1/playlists")
+        ids = [p["id"] for p in resp.json()]
+        assert ids == [1, 2]
+
+    # ------------------------------------------------------------------
+    # GET /api/v1/playlists/{id}/tracks — magic branch
+    # ------------------------------------------------------------------
+
+    def test_get_magic_playlist_tracks_calls_get_magic_tracks(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_core.library import Condition, Group, MagicCriteria
+
+        mc = MagicCriteria(
+            groups=[
+                Group(conditions=[Condition("track.artist", "is", "X")], match="all")
+            ],
+            match="all",
+        )
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.get_magic_playlist_criteria.return_value = mc
+        magic_track = dict(_playlist_track(), playlist_track_id=None, position=0)
+        mock_index.get_magic_playlist_tracks.return_value = [magic_track]
+        resp = client.get("/api/v1/playlists/1/tracks")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["playlist_track_id"] is None
+        mock_index.get_magic_playlist_tracks.assert_called_once_with(1)
+        mock_index.get_playlist_tracks.assert_not_called()
+
+    def test_get_static_playlist_tracks_unaffected(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        # get_magic_playlist_criteria returns None by default (static playlist)
+        mock_index.get_playlist_tracks.return_value = [_playlist_track()]
+        resp = client.get("/api/v1/playlists/1/tracks")
+        assert resp.status_code == 200
+        mock_index.get_playlist_tracks.assert_called_once_with(1)
+        mock_index.get_magic_playlist_tracks.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # PUT /api/v1/playlists/{id}/criteria
+    # ------------------------------------------------------------------
+
+    def test_put_criteria_updates_and_returns_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        resp = client.put(
+            "/api/v1/playlists/1/criteria", json={"criteria": _SAMPLE_CRITERIA}
+        )
+        assert resp.status_code == 200
+        mock_index.update_magic_playlist_criteria.assert_called_once()
+
+    def test_put_criteria_404(self, client: TestClient, mock_index: MagicMock) -> None:
+        mock_index.get_playlist.return_value = None
+        resp = client.put(
+            "/api/v1/playlists/999/criteria", json={"criteria": _SAMPLE_CRITERIA}
+        )
+        assert resp.status_code == 404
+
+    def test_put_criteria_not_magic_returns_400(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.update_magic_playlist_criteria.side_effect = ValueError(
+            "not a magic playlist"
+        )
+        resp = client.put(
+            "/api/v1/playlists/1/criteria", json={"criteria": _SAMPLE_CRITERIA}
+        )
+        assert resp.status_code == 400
+
+    def test_put_criteria_invalid_body_returns_400(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        resp = client.put(
+            "/api/v1/playlists/1/criteria", json={"criteria": {"bad": True}}
+        )
+        assert resp.status_code == 400
+
+    # ------------------------------------------------------------------
+    # GET /api/v1/playlists/{id}/criteria
+    # ------------------------------------------------------------------
+
+    def test_get_criteria_returns_dict_for_magic_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        from kamp_core.library import Condition, Group, MagicCriteria
+
+        mc = MagicCriteria(
+            groups=[
+                Group(conditions=[Condition("track.artist", "is", "X")], match="all")
+            ],
+            match="all",
+        )
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.get_magic_playlist_criteria.return_value = mc
+        resp = client.get("/api/v1/playlists/1/criteria")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "criteria" in body
+        assert body["criteria"]["match"] == "all"
+
+    def test_get_criteria_returns_null_for_static_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        resp = client.get("/api/v1/playlists/1/criteria")
+        assert resp.status_code == 200
+        assert resp.json()["criteria"] is None
+
+    def test_get_criteria_404(self, client: TestClient, mock_index: MagicMock) -> None:
+        mock_index.get_playlist.return_value = None
+        assert client.get("/api/v1/playlists/999/criteria").status_code == 404
+
+    # ------------------------------------------------------------------
+    # POST /api/v1/criteria/preview
+    # ------------------------------------------------------------------
+
+    def test_criteria_preview_returns_count(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.count_magic_criteria.return_value = 42
+        resp = client.post(
+            "/api/v1/criteria/preview", json={"criteria": _SAMPLE_CRITERIA}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"count": 42}
+        mock_index.count_magic_criteria.assert_called_once()
+
+    def test_criteria_preview_invalid_criteria_returns_400(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        resp = client.post("/api/v1/criteria/preview", json={"criteria": {"bad": True}})
+        assert resp.status_code == 400
 
 
 class TestPlaylistArt:


### PR DESCRIPTION
## Summary

- Adds 7 new/modified FastAPI routes for the full magic playlist lifecycle: create with criteria, dynamic track evaluation, criteria CRUD, count preview, and `?type=simple` list filter
- `PlaylistOut` gains a `criteria: dict | None` field; `PlaylistTrackOut.playlist_track_id` is now nullable to support dynamically-evaluated tracks
- Library adds `get_magic_playlist_tracks` (single-query evaluate + full dict return) and `count_magic_criteria` (efficient `SELECT COUNT(*)` for preview)
- 17 new `TestMagicPlaylistEndpoints` server tests + 4 new `TestMagicPlaylists` library tests; 1981 tests passing, 93.34% coverage

## Test plan

- [ ] `POST /api/v1/playlists` with criteria body → response has `criteria` field
- [ ] `GET /api/v1/playlists` → all playlists have `criteria` field; magic ones show their criteria dict
- [ ] `GET /api/v1/playlists?type=simple` → magic playlists absent
- [ ] `GET /api/v1/playlists/{magic_id}/tracks` → returns evaluated tracks with `playlist_track_id=null`
- [ ] `GET /api/v1/playlists/{static_id}/tracks` → returns normal tracks with non-null `playlist_track_id`
- [ ] `PUT /api/v1/playlists/{id}/criteria` → updates and returns playlist with new criteria
- [ ] `GET /api/v1/playlists/{id}/criteria` → returns raw criteria dict or `null`
- [ ] `POST /api/v1/criteria/preview` → returns `{"count": N}` quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)