### PR TITLE
feat(KAMP-480): new-arrival highlight for list-view album rows

### DIFF
--- a/kamp_ui/src/renderer/src/assets/modules.css
+++ b/kamp_ui/src/renderer/src/assets/modules.css
@@ -96,6 +96,7 @@
 }
 
 .module-list-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
+++ b/kamp_ui/src/renderer/src/assets/new-arrival-highlight.css
@@ -520,3 +520,250 @@
     display: none;
   }
 }
+
+/* ── List-row highlight variants ────────────────────────────────────────── */
+/* Modifier class: module-list-row--highlight-<name>                        */
+/* Geometry adapts for the 48px-tall list row vs the ~255px album card.     */
+
+/* ── shiny (list row) ───────────────────────────────────────────────────── */
+
+.module-list-row--highlight-shiny {
+  animation: shiny-aura 3.2s ease-in-out infinite;
+}
+
+.module-list-row--highlight-shiny:hover {
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 8px 2px rgba(255, 215, 0, 0.22);
+  animation: none;
+}
+
+.module-list-row.is-mounting .shiny-sweep {
+  animation: shiny-sweep-once 1.2s cubic-bezier(0.4, 0, 0.2, 1) 1;
+}
+
+.module-list-row--highlight-shiny:hover:not(.is-mounting) .shiny-sweep {
+  animation: shiny-sweep-fast 1.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+/* ── newmoji (list row) ─────────────────────────────────────────────────── */
+
+/* module-list-info needs position:relative so the badge can use absolute positioning */
+.module-list-row--highlight-newmoji .module-list-info {
+  position: relative;
+}
+
+/* Badge smaller (14px vs 18px) to fit the 48px row height */
+.module-list-row--highlight-newmoji .newmoji-badge {
+  font-size: 14px;
+  top: -8px;
+  left: 4px;
+}
+
+.module-list-row--highlight-newmoji:hover .newmoji-badge {
+  animation:
+    newmoji-idle 5s ease-in-out infinite,
+    newmoji-hover-scale 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1 forwards;
+}
+
+/* ── boring (list row) ──────────────────────────────────────────────────── */
+
+/* Ribbon scaled down for 48px thumb: width 80px, top 14px, right -22px.
+   The geometry comment on album-card: W=180, top=23, right=-28, width=120.
+   Scale factor ≈ 48/180 × 120 ≈ 32 (width), adjusted empirically for clean clip. */
+.module-list-row--highlight-boring .module-list-thumb::after,
+.module-list-row--highlight-boring .boring-hover {
+  position: absolute;
+  top: 14px;
+  right: -22px;
+  width: 80px;
+  padding: 4px 0;
+  line-height: 1;
+  background: #3B6FD4;
+  color: #fff;
+  font-family: inherit;
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-align: center;
+  transform: rotate(45deg);
+  pointer-events: none;
+  z-index: 2;
+  transition: opacity 80ms ease;
+}
+
+.module-list-row--highlight-boring .module-list-thumb::after {
+  content: 'New';
+}
+
+.module-list-row--highlight-boring .boring-hover {
+  opacity: 0;
+}
+
+.module-list-row--highlight-boring:hover .module-list-thumb::after {
+  opacity: 0;
+}
+
+.module-list-row--highlight-boring:hover .boring-hover {
+  opacity: 1;
+}
+
+/* ── vaporwave (list row) ───────────────────────────────────────────────── */
+
+.module-list-row--highlight-vaporwave {
+  animation: vaporwave-halo 6s linear infinite;
+}
+
+.module-list-row--highlight-vaporwave:hover {
+  animation: vaporwave-halo 6s linear infinite;
+  filter: brightness(1.08);
+}
+
+.module-list-row--highlight-vaporwave:hover .vaporwave-scanlines {
+  opacity: 0;
+}
+
+/* ── proud (list row) ───────────────────────────────────────────────────── */
+
+/* Same dual background-image + border-box technique as album-card--highlight-proud.
+   .module-list-row:hover uses `background` shorthand — redeclare background-image below. */
+.module-list-row--highlight-proud {
+  border: 3px solid transparent;
+  background-color: var(--surface);
+  background-image:
+    linear-gradient(var(--surface), var(--surface)),
+    repeating-linear-gradient(
+      135deg,
+      #FFFFFF   0px,  #FFFFFF  12px,
+      #F7A8B8  12px,  #F7A8B8  24px,
+      #55CDFC  24px,  #55CDFC  36px,
+      #C47A2B  36px,  #C47A2B  48px,
+      #E40303  48px,  #E40303  60px,
+      #FF8C00  60px,  #FF8C00  72px,
+      #FFED00  72px,  #FFED00  84px,
+      #008026  84px,  #008026  96px,
+      #004DFF  96px,  #004DFF 108px,
+      #750787 108px,  #750787 120px
+    );
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  background-size: auto, 170px 170px;
+  box-shadow: inset 0 0 8px 1px rgba(85, 205, 252, 0.15);
+  animation: proud-barber 6s linear infinite;
+}
+
+.module-list-row--highlight-proud:hover {
+  background-color: var(--surface-hover);
+  background-image:
+    linear-gradient(var(--surface-hover), var(--surface-hover)),
+    repeating-linear-gradient(
+      135deg,
+      #FFFFFF   0px,  #FFFFFF  12px,
+      #F7A8B8  12px,  #F7A8B8  24px,
+      #55CDFC  24px,  #55CDFC  36px,
+      #C47A2B  36px,  #C47A2B  48px,
+      #E40303  48px,  #E40303  60px,
+      #FF8C00  60px,  #FF8C00  72px,
+      #FFED00  72px,  #FFED00  84px,
+      #008026  84px,  #008026  96px,
+      #004DFF  96px,  #004DFF 108px,
+      #750787 108px,  #750787 120px
+    );
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  background-size: auto, 170px 170px;
+  animation-duration: 1.6s;
+}
+
+/* ── pressed (list row) ─────────────────────────────────────────────────── */
+
+.module-list-row--highlight-pressed {
+  animation: pressed-breath 4s ease-in-out infinite;
+}
+
+.module-list-row--highlight-pressed:hover .pressed-glint-hover {
+  animation: pressed-glint-once 0.5s ease-in-out forwards;
+}
+
+/* ── static (list row) ──────────────────────────────────────────────────── */
+
+/* Same dual background-image + --static-border-gradient technique.
+   .module-list-row:hover shorthand resets background-image — redeclare below. */
+.module-list-row--highlight-static {
+  border: 3px solid transparent;
+  background-color: var(--surface);
+  background-image:
+    linear-gradient(var(--surface), var(--surface)),
+    var(--static-border-gradient, conic-gradient(from 180deg, #bbb 0deg, #999 180deg, #bbb 360deg));
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+}
+
+.module-list-row--highlight-static:hover {
+  background-color: var(--surface-hover);
+  background-image:
+    linear-gradient(var(--surface-hover), var(--surface-hover)),
+    var(--static-border-gradient, conic-gradient(from 180deg, #bbb 0deg, #999 180deg, #bbb 360deg));
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+}
+
+.module-list-row--highlight-static:hover .static-sparks,
+.module-list-row--highlight-static:hover .static-aura {
+  opacity: 0;
+}
+
+/* ── Reduced motion: list-row variants ──────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .module-list-row--highlight-shiny {
+    animation: none;
+    box-shadow: none;
+    outline: 2px solid rgba(255, 215, 0, 0.6);
+    outline-offset: 0;
+  }
+
+  .module-list-row--highlight-newmoji .newmoji-badge {
+    animation: none;
+    translate: 0 0;
+    rotate: 0deg;
+    scale: 1;
+  }
+
+  .module-list-row--highlight-vaporwave {
+    animation: none;
+    box-shadow: 0 0 0 2px #A855F7;
+  }
+
+  .module-list-row--highlight-vaporwave .vaporwave-scanlines {
+    display: none;
+  }
+
+  .module-list-row--highlight-proud {
+    animation: none;
+  }
+
+  .module-list-row--highlight-pressed {
+    animation: none;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.50);
+  }
+
+  .module-list-row--highlight-pressed .pressed-glint,
+  .module-list-row--highlight-pressed .pressed-glint-hover {
+    display: none;
+  }
+
+  .module-list-row--highlight-static {
+    --static-border-gradient: conic-gradient(
+      from 180deg,
+      #bbb 0deg,
+      #999 180deg,
+      #bbb 360deg
+    ) !important;
+  }
+
+  .module-list-row--highlight-static .static-spark,
+  .module-list-row--highlight-static .static-aura {
+    display: none;
+  }
+}

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -4,6 +4,7 @@ import { artUrl } from '../api/client'
 import type { Album } from '../api/client'
 import { AlbumContextMenu } from './AlbumContextMenu'
 import { BandcampIcon, CloudIcon, FavoriteIcon, PlayIcon, WarnIcon } from './TransportIcons'
+import { useNewArrivalHighlight } from './useNewArrivalHighlight'
 
 type MenuPos = { x: number; y: number }
 
@@ -11,42 +12,6 @@ function sourceIcon(source: string, size: number): React.JSX.Element {
   if (source === 'bandcamp') return <BandcampIcon size={size} />
   return <CloudIcon size={size} />
 }
-
-function rnd(min: number, max: number): number {
-  return min + Math.random() * (max - min)
-}
-
-interface StarParticle {
-  id: number
-  left: number
-  top: number
-  duration: number
-  delay: number
-}
-
-interface SparkParticle {
-  id: number
-  left: number
-  top: number
-  blinkDur: number
-  blinkDelay: number
-  sparkOpacity: number
-}
-
-// Frame 0 is the brightest gray — shown when prefers-reduced-motion is set.
-// All frames use `from 180deg` so the 0/360deg seam lands at the bottom of the
-// card (behind the album-info text) rather than the visible top edge.
-// First and last stops match so the gradient closes without a color jump.
-const STATIC_BORDER_FRAMES = [
-  'conic-gradient(from 180deg, #bbb 0deg, #888 50deg, #aaa 110deg, #ccc 170deg, #999 220deg, #aaa 280deg, #bbb 360deg)',
-  'conic-gradient(from 180deg, #222 0deg, #777 45deg, #111 90deg, #555 145deg, #333 195deg, #888 250deg, #111 310deg, #222 360deg)',
-  'conic-gradient(from 180deg, #555 0deg, #111 55deg, #888 115deg, #222 165deg, #666 225deg, #333 280deg, #555 360deg)',
-  'conic-gradient(from 180deg, #888 0deg, #333 70deg, #111 140deg, #666 205deg, #222 265deg, #888 360deg)',
-  'conic-gradient(from 180deg, #111 0deg, #666 60deg, #333 125deg, #999 185deg, #444 245deg, #777 305deg, #111 360deg)',
-  'conic-gradient(from 180deg, #333 0deg, #999 50deg, #111 105deg, #666 160deg, #444 215deg, #111 270deg, #333 360deg)',
-  'conic-gradient(from 180deg, #777 0deg, #222 65deg, #555 135deg, #111 200deg, #888 270deg, #777 360deg)',
-  'conic-gradient(from 180deg, #444 0deg, #888 80deg, #111 160deg, #777 220deg, #333 290deg, #444 360deg)'
-]
 
 export function AlbumCard({
   album,
@@ -62,11 +27,6 @@ export function AlbumCard({
   const activeView = useStore((s) => s.activeView)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
-  const highlightEnabled = useStore((s) => s.highlightEnabled)
-  const highlightCutoffSecs = useStore((s) => s.highlightCutoffSecs)
-  const highlightStyle = useStore((s) => s.highlightStyle)
-  const dismissedHighlightKeys = useStore((s) => s.dismissedHighlightKeys)
-  const dismissHighlight = useStore((s) => s.dismissHighlight)
   const configValues = useStore((s) => s.configValues)
   const downloadingAlbumIds = useStore((s) => s.downloadingAlbumIds)
   const queuedAlbumIds = useStore((s) => s.queuedAlbumIds)
@@ -83,15 +43,19 @@ export function AlbumCard({
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
-  const albumHighlightKey = album.missing_album
-    ? (album.file_path ?? '')
-    : `${album.album_artist}::${album.album}`
-  const isNew =
-    highlightEnabled &&
-    album.added_at !== null &&
-    album.added_at >= highlightCutoffSecs &&
-    album.last_played_at === null &&
-    !dismissedHighlightKeys.has(albumHighlightKey)
+  const {
+    isNew,
+    highlightStyle,
+    isMounting,
+    starParticles,
+    sparkParticles,
+    hoverSparkParticles,
+    isHovered,
+    setIsHovered,
+    auraActive,
+    staticBorderGradient,
+    dismissHighlight
+  } = useNewArrivalHighlight(album)
 
   // Dismiss the highlight the first time this album becomes the active playing track.
   useEffect(() => {
@@ -112,120 +76,6 @@ export function AlbumCard({
     const t = setTimeout(() => setArtBlurred(false), 0)
     return () => clearTimeout(t)
   }, [album.has_art, isDownloading])
-
-  // Start mounting=true so the fast sweep fires immediately; cleared after 1.2s
-  const [isMounting, setIsMounting] = useState(isNew)
-  const [starParticles, setStarParticles] = useState<StarParticle[]>([])
-  const [sparkParticles, setSparkParticles] = useState<SparkParticle[]>([])
-  const [hoverSparkParticles, setHoverSparkParticles] = useState<SparkParticle[]>([])
-  const [isHovered, setIsHovered] = useState(false)
-  const [auraActive, setAuraActive] = useState(false)
-  const [borderFrame, setBorderFrame] = useState(0)
-
-  useEffect(() => {
-    if (!isNew) return
-    // Math.random() and setState must be in callbacks, not the effect body directly
-    const initTimer = setTimeout(() => {
-      const count = 3 + Math.floor(Math.random() * 3) // 3–5
-      setStarParticles(
-        Array.from({ length: count }, (_, i) => ({
-          id: i,
-          left: 10 + Math.random() * 80,
-          top: 15 + Math.random() * 50,
-          duration: 2.8 + Math.random() * 1.6,
-          delay: Math.random() * 2
-        }))
-      )
-      const sparkCount = 25 + Math.floor(Math.random() * 16) // 25–40
-      setSparkParticles(
-        Array.from({ length: sparkCount }, (_, i) => ({
-          id: i,
-          left: rnd(5, 85),
-          top: rnd(5, 85),
-          blinkDur: rnd(0.08, 0.22),
-          blinkDelay: rnd(0, 0.5),
-          sparkOpacity: rnd(0.4, 1.0)
-        }))
-      )
-      // pre-generate hover spark positions so they don't jump on every hover
-      setHoverSparkParticles(
-        Array.from({ length: 6 }, (_, i) => ({
-          id: i + 100,
-          left: rnd(5, 85),
-          top: rnd(5, 85),
-          blinkDur: rnd(0.3, 0.5),
-          blinkDelay: rnd(0, 0.5),
-          sparkOpacity: rnd(0.4, 1.0)
-        }))
-      )
-    }, 0)
-    const mountTimer = setTimeout(() => setIsMounting(false), 1200)
-    return () => {
-      clearTimeout(initTimer)
-      clearTimeout(mountTimer)
-    }
-  }, [isNew])
-
-  // Randomize spark positions over time — updating top/left without touching the
-  // animation props so blink cycles continue uninterrupted (no jarring reset)
-  useEffect(() => {
-    if (!isNew || highlightStyle !== 'static') return
-    const id = setInterval(() => {
-      setSparkParticles((prev) => prev.map((p) => ({ ...p, left: rnd(5, 85), top: rnd(5, 85) })))
-    }, 150)
-    return () => clearInterval(id)
-  }, [isNew, highlightStyle])
-
-  // Gradient border: cycle through gray/black frames at random ~60–150ms intervals.
-  // Skip when prefers-reduced-motion is set — frame 0 (brightest) stays active.
-  useEffect(() => {
-    if (!isNew || highlightStyle !== 'static') return
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
-    let cancelled = false
-    const schedule = (): void => {
-      setTimeout(
-        () => {
-          if (cancelled) return
-          setBorderFrame(Math.floor(Math.random() * STATIC_BORDER_FRAMES.length))
-          schedule()
-        },
-        rnd(60, 150)
-      )
-    }
-    schedule()
-    return () => {
-      cancelled = true
-    }
-  }, [isNew, highlightStyle])
-
-  // White aura that fires at random intervals — like a voltage surge on a CRT
-  useEffect(() => {
-    if (!isNew || highlightStyle !== 'static') return
-    let cancelled = false
-
-    const schedule = (): void => {
-      setTimeout(
-        () => {
-          if (cancelled) return
-          setAuraActive(true)
-          setTimeout(
-            () => {
-              if (cancelled) return
-              setAuraActive(false)
-              schedule()
-            },
-            rnd(10, 300)
-          )
-        },
-        rnd(30, 1000)
-      )
-    }
-
-    schedule()
-    return () => {
-      cancelled = true
-    }
-  }, [isNew, highlightStyle])
 
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
@@ -250,10 +100,8 @@ export function AlbumCard({
     <div
       className={cardClass}
       style={
-        isNew && highlightStyle === 'static'
-          ? ({
-              '--static-border-gradient': STATIC_BORDER_FRAMES[borderFrame]
-            } as React.CSSProperties)
+        staticBorderGradient !== undefined
+          ? ({ '--static-border-gradient': staticBorderGradient } as React.CSSProperties)
           : undefined
       }
       tabIndex={0}

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import type { Album } from '../../api/client'
 import { artUrl } from '../../api/client'
 import { useStore } from '../../store'
 import { AlbumContextMenu } from '../AlbumContextMenu'
 import { PlayIcon } from '../TransportIcons'
+import { useNewArrivalHighlight } from '../useNewArrivalHighlight'
 
 type MenuPos = { x: number; y: number }
 
@@ -30,18 +31,53 @@ function ListRow({
     ? currentTrack?.file_path === album.file_path
     : currentTrack?.album === album.album && currentTrack?.album_artist === album.album_artist
 
+  const {
+    isNew,
+    highlightStyle,
+    isMounting,
+    starParticles,
+    sparkParticles,
+    hoverSparkParticles,
+    isHovered,
+    setIsHovered,
+    auraActive,
+    staticBorderGradient,
+    dismissHighlight
+  } = useNewArrivalHighlight(album)
+
+  // Dismiss the highlight the first time this album becomes the active playing track.
+  useEffect(() => {
+    if (isNew && isActive && playing) dismissHighlight(album)
+  }, [isNew, isActive, playing]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleSelect = (): void => {
     if (activeView !== 'library') void setActiveView('library')
     void selectAlbum(album)
   }
 
+  const rowClass = [
+    'module-list-row',
+    isActive ? 'playing' : '',
+    isNew ? `module-list-row--highlight-${highlightStyle}` : '',
+    isNew && isMounting ? 'is-mounting' : ''
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
     <div
-      className={`module-list-row${isActive ? ' playing' : ''}`}
+      className={rowClass}
+      style={
+        staticBorderGradient !== undefined
+          ? ({ '--static-border-gradient': staticBorderGradient } as React.CSSProperties)
+          : undefined
+      }
       tabIndex={0}
       draggable
       onClick={handleSelect}
       onKeyDown={(e) => e.key === 'Enter' && handleSelect()}
+      onMouseEnter={isNew && highlightStyle === 'static' ? () => setIsHovered(true) : undefined}
+      onMouseLeave={isNew && highlightStyle === 'static' ? () => setIsHovered(false) : undefined}
       onContextMenu={(e) => {
         e.preventDefault()
         setMenu({ x: e.clientX, y: e.clientY })
@@ -70,8 +106,70 @@ function ListRow({
             <PlayIcon size={16} />
           </div>
         )}
+        {isNew && highlightStyle === 'shiny' && <span className="shiny-sweep" aria-hidden="true" />}
+        {isNew && highlightStyle === 'boring' && (
+          <span className="boring-hover" aria-hidden="true">
+            wow!
+          </span>
+        )}
+        {isNew && highlightStyle === 'vaporwave' && (
+          <span className="vaporwave-scanlines" aria-hidden="true" />
+        )}
+        {isNew && highlightStyle === 'pressed' && (
+          <>
+            <span className="pressed-glint" aria-hidden="true" />
+            <span className="pressed-glint-hover" aria-hidden="true" />
+          </>
+        )}
+        {isNew && highlightStyle === 'static' && (
+          <div className="static-aura" style={{ opacity: auraActive ? 1 : 0 }} aria-hidden="true" />
+        )}
+        {isNew && highlightStyle === 'static' && (
+          <div
+            className="static-sparks"
+            style={{ '--spark-speed-mult': isHovered ? 1.4 : 1 } as React.CSSProperties}
+            aria-hidden="true"
+          >
+            {sparkParticles.map((p) => (
+              <span
+                key={p.id}
+                className="static-spark"
+                style={
+                  {
+                    '--blink-dur': `${p.blinkDur}s`,
+                    '--blink-delay': `${p.blinkDelay}s`,
+                    '--spark-opacity': p.sparkOpacity,
+                    top: `${p.top}%`,
+                    left: `${p.left}%`
+                  } as React.CSSProperties
+                }
+              />
+            ))}
+            {isHovered &&
+              hoverSparkParticles.map((p) => (
+                <span
+                  key={p.id}
+                  className="static-spark"
+                  style={
+                    {
+                      '--blink-dur': `${p.blinkDur}s`,
+                      '--blink-delay': `${p.blinkDelay}s`,
+                      '--spark-opacity': p.sparkOpacity,
+                      top: `${p.top}%`,
+                      left: `${p.left}%`
+                    } as React.CSSProperties
+                  }
+                />
+              ))}
+          </div>
+        )}
       </div>
       <div className="module-list-info">
+        {isNew && highlightStyle === 'newmoji' && (
+          <span className="newmoji-badge" aria-hidden="true">
+            🆕
+          </span>
+        )}
         <div className="module-list-title">
           {album.missing_album ? <em>{album.album}</em> : album.album}
         </div>
@@ -80,6 +178,23 @@ function ListRow({
       {showPlayCount && album.play_count_avg > 0 && (
         <span className="module-list-play-count">avg {album.play_count_avg.toFixed(1)}</span>
       )}
+      {isNew &&
+        highlightStyle === 'shiny' &&
+        starParticles.map((p) => (
+          <span
+            key={p.id}
+            className="shiny-star"
+            aria-hidden="true"
+            style={
+              {
+                '--star-left': `${p.left}%`,
+                '--star-top': `${p.top}%`,
+                '--star-dur': `${p.duration}s`,
+                '--star-delay': `${p.delay}s`
+              } as React.CSSProperties
+            }
+          />
+        ))}
       {menu && (
         <AlbumContextMenu x={menu.x} y={menu.y} album={album} onClose={() => setMenu(null)} />
       )}

--- a/kamp_ui/src/renderer/src/components/useNewArrivalHighlight.ts
+++ b/kamp_ui/src/renderer/src/components/useNewArrivalHighlight.ts
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react'
+import { useStore } from '../store'
+import type { Album } from '../api/client'
+
+export interface StarParticle {
+  id: number
+  left: number
+  top: number
+  duration: number
+  delay: number
+}
+
+export interface SparkParticle {
+  id: number
+  left: number
+  top: number
+  blinkDur: number
+  blinkDelay: number
+  sparkOpacity: number
+}
+
+function rnd(min: number, max: number): number {
+  return min + Math.random() * (max - min)
+}
+
+// Frame 0 is the brightest gray — shown when prefers-reduced-motion is set.
+// All frames use `from 180deg` so the 0/360deg seam lands at the bottom of the
+// card (behind the album-info text) rather than the visible top edge.
+// First and last stops match so the gradient closes without a color jump.
+const STATIC_BORDER_FRAMES = [
+  'conic-gradient(from 180deg, #bbb 0deg, #888 50deg, #aaa 110deg, #ccc 170deg, #999 220deg, #aaa 280deg, #bbb 360deg)',
+  'conic-gradient(from 180deg, #222 0deg, #777 45deg, #111 90deg, #555 145deg, #333 195deg, #888 250deg, #111 310deg, #222 360deg)',
+  'conic-gradient(from 180deg, #555 0deg, #111 55deg, #888 115deg, #222 165deg, #666 225deg, #333 280deg, #555 360deg)',
+  'conic-gradient(from 180deg, #888 0deg, #333 70deg, #111 140deg, #666 205deg, #222 265deg, #888 360deg)',
+  'conic-gradient(from 180deg, #111 0deg, #666 60deg, #333 125deg, #999 185deg, #444 245deg, #777 305deg, #111 360deg)',
+  'conic-gradient(from 180deg, #333 0deg, #999 50deg, #111 105deg, #666 160deg, #444 215deg, #111 270deg, #333 360deg)',
+  'conic-gradient(from 180deg, #777 0deg, #222 65deg, #555 135deg, #111 200deg, #888 270deg, #777 360deg)',
+  'conic-gradient(from 180deg, #444 0deg, #888 80deg, #111 160deg, #777 220deg, #333 290deg, #444 360deg)'
+]
+
+export interface NewArrivalHighlight {
+  isNew: boolean
+  highlightStyle: string
+  isMounting: boolean
+  starParticles: StarParticle[]
+  sparkParticles: SparkParticle[]
+  hoverSparkParticles: SparkParticle[]
+  isHovered: boolean
+  setIsHovered: (v: boolean) => void
+  auraActive: boolean
+  // Defined only when isNew && highlightStyle === 'static'; set as --static-border-gradient
+  staticBorderGradient: string | undefined
+  dismissHighlight: (album: Album) => void
+}
+
+export function useNewArrivalHighlight(album: Album): NewArrivalHighlight {
+  const highlightEnabled = useStore((s) => s.highlightEnabled)
+  const highlightCutoffSecs = useStore((s) => s.highlightCutoffSecs)
+  const highlightStyle = useStore((s) => s.highlightStyle)
+  const dismissedHighlightKeys = useStore((s) => s.dismissedHighlightKeys)
+  const dismissHighlight = useStore((s) => s.dismissHighlight)
+
+  const albumHighlightKey = album.missing_album
+    ? (album.file_path ?? '')
+    : `${album.album_artist}::${album.album}`
+  const isNew =
+    highlightEnabled &&
+    album.added_at !== null &&
+    album.added_at >= highlightCutoffSecs &&
+    album.last_played_at === null &&
+    !dismissedHighlightKeys.has(albumHighlightKey)
+
+  // Start mounting=true so the fast sweep fires immediately; cleared after 1.2s
+  const [isMounting, setIsMounting] = useState(isNew)
+  const [starParticles, setStarParticles] = useState<StarParticle[]>([])
+  const [sparkParticles, setSparkParticles] = useState<SparkParticle[]>([])
+  const [hoverSparkParticles, setHoverSparkParticles] = useState<SparkParticle[]>([])
+  const [isHovered, setIsHovered] = useState(false)
+  const [auraActive, setAuraActive] = useState(false)
+  const [borderFrame, setBorderFrame] = useState(0)
+
+  useEffect(() => {
+    if (!isNew) return
+    // Math.random() and setState must be in callbacks, not the effect body directly
+    const initTimer = setTimeout(() => {
+      const count = 3 + Math.floor(Math.random() * 3) // 3–5
+      setStarParticles(
+        Array.from({ length: count }, (_, i) => ({
+          id: i,
+          left: 10 + Math.random() * 80,
+          top: 15 + Math.random() * 50,
+          duration: 2.8 + Math.random() * 1.6,
+          delay: Math.random() * 2
+        }))
+      )
+      const sparkCount = 25 + Math.floor(Math.random() * 16) // 25–40
+      setSparkParticles(
+        Array.from({ length: sparkCount }, (_, i) => ({
+          id: i,
+          left: rnd(5, 85),
+          top: rnd(5, 85),
+          blinkDur: rnd(0.08, 0.22),
+          blinkDelay: rnd(0, 0.5),
+          sparkOpacity: rnd(0.4, 1.0)
+        }))
+      )
+      // pre-generate hover spark positions so they don't jump on every hover
+      setHoverSparkParticles(
+        Array.from({ length: 6 }, (_, i) => ({
+          id: i + 100,
+          left: rnd(5, 85),
+          top: rnd(5, 85),
+          blinkDur: rnd(0.3, 0.5),
+          blinkDelay: rnd(0, 0.5),
+          sparkOpacity: rnd(0.4, 1.0)
+        }))
+      )
+    }, 0)
+    const mountTimer = setTimeout(() => setIsMounting(false), 1200)
+    return () => {
+      clearTimeout(initTimer)
+      clearTimeout(mountTimer)
+    }
+  }, [isNew])
+
+  // Randomize spark positions over time — updating top/left without touching the
+  // animation props so blink cycles continue uninterrupted (no jarring reset)
+  useEffect(() => {
+    if (!isNew || highlightStyle !== 'static') return
+    const id = setInterval(() => {
+      setSparkParticles((prev) => prev.map((p) => ({ ...p, left: rnd(5, 85), top: rnd(5, 85) })))
+    }, 150)
+    return () => clearInterval(id)
+  }, [isNew, highlightStyle])
+
+  // Gradient border: cycle through gray/black frames at random ~60–150ms intervals.
+  // Skip when prefers-reduced-motion is set — frame 0 (brightest) stays active.
+  useEffect(() => {
+    if (!isNew || highlightStyle !== 'static') return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    let cancelled = false
+    const schedule = (): void => {
+      setTimeout(
+        () => {
+          if (cancelled) return
+          setBorderFrame(Math.floor(Math.random() * STATIC_BORDER_FRAMES.length))
+          schedule()
+        },
+        rnd(60, 150)
+      )
+    }
+    schedule()
+    return () => {
+      cancelled = true
+    }
+  }, [isNew, highlightStyle])
+
+  // White aura that fires at random intervals — like a voltage surge on a CRT
+  useEffect(() => {
+    if (!isNew || highlightStyle !== 'static') return
+    let cancelled = false
+
+    const schedule = (): void => {
+      setTimeout(
+        () => {
+          if (cancelled) return
+          setAuraActive(true)
+          setTimeout(
+            () => {
+              if (cancelled) return
+              setAuraActive(false)
+              schedule()
+            },
+            rnd(10, 300)
+          )
+        },
+        rnd(30, 1000)
+      )
+    }
+
+    schedule()
+    return () => {
+      cancelled = true
+    }
+  }, [isNew, highlightStyle])
+
+  const staticBorderGradient =
+    isNew && highlightStyle === 'static' ? STATIC_BORDER_FRAMES[borderFrame] : undefined
+
+  return {
+    isNew,
+    highlightStyle,
+    isMounting,
+    starParticles,
+    sparkParticles,
+    hoverSparkParticles,
+    isHovered,
+    setIsHovered,
+    auraActive,
+    staticBorderGradient,
+    dismissHighlight
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts the new-arrival highlight state machine from `AlbumCard.tsx` into a shared `useNewArrivalHighlight` hook, eliminating ~80 lines of duplicated state/effects between the two surfaces
- Adds all 7 highlight styles (`shiny`, `newmoji`, `boring`, `vaporwave`, `proud`, `pressed`, `static`) to list-view rows in Base Kamp modules
- CSS variants adapt each style's geometry for the 48px-tall list row: scaled-down `boring` ribbon, adapted `newmoji` badge placement, and correctly positioned `shiny` stars that float across the full row width
- The `proud` and `static` border-image styles include hover overrides to survive the `.module-list-row:hover { background }` shorthand reset
- Full `prefers-reduced-motion` support for all row variants

## Test plan

- [ ] Each of the 7 styles shows on a list-view row for a qualifying new album (unplayed, within cutoff)
- [ ] Dismiss-on-play: play an album from a list row → highlight disappears once playback starts
- [ ] Shiny: aura glow on the row; sweep inside the thumb; stars float across the full row width
- [ ] Newmoji: badge visible at art/info boundary; pops on hover
- [ ] Boring: scaled-down diagonal "New" ribbon in thumb corner; swaps to "wow!" on hover
- [ ] Vaporwave: color-cycling halo on the row; scanlines inside thumb; clears on hover
- [ ] Proud: barber-pole pride border on the row; speeds up on hover
- [ ] Pressed: breathing white ring on the row; glint sweeps across thumb on hover
- [ ] Static: cycling conic-gradient border on the row; sparks + aura inside thumb; fades on hover
- [ ] Mount burst: loading a module with a qualifying list album → shiny sweep fires once immediately
- [ ] AlbumCard behavior unchanged (shelf/grid views still work for all 7 styles)
- [ ] `prefers-reduced-motion`: all animations suppressed; static fallbacks apply to row variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)