### PR TITLE
feat(KAMP-463): magic playlist visual identity + collection filter

### DIFF
--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -80,6 +80,14 @@ export type ScanResult = {
   updated: number
 }
 
+export type CriteriaCondition = { field: string; op: string; value: string }
+export type CriteriaGroup = {
+  match: 'all' | 'any'
+  negate: boolean
+  conditions: CriteriaCondition[]
+}
+export type CriteriaDoc = { match: 'all' | 'any'; groups: CriteriaGroup[] }
+
 export type Playlist = {
   id: number
   title: string
@@ -88,6 +96,7 @@ export type Playlist = {
   created_at: number
   updated_at: number
   last_played_at: number | null
+  criteria: CriteriaDoc | null
 }
 
 export type PlaylistTrack = Track & {

--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -219,3 +219,43 @@
   pointer-events: none;
   z-index: 2;
 }
+
+/* Magic playlist badge — top-left of art area (KAMP-463) */
+.playlist-magic-badge {
+  position: absolute;
+  left: 6px;
+  top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 5px;
+  border-radius: 3px;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.playlist-magic-badge::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.25) 50%, transparent 100%);
+  transform: translateX(-100%);
+}
+
+.album-card:hover .playlist-magic-badge::after {
+  animation: magic-shimmer 0.7s ease-out 1 forwards;
+}
+
+@keyframes magic-shimmer {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}

--- a/kamp_ui/src/renderer/src/assets/album-grid.css
+++ b/kamp_ui/src/renderer/src/assets/album-grid.css
@@ -208,3 +208,74 @@
   padding: 40px;
   text-align: center;
 }
