### PR TITLE
feat(KAMP-483): format aggregated durations as compact multi-unit strings

### DIFF
--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -20,7 +20,7 @@ import {
   SparkleIcon,
   WarnIcon
 } from './TransportIcons'
-import { formatTime } from '../utils/formatTime'
+import { formatTime, formatLongDuration } from '../utils/formatTime'
 
 const HERO_DEFAULT = 45
 const HERO_MIN = 15
@@ -636,7 +636,7 @@ export function PlaylistView(): React.JSX.Element | null {
             >
               {playlistTracks.length === 1 ? '1 track' : `${playlistTracks.length} tracks`}
             </span>
-            {totalDuration > 0 && ` · ${formatTime(totalDuration)}`}
+            {totalDuration > 0 && ` · ${formatLongDuration(totalDuration)}`}
           </div>
         </div>
         <div className="album-controls-group">

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -33,7 +33,7 @@ import {
   WarnIcon
 } from './TransportIcons'
 import { downloadAlbum } from '../api/client'
-import { formatTime } from '../utils/formatTime'
+import { formatTime, formatLongDuration } from '../utils/formatTime'
 
 const TOAST_TTL = 10_000 // ms
 
@@ -604,7 +604,7 @@ export function TrackList(): React.JSX.Element | null {
           />
           {(album.year || totalDuration > 0) && (
             <div className="track-list-album-year">
-              {[album.year, totalDuration > 0 ? formatTime(totalDuration) : '']
+              {[album.year, totalDuration > 0 ? formatLongDuration(totalDuration) : '']
                 .filter(Boolean)
                 .join(' · ')}
             </div>

--- a/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StatsModule.tsx
@@ -2,28 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { getStats } from '../../api/client'
 import type { Stats } from '../../api/client'
 import { useStore } from '../../store'
+import { formatLongDuration } from '../../utils/formatTime'
 import type { ModuleProps } from './registry'
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatSeconds(n: number): string {
-  if (n <= 0) return '—'
-  const totalMinutes = Math.floor(n / 60)
-  const totalHours = Math.floor(n / 3600)
-  const totalDays = Math.floor(n / 86400)
-  const totalYears = Math.floor(totalDays / 365)
-  const months = Math.floor((totalDays % 365) / 30)
-  const days = totalDays % 30
-  const hours = totalHours % 24
-  const minutes = totalMinutes % 60
-  if (totalYears > 0) return `${totalYears}y ${months}mo ${days}d ${hours}h`
-  if (totalDays > 0) return `${totalDays}d ${hours}h`
-  if (totalHours > 0) return `${totalHours}h ${minutes}m`
-  if (totalMinutes > 0) return `${totalMinutes} min`
-  return '< 1 min'
-}
 
 // ---------------------------------------------------------------------------
 // Config
@@ -113,7 +93,7 @@ export function StatsModule({ displayStyle: _ds }: ModuleProps): React.JSX.Eleme
           <>
             <div className="stats-row">
               <div className="stats-stat">
-                <div className="stats-number">{formatSeconds(stats.total_play_seconds)}</div>
+                <div className="stats-number">{formatLongDuration(stats.total_play_seconds)}</div>
                 <div className="stats-label">Time Listened</div>
               </div>
               <div className="stats-stat">
@@ -132,7 +112,7 @@ export function StatsModule({ displayStyle: _ds }: ModuleProps): React.JSX.Eleme
                 <span className="stats-top-artist-name">{stats.top_artist_name}</span>
                 {stats.top_artist_seconds !== null && (
                   <span className="stats-top-artist-time">
-                    {formatSeconds(stats.top_artist_seconds)}
+                    {formatLongDuration(stats.top_artist_seconds)}
                   </span>
                 )}
               </div>

--- a/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopArtistsModule.tsx
@@ -3,17 +3,12 @@ import { getTopArtists, artUrl } from '../../api/client'
 import type { Artist } from '../../api/client'
 import { useStore } from '../../store'
 import { ArtistContextMenu } from '../ArtistContextMenu'
+import { formatLongDuration } from '../../utils/formatTime'
 import type { ModuleProps, DisplayStyle } from './registry'
 
 type MenuPos = { x: number; y: number; artist: Artist }
 
 const SCROLL_PX = 500
-
-function formatPlayTime(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  return h > 0 ? `${h}h ${m}m` : `${m}m`
-}
 
 function ArtistCard({ artist }: { artist: Artist }): React.JSX.Element {
   const selectArtist = useStore((s) => s.selectArtist)
@@ -59,7 +54,7 @@ function ArtistCard({ artist }: { artist: Artist }): React.JSX.Element {
       </div>
       <div className="track-card-info">
         <div className="track-card-title">{artist.name}</div>
-        <div className="track-card-play-count">{formatPlayTime(artist.play_time)}</div>
+        <div className="track-card-play-count">{formatLongDuration(artist.play_time)}</div>
       </div>
       {menu && (
         <ArtistContextMenu
@@ -112,7 +107,7 @@ function ArtistListRow({ artist }: { artist: Artist }): React.JSX.Element {
       <div className="module-list-info">
         <div className="module-list-title">{artist.name}</div>
       </div>
-      <span className="track-card-play-count">{formatPlayTime(artist.play_time)}</span>
+      <span className="track-card-play-count">{formatLongDuration(artist.play_time)}</span>
       {menu && (
         <ArtistContextMenu
           x={menu.x}

--- a/kamp_ui/src/renderer/src/utils/formatTime.ts
+++ b/kamp_ui/src/renderer/src/utils/formatTime.ts
@@ -3,3 +3,51 @@ export function formatTime(seconds: number): string {
   const s = Math.floor(seconds % 60)
   return `${m}:${s.toString().padStart(2, '0')}`
 }
+
+// Formats aggregated durations (playlist total, album total, stats) as a compact
+// multi-unit string using three consecutive tiers from the leading non-zero unit:
+//   hours  → h/m/s  e.g. "1h4m30s"
+//   days   → d/h/m  e.g. "5d12h30m"
+//   months → mo/d/h e.g. "3mo5d12h"
+//   years  → y/mo/d e.g. "2y3mo15d"
+// Interior zeros within the tier are omitted.
+export function formatLongDuration(seconds: number): string {
+  if (seconds <= 0) return '—'
+
+  const totalSecs = Math.floor(seconds)
+  const s = totalSecs % 60
+  const totalMinutes = Math.floor(totalSecs / 60)
+  const m = totalMinutes % 60
+  const totalHours = Math.floor(totalSecs / 3600)
+  const h = totalHours % 24
+  const totalDays = Math.floor(totalSecs / 86400)
+  const years = Math.floor(totalDays / 365)
+  const months = Math.floor((totalDays % 365) / 30)
+  const days = totalDays % 30
+
+  const parts: string[] = []
+  if (years > 0) {
+    parts.push(`${years}y`)
+    if (months > 0) parts.push(`${months}mo`)
+    if (days > 0) parts.push(`${days}d`)
+  } else if (months > 0) {
+    parts.push(`${months}mo`)
+    if (days > 0) parts.push(`${days}d`)
+    if (h > 0) parts.push(`${h}h`)
+  } else if (totalDays > 0) {
+    parts.push(`${totalDays}d`)
+    if (h > 0) parts.push(`${h}h`)
+    if (m > 0) parts.push(`${m}m`)
+  } else if (totalHours > 0) {
+    parts.push(`${totalHours}h`)
+    if (m > 0) parts.push(`${m}m`)
+    if (s > 0) parts.push(`${s}s`)
+  } else if (m > 0) {
+    parts.push(`${m}m`)
+    if (s > 0) parts.push(`${s}s`)
+  } else {
+    parts.push(`${s}s`)
+  }
+
+  return parts.join('')
+}


### PR DESCRIPTION
## Summary

- Adds `formatLongDuration(seconds)` to `formatTime.ts` — formats aggregated durations using three consecutive tiers from the leading non-zero unit: `h/m/s`, `d/h/m`, `mo/d/h`, `y/mo/d` (interior zeros omitted)
- Switches playlist total, album total, Stats module, and Top Artists module to the new formatter
- Removes the ad-hoc local `formatSeconds` and `formatPlayTime` functions from their respective modules
- Transport bar and per-track duration cells remain on `m:ss` `formatTime`

## Test plan

- [ ] Open a playlist — header shows e.g. `1h34m22s` instead of `94:22`
- [ ] Open an album view — footer shows e.g. `42m15s`
- [ ] Open Stats module — "Time Listened" and "Top Artist" time use compact format
- [ ] Open Top Artists module — per-artist play time shows compact format
- [ ] Transport bar during playback still shows `m:ss`
- [ ] Short playlist (< 1 min total) shows e.g. `45s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)