### PR TITLE
fix(KAMP-474): include last_played_at in search_library AlbumOut

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2540,6 +2540,7 @@ def create_app(
                 file_path=a.file_path,
                 art_version=a.art_version,
                 added_at=a.added_at,
+                last_played_at=a.last_played_at,
                 play_count_avg=a.play_count_avg,
                 favorite=a.favorite,
                 has_favorite_track=a.has_favorite_track,


### PR DESCRIPTION
## Summary

- `search_library` was constructing `AlbumOut` objects without `last_played_at`, so it always defaulted to `None` — every recently-added album in search results appeared as "never played" and the new-arrival highlight fired unconditionally
- One-line fix: add `last_played_at=a.last_played_at` to the list comprehension, matching all other `AlbumOut` constructions in the file

## Test plan

- [ ] Search for a recently-added album that has been played — confirm no new-arrival highlight
- [ ] Search for a recently-added album that has not been played — confirm highlight appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)