### PR TITLE
feat(KAMP-452): buffering indicator for remote stream loading

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -849,7 +849,13 @@ def create_app(
 
     def _notify_play_state_changed() -> None:
         """Broadcast a play_state.changed push event to all connected WebSocket clients."""
-        _state["buffering"] = False
+        # Only clear buffering when mpv reports it is actively playing. During a
+        # playing→playing track switch, mpv briefly sets pause=True as the old
+        # file ends; clearing on that transition would kill the indicator before
+        # the new file loads. Clearing on playing=True is redundant (file-loaded
+        # already cleared it) but harmless.
+        if engine.state.playing:
+            _state["buffering"] = False
         _broadcast({"type": "play_state.changed", **_state_snapshot().model_dump()})
 
     def _notify_album_download_status(sale_item_id: str, state: str) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -269,6 +269,7 @@ class PlayerStateOut(BaseModel):
     volume: int
     current_track: TrackOut | None
     next_track: TrackOut | None = None
+    buffering: bool = False
 
 
 class PlayRequest(BaseModel):
@@ -814,6 +815,7 @@ def create_app(
         # Pending proxy-fetch requests from the Python daemon subprocess.
         # id → {"id", "url", "method", "headers", "body", "event", "result"}
         "bandcamp_proxy_requests": {},
+        "buffering": False,
     }
 
     # Proxy-fetch events that were broadcast but had no WS client connected to
@@ -847,6 +849,7 @@ def create_app(
 
     def _notify_play_state_changed() -> None:
         """Broadcast a play_state.changed push event to all connected WebSocket clients."""
+        _state["buffering"] = False
         _broadcast({"type": "play_state.changed", **_state_snapshot().model_dump()})
 
     def _notify_album_download_status(sale_item_id: str, state: str) -> None:
@@ -957,7 +960,16 @@ def create_app(
         t.start()
 
     def _resolve_playback(track: "Track") -> str:
-        return resolve_playback_uri(track, index, refresh_stream_url, check_stream_url)
+        if track.is_remote:
+            _state["buffering"] = True
+            _broadcast({"type": "player.state", **_state_snapshot().model_dump()})
+        try:
+            return resolve_playback_uri(
+                track, index, refresh_stream_url, check_stream_url
+            )
+        except Exception:
+            _state["buffering"] = False
+            raise
 
     # Wire play-state change callback directly — the engine fires it from its
     # background reader thread whenever mpv's pause property flips.
@@ -1066,6 +1078,7 @@ def create_app(
             volume=engine.state.volume,
             current_track=TrackOut.from_track(current) if current else None,
             next_track=TrackOut.from_track(nxt) if nxt else None,
+            buffering=_state["buffering"],
         )
 
     # -----------------------------------------------------------------------
@@ -3098,6 +3111,7 @@ def create_app(
 
     @app.post("/api/v1/player/stop")
     def stop() -> dict[str, Any]:
+        _state["buffering"] = False
         engine.stop()
         _notify_track_changed()
         return {"ok": True}
@@ -3680,6 +3694,11 @@ def create_app(
                     if _recv_exc is not None:
                         raise _recv_exc
                     # Each "ping" from the client triggers a fresh snapshot.
+                    # Backstop: if mpv started playing without a pause-property
+                    # change (playing→playing transition), clear the buffering
+                    # flag once position advances so the indicator doesn't linger.
+                    if _state["buffering"] and engine.state.position > 0:
+                        _state["buffering"] = False
                     await ws.send_json(
                         {"type": "player.state", **_state_snapshot().model_dump()}
                     )

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -976,6 +976,19 @@ def create_app(
     engine.on_play_state_changed = _notify_play_state_changed
     engine.on_audio_level = _notify_audio_level
 
+    # Outermost on_file_loaded wrapper: clear buffering the moment mpv opens
+    # the new file. Wraps the __main__.py chain (gapless preload + scrobble)
+    # which is already assigned before create_app is called.
+    _outer_on_file_loaded = engine.on_file_loaded
+
+    def _on_file_loaded_clear_buffering() -> None:
+        _state["buffering"] = False
+        _broadcast({"type": "player.state", **_state_snapshot().model_dump()})
+        if _outer_on_file_loaded is not None:
+            _outer_on_file_loaded()
+
+    engine.on_file_loaded = _on_file_loaded_clear_buffering
+
     # Magic playlist field_index: maps field name → set of playlist IDs whose
     # criteria reference that field.  Rebuilt at startup and after CRUD ops.
     field_index: dict[str, set[int]] = {}
@@ -3694,11 +3707,6 @@ def create_app(
                     if _recv_exc is not None:
                         raise _recv_exc
                     # Each "ping" from the client triggers a fresh snapshot.
-                    # Backstop: if mpv started playing without a pause-property
-                    # change (playing→playing transition), clear the buffering
-                    # flag once position advances so the indicator doesn't linger.
-                    if _state["buffering"] and engine.state.position > 0:
-                        _state["buffering"] = False
                     await ws.send_json(
                         {"type": "player.state", **_state_snapshot().model_dump()}
                     )

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -74,6 +74,7 @@ export type PlayerState = {
   volume: number
   current_track: Track | null
   next_track: Track | null
+  buffering?: boolean
 }
 
 export type ScanResult = {

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -74,7 +74,7 @@ export type PlayerState = {
   volume: number
   current_track: Track | null
   next_track: Track | null
-  buffering?: boolean
+  buffering: boolean
 }
 
 export type ScanResult = {

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -254,10 +254,10 @@
    a replaced-element pseudo-element that Chromium silently refuses to animate. */
 @keyframes shimmer-scan {
   from {
-    background-position: 0% center;
+    background-position: 100% center;
   }
   to {
-    background-position: 100% center;
+    background-position: 0% center;
   }
 }
 

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -120,6 +120,13 @@
   gap: 8px;
 }
 
+.seek-bar-wrapper {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .seek-bar {
   flex: 1;
   cursor: pointer;
@@ -233,46 +240,44 @@
 
 /* Buffering indicator -------------------------------------------------------- */
 
-/* Pulsing opacity on the element (not the pseudo-element track) because
-   background-position animation on ::webkit-slider-runnable-track is a layout
-   paint operation that Chromium cannot GPU-composite — it silently drops the
-   animation while still applying the static gradient. Opacity is compositable
-   and always animates correctly. */
-@keyframes buffering-pulse {
-  0%,
-  100% {
-    opacity: 0.35;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
-/* Disable interaction and animate the seek bar element itself. */
+/* Disable interaction; the seek-bar-wrapper::after overlay replaces the
+   visual while buffering, so hide the input itself. */
 .is-buffering .seek-bar {
   cursor: default;
   pointer-events: none;
-  animation: buffering-pulse 1.2s ease-in-out infinite;
-}
-
-/* Hide the thumb — no draggable handle while buffering. */
-.is-buffering .seek-bar::-webkit-slider-thumb {
   opacity: 0;
-  pointer-events: none;
 }
 
-/* Static accent-colour track during buffering. With --range-progress: 100%
-   (set when no duration is known yet), the full track shows as accent. */
-.is-buffering .seek-bar::-webkit-slider-runnable-track {
-  background: linear-gradient(
+/* Shimmer overlay: a 4px stripe, vertically centred, that scans left→right.
+   Lives on ::after of .seek-bar-wrapper (a real div) so Chromium can paint
+   and animate it — background-position on ::webkit-slider-runnable-track is
+   a replaced-element pseudo-element that Chromium silently refuses to animate. */
+@keyframes shimmer-scan {
+  from {
+    background-position: 0% center;
+  }
+  to {
+    background-position: 100% center;
+  }
+}
+
+.is-buffering .seek-bar-wrapper::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 4px;
+  top: 50%;
+  margin-top: -2px;
+  border-radius: 2px;
+  pointer-events: none;
+  background-color: var(--border);
+  background-image: linear-gradient(
     90deg,
-    #3a3a3a 0%,
-    var(--accent) 45%,
-    #3a3a3a 55%,
-    #3a3a3a 100%
+    transparent 30%,
+    var(--accent) 50%,
+    transparent 70%
   );
   background-size: 300% 100%;
-  /* 50% centers the accent stripe (at 45–55% of the 300%-wide gradient)
-     over the middle of the track element. */
-  background-position: 50% center;
+  animation: shimmer-scan 1.5s ease-in-out infinite;
 }

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -233,26 +233,37 @@
 
 /* Buffering indicator -------------------------------------------------------- */
 
-@keyframes buffering-shimmer {
-  0%   { background-position: 200% center; }
-  100% { background-position: -200% center; }
+/* Pulsing opacity on the element (not the pseudo-element track) because
+   background-position animation on ::webkit-slider-runnable-track is a layout
+   paint operation that Chromium cannot GPU-composite — it silently drops the
+   animation while still applying the static gradient. Opacity is compositable
+   and always animates correctly. */
+@keyframes buffering-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
-/* Disable interaction on the seek bar while buffering. */
+/* Disable interaction and animate the seek bar element itself. */
 .is-buffering .seek-bar {
   cursor: default;
   pointer-events: none;
+  animation: buffering-pulse 1.2s ease-in-out infinite;
 }
 
-/* Hide the thumb so there's no draggable handle sitting at position 0. */
+/* Hide the thumb — no draggable handle while buffering. */
 .is-buffering .seek-bar::-webkit-slider-thumb {
   opacity: 0;
   pointer-events: none;
 }
 
+/* Static accent-colour track during buffering. With --range-progress: 100%
+   (set when no duration is known yet), the full track shows as accent. */
 .is-buffering .seek-bar::-webkit-slider-runnable-track {
-  /* Use #3a3a3a (lighter than --border #2e2e2e) so the sweep is visible
-     even when --range-progress is 0% (no track duration yet). */
   background: linear-gradient(
     90deg,
     #3a3a3a 0%,
@@ -261,22 +272,7 @@
     #3a3a3a 100%
   );
   background-size: 300% 100%;
-  animation: buffering-shimmer 1.4s infinite linear;
-}
-
-.is-buffering .seek-bar::-moz-range-thumb {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.is-buffering .seek-bar::-moz-range-track {
-  background: linear-gradient(
-    90deg,
-    #3a3a3a 0%,
-    var(--accent) 45%,
-    #3a3a3a 55%,
-    #3a3a3a 100%
-  );
-  background-size: 300% 100%;
-  animation: buffering-shimmer 1.4s infinite linear;
+  /* 50% centers the accent stripe (at 45–55% of the 300%-wide gradient)
+     over the middle of the track element. */
+  background-position: 50% center;
 }

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -230,3 +230,27 @@
   min-width: 24px;
   font-variant-numeric: tabular-nums;
 }
+
+/* Buffering indicator -------------------------------------------------------- */
+
+@keyframes buffering-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
+.is-buffering .seek-bar::-webkit-slider-runnable-track {
+  background: linear-gradient(
+    90deg,
+    var(--border) 0%,
+    var(--accent) 45%,
+    var(--border) 55%,
+    var(--border) 100%
+  );
+  background-size: 300% 100%;
+  animation: buffering-shimmer 1.4s infinite linear;
+}
+
+.is-buffering .seek-bar::-moz-range-track {
+  background: var(--border);
+  animation: buffering-shimmer 1.4s infinite linear;
+}

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -238,19 +238,45 @@
   100% { background-position: -200% center; }
 }
 
+/* Disable interaction on the seek bar while buffering. */
+.is-buffering .seek-bar {
+  cursor: default;
+  pointer-events: none;
+}
+
+/* Hide the thumb so there's no draggable handle sitting at position 0. */
+.is-buffering .seek-bar::-webkit-slider-thumb {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .is-buffering .seek-bar::-webkit-slider-runnable-track {
+  /* Use #3a3a3a (lighter than --border #2e2e2e) so the sweep is visible
+     even when --range-progress is 0% (no track duration yet). */
   background: linear-gradient(
     90deg,
-    var(--border) 0%,
+    #3a3a3a 0%,
     var(--accent) 45%,
-    var(--border) 55%,
-    var(--border) 100%
+    #3a3a3a 55%,
+    #3a3a3a 100%
   );
   background-size: 300% 100%;
   animation: buffering-shimmer 1.4s infinite linear;
 }
 
+.is-buffering .seek-bar::-moz-range-thumb {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .is-buffering .seek-bar::-moz-range-track {
-  background: var(--border);
+  background: linear-gradient(
+    90deg,
+    #3a3a3a 0%,
+    var(--accent) 45%,
+    #3a3a3a 55%,
+    #3a3a3a 100%
+  );
+  background-size: 300% 100%;
   animation: buffering-shimmer 1.4s infinite linear;
 }

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -37,7 +37,7 @@ export function TransportBar(): React.JSX.Element {
   const selectArtist = useStore((s) => s.selectArtist)
   const setActiveView = useStore((s) => s.setActiveView)
 
-  const { playing, position, duration, volume, current_track } = player
+  const { playing, position, duration, volume, current_track, buffering } = player
 
   const currentAlbum = current_track
     ? albums.find(
@@ -166,8 +166,8 @@ export function TransportBar(): React.JSX.Element {
         </button>
       </div>
 
-      <div className="transport-progress">
-        <span className="time">{formatTime(displayPosition)}</span>
+      <div className={`transport-progress${buffering ? ' is-buffering' : ''}`}>
+        <span className="time">{buffering ? '…' : formatTime(displayPosition)}</span>
         <input
           type="range"
           className="seek-bar"

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -185,7 +185,6 @@ export function TransportBar(): React.JSX.Element {
           max={duration || 1}
           step={0.5}
           value={displayPosition}
-          disabled={isBuffering}
           onPointerDown={(e) => {
             pointerDown.current = true
             setScrubPos(position)

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
@@ -67,6 +67,16 @@ export function TransportBar(): React.JSX.Element {
   const pointerDown = useRef(false)
   const tooltip = useTooltip()
   const displayPosition = scrubPos !== null ? scrubPos : position
+
+  // Debounce the buffering indicator: only show it if buffering persists for
+  // >250ms. This prevents a 1-2 frame shimmer flash when the cached URL
+  // resolves immediately (CSS animation-delay doesn't suppress a class that
+  // is added then removed within the delay window — only React state can).
+  const [isBuffering, setIsBuffering] = useState(false)
+  useEffect(() => {
+    const timerId = setTimeout(() => setIsBuffering(!!buffering), buffering ? 250 : 0)
+    return () => clearTimeout(timerId)
+  }, [buffering])
 
   // Force-clear scrub state when the track changes. Without this, a pointerup
   // event that didn't reach the slider (release outside its bounds, OS-level
@@ -166,8 +176,8 @@ export function TransportBar(): React.JSX.Element {
         </button>
       </div>
 
-      <div className={`transport-progress${buffering ? ' is-buffering' : ''}`}>
-        <span className="time">{buffering ? '…' : formatTime(displayPosition)}</span>
+      <div className={`transport-progress${isBuffering ? ' is-buffering' : ''}`}>
+        <span className="time">{isBuffering ? '…' : formatTime(displayPosition)}</span>
         <input
           type="range"
           className="seek-bar"
@@ -175,6 +185,7 @@ export function TransportBar(): React.JSX.Element {
           max={duration || 1}
           step={0.5}
           value={displayPosition}
+          disabled={isBuffering}
           onPointerDown={(e) => {
             pointerDown.current = true
             setScrubPos(position)
@@ -208,11 +219,12 @@ export function TransportBar(): React.JSX.Element {
           }}
           style={
             {
-              '--range-progress': `${(displayPosition / (duration || 1)) * 100}%`
+              '--range-progress':
+                isBuffering && !duration ? '100%' : `${(displayPosition / (duration || 1)) * 100}%`
             } as React.CSSProperties
           }
         />
-        <span className="time">{formatTime(duration)}</span>
+        <span className="time">{isBuffering && !duration ? '' : formatTime(duration)}</span>
       </div>
 
       <div className="transport-mode-btns">

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -178,51 +178,55 @@ export function TransportBar(): React.JSX.Element {
 
       <div className={`transport-progress${isBuffering ? ' is-buffering' : ''}`}>
         <span className="time">{isBuffering ? '…' : formatTime(displayPosition)}</span>
-        <input
-          type="range"
-          className="seek-bar"
-          min={0}
-          max={duration || 1}
-          step={0.5}
-          value={displayPosition}
-          onPointerDown={(e) => {
-            pointerDown.current = true
-            setScrubPos(position)
-            // Pin pointer events to the slider so pointerup is guaranteed to
-            // fire here even if the user releases the pointer outside the
-            // slider bounds. Without this, scrubPos can wedge — the
-            // track-change reset above (currentPath comparison) is the
-            // escape hatch for any wedge that still slips through.
-            try {
-              e.currentTarget.setPointerCapture(e.pointerId)
-            } catch {
-              // Some browsers reject setPointerCapture on non-trusted events
-              // (synthetic pointer events from automation, etc.) — ignore.
+        <div className="seek-bar-wrapper">
+          <input
+            type="range"
+            className="seek-bar"
+            min={0}
+            max={duration || 1}
+            step={0.5}
+            value={displayPosition}
+            onPointerDown={(e) => {
+              pointerDown.current = true
+              setScrubPos(position)
+              // Pin pointer events to the slider so pointerup is guaranteed to
+              // fire here even if the user releases the pointer outside the
+              // slider bounds. Without this, scrubPos can wedge — the
+              // track-change reset above (currentPath comparison) is the
+              // escape hatch for any wedge that still slips through.
+              try {
+                e.currentTarget.setPointerCapture(e.pointerId)
+              } catch {
+                // Some browsers reject setPointerCapture on non-trusted events
+                // (synthetic pointer events from automation, etc.) — ignore.
+              }
+            }}
+            onChange={(e) => {
+              const val = parseFloat(e.target.value)
+              setScrubPos(val)
+              if (pointerDown.current) seek(val)
+            }}
+            onPointerUp={() => {
+              pointerDown.current = false
+              setScrubPos(null)
+            }}
+            onPointerCancel={() => {
+              // Touch-cancel, OS-level capture loss, or a programmatic
+              // releasePointerCapture call — treat exactly like pointerup so
+              // the slider can never stay wedged on scrubPos.
+              pointerDown.current = false
+              setScrubPos(null)
+            }}
+            style={
+              {
+                '--range-progress':
+                  isBuffering && !duration
+                    ? '100%'
+                    : `${(displayPosition / (duration || 1)) * 100}%`
+              } as React.CSSProperties
             }
-          }}
-          onChange={(e) => {
-            const val = parseFloat(e.target.value)
-            setScrubPos(val)
-            if (pointerDown.current) seek(val)
-          }}
-          onPointerUp={() => {
-            pointerDown.current = false
-            setScrubPos(null)
-          }}
-          onPointerCancel={() => {
-            // Touch-cancel, OS-level capture loss, or a programmatic
-            // releasePointerCapture call — treat exactly like pointerup so
-            // the slider can never stay wedged on scrubPos.
-            pointerDown.current = false
-            setScrubPos(null)
-          }}
-          style={
-            {
-              '--range-progress':
-                isBuffering && !duration ? '100%' : `${(displayPosition / (duration || 1)) * 100}%`
-            } as React.CSSProperties
-          }
-        />
+          />
+        </div>
         <span className="time">{isBuffering && !duration ? '' : formatTime(duration)}</span>
       </div>
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -244,7 +244,8 @@ const initialPlayer: PlayerState = {
   duration: 0,
   volume: 100,
   current_track: null,
-  next_track: null
+  next_track: null,
+  buffering: false
 }
 
 export const useStore = create<PlayerStore>((set, get) => ({

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -119,6 +119,7 @@ export type PlayerState = {
   duration: number
   volume: number
   current_track: Track | null
+  buffering?: boolean
 }
 
 /** The full shape of window.KampAPI. */

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1401,10 +1401,10 @@ class TestPlayerWebSocket:
             msg = ws.receive_json()
         assert msg["type"] == "track.changed"
 
-    def test_buffering_backstop_cleared_by_ping_when_position_advances(
+    def test_buffering_cleared_by_on_file_loaded(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
-        """WS ping clears buffering when position > 0 (playing→playing backstop)."""
+        """on_file_loaded clears buffering when mpv opens the new file."""
         import time
 
         remote = Track(
@@ -1426,7 +1426,6 @@ class TestPlayerWebSocket:
         )
         mock_queue.next.return_value = remote
         mock_index.get_collection_item.return_value = None
-        mock_engine.state = PlaybackState(playing=True, position=0.0)
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
 
@@ -1434,15 +1433,10 @@ class TestPlayerWebSocket:
         c.post("/api/v1/player/next")
         assert c.get("/api/v1/player/state").json()["buffering"] is True
 
-        # Simulate mpv advancing position (audio started).
-        mock_engine.state = PlaybackState(playing=True, position=2.5)
-        with c.websocket_connect("/api/v1/ws") as ws:
-            ws.receive_json()  # initial snapshot (may still show buffering)
-            ws.send_text("ping")
-            msg = ws.receive_json()
+        # Simulate mpv firing file-loaded (new file opened and decoding begun).
+        mock_engine.on_file_loaded()
 
-        # Ping backstop must clear buffering once position > 0.
-        assert msg["buffering"] is False
+        assert c.get("/api/v1/player/state").json()["buffering"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4699,8 +4699,10 @@ class TestResolvePlaybackRemote:
     def test_buffering_true_after_remote_play_cleared_by_play_state_change(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
-        """Buffering flag is set while resolving a remote URL and cleared when
-        on_play_state_changed fires (simulating mpv reporting playback started)."""
+        """Buffering is cleared by on_play_state_changed only when playing=True.
+        A pause transition (playing=False) must NOT clear it — mpv briefly sets
+        pause=True during a playing→playing file switch and we must not lose the
+        indicator before the new file has actually loaded."""
         import time
 
         remote = Track(
@@ -4727,13 +4729,18 @@ class TestResolvePlaybackRemote:
 
         c.post("/api/v1/player/next")
 
-        # After the endpoint returns the URL is resolved but buffering stays True
-        # until mpv confirms playback via on_play_state_changed.
+        # Buffering stays True after the endpoint returns — mpv hasn't started yet.
         assert c.get("/api/v1/player/state").json()["buffering"] is True
 
-        # Simulate mpv firing the play-state callback (pause → False).
+        # Simulate mpv's internal pause=True transition (old file ending during
+        # a playing→playing switch) — must NOT clear the indicator.
+        mock_engine.state.playing = False
         app.state.notify_play_state_changed()
+        assert c.get("/api/v1/player/state").json()["buffering"] is True
 
+        # Simulate mpv reporting playing=True (new file is playing).
+        mock_engine.state.playing = True
+        app.state.notify_play_state_changed()
         assert c.get("/api/v1/player/state").json()["buffering"] is False
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -875,6 +875,10 @@ class TestPlayerStateEndpoint:
         data = c.get("/api/v1/player/state").json()
         assert data["position"] == pytest.approx(42.0)
 
+    def test_buffering_false_by_default(self, client: TestClient) -> None:
+        data = client.get("/api/v1/player/state").json()
+        assert data["buffering"] is False
+
 
 class TestPlayerPlayEndpoint:
     def test_play_loads_album_and_starts_playback(
@@ -1396,6 +1400,49 @@ class TestPlayerWebSocket:
             c.post("/api/v1/player/next")
             msg = ws.receive_json()
         assert msg["type"] == "track.changed"
+
+    def test_buffering_backstop_cleared_by_ping_when_position_advances(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """WS ping clears buffering when position > 0 (playing→playing backstop)."""
+        import time
+
+        remote = Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/track.mp3",
+            stream_url_expires_at=time.time() + 7200,
+        )
+        mock_queue.next.return_value = remote
+        mock_index.get_collection_item.return_value = None
+        mock_engine.state = PlaybackState(playing=True, position=0.0)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        # Trigger buffering=True via a remote-track play.
+        c.post("/api/v1/player/next")
+        assert c.get("/api/v1/player/state").json()["buffering"] is True
+
+        # Simulate mpv advancing position (audio started).
+        mock_engine.state = PlaybackState(playing=True, position=2.5)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # initial snapshot (may still show buffering)
+            ws.send_text("ping")
+            msg = ws.receive_json()
+
+        # Ping backstop must clear buffering once position > 0.
+        assert msg["buffering"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -4612,6 +4659,88 @@ class TestResolvePlaybackRemote:
 
         c.post("/api/v1/player/next")
         mock_engine.play.assert_called_once_with("https://cdn.example.com/existing.mp3")
+
+    def test_buffering_cleared_on_resolve_exception(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """If resolve_playback_uri raises, buffering is cleared immediately."""
+        import time
+
+        remote = Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/track.mp3",
+            stream_url_expires_at=time.time() - 1,  # expired — triggers refresh
+        )
+        mock_queue.next.return_value = remote
+        mock_index.get_collection_item.return_value = {
+            "sale_item_id": "999",
+            "album_url": "https://artist.bandcamp.com/album/x",
+        }
+        refresh_fn = MagicMock(side_effect=RuntimeError("network failure"))
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            refresh_stream_url=refresh_fn,
+        )
+        c = TestClient(app, raise_server_exceptions=False)
+
+        c.post("/api/v1/player/next")
+
+        # Buffering must be False after the exception — not stuck on.
+        assert c.get("/api/v1/player/state").json()["buffering"] is False
+
+    def test_buffering_true_after_remote_play_cleared_by_play_state_change(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """Buffering flag is set while resolving a remote URL and cleared when
+        on_play_state_changed fires (simulating mpv reporting playback started)."""
+        import time
+
+        remote = Track(
+            file_path=Path("bandcamp://999/1"),
+            title="Song",
+            artist="Artist",
+            album_artist="Artist",
+            album="Album",
+            year="2024",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            stream_url="https://cdn.example.com/track.mp3",
+            stream_url_expires_at=time.time() + 7200,
+        )
+        mock_queue.next.return_value = remote
+        mock_index.get_collection_item.return_value = None
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+
+        c.post("/api/v1/player/next")
+
+        # After the endpoint returns the URL is resolved but buffering stays True
+        # until mpv confirms playback via on_play_state_changed.
+        assert c.get("/api/v1/player/state").json()["buffering"] is True
+
+        # Simulate mpv firing the play-state callback (pause → False).
+        app.state.notify_play_state_changed()
+
+        assert c.get("/api/v1/player/state").json()["buffering"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a shimmer animation on the seek bar and `…` in the time display while a remote Bandcamp stream URL is being resolved or mpv is buffering the new file
- `buffering` flag is set in `_resolve_playback()` when a remote track URL is being fetched and cleared reliably via `engine.on_file_loaded` (fires after mpv opens the new file), replacing an incorrect WS-ping backstop that used Track A's position to clear Track B's buffering state
- Guards `_notify_play_state_changed` so the brief `pause=True` mpv emits during a playing→playing file switch does not prematurely clear the buffering flag

## Implementation notes

- **`kamp_core/server.py`**: sets `_state["buffering"] = True` on remote URL resolution; wires `engine.on_file_loaded` to broadcast the clear; guards `_notify_play_state_changed` with `if engine.state.playing:`; removes the old position-based backstop
- **`transport.css`**: `opacity` animation on `.seek-bar` (not `background-position` on `::webkit-slider-runnable-track`, which Chromium cannot GPU-composite and silently drops); thumb hidden; full-width accent stripe static gradient; pointer-events disabled
- **`TransportBar.tsx`**: 250ms debounce suppresses flash on cached URLs; `…` replaces position display; duration hidden until file is loaded
- **`tests/test_server.py`**: 4 new tests covering default state, `on_file_loaded` clearing, exception path clearing, and the `playing=False` guard

## Test plan

- [ ] Slow network (Network Link Conditioner 3G): double-click remote track — shimmer appears within 250ms and holds until audio starts
- [ ] Fast network / cached URL: play remote track — no visible shimmer (resolves in <250ms debounce)
- [ ] Stop during buffering — shimmer clears immediately
- [ ] Track switch while paused — shimmer shows during load, clears on playback start
- [ ] Local track — no shimmer at any point

🤖 Generated with [Claude Code](https://claude.com/claude-code)