### PR TITLE
feat(KAMP-464): criteria builder modal for magic playlists

### DIFF
--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -45,8 +45,12 @@ def _coerce(value: str, vtype: str) -> Any:
     if vtype == "bool":
         return 1 if value.lower() == "true" else 0
     if vtype == "int":
+        if not value.strip():
+            raise ValueError(f"empty value for int field")
         return int(value)
     if vtype == "float":
+        if not value.strip():
+            raise ValueError(f"empty value for float field")
         return float(value)
     # "text" and "year" pass through as-is; year CAST happens in SQL.
     return value
@@ -120,7 +124,7 @@ def _condition_sql(cond: "Condition") -> tuple[str, list[Any], bool]:
 def _group_sql(group: "Group") -> tuple[str, list[Any], bool]:
     """Return ``(sql_fragment, params, needs_album_join)`` for a condition group."""
     if not group.conditions:
-        return "1", [], False
+        return "0", [], False
 
     joiner = " AND " if group.match == "all" else " OR "
     parts: list[str] = []
@@ -150,10 +154,11 @@ def build_query(criteria: "MagicCriteria") -> tuple[str, list[Any], bool]:
     Returns ``(where_fragment, params, needs_album_join)``.  The caller is
     responsible for composing the full SELECT and adding a LEFT JOIN on albums
     when ``needs_album_join`` is True.  An empty criteria (no groups) returns
-    ``("1", [], False)`` so the caller always gets a valid SQL fragment.
+    ``("0", [], False)`` — matching nothing — so the caller always gets a valid
+    SQL fragment.
     """
     if not criteria.groups:
-        return "1", [], False
+        return "0", [], False
 
     joiner = " AND " if criteria.match == "all" else " OR "
     parts: list[str] = []

--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -25,6 +25,7 @@ _FIELD_MAP: dict[str, tuple[str, str]] = {
     "track.year": ("tracks.year", "year"),
     "track.genre": ("tracks.genre", "text"),
     "track.artist": ("tracks.artist", "text"),
+    "track.album_artist": ("tracks.album_artist", "text"),
     "track.album": ("tracks.album", "text"),
     "track.source": ("tracks.source", "text"),
 }

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 33
+_SCHEMA_VERSION = 34
 
 
 @dataclass
@@ -342,10 +342,12 @@ CREATE TABLE IF NOT EXISTS playlist_tracks (
 -- Magic playlist criteria (KAMP-459). A playlist is magic iff it has a row here.
 -- criteria_json stores a MagicCriteria JSON blob. evaluated_at is the epoch time of
 -- the last evaluation; NULL means the cache is stale and must be rebuilt.
+-- cached_track_count stores the result count from the last evaluation (KAMP-464).
 CREATE TABLE IF NOT EXISTS magic_playlist_criteria (
-    playlist_id  INTEGER PRIMARY KEY REFERENCES playlists(id) ON DELETE CASCADE,
-    criteria_json TEXT NOT NULL,
-    evaluated_at  REAL
+    playlist_id         INTEGER PRIMARY KEY REFERENCES playlists(id) ON DELETE CASCADE,
+    criteria_json       TEXT NOT NULL,
+    evaluated_at        REAL,
+    cached_track_count  INTEGER
 );
 """
 
@@ -1239,7 +1241,25 @@ class LibraryIndex:
             """)
             self._conn.execute("UPDATE schema_version SET version = 33")
             self._conn.commit()
-            version = 33  # noqa: F841
+            version = 33
+
+        if version == 33:
+            # v33 → v34: cache evaluated track count in magic_playlist_criteria.
+            # Guard with PRAGMA in case a fresh DB already has the column via DDL.
+            cols = {
+                r[1]
+                for r in self._conn.execute(
+                    "PRAGMA table_info(magic_playlist_criteria)"
+                )
+            }
+            if "cached_track_count" not in cols:
+                self._conn.execute(
+                    "ALTER TABLE magic_playlist_criteria"
+                    " ADD COLUMN cached_track_count INTEGER"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 34")
+            self._conn.commit()
+            version = 34  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table."""
@@ -3167,9 +3187,15 @@ class LibraryIndex:
         """Return all playlists with their track counts, ordered by title."""
         rows = self._conn.execute("""
             SELECT p.id, p.title, p.favorite, p.created_at, p.updated_at,
-                   p.last_played_at, COUNT(pt.id) AS track_count
+                   p.last_played_at,
+                   CASE
+                     WHEN mpc.playlist_id IS NOT NULL
+                       THEN COALESCE(mpc.cached_track_count, 0)
+                     ELSE COUNT(pt.id)
+                   END AS track_count
             FROM playlists p
             LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+            LEFT JOIN magic_playlist_criteria mpc ON mpc.playlist_id = p.id
             GROUP BY p.id
             ORDER BY p.title COLLATE NOCASE
             """).fetchall()
