### PR TITLE
fix(KAMP-487): navigate to library view when selecting playlist from module

### DIFF
--- a/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistCard.tsx
@@ -16,6 +16,7 @@ export function PlaylistCard({
 }): React.JSX.Element {
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const setCollectionType = useStore((s) => s.setCollectionType)
+  const setActiveView = useStore((s) => s.setActiveView)
   const [menu, setMenu] = useState<MenuPos | null>(null)
   const [artLoaded, setArtLoaded] = useState(false)
 
@@ -23,6 +24,7 @@ export function PlaylistCard({
     if (menu) return
     setCollectionType('playlists')
     void selectPlaylist(playlist)
+    void setActiveView('library')
     onAfterSelect?.()
   }
 

--- a/kamp_ui/src/renderer/src/components/modules/PlaylistViews.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/PlaylistViews.tsx
@@ -75,6 +75,7 @@ type MenuPos = { x: number; y: number }
 function PlaylistListRow({ playlist }: { playlist: Playlist }): React.JSX.Element {
   const selectPlaylist = useStore((s) => s.selectPlaylist)
   const setCollectionType = useStore((s) => s.setCollectionType)
+  const setActiveView = useStore((s) => s.setActiveView)
   const [artLoaded, setArtLoaded] = useState(false)
   const [menu, setMenu] = useState<MenuPos | null>(null)
 
@@ -82,6 +83,7 @@ function PlaylistListRow({ playlist }: { playlist: Playlist }): React.JSX.Elemen
     if (menu) return
     setCollectionType('playlists')
     void selectPlaylist(playlist)
+    void setActiveView('library')
   }
 
   return (


### PR DESCRIPTION
## Summary

- `PlaylistCard` and `PlaylistListRow` both called `selectPlaylist` + `setCollectionType` but never `setActiveView('library')`, so the playlist loaded silently in the background while the user stayed on the Home screen
- Added `void setActiveView('library')` to both `handleSelect` handlers, matching the pattern already used in `MagicPlaylistModule`

## Test plan

- [ ] Favorite Playlists module (shelf): click a card → view switches to library showing that playlist
- [ ] Favorite Playlists module (grid): same
- [ ] Favorite Playlists module (list): click a row → same
- [ ] Keyboard: focus a card, press Enter → same
- [ ] Right-click context menu still opens without triggering navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)