### PR TITLE
feat(KAMP-462): reactive magic playlist auto-refresh via WebSocket

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -545,6 +545,10 @@ class LibraryIndex:
         # all down cleanly at server shutdown.
         self._all_conns: list[sqlite3.Connection] = []
         self._all_conns_lock = threading.Lock()
+        # Injected by the server to push magic_playlist.updated WebSocket events
+        # when a field referenced by magic criteria changes. Default None so
+        # library mutations work without a server context (e.g. in tests).
+        self.on_fields_changed: Callable[[set[str]], None] | None = None
         # Correct permissions on existing installs where the file was created
         # with the default umask (644).
         if db_path.exists():
@@ -1944,6 +1948,16 @@ class LibraryIndex:
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed(
+                {
+                    "track.artist",
+                    "track.album",
+                    "track.genre",
+                    "track.source",
+                    "track.year",
+                }
+            )
 
     def move_track(
         self,
@@ -2205,6 +2219,19 @@ class LibraryIndex:
         # Sync FTS — rebuilding is simpler than per-row deletes with FTS5 content tables.
         self._rebuild_fts()
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed(
+                {
+                    "track.artist",
+                    "track.album",
+                    "track.genre",
+                    "track.source",
+                    "track.year",
+                    "track.favorite",
+                    "track.play_count",
+                    "track.last_played",
+                }
+            )
 
     def all_tracks(self) -> list[Track]:
         """Return all indexed tracks in insertion order."""
@@ -2237,6 +2264,8 @@ class LibraryIndex:
             (now, key, now),
         )
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.last_played"})
 
     def record_played(self, file_path: Path) -> None:
         """Increment play_count for the track at *file_path*.
@@ -2261,6 +2290,8 @@ class LibraryIndex:
             (key,),
         )
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.play_count"})
 
     def set_favorite(self, file_path: "Path | str", favorite: bool) -> None:
         """Set or clear the favorite flag for the track at *file_path*.
