### PR TITLE
feat(KAMP-468): art reposition for streaming albums

### DIFF
--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -369,6 +369,7 @@ export function TrackList(): React.JSX.Element | null {
       {/* Hero: full-width art — image intentionally taller than hero to bleed into track list */}
       <div
         className={`track-list-hero${album.has_art ? ' has-art' : ''}`}
+        title={albumEditMode && album.has_art ? 'Drag to reposition art' : undefined}
         onMouseDown={albumEditMode && album.has_art ? handleArtPanMouseDown : undefined}
         onContextMenu={(e) => {
           if (!album.album_url) return


### PR DESCRIPTION
## Summary

- KAMP-467 removed the source guard on the Edit tags button, unblocking `albumEditMode` for Bandcamp albums — and since the art pan gesture was already gated on `albumEditMode && album.has_art` (always true for remote albums), panning was already functional in edit mode as a side effect
- This PR adds a `title="Drag to reposition art"` tooltip to the hero div so the gesture is discoverable when in edit mode, rather than relying solely on `cursor: grab`
- No backend changes; no new logic; no CSS changes needed — existing `.track-list-view--edit .track-list-hero.has-art { cursor: grab }` already covers remote albums in edit mode

## Test plan

- [ ] Open a Bandcamp streaming album (requires `bandcamp.connected = true`)
- [ ] Without clicking "Edit tags": hover over hero — cursor is default, no tooltip
- [ ] Click "Edit tags" — hover hero — cursor is `grab`, tooltip reads "Drag to reposition art"
- [ ] Drag up/down — image repositions vertically
- [ ] Click "Done", navigate away, return, click "Edit tags" again — offset restored
- [ ] Verify local album behavior unchanged (pan still requires edit mode, works identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)