### PR TITLE
feat(KAMP-472): unify app font to DM Sans — kill Arial

### DIFF
--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -37,7 +37,7 @@
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 1px 6px;
-  font-family: monospace;
+  font-family: ui-monospace, 'SF Mono', monospace;
 }
 
 /* -------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -156,7 +156,7 @@
   line-height: 1;
   background: #3B6FD4;
   color: #fff;
-  font-family: system-ui, sans-serif;
+  font-family: inherit;
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.12em;

--- a/kamp_ui/src/renderer/src/assets/reset.css
+++ b/kamp_ui/src/renderer/src/assets/reset.css
@@ -16,6 +16,15 @@ textarea {
   -webkit-user-select: text;
 }
 
+/* Form elements don't inherit font from the page by default (UA stylesheet).
+   Force inheritance so DM Sans applies everywhere without per-component overrides. */
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
 html,
 body,
 #root {

--- a/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/OnboardingScreen.tsx
@@ -529,7 +529,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 fontSize="31"
                 fontWeight="700"
                 letterSpacing="8"
-                fontFamily="'DM Sans', sans-serif"
+                fontFamily="inherit"
               >
                 KAMP
               </text>
@@ -541,7 +541,7 @@ export function OnboardingScreen({ onComplete, onTitleChange }: Props): React.JS
                 fill="#1c1a16"
                 fontSize="17"
                 letterSpacing="5"
-                fontFamily="'DM Sans', sans-serif"
+                fontFamily="inherit"
               >
                 HI · FI
               </text>

--- a/kamp_ui/src/renderer/src/components/SplashScreen.tsx
+++ b/kamp_ui/src/renderer/src/components/SplashScreen.tsx
@@ -102,7 +102,7 @@ export function SplashScreen({
             fontSize="9"
             fontWeight="700"
             letterSpacing="2.5"
-            fontFamily="'DM Sans', sans-serif"
+            fontFamily="inherit"
           >
             KAMP
           </text>
@@ -113,7 +113,7 @@ export function SplashScreen({
             fill="#1c1a16"
             fontSize="4.8"
             letterSpacing="1.5"
-            fontFamily="'DM Sans', sans-serif"
+            fontFamily="inherit"
           >
             HI · FI
           </text>


### PR DESCRIPTION
## Summary

- **Root fix** (`reset.css`): Browser UA stylesheets exempt `button`, `input`, `select`, and `textarea` from CSS font inheritance — so `'DM Sans'` from `:root` was silently overridden by Arial in sort/filter rails, search bar, edit-tags pills, and dropdowns. Adding `font: inherit` to all four types is the standard normalize/reset pattern and fixes the majority of leakage in one rule.
- **`new-arrival-highlight.css`**: Changed the explicit `font-family: system-ui, sans-serif` on `.boring-hover` to `font-family: inherit`
- **`layout.css`**: Upgraded the server-offline code hint from bare `monospace` to `ui-monospace, 'SF Mono', monospace` (consistent with stereo-rack.css and preferences.css)
- **`SplashScreen.tsx` / `OnboardingScreen.tsx`**: Simplified 4 inline `fontFamily="'DM Sans', sans-serif"` SVG text props to `fontFamily="inherit"` — redundant now that the root declaration is trusted

## Test plan

- [ ] Sort/filter rail — all text in DM Sans (no Arial)
- [ ] Search bar — placeholder and typed text in DM Sans
- [ ] Edit tags pills — DM Sans
- [ ] Base-kamp editor input fields — DM Sans
- [ ] Dropdowns — DM Sans
- [ ] Album card "Boring?" hover ribbon — DM Sans (was `system-ui`)
- [ ] Server-offline hint `code` — SF Mono on macOS / monospace elsewhere
- [ ] Splash screen and Onboarding — visually identical to before
- [ ] Stereo rack — monospace elements unchanged (intentional exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)