### PR TITLE
feat(KAMP-467): editable display tags + year/genre/label for streaming albums

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 34
+_SCHEMA_VERSION = 35
 
 
 @dataclass
@@ -180,7 +180,12 @@ CREATE TABLE IF NOT EXISTS tracks (
     stream_url_expires_at REAL,
     album_id             INTEGER REFERENCES albums(id),
     is_available         INTEGER NOT NULL DEFAULT 1,
-    duration             REAL    NOT NULL DEFAULT 0
+    duration             REAL    NOT NULL DEFAULT 0,
+    -- User-set display overrides for streaming tracks (KAMP-467).
+    -- NULL means "use the canonical value from Bandcamp".
+    display_title        TEXT,
+    display_album        TEXT,
+    display_album_artist TEXT
 );
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
@@ -203,6 +208,10 @@ CREATE TABLE IF NOT EXISTS albums (
     last_played_at REAL,
     play_count_avg REAL    NOT NULL DEFAULT 0,
     art_version    REAL,
+    -- User-set display overrides for streaming albums (KAMP-467).
+    -- NULL means "use the canonical value from Bandcamp".
+    display_album        TEXT,
+    display_album_artist TEXT,
     UNIQUE (album_artist, album)
 );
 
@@ -393,7 +402,7 @@ def _get_date_added(path: Path) -> float | None:
 # is always ASC so results are deterministic regardless of chosen direction.
 _SORT_CLAUSES: dict[str, str] = {
     "album_artist": "album_artist COLLATE NOCASE {dir}, album COLLATE NOCASE",
-    "album": "album COLLATE NOCASE {dir}, album_artist COLLATE NOCASE",
+    "album": "sort_album COLLATE NOCASE {dir}, album_artist COLLATE NOCASE",
     # These reference the sort_date_added / sort_last_played / sort_play_count_avg
     # columns produced by the UNION ALL query in albums().
     "date_added": "sort_date_added {dir}, album_artist COLLATE NOCASE",
@@ -508,6 +517,10 @@ class AlbumInfo:
     album_url: str = ""
     # Stable integer PK of the albums row; 0 for missing-album virtual entries.
     album_id: int = field(default=0, compare=False)
+    # User-set display overrides for streaming albums (KAMP-467). None means
+    # no override; the canonical album/album_artist is the authoritative value.
+    display_album: str | None = None
+    display_album_artist: str | None = None
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -1259,15 +1272,52 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 34")
             self._conn.commit()
-            version = 34  # noqa: F841
+            version = 34
+
+        if version == 34:
+            # v34 → v35: add display override columns for streaming albums/tracks (KAMP-467).
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            for col in ("display_title", "display_album", "display_album_artist"):
+                if col not in track_cols:
+                    self._conn.execute(f"ALTER TABLE tracks ADD COLUMN {col} TEXT")
+            album_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+            }
+            for col in ("display_album", "display_album_artist"):
+                if col not in album_cols:
+                    self._conn.execute(f"ALTER TABLE albums ADD COLUMN {col} TEXT")
+            self._conn.execute("UPDATE schema_version SET version = 35")
+            self._conn.commit()
+            version = 35  # noqa: F841
 
     def _rebuild_fts(self) -> None:
