### PR TITLE
fix(KAMP-486): refresh selectedPlaylist after updating magic criteria

### DIFF
--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -841,6 +841,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
       .loadPlaylists()
       .catch(() => undefined)
     if (get().library.selectedPlaylist?.id === id) {
+      const fresh = get().library.playlists.find((p) => p.id === id) ?? null
+      set((s) => ({ library: { ...s.library, selectedPlaylist: fresh } }))
       void get().loadPlaylistTracks(id)
     }
     return playlist


### PR DESCRIPTION
## Summary

`updateMagicPlaylistCriteria` called `loadPlaylists()` (refreshing `library.playlists`) but never updated `library.selectedPlaylist`. When Edit Criteria was reopened, the modal received a stale `playlist` prop — the key-bump remount was working correctly, but the prop itself carried old criteria.

Added the same 2-line `selectedPlaylist` refresh pattern used by `setPlaylistFavorite`: find the updated playlist in the freshly loaded list and set it as `selectedPlaylist` when it matches the current selection.

## Test plan

- [ ] Create a magic playlist with criteria "Artist contains X"
- [ ] Navigate away and back to the playlist
- [ ] Open Edit Criteria, change to "Artist contains Y", save
- [ ] Immediately reopen Edit Criteria → shows "Artist contains Y", not "X"
- [ ] Playlist track list also refreshes to reflect the new criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)