+
+/* Playlist type filter (KAMP-463) ------------------------------------------ */
+
+.playlist-type-filter {
+  display: flex;
+  gap: 2px;
+}
+
+.playlist-type-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 3px 8px;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.playlist-type-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.playlist-type-btn.active {
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* Playlist CTA buttons (KAMP-463) ------------------------------------------ */
+
+.playlist-cta-group {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.playlist-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 3px 8px;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.playlist-cta-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.playlist-cta-btn--magic {
+  color: var(--accent);
+  border-color: var(--accent-dim);
+}
+
+.playlist-cta-btn--magic:hover {
+  background: var(--accent-dim);
+}

--- a/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
@@ -3,7 +3,7 @@ import { useStore } from '../store'
 import { playlistArtUrl } from '../api/client'
 import type { Playlist } from '../api/client'
 import { PlaylistContextMenu } from './PlaylistContextMenu'
-import { FavoriteIcon } from './TransportIcons'
+import { FavoriteIcon, SparkleIcon } from './TransportIcons'
 
 type MenuPos = { x: number; y: number }
 
@@ -50,6 +50,12 @@ export function PlaylistCard({
           onLoad={() => setArtLoaded(true)}
           onError={() => setArtLoaded(false)}
         />
+        {playlist.criteria !== null && (
+          <div className="playlist-magic-badge">
+            <SparkleIcon size={10} />
+            <span>Magic</span>
+          </div>
+        )}
       </div>
       <div className="album-info">
         <div className="album-title">{playlist.title}</div>

--- a/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useStore } from '../store'
 import { PlaylistCard } from './PlaylistCard'
 import { SortControl } from './SortControl'
+import { SparkleIcon } from './TransportIcons'
 import type { Playlist } from '../api/client'
 
 const PLAYLIST_SORT_OPTIONS = [
@@ -12,8 +13,10 @@ const PLAYLIST_SORT_OPTIONS = [
 ]
 
 type PlaylistSortOrder = 'title' | 'track_count' | 'updated_at' | 'last_played_at'
+type TypeFilter = 'all' | 'magic' | 'simple'
 
 const STORAGE_KEY = 'kamp:playlists-sort'
+const TYPE_FILTER_KEY = 'kamp:playlists-type-filter'
 
 function loadStoredSort(): { order: PlaylistSortOrder; dir: 'asc' | 'desc' } {
   try {
@@ -26,6 +29,16 @@ function loadStoredSort(): { order: PlaylistSortOrder; dir: 'asc' | 'desc' } {
     // ignore malformed storage
   }
   return { order: 'title', dir: 'asc' }
+}
+
+function loadStoredTypeFilter(): TypeFilter {
+  try {
+    const raw = localStorage.getItem(TYPE_FILTER_KEY)
+    if (raw === 'magic' || raw === 'simple') return raw
+  } catch {
+    // ignore malformed storage
+  }
+  return 'all'
 }
 
 function sortPlaylists(
@@ -56,9 +69,11 @@ function sortPlaylists(
 
 export function PlaylistGrid(): React.JSX.Element {
   const playlists = useStore((s) => s.library.playlists)
+  const createPlaylist = useStore((s) => s.createPlaylist)
   const stored = loadStoredSort()
   const [sortOrder, setSortOrderLocal] = useState<PlaylistSortOrder>(stored.order)
   const [sortDir, setSortDirLocal] = useState<'asc' | 'desc'>(stored.dir)
+  const [typeFilter, setTypeFilterLocal] = useState<TypeFilter>(loadStoredTypeFilter)
 
   const persist = (order: PlaylistSortOrder, dir: 'asc' | 'desc'): void => {
     try {
@@ -79,7 +94,33 @@ export function PlaylistGrid(): React.JSX.Element {
     persist(sortOrder, dir)
   }
 
-  const visible = sortPlaylists(playlists, sortOrder, sortDir)
+  const handleTypeFilter = (f: TypeFilter): void => {
+    setTypeFilterLocal(f)
+    try {
+      localStorage.setItem(TYPE_FILTER_KEY, f)
+    } catch {
+      // ignore storage errors
+    }
+  }
+
+  const handleNewPlaylist = async (): Promise<void> => {
+    const title = window.prompt('Playlist name:')
+    if (!title?.trim()) return
+    await createPlaylist(title.trim())
+  }
+
+  const handleNewMagicPlaylist = (): void => {
+    // KAMP-464 opens the criteria builder modal here
+  }
+
+  const typeFiltered =
+    typeFilter === 'magic'
+      ? playlists.filter((p) => p.criteria !== null)
+      : typeFilter === 'simple'
+        ? playlists.filter((p) => p.criteria === null)
+        : playlists
+
+  const visible = sortPlaylists(typeFiltered, sortOrder, sortDir)
 
   if (playlists.length === 0) {
     return (
@@ -95,6 +136,26 @@ export function PlaylistGrid(): React.JSX.Element {
   return (
     <div className="album-grid-container">
       <div className="album-grid-toolbar">
+        <div className="playlist-type-filter">
+          <button
+            className={`playlist-type-btn${typeFilter === 'all' ? ' active' : ''}`}
+            onClick={() => handleTypeFilter('all')}
+          >
+            All
+          </button>
+          <button
+            className={`playlist-type-btn${typeFilter === 'magic' ? ' active' : ''}`}
+            onClick={() => handleTypeFilter('magic')}
+          >
+            Magic
+          </button>
+          <button
+            className={`playlist-type-btn${typeFilter === 'simple' ? ' active' : ''}`}
+            onClick={() => handleTypeFilter('simple')}
+          >
+            Simple
+          </button>
+        </div>
         <SortControl
           value={sortOrder}
           options={PLAYLIST_SORT_OPTIONS}
@@ -102,12 +163,27 @@ export function PlaylistGrid(): React.JSX.Element {
           onChange={handleOrderChange}
           onDirChange={handleDirChange}
         />
+        <div className="playlist-cta-group">
+          <button className="playlist-cta-btn" onClick={() => void handleNewPlaylist()}>
+            New Playlist
+          </button>
+          <button className="playlist-cta-btn playlist-cta-btn--magic" onClick={handleNewMagicPlaylist}>
+            <SparkleIcon size={12} />
+            New Magic Playlist
+          </button>
+        </div>
       </div>
-      <div className="album-grid">
-        {visible.map((pl) => (
-          <PlaylistCard key={pl.id} playlist={pl} />
-        ))}
-      </div>
+      {visible.length === 0 && typeFilter === 'magic' ? (
+        <div className="album-grid-empty">
+          No magic playlists yet. Set some rules and Kamp builds the playlist for you &mdash; automatically.
+        </div>
+      ) : (
+        <div className="album-grid">
+          {visible.map((pl) => (
+            <PlaylistCard key={pl.id} playlist={pl} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
@@ -167,7 +167,10 @@ export function PlaylistGrid(): React.JSX.Element {
           <button className="playlist-cta-btn" onClick={() => void handleNewPlaylist()}>
             New Playlist
           </button>
-          <button className="playlist-cta-btn playlist-cta-btn--magic" onClick={handleNewMagicPlaylist}>
+          <button
+            className="playlist-cta-btn playlist-cta-btn--magic"
+            onClick={handleNewMagicPlaylist}
+          >
             <SparkleIcon size={12} />
             New Magic Playlist
           </button>
@@ -175,7 +178,8 @@ export function PlaylistGrid(): React.JSX.Element {
       </div>
       {visible.length === 0 && typeFilter === 'magic' ? (
         <div className="album-grid-empty">
-          No magic playlists yet. Set some rules and Kamp builds the playlist for you &mdash; automatically.
+          No magic playlists yet. Set some rules and Kamp builds the playlist for you &mdash;
+          automatically.
         </div>
       ) : (
         <div className="album-grid">

--- a/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
@@ -70,6 +70,8 @@ function sortPlaylists(
 export function PlaylistGrid(): React.JSX.Element {
   const playlists = useStore((s) => s.library.playlists)
   const createPlaylist = useStore((s) => s.createPlaylist)
+  const selectPlaylist = useStore((s) => s.selectPlaylist)
+  const setCollectionType = useStore((s) => s.setCollectionType)
   const stored = loadStoredSort()
   const [sortOrder, setSortOrderLocal] = useState<PlaylistSortOrder>(stored.order)
   const [sortDir, setSortDirLocal] = useState<'asc' | 'desc'>(stored.dir)
@@ -103,10 +105,12 @@ export function PlaylistGrid(): React.JSX.Element {
     }
   }
 
-  const handleNewPlaylist = async (): Promise<void> => {
-    const title = window.prompt('Playlist name:')
-    if (!title?.trim()) return
-    await createPlaylist(title.trim())
+  const handleNewPlaylist = (): void => {
+    void (async () => {
+      const pl = await createPlaylist('New Playlist')
+      setCollectionType('playlists')
+      await selectPlaylist(pl)
+    })()
   }
 
   const handleNewMagicPlaylist = (): void => {
@@ -164,7 +168,7 @@ export function PlaylistGrid(): React.JSX.Element {
           onDirChange={handleDirChange}
         />
         <div className="playlist-cta-group">
-          <button className="playlist-cta-btn" onClick={() => void handleNewPlaylist()}>
+          <button className="playlist-cta-btn" onClick={handleNewPlaylist}>
             New Playlist
           </button>
           <button

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -264,16 +264,18 @@ export function TrackContextMenu({
             </button>
           )}
           <ContextMenuSubmenu label="Add to Playlist">
-            {playlists.map((pl) => (
-              <button
-                key={pl.id}
-                className="track-context-menu-item"
-                onClick={() => handleAddToPlaylist(pl.id)}
-              >
-                {truncateTitle(pl.title)}
-              </button>
-            ))}
-            {playlists.length > 0 && <div className="track-context-menu-divider" />}
+            {playlists
+              .filter((pl) => !pl.criteria)
+              .map((pl) => (
+                <button
+                  key={pl.id}
+                  className="track-context-menu-item"
+                  onClick={() => handleAddToPlaylist(pl.id)}
+                >
+                  {truncateTitle(pl.title)}
+                </button>
+              ))}
+            {playlists.some((pl) => !pl.criteria) && <div className="track-context-menu-divider" />}
             <button className="track-context-menu-item" onClick={handleNewPlaylist}>
               New Playlist
             </button>

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -319,3 +319,22 @@ export function SortDescIcon({ size = 12 }: IconProps): React.JSX.Element {
     </svg>
   )
 }
+
+export function SparkleIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <path d="M12 2 L13.5 10.5 L22 12 L13.5 13.5 L12 22 L10.5 13.5 L2 12 L10.5 10.5 Z" />
+    </svg>
+  )
+}
+
+export function GridViewIcon({ size = 20 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...FILL_PROPS}>
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

- `client.ts`: adds `CriteriaDoc` / `CriteriaGroup` / `CriteriaCondition` types; `Playlist` gains `criteria: CriteriaDoc | null` so magic vs. simple is derivable client-side
- `TransportIcons.tsx`: `SparkleIcon` (four-pointed diamond star) and `GridViewIcon` (2×2 squares)
- `PlaylistCard.tsx`: sparkle badge positioned top-left of art area on magic playlists; hover-only single-pass CSS shimmer (`transform: translateX`) via `album-card.css`
- `PlaylistGrid.tsx`: All / Magic / Simple type filter (localStorage-persisted), "New Playlist" (window.prompt → createPlaylist) and "New Magic Playlist" CTAs, magic-filter empty state
- `TrackContextMenu.tsx`: "Add to Playlist" submenu now filters out magic playlists (`playlists.filter(pl => !pl.criteria)`) since magic playlists are auto-managed

## Test plan

- [ ] Create a simple and a magic playlist; verify magic card shows sparkle badge top-left of art
- [ ] Hover magic card; shimmer fires once and stops (not looping)
- [ ] Type filter: All shows both; Magic shows only magic; Simple shows only simple
- [ ] Magic filter with no magic playlists → correct empty-state message
- [ ] Reload; type filter selection restored from localStorage
- [ ] Right-click track → Add to Playlist submenu: magic playlists absent
- [ ] "New Playlist" button: prompt → title → playlist appears in grid
- [ ] "New Magic Playlist" button: clickable, no crash (modal wired in KAMP-464)

🤖 Generated with [Claude Code](https://claude.com/claude-code)