-        """Rebuild the FTS index from the current contents of the tracks table."""
+        """Rebuild the FTS index from the current contents of the tracks table.
+
+        Uses COALESCE with display override columns when they exist (v35+).
+        Falls back to the canonical columns during early migration runs where
+        the display columns have not yet been added.
+        """
+        cols = {
+            r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
         self._conn.execute("DELETE FROM tracks_fts")
-        self._conn.execute(
-            "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album) "
-            "SELECT id, title, artist, album_artist, album FROM tracks"
-        )
+        if "display_title" in cols:
+            self._conn.execute(
+                "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album) "
+                "SELECT id"
+                ", COALESCE(display_title, title)"
+                ", artist"
+                ", COALESCE(display_album_artist, album_artist)"
+                ", COALESCE(display_album, album)"
+                " FROM tracks"
+            )
+        else:
+            self._conn.execute(
+                "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album) "
+                "SELECT id, title, artist, album_artist, album FROM tracks"
+            )
         self._conn.execute("DELETE FROM playlists_fts")
         self._conn.execute(
             "INSERT INTO playlists_fts(rowid, title) SELECT id, title FROM playlists"
@@ -1784,6 +1834,91 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def update_track_display_title(
+        self, track_id: int, display_title: str | None
+    ) -> "Track | None":
+        """Set (or clear) the display title override for a streaming track (KAMP-467).
+
+        Passing None or an empty string clears the override and restores the
+        Bandcamp canonical title.  Returns the updated Track, or None if the
+        track is not found.
+        """
+        value = display_title or None  # normalise empty string → NULL
+        self._conn.execute(
+            "UPDATE tracks SET display_title = ? WHERE id = ?", (value, track_id)
+        )
+        # Update FTS so the new display title is immediately searchable.
+        self._conn.execute("DELETE FROM tracks_fts WHERE rowid=?", (track_id,))
+        self._conn.execute(
+            "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album)"
+            " SELECT id"
+            ", COALESCE(display_title, title)"
+            ", artist"
+            ", COALESCE(display_album_artist, album_artist)"
+            ", COALESCE(display_album, album)"
+            " FROM tracks WHERE id=?",
+            (track_id,),
+        )
+        self._conn.commit()
+        return self.get_track_by_id(track_id)
+
+    def update_album_display(
+        self,
+        album_artist: str,
+        album: str,
+        display_album: str | None,
+        display_album_artist: str | None,
+    ) -> "AlbumInfo | None":
+        """Set (or clear) display overrides for a streaming album (KAMP-467).
+
+        Writes to the albums row and denormalizes onto all constituent tracks so
+        that _row_to_track and FTS both see effective values without needing a
+        JOIN.  Passing None or empty string for a field clears that override.
+        Returns the updated AlbumInfo, or None if the album is not found.
+        """
+        album_id = self._album_id(album_artist, album)
+        if album_id is None:
+            return None
+        d_album = display_album or None
+        d_artist = display_album_artist or None
+        self._conn.execute(
+            "UPDATE albums SET display_album = ?, display_album_artist = ? WHERE id = ?",
+            (d_album, d_artist, album_id),
+        )
+        # Denormalize onto tracks so _row_to_track needs no JOIN.
+        self._conn.execute(
+            "UPDATE tracks SET display_album = ?, display_album_artist = ? WHERE album_id = ?",
+            (d_album, d_artist, album_id),
+        )
+        # Rebuild FTS for all affected tracks.
+        track_ids = [
+            r["id"]
+            for r in self._conn.execute(
+                "SELECT id FROM tracks WHERE album_id = ?", (album_id,)
+            ).fetchall()
+        ]
+        for tid in track_ids:
+            self._conn.execute("DELETE FROM tracks_fts WHERE rowid=?", (tid,))
+            self._conn.execute(
+                "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album)"
+                " SELECT id"
+                ", COALESCE(display_title, title)"
+                ", artist"
+                ", COALESCE(display_album_artist, album_artist)"
+                ", COALESCE(display_album, album)"
+                " FROM tracks WHERE id=?",
+                (tid,),
+            )
+        self._conn.commit()
+        results = self.albums()
+        for a in results:
+            if (
+                a.album_artist.lower() == album_artist.lower()
+                and a.album.lower() == album.lower()
+            ):
+                return a
+        return None
+
     # ------------------------------------------------------------------
     # Settings (application configuration)
     # ------------------------------------------------------------------
@@ -2228,7 +2363,12 @@ class LibraryIndex:
         self._conn.execute("DELETE FROM tracks_fts WHERE rowid=?", (track_id,))
         self._conn.execute(
             "INSERT INTO tracks_fts(rowid, title, artist, album_artist, album)"
-            " SELECT id, title, artist, album_artist, album FROM tracks WHERE id=?",
+            " SELECT id"
+            ", COALESCE(display_title, title)"
+            ", artist"
+            ", COALESCE(display_album_artist, album_artist)"
+            ", COALESCE(display_album, album)"
+            " FROM tracks WHERE id=?",
             (track_id,),
         )
         self._conn.commit()
@@ -2593,7 +2733,12 @@ class LibraryIndex:
                 -- is_preorder: True when the album is a Bandcamp pre-order (KAMP-423).
                 CASE WHEN bc.mode = 'preorder' THEN 1 ELSE 0 END AS is_preorder,
                 -- album_url: Bandcamp page URL for sharing (KAMP-367).
-                COALESCE(bc.album_url, '') AS album_url
+                COALESCE(bc.album_url, '') AS album_url,
+                -- display overrides for streaming albums (KAMP-467).
+                a.display_album,
+                a.display_album_artist,
+                -- effective album title used for sort-by-album ordering.
+                COALESCE(a.display_album, a.album) AS sort_album
             FROM albums a
             LEFT JOIN tracks t ON t.album_id = a.id
             LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id
@@ -2620,7 +2765,10 @@ class LibraryIndex:
                 t.favorite          AS has_favorite_track,
                 0                   AS in_bc,
                 0                   AS is_preorder,
-                ''                  AS album_url
+                ''                  AS album_url,
+                NULL                AS display_album,
+                NULL                AS display_album_artist,
+                t.title             AS sort_album
             FROM tracks t
             WHERE t.album = ''
             ORDER BY {order_by}
@@ -2647,6 +2795,8 @@ class LibraryIndex:
                 is_preorder=bool(r["is_preorder"]),
                 album_url=r["album_url"] or "",
                 sale_item_id=r["sale_item_id"],
+                display_album=r["display_album"],
+                display_album_artist=r["display_album_artist"],
             )
             for r in rows
         ]