@@ -2274,6 +2305,8 @@ class LibraryIndex:
             (int(favorite), key),
         )
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.favorite"})
 
     def inherit_remote_favorites(self, new_tracks: "list[Track]") -> None:
         """Copy the favorite flag from a matching remote bandcamp:// row to each
@@ -2483,6 +2516,8 @@ class LibraryIndex:
             (int(favorite), album_artist, album),
         )
         self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"album.favorite"})
 
     def albums(
         self, sort: str = "album_artist", sort_dir: str | None = None
@@ -3527,6 +3562,19 @@ class LibraryIndex:
         sql = f"SELECT COUNT(*) FROM tracks {album_join} WHERE {where_fragment}"
         row = self._conn.execute(sql, params).fetchone()
         return int(row[0])
+
+    def list_all_magic_criteria(self) -> list[tuple[int, "MagicCriteria"]]:
+        """Return ``(playlist_id, MagicCriteria)`` pairs for every magic playlist.
+
+        Used by the server to build the field_index at startup and after CRUD.
+        """
+        rows = self._conn.execute(
+            "SELECT playlist_id, criteria_json FROM magic_playlist_criteria"
+        ).fetchall()
+        return [
+            (r["playlist_id"], MagicCriteria.from_dict(json.loads(r["criteria_json"])))
+            for r in rows
+        ]
 
 
 # Track fields that extensions are permitted to write via apply_metadata_update.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -921,6 +921,46 @@ def create_app(
     engine.on_play_state_changed = _notify_play_state_changed
     engine.on_audio_level = _notify_audio_level
 
+    # Magic playlist field_index: maps field name → set of playlist IDs whose
+    # criteria reference that field.  Rebuilt at startup and after CRUD ops.
+    field_index: dict[str, set[int]] = {}
+    # Per-playlist timestamp of last broadcast (for ≤1 event/second debounce).
+    _last_magic_broadcast: dict[int, float] = {}
+
+    def _rebuild_field_index() -> None:
+        new_index: dict[str, set[int]] = {}
+        for playlist_id, mc in index.list_all_magic_criteria():
+            for group in mc.groups:
+                for cond in group.conditions:
+                    new_index.setdefault(cond.field, set()).add(playlist_id)
+        field_index.clear()
+        field_index.update(new_index)
+
+    def _on_fields_changed(fields: set[str]) -> None:
+        """Broadcast magic_playlist.updated for each playlist affected by *fields*.
+
+        Called from LibraryIndex mutation methods (which run on various threads).
+        _broadcast is thread-safe. Debounce suppresses duplicate events within 1s.
+        """
+        affected: set[int] = set()
+        for f in fields:
+            affected |= field_index.get(f, set())
+        if not affected:
+            return
+        import time as _t  # noqa: PLC0415
+
+        now = _t.time()
+        for pid in affected:
+            if now - _last_magic_broadcast.get(pid, 0.0) < 1.0:
+                continue
+            _last_magic_broadcast[pid] = now
+            _broadcast({"type": "magic_playlist.updated", "id": pid})
+
+    index.on_fields_changed = _on_fields_changed
+    _rebuild_field_index()
+    app.state.field_index = field_index
+    app.state.on_fields_changed = _on_fields_changed
+
     # Auth middleware must be defined before add_middleware(CORSMiddleware) so
     # CORS ends up as the outermost wrapper (handles OPTIONS preflight first).
     @app.middleware("http")
@@ -3200,6 +3240,7 @@ def create_app(
             new_id = index.create_magic_playlist(req.title, mc)
             pl = index.get_playlist(new_id)
             assert pl is not None
+            _rebuild_field_index()
         else:
             pl = index.create_playlist(req.title)
         return _enrich_playlist(pl)
@@ -3241,6 +3282,7 @@ def create_app(
         if pl is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
         index.delete_playlist(playlist_id)
+        _rebuild_field_index()
         return Response(status_code=204)
 
     @app.post("/api/v1/playlists/{playlist_id}/played", status_code=204)
@@ -3275,6 +3317,7 @@ def create_app(
             index.update_magic_playlist_criteria(playlist_id, mc)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        _rebuild_field_index()
         updated = index.get_playlist(playlist_id)
         assert updated is not None
         return _enrich_playlist(updated)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8265,3 +8265,188 @@ class TestMagicPlaylists:
         count = index.count_magic_criteria(criteria)
         index.close()
         assert count == 2
+
+
+class TestMagicPlaylistReactivity:
+    """Tests for the on_fields_changed callback wired into LibraryIndex mutations."""
+
+    def _make_index_with_track(self, tmp_path: Path) -> tuple["LibraryIndex", Path]:
+        from kamp_core.library import Track
+
+        index = LibraryIndex(tmp_path / "library.db")
+        track = Track(
+            file_path=tmp_path / "a.mp3",
+            title="Song A",
+            artist="Alvvays",
+            album_artist="Alvvays",
+            album="Antisocialites",
+            year="2017",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="Indie",
+            favorite=False,
+            play_count=0,
+            source="local",
+        )
+        index.upsert_many([track])
+        return index, tmp_path / "a.mp3"
+
+    def test_on_fields_changed_none_does_not_crash(self, tmp_path: Path) -> None:
+        """All 6 mutations must work when on_fields_changed is None (default)."""
+        from kamp_core.library import Track
+
+        index, track_path = self._make_index_with_track(tmp_path)
+        assert index.on_fields_changed is None
+        index.set_favorite(track_path, True)
+        index.toggle_album_favorite("Alvvays", "Antisocialites", True)
+        index.record_played(track_path)
+        index.record_track_started(track_path)
+        second = Track(
+            file_path=tmp_path / "b.mp3",
+            title="Song B",
+            artist="Weezer",
+            album_artist="Weezer",
+            album="Blue",
+            year="1994",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="Rock",
+            favorite=False,
+            play_count=0,
+            source="local",
+        )
+        index.upsert_many([second])
+        index.remove_track(track_path)
+        index.close()
+
+    def test_set_favorite_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        index, track_path = self._make_index_with_track(tmp_path)
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        index.set_favorite(track_path, True)
+        index.close()
+        cb.assert_called_once_with({"track.favorite"})
+
+    def test_toggle_album_favorite_fires_on_fields_changed(
+        self, tmp_path: Path
+    ) -> None:
+        index, _ = self._make_index_with_track(tmp_path)
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        index.toggle_album_favorite("Alvvays", "Antisocialites", True)
+        index.close()
+        cb.assert_called_once_with({"album.favorite"})
+
+    def test_record_played_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        index, track_path = self._make_index_with_track(tmp_path)
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        index.record_played(track_path)
+        index.close()
+        cb.assert_called_once_with({"track.play_count"})
+
+    def test_record_track_started_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        index, track_path = self._make_index_with_track(tmp_path)
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        index.record_track_started(track_path)
+        index.close()
+        cb.assert_called_once_with({"track.last_played"})
+
+    def test_upsert_many_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        from kamp_core.library import Track
+
+        index = LibraryIndex(tmp_path / "library.db")
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        track = Track(
+            file_path=tmp_path / "a.mp3",
+            title="Song A",
+            artist="Alvvays",
+            album_artist="Alvvays",
+            album="Antisocialites",
+            year="2017",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="Indie",
+            favorite=False,
+            play_count=0,
+            source="local",
+        )
+        index.upsert_many([track])
+        index.close()
+        cb.assert_called_once()
+        fields_arg = cb.call_args[0][0]
+        assert "track.artist" in fields_arg
+        assert "track.album" in fields_arg
+        assert "track.genre" in fields_arg
+        assert "track.source" in fields_arg
+        assert "track.year" in fields_arg
+
+    def test_remove_track_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        index, track_path = self._make_index_with_track(tmp_path)
+        cb = MagicMock()
+        index.on_fields_changed = cb
+        index.remove_track(track_path)
+        index.close()
+        cb.assert_called_once()
+        fields_arg = cb.call_args[0][0]
+        assert "track.artist" in fields_arg
+        assert "track.favorite" in fields_arg
+        assert "track.play_count" in fields_arg
+        assert "track.last_played" in fields_arg
+
+    def test_list_all_magic_criteria_returns_all(self, tmp_path: Path) -> None:
+        index, _ = self._make_index_with_track(tmp_path)
+        mc1 = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.favorite", op="is", value="true")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        mc2 = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.play_count", op="gt", value="5")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        id1 = index.create_magic_playlist("Favorites", mc1)
+        id2 = index.create_magic_playlist("Most Played", mc2)
+        result = index.list_all_magic_criteria()
+        index.close()
+        assert len(result) == 2
+        ids = {pair[0] for pair in result}
+        assert ids == {id1, id2}
+        criteria_by_id = {pair[0]: pair[1] for pair in result}
+        assert criteria_by_id[id1].groups[0].conditions[0].field == "track.favorite"
+        assert criteria_by_id[id2].groups[0].conditions[0].field == "track.play_count"
+
+    def test_list_all_magic_criteria_empty_when_none(self, tmp_path: Path) -> None:
+        index, _ = self._make_index_with_track(tmp_path)
+        index.close()
+        index2 = LibraryIndex(tmp_path / "library.db")
+        result = index2.list_all_magic_criteria()
+        index2.close()
+        assert result == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,6 +57,8 @@ def mock_index() -> MagicMock:
     index.get_playlist_cover.return_value = None
     # Default: no magic criteria (static playlist). Individual tests override.
     index.get_magic_playlist_criteria.return_value = None
+    # Default: no magic playlists for field_index building.
+    index.list_all_magic_criteria.return_value = []
     return index
 
 
@@ -5575,3 +5577,52 @@ class TestPlaylistArt:
             )
 
         assert resp.status_code == 422
+
+
+class TestMagicPlaylistReactivity:
+    """Tests for the field_index rebuild and on_fields_changed callback (KAMP-462)."""
+
+    def test_field_index_rebuilt_after_create_magic_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.create_magic_playlist.return_value = 5
+        mock_index.get_playlist.return_value = _playlist(id=5, title="Favs")
+        mock_index.list_all_magic_criteria.reset_mock()
+        client.post(
+            "/api/v1/playlists",
+            json={"title": "Favs", "criteria": _SAMPLE_CRITERIA},
+        )
+        mock_index.list_all_magic_criteria.assert_called()
+
+    def test_field_index_not_rebuilt_after_create_static_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.create_playlist.return_value = _playlist(title="Static")
+        mock_index.list_all_magic_criteria.reset_mock()
+        client.post("/api/v1/playlists", json={"title": "Static"})
+        mock_index.list_all_magic_criteria.assert_not_called()
+
+    def test_field_index_rebuilt_after_delete_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.list_all_magic_criteria.reset_mock()
+        client.delete("/api/v1/playlists/1")
+        mock_index.list_all_magic_criteria.assert_called()
+
+    def test_field_index_rebuilt_after_update_criteria(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.list_all_magic_criteria.reset_mock()
+        client.put("/api/v1/playlists/1/criteria", json={"criteria": _SAMPLE_CRITERIA})
+        mock_index.list_all_magic_criteria.assert_called()
+
+    def test_on_fields_changed_is_callable_and_no_crash(
+        self, client: TestClient
+    ) -> None:
+        # Verify the callback is exposed on app.state and can be called without
+        # error even with no WebSocket clients connected (_event_loop is None).
+        on_fields_changed = client.app.state.on_fields_changed
+        assert callable(on_fields_changed)
+        on_fields_changed({"track.favorite"})  # must not raise


### PR DESCRIPTION
## Summary

- Adds a `field_index: dict[str, set[int]]` in the server closure mapping field names to the set of magic playlist IDs whose criteria reference that field
- `LibraryIndex` gains `on_fields_changed: Callable[[set[str]], None] | None = None` attribute + new `list_all_magic_criteria()` method
- Six mutation methods (`set_favorite`, `toggle_album_favorite`, `record_played`, `record_track_started`, `upsert_many`, `remove_track`) fire the callback after committing with the relevant field set
- Server callback looks up affected playlist IDs, debounces to ≤1 event/second per playlist, and broadcasts `{"type": "magic_playlist.updated", "id": N}`
- Field_index rebuilt at startup and after magic CRUD (create playlist with criteria, DELETE playlist, PUT criteria)
- 9 new library tests + 5 new server tests; 1995 tests passing, 93.18% coverage

## Test plan

- [ ] Create a magic playlist filtering on `track.favorite = true`
- [ ] Connect a WS client (browser devtools or wscat) and subscribe
- [ ] Toggle a track's favorite flag → observe `{"type": "magic_playlist.updated", "id": N}` on the WS feed
- [ ] Toggle same track's favorite again within 1 second → observe only one event (debounce)
- [ ] Toggle a field not referenced by any magic playlist → no event
- [ ] Delete the magic playlist → toggle the track favorite again → no event (field_index cleaned up)
- [ ] Create a magic playlist filtering on `track.play_count > 5`; play a track to natural end → event for that playlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)