### PR TITLE
feat(KAMP-482): show play count average in Top Albums module

### DIFF
--- a/kamp_ui/src/renderer/src/assets/album-card.css
+++ b/kamp_ui/src/renderer/src/assets/album-card.css
@@ -136,6 +136,12 @@
   margin-top: 1px;
 }
 
+.album-play-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+
 /* Source badge (in .album-info, upper-right) -------------------------------- */
 
 .album-source-badge {

--- a/kamp_ui/src/renderer/src/assets/modules.css
+++ b/kamp_ui/src/renderer/src/assets/modules.css
@@ -168,6 +168,13 @@
   margin-top: 2px;
 }
 
+.module-list-play-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  flex: 0 0 auto;
+  padding-left: 8px;
+}
+
 .module-empty {
   padding: 48px 16px;
   text-align: center;

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -50,10 +50,12 @@ const STATIC_BORDER_FRAMES = [
 
 export function AlbumCard({
   album,
-  onAfterSelect
+  onAfterSelect,
+  showPlayCount = false
 }: {
   album: Album
   onAfterSelect?: () => void
+  showPlayCount?: boolean
 }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
@@ -406,6 +408,9 @@ export function AlbumCard({
         )}
         <div className="album-artist">{album.display_album_artist ?? album.album_artist}</div>
         <div className="album-year">{album.year}</div>
+        {showPlayCount && album.play_count_avg > 0 && (
+          <div className="album-play-count">avg {album.play_count_avg.toFixed(1)}</div>
+        )}
         {album.favorite && (
           <div className="album-fav-badge">
             <FavoriteIcon active size={14} />

--- a/kamp_ui/src/renderer/src/components/modules/GridView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/GridView.tsx
@@ -4,15 +4,17 @@ import { AlbumCard } from '../AlbumCard'
 
 interface GridViewProps {
   albums: Album[]
+  showPlayCount?: boolean
 }
 
-export function GridView({ albums }: GridViewProps): React.JSX.Element {
+export function GridView({ albums, showPlayCount = false }: GridViewProps): React.JSX.Element {
   return (
     <div className="album-grid module-grid">
       {albums.map((album) => (
         <AlbumCard
           key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
           album={album}
+          showPlayCount={showPlayCount}
         />
       ))}
     </div>

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -9,9 +9,10 @@ type MenuPos = { x: number; y: number }
 
 interface ListViewProps {
   albums: Album[]
+  showPlayCount?: boolean
 }
 
-function ListRow({ album }: { album: Album }): React.JSX.Element {
+function ListRow({ album, showPlayCount = false }: { album: Album; showPlayCount?: boolean }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)
@@ -70,6 +71,9 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
         </div>
         <div className="module-list-artist">{album.album_artist}</div>
       </div>
+      {showPlayCount && album.play_count_avg > 0 && (
+        <span className="module-list-play-count">avg {album.play_count_avg.toFixed(1)}</span>
+      )}
       {menu && (
         <AlbumContextMenu x={menu.x} y={menu.y} album={album} onClose={() => setMenu(null)} />
       )}
@@ -77,13 +81,14 @@ function ListRow({ album }: { album: Album }): React.JSX.Element {
   )
 }
 
-export function ListView({ albums }: ListViewProps): React.JSX.Element {
+export function ListView({ albums, showPlayCount = false }: ListViewProps): React.JSX.Element {
   return (
     <div className="module-list">
       {albums.map((album) => (
         <ListRow
           key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
           album={album}
+          showPlayCount={showPlayCount}
         />
       ))}
     </div>

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -12,7 +12,13 @@ interface ListViewProps {
   showPlayCount?: boolean
 }
 
-function ListRow({ album, showPlayCount = false }: { album: Album; showPlayCount?: boolean }): React.JSX.Element {
+function ListRow({
+  album,
+  showPlayCount = false
+}: {
+  album: Album
+  showPlayCount?: boolean
+}): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
   const activeView = useStore((s) => s.activeView)

--- a/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ShelfView.tsx
@@ -6,6 +6,7 @@ import { useStore } from '../../store'
 interface ShelfViewProps {
   albums: Album[]
   scrollToPlaying?: boolean
+  showPlayCount?: boolean
 }
 
 const SCROLL_PX = 500
@@ -14,7 +15,11 @@ const SCROLL_PX = 500
 // shelf position.
 const SCROLL_DEBOUNCE_MS = 5000
 
-export function ShelfView({ albums, scrollToPlaying = false }: ShelfViewProps): React.JSX.Element {
+export function ShelfView({
+  albums,
+  scrollToPlaying = false,
+  showPlayCount = false
+}: ShelfViewProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null)
   const hasMounted = useRef(false)
   const currentTrack = useStore((s) => s.player.current_track)
@@ -116,6 +121,7 @@ export function ShelfView({ albums, scrollToPlaying = false }: ShelfViewProps): 
           <AlbumCard
             key={album.missing_album ? album.file_path : `${album.album_artist}\0${album.album}`}
             album={album}
+            showPlayCount={showPlayCount}
           />
         ))}
       </div>

--- a/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
@@ -83,6 +83,10 @@ export function TopAlbumsModule({ displayStyle }: ModuleProps): React.JSX.Elemen
     return <div className="module-empty">No albums played yet.</div>
   }
 
-  if (displayStyle === 'list') return <ListView albums={albums} />
-  return displayStyle === 'grid' ? <GridView albums={albums} /> : <ShelfView albums={albums} />
+  if (displayStyle === 'list') return <ListView albums={albums} showPlayCount />
+  return displayStyle === 'grid' ? (
+    <GridView albums={albums} showPlayCount />
+  ) : (
+    <ShelfView albums={albums} showPlayCount />
+  )
 }


### PR DESCRIPTION
## Summary

- Adds `play_count_avg` display (formatted as `avg N.N`) to each album entry in the Top Albums module
- Gated behind a `showPlayCount` prop threaded through `ShelfView`, `GridView`, and `ListView` so the stat only appears in the Top Albums context — Last Played, New Arrivals, library grid, and search are unaffected
- Covers all three display styles: Shelf (AlbumCard), Grid (AlbumCard), and List (ListRow)
- No backend changes — `play_count_avg` was already computed, stored, and present on the `Album` TypeScript type

## Test plan

- [ ] Top Albums — Shelf style: each album shows "avg N.N" below the artist name
- [ ] Top Albums — Grid style: same stat visible on each card
- [ ] Top Albums — List style: stat appears right-aligned on each row
- [ ] Last Played module: no play count stat in any display style
- [ ] New Arrivals module: no play count stat in any display style
- [ ] Library grid and search results: no play count stat

🤖 Generated with [Claude Code](https://claude.com/claude-code)