@@ -3728,10 +3878,13 @@ def _row_to_track(row: sqlite3.Row) -> Track:
     return Track(
         id=row["id"],
         file_path=Path(row["file_path"]),
-        title=row["title"],
+        # Apply display overrides (KAMP-467): if the user has set a display value,
+        # use it in place of the Bandcamp-sourced canonical value.  The override is
+        # NULL for local tracks and for streaming tracks the user has not edited.
+        title=row["display_title"] or row["title"],
         artist=row["artist"],
-        album_artist=row["album_artist"],
-        album=row["album"],
+        album_artist=row["display_album_artist"] or row["album_artist"],
+        album=row["display_album"] or row["album"],
         year=row["year"],
         track_number=row["track_number"],
         disc_number=row["disc_number"],

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2005,7 +2005,11 @@ class LibraryIndex:
                 artist                = excluded.artist,
                 album_artist          = excluded.album_artist,
                 album                 = excluded.album,
-                year                  = excluded.year,
+                -- For streaming tracks, preserve user-edited year/genre/label if the
+                -- incoming sync value is empty (Bandcamp never sends these fields).
+                year                  = CASE WHEN excluded.source = 'bandcamp'
+                                             THEN COALESCE(NULLIF(excluded.year,  ''), year)
+                                             ELSE excluded.year  END,
                 track_number          = excluded.track_number,
                 disc_number           = excluded.disc_number,
                 ext                   = excluded.ext,
@@ -2013,8 +2017,12 @@ class LibraryIndex:
                 mb_release_id         = excluded.mb_release_id,
                 mb_recording_id       = excluded.mb_recording_id,
                 file_mtime            = excluded.file_mtime,
-                genre                 = excluded.genre,
-                label                 = excluded.label,
+                genre                 = CASE WHEN excluded.source = 'bandcamp'
+                                             THEN COALESCE(NULLIF(excluded.genre, ''), genre)
+                                             ELSE excluded.genre END,
+                label                 = CASE WHEN excluded.source = 'bandcamp'
+                                             THEN COALESCE(NULLIF(excluded.label, ''), label)
+                                             ELSE excluded.label END,
                 source                = excluded.source,
                 -- Preserve the cached CDN URL if the incoming row has none.
                 -- fetch_album_tracks never populates stream_url; without this

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -257,6 +257,9 @@ class AlbumOut(BaseModel):
     is_preorder: bool = False
     # Bandcamp album page URL — non-empty for Bandcamp albums (KAMP-367).
     album_url: str = ""
+    # User-set display overrides for streaming albums (KAMP-467). None means no override.
+    display_album: str | None = None
+    display_album_artist: str | None = None
 
 
 class PlayerStateOut(BaseModel):
@@ -475,6 +478,21 @@ class AlbumTagsOut(BaseModel):
     # Paths of files left at their original location due to skip_conflicts.
     skipped: list[str]
     failed: list[AlbumTagsTrackResult]
+
+
+class TrackDisplayRequest(BaseModel):
+    """Display-only title override for a streaming track (KAMP-467)."""
+
+    display_title: str | None = None
+
+
+class AlbumDisplayRequest(BaseModel):
+    """Display-only overrides for a streaming album's title and artist (KAMP-467)."""
+
+    album_artist: str
+    album: str
+    display_album: str | None = None
+    display_album_artist: str | None = None
 
 
 class AlbumMetaRequest(BaseModel):
@@ -1053,6 +1071,8 @@ def create_app(
                 sale_item_id=a.sale_item_id,
                 is_preorder=a.is_preorder,
                 album_url=a.album_url,
+                display_album=a.display_album,
+                display_album_artist=a.display_album_artist,
             )
             for a in index.albums(sort=sort, sort_dir=sort_dir)
         ]
@@ -1795,6 +1815,62 @@ def create_app(
             moved=moved, deferred=deferred, skipped=skipped, failed=failed
         )
 
