### PR TITLE
fix(KAMP-466): playlist album-grid drag enqueues only playlist-filtered tracks

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -16,11 +16,13 @@ function sourceIcon(source: string, size: number): React.JSX.Element {
 export function AlbumCard({
   album,
   onAfterSelect,
-  showPlayCount = false
+  showPlayCount = false,
+  dragTracks
 }: {
   album: Album
   onAfterSelect?: () => void
   showPlayCount?: boolean
+  dragTracks?: string[]
 }): React.JSX.Element {
   const selectAlbum = useStore((s) => s.selectAlbum)
   const setActiveView = useStore((s) => s.setActiveView)
@@ -115,14 +117,26 @@ export function AlbumCard({
         setMenu({ x: e.clientX, y: e.clientY })
       }}
       onDragStart={(e) => {
-        e.dataTransfer.setData(
-          'text/kamp-album',
-          JSON.stringify({
-            album_artist: album.album_artist,
-            album: album.album,
-            file_path: album.file_path
-          })
-        )
+        if (dragTracks && dragTracks.length > 0) {
+          e.dataTransfer.setData('text/kamp-file-paths', JSON.stringify(dragTracks))
+          const count = dragTracks.length
+          const ghost = document.createElement('div')
+          ghost.textContent = `${count} track${count === 1 ? '' : 's'}`
+          ghost.style.cssText =
+            'position:fixed;top:-100px;background:var(--accent);color:#fff;padding:4px 10px;border-radius:3px;font-size:12px;font-weight:600'
+          document.body.appendChild(ghost)
+          e.dataTransfer.setDragImage(ghost, 0, 0)
+          requestAnimationFrame(() => document.body.removeChild(ghost))
+        } else {
+          e.dataTransfer.setData(
+            'text/kamp-album',
+            JSON.stringify({
+              album_artist: album.album_artist,
+              album: album.album,
+              file_path: album.file_path
+            })
+          )
+        }
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -297,6 +297,21 @@ export function PlaylistView(): React.JSX.Element | null {
     return [...seen.values()]
   }, [displayTracks, displayMode, libraryAlbums])
 
+  const albumTrackPaths = useMemo<Map<string, string[]>>(() => {
+    if (displayMode !== 'albums') return new Map()
+    const map = new Map<string, string[]>()
+    for (const t of displayTracks) {
+      const key = `${t.album_artist || t.artist}::${t.album}`
+      const paths = map.get(key)
+      if (paths) {
+        paths.push(t.file_path)
+      } else {
+        map.set(key, [t.file_path])
+      }
+    }
+    return map
+  }, [displayTracks, displayMode])
+
   if (!playlist) return null
 
   const persistTrackSort = (order: TrackSortOrder, dir: 'asc' | 'desc'): void => {
@@ -693,7 +708,11 @@ export function PlaylistView(): React.JSX.Element | null {
         <div className="track-list-body">
           <div className="album-grid" style={{ padding: 10 }}>
             {albumGroups.map((a) => (
-              <AlbumCard key={`${a.album_artist}::${a.album}`} album={a} />
+              <AlbumCard
+                key={`${a.album_artist}::${a.album}`}
+                album={a}
+                dragTracks={albumTrackPaths.get(`${a.album_artist}::${a.album}`)}
+              />
             ))}
           </div>
           {albumGroups.length === 0 && (


### PR DESCRIPTION
## Summary

- `AlbumCard` gains an optional `dragTracks?: string[]` prop. When provided, `onDragStart` encodes `text/kamp-file-paths` (the per-track list) instead of `text/kamp-album` (the whole album), and sets a ghost badge reading "n track(s)"
- `PlaylistView` adds an `albumTrackPaths` memo that maps each album key to the ordered file paths of that album's tracks within the playlist (`displayTracks` is already sorted by the active sort order)
- `QueuePanel` already handles `text/kamp-file-paths` at both drop positions — no changes needed
- All non-playlist `AlbumCard` usages (library grid, search, top artists) pass no `dragTracks` and continue to enqueue the full album

## Test plan

- [ ] Add 1 track from a multi-track album to a playlist; switch to album-art grid; drag the card to queue — confirm only 1 track enqueued and ghost shows "1 track"
- [ ] Add 3 tracks from the same album; drag again — confirm 3 tracks enqueued in playlist sort order
- [ ] Drag an album card from the main library grid — confirm full album still enqueues (existing behavior unbroken)
- [ ] Drag to "play next" — confirm only playlist tracks inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)