@@ -3191,9 +3217,15 @@ class LibraryIndex:
         row = self._conn.execute(
             """
             SELECT p.id, p.title, p.favorite, p.created_at, p.updated_at,
-                   p.last_played_at, COUNT(pt.id) AS track_count
+                   p.last_played_at,
+                   CASE
+                     WHEN mpc.playlist_id IS NOT NULL
+                       THEN COALESCE(mpc.cached_track_count, 0)
+                     ELSE COUNT(pt.id)
+                   END AS track_count
             FROM playlists p
             LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+            LEFT JOIN magic_playlist_criteria mpc ON mpc.playlist_id = p.id
             WHERE p.id = ?
             GROUP BY p.id
             """,
@@ -3520,6 +3552,15 @@ class LibraryIndex:
             ORDER BY tracks.id
         """
         rows = self._conn.execute(sql, params).fetchall()
+        # Cache the evaluated count so get_playlists can show it immediately.
+        import time as _t  # noqa: PLC0415
+
+        self._conn.execute(
+            "UPDATE magic_playlist_criteria"
+            " SET cached_track_count = ?, evaluated_at = ? WHERE playlist_id = ?",
+            (len(rows), _t.time(), playlist_id),
+        )
+        self._conn.commit()
         return [
             {
                 "playlist_track_id": None,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3333,9 +3333,9 @@ def create_app(
     def preview_criteria(req: CriteriaPreviewRequest) -> dict[str, Any]:
         try:
             mc = MagicCriteria.from_dict(req.criteria)
+            return {"count": index.count_magic_criteria(mc)}
         except (KeyError, TypeError, ValueError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return {"count": index.count_magic_criteria(mc)}
 
     @app.post("/api/v1/playlists/{playlist_id}/tracks")
     def add_to_playlist(

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3422,7 +3422,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="Playlist not found")
 
         updated = index.set_playlist_cover(playlist_id, image_data)
-        return PlaylistOut(**updated)  # type: ignore[arg-type]
+        return PlaylistOut(**_enrich_playlist(updated))  # type: ignore[arg-type]
 
     # -----------------------------------------------------------------------
     # WebSocket: player state stream

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp",
-  "version": "1.20.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp",
-      "version": "1.20.0",
+      "version": "1.23.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
+        "@tanstack/react-virtual": "^3.14.2",
         "react-markdown": "^10.1.0",
         "zustand": "^5.0.12"
       },
@@ -2274,6 +2275,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+      "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {
@@ -8848,7 +8876,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -9295,7 +9322,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/kamp_ui/package.json
+++ b/kamp_ui/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@tanstack/react-virtual": "^3.14.2",
     "react-markdown": "^10.1.0",
     "zustand": "^5.0.12"
   },

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -261,6 +261,12 @@ export default function App(): React.JSX.Element {
               void useStore.getState().refreshOpenAlbum()
             }
           }
+        },
+        (id) => {
+          const { selectedPlaylist } = useStore.getState().library
+          if (selectedPlaylist?.id === id) {
+            void useStore.getState().loadPlaylistTracks(id)
+          }
         }
       )
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -622,6 +622,10 @@ export type AlbumDownloadMessage = {
   sale_item_id: string
   state: 'queued' | 'downloading' | 'done' | 'error'
 }
+export type MagicPlaylistUpdatedMessage = {
+  type: 'magic_playlist.updated'
+  id: number
+}
 export type ServerMessage =
   | StateMessage
   | TrackChangedMessage
@@ -630,6 +634,7 @@ export type ServerMessage =
   | DeferredOpCompletedMessage
   | AudioLevelMessage
   | AlbumDownloadMessage
+  | MagicPlaylistUpdatedMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -648,7 +653,11 @@ export function connectStateStream(
   onDeferredOpCompleted?: (trackId: number, opId: number) => void,
   onAudioLevel?: (leftDb: number, rightDb: number, crestDb: number, peakDb: number) => void,
   onTrackChanged?: () => void,
-  onAlbumDownload?: (saleItemId: string, state: 'queued' | 'downloading' | 'done' | 'error') => void
+  onAlbumDownload?: (
+    saleItemId: string,
+    state: 'queued' | 'downloading' | 'done' | 'error'
+  ) => void,
+  onMagicPlaylistUpdated?: (id: number) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -667,6 +676,7 @@ export function connectStateStream(
         onAudioLevel?.(msg.left_db, msg.right_db, msg.crest_db, msg.peak_db)
       else if (msg.type === 'bandcamp.album-download')
         onAlbumDownload?.(msg.sale_item_id, msg.state)
+      else if (msg.type === 'magic_playlist.updated') onMagicPlaylistUpdated?.(msg.id)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -80,7 +80,30 @@ export type ScanResult = {
   updated: number
 }
 
-export type CriteriaCondition = { field: string; op: string; value: string }
+export type CriteriaField =
+  | 'track.favorite'
+  | 'album.favorite'
+  | 'track.play_count'
+  | 'track.year'
+  | 'track.last_played'
+  | 'track.date_added'
+  | 'track.genre'
+  | 'track.artist'
+  | 'track.album'
+  | 'track.source'
+  | 'in_playlist'
+
+export type CriteriaOperator =
+  | 'is'
+  | 'is_not'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'contains'
+  | 'not_contains'
+
+export type CriteriaCondition = { field: CriteriaField; op: CriteriaOperator; value: string }
 export type CriteriaGroup = {
   match: 'all' | 'any'
   negate: boolean
@@ -787,3 +810,12 @@ export const reorderPlaylistTracks = (id: number, trackIds: number[]): Promise<v
 
 export const recordPlaylistPlayed = (id: number): Promise<void> =>
   post(`/api/v1/playlists/${id}/played`, {})
+
+export const previewCriteria = (criteria: CriteriaDoc): Promise<{ count: number }> =>
+  post('/api/v1/criteria/preview', { criteria })
+
+export const createMagicPlaylist = (title: string, criteria: CriteriaDoc): Promise<Playlist> =>
+  post('/api/v1/playlists', { title, criteria })
+
+export const updateMagicPlaylistCriteria = (id: number, criteria: CriteriaDoc): Promise<Playlist> =>
+  put(`/api/v1/playlists/${id}/criteria`, { criteria })

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -89,6 +89,7 @@ export type CriteriaField =
   | 'track.date_added'
   | 'track.genre'
   | 'track.artist'
+  | 'track.album_artist'
   | 'track.album'
   | 'track.source'
   | 'in_playlist'

--- a/kamp_ui/src/renderer/src/assets/magic-playlist-modal.css
+++ b/kamp_ui/src/renderer/src/assets/magic-playlist-modal.css
@@ -1,0 +1,362 @@
+/* Magic Playlist criteria builder modal (KAMP-464) */
+/* .prefs-overlay is reused from preferences.css for the backdrop */
+
+.magic-playlist-dialog {
+  width: 600px;
+  max-height: 80vh;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: prefs-in 150ms ease;
+}
+
+/* Header ------------------------------------------------------------------- */
+
+.magic-playlist-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  height: 44px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.magic-playlist-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.magic-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0 4px;
+  transition: color 0.1s;
+}
+
+.magic-close-btn:hover {
+  color: var(--text);
+}
+
+/* Body --------------------------------------------------------------------- */
+
+.magic-playlist-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Title row (create mode) */
+.magic-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.magic-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+  width: 40px;
+}
+
+/* Top-level match sentence */
+.magic-top-match-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+/* Groups ------------------------------------------------------------------- */
+
+.magic-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.magic-group {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: var(--surface-hover);
+}
+
+.magic-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.magic-group-label {
+  flex: 1;
+}
+
+.magic-conditions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.magic-group-separator {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  padding: 4px 0;
+  margin-bottom: 8px;
+}
+
+/* Condition row ------------------------------------------------------------ */
+
+.magic-condition {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.magic-date-input {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Add rule / Add group buttons */
+.magic-add-rule-btn,
+.magic-add-group-btn {
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 10px;
+  transition:
+    border-color 0.1s,
+    color 0.1s;
+  align-self: flex-start;
+}
+
+.magic-add-rule-btn:hover,
+.magic-add-group-btn:hover {
+  border-color: var(--accent-dim);
+  color: var(--accent);
+}
+
+.magic-add-group-btn {
+  align-self: flex-start;
+}
+
+/* Shared form controls ----------------------------------------------------- */
+
+.magic-select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  height: 28px;
+  padding: 0 6px;
+  outline: none;
+}
+
+.magic-select:focus {
+  border-color: var(--accent-dim);
+}
+
+.magic-select--field {
+  min-width: 140px;
+}
+
+.magic-select--wide {
+  min-width: 180px;
+  max-width: 240px;
+}
+
+.magic-input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 12px;
+  height: 28px;
+  padding: 0 8px;
+  outline: none;
+}
+
+.magic-input:focus {
+  border-color: var(--accent-dim);
+}
+
+.magic-input--title {
+  flex: 1;
+}
+
+.magic-input--text {
+  min-width: 140px;
+  flex: 1;
+}
+
+.magic-input--number {
+  width: 64px;
+}
+
+/* Match pill --------------------------------------------------------------- */
+
+.match-pill {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 10px;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.match-pill--active,
+.match-pill:hover {
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* Negate button ------------------------------------------------------------ */
+
+.magic-negate-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.magic-negate-btn:hover,
+.magic-negate-btn--active {
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* Remove buttons ----------------------------------------------------------- */
+
+.magic-remove-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+  flex-shrink: 0;
+  transition: color 0.1s;
+}
+
+.magic-remove-btn:hover {
+  color: var(--error);
+}
+
+.magic-remove-btn--group {
+  margin-left: auto;
+}
+
+/* Footer ------------------------------------------------------------------- */
+
+.magic-playlist-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.magic-preview-text {
+  font-size: 12px;
+  color: var(--text-dim);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.magic-footer-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.magic-btn {
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 14px;
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+
+.magic-btn--cancel {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+.magic-btn--cancel:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.magic-btn--save {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: var(--text-on-accent);
+}
+
+.magic-btn--save:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.magic-btn--save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
@@ -12,6 +12,7 @@ type FieldType = 'bool' | 'int' | 'date' | 'text' | 'source' | 'playlist'
 
 const FIELD_META: Record<CriteriaField, { label: string; type: FieldType }> = {
   'track.artist': { label: 'Artist', type: 'text' },
+  'track.album_artist': { label: 'Album Artist', type: 'text' },
   'track.album': { label: 'Album', type: 'text' },
   'track.genre': { label: 'Genre', type: 'text' },
   'track.year': { label: 'Year', type: 'int' },
@@ -26,6 +27,7 @@ const FIELD_META: Record<CriteriaField, { label: string; type: FieldType }> = {
 
 const FIELD_ORDER: CriteriaField[] = [
   'track.artist',
+  'track.album_artist',
   'track.album',
   'track.genre',
   'track.year',

--- a/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
@@ -1,0 +1,774 @@
+import React, { useEffect, useReducer, useState } from 'react'
+import { useStore } from '../store'
+import { previewCriteria } from '../api/client'
+import type { CriteriaDoc, CriteriaField, CriteriaOperator, Playlist } from '../api/client'
+import '../assets/magic-playlist-modal.css'
+
+// ---------------------------------------------------------------------------
+// Field metadata
+// ---------------------------------------------------------------------------
+
+type FieldType = 'bool' | 'int' | 'date' | 'text' | 'source' | 'playlist'
+
+const FIELD_META: Record<CriteriaField, { label: string; type: FieldType }> = {
+  'track.artist': { label: 'Artist', type: 'text' },
+  'track.album': { label: 'Album', type: 'text' },
+  'track.genre': { label: 'Genre', type: 'text' },
+  'track.year': { label: 'Year', type: 'int' },
+  'track.play_count': { label: 'Play Count', type: 'int' },
+  'track.favorite': { label: 'Favorited Track', type: 'bool' },
+  'album.favorite': { label: 'Favorited Album', type: 'bool' },
+  'track.last_played': { label: 'Last Played', type: 'date' },
+  'track.date_added': { label: 'Date Added', type: 'date' },
+  'track.source': { label: 'Source', type: 'source' },
+  in_playlist: { label: 'In Playlist', type: 'playlist' }
+}
+
+const FIELD_ORDER: CriteriaField[] = [
+  'track.artist',
+  'track.album',
+  'track.genre',
+  'track.year',
+  'track.play_count',
+  'track.favorite',
+  'album.favorite',
+  'track.last_played',
+  'track.date_added',
+  'track.source',
+  'in_playlist'
+]
+
+// Operators available per field type, with display labels
+const OPS_FOR_TYPE: Record<FieldType, { op: CriteriaOperator; label: string }[]> = {
+  bool: [{ op: 'is', label: 'is' }],
+  int: [
+    { op: 'is', label: 'is' },
+    { op: 'is_not', label: 'is not' },
+    { op: 'gt', label: '>' },
+    { op: 'lt', label: '<' },
+    { op: 'gte', label: '≥' },
+    { op: 'lte', label: '≤' }
+  ],
+  date: [
+    { op: 'gt', label: 'after' },
+    { op: 'lt', label: 'before' },
+    { op: 'gte', label: 'on or after' },
+    { op: 'lte', label: 'on or before' }
+  ],
+  text: [
+    { op: 'contains', label: 'contains' },
+    { op: 'not_contains', label: 'does not contain' },
+    { op: 'is', label: 'is' },
+    { op: 'is_not', label: 'is not' }
+  ],
+  source: [
+    { op: 'is', label: 'is' },
+    { op: 'is_not', label: 'is not' }
+  ],
+  playlist: [
+    { op: 'is', label: 'is in' },
+    { op: 'is_not', label: 'is not in' }
+  ]
+}
+
+function defaultOpForType(type: FieldType): CriteriaOperator {
+  return OPS_FOR_TYPE[type][0].op
+}
+
+// ---------------------------------------------------------------------------
+// State types
+// ---------------------------------------------------------------------------
+
+type DateMeta =
+  | { mode: 'relative'; amount: number; unit: 'days' | 'weeks' | 'months' }
+  | { mode: 'absolute'; date: string }
+
+type ConditionState = {
+  id: string
+  field: CriteriaField
+  op: CriteriaOperator
+  value: string
+  dateMeta?: DateMeta
+}
+
+type GroupState = {
+  id: string
+  match: 'all' | 'any'
+  negate: boolean
+  conditions: ConditionState[]
+}
+
+type ModalState = {
+  title: string
+  match: 'all' | 'any'
+  groups: GroupState[]
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+type Action =
+  | { type: 'SET_TITLE'; title: string }
+  | { type: 'SET_TOP_MATCH'; match: 'all' | 'any' }
+  | { type: 'ADD_GROUP' }
+  | { type: 'REMOVE_GROUP'; groupId: string }
+  | { type: 'SET_GROUP_MATCH'; groupId: string; match: 'all' | 'any' }
+  | { type: 'TOGGLE_GROUP_NEGATE'; groupId: string }
+  | { type: 'ADD_CONDITION'; groupId: string }
+  | { type: 'REMOVE_CONDITION'; groupId: string; conditionId: string }
+  | {
+      type: 'UPDATE_CONDITION'
+      groupId: string
+      conditionId: string
+      patch: Partial<ConditionState>
+    }
+
+let _nextId = 0
+function uid(): string {
+  return String(++_nextId)
+}
+
+function defaultCondition(): ConditionState {
+  return { id: uid(), field: 'track.artist', op: 'contains', value: '' }
+}
+
+function defaultGroup(): GroupState {
+  return { id: uid(), match: 'all', negate: false, conditions: [defaultCondition()] }
+}
+
+function reducer(state: ModalState, action: Action): ModalState {
+  switch (action.type) {
+    case 'SET_TITLE':
+      return { ...state, title: action.title }
+
+    case 'SET_TOP_MATCH':
+      return { ...state, match: action.match }
+
+    case 'ADD_GROUP':
+      return { ...state, groups: [...state.groups, defaultGroup()] }
+
+    case 'REMOVE_GROUP':
+      return { ...state, groups: state.groups.filter((g) => g.id !== action.groupId) }
+
+    case 'SET_GROUP_MATCH':
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId ? { ...g, match: action.match } : g
+        )
+      }
+
+    case 'TOGGLE_GROUP_NEGATE':
+      return {
+        ...state,
+        groups: state.groups.map((g) => (g.id === action.groupId ? { ...g, negate: !g.negate } : g))
+      }
+
+    case 'ADD_CONDITION':
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId ? { ...g, conditions: [...g.conditions, defaultCondition()] } : g
+        )
+      }
+
+    case 'REMOVE_CONDITION':
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId
+            ? { ...g, conditions: g.conditions.filter((c) => c.id !== action.conditionId) }
+            : g
+        )
+      }
+
+    case 'UPDATE_CONDITION': {
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId
+            ? {
+                ...g,
+                conditions: g.conditions.map((c) =>
+                  c.id === action.conditionId ? { ...c, ...action.patch } : c
+                )
+              }
+            : g
+        )
+      }
+    }
+
+    default:
+      return state
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CriteriaDoc builder
+// ---------------------------------------------------------------------------
+
+const UNIT_SECONDS: Record<'days' | 'weeks' | 'months', number> = {
+  days: 86400,
+  weeks: 604800,
+  months: 2592000
+}
+
+function buildCriteriaDoc(state: ModalState): CriteriaDoc {
+  return {
+    match: state.match,
+    groups: state.groups.map((g) => ({
+      match: g.match,
+      negate: g.negate,
+      conditions: g.conditions.map((c) => {
+        const fieldType = FIELD_META[c.field].type
+        let op: CriteriaOperator = c.op
+        let value = c.value
+
+        if (fieldType === 'date' && c.dateMeta) {
+          if (c.dateMeta.mode === 'relative') {
+            op = 'gt'
+            value = String(Date.now() / 1000 - c.dateMeta.amount * UNIT_SECONDS[c.dateMeta.unit])
+          } else if (c.dateMeta.date) {
+            value = String(new Date(c.dateMeta.date).getTime() / 1000)
+          }
+        } else if (fieldType === 'bool') {
+          op = 'is'
+        }
+
+        return { field: c.field, op, value }
+      })
+    }))
+  }
+}
+
+function hasAnyCriteria(state: ModalState): boolean {
+  return state.groups.some((g) => g.conditions.length > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components for condition value inputs
+// ---------------------------------------------------------------------------
+
+function BoolInput({
+  value,
+  onChange
+}: {
+  value: string
+  onChange: (v: string) => void
+}): React.JSX.Element {
+  return (
+    <select
+      className="magic-select"
+      value={value || 'true'}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="true">Yes</option>
+      <option value="false">No</option>
+    </select>
+  )
+}
+
+function SourceInput({
+  value,
+  onChange
+}: {
+  value: string
+  onChange: (v: string) => void
+}): React.JSX.Element {
+  return (
+    <select
+      className="magic-select"
+      value={value || 'local'}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="local">Local</option>
+      <option value="bandcamp">Bandcamp</option>
+    </select>
+  )
+}
+
+function PlaylistInput({
+  value,
+  onChange
+}: {
+  value: string
+  onChange: (v: string) => void
+}): React.JSX.Element {
+  const playlists = useStore((s) => s.library.playlists).filter((p) => !p.criteria)
+  return (
+    <select
+      className="magic-select magic-select--wide"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {playlists.length === 0 && <option value="">No simple playlists</option>}
+      {playlists.map((p) => (
+        <option key={p.id} value={String(p.id)}>
+          {p.title}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function DateInput({
+  dateMeta,
+  op,
+  onChangeDateMeta,
+  onChangeOp
+}: {
+  dateMeta: DateMeta | undefined
+  op: CriteriaOperator
+  onChangeDateMeta: (m: DateMeta) => void
+  onChangeOp: (op: CriteriaOperator) => void
+}): React.JSX.Element {
+  const meta: DateMeta = dateMeta ?? { mode: 'relative', amount: 7, unit: 'days' }
+  const isRelative = meta.mode === 'relative'
+
+  return (
+    <div className="magic-date-input">
+      <select
+        className="magic-select"
+        value={meta.mode}
+        onChange={(e) => {
+          const mode = e.target.value as 'relative' | 'absolute'
+          if (mode === 'relative') {
+            onChangeDateMeta({ mode: 'relative', amount: 7, unit: 'days' })
+          } else {
+            onChangeOp('gt')
+            onChangeDateMeta({ mode: 'absolute', date: '' })
+          }
+        }}
+      >
+        <option value="relative">in the last</option>
+        <option value="absolute">absolute date</option>
+      </select>
+
+      {isRelative && meta.mode === 'relative' ? (
+        <>
+          <input
+            className="magic-input magic-input--number"
+            type="number"
+            min={1}
+            value={meta.amount}
+            onChange={(e) =>
+              onChangeDateMeta({ ...meta, amount: Math.max(1, Number(e.target.value)) })
+            }
+          />
+          <select
+            className="magic-select"
+            value={meta.unit}
+            onChange={(e) =>
+              onChangeDateMeta({ ...meta, unit: e.target.value as 'days' | 'weeks' | 'months' })
+            }
+          >
+            <option value="days">days</option>
+            <option value="weeks">weeks</option>
+            <option value="months">months</option>
+          </select>
+        </>
+      ) : (
+        <>
+          <select
+            className="magic-select"
+            value={op}
+            onChange={(e) => onChangeOp(e.target.value as CriteriaOperator)}
+          >
+            {OPS_FOR_TYPE.date.map(({ op: o, label }) => (
+              <option key={o} value={o}>
+                {label}
+              </option>
+            ))}
+          </select>
+          <input
+            className="magic-input"
+            type="date"
+            value={meta.mode === 'absolute' ? meta.date : ''}
+            onChange={(e) => onChangeDateMeta({ mode: 'absolute', date: e.target.value })}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Condition row
+// ---------------------------------------------------------------------------
+
+function ConditionRow({
+  condition,
+  onUpdate,
+  onRemove
+}: {
+  condition: ConditionState
+  onUpdate: (patch: Partial<ConditionState>) => void
+  onRemove: () => void
+}): React.JSX.Element {
+  const fieldType = FIELD_META[condition.field].type
+  const ops = OPS_FOR_TYPE[fieldType]
+  const isBool = fieldType === 'bool'
+  const isDate = fieldType === 'date'
+
+  const handleFieldChange = (newField: CriteriaField): void => {
+    const newType = FIELD_META[newField].type
+    const newOp = defaultOpForType(newType)
+    const patch: Partial<ConditionState> = {
+      field: newField,
+      op: newOp,
+      value: '',
+      dateMeta: undefined
+    }
+    if (newType === 'date') {
+      patch.dateMeta = { mode: 'relative', amount: 7, unit: 'days' }
+    } else if (newType === 'bool') {
+      patch.value = 'true'
+    }
+    onUpdate(patch)
+  }
+
+  return (
+    <div className="magic-condition">
+      <select
+        className="magic-select magic-select--field"
+        value={condition.field}
+        onChange={(e) => handleFieldChange(e.target.value as CriteriaField)}
+      >
+        {FIELD_ORDER.map((f) => (
+          <option key={f} value={f}>
+            {FIELD_META[f].label}
+          </option>
+        ))}
+      </select>
+
+      {!isBool && !isDate && (
+        <select
+          className="magic-select"
+          value={condition.op}
+          onChange={(e) => onUpdate({ op: e.target.value as CriteriaOperator })}
+        >
+          {ops.map(({ op, label }) => (
+            <option key={op} value={op}>
+              {label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {isBool && <BoolInput value={condition.value} onChange={(v) => onUpdate({ value: v })} />}
+
+      {isDate && (
+        <DateInput
+          dateMeta={condition.dateMeta}
+          op={condition.op}
+          onChangeDateMeta={(m) => onUpdate({ dateMeta: m })}
+          onChangeOp={(op) => onUpdate({ op })}
+        />
+      )}
+
+      {fieldType === 'text' && (
+        <input
+          className="magic-input magic-input--text"
+          type="text"
+          value={condition.value}
+          placeholder="value"
+          onChange={(e) => onUpdate({ value: e.target.value })}
+        />
+      )}
+
+      {fieldType === 'int' && (
+        <input
+          className="magic-input magic-input--number"
+          type="number"
+          value={condition.value}
+          onChange={(e) => onUpdate({ value: e.target.value })}
+        />
+      )}
+
+      {fieldType === 'source' && (
+        <SourceInput value={condition.value} onChange={(v) => onUpdate({ value: v })} />
+      )}
+
+      {fieldType === 'playlist' && (
+        <PlaylistInput value={condition.value} onChange={(v) => onUpdate({ value: v })} />
+      )}
+
+      <button className="magic-remove-btn" title="Remove rule" onClick={onRemove}>
+        ×
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------------
+
+function GroupBlock({
+  group,
+  groupIndex,
+  totalGroups,
+  dispatch
+}: {
+  group: GroupState
+  groupIndex: number
+  totalGroups: number
+  dispatch: React.Dispatch<Action>
+}): React.JSX.Element {
+  return (
+    <div className="magic-group">
+      <div className="magic-group-header">
+        <button
+          className={`match-pill${group.match === 'all' ? ' match-pill--active' : ''}`}
+          title="Toggle All / Any"
+          onClick={() =>
+            dispatch({
+              type: 'SET_GROUP_MATCH',
+              groupId: group.id,
+              match: group.match === 'all' ? 'any' : 'all'
+            })
+          }
+        >
+          {group.match === 'all' ? 'All' : 'Any'}
+        </button>
+        <span className="magic-group-label">of the following rules match</span>
+        <button
+          className={`magic-negate-btn${group.negate ? ' magic-negate-btn--active' : ''}`}
+          title="Toggle NOT"
+          onClick={() => dispatch({ type: 'TOGGLE_GROUP_NEGATE', groupId: group.id })}
+        >
+          NOT
+        </button>
+        {totalGroups > 1 && (
+          <button
+            className="magic-remove-btn magic-remove-btn--group"
+            title="Remove group"
+            onClick={() => dispatch({ type: 'REMOVE_GROUP', groupId: group.id })}
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      <div className="magic-conditions">
+        {group.conditions.map((c) => (
+          <ConditionRow
+            key={c.id}
+            condition={c}
+            onUpdate={(patch) =>
+              dispatch({ type: 'UPDATE_CONDITION', groupId: group.id, conditionId: c.id, patch })
+            }
+            onRemove={() =>
+              dispatch({ type: 'REMOVE_CONDITION', groupId: group.id, conditionId: c.id })
+            }
+          />
+        ))}
+      </div>
+
+      <button
+        className="magic-add-rule-btn"
+        onClick={() => dispatch({ type: 'ADD_CONDITION', groupId: group.id })}
+      >
+        + Add a rule
+      </button>
+
+      {groupIndex < totalGroups - 1 && <div className="magic-group-separator">AND</div>}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Modal
+// ---------------------------------------------------------------------------
+
+function initialState(playlist?: Playlist): ModalState {
+  if (playlist?.criteria) {
+    // Edit mode: load existing criteria into local state
+    const doc = playlist.criteria
+    return {
+      title: playlist.title,
+      match: doc.match,
+      groups: doc.groups.map((g) => ({
+        id: uid(),
+        match: g.match,
+        negate: g.negate,
+        conditions: g.conditions.map((c) => ({
+          id: uid(),
+          field: c.field,
+          op: c.op,
+          value: c.value,
+          // Loaded as absolute mode; relative intent is not round-tripped
+          dateMeta:
+            FIELD_META[c.field]?.type === 'date'
+              ? {
+                  mode: 'absolute',
+                  date: new Date(Number(c.value) * 1000).toISOString().slice(0, 10)
+                }
+              : undefined
+        }))
+      }))
+    }
+  }
+  return { title: '', match: 'all', groups: [defaultGroup()] }
+}
+
+export function MagicPlaylistModal({
+  open,
+  onClose,
+  playlist
+}: {
+  open: boolean
+  onClose: () => void
+  playlist?: Playlist
+}): React.JSX.Element | null {
+  const createMagicPlaylist = useStore((s) => s.createMagicPlaylist)
+  const updateMagicPlaylistCriteria = useStore((s) => s.updateMagicPlaylistCriteria)
+  const selectPlaylist = useStore((s) => s.selectPlaylist)
+  const setCollectionType = useStore((s) => s.setCollectionType)
+
+  const isEditMode = !!playlist
+
+  const [state, dispatch] = useReducer(reducer, playlist, initialState)
+  const [previewText, setPreviewText] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+
+  // Reset state when modal opens with a new playlist prop
+  useEffect(() => {
+    if (open) {
+      // Re-initialize reducer by dispatching to a fresh state isn't ergonomic with useReducer.
+      // We rely on the key prop in PlaylistGrid to remount on each open (see wiring in PlaylistGrid).
+    }
+  }, [open])
+
+  // Debounced preview — only fires when there are actual conditions
+  useEffect(() => {
+    if (!open || !hasAnyCriteria(state)) return
+    const criteria = buildCriteriaDoc(state)
+    const timeout = setTimeout(async () => {
+      try {
+        const result = await previewCriteria(criteria)
+        setPreviewText(`Matches ${result.count} track${result.count === 1 ? '' : 's'}`)
+      } catch {
+        setPreviewText('Preview unavailable')
+      }
+    }, 300)
+    return () => clearTimeout(timeout)
+  }, [open, state])
+
+  // Escape key
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const handleBackdropClick = (e: React.MouseEvent): void => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  const handleSave = (): void => {
+    if (saving) return
+    setSaving(true)
+    const criteria = buildCriteriaDoc(state)
+    void (async () => {
+      try {
+        if (isEditMode && playlist) {
+          await updateMagicPlaylistCriteria(playlist.id, criteria)
+          onClose()
+        } else {
+          const title = state.title.trim() || 'Magic Playlist'
+          const pl = await createMagicPlaylist(title, criteria)
+          setCollectionType('playlists')
+          await selectPlaylist(pl)
+          onClose()
+        }
+      } finally {
+        setSaving(false)
+      }
+    })()
+  }
+
+  return (
+    <div className="prefs-overlay" onClick={handleBackdropClick}>
+      <div className="magic-playlist-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="magic-playlist-header">
+          <span className="magic-playlist-title">
+            {isEditMode ? `Edit: ${playlist.title}` : 'New Magic Playlist'}
+          </span>
+          <button className="magic-close-btn" onClick={onClose} title="Close">
+            ×
+          </button>
+        </div>
+
+        <div className="magic-playlist-body">
+          {!isEditMode && (
+            <div className="magic-title-row">
+              <label className="magic-label" htmlFor="magic-title">
+                Name
+              </label>
+              <input
+                id="magic-title"
+                className="magic-input magic-input--title"
+                type="text"
+                placeholder="Magic Playlist"
+                value={state.title}
+                onChange={(e) => dispatch({ type: 'SET_TITLE', title: e.target.value })}
+              />
+            </div>
+          )}
+
+          <div className="magic-top-match-row">
+            <span>Match</span>
+            <button
+              className="match-pill match-pill--active"
+              onClick={() =>
+                dispatch({ type: 'SET_TOP_MATCH', match: state.match === 'all' ? 'any' : 'all' })
+              }
+            >
+              {state.match === 'all' ? 'All' : 'Any'}
+            </button>
+            <span>of the following groups:</span>
+          </div>
+
+          <div className="magic-groups">
+            {state.groups.map((g, i) => (
+              <GroupBlock
+                key={g.id}
+                group={g}
+                groupIndex={i}
+                totalGroups={state.groups.length}
+                dispatch={dispatch}
+              />
+            ))}
+          </div>
+
+          <button className="magic-add-group-btn" onClick={() => dispatch({ type: 'ADD_GROUP' })}>
+            + Add group
+          </button>
+        </div>
+
+        <div className="magic-playlist-footer">
+          <span className="magic-preview-text">
+            {hasAnyCriteria(state)
+              ? previewText || 'Matches…'
+              : 'Every track in your library qualifies right now — add a rule to narrow it down.'}
+          </span>
+          <div className="magic-footer-actions">
+            <button className="magic-btn magic-btn--cancel" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="magic-btn magic-btn--save" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
@@ -246,6 +246,17 @@ function hasAnyCriteria(state: ModalState): boolean {
   return state.groups.some((g) => g.conditions.length > 0)
 }
 
+function hasAllConditionsComplete(state: ModalState): boolean {
+  return state.groups.every((g) =>
+    g.conditions.every((c) => {
+      const { type } = FIELD_META[c.field]
+      if (type === 'bool' || type === 'source') return true
+      if (type === 'date') return !!c.dateMeta
+      return c.value.trim() !== ''
+    })
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components for condition value inputs
 // ---------------------------------------------------------------------------
@@ -641,9 +652,9 @@ export function MagicPlaylistModal({
     }
   }, [open])
 
-  // Debounced preview — only fires when there are actual conditions
+  // Debounced preview — only fires when all conditions are present and filled in
   useEffect(() => {
-    if (!open || !hasAnyCriteria(state)) return
+    if (!open || !hasAnyCriteria(state) || !hasAllConditionsComplete(state)) return
     const criteria = buildCriteriaDoc(state)
     const timeout = setTimeout(async () => {
       try {
@@ -755,15 +766,21 @@ export function MagicPlaylistModal({
 
         <div className="magic-playlist-footer">
           <span className="magic-preview-text">
-            {hasAnyCriteria(state)
-              ? previewText || 'Matches…'
-              : 'Every track in your library qualifies right now — add a rule to narrow it down.'}
+            {!hasAnyCriteria(state)
+              ? 'No conditions set — will match no tracks.'
+              : !hasAllConditionsComplete(state)
+                ? 'Fill in all condition values to see a preview.'
+                : previewText || 'Matches…'}
           </span>
           <div className="magic-footer-actions">
             <button className="magic-btn magic-btn--cancel" onClick={onClose}>
               Cancel
             </button>
-            <button className="magic-btn magic-btn--save" onClick={handleSave} disabled={saving}>
+            <button
+              className="magic-btn magic-btn--save"
+              onClick={handleSave}
+              disabled={saving || !hasAllConditionsComplete(state)}
+            >
               {saving ? 'Saving…' : 'Save'}
             </button>
           </div>

--- a/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
@@ -734,18 +734,23 @@ export function MagicPlaylistModal({
             </div>
           )}
 
-          <div className="magic-top-match-row">
-            <span>Match</span>
-            <button
-              className="match-pill match-pill--active"
-              onClick={() =>
-                dispatch({ type: 'SET_TOP_MATCH', match: state.match === 'all' ? 'any' : 'all' })
-              }
-            >
-              {state.match === 'all' ? 'All' : 'Any'}
-            </button>
-            <span>of the following groups:</span>
-          </div>
+          {state.groups.length > 1 && (
+            <div className="magic-top-match-row">
+              <span>Match</span>
+              <button
+                className="match-pill match-pill--active"
+                onClick={() =>
+                  dispatch({
+                    type: 'SET_TOP_MATCH',
+                    match: state.match === 'all' ? 'any' : 'all'
+                  })
+                }
+              >
+                {state.match === 'all' ? 'All' : 'Any'}
+              </button>
+              <span>of the following groups:</span>
+            </div>
+          )}
 
           <div className="magic-groups">
             {state.groups.map((g, i) => (

--- a/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistGrid.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../store'
 import { PlaylistCard } from './PlaylistCard'
 import { SortControl } from './SortControl'
 import { SparkleIcon } from './TransportIcons'
+import { MagicPlaylistModal } from './MagicPlaylistModal'
 import type { Playlist } from '../api/client'
 
 const PLAYLIST_SORT_OPTIONS = [
@@ -76,6 +77,8 @@ export function PlaylistGrid(): React.JSX.Element {
   const [sortOrder, setSortOrderLocal] = useState<PlaylistSortOrder>(stored.order)
   const [sortDir, setSortDirLocal] = useState<'asc' | 'desc'>(stored.dir)
   const [typeFilter, setTypeFilterLocal] = useState<TypeFilter>(loadStoredTypeFilter)
+  const [magicModalOpen, setMagicModalOpen] = useState(false)
+  const [magicModalKey, setMagicModalKey] = useState(0)
 
   const persist = (order: PlaylistSortOrder, dir: 'asc' | 'desc'): void => {
     try {
@@ -114,7 +117,8 @@ export function PlaylistGrid(): React.JSX.Element {
   }
 
   const handleNewMagicPlaylist = (): void => {
-    // KAMP-464 opens the criteria builder modal here
+    setMagicModalKey((k) => k + 1)
+    setMagicModalOpen(true)
   }
 
   const typeFiltered =
@@ -192,6 +196,11 @@ export function PlaylistGrid(): React.JSX.Element {
           ))}
         </div>
       )}
+      <MagicPlaylistModal
+        key={magicModalKey}
+        open={magicModalOpen}
+        onClose={() => setMagicModalOpen(false)}
+      />
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -4,6 +4,7 @@ import { applyPlaylistArtLocal, playlistArtUrl } from '../api/client'
 import type { PlaylistTrack } from '../api/client'
 import { TrackContextMenu } from './TrackContextMenu'
 import { SortControl } from './SortControl'
+import { MagicPlaylistModal } from './MagicPlaylistModal'
 import { computeNewOrder } from '../utils/computeNewOrder'
 import { truncateTitle } from '../utils/truncateTitle'
 import {
@@ -12,6 +13,7 @@ import {
   PlayIcon,
   PlayNextIcon,
   QueueAddIcon,
+  SparkleIcon,
   WarnIcon
 } from './TransportIcons'
 import { formatTime } from '../utils/formatTime'
@@ -115,6 +117,7 @@ function HeroImage({ src }: { src: string }): React.JSX.Element {
 export function PlaylistView(): React.JSX.Element | null {
   const playlist = useStore((s) => s.library.selectedPlaylist)
   const playlistTracks = useStore((s) => s.library.playlistTracks)
+  const playlistTracksLoading = useStore((s) => s.library.playlistTracksLoading)
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const reorderPlaylistTracks = useStore((s) => s.reorderPlaylistTracks)
   const removeTrackFromPlaylist = useStore((s) => s.removeTrackFromPlaylist)
@@ -134,6 +137,8 @@ export function PlaylistView(): React.JSX.Element | null {
 
   const [menu, setMenu] = useState<TrackMenu | null>(null)
   const [editingTitle, setEditingTitle] = useState(false)
+  const [magicModalOpen, setMagicModalOpen] = useState(false)
+  const [magicModalKey, setMagicModalKey] = useState(0)
   const [titleDraft, setTitleDraft] = useState('')
   const [heroHeightPct, setHeroHeightPct] = useState<number>(() => {
     const saved = parseFloat(localStorage.getItem(HERO_KEY) ?? '')
@@ -521,6 +526,18 @@ export function PlaylistView(): React.JSX.Element | null {
           onDirChange={handleTrackDirChange}
           showDir={trackSortOrder !== 'position'}
         />
+        {playlist.criteria !== null && (
+          <button
+            className="playlist-cta-btn playlist-cta-btn--magic"
+            onClick={() => {
+              setMagicModalKey((k) => k + 1)
+              setMagicModalOpen(true)
+            }}
+          >
+            <SparkleIcon size={12} />
+            Edit criteria
+          </button>
+        )}
       </div>
 
       <div className="track-list-body">
@@ -624,10 +641,21 @@ export function PlaylistView(): React.JSX.Element | null {
         </ol>
         {playlistTracks.length === 0 && (
           <div className="album-grid-empty">
-            No tracks yet. Right-click any track or album and choose Add to Playlist.
+            {playlistTracksLoading
+              ? 'Loading…'
+              : playlist.criteria !== null
+                ? 'No tracks match these criteria yet.'
+                : 'No tracks yet. Right-click any track or album and choose Add to Playlist.'}
           </div>
         )}
       </div>
+
+      <MagicPlaylistModal
+        key={magicModalKey}
+        open={magicModalOpen}
+        onClose={() => setMagicModalOpen(false)}
+        playlist={playlist.criteria !== null ? playlist : undefined}
+      />
 
       {menu && (
         <TrackContextMenu

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useStore } from '../store'
 import { applyPlaylistArtLocal, playlistArtUrl } from '../api/client'
@@ -198,6 +198,18 @@ export function PlaylistView(): React.JSX.Element | null {
     setAnchorIdx(null)
   }, [playlistTracks.length, trackSortOrder])
 
+  // Memoized before the early return (hooks must be unconditional).
+  // Spreading + sorting 9000 tracks on every currentTrack/playing re-render
+  // was causing ~500 ms UI lag on large magic playlists.
+  const displayTracks = useMemo(
+    () => applySortToTracks(playlistTracks, trackSortOrder, trackSortDir),
+    [playlistTracks, trackSortOrder, trackSortDir]
+  )
+  const totalDuration = useMemo(
+    () => playlistTracks.reduce((sum, t) => sum + (t.duration || 0), 0),
+    [playlistTracks]
+  )
+
   if (!playlist) return null
 
   const persistTrackSort = (order: TrackSortOrder, dir: 'asc' | 'desc'): void => {
@@ -230,10 +242,7 @@ export function PlaylistView(): React.JSX.Element | null {
 
   // Apply sort for display only. When not in playlist-order mode,
   // drag-to-reorder is disabled (it's nonsensical on a sorted view).
-  const displayTracks = applySortToTracks(playlistTracks, trackSortOrder, trackSortDir)
   const isDragEnabled = trackSortOrder === 'position'
-
-  const totalDuration = playlistTracks.reduce((sum, t) => sum + (t.duration || 0), 0)
 
   const handleResizeMouseDown = (e: React.MouseEvent): void => {
     e.preventDefault()

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { useStore } from '../store'
 import { applyPlaylistArtLocal, playlistArtUrl } from '../api/client'
 import type { PlaylistTrack } from '../api/client'
@@ -155,7 +156,18 @@ export function PlaylistView(): React.JSX.Element | null {
 
   const titleInputRef = useRef<HTMLInputElement>(null)
   const artInputRef = useRef<HTMLInputElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const dragFromIdx = useRef<number | null>(null)
+
+  // Must be declared before the early return — hook call order must be unconditional.
+  // playlistTracks.length === displayTracks.length (sort never adds/removes items).
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: playlistTracks.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 38,
+    overscan: 8
+  })
   const didDragRef = useRef(false)
   const dragStartYRef = useRef(0)
   const heroAtDragStartRef = useRef(HERO_DEFAULT)
@@ -176,14 +188,12 @@ export function PlaylistView(): React.JSX.Element | null {
   useEffect(() => {
     if (!playlist) return
     const s = loadTrackSort(playlist.id, !!playlist.criteria)
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setTrackSortOrder(s.order)
     setTrackSortDir(s.dir)
   }, [playlist])
 
   // Clear selection when tracks change or sort changes (display indices shift).
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedIndices(new Set())
     setAnchorIdx(null)
   }, [playlistTracks.length, trackSortOrder])
@@ -550,9 +560,19 @@ export function PlaylistView(): React.JSX.Element | null {
         )}
       </div>
 
-      <div className="track-list-body">
-        <ol className="track-rows">
-          {displayTracks.map((track, i) => {
+      <div className="track-list-body" ref={scrollRef}>
+        {/* Tall positioning context; only visible rows are in the DOM. */}
+        <ol
+          className="track-rows"
+          style={{
+            position: 'relative',
+            height: virtualizer.getTotalSize() + 80,
+            padding: 0
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const i = virtualRow.index
+            const track = displayTracks[i]
             const isCurrent = currentTrack?.file_path === track.file_path
             const isRemote = track.source !== 'local'
             const isOffline = isRemote && !connected
@@ -568,6 +588,13 @@ export function PlaylistView(): React.JSX.Element | null {
                 ]
                   .filter(Boolean)
                   .join(' ')}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 20,
+                  right: 20,
+                  transform: `translateY(${virtualRow.start}px)`
+                }}
                 tabIndex={0}
                 draggable
                 onMouseDown={(e) => handleRowMouseDown(e, i)}

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -549,7 +549,7 @@ export function PlaylistView(): React.JSX.Element | null {
             const isSelected = selectedIndices.has(i)
             return (
               <li
-                key={track.playlist_track_id}
+                key={track.playlist_track_id ?? track.id}
                 className={[
                   'track-row',
                   isCurrent ? 'current' : '',
@@ -668,15 +668,19 @@ export function PlaylistView(): React.JSX.Element | null {
               : undefined
           }
           onClose={() => setMenu(null)}
-          onRemoveFromPlaylist={() => {
-            const targets =
-              selectedIndices.size > 0
-                ? [...selectedIndices]
-                    .sort((a, b) => b - a)
-                    .map((i) => displayTracks[i].playlist_track_id)
-                : [menu.track.playlist_track_id]
-            targets.forEach((ptId) => void removeTrackFromPlaylist(playlist.id, ptId))
-          }}
+          onRemoveFromPlaylist={
+            playlist.criteria === null
+              ? () => {
+                  const targets =
+                    selectedIndices.size > 0
+                      ? [...selectedIndices]
+                          .sort((a, b) => b - a)
+                          .map((i) => displayTracks[i].playlist_track_id!)
+                      : [menu.track.playlist_track_id!]
+                  targets.forEach((ptId) => void removeTrackFromPlaylist(playlist.id, ptId))
+                }
+              : undefined
+          }
         />
       )}
     </div>

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -45,17 +45,20 @@ function sortKey(playlistId: number): string {
   return `kamp:playlist:${playlistId}:sort`
 }
 
-function loadTrackSort(playlistId: number): { order: TrackSortOrder; dir: 'asc' | 'desc' } {
+function loadTrackSort(
+  playlistId: number,
+  isMagic: boolean
+): { order: TrackSortOrder; dir: 'asc' | 'desc' } {
   try {
     const raw = localStorage.getItem(sortKey(playlistId))
     if (raw) {
       const parsed = JSON.parse(raw) as { order: TrackSortOrder; dir: 'asc' | 'desc' }
-      if (parsed.order && parsed.dir) return parsed
+      if (parsed.order && parsed.dir && !(isMagic && parsed.order === 'position')) return parsed
     }
   } catch {
     // ignore malformed storage
   }
-  return { order: 'position', dir: 'asc' }
+  return { order: isMagic ? 'title' : 'position', dir: 'asc' }
 }
 
 function applySortToTracks(
@@ -75,6 +78,8 @@ function applySortToTracks(
         break
       case 'album':
         cmp = a.album.localeCompare(b.album, undefined, { sensitivity: 'base' })
+        if (cmp === 0) cmp = a.disc_number - b.disc_number
+        if (cmp === 0) cmp = a.track_number - b.track_number
         break
       case 'duration':
         cmp = a.duration - b.duration
@@ -157,15 +162,20 @@ export function PlaylistView(): React.JSX.Element | null {
   const pendingSingleSelect = useRef<number | null>(null)
 
   // Per-playlist sort state — loaded from localStorage when playlist changes.
+  const isMagic = !!playlist?.criteria
   const playlistId = playlist?.id ?? 0
-  const storedSort = loadTrackSort(playlistId)
+  const storedSort = loadTrackSort(playlistId, isMagic)
   const [trackSortOrder, setTrackSortOrder] = useState<TrackSortOrder>(storedSort.order)
   const [trackSortDir, setTrackSortDir] = useState<'asc' | 'desc'>(storedSort.dir)
+
+  const trackSortOptions = isMagic
+    ? TRACK_SORT_OPTIONS.filter((o) => o.key !== 'position')
+    : TRACK_SORT_OPTIONS
 
   // Reload sort state when navigating to a different playlist.
   useEffect(() => {
     if (!playlist) return
-    const s = loadTrackSort(playlist.id)
+    const s = loadTrackSort(playlist.id, !!playlist.criteria)
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setTrackSortOrder(s.order)
     setTrackSortDir(s.dir)
@@ -520,7 +530,7 @@ export function PlaylistView(): React.JSX.Element | null {
       <div className="album-grid-toolbar" style={{ margin: '0 -16px', padding: '0 16px' }}>
         <SortControl
           value={trackSortOrder}
-          options={TRACK_SORT_OPTIONS}
+          options={trackSortOptions}
           dir={trackSortDir}
           onChange={handleTrackSortChange}
           onDirChange={handleTrackDirChange}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -39,6 +39,7 @@ type LibraryState = {
   playlists: Playlist[]
   selectedPlaylist: Playlist | null
   playlistTracks: PlaylistTrack[]
+  playlistTracksLoading: boolean
 }
 
 type PlayerStore = {
@@ -250,7 +251,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
     collectionType: 'albums',
     playlists: [],
     selectedPlaylist: null,
-    playlistTracks: []
+    playlistTracks: [],
+    playlistTracksLoading: false
   },
   serverStatus: 'reconnecting',
   scanStatus: 'idle',
@@ -701,13 +703,20 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   selectPlaylist: async (playlist) => {
-    set((s) => ({ library: { ...s.library, selectedPlaylist: playlist, playlistTracks: [] } }))
+    set((s) => ({
+      library: {
+        ...s.library,
+        selectedPlaylist: playlist,
+        playlistTracks: [],
+        playlistTracksLoading: !!playlist
+      }
+    }))
     if (playlist) await get().loadPlaylistTracks(playlist.id)
   },
 
   loadPlaylistTracks: async (playlistId) => {
     const playlistTracks = await api.getPlaylistTracks(playlistId)
-    set((s) => ({ library: { ...s.library, playlistTracks } }))
+    set((s) => ({ library: { ...s.library, playlistTracks, playlistTracksLoading: false } }))
   },
 
   addTrackToPlaylist: async (playlistId, filePath) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -12,6 +12,7 @@ import type {
   Album,
   AlbumTagsCollision,
   ConfigValues,
+  CriteriaDoc,
   PlayerState,
   Playlist,
   PlaylistTrack,
@@ -142,6 +143,8 @@ type PlayerStore = {
   recordPlaylistPlayed: (playlistId: number) => Promise<void>
   loadPlaylists: () => Promise<void>
   createPlaylist: (title: string) => Promise<Playlist>
+  createMagicPlaylist: (title: string, criteria: CriteriaDoc) => Promise<Playlist>
+  updateMagicPlaylistCriteria: (id: number, criteria: CriteriaDoc) => Promise<Playlist>
   selectPlaylist: (playlist: Playlist | null) => Promise<void>
   loadPlaylistTracks: (playlistId: number) => Promise<void>
   addTrackToPlaylist: (playlistId: number, filePath: string) => Promise<void>
@@ -675,6 +678,22 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   createPlaylist: async (title) => {
     const playlist = await api.createPlaylist(title)
+    await get()
+      .loadPlaylists()
+      .catch(() => undefined)
+    return playlist
+  },
+
+  createMagicPlaylist: async (title, criteria) => {
+    const playlist = await api.createMagicPlaylist(title, criteria)
+    await get()
+      .loadPlaylists()
+      .catch(() => undefined)
+    return playlist
+  },
+
+  updateMagicPlaylistCriteria: async (id, criteria) => {
+    const playlist = await api.updateMagicPlaylistCriteria(id, criteria)
     await get()
       .loadPlaylists()
       .catch(() => undefined)

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -699,6 +699,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
     await get()
       .loadPlaylists()
       .catch(() => undefined)
+    if (get().library.selectedPlaylist?.id === id) {
+      void get().loadPlaylistTracks(id)
+    }
     return playlist
   },
 
@@ -716,7 +719,19 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   loadPlaylistTracks: async (playlistId) => {
     const playlistTracks = await api.getPlaylistTracks(playlistId)
-    set((s) => ({ library: { ...s.library, playlistTracks, playlistTracksLoading: false } }))
+    set((s) => ({
+      library: {
+        ...s.library,
+        playlistTracks,
+        playlistTracksLoading: false,
+        // Keep the playlist card count in sync with the just-evaluated result
+        playlists: s.library.playlists.map((p) =>
+          p.id === playlistId && p.criteria !== null
+            ? { ...p, track_count: playlistTracks.length }
+            : p
+        )
+      }
+    }))
   },
 
   addTrackToPlaylist: async (playlistId, filePath) => {
@@ -796,7 +811,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   patchOpenPlaylist: (playlist) =>
-    set((s) => ({ library: { ...s.library, selectedPlaylist: playlist } })),
+    set((s) => ({
+      library: {
+        ...s.library,
+        selectedPlaylist: playlist,
+        playlists: s.library.playlists.map((p) => (p.id === playlist.id ? playlist : p))
+      }
+    })),
 
   playAlbum: async (albumArtist, album, trackIndex = 0, filePath = '') => {
     await api.playAlbum(albumArtist, album, trackIndex, filePath)

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -183,6 +183,14 @@ def test_track_album_contains() -> None:
     assert params == ["%Blue%"]
 
 
+def test_track_album_artist_contains() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.album_artist", "contains", "Beach")))
+    )
+    assert "tracks.album_artist" in frag
+    assert params == ["%Beach%"]
+
+
 def test_track_source_is() -> None:
     frag, params, _ = build_query(
         _criteria(_group(_cond("track.source", "is", "bandcamp")))

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -29,16 +29,16 @@ def _cond(field: str, op: str, value: str) -> Condition:
 # ---------------------------------------------------------------------------
 
 
-def test_empty_criteria_returns_passthrough() -> None:
+def test_empty_criteria_returns_nothing() -> None:
     frag, params, join = build_query(MagicCriteria(groups=[], match="all"))
-    assert frag == "1"
+    assert frag == "0"
     assert params == []
     assert join is False
 
 
-def test_empty_group_returns_passthrough() -> None:
+def test_empty_group_returns_nothing() -> None:
     frag, params, join = build_query(_criteria(_group()))
-    assert frag == "1"
+    assert frag == "0"
     assert params == []
     assert join is False
 
@@ -307,4 +307,16 @@ def test_unknown_field_raises() -> None:
 def test_unknown_operator_raises() -> None:
     g = _group(_cond("track.artist", "between", "A"))
     with pytest.raises(ValueError, match="Unknown magic playlist operator"):
+        build_query(_criteria(g))
+
+
+def test_empty_value_for_int_field_raises() -> None:
+    g = _group(_cond("track.play_count", "is", ""))
+    with pytest.raises(ValueError, match="empty value"):
+        build_query(_criteria(g))
+
+
+def test_empty_value_for_float_field_raises() -> None:
+    g = _group(_cond("track.last_played", "gt", ""))
+    with pytest.raises(ValueError, match="empty value"):
         build_query(_criteria(g))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -132,7 +132,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 33
+        assert version == 34
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1457,7 +1457,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1514,7 +1514,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1927,7 +1927,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert row is not None
         assert row[0] == 0
 
@@ -2181,7 +2181,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2277,7 +2277,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2458,7 +2458,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2553,7 +2553,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 33
+        assert version == 34
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2561,7 +2561,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 33
+        assert version == 34
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3438,7 +3438,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 33
+        assert version == 34
 
         index.close()
 
@@ -4123,7 +4123,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 33
+        assert version == 34
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4158,7 +4158,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 33
+        assert version == 34
         index.close()
 
 
@@ -4606,7 +4606,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 33
+        assert version == 34
 
 
 class TestRemoteTrackSchema:
@@ -4940,7 +4940,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5001,7 +5001,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5668,7 +5668,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5783,7 +5783,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5861,7 +5861,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6067,7 +6067,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6416,7 +6416,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6513,7 +6513,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6628,7 +6628,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7117,7 +7117,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7232,7 +7232,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -7330,7 +7330,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -7430,7 +7430,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -7937,7 +7937,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 33
+        assert version == 34
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -8123,12 +8123,13 @@ class TestMagicPlaylists:
         assert result == []
 
     def test_evaluate_all_results_with_empty_criteria(self, tmp_path: Path) -> None:
-        index, id_a, id_b = self._seeded_index(tmp_path)
+        # Empty criteria matches nothing — "no conditions" is not a pass-through.
+        index, _, _ = self._seeded_index(tmp_path)
         criteria = MagicCriteria(groups=[], match="all")
-        pid = index.create_magic_playlist("Everything", criteria)
+        pid = index.create_magic_playlist("Empty", criteria)
         result = index.evaluate_magic_playlist(pid)
         index.close()
-        assert sorted(result) == sorted([id_a, id_b])
+        assert result == []
 
     def test_evaluate_match_any_combines_artists(self, tmp_path: Path) -> None:
         index, id_a, id_b = self._seeded_index(tmp_path)
@@ -8259,12 +8260,13 @@ class TestMagicPlaylists:
         index.close()
         assert count == 1
 
-    def test_count_magic_criteria_empty_returns_all(self, tmp_path: Path) -> None:
+    def test_count_magic_criteria_empty_returns_nothing(self, tmp_path: Path) -> None:
+        # Empty criteria matches nothing — "no conditions" is not a pass-through.
         index, _, _ = self._seeded_index(tmp_path)
         criteria = MagicCriteria(groups=[], match="all")
         count = index.count_magic_criteria(criteria)
         index.close()
-        assert count == 2
+        assert count == 0
 
 
 class TestMagicPlaylistReactivity:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5578,6 +5578,38 @@ class TestPlaylistArt:
 
         assert resp.status_code == 422
 
+    def test_post_art_preserves_criteria_for_magic_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        """Regression: POST /art used to return criteria: null for magic playlists."""
+        from kamp_core.library import Condition, Group, MagicCriteria
+
+        mc = MagicCriteria(
+            groups=[
+                Group(
+                    match="all",
+                    conditions=[
+                        Condition(field="track.favorite", op="is", value="true")
+                    ],
+                )
+            ],
+            match="all",
+        )
+        updated = _playlist(id=5, title="Faves")
+        mock_index.get_playlist.return_value = _playlist(id=5)
+        mock_index.set_playlist_cover.return_value = updated
+        mock_index.get_magic_playlist_criteria.return_value = mc
+        image_bytes = self._make_jpeg_bytes()
+
+        with patch("kamp_daemon.artwork.validate_image_bytes"):
+            resp = client.post(
+                "/api/v1/playlists/5/art",
+                files={"file": ("cover.jpg", image_bytes, "image/jpeg")},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["criteria"] is not None
+
 
 class TestMagicPlaylistReactivity:
     """Tests for the field_index rebuild and on_fields_changed callback (KAMP-462)."""


### PR DESCRIPTION
## Summary

- Implements `MagicPlaylistModal.tsx`: full criteria builder using `useReducer` with 7 action types (SET_TITLE, SET_TOP_MATCH, ADD/REMOVE_GROUP, SET_GROUP_MATCH, TOGGLE_GROUP_NEGATE, ADD/REMOVE/UPDATE_CONDITION)
- Field-type-specific inputs: bool (Yes/No select), int (number input), date (relative "in the last N days/weeks/months" or absolute date picker), text, source (Local/Bandcamp), in_playlist (simple playlists only)
- Debounced 300ms preview against `POST /api/v1/criteria/preview`; preview text derived at render time to avoid synchronous setState in effects
- Create mode: `POST /api/v1/playlists` with criteria; navigates to new playlist on save
- Edit mode: loads existing `playlist.criteria` into reducer via `initialState(playlist)`; saves via `PUT /api/v1/playlists/{id}/criteria`
- Adds `CriteriaField` / `CriteriaOperator` union types to `client.ts`; wires `createMagicPlaylist` and `updateMagicPlaylistCriteria` store actions
- `key` prop increment on each open (`magicModalKey`) forces reducer remount and clean state

## Test plan

- [ ] Click "New Magic Playlist" → modal opens with title input and one empty condition row
- [ ] Add "Artist contains Radiohead" → footer shows "Matches N tracks" after 300ms
- [ ] Change field to "Favorited Track" → operator hidden, Yes/No select appears
- [ ] Change field to "Last Played" → relative mode ("in the last 7 days"); toggle to absolute → date picker
- [ ] Change field to "Source" → Local/Bandcamp dropdown
- [ ] Change field to "In Playlist" → simple playlists listed (no magic playlists)
- [ ] Add second group → match pill between groups; click to toggle AND/OR
- [ ] Toggle negate on group → NOT prefix shown
- [ ] Empty criteria → footer shows "Every track…" copy
- [ ] Cancel → no playlist created
- [ ] Save → playlist created, modal closes, navigates to new playlist
- [ ] Escape key → modal closes
- [ ] Backdrop click → modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)