### PR TITLE
fix(KAMP-470): restore liner notes label centering in album-meta toggle bar

### DIFF
--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1003,9 +1003,11 @@
    and ns-resize cursor signal the drag affordance. */
 .album-meta-toggle {
   display: flex;
-  align-items: stretch;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   width: 100%;
-  padding: 0;
+  padding: 7px 20px;
   background: none;
   border: none;
   border-top: 2px solid rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
## Summary

- The KAMP-465 grab-bar transparency refactor changed `.album-meta-toggle` from `align-items: center / justify-content: center / gap: 6px / padding: 7px 20px` to `align-items: stretch / padding: 0`, which dropped all the centering properties for the liner notes label and icons
- Restored the four original properties — the embedded toolbar in `PlaylistView` is unaffected since it uses `flex: 1` on its own inner container and centers correctly with `align-items: center` on the parent

## Test plan

- [ ] Album page: "LINER NOTES" label centered between tag icon and chevron
- [ ] Playlist view: view-mode toggle + sort control in resize band still render correctly
- [ ] Liner Notes expand/collapse animation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)