### PR TITLE
feat(KAMP-457): Favorite Playlists Base Kamp module

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/FavoritePlaylistsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/FavoritePlaylistsModule.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import type { Playlist } from '../../api/client'
+import { useStore } from '../../store'
+import { PlaylistShelfView, PlaylistGridView, PlaylistListView } from './PlaylistViews'
+import type { ModuleProps, DisplayStyle } from './registry'
+
+function sortFavPlaylists(playlists: Playlist[], sort: 'last_played_at' | 'title'): Playlist[] {
+  if (sort === 'last_played_at') {
+    const withVal = playlists.filter((p) => p.last_played_at !== null)
+    const nulls = playlists.filter((p) => p.last_played_at === null)
+    withVal.sort((a, b) => b.last_played_at! - a.last_played_at!)
+    return [...withVal, ...nulls]
+  }
+  return [...playlists].sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+  )
+}
+
+export function FavoritePlaylistsConfig({ moduleId }: { moduleId?: string }): React.JSX.Element {
+  const id = moduleId ?? 'kamp.favorite-playlists'
+  const count = useStore((s) => s.favoritePlaylistsCount)
+  const sortOrder = useStore((s) => s.favoritePlaylistsSortOrder)
+  const displayStyle = useStore((s) => s.moduleDisplayStyles[id] ?? 'shelf')
+  const setCount = useStore((s) => s.setFavoritePlaylistsCount)
+  const setSortOrder = useStore((s) => s.setFavoritePlaylistsSortOrder)
+  const setDisplayStyle = useStore((s) => s.setModuleDisplayStyle)
+
+  return (
+    <div className="module-config-row">
+      <label className="module-config-field">
+        <span>Playlists</span>
+        <input
+          type="number"
+          min={1}
+          max={50}
+          value={count}
+          onChange={(e) => setCount(parseInt(e.target.value) || 10)}
+        />
+      </label>
+      <label className="module-config-field">
+        <span>Sort</span>
+        <select
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as 'last_played_at' | 'title')}
+        >
+          <option value="last_played_at">Last Played</option>
+          <option value="title">A→Z</option>
+        </select>
+      </label>
+      <label className="module-config-field">
+        <span>Style</span>
+        <select
+          value={displayStyle}
+          onChange={(e) => setDisplayStyle(id, e.target.value as DisplayStyle)}
+        >
+          <option value="shelf">Shelf</option>
+          <option value="grid">Grid</option>
+          <option value="list">List</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+export function FavoritePlaylistsModule({ displayStyle }: ModuleProps): React.JSX.Element {
+  const allPlaylists = useStore((s) => s.library.playlists)
+  const count = useStore((s) => s.favoritePlaylistsCount)
+  const sortOrder = useStore((s) => s.favoritePlaylistsSortOrder)
+
+  const favorites = sortFavPlaylists(
+    allPlaylists.filter((p) => p.favorite),
+    sortOrder
+  ).slice(0, count)
+
+  if (favorites.length === 0) {
+    return <div className="module-empty">No favorite playlists yet.</div>
+  }
+
+  if (displayStyle === 'list') return <PlaylistListView playlists={favorites} />
+  if (displayStyle === 'grid') return <PlaylistGridView playlists={favorites} />
+  return <PlaylistShelfView playlists={favorites} />
+}

