### PR TITLE
feat(KAMP-431): keyboard shortcut reference overlay

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { TransportBar } from './components/TransportBar'
 import { SandboxedExtensionLoader } from './components/SandboxedExtensionLoader'
 import { ExtensionPermissionPrompt } from './components/ExtensionPermissionPrompt'
 import { UpdateBanner } from './components/UpdateBanner'
+import { KeyboardShortcutsOverlay } from './components/KeyboardShortcutsOverlay'
 import { registerBuiltInPanel, usePanelLayout } from './hooks/usePanelLayout'
 import { useExtensionState } from './hooks/useExtensionState'
 import type { UnifiedPanel } from './hooks/usePanelLayout'
@@ -116,6 +117,7 @@ export default function App(): React.JSX.Element {
   const extState = useExtensionState()
 
   // Active extension panel id, or null when a built-in view is showing.
+  const [showShortcuts, setShowShortcuts] = useState(false)
   const [activeExtPanel, setActiveExtPanel] = useState<string | null>(null)
   // All discovered extensions (used by PreferencesDialog for the Extensions tab).
   const [allExtensions, setAllExtensions] = useState<ExtensionInfo[]>([])
@@ -303,6 +305,9 @@ export default function App(): React.JSX.Element {
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
 
       switch (e.key) {
+        case '?':
+          setShowShortcuts((prev) => !prev)
+          break
         case ' ':
           e.preventDefault()
           void togglePlayPause()
@@ -626,6 +631,7 @@ export default function App(): React.JSX.Element {
       </div>
       {bottomPanel && <SlotPanel panel={bottomPanel} />}
       <UpdateBanner />
+      {showShortcuts && <KeyboardShortcutsOverlay onClose={() => setShowShortcuts(false)} />}
       {!splashGone && <SplashScreen hiding={splashHiding} slowStart={slowStart} />}
       <PreferencesDialog
         extensions={allExtensions}

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -21,4 +21,5 @@
 @import './stereo-rack.css';
 @import './animations.css';
 @import './musicbrainz-modal.css';
+@import './shortcuts-overlay.css';
 @import './update-banner.css';

--- a/kamp_ui/src/renderer/src/assets/shortcuts-overlay.css
+++ b/kamp_ui/src/renderer/src/assets/shortcuts-overlay.css
@@ -1,0 +1,109 @@
+/* Keyboard shortcuts overlay ----------------------------------------------- */
+
+.shortcuts-overlay {
+  width: min(480px, 90vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 24px;
+  gap: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.shortcuts-overlay-title {
+  margin: 0 0 20px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.shortcuts-group {
+  margin-bottom: 20px;
+}
+
+.shortcuts-group:last-child {
+  margin-bottom: 0;
+}
+
+.shortcuts-group-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+
+.shortcuts-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.shortcuts-row:last-child {
+  border-bottom: none;
+}
+
+.shortcuts-keys {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.shortcuts-description {
+  font-size: 12px;
+  color: var(--text-dim);
+  flex: 1;
+  text-align: right;
+}
+
+.shortcuts-note {
+  font-size: 10px;
+  color: var(--text-dim);
+  opacity: 0.6;
+  margin-left: 4px;
+}
+
+.shortcuts-row kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  box-shadow: 0 1px 0 var(--border);
+}
+
+.shortcuts-plus {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.shortcuts-close-btn {
+  display: block;
+  margin: 20px auto 0;
+  padding: 6px 20px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.shortcuts-close-btn:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect } from 'react'
+
+const isMac = navigator.platform.startsWith('Mac')
+const mod = isMac ? 'Cmd' : 'Ctrl'
+
+type Shortcut = {
+  keys: string[]
+  description: string
+  note?: string
+}
+
+type Group = {
+  label: string
+  shortcuts: Shortcut[]
+}
+
+const GROUPS: Group[] = [
+  {
+    label: 'Playback',
+    shortcuts: [
+      { keys: ['Space'], description: 'Play / Pause' },
+      { keys: ['→'], description: 'Next track' },
+      { keys: ['←'], description: 'Previous track' }
+    ]
+  },
+  {
+    label: 'Navigation',
+    shortcuts: [
+      { keys: [mod, 'K'], description: 'Focus search' },
+      { keys: ['L'], description: 'Library / Now Playing' },
+      { keys: ['Q'], description: 'Queue panel' },
+      { keys: ['A'], description: 'Artist panel', note: 'Library only' },
+      { keys: [mod, ','], description: 'Preferences' }
+    ]
+  },
+  {
+    label: 'Queue',
+    shortcuts: [
+      { keys: ['Alt'], description: 'Toggle album grouping mode' },
+      { keys: ['Esc'], description: 'Exit album grouping mode' },
+      { keys: ['Shift', 'click'], description: 'Range select in Next Up' }
+    ]
+  },
+  {
+    label: 'Help',
+    shortcuts: [
+      { keys: ['?'], description: 'Show / hide keyboard shortcuts' },
+      { keys: ['Esc'], description: 'Close this overlay' }
+    ]
+  }
+]
+
+interface Props {
+  onClose: () => void
+}
+
+export function KeyboardShortcutsOverlay({ onClose }: Props): React.JSX.Element {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') onClose()
+      // Prevent playback shortcuts from firing while overlay is open.
+      e.stopPropagation()
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [onClose])
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="modal shortcuts-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="shortcuts-title" className="shortcuts-overlay-title">
+          Keyboard Shortcuts
+        </h2>
+        {GROUPS.map((group) => (
+          <div key={group.label} className="shortcuts-group">
+            <div className="shortcuts-group-label">{group.label}</div>
+            {group.shortcuts.map((shortcut) => (
+              <div key={shortcut.description} className="shortcuts-row">
+                <span className="shortcuts-keys">
+                  {shortcut.keys.map((key, i) => (
+                    <React.Fragment key={key}>
+                      {i > 0 && <span className="shortcuts-plus">+</span>}
+                      <kbd>{key}</kbd>
+                    </React.Fragment>
+                  ))}
+                </span>
+                <span className="shortcuts-description">
+                  {shortcut.description}
+                  {shortcut.note && <span className="shortcuts-note">({shortcut.note})</span>}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+        <button className="shortcuts-close-btn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Press `?` to toggle a modal listing all keyboard shortcuts grouped by context (Playback, Navigation, Queue, Help)
- Closes on `Escape` or backdrop click; capture-phase keydown listener blocks playback shortcuts while open
- Platform-aware modifier label (`Cmd` on macOS, `Ctrl` elsewhere)
- Shortcut list is a static `GROUPS` constant in `KeyboardShortcutsOverlay.tsx` — easy to extend when new shortcuts are added

## Test plan

- [ ] Press `?` — overlay appears with all grouped shortcuts
- [ ] Press `?` again — overlay closes (toggle)
- [ ] Press `Escape` while overlay is open — overlay closes
- [ ] Click backdrop — overlay closes; click inside dialog — does NOT close
- [ ] Focus search bar (`Cmd+K`), type `?` — overlay does NOT open
- [ ] While overlay is open, press `Space` / `→` / `←` — playback does not fire
- [ ] On macOS: modifier shown as `Cmd`; on other platforms: `Ctrl`
- [ ] All shortcuts in the inventory are present and accurately described

🤖 Generated with [Claude Code](https://claude.com/claude-code)