### PR TITLE
feat(KAMP-475): add 'date added to library' sort to playlists

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3747,7 +3747,8 @@ class LibraryIndex:
                    t.id, t.file_path, t.title, t.artist, t.album_artist, t.album,
                    t.year, t.track_number, t.disc_number, t.ext, t.embedded_art,
                    t.mb_release_id, t.mb_recording_id, t.genre, t.label,
-                   t.favorite, t.play_count, t.last_played, t.source, t.is_available, t.duration
+                   t.favorite, t.play_count, t.last_played, t.date_added,
+                   t.source, t.is_available, t.duration
             FROM playlist_tracks pt
             JOIN tracks t ON t.id = pt.track_id
             WHERE pt.playlist_id = ?
@@ -3777,6 +3778,7 @@ class LibraryIndex:
                 "favorite": bool(r["favorite"]),
                 "play_count": r["play_count"],
                 "last_played": r["last_played"],
+                "date_added": r["date_added"],
                 "source": r["source"],
                 "is_available": bool(r["is_available"]),
                 "duration": r["duration"],
@@ -4029,7 +4031,8 @@ class LibraryIndex:
                    tracks.track_number, tracks.disc_number, tracks.ext,
                    tracks.embedded_art, tracks.mb_release_id, tracks.mb_recording_id,
                    tracks.genre, tracks.label, tracks.favorite, tracks.play_count,
-                   tracks.last_played, tracks.source, tracks.is_available, tracks.duration
+                   tracks.last_played, tracks.date_added,
+                   tracks.source, tracks.is_available, tracks.duration
             FROM tracks {album_join}
             WHERE {where_fragment} AND tracks.is_available = 1
             ORDER BY tracks.id
@@ -4066,6 +4069,7 @@ class LibraryIndex:
                 "favorite": bool(r["favorite"]),
                 "play_count": r["play_count"],
                 "last_played": r["last_played"],
+                "date_added": r["date_added"],
                 "source": r["source"],
                 "is_available": bool(r["is_available"]),
                 "duration": r["duration"],

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -632,6 +632,7 @@ class PlaylistTrackOut(BaseModel):
     favorite: bool
     play_count: int
     last_played: float | None = None
+    date_added: float | None = None
     source: str
     is_available: bool
     duration: float

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -134,6 +134,7 @@ export type PlaylistTrack = Track & {
   playlist_track_id: number
   position: number
   last_played: number | null
+  date_added: number | null
 }
 
 // Configurable base URL: defaults to localhost but can be overridden via

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -33,7 +33,8 @@ const TRACK_SORT_OPTIONS = [
   { key: 'album', label: 'Album' },
   { key: 'duration', label: 'Duration' },
   { key: 'last_played', label: 'Last Played' },
-  { key: 'most_played', label: 'Most Played' }
+  { key: 'most_played', label: 'Most Played' },
+  { key: 'date_added', label: 'Date Added' }
 ]
 
 type TrackSortOrder =
@@ -44,6 +45,7 @@ type TrackSortOrder =
   | 'duration'
   | 'last_played'
   | 'most_played'
+  | 'date_added'
 
 function sortKey(playlistId: number): string {
   return `kamp:playlist:${playlistId}:sort`
@@ -106,6 +108,16 @@ function applySortToTracks(
       case 'most_played':
         cmp = a.play_count - b.play_count
         break
+      case 'date_added': {
+        // Tracks without a date_added (pre-column) always sort last.
+        const aD = a.date_added
+        const bD = b.date_added
+        if (aD === null && bD === null) return 0
+        if (aD === null) return 1
+        if (bD === null) return -1
+        cmp = aD - bD
+        break
+      }
     }
     return dir === 'desc' ? -cmp : cmp
   })
@@ -342,8 +354,11 @@ export function PlaylistView(): React.JSX.Element | null {
 
   const handleTrackSortChange = (key: string): void => {
     const order = key as TrackSortOrder
+    // Default 'date_added' to descending (newest first) when first selected.
+    const dir: 'asc' | 'desc' = order === 'date_added' ? 'desc' : trackSortDir
     setTrackSortOrder(order)
-    persistTrackSort(order, trackSortDir)
+    setTrackSortDir(dir)
+    persistTrackSort(order, dir)
   }
 
   const handleTrackDirChange = (dir: 'asc' | 'desc'): void => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7400,6 +7400,22 @@ class TestPlaylists:
         assert index.get_playlist_tracks(pl["id"]) != []
         index.close()
 
+    def test_get_playlist_tracks_includes_date_added(self, tmp_path: Path) -> None:
+        """get_playlist_tracks must expose date_added so the UI can sort by it."""
+        index = self._index(tmp_path)
+        index._conn.execute(
+            "UPDATE tracks SET date_added = 1234.0 WHERE file_path = ?",
+            (str(tmp_path / "a.mp3"),),
+        )
+        index._conn.commit()
+        pl = index.create_playlist("Mix")
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "a.mp3"))
+        tracks = index.get_playlist_tracks(pl["id"])
+        index.close()
+
+        assert len(tracks) == 1
+        assert tracks[0]["date_added"] == 1234.0
+
     # ------------------------------------------------------------------
     # reorder
     # ------------------------------------------------------------------
@@ -8748,6 +8764,33 @@ class TestMagicPlaylists:
         assert id_a in ids
         assert unavailable not in [t["file_path"] for t in tracks]
         assert all(t["is_available"] for t in tracks)
+
+    def test_get_magic_playlist_tracks_includes_date_added(
+        self, tmp_path: Path
+    ) -> None:
+        """get_magic_playlist_tracks must expose date_added so the UI can sort by it."""
+        index, id_a, _ = self._seeded_index(tmp_path)
+        index._conn.execute(
+            "UPDATE tracks SET date_added = 9999.0 WHERE id = ?", (id_a,)
+        )
+        index._conn.commit()
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.artist", op="is", value="Alvvays")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Date Sort Test", criteria)
+        tracks = index.get_magic_playlist_tracks(pid)
+        index.close()
+
+        assert len(tracks) == 1
+        assert tracks[0]["date_added"] == 9999.0
 
     def test_count_magic_criteria_returns_match_count(self, tmp_path: Path) -> None:
         index, _, _ = self._seeded_index(tmp_path)


### PR DESCRIPTION
## Summary

- Adds `date_added` to `PlaylistTrackOut` and both `get_playlist_tracks` / `get_magic_playlist_tracks` SQL helpers so the field flows through to the API response
- Extends `PlaylistTrack` TypeScript type with `date_added: number | null`
- Adds a 'Date Added' sort option to the playlist sort dropdown (available in both static and magic playlists); defaults to descending (newest first) on selection; sorts NULL-date tracks last matching the existing `last_played` null-last pattern

## Test plan

- [ ] Open any static playlist — 'Date Added' appears in sort dropdown
- [ ] Select 'Date Added' — direction auto-sets to descending (newest first)
- [ ] Toggle direction to ascending — oldest track appears first
- [ ] Open a magic playlist — 'Date Added' also appears (not filtered like 'Playlist Order')
- [ ] Tracks without a date_added value sort last regardless of direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)