### PR TITLE
feat(KAMP-469): remove download — revert downloaded Bandcamp album to streaming

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1834,10 +1834,10 @@ class LibraryIndex:
             return []
         album_id: int = row["id"]
 
-        # Fetch local tracks before deletion so we can migrate play counts.
+        # Fetch local tracks before deletion so we can migrate play counts and favorites.
         local_rows = self._conn.execute(
             """
-            SELECT file_path, play_count, track_number, disc_number
+            SELECT file_path, play_count, favorite, track_number, disc_number
             FROM tracks
             WHERE album_id = ?
               AND file_path NOT LIKE 'bandcamp://%'
@@ -1846,18 +1846,25 @@ class LibraryIndex:
             (album_id,),
         ).fetchall()
 
-        # Migrate play counts: MAX(local, streaming) written to the streaming row.
+        # Migrate play counts (MAX wins) and favorites (OR wins) to streaming rows.
         for r in local_rows:
             self._conn.execute(
                 """
                 UPDATE tracks
-                SET play_count = MAX(play_count, ?)
+                SET play_count = MAX(play_count, ?),
+                    favorite   = MAX(favorite, ?)
                 WHERE album_id = ?
                   AND track_number = ?
                   AND disc_number = ?
                   AND (file_path LIKE 'bandcamp://%' OR file_path LIKE 'bandcamp:\\%')
                 """,
-                (r["play_count"], album_id, r["track_number"], r["disc_number"]),
+                (
+                    r["play_count"],
+                    r["favorite"],
+                    album_id,
+                    r["track_number"],
+                    r["disc_number"],
+                ),
             )
 
         file_paths = [Path(r["file_path"]) for r in local_rows]
@@ -1899,6 +1906,7 @@ class LibraryIndex:
                 {
                     "track.source",
                     "track.play_count",
+                    "track.favorite",
                     "album.source",
                 }
             )

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1793,6 +1793,27 @@ class LibraryIndex:
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
+    def streaming_track_for_local_id(self, local_track_id: int) -> "Track | None":
+        """Return the streaming (bandcamp://) equivalent of a local track.
+
+        Joins on (album_id, track_number, disc_number) to find the bandcamp://
+        row that corresponds to the given local track ID.  Used to swap a queue
+        entry to its streaming counterpart before deleting the local file.
+        """
+        row = self._conn.execute(
+            """
+            SELECT s.* FROM tracks s
+            JOIN tracks l ON l.album_id = s.album_id
+                          AND l.track_number = s.track_number
+                          AND l.disc_number = s.disc_number
+            WHERE l.id = ?
+              AND (s.file_path LIKE 'bandcamp://%' OR s.file_path LIKE 'bandcamp:\\%')
+            LIMIT 1
+            """,
+            (local_track_id,),
+        ).fetchone()
+        return _row_to_track(row) if row is not None else None
+
     def remove_download(self, sale_item_id: str) -> "list[Path]":
         """Revert a downloaded collection item back to streaming state.
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1774,6 +1774,116 @@ class LibraryIndex:
         ).fetchone()
         return row is not None
 
+    def local_tracks_for_sale_item_id(self, sale_item_id: str) -> "list[Track]":
+        """Return local (non-bandcamp://) Track objects for a downloaded collection item.
+
+        Used by the server layer to obtain track IDs for the playing-guard check
+        and to collect file paths for deletion before calling remove_download().
+        """
+        rows = self._conn.execute(
+            """
+            SELECT t.* FROM tracks t
+            JOIN albums a ON a.id = t.album_id
+            WHERE a.sale_item_id = ?
+              AND t.file_path NOT LIKE 'bandcamp://%'
+              AND t.file_path NOT LIKE 'bandcamp:\\%'
+            ORDER BY t.disc_number, t.track_number
+            """,
+            (sale_item_id,),
+        ).fetchall()
+        return [_row_to_track(r) for r in rows]
+
+    def remove_download(self, sale_item_id: str) -> "list[Path]":
+        """Revert a downloaded collection item back to streaming state.
+
+        1. Migrates play counts from local track rows to their matching streaming
+           counterparts (MAX wins) so counts accumulated during local playback are
+           not lost.
+        2. Deletes local track rows for the album.
+        3. Refreshes albums.source so the album immediately shows as 'bandcamp'.
+        4. Sets bandcamp_collection.mode = 'remote'.
+
+        Returns the list of local file paths that the caller should delete from
+        the filesystem (file deletion is handled in the server layer).
+        """
+        row = self._conn.execute(
+            "SELECT id FROM albums WHERE sale_item_id = ?", (sale_item_id,)
+        ).fetchone()
+        if row is None:
+            return []
+        album_id: int = row["id"]
+
+        # Fetch local tracks before deletion so we can migrate play counts.
+        local_rows = self._conn.execute(
+            """
+            SELECT file_path, play_count, track_number, disc_number
+            FROM tracks
+            WHERE album_id = ?
+              AND file_path NOT LIKE 'bandcamp://%'
+              AND file_path NOT LIKE 'bandcamp:\\%'
+            """,
+            (album_id,),
+        ).fetchall()
+
+        # Migrate play counts: MAX(local, streaming) written to the streaming row.
+        for r in local_rows:
+            self._conn.execute(
+                """
+                UPDATE tracks
+                SET play_count = MAX(play_count, ?)
+                WHERE album_id = ?
+                  AND track_number = ?
+                  AND disc_number = ?
+                  AND (file_path LIKE 'bandcamp://%' OR file_path LIKE 'bandcamp:\\%')
+                """,
+                (r["play_count"], album_id, r["track_number"], r["disc_number"]),
+            )
+
+        file_paths = [Path(r["file_path"]) for r in local_rows]
+
+        # Remove local track rows.
+        self._conn.execute(
+            """
+            DELETE FROM tracks
+            WHERE album_id = ?
+              AND file_path NOT LIKE 'bandcamp://%'
+              AND file_path NOT LIKE 'bandcamp:\\%'
+            """,
+            (album_id,),
+        )
+
+        # Refresh albums.source — same subquery pattern as set_track_source_for_item.
+        self._conn.execute(
+            """
+            UPDATE albums SET source = (
+                SELECT CASE
+                    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+                         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
+                    THEN 'local'
+                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                    ELSE MIN(t.source)
+                END
+                FROM tracks t WHERE t.album_id = albums.id
+            )
+            WHERE id = ?
+            """,
+            (album_id,),
+        )
+
+        self.set_collection_item_mode(sale_item_id, "remote")
+        self._rebuild_fts()
+        self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed(
+                {
+                    "track.source",
+                    "track.play_count",
+                    "album.source",
+                }
+            )
+
+        return file_paths
+
     def reset_collection_sync_state(self) -> None:
         """Set synced_at = NULL for all rows so the next sync re-downloads everything."""
         self._conn.execute("UPDATE bandcamp_collection SET synced_at = NULL")

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1345,6 +1345,21 @@ class MpvPlaybackEngine:
         self._send_command("set_property", "pause", True)
         self._send_command("seek", 0, "absolute")
 
+    def unload(self) -> None:
+        # Fully unload the current file from mpv using mpv's "stop" command.
+        # Used before deleting a file that is loaded but not actively playing;
+        # "stop" reason in the end-file event does NOT trigger queue advancement.
+        with self._lock:
+            self._lookahead_path = None
+            self._lookahead_url = None
+            self._lookahead_id = None
+            self._current_uri = None
+            self.state.playing = False
+            self.state.position = 0.0
+            self.state.duration = 0.0
+            self.state.position_updated_at = time.time()
+            self._send_command("stop")
+
     @property
     def volume(self) -> int:
         return self.state.volume

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2867,14 +2867,23 @@ def create_app(
             la = queue.peek_next()
             return (c is not None and c.id == tid) or (la is not None and la.id == tid)
 
-        if any(_is_track_locked(t.id) for t in local_tracks):
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "A track in this album is currently playing. "
-                    "Stop playback before removing the download."
-                ),
-            )
+        locked = [t for t in local_tracks if _is_track_locked(t.id)]
+        if locked:
+            if engine.state.playing:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "A track in this album is currently playing. "
+                        "Stop playback before removing the download."
+                    ),
+                )
+            # Stopped/paused: swap queue entries to streaming equivalents and
+            # unload the file so it can be deleted without a held file handle.
+            for local_track in locked:
+                streaming = index.streaming_track_for_local_id(local_track.id)
+                if streaming is not None:
+                    queue.update_track_by_id(local_track.id, streaming)
+            engine.unload()
 
         file_paths = index.remove_download(sale_item_id)
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2893,21 +2893,27 @@ def create_app(
             return (c is not None and c.id == tid) or (la is not None and la.id == tid)
 
         locked = [t for t in local_tracks if _is_track_locked(t.id)]
+        if locked and engine.state.playing:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "A track in this album is currently playing. "
+                    "Stop playback before removing the download."
+                ),
+            )
+
+        # Swap every local track in the queue to its streaming equivalent so
+        # that on restart the queue can be fully restored from the DB.  Without
+        # this, only the swapped current/next entries survive; all other queue
+        # positions point at local paths that no longer exist after deletion.
+        for local_track in local_tracks:
+            streaming = index.streaming_track_for_local_id(local_track.id)
+            if streaming is not None:
+                queue.update_track_by_id(local_track.id, streaming)
+
         if locked:
-            if engine.state.playing:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        "A track in this album is currently playing. "
-                        "Stop playback before removing the download."
-                    ),
-                )
-            # Stopped/paused: swap queue entries to streaming equivalents and
-            # unload the file so it can be deleted without a held file handle.
-            for local_track in locked:
-                streaming = index.streaming_track_for_local_id(local_track.id)
-                if streaming is not None:
-                    queue.update_track_by_id(local_track.id, streaming)
+            # Current track's file is loaded in mpv — unload it so the handle
+            # is released before we delete the file from disk.
             engine.unload()
 
         file_paths = index.remove_download(sale_item_id)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -668,6 +668,10 @@ _OS_METADATA_NAMES: frozenset[str] = frozenset(
     {".DS_Store", "Thumbs.db", "desktop.ini", ".Spotlight-V100", ".Trashes"}
 )
 
+_COVER_ART_EXTENSIONS: frozenset[str] = frozenset(
+    {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
+)
+
 
 def _scrub_os_metadata(directory: Path) -> None:
     """Remove known OS-generated metadata files from *directory*.
@@ -678,6 +682,27 @@ def _scrub_os_metadata(directory: Path) -> None:
     try:
         for entry in directory.iterdir():
             if entry.name in _OS_METADATA_NAMES:
+                try:
+                    entry.unlink()
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
+def _scrub_cover_art(directory: Path) -> None:
+    """Remove image files and macOS resource forks from *directory*.
+
+    Called before rmdir() on an album directory being vacated by
+    remove_download, so cover.jpg and similar bundled artwork files don't
+    prevent cleanup.  Only touches the top level — does not recurse.
+    """
+    try:
+        for entry in directory.iterdir():
+            if entry.is_file() and (
+                entry.suffix.lower() in _COVER_ART_EXTENSIONS
+                or entry.name.startswith("._")
+            ):
                 try:
                     entry.unlink()
                 except OSError:
@@ -2894,12 +2919,24 @@ def create_app(
                 pass
 
         lib_path: Path | None = _state["library_path"]
-        dirs_to_try: set[Path] = set()
-        for fp in file_paths:
-            dirs_to_try.add(fp.parent)
-            if fp.parent.parent != fp.parent:
-                dirs_to_try.add(fp.parent.parent)
-        for d in sorted(dirs_to_try, key=lambda p: len(p.parts), reverse=True):
+        # Album-level dirs (directly contained the track files): scrub OS
+        # metadata and cover-art images before attempting rmdir.
+        album_dirs: set[Path] = {fp.parent for fp in file_paths}
+        for d in album_dirs:
+            if lib_path is not None and d == lib_path:
+                continue
+            _scrub_os_metadata(d)
+            _scrub_cover_art(d)
+            try:
+                d.rmdir()
+            except OSError:
+                pass
+        # Parent (artist-level) dirs: only scrub OS metadata — cover art
+        # doesn't live here, and rmdir fails safely if other albums remain.
+        parent_dirs: set[Path] = {
+            fp.parent.parent for fp in file_paths if fp.parent.parent != fp.parent
+        }
+        for d in parent_dirs:
             if lib_path is not None and d == lib_path:
                 continue
             _scrub_os_metadata(d)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2846,6 +2846,68 @@ def create_app(
         )
         return {"ok": True}
 
+    @app.delete("/api/v1/bandcamp/collection/{sale_item_id}/download")
+    def remove_downloaded_item(sale_item_id: str) -> dict[str, Any]:
+        """Revert a downloaded Bandcamp album back to streaming state.
+
+        Deletes the local files, removes local track rows from the DB (streaming
+        rows are preserved and become the primary tracks again), and sets
+        bandcamp_collection.mode back to 'remote'.
+
+        Returns 404 if the item is not in the collection.
+        Returns 409 if a track from this album is currently playing.
+        """
+        if not index.get_collection_item(sale_item_id):
+            raise HTTPException(status_code=404, detail="Collection item not found")
+
+        local_tracks = index.local_tracks_for_sale_item_id(sale_item_id)
+
+        def _is_track_locked(tid: int) -> bool:
+            c = queue.current()
+            la = queue.peek_next()
+            return (c is not None and c.id == tid) or (la is not None and la.id == tid)
+
+        if any(_is_track_locked(t.id) for t in local_tracks):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "A track in this album is currently playing. "
+                    "Stop playback before removing the download."
+                ),
+            )
+
+        file_paths = index.remove_download(sale_item_id)
+
+        for fp in file_paths:
+            try:
+                fp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+        lib_path: Path | None = _state["library_path"]
+        dirs_to_try: set[Path] = set()
+        for fp in file_paths:
+            dirs_to_try.add(fp.parent)
+            if fp.parent.parent != fp.parent:
+                dirs_to_try.add(fp.parent.parent)
+        for d in sorted(dirs_to_try, key=lambda p: len(p.parts), reverse=True):
+            if lib_path is not None and d == lib_path:
+                continue
+            _scrub_os_metadata(d)
+            try:
+                d.rmdir()
+            except OSError:
+                pass
+
+        _broadcast(
+            {
+                "type": "bandcamp.album-download",
+                "sale_item_id": sale_item_id,
+                "state": "removed",
+            }
+        )
+        return {"ok": True}
+
     # -----------------------------------------------------------------------
     # Player
     # -----------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -256,7 +256,7 @@ export default function App(): React.JSX.Element {
           } else {
             useStore.getState().clearAlbumQueued(saleItemId)
             useStore.getState().clearAlbumDownloading(saleItemId)
-            if (state === 'done') {
+            if (state === 'done' || state === 'removed') {
               void useStore.getState().loadLibrary()
               void useStore.getState().refreshOpenAlbum()
             }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -645,7 +645,7 @@ export default function App(): React.JSX.Element {
       {flashToast && (
         <div className="flash-toast" role="status">
           <span className="album-rename-toast-text">{flashToast}</span>
-          <div className="album-rename-toast-bar" style={{ animationDuration: '2000ms' }} />
+          <div className="album-rename-toast-bar" style={{ animationDuration: '5000ms' }} />
         </div>
       )}
     </div>

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -347,6 +347,9 @@ export const disconnectBandcamp = (): Promise<{ ok: boolean }> => del('/api/v1/b
 export const downloadAlbum = (saleItemId: string): Promise<{ ok: boolean }> =>
   post(`/api/v1/bandcamp/collection/${encodeURIComponent(saleItemId)}/download`)
 
+export const removeDownload = (saleItemId: string): Promise<{ ok: boolean }> =>
+  del(`/api/v1/bandcamp/collection/${encodeURIComponent(saleItemId)}/download`)
+
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------
@@ -657,7 +660,7 @@ export type AudioLevelMessage = {
 export type AlbumDownloadMessage = {
   type: 'bandcamp.album-download'
   sale_item_id: string
-  state: 'queued' | 'downloading' | 'done' | 'error'
+  state: 'queued' | 'downloading' | 'done' | 'error' | 'removed'
 }
 export type MagicPlaylistUpdatedMessage = {
   type: 'magic_playlist.updated'
@@ -692,7 +695,7 @@ export function connectStateStream(
   onTrackChanged?: () => void,
   onAlbumDownload?: (
     saleItemId: string,
-    state: 'queued' | 'downloading' | 'done' | 'error'
+    state: 'queued' | 'downloading' | 'done' | 'error' | 'removed'
   ) => void,
   onMagicPlaylistUpdated?: (id: number) => void
 ): () => void {

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useStore } from '../store'
 import { getTracksForAlbum, downloadAlbum, getPlaylistTracks } from '../api/client'
+import { RemoveFromQueueIcon } from './TransportIcons'
 import type { Album } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { ContextMenuSubmenu } from './ContextMenuSubmenu'
@@ -34,6 +35,7 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
   const setAlbumFavorite = useStore((s) => s.setAlbumFavorite)
   const markAlbumDownloading = useStore((s) => s.markAlbumDownloading)
+  const removeDownload = useStore((s) => s.removeDownload)
   const showFlashToast = useStore((s) => s.showFlashToast)
   const playlists = useStore((s) => s.library.playlists)
   const addTrackToPlaylist = useStore((s) => s.addTrackToPlaylist)
@@ -220,6 +222,27 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
                 <DownloadArrowIcon size={12} />
               </span>
               Download this album
+            </button>
+          )}
+          {album.source === 'local' && album.sale_item_id && (
+            <button
+              className="track-context-menu-item track-context-menu-item--action"
+              onClick={() => {
+                void removeDownload(album.sale_item_id!)
+                onClose()
+              }}
+            >
+              <span
+                style={{
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                  flexShrink: 0,
+                  display: 'inline-flex'
+                }}
+              >
+                <RemoveFromQueueIcon size={12} />
+              </span>
+              Remove download
             </button>
           )}
           {album.source === 'local' && (

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -28,6 +28,7 @@ import {
   PauseIcon,
   QueueAddIcon,
   PlayNextIcon,
+  RemoveFromQueueIcon,
   ShareIcon,
   WarnIcon
 } from './TransportIcons'
@@ -98,6 +99,7 @@ export function TrackList(): React.JSX.Element | null {
   const connected = configValues?.['bandcamp.connected'] ?? false
   const downloadingAlbumIds = useStore((s) => s.downloadingAlbumIds)
   const markAlbumDownloading = useStore((s) => s.markAlbumDownloading)
+  const removeDownload = useStore((s) => s.removeDownload)
 
   const albumEditMode = useStore((s) => s.albumEditMode)
   const setAlbumEditMode = useStore((s) => s.setAlbumEditMode)
@@ -612,10 +614,12 @@ export function TrackList(): React.JSX.Element | null {
           )}
         </div>
         <div className="album-controls-group">
-          {isRemoteAlbum && (
+          {(isRemoteAlbum || album.sale_item_id) && (
             <div className="streaming-controls">
-              <span className="source-pill">{sourceIcon(album.source, 16)}</span>
-              {saleItemId && (
+              <span className="source-pill">
+                {sourceIcon(isRemoteAlbum ? album.source : 'bandcamp', 16)}
+              </span>
+              {isRemoteAlbum && saleItemId && (
                 <button
                   className={`album-download-btn${isDownloading ? ' album-download-btn--downloading' : ''}`}
                   {...tooltip('Download Album')}
@@ -627,6 +631,16 @@ export function TrackList(): React.JSX.Element | null {
                   }}
                 >
                   <DownloadArrowIcon size={16} />
+                </button>
+              )}
+              {!isRemoteAlbum && album.sale_item_id && (
+                <button
+                  className="album-download-btn"
+                  {...tooltip('Remove download')}
+                  aria-label="Remove download"
+                  onClick={() => void removeDownload(album.sale_item_id!)}
+                >
+                  <RemoveFromQueueIcon size={16} />
                 </button>
               )}
               {album.album_url && (

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -498,7 +498,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
       return { queuedAlbumIds: next }
     }),
   removeDownload: async (saleItemId) => {
-    await api.removeDownload(saleItemId)
+    try {
+      await api.removeDownload(saleItemId)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not remove download'
+      get().showFlashToast(msg)
+    }
   },
   showFlashToast: (msg) => {
     set({ flashToast: msg })
@@ -611,10 +616,22 @@ export const useStore = create<PlayerStore>((set, get) => ({
         api.getArtists(),
         api.getPlaylists()
       ])
-      set((s) => ({
-        library: { ...s.library, albums, artists, playlists },
-        serverStatus: 'connected'
-      }))
+      set((s) => {
+        // Refresh selectedAlbum so metadata changes (source, sale_item_id, etc.)
+        // are visible immediately without needing to navigate away and back.
+        const { selectedAlbum } = s.library
+        const refreshedSelectedAlbum = selectedAlbum
+          ? (albums.find((a) =>
+              a.album_artist === selectedAlbum.album_artist &&
+              a.album === selectedAlbum.album &&
+              a.file_path === selectedAlbum.file_path
+            ) ?? selectedAlbum)
+          : null
+        return {
+          library: { ...s.library, albums, artists, playlists, selectedAlbum: refreshedSelectedAlbum },
+          serverStatus: 'connected'
+        }
+      })
     } catch {
       // During initial startup or mid-session reconnect the server may not be
       // ready yet — the WebSocket retry loop owns recovery. Only signal

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -115,6 +115,7 @@ type PlayerStore = {
   clearAlbumDownloading: (saleItemId: string) => void
   markAlbumQueued: (saleItemId: string) => void
   clearAlbumQueued: (saleItemId: string) => void
+  removeDownload: (saleItemId: string) => Promise<void>
   showFlashToast: (msg: string) => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
@@ -496,6 +497,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
       next.delete(saleItemId)
       return { queuedAlbumIds: next }
     }),
+  removeDownload: async (saleItemId) => {
+    await api.removeDownload(saleItemId)
+  },
   showFlashToast: (msg) => {
     set({ flashToast: msg })
     setTimeout(() => set({ flashToast: null }), 2000)

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -507,7 +507,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
   showFlashToast: (msg) => {
     set({ flashToast: msg })
-    setTimeout(() => set({ flashToast: null }), 2000)
+    setTimeout(() => set({ flashToast: null }), 5000)
   },
 
   setRecentlyAddedCount: (n) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -621,14 +621,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
         // are visible immediately without needing to navigate away and back.
         const { selectedAlbum } = s.library
         const refreshedSelectedAlbum = selectedAlbum
-          ? (albums.find((a) =>
-              a.album_artist === selectedAlbum.album_artist &&
-              a.album === selectedAlbum.album &&
-              a.file_path === selectedAlbum.file_path
+          ? (albums.find(
+              (a) =>
+                a.album_artist === selectedAlbum.album_artist &&
+                a.album === selectedAlbum.album &&
+                a.file_path === selectedAlbum.file_path
             ) ?? selectedAlbum)
           : null
         return {
-          library: { ...s.library, albums, artists, playlists, selectedAlbum: refreshedSelectedAlbum },
+          library: {
+            ...s.library,
+            albums,
+            artists,
+            playlists,
+            selectedAlbum: refreshedSelectedAlbum
+          },
           serverStatus: 'connected'
         }
       })

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -5727,6 +5727,169 @@ class TestDownloadQueue:
         index.close()
 
 
+class TestRemoveDownload:
+    """Tests for local_tracks_for_sale_item_id and remove_download."""
+
+    def _setup_downloaded_album(self, tmp_path: Path) -> LibraryIndex:
+        """Create an index with a downloaded album: both local and streaming tracks present.
+
+        Streaming tracks keep play_count 2 and 5; local tracks keep 7 and 3.
+        play_count is set via raw SQL because upsert_many intentionally omits it
+        (play counts are managed exclusively by record_played() in production).
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("sid42", mode="local", synced_at=1.0)
+
+        # Streaming tracks (bandcamp://) inserted first, as they would be pre-download.
+        streaming1 = _sample_track(Path("bandcamp://sid42/1"))
+        streaming1.track_number = 1
+        streaming1.source = "bandcamp"
+        streaming2 = _sample_track(Path("bandcamp://sid42/2"))
+        streaming2.track_number = 2
+        streaming2.source = "bandcamp"
+        index.upsert_many([streaming1, streaming2])
+
+        # Link sale_item_id on the albums row and set play counts directly.
+        index._conn.execute(
+            "UPDATE albums SET sale_item_id = 'sid42', source = 'local' WHERE album = 'The Album'"
+        )
+        index._conn.execute(
+            "UPDATE tracks SET play_count = 2 WHERE file_path = 'bandcamp://sid42/1'"
+        )
+        index._conn.execute(
+            "UPDATE tracks SET play_count = 5 WHERE file_path = 'bandcamp://sid42/2'"
+        )
+        index._conn.commit()
+
+        # Local tracks — play_count set via SQL after upsert.
+        local1 = _sample_track(tmp_path / "track1.mp3")
+        local1.track_number = 1
+        local2 = _sample_track(tmp_path / "track2.mp3")
+        local2.track_number = 2
+        index.upsert_many([local1, local2])
+        index._conn.execute(
+            "UPDATE tracks SET play_count = 7 WHERE file_path = ?",
+            (str(tmp_path / "track1.mp3"),),
+        )
+        index._conn.execute(
+            "UPDATE tracks SET play_count = 3 WHERE file_path = ?",
+            (str(tmp_path / "track2.mp3"),),
+        )
+        index._conn.commit()
+
+        return index
+
+    def test_local_tracks_for_sale_item_id_returns_local_only(
+        self, tmp_path: Path
+    ) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        tracks = index.local_tracks_for_sale_item_id("sid42")
+        index.close()
+
+        paths = [str(t.file_path) for t in tracks]
+        assert all("bandcamp" not in p for p in paths)
+        assert len(tracks) == 2
+
+    def test_local_tracks_for_sale_item_id_returns_empty_for_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.local_tracks_for_sale_item_id("no-such-id") == []
+        index.close()
+
+    def test_remove_download_returns_local_file_paths(self, tmp_path: Path) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        paths = index.remove_download("sid42")
+        index.close()
+
+        assert len(paths) == 2
+        assert all(isinstance(p, Path) for p in paths)
+        assert all("bandcamp" not in str(p) for p in paths)
+
+    def test_remove_download_deletes_local_tracks_from_db(self, tmp_path: Path) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        remaining = index._conn.execute(
+            "SELECT file_path FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchall()
+        index.close()
+
+        assert remaining == []
+
+    def test_remove_download_streaming_tracks_remain(self, tmp_path: Path) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        streaming = index._conn.execute(
+            "SELECT file_path FROM tracks WHERE file_path LIKE 'bandcamp://%'"
+        ).fetchall()
+        index.close()
+
+        assert len(streaming) == 2
+
+    def test_remove_download_sets_mode_remote(self, tmp_path: Path) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT mode FROM bandcamp_collection WHERE sale_item_id = 'sid42'"
+        ).fetchone()
+        index.close()
+
+        assert row["mode"] == "remote"
+
+    def test_remove_download_preserves_higher_local_play_count(
+        self, tmp_path: Path
+    ) -> None:
+        """Track 1: local play_count=7 > streaming=2; streaming should end up at 7."""
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT play_count FROM tracks WHERE file_path = 'bandcamp://sid42/1'"
+        ).fetchone()
+        index.close()
+
+        assert row["play_count"] == 7
+
+    def test_remove_download_keeps_streaming_count_when_higher(
+        self, tmp_path: Path
+    ) -> None:
+        """Track 2: streaming play_count=5 > local=3; streaming should keep 5."""
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT play_count FROM tracks WHERE file_path = 'bandcamp://sid42/2'"
+        ).fetchone()
+        index.close()
+
+        assert row["play_count"] == 5
+
+    def test_remove_download_updates_albums_source_to_bandcamp(
+        self, tmp_path: Path
+    ) -> None:
+        index = self._setup_downloaded_album(tmp_path)
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT source FROM albums WHERE sale_item_id = 'sid42'"
+        ).fetchone()
+        index.close()
+
+        assert row["source"] == "bandcamp"
+
+    def test_remove_download_returns_empty_for_unknown_sale_item_id(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.remove_download("no-such-id")
+        index.close()
+
+        assert result == []
+
+
 class TestMigrationV23:
     """v22 → v23: download_queue table created on upgrade from v22."""
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -5880,6 +5880,45 @@ class TestRemoveDownload:
 
         assert row["source"] == "bandcamp"
 
+    def test_remove_download_migrates_favorite_to_streaming_track(
+        self, tmp_path: Path
+    ) -> None:
+        """Favorite set on the local track is carried over to the streaming row."""
+        index = self._setup_downloaded_album(tmp_path)
+        index._conn.execute(
+            "UPDATE tracks SET favorite = 1 WHERE file_path = ?",
+            (str(tmp_path / "track1.mp3"),),
+        )
+        index._conn.commit()
+
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT favorite FROM tracks WHERE file_path = 'bandcamp://sid42/1'"
+        ).fetchone()
+        index.close()
+
+        assert row["favorite"] == 1
+
+    def test_remove_download_preserves_existing_streaming_favorite(
+        self, tmp_path: Path
+    ) -> None:
+        """Favorite already set on the streaming row is kept even if local is unfavorited."""
+        index = self._setup_downloaded_album(tmp_path)
+        index._conn.execute(
+            "UPDATE tracks SET favorite = 1 WHERE file_path = 'bandcamp://sid42/2'"
+        )
+        index._conn.commit()
+
+        index.remove_download("sid42")
+
+        row = index._conn.execute(
+            "SELECT favorite FROM tracks WHERE file_path = 'bandcamp://sid42/2'"
+        ).fetchone()
+        index.close()
+
+        assert row["favorite"] == 1
+
     def test_remove_download_returns_empty_for_unknown_sale_item_id(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2713,7 +2713,7 @@ class TestBandcampRemoveDownload:
         resp = TestClient(app).delete("/api/v1/bandcamp/collection/99/download")
         assert resp.status_code == 404
 
-    def test_returns_409_when_track_is_playing(
+    def test_returns_409_when_track_is_actively_playing(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
@@ -2743,10 +2743,73 @@ class TestBandcampRemoveDownload:
         playing_track.id = 77
         mock_index.local_tracks_for_sale_item_id.return_value = [playing_track]
         mock_queue.current.return_value = playing_track
+        mock_engine.state.playing = True
 
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
         assert resp.status_code == 409
+
+    def test_swaps_queue_to_streaming_when_stopped(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """When the local track is queued but transport is stopped, swap the
+        queue entry to the streaming equivalent and proceed without a 409."""
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        local_track = Track(
+            file_path=_Path("/music/Artist/Album/01.flac"),
+            title="Track",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="flac",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        local_track.id = 77
+        local_track.album_id = 5
+
+        streaming_track = Track(
+            file_path=_Path("bandcamp://42/1"),
+            title="Track",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        streaming_track.id = 78
+
+        mock_index.local_tracks_for_sale_item_id.return_value = [local_track]
+        mock_index.streaming_track_for_local_id.return_value = streaming_track
+        mock_index.remove_download.return_value = []
+        mock_queue.current.return_value = local_track
+        mock_queue.peek_next.return_value = None
+        mock_engine.state.playing = False
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 200
+        mock_queue.update_track_by_id.assert_called_once_with(77, streaming_track)
+        mock_engine.unload.assert_called_once()
 
     def test_returns_200_and_broadcasts_removed(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2695,6 +2695,136 @@ class TestBandcampCollectionDownload:
         assert callable(getattr(app.state, "notify_album_download_status", None))
 
 
+# DELETE /api/v1/bandcamp/collection/{sale_item_id}/download
+# ---------------------------------------------------------------------------
+
+
+class TestBandcampRemoveDownload:
+    """Tests for DELETE /api/v1/bandcamp/collection/{sale_item_id}/download."""
+
+    def test_returns_404_when_item_not_in_collection(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_collection_item.return_value = None
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/99/download")
+        assert resp.status_code == 404
+
+    def test_returns_409_when_track_is_playing(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        playing_track = Track(
+            file_path=_Path("/music/Artist/Album/01.flac"),
+            title="Playing Track",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="flac",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        playing_track.id = 77
+        mock_index.local_tracks_for_sale_item_id.return_value = [playing_track]
+        mock_queue.current.return_value = playing_track
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+        assert resp.status_code == 409
+
+    def test_returns_200_and_broadcasts_removed(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        from pathlib import Path as _Path
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = []
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # consume initial state push
+                resp = c.delete("/api/v1/bandcamp/collection/42/download")
+                msg = ws.receive_json()
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert msg["type"] == "bandcamp.album-download"
+        assert msg["sale_item_id"] == "42"
+        assert msg["state"] == "removed"
+
+    def test_deletes_local_files(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        from pathlib import Path as _Path
+
+        track_file = tmp_path / "track.flac"  # type: ignore[operator]
+        track_file.write_bytes(b"dummy")
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = [track_file]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert not track_file.exists()
+
+    def test_no_error_when_file_already_missing(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        from pathlib import Path as _Path
+
+        missing_file = tmp_path / "gone.flac"  # type: ignore[operator]
+        # Do not create the file — simulates already-deleted scenario.
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = [missing_file]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 200
+
+
 # Bandcamp session-cookies endpoint
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2811,6 +2811,84 @@ class TestBandcampRemoveDownload:
         mock_queue.update_track_by_id.assert_called_once_with(77, streaming_track)
         mock_engine.unload.assert_called_once()
 
+    def test_swaps_all_queued_tracks_not_just_current(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """All local tracks in the queue are swapped, not just current/next.
+
+        Without this, tracks beyond 'next' survive in memory but point at local
+        paths that no longer exist in the DB after deletion, so they are silently
+        dropped when the queue is restored on the next restart."""
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+
+        def _make_local(n: int) -> Track:
+            t = Track(
+                file_path=_Path(f"/music/Artist/Album/0{n}.flac"),
+                title=f"Track {n}",
+                artist="Artist",
+                album_artist="Artist",
+                album="Album",
+                year="2024",
+                track_number=n,
+                disc_number=1,
+                ext="flac",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+            )
+            t.id = 100 + n
+            return t
+
+        def _make_streaming(n: int) -> Track:
+            t = Track(
+                file_path=_Path(f"bandcamp://42/{n}"),
+                title=f"Track {n}",
+                artist="Artist",
+                album_artist="Artist",
+                album="Album",
+                year="2024",
+                track_number=n,
+                disc_number=1,
+                ext="mp3",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+            )
+            t.id = 200 + n
+            return t
+
+        local_tracks = [_make_local(i) for i in range(1, 5)]
+        streaming_tracks = {100 + i: _make_streaming(i) for i in range(1, 5)}
+
+        mock_index.local_tracks_for_sale_item_id.return_value = local_tracks
+        mock_index.streaming_track_for_local_id.side_effect = (
+            lambda tid: streaming_tracks.get(tid)
+        )
+        mock_index.remove_download.return_value = []
+        # Only track 1 is current; tracks 2–4 are further in the queue (not locked).
+        mock_queue.current.return_value = local_tracks[0]
+        mock_queue.peek_next.return_value = local_tracks[1]
+        mock_engine.state.playing = False
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 200
+        # All four tracks must have been swapped.
+        swapped_ids = {
+            call.args[0] for call in mock_queue.update_track_by_id.call_args_list
+        }
+        assert swapped_ids == {101, 102, 103, 104}
+
     def test_returns_200_and_broadcasts_removed(
         self,
         mock_index: MagicMock,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2887,6 +2887,65 @@ class TestBandcampRemoveDownload:
 
         assert resp.status_code == 200
 
+    def test_removes_cover_art_before_rmdir(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """Cover art left in the album dir after track deletion is cleaned up."""
+        album_dir = tmp_path / "Artist" / "Album"  # type: ignore[operator]
+        album_dir.mkdir(parents=True)
+        track_file = album_dir / "01.flac"
+        cover_file = album_dir / "cover.jpg"
+        track_file.write_bytes(b"audio")
+        cover_file.write_bytes(b"img")
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = [track_file]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert not cover_file.exists()
+        assert not album_dir.exists()
+
+    def test_preserves_artist_dir_when_other_album_remains(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """Artist dir is kept when another album's folder still lives in it."""
+        artist_dir = tmp_path / "Artist"  # type: ignore[operator]
+        album_dir = artist_dir / "Album A"
+        other_album_dir = artist_dir / "Album B"
+        album_dir.mkdir(parents=True)
+        other_album_dir.mkdir(parents=True)
+        (other_album_dir / "01.flac").write_bytes(b"audio")
+
+        track_file = album_dir / "01.flac"
+        track_file.write_bytes(b"audio")
+
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "42",
+            "mode": "local",
+        }
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = [track_file]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert not album_dir.exists()
+        assert artist_dir.exists()  # kept — other album still present
+
 
 # Bandcamp session-cookies endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a `DELETE /api/v1/bandcamp/collection/{sale_item_id}/download` endpoint that deletes local files, migrates play counts to streaming track rows, and resets `bandcamp_collection.mode` back to `'remote'`.
- Streaming (`bandcamp://`) tracks are never deleted from the DB during download — the `tracks_for_album` filter just hides them in favour of local rows. Once local rows are removed, streaming tracks become primary again with no re-sync required.
- Play counts are preserved: `MAX(local, streaming)` is written to each streaming track row before the local rows are deleted.
- Returns 409 if any local track from the album is currently playing or in the gapless-lookahead slot.
- UI: downloaded albums now show a Bandcamp source pill and an X (remove-download) button in the streaming-controls area. A "Remove download" context menu item also appears above "Reveal in Finder".
- WS `bandcamp.album-download` state expanded with `'removed'`; handled the same as `'done'` (reload library + refresh open album).

## Test plan

- [ ] Open a downloaded Bandcamp album — Bandcamp source pill and X button visible in album controls
- [ ] X button removes local files and album transitions to streaming state immediately
- [ ] Right-click a downloaded album — "Remove download" appears above "Reveal in Finder"
- [ ] Play count on streaming tracks equals the higher of local vs streaming count
- [ ] Attempting remove while album is playing returns 409 (no action / future toast)
- [ ] Non-Bandcamp local albums: no source pill, no remove-download affordance
- [ ] Streaming-only albums: source pill + download arrow unchanged
- [ ] Share / copy Bandcamp link still works on downloaded albums
- [ ] `poetry run pytest tests/test_library.py::TestRemoveDownload tests/test_server.py::TestBandcampRemoveDownload -v` — all 15 tests pass
- [ ] `poetry run pytest` — full suite passes with coverage ≥ 93%

🤖 Generated with [Claude Code](https://claude.com/claude-code)