+    @app.patch("/api/v1/tracks/{track_id}/display", response_model=TrackOut)
+    def patch_track_display(track_id: int, req: "TrackDisplayRequest") -> TrackOut:
+        """Set (or clear) the display title for a streaming track (KAMP-467).
+
+        Writes only to the DB — no file operations are performed.
+        Passing null or empty string for display_title clears the override and
+        restores the Bandcamp canonical title.
+        Returns 404 if the track is not found.
+        """
+        track = index.get_track_by_id(track_id)
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        updated = index.update_track_display_title(track_id, req.display_title)
+        _notify_library_changed()
+        return TrackOut.from_track(updated)  # type: ignore[arg-type]
+
+    @app.patch("/api/v1/albums/display", response_model=AlbumOut)
+    def patch_album_display(req: "AlbumDisplayRequest") -> AlbumOut:
+        """Set (or clear) display overrides for a streaming album (KAMP-467).
+
+        Writes only to the DB — no file operations are performed.
+        Passing null or empty string for a field clears that override.
+        Returns 404 if the album is not found.
+        """
+        result = index.update_album_display(
+            req.album_artist,
+            req.album,
+            req.display_album,
+            req.display_album_artist,
+        )
+        if result is None:
+            raise HTTPException(status_code=404, detail="Album not found")
+        _notify_library_changed()
+        return AlbumOut(
+            album_artist=result.album_artist,
+            album=result.album,
+            year=result.year,
+            track_count=result.track_count,
+            has_art=result.has_art,
+            missing_album=result.missing_album,
+            file_path=result.file_path,
+            art_version=result.art_version,
+            added_at=result.added_at,
+            last_played_at=result.last_played_at,
+            play_count_avg=result.play_count_avg,
+            favorite=result.favorite,
+            has_favorite_track=result.has_favorite_track,
+            source=result.source,
+            has_remote_tracks=result.has_remote_tracks,
+            sale_item_id=result.sale_item_id,
+            is_preorder=result.is_preorder,
+            album_url=result.album_url,
+            display_album=result.display_album,
+            display_album_artist=result.display_album_artist,
+        )
+
     @app.patch("/api/v1/albums/meta")
     def patch_album_meta(
         album_artist: str, album: str, req: "AlbumMetaRequest"
@@ -2076,6 +2152,8 @@ def create_app(
                     sale_item_id=a.sale_item_id,
                     is_preorder=a.is_preorder,
                     album_url=a.album_url,
+                    display_album=a.display_album,
+                    display_album_artist=a.display_album_artist,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -2203,6 +2281,8 @@ def create_app(
                     sale_item_id=a.sale_item_id,
                     is_preorder=a.is_preorder,
                     album_url=a.album_url,
+                    display_album=a.display_album,
+                    display_album_artist=a.display_album_artist,
                 )
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
@@ -2359,6 +2439,8 @@ def create_app(
                 sale_item_id=a.sale_item_id,
                 is_preorder=a.is_preorder,
                 album_url=a.album_url,
+                display_album=a.display_album,
+                display_album_artist=a.display_album_artist,
             )
             for a in index.albums(sort=sort)
             if (a.album_artist, a.album) in fts_keys

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1895,6 +1895,8 @@ def create_app(
             raise HTTPException(status_code=400, detail="No changes requested")
 
         for track in tracks:
+            if track.is_remote:
+                continue
             try:
                 write_meta_tags_to_file(
                     track.file_path,

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -62,6 +62,9 @@ export type Album = {
   is_preorder?: boolean
   // Bandcamp album page URL — non-empty for Bandcamp albums; used for sharing.
   album_url?: string
+  // User-set display overrides for streaming albums (KAMP-467). Undefined means no override.
+  display_album?: string
+  display_album_artist?: string
 }
 
 export type PlayerState = {
@@ -461,6 +464,39 @@ export async function patchTrackTags(
   }
   return res.json() as Promise<Track>
 }
+export async function patchTrackDisplay(
+  trackId: number,
+  displayTitle: string | null
+): Promise<Track> {
+  const res = await fetch(`${BASE_URL}/api/v1/tracks/${trackId}/display`, {
+    method: 'PATCH',
+    headers: _authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ display_title: displayTitle || null })
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json() as Promise<Track>
+}
+
+export async function patchAlbumDisplay(
+  albumArtist: string,
+  album: string,
+  displayAlbum: string | null,
+  displayAlbumArtist: string | null
+): Promise<Album> {
+  const res = await fetch(`${BASE_URL}/api/v1/albums/display`, {
+    method: 'PATCH',
+    headers: _authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({
+      album_artist: albumArtist,
+      album,
+      display_album: displayAlbum || null,
+      display_album_artist: displayAlbumArtist || null
+    })
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json() as Promise<Album>
+}
+
 export const setAlbumFavorite = (
   albumArtist: string,
   album: string,

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -399,12 +399,12 @@ export function AlbumCard({
         )}
         {album.missing_album ? (
           <div className="album-title">
-            <em>{album.album}</em>
+            <em>{album.display_album ?? album.album}</em>
           </div>
         ) : (
-          <div className="album-title">{album.album}</div>
+          <div className="album-title">{album.display_album ?? album.album}</div>
         )}
-        <div className="album-artist">{album.album_artist}</div>
+        <div className="album-artist">{album.display_album_artist ?? album.album_artist}</div>
         <div className="album-year">{album.year}</div>
         {album.favorite && (
           <div className="album-fav-badge">

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -114,7 +114,7 @@ export function AlbumMetaPanel({
   }, [expanded])
 
   const mbId = tracks[0]?.mb_release_id ?? ''
-  const hasContent = hasAnyMeta(tracks, year)
+  const hasContent = hasAnyMeta(tracks, commonValue(tracks, 'year'))
 
   const handleSaveGenre = (): void => {
     const current = commonValue(tracks, 'genre')
@@ -155,7 +155,7 @@ export function AlbumMetaPanel({
         aria-hidden={!expanded}
       >
         <dl className="album-meta-rows">
-          {year && (
+          {(year || editMode) && (
             <MetaField
               label="YEAR"
               value={year}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -525,7 +525,12 @@ export function TrackList(): React.JSX.Element | null {
               const oldAlbum = album.album
               const oldArtist = album.album_artist
               if (album.source === 'bandcamp') {
-                await patchAlbumDisplay(oldArtist, oldAlbum, newAlbum, album.display_album_artist ?? null)
+                await patchAlbumDisplay(
+                  oldArtist,
+                  oldAlbum,
+                  newAlbum,
+                  album.display_album_artist ?? null
+                )
                 return
               }
               const count = album.track_count

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -105,7 +105,9 @@ export function TrackList(): React.JSX.Element | null {
   const setAlbumMetaExpanded = useStore((s) => s.setAlbumMetaExpanded)
   const patchAlbumMeta = useStore((s) => s.patchAlbumMeta)
   const patchTrackTitle = useStore((s) => s.patchTrackTitle)
+  const patchTrackDisplay = useStore((s) => s.patchTrackDisplay)
   const patchAlbumTags = useStore((s) => s.patchAlbumTags)
+  const patchAlbumDisplay = useStore((s) => s.patchAlbumDisplay)
   const refreshOpenAlbum = useStore((s) => s.refreshOpenAlbum)
   const patchOpenAlbum = useStore((s) => s.patchOpenAlbum)
   const albumRenameProgress = useStore((s) => s.albumRenameProgress)
@@ -427,12 +429,12 @@ export function TrackList(): React.JSX.Element | null {
             selectArtist(album.album_artist)
           }}
         >
-          {album.album_artist}
+          {album.display_album_artist ?? album.album_artist}
         </button>
         <span className="breadcrumb-sep" aria-hidden="true">
           ›
         </span>
-        <span>{album.album}</span>
+        <span>{album.display_album ?? album.album}</span>
         {album.is_preorder && (
           <span className="album-preorder-badge" aria-label="Pre-Order">
             Pre-Order
@@ -440,17 +442,15 @@ export function TrackList(): React.JSX.Element | null {
         )}
       </nav>
 
-      {/* Edit toggle — suppressed for bandcamp-only albums (no local files to edit) */}
-      {album.source !== 'bandcamp' && (
-        <button
-          className={`breadcrumb-edit-btn${albumEditMode ? ' active' : ''}`}
-          aria-pressed={albumEditMode}
-          onClick={() => setAlbumEditMode(!albumEditMode)}
-        >
-          <PencilIcon size={11} />
-          {albumEditMode ? 'Done' : 'Edit tags'}
-        </button>
-      )}
+      {/* Edit toggle */}
+      <button
+        className={`breadcrumb-edit-btn${albumEditMode ? ' active' : ''}`}
+        aria-pressed={albumEditMode}
+        onClick={() => setAlbumEditMode(!albumEditMode)}
+      >
+        <PencilIcon size={11} />
+        {albumEditMode ? 'Done' : 'Edit tags'}
+      </button>
 
       {/* MusicBrainz fetch pill — only for local albums in edit mode */}
       {album.source === 'local' && albumEditMode && (
@@ -517,13 +517,17 @@ export function TrackList(): React.JSX.Element | null {
             <FavoriteIcon active={album.favorite} size={36} />
           </button>
           <EditableAlbumField
-            value={album.album}
+            value={album.display_album ?? album.album}
             editMode={albumEditMode}
             disabled={albumRenameProgress !== null}
             className="track-list-album-title"
             onSave={async (newAlbum) => {
               const oldAlbum = album.album
               const oldArtist = album.album_artist
+              if (album.source === 'bandcamp') {
+                await patchAlbumDisplay(oldArtist, oldAlbum, newAlbum, album.display_album_artist ?? null)
+                return
+              }
               const count = album.track_count
               try {
                 const result = await patchAlbumTags(oldArtist, oldAlbum, { album: newAlbum })
@@ -546,13 +550,17 @@ export function TrackList(): React.JSX.Element | null {
             )}
           />
           <EditableAlbumField
-            value={album.album_artist}
+            value={album.display_album_artist ?? album.album_artist}
             editMode={albumEditMode}
             disabled={albumRenameProgress !== null}
             className="track-list-album-artist-input"
             onSave={async (newArtist) => {
               const oldArtist = album.album_artist
               const oldAlbum = album.album
+              if (album.source === 'bandcamp') {
+                await patchAlbumDisplay(oldArtist, oldAlbum, album.display_album ?? null, newArtist)
+                return
+              }
               const count = album.track_count
               try {
                 const result = await patchAlbumTags(oldArtist, oldAlbum, {
@@ -748,9 +756,13 @@ export function TrackList(): React.JSX.Element | null {
                   <EditableTrackTitle
                     trackId={track.id}
                     title={track.title}
-                    editMode={albumEditMode && !isRemoteTrack}
+                    editMode={albumEditMode}
                     deferred={track.id in deferredOps}
                     onSave={async (trackId, newTitle) => {
+                      if (isRemoteTrack) {
+                        await patchTrackDisplay(trackId, newTitle)
+                        return
+                      }
                       const result = await patchTrackTitle(trackId, newTitle)
                       if (result?.collision) {
                         setCollision({ ...result, pendingTrackId: trackId, pendingTitle: newTitle })

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -201,11 +201,18 @@ type PlayerStore = {
     title: string,
     overwrite?: boolean
   ) => Promise<api.TrackTagsCollision | null>
+  patchTrackDisplay: (trackId: number, displayTitle: string | null) => Promise<void>
   patchAlbumTags: (
     albumArtist: string,
     album: string,
     opts: { album?: string; album_artist?: string; overwrite?: boolean; skip_conflicts?: boolean }
   ) => Promise<AlbumTagsCollision | null>
+  patchAlbumDisplay: (
+    albumArtist: string,
+    album: string,
+    displayAlbum: string | null,
+    displayAlbumArtist: string | null
+  ) => Promise<void>
   deferredOps: Record<number, number> // track_id → op_id
   clearDeferredOp: (trackId: number) => void
   setAlbumRenameProgress: (progress: { done: number; total: number } | null) => void
@@ -1036,6 +1043,18 @@ export const useStore = create<PlayerStore>((set, get) => ({
     return null
   },
 
+  patchTrackDisplay: async (trackId, displayTitle) => {
+    const updated = await api.patchTrackDisplay(trackId, displayTitle)
+    // Update the track in the open track list without reloading the whole library.
+    set((s) => ({
+      library: {
+        ...s.library,
+        tracks: s.library.tracks.map((t) => (t.id === trackId ? updated : t))
+      }
+    }))
+    void get().loadQueue()
+  },
+
   clearDeferredOp: (trackId) =>
     set((s) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1080,6 +1099,22 @@ export const useStore = create<PlayerStore>((set, get) => ({
       await get().loadTracks(newArtist, newAlbum)
     }
     return null
+  },
+
+  patchAlbumDisplay: async (albumArtist, album, displayAlbum, displayAlbumArtist) => {
+    const updated = await api.patchAlbumDisplay(albumArtist, album, displayAlbum, displayAlbumArtist)
+    // Update the album in the library list and selectedAlbum without a full reload.
+    set((s) => {
+      const albums = s.library.albums.map((a) =>
+        a.album_artist === albumArtist && a.album === album ? { ...a, ...updated } : a
+      )
+      const selectedAlbum =
+        s.library.selectedAlbum?.album_artist === albumArtist &&
+        s.library.selectedAlbum?.album === album
+          ? { ...s.library.selectedAlbum, ...updated }
+          : s.library.selectedAlbum
+      return { library: { ...s.library, albums, selectedAlbum } }
+    })
   },
 
   patchAlbumMeta: async (albumArtist, album, opts) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -1102,7 +1102,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   patchAlbumDisplay: async (albumArtist, album, displayAlbum, displayAlbumArtist) => {
-    const updated = await api.patchAlbumDisplay(albumArtist, album, displayAlbum, displayAlbumArtist)
+    const updated = await api.patchAlbumDisplay(
+      albumArtist,
+      album,
+      displayAlbum,
+      displayAlbumArtist
+    )
     // Update the album in the library list and selectedAlbum without a full reload.
     set((s) => {
       const albums = s.library.albums.map((a) =>

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8477,6 +8477,26 @@ def _make_bandcamp_track(uri: str, title: str = "Track", album: str = "Album") -
     )
 
 
+def _bandcamp_track() -> Track:
+    return Track(
+        file_path=Path("bandcamp://sale123/1"),
+        title="Stream Track",
+        artist="Band",
+        album_artist="Band",
+        album="Stream Album",
+        year="",
+        track_number=1,
+        disc_number=1,
+        ext="",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+        genre="",
+        label="",
+        source="bandcamp",
+    )
+
+
 class TestDisplayOverrides:
     """update_track_display_title and update_album_display (KAMP-467)."""
 
@@ -8598,3 +8618,63 @@ class TestDisplayOverrides:
         index.close()
 
         assert any(t.title == "Glum" for t in results)
+
+
+class TestUpsertSyncProtection:
+    """Bandcamp syncs must not overwrite user-edited genre/label/year."""
+
+    def test_bandcamp_sync_preserves_user_genre(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _bandcamp_track()
+        index.upsert_many([track])
+        index.update_album_meta("Band", "Stream Album", genre="Jazz")
+
+        synced = Track(**{**track.__dict__, "genre": ""})
+        index.upsert_many([synced])
+
+        result = index.all_tracks()[0]
+        index.close()
+        assert result.genre == "Jazz"
+
+    def test_bandcamp_sync_preserves_user_label_and_year(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _bandcamp_track()
+        index.upsert_many([track])
+        index.update_album_meta("Band", "Stream Album", label="ECM", year="1975")
+
+        synced = Track(**{**track.__dict__, "label": "", "year": ""})
+        index.upsert_many([synced])
+
+        result = index.all_tracks()[0]
+        index.close()
+        assert result.label == "ECM"
+        assert result.year == "1975"
+
+    def test_local_track_empty_genre_always_wins(self, tmp_path: Path) -> None:
+        """Rescanning a local file with no genre tag must clear the DB genre."""
+        index = LibraryIndex(tmp_path / "library.db")
+        path = tmp_path / "01.mp3"
+        track = Track(**{**_sample_track(path).__dict__, "genre": "Rock"})
+        index.upsert_many([track])
+
+        rescanned = Track(**{**track.__dict__, "genre": ""})
+        index.upsert_many([rescanned])
+
+        result = index.all_tracks()[0]
+        index.close()
+        assert result.genre == ""
+
+    def test_bandcamp_sync_overwrites_when_incoming_is_nonempty(
+        self, tmp_path: Path
+    ) -> None:
+        """If Bandcamp ever does send a genre, it must win over the empty DB value."""
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _bandcamp_track()
+        index.upsert_many([track])
+
+        synced = Track(**{**track.__dict__, "genre": "Electronic"})
+        index.upsert_many([synced])
+
+        result = index.all_tracks()[0]
+        index.close()
+        assert result.genre == "Electronic"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -132,7 +132,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 34
+        assert version == 35
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1457,7 +1457,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1514,7 +1514,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -1927,7 +1927,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert row is not None
         assert row[0] == 0
 
@@ -2181,7 +2181,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2277,7 +2277,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2458,7 +2458,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2553,7 +2553,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 34
+        assert version == 35
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2561,7 +2561,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 34
+        assert version == 35
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3438,7 +3438,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 34
+        assert version == 35
 
         index.close()
 
@@ -4123,7 +4123,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 34
+        assert version == 35
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4158,7 +4158,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 34
+        assert version == 35
         index.close()
 
 
@@ -4606,7 +4606,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 34
+        assert version == 35
 
 
 class TestRemoteTrackSchema:
@@ -4940,7 +4940,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5001,7 +5001,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5668,7 +5668,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -5783,7 +5783,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -5861,7 +5861,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6067,7 +6067,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6416,7 +6416,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6513,7 +6513,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6628,7 +6628,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7117,7 +7117,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7232,7 +7232,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -7330,7 +7330,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -7430,7 +7430,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -7937,7 +7937,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 34
+        assert version == 35
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -8452,3 +8452,149 @@ class TestMagicPlaylistReactivity:
         result = index2.list_all_magic_criteria()
         index2.close()
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Display overrides (KAMP-467)
+# ---------------------------------------------------------------------------
+
+
+def _make_bandcamp_track(uri: str, title: str = "Track", album: str = "Album") -> Track:
+    return Track(
+        file_path=Path(uri),
+        title=title,
+        artist="Band",
+        album_artist="Band",
+        album=album,
+        year="2020",
+        track_number=1,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+        source="bandcamp",
+    )
+
+
+class TestDisplayOverrides:
+    """update_track_display_title and update_album_display (KAMP-467)."""
+
+    def test_schema_v35_adds_display_columns_to_tracks(self, tmp_path: Path) -> None:
+        LibraryIndex(tmp_path / "library.db").close()
+        conn = sqlite3.connect(str(tmp_path / "library.db"))
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(tracks)").fetchall()}
+        conn.close()
+        assert "display_title" in cols
+        assert "display_album" in cols
+        assert "display_album_artist" in cols
+
+    def test_schema_v35_adds_display_columns_to_albums(self, tmp_path: Path) -> None:
+        LibraryIndex(tmp_path / "library.db").close()
+        conn = sqlite3.connect(str(tmp_path / "library.db"))
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(albums)").fetchall()}
+        conn.close()
+        assert "display_album" in cols
+        assert "display_album_artist" in cols
+
+    def test_update_track_display_title_returns_effective_title(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track("bandcamp://42/1", title="Original")
+        index.upsert_many([track])
+        inserted = index.all_tracks()[0]
+
+        updated = index.update_track_display_title(inserted.id, "Renamed")
+        index.close()
+
+        assert updated is not None
+        assert updated.title == "Renamed"
+
+    def test_update_track_display_title_clears_override_on_empty(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track("bandcamp://42/1", title="Original")
+        index.upsert_many([track])
+        inserted = index.all_tracks()[0]
+        index.update_track_display_title(inserted.id, "Renamed")
+
+        # Clear by passing empty string
+        cleared = index.update_track_display_title(inserted.id, "")
+        index.close()
+
+        assert cleared is not None
+        assert cleared.title == "Original"
+
+    def test_update_track_display_title_returns_none_for_missing_track(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.update_track_display_title(99999, "Ghost")
+        index.close()
+        assert result is None
+
+    def test_display_title_preserved_through_upsert(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track("bandcamp://42/1", title="Original")
+        index.upsert_many([track])
+        inserted = index.all_tracks()[0]
+        index.update_track_display_title(inserted.id, "Renamed")
+
+        # Re-upsert simulates a Bandcamp sync bringing back the canonical title.
+        index.upsert_many([track])
+        after_sync = index.all_tracks()[0]
+        index.close()
+
+        assert after_sync.title == "Renamed"
+
+    def test_update_album_display_sets_overrides_on_album_and_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track("bandcamp://42/1", album="Long Ugly Name")
+        index.upsert_many([track])
+
+        result = index.update_album_display("Band", "Long Ugly Name", "Short", "B")
+        all_tracks = index.all_tracks()
+        index.close()
+
+        assert result is not None
+        assert all_tracks[0].album == "Short"
+        assert all_tracks[0].album_artist == "B"
+
+    def test_update_album_display_returns_none_for_missing_album(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.update_album_display("Ghost", "Phantom", "X", "Y")
+        index.close()
+        assert result is None
+
+    def test_display_album_preserved_through_upsert(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track("bandcamp://42/1", album="Long Ugly Name")
+        index.upsert_many([track])
+        index.update_album_display("Band", "Long Ugly Name", "Short", None)
+
+        # Re-upsert simulates a Bandcamp sync.
+        index.upsert_many([track])
+        all_tracks = index.all_tracks()
+        index.close()
+
+        assert all_tracks[0].album == "Short"
+
+    def test_fts_finds_display_title(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        track = _make_bandcamp_track(
+            "bandcamp://42/1", title="Glum (20th Anniversary Edition)"
+        )
+        index.upsert_many([track])
+        inserted = index.all_tracks()[0]
+        index.update_track_display_title(inserted.id, "Glum")
+
+        results = index.search("Glum")
+        index.close()
+
+        assert any(t.title == "Glum" for t in results)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3484,6 +3484,79 @@ class TestPatchAlbumMetaEndpoint:
         assert data[0]["source"] == "bandcamp"
         assert data[0]["has_remote_tracks"] is True
 
+    def _make_remote_track(self, n: int = 1) -> Track:
+        return Track(
+            file_path=Path(f"bandcamp://123/{n}"),
+            title=f"Stream {n}",
+            artist="Artist",
+            album_artist="Artist",
+            album="Record",
+            year="",
+            track_number=n,
+            disc_number=1,
+            ext="",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genre="",
+            label="",
+            source="bandcamp",
+        )
+
+    def test_remote_tracks_skip_file_write_but_update_db(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Bandcamp tracks must not trigger write_meta_tags_to_file."""
+        remote = self._make_remote_track()
+        updated = Track(**{**remote.__dict__, "genre": "Jazz"})
+        mock_index.tracks_for_album.return_value = [remote]
+        mock_index.update_album_meta.return_value = [updated]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch("kamp_core.library.write_meta_tags_to_file") as mock_write:
+            resp = TestClient(app).patch(
+                "/api/v1/albums/meta",
+                params={"album_artist": "Artist", "album": "Record"},
+                json={"genre": "Jazz"},
+            )
+
+        assert resp.status_code == 200
+        mock_write.assert_not_called()
+        mock_index.update_album_meta.assert_called_once_with(
+            "Artist", "Record", genre="Jazz", label=None, year=None, mb_release_id=None
+        )
+
+    def test_mixed_album_writes_files_only_for_local_tracks(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Only local tracks in a mixed album receive file-tag writes."""
+        local = self._make_track(1)
+        remote = self._make_remote_track(2)
+        updated = [
+            Track(**{**local.__dict__, "genre": "Jazz"}),
+            Track(**{**remote.__dict__, "genre": "Jazz"}),
+        ]
+        mock_index.tracks_for_album.return_value = [local, remote]
+        mock_index.update_album_meta.return_value = updated
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch("kamp_core.library.write_meta_tags_to_file") as mock_write:
+            resp = TestClient(app).patch(
+                "/api/v1/albums/meta",
+                params={"album_artist": "Artist", "album": "Record"},
+                json={"genre": "Jazz"},
+            )
+
+        assert resp.status_code == 200
+        assert mock_write.call_count == 1
+        assert mock_write.call_args[0][0] == local.file_path
+
 
 # ---------------------------------------------------------------------------
 # iTunes art search / apply (KAMP-341)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5658,3 +5658,131 @@ class TestMagicPlaylistReactivity:
         on_fields_changed = client.app.state.on_fields_changed
         assert callable(on_fields_changed)
         on_fields_changed({"track.favorite"})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Display override endpoints (KAMP-467)
+# ---------------------------------------------------------------------------
+
+
+def _bandcamp_track(n: int = 1) -> Track:
+    return Track(
+        file_path=Path(f"bandcamp://42/{n}"),
+        title=f"Track {n}",
+        artist="Band",
+        album_artist="Band",
+        album="Long Name",
+        year="2020",
+        track_number=n,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+        source="bandcamp",
+    )
+
+
+class TestPatchTrackDisplayEndpoint:
+    """PATCH /api/v1/tracks/{track_id}/display — display-only title override."""
+
+    def test_returns_updated_track(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        track = _bandcamp_track()
+        track.id = 7
+        updated = Track(**{**track.__dict__, "title": "Short Name"})
+        updated.id = 7
+        mock_index.get_track_by_id.return_value = track
+        mock_index.update_track_display_title.return_value = updated
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/tracks/7/display", json={"display_title": "Short Name"}
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Short Name"
+        mock_index.update_track_display_title.assert_called_once_with(7, "Short Name")
+
+    def test_returns_404_for_missing_track(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_track_by_id.return_value = None
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/tracks/9999/display", json={"display_title": "X"}
+        )
+
+        assert resp.status_code == 404
+
+
+class TestPatchAlbumDisplayEndpoint:
+    """PATCH /api/v1/albums/display — display-only album title and artist override."""
+
+    def _album_info(self) -> AlbumInfo:
+        return AlbumInfo(
+            album_artist="Band",
+            album="Long Name",
+            year="2020",
+            track_count=1,
+            has_art=False,
+            source="bandcamp",
+            display_album="Short",
+            display_album_artist="B",
+        )
+
+    def test_returns_updated_album(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.update_album_display.return_value = self._album_info()
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/albums/display",
+            json={
+                "album_artist": "Band",
+                "album": "Long Name",
+                "display_album": "Short",
+                "display_album_artist": "B",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["display_album"] == "Short"
+        assert data["display_album_artist"] == "B"
+        mock_index.update_album_display.assert_called_once_with(
+            "Band", "Long Name", "Short", "B"
+        )
+
+    def test_returns_404_for_missing_album(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.update_album_display.return_value = None
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/albums/display",
+            json={
+                "album_artist": "Ghost",
+                "album": "Phantom",
+                "display_album": None,
+                "display_album_artist": None,
+            },
+        )
+
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **Display overrides for title, album, and album artist** on Bandcamp albums: separate nullable `display_*` columns COALESCE'd at read time so canonical values remain stable for API lookups, art URLs, and queue logic. Syncs never overwrite display columns (absent from ON CONFLICT clause / INSERT OR IGNORE).
- **Year, genre, and label editing** for streaming albums: `patch_album_meta` skips `write_meta_tags_to_file` for remote tracks; upsert_many uses `CASE WHEN source='bandcamp' THEN COALESCE(NULLIF(incoming,''), existing) ELSE incoming END` so user-set values survive resyncs while local file rescans continue to win unconditionally.
- Schema migration to v35 (display columns on `tracks` and `albums`).
- FTS rebuilt to search display values; album sort uses `COALESCE(display_album, album)`.
- Two new API endpoints: `PATCH /api/v1/tracks/{id}/display` and `PATCH /api/v1/albums/display`.
- UI: edit mode unlocked for Bandcamp albums; `onSave` branches on source to call display vs. rename endpoints; `AlbumCard` renders display names.

## Test plan

- [ ] Open a Bandcamp album — verify edit-tags button appears
- [ ] Edit album title, album artist, individual track titles — verify changes render in header, breadcrumb, and album grid card
- [ ] Trigger a Bandcamp sync — confirm all display overrides survive
- [ ] Expand the meta panel in edit mode on a Bandcamp album — edit genre, label, year and save — verify no 500 error
- [ ] Trigger sync again — confirm genre/label/year edits survive
- [ ] Clear an overridden track title (save empty) — confirm it reverts to canonical Bandcamp title
- [ ] Search for a display-renamed album — confirm FTS finds it
- [ ] Verify local album edit mode unchanged (file-rename path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)