### PR TITLE
fix(KAMP-476): use local date parts for Stereo Rack date-line comparison

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TrackDisplay.tsx
@@ -312,7 +312,8 @@ function TrackLeft({
   // line for 8s if the calendar date has changed since the last session.
   useEffect(() => {
     if (!isPlaying) return
-    const today = new Date().toISOString().slice(0, 10)
+    const _d = new Date()
+    const today = `${_d.getFullYear()}-${String(_d.getMonth() + 1).padStart(2, '0')}-${String(_d.getDate()).padStart(2, '0')}`
     const stored = localStorage.getItem(LAST_PLAY_DATE_KEY)
     localStorage.setItem(LAST_PLAY_DATE_KEY, today)
     if (stored === today) return


### PR DESCRIPTION
## Summary

- `toISOString().slice(0, 10)` returns a UTC date string, causing the "first track of day" date banner to fire at local evening for users west of UTC (e.g. 7 PM for UTC-5)
- Replaced with explicit local-part construction using `getFullYear()` / `getMonth()` / `getDate()`, which produces `YYYY-MM-DD` in local time without any locale assumption
- `formatTodayDate()` already used local-time methods for display; this aligns the comparison to match

## Test plan

- [x] Date banner still appears on the first track played after app launch
- [x] Displayed date label matches the local calendar date

🤖 Generated with [Claude Code](https://claude.com/claude-code)