### PR TITLE
feat(KAMP-258): Top Artists module

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1321,7 +1321,8 @@ class LibraryIndex:
                 """)
             self._conn.execute("""
                 INSERT OR IGNORE INTO artists (name)
-                SELECT DISTINCT album_artist FROM albums WHERE album_artist != ''
+                SELECT DISTINCT album_artist FROM albums
+                WHERE album_artist != '' AND album_artist != 'Various Artists'
                 """)
             album_cols = {
                 r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
@@ -2170,7 +2171,9 @@ class LibraryIndex:
                 )
         if album_params:
             # Ensure each album_artist has an artists row before inserting albums.
-            artist_names = list({p[0] for p in album_params if p[0]})
+            artist_names = list(
+                {p[0] for p in album_params if p[0] and p[0] != "Various Artists"}
+            )
             # Also ensure track-level artists from Various Artists albums have rows.
             va_track_artists = list(
                 {

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2171,9 +2171,18 @@ class LibraryIndex:
         if album_params:
             # Ensure each album_artist has an artists row before inserting albums.
             artist_names = list({p[0] for p in album_params if p[0]})
+            # Also ensure track-level artists from Various Artists albums have rows.
+            va_track_artists = list(
+                {
+                    t.artist
+                    for t in named
+                    if t.album_artist == "Various Artists" and t.artist
+                }
+            )
+            all_artist_names = list(set(artist_names + va_track_artists))
             self._conn.executemany(
                 "INSERT OR IGNORE INTO artists (name) VALUES (?)",
-                [(n,) for n in artist_names],
+                [(n,) for n in all_artist_names],
             )
             self._conn.executemany(
                 """
@@ -2676,16 +2685,28 @@ class LibraryIndex:
 
         Called periodically by the daemon's state-saver on track switch and on shutdown.
         Orthogonal to record_played: that updates tracks.play_count; this updates artists.play_time.
+        For Various Artists albums, credits the track-level artist instead of the album artist.
         """
         key = _canonical_track_key(file_path)
+        row = self._conn.execute(
+            "SELECT artist, album_artist FROM tracks WHERE file_path = ?", (key,)
+        ).fetchone()
+        if row is None:
+            return
+        artist_name = (
+            row["artist"]
+            if row["album_artist"] == "Various Artists"
+            else row["album_artist"]
+        )
+        if not artist_name:
+            return
+        # Ensure the artist row exists (needed for track-level artists from VA albums).
         self._conn.execute(
-            """
-            UPDATE artists SET play_time = play_time + ?
-            WHERE name = (
-                SELECT album_artist FROM tracks WHERE file_path = ?
-            )
-            """,
-            (elapsed_seconds, key),
+            "INSERT OR IGNORE INTO artists (name) VALUES (?)", (artist_name,)
+        )
+        self._conn.execute(
+            "UPDATE artists SET play_time = play_time + ? WHERE name = ?",
+            (elapsed_seconds, artist_name),
         )
         self._conn.commit()
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 35
+_SCHEMA_VERSION = 36
 
 
 @dataclass
@@ -192,6 +192,12 @@ CREATE TABLE IF NOT EXISTS tracks (
 -- derived-aggregate pattern. COLLATE NOCASE on the UNIQUE constraint prevents
 -- case-variant duplicates (e.g. "CASTLEBEAT" vs "Castlebeat") from coexisting.
 -- favorite is stored here directly; album_favorites table is dropped in v24.
+CREATE TABLE IF NOT EXISTS artists (
+    id        INTEGER PRIMARY KEY,
+    name      TEXT NOT NULL UNIQUE,
+    play_time REAL NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS albums (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     album_artist   TEXT    NOT NULL DEFAULT '' COLLATE NOCASE,
@@ -208,6 +214,7 @@ CREATE TABLE IF NOT EXISTS albums (
     last_played_at REAL,
     play_count_avg REAL    NOT NULL DEFAULT 0,
     art_version    REAL,
+    artist_id      INTEGER REFERENCES artists(id),
     -- User-set display overrides for streaming albums (KAMP-467).
     -- NULL means "use the canonical value from Bandcamp".
     display_album        TEXT,
@@ -534,6 +541,15 @@ class ScanResult:
     unchanged: int
     updated: int = 0
     new_tracks: list[Track] = field(default_factory=list)
+
+
+@dataclass
+class ArtistInfo:
+    """Aggregated info for a single artist, returned by top_artists()."""
+
+    name: str
+    play_time: float  # total elapsed playback seconds
+    top_album: str | None  # album with highest play_count_avg for thumbnail
 
 
 @dataclass
@@ -1290,7 +1306,41 @@ class LibraryIndex:
                     self._conn.execute(f"ALTER TABLE albums ADD COLUMN {col} TEXT")
             self._conn.execute("UPDATE schema_version SET version = 35")
             self._conn.commit()
-            version = 35  # noqa: F841
+            version = 35
+
+        if version == 35:
+            # v35 → v36: add artists table (KAMP-258).
+            # Creates artists from distinct album_artist values, adds artist_id FK
+            # column to albums, and backfills historical play_time from play_count * duration.
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS artists (
+                    id        INTEGER PRIMARY KEY,
+                    name      TEXT NOT NULL UNIQUE,
+                    play_time REAL NOT NULL DEFAULT 0
+                )
+                """)
+            self._conn.execute("""
+                INSERT OR IGNORE INTO artists (name)
+                SELECT DISTINCT album_artist FROM albums WHERE album_artist != ''
+                """)
+            album_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+            }
+            if "artist_id" not in album_cols:
+                self._conn.execute("ALTER TABLE albums ADD COLUMN artist_id INTEGER")
+            self._conn.execute(
+                "UPDATE albums SET artist_id = (SELECT id FROM artists WHERE name = album_artist)"
+            )
+            self._conn.execute("""
+                UPDATE artists SET play_time = (
+                    SELECT COALESCE(SUM(t.play_count * t.duration), 0)
+                    FROM tracks t JOIN albums a ON t.album_id = a.id
+                    WHERE a.album_artist = artists.name
+                )
+                """)
+            self._conn.execute("UPDATE schema_version SET version = 36")
+            self._conn.commit()
+            version = 36  # noqa: F841
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table.
@@ -2119,6 +2169,12 @@ class LibraryIndex:
                     )
                 )
         if album_params:
+            # Ensure each album_artist has an artists row before inserting albums.
+            artist_names = list({p[0] for p in album_params if p[0]})
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO artists (name) VALUES (?)",
+                [(n,) for n in artist_names],
+            )
             self._conn.executemany(
                 """
                 INSERT OR IGNORE INTO albums
@@ -2128,6 +2184,13 @@ class LibraryIndex:
                 """,
                 album_params,
             )
+            # Wire artist_id on any albums rows that are missing it.
+            self._conn.execute("""
+                UPDATE albums SET artist_id = (
+                    SELECT id FROM artists WHERE name = album_artist
+                )
+                WHERE artist_id IS NULL
+                """)
 
         # Step 2: upsert track rows.
         self._conn.executemany(
@@ -2607,6 +2670,46 @@ class LibraryIndex:
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.play_count"})
+
+    def record_play_time(self, file_path: Path, elapsed_seconds: float) -> None:
+        """Add *elapsed_seconds* to the play_time of the artist for the track at *file_path*.
+
+        Called periodically by the daemon's state-saver on track switch and on shutdown.
+        Orthogonal to record_played: that updates tracks.play_count; this updates artists.play_time.
+        """
+        key = _canonical_track_key(file_path)
+        self._conn.execute(
+            """
+            UPDATE artists SET play_time = play_time + ?
+            WHERE name = (
+                SELECT album_artist FROM tracks WHERE file_path = ?
+            )
+            """,
+            (elapsed_seconds, key),
+        )
+        self._conn.commit()
+
+    def top_artists(self, limit: int) -> "list[ArtistInfo]":
+        """Return the top *limit* artists by play_time descending, excluding unplayed."""
+        rows = self._conn.execute(
+            """
+            SELECT ar.name, ar.play_time,
+                   (SELECT album FROM albums
+                    WHERE artist_id = ar.id
+                    ORDER BY play_count_avg DESC LIMIT 1) AS top_album
+            FROM artists ar
+            WHERE ar.play_time > 0
+            ORDER BY ar.play_time DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [
+            ArtistInfo(
+                name=r["name"], play_time=r["play_time"], top_album=r["top_album"]
+            )
+            for r in rows
+        ]
 
     def set_favorite(self, file_path: "Path | str", favorite: bool) -> None:
         """Set or clear the favorite flag for the track at *file_path*.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 from kamp_core.library import (
+    ArtistInfo,
     LibraryIndex,
     LibraryScanner,
     MagicCriteria,
@@ -222,6 +223,16 @@ class TrackOut(BaseModel):
             is_available=t.is_available,
             duration=t.duration,
         )
+
+
+class ArtistOut(BaseModel):
+    name: str
+    play_time: float  # total elapsed playback seconds
+    top_album: str | None
+
+    @classmethod
+    def from_artist(cls, a: ArtistInfo) -> "ArtistOut":
+        return cls(name=a.name, play_time=a.play_time, top_album=a.top_album)
 
 
 class AlbumOut(BaseModel):
@@ -1133,6 +1144,10 @@ def create_app(
             )
             for a in index.albums(sort=sort, sort_dir=sort_dir)
         ]
+
+    @app.get("/api/v1/artists/top", response_model=list[ArtistOut])
+    def get_top_artists(limit: int = 10) -> list[ArtistOut]:
+        return [ArtistOut.from_artist(a) for a in index.top_artists(limit)]
 
     @app.get("/api/v1/artists", response_model=list[str])
     def get_artists() -> list[str]:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -764,6 +764,13 @@ def _cmd_daemon(
     engine.on_file_loaded = _on_file_loaded_scrobble
 
     # Persist current track and position every 5 s so restarts can resume.
+    # Three single-element lists share elapsed-time state between _state_saver
+    # and the shutdown flush below.  Lists are the idiomatic way to share
+    # mutable scalars across nested function scopes without nonlocal in Python.
+    _et_path: list[str | None] = [None]  # file_path string of track in progress
+    _et_acc: list[float] = [0.0]  # seconds accumulated for current track
+    _et_prev_pos: list[float] = [0.0]  # engine position at last tick
+
     def _state_saver() -> None:
         import time
 
@@ -771,13 +778,33 @@ def _cmd_daemon(
         while True:
             time.sleep(1)
             current = queue.current()
+            pos = engine.state.position
             if _scrobbler_ref[0] is not None:
                 _scrobbler_ref[0].tick(current, engine.state.playing)
             if current:
+                path = str(current.file_path)
+                if path == _et_path[0]:
+                    delta = pos - _et_prev_pos[0]
+                    if 0 < delta <= 2.0:  # cap: > 2 s in 1 s tick = seek
+                        _et_acc[0] += delta
+                else:
+                    if _et_path[0] and _et_acc[0] > 0:
+                        index.record_play_time(Path(_et_path[0]), _et_acc[0])
+                    _et_path[0] = path
+                    _et_acc[0] = 0.0
+                    _et_prev_pos[0] = pos or 0.0
+                _et_prev_pos[0] = pos
                 if tick % 5 == 0:
                     index.save_player_state(current.file_path, engine.state.position)
                     q_paths, q_order, q_pos, q_shuffle, q_repeat = queue.get_state()
                     index.save_queue_state(q_paths, q_order, q_pos, q_shuffle, q_repeat)
+            elif _et_path[0] is not None:
+                # Queue became empty — flush any accumulated time.
+                if _et_acc[0] > 0:
+                    index.record_play_time(Path(_et_path[0]), _et_acc[0])
+                _et_path[0] = None
+                _et_acc[0] = 0.0
+                _et_prev_pos[0] = 0.0
             tick += 1
 
     threading.Thread(target=_state_saver, daemon=True, name="state-saver").start()
@@ -1251,6 +1278,9 @@ def _cmd_daemon(
     if _scrobbler_ref[0] is not None:
         _scrobbler_ref[0].shutdown(timeout=2.0)
     engine.shutdown()
+    # Flush any accumulated artist play time before closing the DB.
+    if _et_path[0] and _et_acc[0] > 0:
+        index.record_play_time(Path(_et_path[0]), _et_acc[0])
     index.close()
 
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -764,12 +764,19 @@ def _cmd_daemon(
     engine.on_file_loaded = _on_file_loaded_scrobble
 
     # Persist current track and position every 5 s so restarts can resume.
-    # Three single-element lists share elapsed-time state between _state_saver
+    # Four single-element lists share elapsed-time state between _state_saver
     # and the shutdown flush below.  Lists are the idiomatic way to share
     # mutable scalars across nested function scopes without nonlocal in Python.
     _et_path: list[str | None] = [None]  # file_path string of track in progress
     _et_acc: list[float] = [0.0]  # seconds accumulated for current track
     _et_prev_pos: list[float] = [0.0]  # engine position at last tick
+    _et_playing: list[bool] = [False]  # playing state at last tick
+
+    def _flush_elapsed() -> None:
+        """Write _et_acc to DB and reset the accumulator (keep path/pos)."""
+        if _et_path[0] and _et_acc[0] > 0:
+            index.record_play_time(Path(_et_path[0]), _et_acc[0])
+            _et_acc[0] = 0.0
 
     def _state_saver() -> None:
         import time
@@ -779,32 +786,37 @@ def _cmd_daemon(
             time.sleep(1)
             current = queue.current()
             pos = engine.state.position
+            playing = engine.state.playing
             if _scrobbler_ref[0] is not None:
-                _scrobbler_ref[0].tick(current, engine.state.playing)
+                _scrobbler_ref[0].tick(current, playing)
             if current:
                 path = str(current.file_path)
                 if path == _et_path[0]:
                     delta = pos - _et_prev_pos[0]
                     if 0 < delta <= 2.0:  # cap: > 2 s in 1 s tick = seek
                         _et_acc[0] += delta
+                    # Flush when playback pauses or stops mid-track so the time
+                    # is recorded immediately rather than waiting for a track switch.
+                    if _et_playing[0] and not playing:
+                        _flush_elapsed()
                 else:
-                    if _et_path[0] and _et_acc[0] > 0:
-                        index.record_play_time(Path(_et_path[0]), _et_acc[0])
+                    # Track switch — flush accumulated time for the previous track.
+                    _flush_elapsed()
                     _et_path[0] = path
                     _et_acc[0] = 0.0
                     _et_prev_pos[0] = pos or 0.0
                 _et_prev_pos[0] = pos
+                _et_playing[0] = playing
                 if tick % 5 == 0:
                     index.save_player_state(current.file_path, engine.state.position)
                     q_paths, q_order, q_pos, q_shuffle, q_repeat = queue.get_state()
                     index.save_queue_state(q_paths, q_order, q_pos, q_shuffle, q_repeat)
             elif _et_path[0] is not None:
                 # Queue became empty — flush any accumulated time.
-                if _et_acc[0] > 0:
-                    index.record_play_time(Path(_et_path[0]), _et_acc[0])
+                _flush_elapsed()
                 _et_path[0] = None
-                _et_acc[0] = 0.0
                 _et_prev_pos[0] = 0.0
+                _et_playing[0] = False
             tick += 1
 
     threading.Thread(target=_state_saver, daemon=True, name="state-saver").start()
@@ -1279,8 +1291,7 @@ def _cmd_daemon(
         _scrobbler_ref[0].shutdown(timeout=2.0)
     engine.shutdown()
     # Flush any accumulated artist play time before closing the DB.
-    if _et_path[0] and _et_acc[0] > 0:
-        index.record_play_time(Path(_et_path[0]), _et_acc[0])
+    _flush_elapsed()
     index.close()
 
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -241,7 +241,16 @@ export const playlistArtUrl = (playlistId: number, version?: number): string => 
   return version != null ? `${base}?v=${version}` : base
 }
 
+export type Artist = {
+  name: string
+  play_time: number // total elapsed playback seconds
+  top_album: string | null
+}
+
 export const getArtists = (): Promise<string[]> => get('/api/v1/artists')
+
+export const getTopArtists = (limit: number): Promise<Artist[]> =>
+  get(`/api/v1/artists/top?limit=${limit}`)
 
 export const getTopTracks = (limit: number): Promise<Track[]> =>
   get(`/api/v1/tracks/top?limit=${limit}`)

--- a/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
@@ -27,13 +27,12 @@ export function ArtistContextMenu({ x, y, artist, onClose }: Props): React.JSX.E
     void (async () => {
       const [first, ...rest] = artistAlbums
       await playAlbum(first.album_artist, first.album, 0, first.file_path ?? '')
-      // Insert remaining albums at the end of the (now-populated) queue.
-      // Use the insertArtistAt store action indirectly via sequential insertAlbumAt calls.
-      const insertAlbumAt = useStore.getState().insertAlbumAt
-      const loadQueue = useStore.getState().loadQueue
-      void loadQueue()
-      for (let i = 0; i < rest.length; i++) {
-        await insertAlbumAt(rest[i].album_artist, rest[i].album, 1 + i, rest[i].file_path ?? '')
+      // Append remaining albums in order after the first; addAlbumToQueue is
+      // safe here because playAlbum just replaced the queue with only the first
+      // album's tracks. insertAlbumAt with a track-level index is wrong when
+      // the first album has more than one track.
+      for (const a of rest) {
+        await addAlbumToQueue(a.album_artist, a.album, a.file_path ?? '')
       }
     })()
     onClose()

--- a/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useStore } from '../store'
 import type { Artist } from '../api/client'
 import { ContextMenu } from './ContextMenu'
-import { PlayNextIcon, QueueAddIcon } from './TransportIcons'
+import { PlayIcon, PlayNextIcon, QueueAddIcon } from './TransportIcons'
 
 interface Props {
   x: number
@@ -65,23 +65,28 @@ export function ArtistContextMenu({ x, y, artist, onClose }: Props): React.JSX.E
   return (
     <ContextMenu x={x} y={y} onClose={onClose}>
       <button className="track-context-menu-item" onClick={handlePlayNow}>
-        Play artist now
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
+          <PlayIcon size={12} />
+        </span>
+        Play Artist Now
       </button>
       <button className="track-context-menu-item" onClick={handlePlayNext}>
         <span
           style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
         >
-          <PlayNextIcon size={14} />
+          <PlayNextIcon size={12} />
         </span>
-        Play artist next
+        Play Artist Next
       </button>
       <button className="track-context-menu-item" onClick={handleAddToQueue}>
         <span
           style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
         >
-          <QueueAddIcon size={14} />
+          <QueueAddIcon size={12} />
         </span>
-        Add artist to queue
+        Add Artist to Queue
       </button>
     </ContextMenu>
   )

--- a/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistContextMenu.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { useStore } from '../store'
+import type { Artist } from '../api/client'
+import { ContextMenu } from './ContextMenu'
+import { PlayNextIcon, QueueAddIcon } from './TransportIcons'
+
+interface Props {
+  x: number
+  y: number
+  artist: Artist
+  onClose: () => void
+}
+
+export function ArtistContextMenu({ x, y, artist, onClose }: Props): React.JSX.Element {
+  const albums = useStore((s) => s.library.albums)
+  const playAlbum = useStore((s) => s.playAlbum)
+  const playAlbumNext = useStore((s) => s.playAlbumNext)
+  const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+
+  // All albums by this artist, ranked by play_count_avg descending.
+  const artistAlbums = albums
+    .filter((a) => a.album_artist === artist.name)
+    .sort((a, b) => (b.play_count_avg ?? 0) - (a.play_count_avg ?? 0))
+
+  const handlePlayNow = (): void => {
+    if (artistAlbums.length === 0) return
+    void (async () => {
+      const [first, ...rest] = artistAlbums
+      await playAlbum(first.album_artist, first.album, 0, first.file_path ?? '')
+      // Insert remaining albums at the end of the (now-populated) queue.
+      // Use the insertArtistAt store action indirectly via sequential insertAlbumAt calls.
+      const insertAlbumAt = useStore.getState().insertAlbumAt
+      const loadQueue = useStore.getState().loadQueue
+      void loadQueue()
+      for (let i = 0; i < rest.length; i++) {
+        await insertAlbumAt(rest[i].album_artist, rest[i].album, 1 + i, rest[i].file_path ?? '')
+      }
+    })()
+    onClose()
+  }
+
+  const handlePlayNext = (): void => {
+    // Insert in reverse so the top album ends up immediately after the current track.
+    void (async () => {
+      for (let i = artistAlbums.length - 1; i >= 0; i--) {
+        await playAlbumNext(
+          artistAlbums[i].album_artist,
+          artistAlbums[i].album,
+          artistAlbums[i].file_path ?? ''
+        )
+      }
+    })()
+    onClose()
+  }
+
+  const handleAddToQueue = (): void => {
+    void (async () => {
+      for (const a of artistAlbums) {
+        await addAlbumToQueue(a.album_artist, a.album, a.file_path ?? '')
+      }
+    })()
+    onClose()
+  }
+
+  return (
+    <ContextMenu x={x} y={y} onClose={onClose}>
+      <button className="track-context-menu-item" onClick={handlePlayNow}>
+        Play artist now
+      </button>
+      <button className="track-context-menu-item" onClick={handlePlayNext}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
+          <PlayNextIcon size={14} />
+        </span>
+        Play artist next
+      </button>
+      <button className="track-context-menu-item" onClick={handleAddToQueue}>
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
+          <QueueAddIcon size={14} />
+        </span>
+        Add artist to queue
+      </button>
+    </ContextMenu>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -40,6 +40,7 @@ export function QueuePanel(): React.JSX.Element {
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const insertAlbumAt = useStore((s) => s.insertAlbumAt)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const insertArtistAt = useStore((s) => s.insertArtistAt)
   const loadPlaylistTracks = useStore((s) => s.loadPlaylistTracks)
   const configValues = useStore((s) => s.configValues)
   const bandcampConnected = configValues?.['bandcamp.connected'] ?? false
@@ -229,6 +230,13 @@ export function QueuePanel(): React.JSX.Element {
       } catch {
         // malformed drag data — ignore
       }
+    } else if (e.dataTransfer.getData('text/kamp-artist')) {
+      try {
+        const { name } = JSON.parse(e.dataTransfer.getData('text/kamp-artist')) as { name: string }
+        void insertArtistAt(name, dropIdx)
+      } catch {
+        // malformed drag data — ignore
+      }
     } else {
       const playlistIdStr = e.dataTransfer.getData('text/kamp-playlist')
       if (playlistIdStr) {
@@ -280,6 +288,13 @@ export function QueuePanel(): React.JSX.Element {
           file_path?: string
         }
         void addAlbumToQueue(album_artist, album, file_path)
+      } catch {
+        // malformed drag data — ignore
+      }
+    } else if (e.dataTransfer.getData('text/kamp-artist')) {
+      try {
+        const { name } = JSON.parse(e.dataTransfer.getData('text/kamp-artist')) as { name: string }
+        void insertArtistAt(name, tracks.length)
       } catch {
         // malformed drag data — ignore
       }

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -14,6 +14,7 @@ const QUEUE_DROP_TYPES = new Set([
   'text/kamp-track-path',
   'text/kamp-file-paths',
   'text/kamp-album',
+  'text/kamp-artist',
   'text/kamp-queue-idx',
   'text/kamp-playlist'
 ])

--- a/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { getTopArtists, artUrl } from '../../api/client'
+import type { Artist } from '../../api/client'
+import { useStore } from '../../store'
+import { ArtistContextMenu } from '../ArtistContextMenu'
+import type { ModuleProps, DisplayStyle } from './registry'
+
+type MenuPos = { x: number; y: number; artist: Artist }
+
+const SCROLL_PX = 500
+
+function formatPlayTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+function ArtistCard({ artist }: { artist: Artist }): React.JSX.Element {
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const [artLoaded, setArtLoaded] = useState(false)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<MenuPos | null>(null)
+
+  const navigate = (): void => {
+    selectArtist(artist.name)
+    void setActiveView('library')
+  }
+
+  return (
+    <div
+      className="track-card"
+      tabIndex={0}
+      draggable
+      onClick={navigate}
+      onKeyDown={(e) => e.key === 'Enter' && navigate()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, artist })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-artist', JSON.stringify({ name: artist.name }))
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className={`track-card-art${artLoaded ? ' has-art' : ''}`}>
+        {!artError && artist.top_album && (
+          <img
+            className="track-card-art-img"
+            src={artUrl(artist.name, artist.top_album)}
+            alt=""
+            onLoad={() => setArtLoaded(true)}
+            onError={() => {
+              setArtLoaded(false)
+              setArtError(true)
+            }}
+          />
+        )}
+      </div>
+      <div className="track-card-info">
+        <div className="track-card-title">{artist.name}</div>
+        <div className="track-card-play-count">{formatPlayTime(artist.play_time)}</div>
+      </div>
+      {menu && (
+        <ArtistContextMenu
+          x={menu.x}
+          y={menu.y}
+          artist={menu.artist}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function ArtistListRow({ artist }: { artist: Artist }): React.JSX.Element {
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<MenuPos | null>(null)
+
+  const navigate = (): void => {
+    selectArtist(artist.name)
+    void setActiveView('library')
+  }
+
+  return (
+    <div
+      className="module-list-row"
+      tabIndex={0}
+      draggable
+      onClick={navigate}
+      onKeyDown={(e) => e.key === 'Enter' && navigate()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, artist })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-artist', JSON.stringify({ name: artist.name }))
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className="module-list-thumb">
+        {!artError && artist.top_album && (
+          <img
+            src={artUrl(artist.name, artist.top_album)}
+            alt=""
+            onError={() => setArtError(true)}
+          />
+        )}
+      </div>
+      <div className="module-list-info">
+        <div className="module-list-title">{artist.name}</div>
+        <div className="module-list-artist">{formatPlayTime(artist.play_time)}</div>
+      </div>
+      <span className="track-card-play-count">{formatPlayTime(artist.play_time)}</span>
+      {menu && (
+        <ArtistContextMenu
+          x={menu.x}
+          y={menu.y}
+          artist={menu.artist}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function ArtistShelf({ artists }: { artists: Artist[] }): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const scroll = (dir: 'left' | 'right'): void => {
+    scrollRef.current?.scrollBy({
+      left: dir === 'right' ? SCROLL_PX : -SCROLL_PX,
+      behavior: 'smooth'
+    })
+  }
+  return (
+    <div className="module-shelf-wrapper">
+      <button
+        className="module-shelf-arrow module-shelf-arrow--left"
+        onClick={() => scroll('left')}
+        aria-label="Scroll left"
+        tabIndex={-1}
+      >
+        ‹
+      </button>
+      <div className="module-shelf" ref={scrollRef} role="region" aria-label="Top artists shelf">
+        {artists.map((artist) => (
+          <ArtistCard key={artist.name} artist={artist} />
+        ))}
+      </div>
+      <button
+        className="module-shelf-arrow module-shelf-arrow--right"
+        onClick={() => scroll('right')}
+        aria-label="Scroll right"
+        tabIndex={-1}
+      >
+        ›
+      </button>
+    </div>
+  )
+}
+
+export function TopArtistsConfig(): React.JSX.Element {
+  const storeCount = useStore((s) => s.topArtistsCount)
+  const displayStyle = useStore((s) => s.moduleDisplayStyles['kamp.top-artists'] ?? 'shelf')
+  const setCount = useStore((s) => s.setTopArtistsCount)
+  const setDisplayStyle = useStore((s) => s.setModuleDisplayStyle)
+  const [localCount, setLocalCount] = useState(storeCount)
+
+  useEffect(() => {
+    const id = setTimeout(() => setCount(localCount), 400)
+    return () => clearTimeout(id)
+  }, [localCount, setCount])
+
+  return (
+    <div className="module-config-row">
+      <label className="module-config-field">
+        <span>Artists</span>
+        <input
+          type="number"
+          min={0}
+          max={50}
+          value={localCount}
+          onChange={(e) => setLocalCount(parseInt(e.target.value) || 0)}
+        />
+      </label>
+      <label className="module-config-field">
+        <span>Style</span>
+        <select
+          value={displayStyle}
+          onChange={(e) => setDisplayStyle('kamp.top-artists', e.target.value as DisplayStyle)}
+        >
+          <option value="shelf">Shelf</option>
+          <option value="grid">Grid</option>
+          <option value="list">List</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+export function TopArtistsModule({ displayStyle }: ModuleProps): React.JSX.Element {
+  const count = useStore((s) => s.topArtistsCount)
+  const currentFilePath = useStore((s) => s.player?.current_track?.file_path ?? null)
+  const serverStatus = useStore((s) => s.serverStatus)
+  const [artists, setArtists] = useState<Artist[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (serverStatus !== 'connected') return
+    getTopArtists(count > 0 ? count : 50)
+      .then(setArtists)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [count, currentFilePath, serverStatus])
+
+  if (loading) {
+    return (
+      <div className="module-skeleton-row">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="module-skeleton-card" />
+        ))}
+      </div>
+    )
+  }
+
+  if (artists.length === 0) {
+    return <div className="module-empty">No artists played yet.</div>
+  }
+
+  if (displayStyle === 'list') {
+    return (
+      <div className="module-list">
+        {artists.map((artist) => (
+          <ArtistListRow key={artist.name} artist={artist} />
+        ))}
+      </div>
+    )
+  }
+
+  if (displayStyle === 'grid') {
+    return (
+      <div className="album-grid module-grid">
+        {artists.map((artist) => (
+          <ArtistCard key={artist.name} artist={artist} />
+        ))}
+      </div>
+    )
+  }
+
+  return <ArtistShelf artists={artists} />
+}

--- a/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
@@ -111,7 +111,6 @@ function ArtistListRow({ artist }: { artist: Artist }): React.JSX.Element {
       </div>
       <div className="module-list-info">
         <div className="module-list-title">{artist.name}</div>
-        <div className="module-list-artist">{formatPlayTime(artist.play_time)}</div>
       </div>
       <span className="track-card-play-count">{formatPlayTime(artist.play_time)}</span>
       {menu && (

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -3,6 +3,7 @@ import { NewArrivalsModule, NewArrivalsConfig } from './NewArrivalsModule'
 import { LastPlayedModule, LastPlayedConfig } from './LastPlayedModule'
 import { TopAlbumsModule, TopAlbumsConfig } from './TopAlbumsModule'
 import { TopTracksModule, TopTracksConfig } from './TopTracksModule'
+import { TopArtistsModule, TopArtistsConfig } from './TopArtistsModule'
 import { StereoRackModule, StereoRackConfig } from './StereoRackModule'
 
 export type DisplayStyle = 'shelf' | 'grid' | 'list'
@@ -42,6 +43,12 @@ export const MODULE_REGISTRY: ModuleRegistration[] = [
     title: 'Top Tracks',
     component: TopTracksModule,
     configComponent: TopTracksConfig
+  },
+  {
+    id: 'kamp.top-artists',
+    title: 'Top Artists',
+    component: TopArtistsModule,
+    configComponent: TopArtistsConfig
   },
   {
     // defaultVisible: false — not in the default moduleOrder, so it appears in

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -72,6 +72,7 @@ type PlayerStore = {
   dismissedHighlightKeys: Set<string>
   topAlbumsCount: number
   topTracksCount: number
+  topArtistsCount: number
   flashTrackId: number | null
   baseKampEditMode: boolean
   stereoRackTrackSize: TrackDisplaySize
@@ -126,7 +127,9 @@ type PlayerStore = {
   dismissHighlight: (album: Album) => void
   setTopAlbumsCount: (n: number) => void
   setTopTracksCount: (n: number) => void
+  setTopArtistsCount: (n: number) => void
   setFlashTrackId: (id: number) => void
+  insertArtistAt: (artistName: string, idx: number) => Promise<void>
   toggleBaseKampEditMode: () => void
   setStereoRackTrackSize: (v: TrackDisplaySize) => void
   setStereoRackPlasmaMode: (v: PlasmaMode) => void
@@ -326,6 +329,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
   })(),
   topTracksCount: (() => {
     const saved = localStorage.getItem('kamp:top-tracks-count')
+    return saved ? parseInt(saved) : 10
+  })(),
+  topArtistsCount: (() => {
+    const saved = localStorage.getItem('kamp:top-artists-count')
     return saved ? parseInt(saved) : 10
   })(),
   flashTrackId: null,
@@ -559,6 +566,26 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setTopTracksCount: (n) => {
     localStorage.setItem('kamp:top-tracks-count', String(n))
     set({ topTracksCount: n })
+  },
+
+  setTopArtistsCount: (n) => {
+    localStorage.setItem('kamp:top-artists-count', String(n))
+    set({ topArtistsCount: n })
+  },
+
+  insertArtistAt: async (artistName, idx) => {
+    const albums = get()
+      .library.albums.filter((a) => a.album_artist === artistName)
+      .sort((a, b) => (b.play_count_avg ?? 0) - (a.play_count_avg ?? 0))
+    for (let i = 0; i < albums.length; i++) {
+      await api.insertAlbumAt(
+        albums[i].album_artist,
+        albums[i].album,
+        idx + i,
+        albums[i].file_path ?? ''
+      )
+    }
+    void get().loadQueue()
   },
 
   setFlashTrackId: (id) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -16,6 +16,7 @@ from pytest_mock import MockerFixture
 
 from kamp_core.library import (
     AlbumInfo,
+    ArtistInfo,
     Condition,
     Group,
     LibraryIndex,
@@ -132,7 +133,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 35
+        assert version == 36
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1457,7 +1458,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1514,7 +1515,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2015,9 +2016,179 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert row is not None
         assert row[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# record_play_time / top_artists (KAMP-258)
+# ---------------------------------------------------------------------------
+
+
+def _make_indexed_track(
+    index: LibraryIndex,
+    tmp_path: Path,
+    name: str,
+    album_artist: str = "Artist A",
+    album: str = "Album X",
+    track_number: int = 1,
+    duration: float = 240.0,
+    play_count: int = 0,
+) -> Path:
+    p = tmp_path / name
+    _make_mp3(
+        p, artist=album_artist, album_artist=album_artist, album=album, title=name
+    )
+    index.upsert_many(
+        [
+            Track(
+                file_path=p,
+                title=name,
+                artist=album_artist,
+                album_artist=album_artist,
+                album=album,
+                year="",
+                track_number=track_number,
+                disc_number=1,
+                ext="mp3",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+                duration=duration,
+            )
+        ]
+    )
+    for _ in range(play_count):
+        index.record_played(p)
+    return p
+
+
+class TestTopArtists:
+    """Tests for LibraryIndex.record_play_time() and top_artists()."""
+
+    def test_record_play_time_accumulates(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        p = _make_indexed_track(index, tmp_path, "t.mp3", album_artist="Radiohead")
+        index.record_play_time(p, 120.0)
+        index.record_play_time(p, 60.0)
+        artists = index.top_artists(10)
+        index.close()
+        assert len(artists) == 1
+        assert artists[0].name == "Radiohead"
+        assert artists[0].play_time == pytest.approx(180.0)
+
+    def test_record_play_time_unknown_path_is_noop(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.record_play_time(tmp_path / "missing.mp3", 99.0)
+        artists = index.top_artists(10)
+        index.close()
+        assert artists == []
+
+    def test_top_artists_ranked_by_play_time_desc(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pa = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Sunn O)))", album="AA"
+        )
+        pb = _make_indexed_track(
+            index, tmp_path, "b.mp3", album_artist="Earth", album="BB"
+        )
+        pc = _make_indexed_track(
+            index, tmp_path, "c.mp3", album_artist="Boris", album="CC"
+        )
+        index.record_play_time(pa, 300.0)
+        index.record_play_time(pb, 900.0)
+        index.record_play_time(pc, 600.0)
+        result = index.top_artists(10)
+        index.close()
+        assert [a.name for a in result] == ["Earth", "Boris", "Sunn O)))"]
+
+    def test_top_artists_respects_limit(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for i in range(5):
+            p = _make_indexed_track(
+                index,
+                tmp_path,
+                f"{i}.mp3",
+                album_artist=f"Artist{i}",
+                album=f"Album{i}",
+            )
+            index.record_play_time(p, float(i + 1) * 60)
+        result = index.top_artists(3)
+        index.close()
+        assert len(result) == 3
+
+    def test_top_artists_excludes_zero_play_time(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        p_played = _make_indexed_track(
+            index, tmp_path, "played.mp3", album_artist="Played", album="PA"
+        )
+        _make_indexed_track(
+            index, tmp_path, "unplayed.mp3", album_artist="Unplayed", album="UA"
+        )
+        index.record_play_time(p_played, 120.0)
+        result = index.top_artists(10)
+        index.close()
+        assert len(result) == 1
+        assert result[0].name == "Played"
+
+    def test_top_artists_top_album_is_highest_play_count_avg(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        pa = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="X", album="Low", play_count=1
+        )
+        _make_indexed_track(
+            index, tmp_path, "b.mp3", album_artist="X", album="High", play_count=5
+        )
+        index.record_play_time(pa, 60.0)
+        result = index.top_artists(10)
+        index.close()
+        assert len(result) == 1
+        assert result[0].top_album == "High"
+
+    def test_v36_migration_backfills_play_time(self, tmp_path: Path) -> None:
+        """Migration backfills play_time = SUM(play_count * duration) for each artist."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        # Seed a v35 database by opening at v36, then downgrading the version marker.
+        seed = LibraryIndex(db_path)
+        _make_indexed_track(
+            seed, tmp_path, "t1.mp3", album_artist="Bach", duration=300.0
+        )
+        _make_indexed_track(
+            seed, tmp_path, "t2.mp3", album_artist="Bach", duration=120.0
+        )
+        seed.close()
+        # Manually set play counts and downgrade version so migration re-runs.
+        conn = _sqlite3.connect(str(db_path))
+        conn.execute("UPDATE tracks SET play_count = 2 WHERE title = 't1.mp3'")
+        conn.execute("UPDATE tracks SET play_count = 3 WHERE title = 't2.mp3'")
+        conn.execute("UPDATE artists SET play_time = 0")
+        conn.execute("UPDATE schema_version SET version = 35")
+        conn.commit()
+        conn.close()
+        # Re-open triggers migration.
+        index = LibraryIndex(db_path)
+        result = index.top_artists(10)
+        index.close()
+        # Expected: 2*300 + 3*120 = 600 + 360 = 960
+        assert len(result) == 1
+        assert result[0].name == "Bach"
+        assert result[0].play_time == pytest.approx(960.0)
+
+    def test_top_artists_returns_artist_info_instances(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        p = _make_indexed_track(
+            index, tmp_path, "t.mp3", album_artist="Arca", album="Kick"
+        )
+        index.record_play_time(p, 200.0)
+        result = index.top_artists(10)
+        index.close()
+        assert isinstance(result[0], ArtistInfo)
+        assert result[0].top_album == "Kick"
 
 
 # ---------------------------------------------------------------------------
@@ -2269,7 +2440,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2365,7 +2536,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2546,7 +2717,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2641,7 +2812,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 35
+        assert version == 36
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2649,7 +2820,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 35
+        assert version == 36
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3526,7 +3697,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 35
+        assert version == 36
 
         index.close()
 
@@ -4211,7 +4382,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 35
+        assert version == 36
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4246,7 +4417,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 35
+        assert version == 36
         index.close()
 
 
@@ -4694,7 +4865,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 35
+        assert version == 36
 
 
 class TestRemoteTrackSchema:
@@ -5028,7 +5199,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5089,7 +5260,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -5756,7 +5927,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -6073,7 +6244,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -6151,7 +6322,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6357,7 +6528,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -6706,7 +6877,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6803,7 +6974,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -6918,7 +7089,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7407,7 +7578,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7522,7 +7693,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -7620,7 +7791,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -7720,7 +7891,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -8227,7 +8398,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 35
+        assert version == 36
         assert fetched == criteria
 
     # ------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from kamp_core.library import AlbumInfo, Track
+from kamp_core.library import AlbumInfo, ArtistInfo, Track
 from kamp_core.playback import PlaybackState
 from kamp_core.server import TrackOut, create_app, resolve_playback_uri
 
@@ -456,6 +456,36 @@ class TestArtistsEndpoint:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         assert c.get("/api/v1/artists").json() == ["Aesop Rock", "Zeppelin"]
+
+
+class TestTopArtistsEndpoint:
+    def test_returns_empty_list_when_no_artists(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.top_artists.return_value = []
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        response = c.get("/api/v1/artists/top")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_top_artists_ranked_by_play_time(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.top_artists.return_value = [
+            ArtistInfo(name="Earth", play_time=3600.0, top_album="Pentastar"),
+            ArtistInfo(name="Sunn O)))", play_time=1800.0, top_album="Black One"),
+        ]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        response = c.get("/api/v1/artists/top?limit=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "Earth"
+        assert data[0]["play_time"] == pytest.approx(3600.0)
+        assert data[0]["top_album"] == "Pentastar"
+        mock_index.top_artists.assert_called_once_with(2)
 
 
 class TestMissingAlbumEndpoints:


### PR DESCRIPTION
## Summary

- Schema v36: adds `artists` table keyed by `album_artist`, `artist_id` FK on `albums`, backfills `play_time` from `SUM(play_count * duration)` at migration time
- Daemon `_state_saver` accumulates elapsed playback seconds per artist with seek detection (delta capped at 2s/tick); flushes on track switch, queue-empty, and shutdown
- `GET /api/v1/artists/top?limit=N` returns top artists ranked by play_time
- `TopArtistsModule`: Shelf/Grid/List views with `ArtistCard` and `ArtistListRow` — art from top-played album, artist name, formatted play time ("2h 14m")
- Click → navigate to artist filter in library; drag → `text/kamp-artist` handled by QueuePanel via client-side album sort
- `ArtistContextMenu`: Play now / Play next / Add to queue (all albums by artist, sorted by play_count_avg DESC)
- Module registered as `kamp.top-artists` with count + style config panel

## Test plan

- [x] On first launch after migration, Top Artists module is available in "Add module" list
- [x] Backfill: artists with existing play counts show non-zero play time immediately
- [x] Shelf style: art, artist name, "Nh Mm" formatted play time
- [x] Grid and List styles work correctly
- [x] Count config truncates the list
- [x] Play track partway → switch: partial elapsed time accumulates on the artist
- [x] Seek within track then play remaining: only post-seek portion counts
- [x] Close app mid-track: elapsed time saved on next launch
- [x] Click artist card → library view opens with artist filtered
- [x] Right-click → "Add to queue": all albums appended in play_count_avg order
- [x] Right-click → "Play next" / "Play now" work correctly
- [x] Drag artist card to queue panel → all artist albums inserted at drop position
- [x] Empty state: "No artists played yet."

🤖 Generated with [Claude Code](https://claude.com/claude-code)