### PR TITLE
feat(KAMP-247): Magic Playlist Base Kamp module

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4022,6 +4022,186 @@ class LibraryIndex:
             for r in rows
         ]
 
+    def get_playlist_module_content(
+        self,
+        playlist_id: int,
+        contents: str,
+        sort: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Return albums, artists, or tracks for a playlist module.
+
+        ``contents`` is one of 'albums', 'artists', 'tracks'.
+        ``sort`` is one of 'random', 'last_played', 'recently_added', 'most_played'.
+        Works for both static (playlist_tracks) and magic playlists.
+        Returns an empty list when the playlist does not exist.
+        """
+        # Check existence.
+        exists = self._conn.execute(
+            "SELECT 1 FROM playlists WHERE id = ?", (playlist_id,)
+        ).fetchone()
+        if exists is None:
+            return []
+
+        # Resolve track ID set.
+        is_magic = self._conn.execute(
+            "SELECT 1 FROM magic_playlist_criteria WHERE playlist_id = ?",
+            (playlist_id,),
+        ).fetchone()
+        if is_magic:
+            track_ids = self.evaluate_magic_playlist(playlist_id)
+        else:
+            rows = self._conn.execute(
+                "SELECT track_id FROM playlist_tracks WHERE playlist_id = ?",
+                (playlist_id,),
+            ).fetchall()
+            track_ids = [r[0] for r in rows]
+
+        if not track_ids:
+            return []
+
+        placeholders = ",".join("?" * len(track_ids))
+
+        _ALBUM_SORT = {
+            "random": "ORDER BY RANDOM()",
+            "last_played": "ORDER BY a.last_played_at DESC NULLS LAST",
+            "recently_added": "ORDER BY a.date_added DESC",
+            "most_played": "ORDER BY a.play_count_avg DESC",
+        }
+        _TRACK_SORT = {
+            "random": "ORDER BY RANDOM()",
+            "last_played": "ORDER BY t.last_played DESC NULLS LAST",
+            "recently_added": "ORDER BY t.date_added DESC",
+            "most_played": "ORDER BY t.play_count DESC",
+        }
+        # Artists lack per-sort columns; fall back to play_time for non-random.
+        _ARTIST_SORT = {
+            "random": "ORDER BY RANDOM()",
+            "last_played": "ORDER BY ar.play_time DESC",
+            "recently_added": "ORDER BY ar.play_time DESC",
+            "most_played": "ORDER BY ar.play_time DESC",
+        }
+
+        if contents == "albums":
+            order = _ALBUM_SORT.get(sort, "ORDER BY RANDOM()")
+            rows = self._conn.execute(
+                f"""
+                SELECT
+                    a.album_artist, a.album, a.year, a.play_count_avg,
+                    a.date_added, a.last_played_at, a.embedded_art, a.art_version,
+                    a.display_album, a.display_album_artist, a.source, a.sale_item_id,
+                    COUNT(t.id) AS track_count
+                FROM albums a
+                JOIN tracks t ON t.album_id = a.id
+                WHERE a.id IN (
+                    SELECT DISTINCT album_id FROM tracks WHERE id IN ({placeholders})
+                )
+                GROUP BY a.id
+                {order}
+                LIMIT ?
+                """,
+                (*track_ids, limit),
+            ).fetchall()
+            return [
+                {
+                    "album_artist": r["album_artist"],
+                    "album": r["album"],
+                    "year": r["year"] or "",
+                    "track_count": r["track_count"],
+                    "has_art": bool(r["embedded_art"]) or r["source"] == "bandcamp",
+                    "missing_album": False,
+                    "file_path": "",
+                    "art_version": r["art_version"],
+                    "added_at": r["date_added"],
+                    "last_played_at": r["last_played_at"],
+                    "play_count_avg": r["play_count_avg"] or 0.0,
+                    "favorite": False,
+                    "has_favorite_track": False,
+                    "source": r["source"] or "local",
+                    "has_remote_tracks": r["source"] != "local",
+                    "sale_item_id": r["sale_item_id"],
+                    "is_preorder": False,
+                    "album_url": "",
+                    "display_album": r["display_album"],
+                    "display_album_artist": r["display_album_artist"],
+                }
+                for r in rows
+            ]
+
+        if contents == "artists":
+            order = _ARTIST_SORT.get(sort, "ORDER BY RANDOM()")
+            rows = self._conn.execute(
+                f"""
+                SELECT
+                    ar.name, ar.play_time,
+                    (SELECT album FROM albums
+                     WHERE artist_id = ar.id
+                     ORDER BY play_count_avg DESC LIMIT 1) AS top_album
+                FROM artists ar
+                WHERE ar.id IN (
+                    SELECT DISTINCT a.artist_id FROM albums a
+                    JOIN tracks t ON t.album_id = a.id
+                    WHERE t.id IN ({placeholders}) AND a.artist_id IS NOT NULL
+                )
+                {order}
+                LIMIT ?
+                """,
+                (*track_ids, limit),
+            ).fetchall()
+            return [
+                {
+                    "name": r["name"],
+                    "play_time": r["play_time"],
+                    "top_album": r["top_album"],
+                }
+                for r in rows
+            ]
+
+        # Default: tracks.
+        order = _TRACK_SORT.get(sort, "ORDER BY RANDOM()")
+        rows = self._conn.execute(
+            f"""
+            SELECT
+                t.id, t.file_path, t.title, t.artist, t.album_artist, t.album,
+                t.year, t.track_number, t.disc_number, t.ext, t.embedded_art,
+                t.mb_release_id, t.mb_recording_id, t.genre, t.label,
+                t.favorite, t.play_count, t.last_played, t.source, t.is_available, t.duration
+            FROM tracks t
+            WHERE t.id IN ({placeholders})
+            {order}
+            LIMIT ?
+            """,
+            (*track_ids, limit),
+        ).fetchall()
+        return [
+            {
+                "playlist_track_id": None,
+                "position": 0,
+                "id": r["id"],
+                "file_path": r["file_path"],
+                "title": r["title"],
+                "artist": r["artist"],
+                "album_artist": r["album_artist"],
+                "album": r["album"],
+                "year": r["year"],
+                "track_number": r["track_number"],
+                "disc_number": r["disc_number"],
+                "ext": r["ext"],
+                "embedded_art": bool(r["embedded_art"]),
+                "mb_release_id": r["mb_release_id"],
+                "mb_recording_id": r["mb_recording_id"],
+                "genre": r["genre"],
+                "label": r["label"],
+                "favorite": bool(r["favorite"]),
+                "play_count": r["play_count"],
+                "last_played": r["last_played"],
+                "source": r["source"],
+                "is_available": bool(r["is_available"]),
+                "duration": r["duration"],
+            }
+            for r in rows
+        ]
+
     def count_magic_criteria(self, criteria: "MagicCriteria") -> int:
         """Return the number of tracks that match *criteria* without fetching them."""
         from kamp_core.criteria import build_query

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4074,11 +4074,11 @@ class LibraryIndex:
             "recently_added": "ORDER BY t.date_added DESC",
             "most_played": "ORDER BY t.play_count DESC",
         }
-        # Artists lack per-sort columns; fall back to play_time for non-random.
+        # Artist sort is derived from the playlist tracks in scope.
         _ARTIST_SORT = {
             "random": "ORDER BY RANDOM()",
-            "last_played": "ORDER BY ar.play_time DESC",
-            "recently_added": "ORDER BY ar.play_time DESC",
+            "last_played": "ORDER BY artist_last_played DESC NULLS LAST",
+            "recently_added": "ORDER BY artist_recently_added DESC",
             "most_played": "ORDER BY ar.play_time DESC",
         }
 
@@ -4134,15 +4134,16 @@ class LibraryIndex:
                 f"""
                 SELECT
                     ar.name, ar.play_time,
+                    MAX(t.last_played) AS artist_last_played,
+                    MAX(t.date_added) AS artist_recently_added,
                     (SELECT album FROM albums
                      WHERE artist_id = ar.id
                      ORDER BY play_count_avg DESC LIMIT 1) AS top_album
                 FROM artists ar
-                WHERE ar.id IN (
-                    SELECT DISTINCT a.artist_id FROM albums a
-                    JOIN tracks t ON t.album_id = a.id
-                    WHERE t.id IN ({placeholders}) AND a.artist_id IS NOT NULL
-                )
+                JOIN albums a ON a.artist_id = ar.id
+                JOIN tracks t ON t.album_id = a.id
+                WHERE t.id IN ({placeholders}) AND a.artist_id IS NOT NULL
+                GROUP BY ar.id
                 {order}
                 LIMIT ?
                 """,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3542,6 +3542,17 @@ def create_app(
         index.record_playlist_played(playlist_id)
         return Response(status_code=204)
 
+    @app.get("/api/v1/playlists/{playlist_id}/module-content")
+    def get_playlist_module_content(
+        playlist_id: int,
+        contents: str = "albums",
+        sort: str = "random",
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        if index.get_playlist(playlist_id) is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        return index.get_playlist_module_content(playlist_id, contents, sort, limit)
+
     @app.get(
         "/api/v1/playlists/{playlist_id}/tracks", response_model=list[PlaylistTrackOut]
     )

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -92,6 +92,7 @@ export default function App(): React.JSX.Element {
   const setServerStatus = useStore((s) => s.setServerStatus)
   const setAudioLevel = useStore((s) => s.setAudioLevel)
   const bumpLastPlayedVersion = useStore((s) => s.bumpLastPlayedVersion)
+  const bumpMagicPlaylistVersion = useStore((s) => s.bumpMagicPlaylistVersion)
   const serverStatus = useStore((s) => s.serverStatus)
   const flashToast = useStore((s) => s.flashToast)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
@@ -267,6 +268,7 @@ export default function App(): React.JSX.Element {
           if (selectedPlaylist?.id === id) {
             void useStore.getState().loadPlaylistTracks(id)
           }
+          bumpMagicPlaylistVersion()
         }
       )
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -255,6 +255,19 @@ export const getTopArtists = (limit: number): Promise<Artist[]> =>
 export const getTopTracks = (limit: number): Promise<Track[]> =>
   get(`/api/v1/tracks/top?limit=${limit}`)
 
+export type MagicPlaylistContents = 'albums' | 'artists' | 'tracks'
+export type MagicPlaylistSort = 'random' | 'last_played' | 'recently_added' | 'most_played'
+
+export const getMagicPlaylistModuleContent = (
+  playlistId: number,
+  contents: MagicPlaylistContents,
+  sort: MagicPlaylistSort,
+  limit: number
+): Promise<Album[] | Artist[] | PlaylistTrack[]> =>
+  get(
+    `/api/v1/playlists/${playlistId}/module-content?contents=${contents}&sort=${sort}&limit=${limit}`
+  )
+
 export const getTracksForAlbum = (
   albumArtist: string,
   album: string,

--- a/kamp_ui/src/renderer/src/components/BaseKampView.tsx
+++ b/kamp_ui/src/renderer/src/components/BaseKampView.tsx
@@ -8,6 +8,14 @@ import { ContextMenu } from './ContextMenu'
 
 type Menu = { x: number; y: number; id: string }
 
+const MAGIC_PLAYLIST_IDS = [
+  'kamp.magic-playlist-1',
+  'kamp.magic-playlist-2',
+  'kamp.magic-playlist-3',
+  'kamp.magic-playlist-4',
+  'kamp.magic-playlist-5'
+]
+
 export function BaseKampView(): React.JSX.Element {
   const moduleOrder = useStore((s) => s.moduleOrder)
   const setModuleOrder = useStore((s) => s.setModuleOrder)
@@ -29,6 +37,17 @@ export function BaseKampView(): React.JSX.Element {
 
   const visibleIds = new Set(modules.map((m) => m.id))
   const addableModules = MODULE_REGISTRY.filter((m) => !visibleIds.has(m.id))
+
+  // Collapse all 5 magic playlist slots into a single "Magic Playlist" entry
+  // that adds the next unused slot.
+  const nextUnusedMagicSlot = MAGIC_PLAYLIST_IDS.find((id) =>
+    addableModules.some((m) => m.id === id)
+  )
+  const collapsedAddable = addableModules.filter((m) => !MAGIC_PLAYLIST_IDS.includes(m.id))
+  if (nextUnusedMagicSlot) {
+    const reg = MODULE_REGISTRY.find((m) => m.id === nextUnusedMagicSlot)!
+    collapsedAddable.push({ ...reg, id: nextUnusedMagicSlot })
+  }
 
   function moveModule(id: string, direction: 'top' | 'up' | 'down' | 'bottom'): void {
     const idx = moduleOrder.indexOf(id)
@@ -53,7 +72,7 @@ export function BaseKampView(): React.JSX.Element {
     setModuleOrder(next)
   }
 
-  if (modules.length === 0 && addableModules.length === 0) {
+  if (modules.length === 0 && collapsedAddable.length === 0) {
     return <div className="base-kamp-empty">No modules configured.</div>
   }
 
@@ -132,17 +151,20 @@ export function BaseKampView(): React.JSX.Element {
                 </button>
               </>
             )}
-            {mod.title}
+            {mod.titleComponent ? <mod.titleComponent moduleId={mod.id} /> : mod.title}
           </div>
           <div className={`base-kamp-config-row${editMode ? ' visible' : ''}`}>
-            {mod.configComponent && <mod.configComponent />}
+            {mod.configComponent && <mod.configComponent moduleId={mod.id} />}
           </div>
           <div className="base-kamp-module-body">
-            <mod.component displayStyle={moduleDisplayStyles[mod.id] ?? 'shelf'} />
+            <mod.component
+              displayStyle={moduleDisplayStyles[mod.id] ?? 'shelf'}
+              moduleId={mod.id}
+            />
           </div>
         </section>
       ))}
-      {editMode && addableModules.length > 0 && (
+      {editMode && collapsedAddable.length > 0 && (
         <div className="base-kamp-add-module">
           <span>Add Module</span>
           <select
@@ -154,7 +176,7 @@ export function BaseKampView(): React.JSX.Element {
             <option value="" disabled>
               Select…
             </option>
-            {addableModules.map((m) => (
+            {collapsedAddable.map((m) => (
               <option key={m.id} value={m.id}>
                 {m.title}
               </option>

--- a/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
@@ -37,7 +37,8 @@ export function MagicPlaylistTitle({ moduleId }: { moduleId: string }): React.JS
 
 export function MagicPlaylistConfig({ moduleId }: { moduleId?: string }): React.JSX.Element {
   const id = moduleId ?? ''
-  const playlists = useStore((s) => s.library.playlists)
+  const allPlaylists = useStore((s) => s.library.playlists)
+  const playlists = allPlaylists.filter((p) => p.criteria != null)
   const configs = useStore((s) => s.magicPlaylistConfigs)
   const setConfig = useStore((s) => s.setMagicPlaylistConfig)
   const displayStyle = useStore((s) => s.moduleDisplayStyles[id] ?? 'shelf')

--- a/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
@@ -1,0 +1,475 @@
+import React, { useEffect, useState } from 'react'
+import { getMagicPlaylistModuleContent, artUrl } from '../../api/client'
+import type { Album, Artist, PlaylistTrack } from '../../api/client'
+import { useStore } from '../../store'
+import type { MagicPlaylistModuleConfig } from '../../store'
+import { ArtistContextMenu } from '../ArtistContextMenu'
+import { TrackContextMenu } from '../TrackContextMenu'
+import { PlayIcon } from '../TransportIcons'
+import { ShelfView } from './ShelfView'
+import { GridView } from './GridView'
+import { ListView } from './ListView'
+import type { ModuleProps, DisplayStyle } from './registry'
+
+const DEFAULT_CONFIG: MagicPlaylistModuleConfig = {
+  playlistId: null,
+  sort: 'random',
+  contents: 'albums',
+  items: 10
+}
+
+// ---------------------------------------------------------------------------
+// MagicPlaylistTitle — renders the playlist title or "Magic Playlist" fallback
+// ---------------------------------------------------------------------------
+
+export function MagicPlaylistTitle({ moduleId }: { moduleId: string }): React.JSX.Element {
+  const playlists = useStore((s) => s.library.playlists)
+  const configs = useStore((s) => s.magicPlaylistConfigs)
+  const config = configs[moduleId] ?? DEFAULT_CONFIG
+  const playlist =
+    config.playlistId != null ? playlists.find((p) => p.id === config.playlistId) : null
+  return <>{playlist ? playlist.title : 'Magic Playlist'}</>
+}
+
+// ---------------------------------------------------------------------------
+// MagicPlaylistConfig — per-instance configuration controls
+// ---------------------------------------------------------------------------
+
+export function MagicPlaylistConfig({ moduleId }: { moduleId?: string }): React.JSX.Element {
+  const id = moduleId ?? ''
+  const playlists = useStore((s) => s.library.playlists)
+  const configs = useStore((s) => s.magicPlaylistConfigs)
+  const setConfig = useStore((s) => s.setMagicPlaylistConfig)
+  const displayStyle = useStore((s) => s.moduleDisplayStyles[id] ?? 'shelf')
+  const setDisplayStyle = useStore((s) => s.setModuleDisplayStyle)
+
+  const config = configs[id] ?? DEFAULT_CONFIG
+
+  const update = (patch: Partial<MagicPlaylistModuleConfig>): void => {
+    setConfig(id, { ...config, ...patch })
+  }
+
+  return (
+    <div className="module-config-row">
+      <label className="module-config-field">
+        <span>Playlist</span>
+        <select
+          value={config.playlistId ?? ''}
+          onChange={(e) => {
+            const val = e.target.value
+            update({ playlistId: val === '' ? null : parseInt(val) })
+          }}
+        >
+          <option value="">Choose a playlist…</option>
+          {playlists.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.title}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="module-config-field">
+        <span>Contents</span>
+        <select
+          value={config.contents}
+          onChange={(e) =>
+            update({ contents: e.target.value as MagicPlaylistModuleConfig['contents'] })
+          }
+        >
+          <option value="albums">Albums</option>
+          <option value="artists">Artists</option>
+          <option value="tracks">Tracks</option>
+        </select>
+      </label>
+      <label className="module-config-field">
+        <span>Sort</span>
+        <select
+          value={config.sort}
+          onChange={(e) => update({ sort: e.target.value as MagicPlaylistModuleConfig['sort'] })}
+        >
+          <option value="random">Random</option>
+          <option value="most_played">Most Played</option>
+          <option value="last_played">Last Played</option>
+          <option value="recently_added">Recently Added</option>
+        </select>
+      </label>
+      <label className="module-config-field">
+        <span>Items</span>
+        <input
+          type="number"
+          min={1}
+          max={50}
+          value={config.items}
+          onChange={(e) => update({ items: parseInt(e.target.value) || 10 })}
+        />
+      </label>
+      <label className="module-config-field">
+        <span>Style</span>
+        <select
+          value={displayStyle}
+          onChange={(e) => setDisplayStyle(id, e.target.value as DisplayStyle)}
+        >
+          <option value="shelf">Shelf</option>
+          <option value="grid">Grid</option>
+          <option value="list">List</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Artist sub-components (reuse art-card pattern from TopArtistsModule)
+// ---------------------------------------------------------------------------
+
+type ArtistMenuPos = { x: number; y: number; artist: Artist }
+
+function MagicArtistCard({ artist }: { artist: Artist }): React.JSX.Element {
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const [artLoaded, setArtLoaded] = useState(false)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<ArtistMenuPos | null>(null)
+
+  const navigate = (): void => {
+    selectArtist(artist.name)
+    void setActiveView('library')
+  }
+
+  return (
+    <div
+      className="track-card"
+      tabIndex={0}
+      draggable
+      onClick={navigate}
+      onKeyDown={(e) => e.key === 'Enter' && navigate()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, artist })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-artist', JSON.stringify({ name: artist.name }))
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className={`track-card-art${artLoaded ? ' has-art' : ''}`}>
+        {!artError && artist.top_album && (
+          <img
+            className="track-card-art-img"
+            src={artUrl(artist.name, artist.top_album)}
+            alt=""
+            onLoad={() => setArtLoaded(true)}
+            onError={() => {
+              setArtLoaded(false)
+              setArtError(true)
+            }}
+          />
+        )}
+      </div>
+      <div className="track-card-info">
+        <div className="track-card-title">{artist.name}</div>
+      </div>
+      {menu && (
+        <ArtistContextMenu
+          x={menu.x}
+          y={menu.y}
+          artist={menu.artist}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function MagicArtistListRow({ artist }: { artist: Artist }): React.JSX.Element {
+  const selectArtist = useStore((s) => s.selectArtist)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<ArtistMenuPos | null>(null)
+
+  const navigate = (): void => {
+    selectArtist(artist.name)
+    void setActiveView('library')
+  }
+
+  return (
+    <div
+      className="module-list-row"
+      tabIndex={0}
+      draggable
+      onClick={navigate}
+      onKeyDown={(e) => e.key === 'Enter' && navigate()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, artist })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-artist', JSON.stringify({ name: artist.name }))
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className="module-list-thumb">
+        {!artError && artist.top_album && (
+          <img
+            src={artUrl(artist.name, artist.top_album)}
+            alt=""
+            onError={() => setArtError(true)}
+          />
+        )}
+      </div>
+      <div className="module-list-info">
+        <div className="module-list-title">{artist.name}</div>
+      </div>
+      {menu && (
+        <ArtistContextMenu
+          x={menu.x}
+          y={menu.y}
+          artist={menu.artist}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function MagicArtistShelf({ artists }: { artists: Artist[] }): React.JSX.Element {
+  return (
+    <div className="module-shelf-wrapper">
+      <div className="module-shelf" role="region" aria-label="Playlist artists shelf">
+        {artists.map((artist) => (
+          <MagicArtistCard key={artist.name} artist={artist} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Track sub-components (playlist tracks share the same Track shape)
+// ---------------------------------------------------------------------------
+
+type TrackMenuPos = { x: number; y: number; track: PlaylistTrack }
+
+function MagicTrackCard({ track }: { track: PlaylistTrack }): React.JSX.Element {
+  const currentTrack = useStore((s) => s.player.current_track)
+  const playing = useStore((s) => s.player.playing)
+  const [artLoaded, setArtLoaded] = useState(false)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<TrackMenuPos | null>(null)
+  const isCurrent = currentTrack?.id === track.id
+
+  return (
+    <div
+      className={`track-card${isCurrent ? ' playing' : ''}`}
+      tabIndex={0}
+      draggable
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, track })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className={`track-card-art${artLoaded ? ' has-art' : ''}`}>
+        {!artError && (
+          <img
+            className="track-card-art-img"
+            src={artUrl(track.album_artist, track.album)}
+            alt=""
+            onLoad={() => setArtLoaded(true)}
+            onError={() => {
+              setArtLoaded(false)
+              setArtError(true)
+            }}
+          />
+        )}
+        {playing && isCurrent && (
+          <div className="now-playing-badge">
+            <PlayIcon size={10} />
+          </div>
+        )}
+      </div>
+      <div className="track-card-info">
+        <div className="track-card-title">{track.title}</div>
+        <div className="track-card-artist">{track.artist}</div>
+      </div>
+      {menu && (
+        <TrackContextMenu x={menu.x} y={menu.y} track={menu.track} onClose={() => setMenu(null)} />
+      )}
+    </div>
+  )
+}
+
+function MagicTrackListRow({ track }: { track: PlaylistTrack }): React.JSX.Element {
+  const currentTrack = useStore((s) => s.player.current_track)
+  const playing = useStore((s) => s.player.playing)
+  const [artError, setArtError] = useState(false)
+  const [menu, setMenu] = useState<TrackMenuPos | null>(null)
+  const isCurrent = currentTrack?.id === track.id
+
+  return (
+    <div
+      className={`module-list-row${isCurrent ? ' playing' : ''}`}
+      tabIndex={0}
+      draggable
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY, track })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className="module-list-thumb">
+        {!artError && (
+          <img
+            src={artUrl(track.album_artist, track.album)}
+            alt=""
+            onError={() => setArtError(true)}
+          />
+        )}
+        {playing && isCurrent && (
+          <div className="module-list-playing-badge">
+            <PlayIcon size={16} />
+          </div>
+        )}
+      </div>
+      <div className="module-list-info">
+        <div className="module-list-title">{track.title}</div>
+        <div className="module-list-artist">{track.artist}</div>
+      </div>
+      {menu && (
+        <TrackContextMenu x={menu.x} y={menu.y} track={menu.track} onClose={() => setMenu(null)} />
+      )}
+    </div>
+  )
+}
+
+function MagicTrackShelf({ tracks }: { tracks: PlaylistTrack[] }): React.JSX.Element {
+  return (
+    <div className="module-shelf-wrapper">
+      <div className="module-shelf" role="region" aria-label="Playlist tracks shelf">
+        {tracks.map((track) => (
+          <MagicTrackCard key={track.id} track={track} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// MagicPlaylistModule — the main module component
+// ---------------------------------------------------------------------------
+
+export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): React.JSX.Element {
+  const id = moduleId ?? ''
+  const configs = useStore((s) => s.magicPlaylistConfigs)
+  const serverStatus = useStore((s) => s.serverStatus)
+  const magicPlaylistVersion = useStore((s) => s.magicPlaylistVersion)
+  const config = configs[id] ?? DEFAULT_CONFIG
+
+  const [albums, setAlbums] = useState<Album[]>([])
+  const [artists, setArtists] = useState<Artist[]>([])
+  const [tracks, setTracks] = useState<PlaylistTrack[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (serverStatus !== 'connected' || config.playlistId == null) return
+    getMagicPlaylistModuleContent(config.playlistId, config.contents, config.sort, config.items)
+      .then((data) => {
+        if (config.contents === 'albums') {
+          setAlbums(data as Album[])
+          setArtists([])
+          setTracks([])
+        } else if (config.contents === 'artists') {
+          setArtists(data as Artist[])
+          setAlbums([])
+          setTracks([])
+        } else {
+          setTracks(data as PlaylistTrack[])
+          setAlbums([])
+          setArtists([])
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [
+    config.playlistId,
+    config.contents,
+    config.sort,
+    config.items,
+    serverStatus,
+    magicPlaylistVersion
+  ])
+
+  if (config.playlistId == null) {
+    return <div className="module-empty">Choose a playlist in the settings above.</div>
+  }
+
+  if (loading) {
+    return (
+      <div className="module-skeleton-row">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="module-skeleton-card" />
+        ))}
+      </div>
+    )
+  }
+
+  // Albums
+  if (config.contents === 'albums') {
+    if (albums.length === 0) return <div className="module-empty">No albums found.</div>
+    if (displayStyle === 'list') return <ListView albums={albums} />
+    if (displayStyle === 'grid') return <GridView albums={albums} />
+    return <ShelfView albums={albums} />
+  }
+
+  // Artists
+  if (config.contents === 'artists') {
+    if (artists.length === 0) return <div className="module-empty">No artists found.</div>
+    if (displayStyle === 'list') {
+      return (
+        <div className="module-list">
+          {artists.map((artist) => (
+            <MagicArtistListRow key={artist.name} artist={artist} />
+          ))}
+        </div>
+      )
+    }
+    if (displayStyle === 'grid') {
+      return (
+        <div className="album-grid module-grid">
+          {artists.map((artist) => (
+            <MagicArtistCard key={artist.name} artist={artist} />
+          ))}
+        </div>
+      )
+    }
+    return <MagicArtistShelf artists={artists} />
+  }
+
+  // Tracks
+  if (tracks.length === 0) return <div className="module-empty">No tracks found.</div>
+  if (displayStyle === 'list') {
+    return (
+      <div className="module-list">
+        {tracks.map((track) => (
+          <MagicTrackListRow key={track.id} track={track} />
+        ))}
+      </div>
+    )
+  }
+  if (displayStyle === 'grid') {
+    return (
+      <div className="album-grid module-grid">
+        {tracks.map((track) => (
+          <MagicTrackCard key={track.id} track={track} />
+        ))}
+      </div>
+    )
+  }
+  return <MagicTrackShelf tracks={tracks} />
+}

--- a/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
@@ -376,6 +376,13 @@ export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): Re
   const [artists, setArtists] = useState<Artist[]>([])
   const [tracks, setTracks] = useState<PlaylistTrack[]>([])
   const [loading, setLoading] = useState(true)
+  const [randomTick, setRandomTick] = useState(0)
+
+  useEffect(() => {
+    if (config.sort !== 'random') return
+    const id = setInterval(() => setRandomTick((n) => n + 1), 60 * 60 * 1000)
+    return () => clearInterval(id)
+  }, [config.sort])
 
   useEffect(() => {
     if (serverStatus !== 'connected' || config.playlistId == null) return
@@ -403,7 +410,8 @@ export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): Re
     config.sort,
     config.items,
     serverStatus,
-    magicPlaylistVersion
+    magicPlaylistVersion,
+    randomTick
   ])
 
   if (config.playlistId == null) {

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -5,18 +5,21 @@ import { TopAlbumsModule, TopAlbumsConfig } from './TopAlbumsModule'
 import { TopTracksModule, TopTracksConfig } from './TopTracksModule'
 import { TopArtistsModule, TopArtistsConfig } from './TopArtistsModule'
 import { StereoRackModule, StereoRackConfig } from './StereoRackModule'
+import { MagicPlaylistModule, MagicPlaylistConfig, MagicPlaylistTitle } from './MagicPlaylistModule'
 
 export type DisplayStyle = 'shelf' | 'grid' | 'list'
 
 export interface ModuleProps {
   displayStyle: DisplayStyle
+  moduleId?: string
 }
 
 export interface ModuleRegistration {
   id: string
   title: string
   component: React.ComponentType<ModuleProps>
-  configComponent?: React.ComponentType
+  configComponent?: React.ComponentType<{ moduleId?: string }>
+  titleComponent?: React.ComponentType<{ moduleId: string }>
 }
 
 export const MODULE_REGISTRY: ModuleRegistration[] = [
@@ -57,5 +60,40 @@ export const MODULE_REGISTRY: ModuleRegistration[] = [
     title: 'Stereo Rack',
     component: StereoRackModule,
     configComponent: StereoRackConfig
+  },
+  {
+    id: 'kamp.magic-playlist-1',
+    title: 'Magic Playlist',
+    component: MagicPlaylistModule,
+    configComponent: MagicPlaylistConfig,
+    titleComponent: MagicPlaylistTitle
+  },
+  {
+    id: 'kamp.magic-playlist-2',
+    title: 'Magic Playlist',
+    component: MagicPlaylistModule,
+    configComponent: MagicPlaylistConfig,
+    titleComponent: MagicPlaylistTitle
+  },
+  {
+    id: 'kamp.magic-playlist-3',
+    title: 'Magic Playlist',
+    component: MagicPlaylistModule,
+    configComponent: MagicPlaylistConfig,
+    titleComponent: MagicPlaylistTitle
+  },
+  {
+    id: 'kamp.magic-playlist-4',
+    title: 'Magic Playlist',
+    component: MagicPlaylistModule,
+    configComponent: MagicPlaylistConfig,
+    titleComponent: MagicPlaylistTitle
+  },
+  {
+    id: 'kamp.magic-playlist-5',
+    title: 'Magic Playlist',
+    component: MagicPlaylistModule,
+    configComponent: MagicPlaylistConfig,
+    titleComponent: MagicPlaylistTitle
   }
 ]

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -577,13 +577,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const albums = get()
       .library.albums.filter((a) => a.album_artist === artistName)
       .sort((a, b) => (b.play_count_avg ?? 0) - (a.play_count_avg ?? 0))
-    for (let i = 0; i < albums.length; i++) {
-      await api.insertAlbumAt(
-        albums[i].album_artist,
-        albums[i].album,
-        idx + i,
-        albums[i].file_path ?? ''
-      )
+    let offset = 0
+    for (const album of albums) {
+      await api.insertAlbumAt(album.album_artist, album.album, idx + offset, album.file_path ?? '')
+      offset += album.track_count
     }
     void get().loadQueue()
   },

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -23,8 +23,16 @@ import type {
   Track
 } from './api/client'
 import type { DisplayStyle } from './components/modules/registry'
+import type { MagicPlaylistContents, MagicPlaylistSort } from './api/client'
 
 export type TrackDisplaySize = 'teeny' | 'less-teeny' | 'large-print'
+
+export type MagicPlaylistModuleConfig = {
+  playlistId: number | null
+  sort: MagicPlaylistSort
+  contents: MagicPlaylistContents
+  items: number
+}
 export type PlasmaMode = 'always' | 'sometimes' | 'never'
 export type TraceStyle = 'clean' | 'glowy' | 'trippy'
 
@@ -73,6 +81,8 @@ type PlayerStore = {
   topAlbumsCount: number
   topTracksCount: number
   topArtistsCount: number
+  magicPlaylistConfigs: Record<string, MagicPlaylistModuleConfig>
+  magicPlaylistVersion: number
   flashTrackId: number | null
   baseKampEditMode: boolean
   stereoRackTrackSize: TrackDisplaySize
@@ -128,6 +138,8 @@ type PlayerStore = {
   setTopAlbumsCount: (n: number) => void
   setTopTracksCount: (n: number) => void
   setTopArtistsCount: (n: number) => void
+  setMagicPlaylistConfig: (moduleId: string, config: MagicPlaylistModuleConfig) => void
+  bumpMagicPlaylistVersion: () => void
   setFlashTrackId: (id: number) => void
   insertArtistAt: (artistName: string, idx: number) => Promise<void>
   toggleBaseKampEditMode: () => void
@@ -335,6 +347,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const saved = localStorage.getItem('kamp:top-artists-count')
     return saved ? parseInt(saved) : 10
   })(),
+  magicPlaylistConfigs: (() => {
+    try {
+      const saved = localStorage.getItem('kamp:magic-playlist-configs')
+      return saved ? (JSON.parse(saved) as Record<string, MagicPlaylistModuleConfig>) : {}
+    } catch {
+      return {}
+    }
+  })(),
+  magicPlaylistVersion: 0,
   flashTrackId: null,
   baseKampEditMode: localStorage.getItem('kamp:base-kamp-edit-mode') === 'true',
   stereoRackTrackSize:
@@ -572,6 +593,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
     localStorage.setItem('kamp:top-artists-count', String(n))
     set({ topArtistsCount: n })
   },
+
+  setMagicPlaylistConfig: (moduleId, config) => {
+    const next = { ...get().magicPlaylistConfigs, [moduleId]: config }
+    localStorage.setItem('kamp:magic-playlist-configs', JSON.stringify(next))
+    set({ magicPlaylistConfigs: next })
+  },
+
+  bumpMagicPlaylistVersion: () =>
+    set((s) => ({ magicPlaylistVersion: s.magicPlaylistVersion + 1 })),
 
   insertArtistAt: async (artistName, idx) => {
     const albums = get()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8730,6 +8730,140 @@ class TestMagicPlaylists:
         assert count == 0
 
 
+class TestPlaylistModuleContent:
+    """Tests for LibraryIndex.get_playlist_module_content()."""
+
+    def _setup(self, tmp_path: Path) -> tuple[LibraryIndex, int, int]:
+        """Return (index, static_pid, magic_pid) with two tracks seeded."""
+        index = LibraryIndex(tmp_path / "library.db")
+        pa = _make_indexed_track(
+            index,
+            tmp_path,
+            "a.mp3",
+            album_artist="Alvvays",
+            album="Antisocialites",
+            play_count=5,
+        )
+        pb = _make_indexed_track(
+            index,
+            tmp_path,
+            "b.mp3",
+            album_artist="Slowdive",
+            album="Souvlaki",
+            play_count=2,
+        )
+        index.record_play_time(pa, 300.0)
+        index.record_play_time(pb, 100.0)
+        # Static playlist with both tracks.
+        static_pid = index.create_playlist("Static")["id"]
+        t_a = index.tracks_for_album("Alvvays", "Antisocialites")[0]
+        t_b = index.tracks_for_album("Slowdive", "Souvlaki")[0]
+        index.add_track_to_playlist(static_pid, str(t_a.file_path))
+        index.add_track_to_playlist(static_pid, str(t_b.file_path))
+        # Magic playlist matching the same two tracks.
+        magic_pid = index.create_magic_playlist(
+            "Magic",
+            MagicCriteria(
+                groups=[
+                    Group(
+                        conditions=[
+                            Condition(
+                                field="track.album_artist", op="is", value="Alvvays"
+                            ),
+                            Condition(
+                                field="track.album_artist", op="is", value="Slowdive"
+                            ),
+                        ],
+                        match="any",
+                        negate=False,
+                    )
+                ],
+                match="all",
+            ),
+        )
+        return index, static_pid, magic_pid
+
+    # albums ---
+
+    def test_albums_returns_album_dicts(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(static_pid, "albums", "random", 10)
+        index.close()
+        assert len(result) == 2
+        album_names = {r["album"] for r in result}
+        assert album_names == {"Antisocialites", "Souvlaki"}
+
+    def test_albums_most_played_sort(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(
+            static_pid, "albums", "most_played", 10
+        )
+        index.close()
+        assert result[0]["album"] == "Antisocialites"  # play_count=5 > 2
+
+    def test_albums_limit(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(static_pid, "albums", "random", 1)
+        index.close()
+        assert len(result) == 1
+
+    def test_albums_magic_playlist(self, tmp_path: Path) -> None:
+        index, _, magic_pid = self._setup(tmp_path)
+        result = index.get_playlist_module_content(magic_pid, "albums", "random", 10)
+        index.close()
+        assert len(result) == 2
+
+    # artists ---
+
+    def test_artists_returns_artist_dicts(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(static_pid, "artists", "random", 10)
+        index.close()
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"Alvvays", "Slowdive"}
+
+    def test_artists_most_played_sort(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(
+            static_pid, "artists", "most_played", 10
+        )
+        index.close()
+        assert result[0]["name"] == "Alvvays"  # play_time=300 > 100
+
+    def test_artists_have_top_album(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(static_pid, "artists", "random", 10)
+        index.close()
+        by_name = {r["name"]: r for r in result}
+        assert by_name["Alvvays"]["top_album"] == "Antisocialites"
+
+    # tracks ---
+
+    def test_tracks_returns_track_dicts(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(static_pid, "tracks", "random", 10)
+        index.close()
+        assert len(result) == 2
+        assert all("file_path" in r for r in result)
+
+    def test_tracks_most_played_sort(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        result = index.get_playlist_module_content(
+            static_pid, "tracks", "most_played", 10
+        )
+        index.close()
+        assert result[0]["album_artist"] == "Alvvays"
+
+    # missing playlist ---
+
+    def test_missing_playlist_returns_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.get_playlist_module_content(9999, "albums", "random", 10)
+        index.close()
+        assert result == []
+
+
 class TestMagicPlaylistReactivity:
     """Tests for the on_fields_changed callback wired into LibraryIndex mutations."""
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8831,6 +8831,30 @@ class TestPlaylistModuleContent:
         index.close()
         assert result[0]["name"] == "Alvvays"  # play_time=300 > 100
 
+    def test_artists_last_played_sort(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        # Play a Slowdive track most recently — it should sort first.
+        t_b = index.tracks_for_album("Slowdive", "Souvlaki")[0]
+        index.record_track_started(t_b.file_path)
+        result = index.get_playlist_module_content(
+            static_pid, "artists", "last_played", 10
+        )
+        index.close()
+        assert result[0]["name"] == "Slowdive"
+
+    def test_artists_recently_added_sort(self, tmp_path: Path) -> None:
+        index, static_pid, _ = self._setup(tmp_path)
+        # Force Slowdive's track date_added to be more recent than Alvvays.
+        index._conn.execute(
+            "UPDATE tracks SET date_added = 9999999999 WHERE album_artist = 'Slowdive'"
+        )
+        index._conn.commit()
+        result = index.get_playlist_module_content(
+            static_pid, "artists", "recently_added", 10
+        )
+        index.close()
+        assert result[0]["name"] == "Slowdive"
+
     def test_artists_have_top_album(self, tmp_path: Path) -> None:
         index, static_pid, _ = self._setup(tmp_path)
         result = index.get_playlist_module_content(static_pid, "artists", "random", 10)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5816,6 +5816,30 @@ _SAMPLE_CRITERIA = {
 }
 
 
+class TestPlaylistModuleContentEndpoint:
+    def test_returns_content_list(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = _playlist(id=1)
+        mock_index.get_playlist_module_content.return_value = [
+            {"album_artist": "Alvvays", "album": "Antisocialites"}
+        ]
+        resp = client.get(
+            "/api/v1/playlists/1/module-content?contents=albums&sort=random&limit=5"
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]["album"] == "Antisocialites"
+        mock_index.get_playlist_module_content.assert_called_once_with(
+            1, "albums", "random", 5
+        )
+
+    def test_returns_404_for_missing_playlist(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.get_playlist.return_value = None
+        assert client.get("/api/v1/playlists/999/module-content").status_code == 404
+
+
 class TestMagicPlaylistEndpoints:
     """Tests for magic playlist routes added in KAMP-461."""
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/playlists/{id}/module-content` endpoint returning albums, artists, or tracks from any playlist (static or magic), with sort and limit params
- Adds up to 5 independently-configurable Magic Playlist module slots to Base Kamp; Add Module dropdown shows a single "Magic Playlist" entry that fills the next unused slot
- Per-instance config (playlist, contents, sort, items, display style) persisted to localStorage; module header shows the selected playlist's title dynamically
- Artists render as art cards using the `artists` table from KAMP-258; all three content types support shelf/grid/list display styles
- Includes stashed fix from KAMP-258: `insertArtistAt` now correctly accumulates `track_count` offsets instead of using album-level indices

## Test plan

- [ ] Add Module dropdown shows a single "Magic Playlist" entry (not 5)
- [ ] Add Magic Playlist → module appears with "Choose a playlist" empty state
- [ ] Add a second Magic Playlist → independent slot with its own config
- [ ] With 5 slots visible, "Magic Playlist" no longer appears in Add Module
- [ ] Config: select a playlist → module header shows playlist title; content loads
- [ ] Contents: Albums — shelf/grid/list of album cards; Sort changes order
- [ ] Contents: Artists — art cards with top-album art; Sort works
- [ ] Contents: Tracks — track rows with art; Sort works
- [ ] Sort: Random re-shuffles on page reload
- [ ] Items: set to 3 → exactly 3 items returned
- [ ] Magic playlist criteria updated → module re-fetches (via `magic_playlist.updated` WS event)
- [ ] Config survives page reload (localStorage)
- [ ] `play artist now` queues albums in correct order (track_count offset fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)