### PR TITLE
feat(KAMP-481): Stats module — library counts and listening highlights

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -553,6 +553,21 @@ class ArtistInfo:
 
 
 @dataclass
+class LibraryStats:
+    """Aggregate library and listening statistics, returned by get_stats()."""
+
+    track_count: int
+    album_count: int
+    artist_count: int
+    total_play_seconds: float
+    total_track_plays: int
+    albums_played: int
+    top_artist_name: str | None
+    top_artist_seconds: float | None
+    top_tracks: "list[Track]"
+
+
+@dataclass
 class DeferredOp:
     """A tag/rename operation queued while the target track was playing (KAMP-309)."""
 
@@ -2734,6 +2749,42 @@ class LibraryIndex:
             )
             for r in rows
         ]
+
+    def get_stats(self, top_tracks_limit: int = 3) -> LibraryStats:
+        """Return aggregate library and listening statistics."""
+        c = self._conn
+        track_count = c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        # The albums table contains only real albums; virtual "missing_album" entries
+        # are synthesised at query time from tracks with empty album tags — they are
+        # not stored here, so no filter is required.
+        album_count = c.execute("SELECT COUNT(*) FROM albums").fetchone()[0]
+        artist_count = c.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
+        total_seconds = c.execute(
+            "SELECT COALESCE(SUM(play_time), 0) FROM artists"
+        ).fetchone()[0]
+        total_plays = c.execute(
+            "SELECT COALESCE(SUM(play_count), 0) FROM tracks"
+        ).fetchone()[0]
+        albums_played = c.execute(
+            "SELECT COUNT(*) FROM albums WHERE play_count_avg > 0"
+        ).fetchone()[0]
+        top_artist_row = c.execute(
+            "SELECT name, play_time FROM artists"
+            " WHERE play_time > 0 ORDER BY play_time DESC LIMIT 1"
+        ).fetchone()
+        return LibraryStats(
+            track_count=track_count,
+            album_count=album_count,
+            artist_count=artist_count,
+            total_play_seconds=float(total_seconds),
+            total_track_plays=int(total_plays),
+            albums_played=albums_played,
+            top_artist_name=top_artist_row["name"] if top_artist_row else None,
+            top_artist_seconds=(
+                float(top_artist_row["play_time"]) if top_artist_row else None
+            ),
+            top_tracks=self.top_tracks(top_tracks_limit),
+        )
 
     def set_favorite(self, file_path: "Path | str", favorite: bool) -> None:
         """Set or clear the favorite flag for the track at *file_path*.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -45,6 +45,7 @@ from kamp_core.library import (
     ArtistInfo,
     LibraryIndex,
     LibraryScanner,
+    LibraryStats,
     MagicCriteria,
     Track,
     _canonical_track_key,
@@ -233,6 +234,32 @@ class ArtistOut(BaseModel):
     @classmethod
     def from_artist(cls, a: ArtistInfo) -> "ArtistOut":
         return cls(name=a.name, play_time=a.play_time, top_album=a.top_album)
+
+
+class StatsOut(BaseModel):
+    track_count: int
+    album_count: int
+    artist_count: int
+    total_play_seconds: float
+    total_track_plays: int
+    albums_played: int
+    top_artist_name: str | None
+    top_artist_seconds: float | None
+    top_tracks: list[TrackOut]
+
+    @classmethod
+    def from_stats(cls, s: LibraryStats) -> "StatsOut":
+        return cls(
+            track_count=s.track_count,
+            album_count=s.album_count,
+            artist_count=s.artist_count,
+            total_play_seconds=s.total_play_seconds,
+            total_track_plays=s.total_track_plays,
+            albums_played=s.albums_played,
+            top_artist_name=s.top_artist_name,
+            top_artist_seconds=s.top_artist_seconds,
+            top_tracks=[TrackOut.from_track(t) for t in s.top_tracks],
+        )
 
 
 class AlbumOut(BaseModel):
@@ -1144,6 +1171,10 @@ def create_app(
             )
             for a in index.albums(sort=sort, sort_dir=sort_dir)
         ]
+
+    @app.get("/api/v1/stats", response_model=StatsOut)
+    def get_stats(top_tracks: int = 3) -> StatsOut:
+        return StatsOut.from_stats(index.get_stats(top_tracks_limit=top_tracks))
 
     @app.get("/api/v1/artists/top", response_model=list[ArtistOut])
     def get_top_artists(limit: int = 10) -> list[ArtistOut]:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -255,6 +255,21 @@ export const getTopArtists = (limit: number): Promise<Artist[]> =>
 export const getTopTracks = (limit: number): Promise<Track[]> =>
   get(`/api/v1/tracks/top?limit=${limit}`)
 
+export type Stats = {
+  track_count: number
+  album_count: number
+  artist_count: number
+  total_play_seconds: number
+  total_track_plays: number
+  albums_played: number
+  top_artist_name: string | null
+  top_artist_seconds: number | null
+  top_tracks: Track[]
+}
+
+export const getStats = (topTracks = 3): Promise<Stats> =>
+  get(`/api/v1/stats?top_tracks=${topTracks}`)
+
 export type MagicPlaylistContents = 'albums' | 'artists' | 'tracks'
 export type MagicPlaylistSort = 'random' | 'last_played' | 'recently_added' | 'most_played'
 

--- a/kamp_ui/src/renderer/src/assets/modules.css
+++ b/kamp_ui/src/renderer/src/assets/modules.css
@@ -264,3 +264,139 @@
   color: var(--text-dim);
   font-size: 13px;
 }
+
+/* ---------------------------------------------------------------------------
+   Stats module (KAMP-481)
+--------------------------------------------------------------------------- */
+
+.stats-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px 32px;
+  align-items: center;
+}
+
+.stats-section {
+  width: 100%;
+  max-width: 480px;
+}
+
+.stats-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+
+.stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: flex-start;
+}
+
+.stats-stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 80px;
+}
+
+.stats-number {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.stats-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+.stats-top-artist {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.stats-top-artist-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  flex: 0 0 auto;
+}
+
+.stats-top-artist-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.stats-top-artist-time {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.stats-top-tracks {
+  margin-top: 16px;
+}
+
+.stats-track-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.06));
+}
+
+.stats-track-row:last-child {
+  border-bottom: none;
+}
+
+.stats-track-rank {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  width: 16px;
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+.stats-track-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.stats-track-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-track-artist {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-track-plays {
+  font-size: 11px;
+  color: var(--text-dim);
+  flex: 0 0 auto;
+}

--- a/kamp_ui/src/renderer/src/assets/modules.css
+++ b/kamp_ui/src/renderer/src/assets/modules.css
@@ -272,14 +272,14 @@
 .stats-sections {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding: 24px 32px;
+  gap: 40px;
+  padding: 32px 40px;
   align-items: center;
 }
 
 .stats-section {
   width: 100%;
-  max-width: 480px;
+  max-width: 560px;
 }
 
 .stats-section-label {
@@ -288,20 +288,20 @@
   letter-spacing: 0.1em;
   color: var(--text-dim);
   text-transform: uppercase;
-  margin-bottom: 14px;
+  margin-bottom: 16px;
 }
 
 .stats-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 24px;
+  gap: 32px;
   justify-content: flex-start;
 }
 
 .stats-stat {
   display: flex;
   flex-direction: column;
-  min-width: 80px;
+  min-width: 100px;
 }
 
 .stats-number {

--- a/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
@@ -10,12 +10,18 @@ import type { ModuleProps } from './registry'
 
 function formatSeconds(n: number): string {
   if (n <= 0) return '—'
-  const days = Math.floor(n / 86400)
-  const hours = Math.floor((n % 86400) / 3600)
-  const minutes = Math.floor((n % 3600) / 60)
-  if (days > 0) return `${days}d ${hours}h`
-  if (hours > 0) return `${hours}h ${minutes}m`
-  if (minutes > 0) return `${minutes} min`
+  const totalMinutes = Math.floor(n / 60)
+  const totalHours = Math.floor(n / 3600)
+  const totalDays = Math.floor(n / 86400)
+  const totalYears = Math.floor(totalDays / 365)
+  const months = Math.floor((totalDays % 365) / 30)
+  const days = totalDays % 30
+  const hours = totalHours % 24
+  const minutes = totalMinutes % 60
+  if (totalYears > 0) return `${totalYears}y ${months}mo ${days}d ${hours}h`
+  if (totalDays > 0) return `${totalDays}d ${hours}h`
+  if (totalHours > 0) return `${totalHours}h ${minutes}m`
+  if (totalMinutes > 0) return `${totalMinutes} min`
   return '< 1 min'
 }
 

--- a/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react'
+import { getStats } from '../../api/client'
+import type { Stats } from '../../api/client'
+import { useStore } from '../../store'
+import type { ModuleProps } from './registry'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatSeconds(n: number): string {
+  if (n <= 0) return '—'
+  const days = Math.floor(n / 86400)
+  const hours = Math.floor((n % 86400) / 3600)
+  const minutes = Math.floor((n % 3600) / 60)
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes} min`
+  return '< 1 min'
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export function StatsConfig(): React.JSX.Element {
+  const count = useStore((s) => s.statsTopTracksCount)
+  const setCount = useStore((s) => s.setStatsTopTracksCount)
+  return (
+    <div className="module-config-row">
+      <label className="module-config-field">
+        <span>Top Tracks</span>
+        <input
+          type="number"
+          min={1}
+          max={10}
+          value={count}
+          onChange={(e) => setCount(parseInt(e.target.value) || 3)}
+        />
+      </label>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+// displayStyle is required by ModuleProps but unused — Stats has a fixed layout.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function StatsModule({ displayStyle: _ds }: ModuleProps): React.JSX.Element {
+  const count = useStore((s) => s.statsTopTracksCount)
+  const lastPlayedVersion = useStore((s) => s.lastPlayedVersion)
+  const serverStatus = useStore((s) => s.serverStatus)
+
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (serverStatus !== 'connected') return
+    getStats(count)
+      .then((s) => setStats(s))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [count, lastPlayedVersion, serverStatus])
+
+  if (loading) {
+    return (
+      <div className="module-skeleton-row">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="module-skeleton-card" />
+        ))}
+      </div>
+    )
+  }
+
+  if (!stats) return <div className="module-empty">Could not load stats.</div>
+
+  const hasListeningData =
+    stats.total_play_seconds > 0 || stats.total_track_plays > 0 || stats.top_artist_name !== null
+
+  return (
+    <div className="stats-sections">
+      <div className="stats-section">
+        <div className="stats-section-label">Your Library</div>
+        <div className="stats-row">
+          <div className="stats-stat">
+            <div className="stats-number">{stats.track_count.toLocaleString()}</div>
+            <div className="stats-label">Songs</div>
+          </div>
+          <div className="stats-stat">
+            <div className="stats-number">{stats.album_count.toLocaleString()}</div>
+            <div className="stats-label">Albums</div>
+          </div>
+          <div className="stats-stat">
+            <div className="stats-number">{stats.artist_count.toLocaleString()}</div>
+            <div className="stats-label">Artists</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="stats-section">
+        <div className="stats-section-label">Your Listening</div>
+        {!hasListeningData ? (
+          <div className="module-empty">Start listening to build your stats.</div>
+        ) : (
+          <>
+            <div className="stats-row">
+              <div className="stats-stat">
+                <div className="stats-number">{formatSeconds(stats.total_play_seconds)}</div>
+                <div className="stats-label">Time Listened</div>
+              </div>
+              <div className="stats-stat">
+                <div className="stats-number">{stats.total_track_plays.toLocaleString()}</div>
+                <div className="stats-label">Track Plays</div>
+              </div>
+              <div className="stats-stat">
+                <div className="stats-number">{stats.albums_played.toLocaleString()}</div>
+                <div className="stats-label">Albums Played</div>
+              </div>
+            </div>
+
+            {stats.top_artist_name !== null && (
+              <div className="stats-top-artist">
+                <span className="stats-top-artist-label">Top Artist</span>
+                <span className="stats-top-artist-name">{stats.top_artist_name}</span>
+                {stats.top_artist_seconds !== null && (
+                  <span className="stats-top-artist-time">
+                    {formatSeconds(stats.top_artist_seconds)}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {stats.top_tracks.length > 0 && (
+              <div className="stats-top-tracks">
+                <div className="stats-section-label">Top Tracks</div>
+                {stats.top_tracks.map((track, i) => (
+                  <div key={track.id} className="stats-track-row">
+                    <span className="stats-track-rank">{i + 1}</span>
+                    <span className="stats-track-info">
+                      <span className="stats-track-title">{track.title}</span>
+                      <span className="stats-track-artist">{track.artist}</span>
+                    </span>
+                    <span className="stats-track-plays">
+                      {track.play_count === 1 ? '1 play' : `${track.play_count} plays`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/modules/registry.ts
+++ b/kamp_ui/src/renderer/src/components/modules/registry.ts
@@ -7,6 +7,7 @@ import { TopArtistsModule, TopArtistsConfig } from './TopArtistsModule'
 import { StereoRackModule, StereoRackConfig } from './StereoRackModule'
 import { MagicPlaylistModule, MagicPlaylistConfig, MagicPlaylistTitle } from './MagicPlaylistModule'
 import { FavoritePlaylistsModule, FavoritePlaylistsConfig } from './FavoritePlaylistsModule'
+import { StatsModule, StatsConfig } from './StatsModule'
 
 export type DisplayStyle = 'shelf' | 'grid' | 'list'
 
@@ -67,6 +68,12 @@ export const MODULE_REGISTRY: ModuleRegistration[] = [
     title: 'Favorite Playlists',
     component: FavoritePlaylistsModule,
     configComponent: FavoritePlaylistsConfig
+  },
+  {
+    id: 'kamp.stats',
+    title: 'Stats',
+    component: StatsModule,
+    configComponent: StatsConfig
   },
   {
     id: 'kamp.magic-playlist-1',

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -81,6 +81,7 @@ type PlayerStore = {
   topAlbumsCount: number
   topTracksCount: number
   topArtistsCount: number
+  statsTopTracksCount: number
   favoritePlaylistsCount: number
   favoritePlaylistsSortOrder: 'last_played_at' | 'title'
   magicPlaylistConfigs: Record<string, MagicPlaylistModuleConfig>
@@ -140,6 +141,7 @@ type PlayerStore = {
   setTopAlbumsCount: (n: number) => void
   setTopTracksCount: (n: number) => void
   setTopArtistsCount: (n: number) => void
+  setStatsTopTracksCount: (n: number) => void
   setFavoritePlaylistsCount: (n: number) => void
   setFavoritePlaylistsSortOrder: (order: 'last_played_at' | 'title') => void
   setMagicPlaylistConfig: (moduleId: string, config: MagicPlaylistModuleConfig) => void
@@ -350,6 +352,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
   topArtistsCount: (() => {
     const saved = localStorage.getItem('kamp:top-artists-count')
     return saved ? parseInt(saved) : 10
+  })(),
+  statsTopTracksCount: (() => {
+    const saved = localStorage.getItem('kamp:stats-top-tracks-count')
+    return saved ? parseInt(saved) : 3
   })(),
   favoritePlaylistsCount: (() => {
     const saved = localStorage.getItem('kamp:fav-playlists-count')
@@ -603,6 +609,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setTopArtistsCount: (n) => {
     localStorage.setItem('kamp:top-artists-count', String(n))
     set({ topArtistsCount: n })
+  },
+
+  setStatsTopTracksCount: (n) => {
+    localStorage.setItem('kamp:stats-top-tracks-count', String(n))
+    set({ statsTopTracksCount: n })
   },
 
   setFavoritePlaylistsCount: (n) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -21,6 +21,7 @@ from kamp_core.library import (
     Group,
     LibraryIndex,
     LibraryScanner,
+    LibraryStats,
     MagicCriteria,
     ScanResult,
     Track,
@@ -9297,3 +9298,151 @@ class TestUpsertSyncProtection:
         result = index.all_tracks()[0]
         index.close()
         assert result.genre == "Electronic"
+
+
+# ---------------------------------------------------------------------------
+# get_stats (KAMP-481)
+# ---------------------------------------------------------------------------
+
+
+class TestGetStats:
+    """Tests for LibraryIndex.get_stats()."""
+
+    def test_empty_library(self, tmp_path: Path) -> None:
+        """An empty index returns zero counts and no top artist."""
+        index = LibraryIndex(tmp_path / "library.db")
+        stats = index.get_stats()
+        index.close()
+        assert isinstance(stats, LibraryStats)
+        assert stats.track_count == 0
+        assert stats.album_count == 0
+        assert stats.artist_count == 0
+        assert stats.total_play_seconds == pytest.approx(0.0)
+        assert stats.total_track_plays == 0
+        assert stats.albums_played == 0
+        assert stats.top_artist_name is None
+        assert stats.top_artist_seconds is None
+        assert stats.top_tracks == []
+
+    def test_counts(self, tmp_path: Path) -> None:
+        """track_count, album_count, and artist_count reflect indexed content."""
+        index = LibraryIndex(tmp_path / "library.db")
+        _make_indexed_track(
+            index, tmp_path, "t1.mp3", album_artist="Slowdive", album="Souvlaki"
+        )
+        _make_indexed_track(
+            index,
+            tmp_path,
+            "t2.mp3",
+            album_artist="Slowdive",
+            album="Souvlaki",
+            track_number=2,
+        )
+        _make_indexed_track(
+            index, tmp_path, "t3.mp3", album_artist="Bark Psychosis", album="Hex"
+        )
+        stats = index.get_stats()
+        index.close()
+        assert stats.track_count == 3
+        assert stats.album_count == 2
+        assert stats.artist_count == 2
+
+    def test_total_play_seconds(self, tmp_path: Path) -> None:
+        """total_play_seconds accumulates from artists.play_time via record_play_time."""
+        index = LibraryIndex(tmp_path / "library.db")
+        p1 = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Slowdive", album="Just For a Day"
+        )
+        p2 = _make_indexed_track(
+            index, tmp_path, "b.mp3", album_artist="Bark Psychosis", album="Hex"
+        )
+        index.record_play_time(p1, 300.0)
+        index.record_play_time(p2, 120.0)
+        stats = index.get_stats()
+        index.close()
+        assert stats.total_play_seconds == pytest.approx(420.0)
+
+    def test_total_track_plays(self, tmp_path: Path) -> None:
+        """total_track_plays is the sum of play_count across all tracks."""
+        index = LibraryIndex(tmp_path / "library.db")
+        p1 = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Slowdive", album="Souvlaki"
+        )
+        p2 = _make_indexed_track(
+            index,
+            tmp_path,
+            "b.mp3",
+            album_artist="Slowdive",
+            album="Souvlaki",
+            track_number=2,
+        )
+        index.record_played(p1)
+        index.record_played(p1)
+        index.record_played(p2)
+        stats = index.get_stats()
+        index.close()
+        assert stats.total_track_plays == 3
+
+    def test_albums_played(self, tmp_path: Path) -> None:
+        """albums_played counts albums where play_count_avg > 0."""
+        index = LibraryIndex(tmp_path / "library.db")
+        p1 = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Slowdive", album="Souvlaki"
+        )
+        _make_indexed_track(
+            index, tmp_path, "b.mp3", album_artist="Bark Psychosis", album="Hex"
+        )
+        index.record_played(p1)
+        stats = index.get_stats()
+        index.close()
+        assert stats.albums_played == 1
+
+    def test_top_artist(self, tmp_path: Path) -> None:
+        """top_artist_name is the artist with the highest play_time."""
+        index = LibraryIndex(tmp_path / "library.db")
+        pa = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Slowdive", album="AA"
+        )
+        pb = _make_indexed_track(
+            index, tmp_path, "b.mp3", album_artist="Bark Psychosis", album="BB"
+        )
+        index.record_play_time(pa, 100.0)
+        index.record_play_time(pb, 500.0)
+        stats = index.get_stats()
+        index.close()
+        assert stats.top_artist_name == "Bark Psychosis"
+        assert stats.top_artist_seconds == pytest.approx(500.0)
+
+    def test_top_tracks_ordered_by_play_count(self, tmp_path: Path) -> None:
+        """top_tracks are returned in descending play_count order, respecting the limit."""
+        index = LibraryIndex(tmp_path / "library.db")
+        pa = _make_indexed_track(
+            index, tmp_path, "a.mp3", album_artist="Slowdive", album="AA"
+        )
+        pb = _make_indexed_track(
+            index,
+            tmp_path,
+            "b.mp3",
+            album_artist="Slowdive",
+            album="AA",
+            track_number=2,
+        )
+        pc = _make_indexed_track(
+            index,
+            tmp_path,
+            "c.mp3",
+            album_artist="Slowdive",
+            album="AA",
+            track_number=3,
+        )
+        for _ in range(3):
+            index.record_played(pa)
+        for _ in range(5):
+            index.record_played(pb)
+        for _ in range(1):
+            index.record_played(pc)
+        stats = index.get_stats(top_tracks_limit=2)
+        index.close()
+        assert len(stats.top_tracks) == 2
+        assert stats.top_tracks[0].file_path == pb
+        assert stats.top_tracks[1].file_path == pa

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from kamp_core.library import AlbumInfo, ArtistInfo, Track
+from kamp_core.library import AlbumInfo, ArtistInfo, LibraryStats, Track
 from kamp_core.playback import PlaybackState
 from kamp_core.server import TrackOut, create_app, resolve_playback_uri
 
@@ -6373,3 +6373,57 @@ class TestPatchAlbumDisplayEndpoint:
         )
 
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/stats (KAMP-481)
+# ---------------------------------------------------------------------------
+
+
+class TestStatsEndpoint:
+    def test_returns_stats_with_defaults(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_stats.return_value = LibraryStats(
+            track_count=100,
+            album_count=12,
+            artist_count=8,
+            total_play_seconds=3600.0,
+            total_track_plays=50,
+            albums_played=5,
+            top_artist_name="Slowdive",
+            top_artist_seconds=1800.0,
+            top_tracks=[],
+        )
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).get("/api/v1/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["track_count"] == 100
+        assert data["album_count"] == 12
+        assert data["artist_count"] == 8
+        assert data["total_play_seconds"] == pytest.approx(3600.0)
+        assert data["total_track_plays"] == 50
+        assert data["albums_played"] == 5
+        assert data["top_artist_name"] == "Slowdive"
+        assert data["top_artist_seconds"] == pytest.approx(1800.0)
+        assert data["top_tracks"] == []
+        mock_index.get_stats.assert_called_once_with(top_tracks_limit=3)
+
+    def test_top_tracks_query_param_forwarded(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.get_stats.return_value = LibraryStats(
+            track_count=0,
+            album_count=0,
+            artist_count=0,
+            total_play_seconds=0.0,
+            total_track_plays=0,
+            albums_played=0,
+            top_artist_name=None,
+            top_artist_seconds=None,
+            top_tracks=[],
+        )
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        TestClient(app).get("/api/v1/stats?top_tracks=5")
+        mock_index.get_stats.assert_called_once_with(top_tracks_limit=5)


### PR DESCRIPTION
## Summary

- Adds `LibraryIndex.get_stats()` with 5 aggregate SQL queries (track/album/artist counts, total listening time from `artists.play_time`, top artist, top tracks)
- New `GET /api/v1/stats` endpoint + `StatsOut` Pydantic model in `server.py`
- New `StatsModule` and `StatsConfig` components: two-section layout (Your Library / Your Listening) with big numbers, formatted time, top artist, and a ranked top-tracks list
- `statsTopTracksCount` store state (configurable 1–10, default 3, localStorage-persisted)
- Stats refresh on `lastPlayedVersion` bump (fires when a track completes)
- 9 new tests: 7 in `TestGetStats` (library.py) + 2 in `TestStatsEndpoint` (server.py)

## Test plan

- [ ] Add Module → "Stats" appears; add it
- [ ] Library counts (Songs/Albums/Artists) match numbers visible in the Library tab
- [ ] With no listening history: "Your Listening" section shows "Start listening to build your stats."
- [ ] Play a track to completion → stats refresh → plays count and time increment
- [ ] Config: set Top Tracks to 1 → only 1 track shown; set to 5 → 5 shown
- [ ] Time format: short history → minutes; longer history → hours/days
- [ ] Top Artist matches #1 in Top Artists module
- [ ] Top Tracks ordering matches Top Tracks module
- [ ] Loading skeleton visible on initial render
- [ ] Config persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)