--- a/kamp_ui/src/renderer/src/components/modules/PlaylistViews.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/PlaylistViews.tsx
@@ -1,0 +1,142 @@
+import React, { useRef, useState } from 'react'
+import { playlistArtUrl } from '../../api/client'
+import type { Playlist } from '../../api/client'
+import { useStore } from '../../store'
+import { PlaylistCard } from '../PlaylistCard'
+import { PlaylistContextMenu } from '../PlaylistContextMenu'
+import { SparkleIcon } from '../TransportIcons'
+
+const SCROLL_PX = 500
+
+// ---------------------------------------------------------------------------
+// Shelf
+// ---------------------------------------------------------------------------
+
+export function PlaylistShelfView({ playlists }: { playlists: Playlist[] }): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const scroll = (dir: 'left' | 'right'): void => {
+    scrollRef.current?.scrollBy({
+      left: dir === 'right' ? SCROLL_PX : -SCROLL_PX,
+      behavior: 'smooth'
+    })
+  }
+  return (
+    <div className="module-shelf-wrapper">
+      <button
+        className="module-shelf-arrow module-shelf-arrow--left"
+        onClick={() => scroll('left')}
+        aria-label="Scroll left"
+        tabIndex={-1}
+      >
+        ‹
+      </button>
+      <div
+        className="module-shelf"
+        ref={scrollRef}
+        role="region"
+        aria-label="Favorite playlists shelf"
+      >
+        {playlists.map((pl) => (
+          <PlaylistCard key={pl.id} playlist={pl} />
+        ))}
+      </div>
+      <button
+        className="module-shelf-arrow module-shelf-arrow--right"
+        onClick={() => scroll('right')}
+        aria-label="Scroll right"
+        tabIndex={-1}
+      >
+        ›
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Grid
+// ---------------------------------------------------------------------------
+
+export function PlaylistGridView({ playlists }: { playlists: Playlist[] }): React.JSX.Element {
+  return (
+    <div className="album-grid module-grid">
+      {playlists.map((pl) => (
+        <PlaylistCard key={pl.id} playlist={pl} />
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+type MenuPos = { x: number; y: number }
+
+function PlaylistListRow({ playlist }: { playlist: Playlist }): React.JSX.Element {
+  const selectPlaylist = useStore((s) => s.selectPlaylist)
+  const setCollectionType = useStore((s) => s.setCollectionType)
+  const [artLoaded, setArtLoaded] = useState(false)
+  const [menu, setMenu] = useState<MenuPos | null>(null)
+
+  const handleSelect = (): void => {
+    if (menu) return
+    setCollectionType('playlists')
+    void selectPlaylist(playlist)
+  }
+
+  return (
+    <div
+      className="module-list-row"
+      tabIndex={0}
+      draggable
+      onClick={handleSelect}
+      onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setMenu({ x: e.clientX, y: e.clientY })
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/kamp-playlist', String(playlist.id))
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
+    >
+      <div className={`module-list-thumb${artLoaded ? ' has-art' : ''}`}>
+        <img
+          src={playlistArtUrl(playlist.id, playlist.updated_at)}
+          alt=""
+          onLoad={() => setArtLoaded(true)}
+          onError={() => setArtLoaded(false)}
+        />
+      </div>
+      <div className="module-list-info">
+        <div className="module-list-title">{playlist.title}</div>
+        <div className="module-list-artist">
+          {playlist.track_count === 1 ? '1 track' : `${playlist.track_count} tracks`}
+          {playlist.criteria !== null && (
+            <span className="module-list-magic-badge">
+              <SparkleIcon size={10} />
+            </span>
+          )}
+        </div>
+      </div>
+      {menu && (
+        <PlaylistContextMenu
+          x={menu.x}
+          y={menu.y}
+          playlist={playlist}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+export function PlaylistListView({ playlists }: { playlists: Playlist[] }): React.JSX.Element {
+  return (
+    <div className="module-list">
+      {playlists.map((pl) => (
+        <PlaylistListRow key={pl.id} playlist={pl} />
+      ))}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -6,6 +6,7 @@ import { TopTracksModule, TopTracksConfig } from './TopTracksModule'
 import { TopArtistsModule, TopArtistsConfig } from './TopArtistsModule'
 import { StereoRackModule, StereoRackConfig } from './StereoRackModule'
 import { MagicPlaylistModule, MagicPlaylistConfig, MagicPlaylistTitle } from './MagicPlaylistModule'
+import { FavoritePlaylistsModule, FavoritePlaylistsConfig } from './FavoritePlaylistsModule'
 
 export type DisplayStyle = 'shelf' | 'grid' | 'list'
 
@@ -60,6 +61,12 @@ export const MODULE_REGISTRY: ModuleRegistration[] = [
     title: 'Stereo Rack',
     component: StereoRackModule,
     configComponent: StereoRackConfig
+  },
+  {
+    id: 'kamp.favorite-playlists',
+    title: 'Favorite Playlists',
+    component: FavoritePlaylistsModule,
+    configComponent: FavoritePlaylistsConfig
   },
   {
     id: 'kamp.magic-playlist-1',

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -81,6 +81,8 @@ type PlayerStore = {
   topAlbumsCount: number
   topTracksCount: number
   topArtistsCount: number
+  favoritePlaylistsCount: number
+  favoritePlaylistsSortOrder: 'last_played_at' | 'title'
   magicPlaylistConfigs: Record<string, MagicPlaylistModuleConfig>
   magicPlaylistVersion: number
   flashTrackId: number | null
@@ -138,6 +140,8 @@ type PlayerStore = {
   setTopAlbumsCount: (n: number) => void
   setTopTracksCount: (n: number) => void
   setTopArtistsCount: (n: number) => void
+  setFavoritePlaylistsCount: (n: number) => void
+  setFavoritePlaylistsSortOrder: (order: 'last_played_at' | 'title') => void
   setMagicPlaylistConfig: (moduleId: string, config: MagicPlaylistModuleConfig) => void
   bumpMagicPlaylistVersion: () => void
   setFlashTrackId: (id: number) => void
@@ -347,6 +351,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
     const saved = localStorage.getItem('kamp:top-artists-count')
     return saved ? parseInt(saved) : 10
   })(),
+  favoritePlaylistsCount: (() => {
+    const saved = localStorage.getItem('kamp:fav-playlists-count')
+    return saved ? parseInt(saved) : 10
+  })(),
+  favoritePlaylistsSortOrder:
+    (localStorage.getItem('kamp:fav-playlists-sort') as 'last_played_at' | 'title' | null) ??
+    'last_played_at',
   magicPlaylistConfigs: (() => {
     try {
       const saved = localStorage.getItem('kamp:magic-playlist-configs')
@@ -592,6 +603,16 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setTopArtistsCount: (n) => {
     localStorage.setItem('kamp:top-artists-count', String(n))
     set({ topArtistsCount: n })
+  },
+
+  setFavoritePlaylistsCount: (n) => {
+    localStorage.setItem('kamp:fav-playlists-count', String(n))
+    set({ favoritePlaylistsCount: n })
+  },
+
+  setFavoritePlaylistsSortOrder: (order) => {
+    localStorage.setItem('kamp:fav-playlists-sort', order)
+    set({ favoritePlaylistsSortOrder: order })
   },
 
   setMagicPlaylistConfig: (moduleId, config) => {


### PR DESCRIPTION
## Summary

- New "Favorite Playlists" module available in Base Kamp (Add Module dropdown)
- Filters `library.playlists` by `favorite === true`, sorts and slices per config
- Config: count (default 10), sort (Last Played / A→Z), style (Shelf / Grid / List)
- `PlaylistCard` reused directly for shelf/grid; new `PlaylistListRow` for list view (thumbnail, title, track count, magic badge, context menu, drag)
- Module is reactive — favoring/unfavoring a playlist updates the module instantly without page reload

## Test plan

- [ ] Add Module → "Favorite Playlists" appears; add it
- [ ] No favorited playlists → "No favorite playlists yet." empty state
- [ ] Favorite a playlist → module updates immediately
- [ ] Count: set to 3 → only 3 shown
- [ ] Sort: Last Played → most recently played first, unplayed at bottom
- [ ] Sort: A→Z → alphabetical
- [ ] Style: Shelf / Grid / List all render correctly
- [ ] List style: thumbnail, title, track count, magic badge (on magic playlists)
- [ ] Drag card to queue → drop target appears; queues playlist
- [ ] Context menu on card works
- [ ] Click card → navigates to playlist in library
- [ ] Unfavorite → disappears from module
- [ ] Config persists across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)