### PR TITLE
feat(queue): discoverable album view toggle (KAMP-492)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -295,6 +295,28 @@
   background: var(--surface-hover);
 }
 
+.queue-album-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 2px;
+  line-height: 1;
+}
+
+.queue-album-toggle:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.queue-album-toggle--active {
+  color: var(--accent);
+}
+
 /* Right-click context menu on track rows */
 .track-context-menu {
   position: fixed;

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -4,7 +4,7 @@ import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
 import { QueueContextMenu } from './QueueContextMenu'
 import { QueueAlbumCard } from './QueueAlbumCard'
-import { FavoriteIcon, WarnIcon } from './TransportIcons'
+import { FavoriteIcon, WarnIcon, GoToAlbumIcon } from './TransportIcons'
 import type { Track } from '../api/client'
 import { computeNewOrder } from '../utils/computeNewOrder'
 
@@ -72,7 +72,9 @@ export function QueuePanel(): React.JSX.Element {
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(QUEUE_WIDTH_DEFAULT)
   const didDragRef = useRef(false)
-  const [albumGroupingActive, setAlbumGroupingActive] = useState(false)
+  const [albumGroupingActive, setAlbumGroupingActive] = useState(
+    () => localStorage.getItem('kamp:album-view') === 'true'
+  )
   const nowPlayingListRef = useRef<HTMLOListElement>(null)
   // Tracks the currently highlighted drop-indicator element to avoid a DOM query on clear.
   const activeDropIndicatorRef = useRef<HTMLElement | null>(null)
@@ -108,6 +110,12 @@ export function QueuePanel(): React.JSX.Element {
 
     setAnchorIdx(null)
   }, [tracks.length, position])
+
+  // Persist album-view state so it survives app relaunch. A single effect keyed on
+  // the state covers every toggle path — the header button, the Alt shortcut, and Escape.
+  useEffect(() => {
+    localStorage.setItem('kamp:album-view', String(albumGroupingActive))
+  }, [albumGroupingActive])
 
   // Alt → enter album-grouping mode; Escape → exit it.
   useEffect(() => {
@@ -341,6 +349,11 @@ export function QueuePanel(): React.JSX.Element {
     const next = !historyCollapsed
     setHistoryCollapsed(next)
     localStorage.setItem('kamp:queue-history-collapsed', String(next))
+  }
+
+  // Persistence is handled by the localStorage effect keyed on albumGroupingActive.
+  function toggleAlbumGrouping(): void {
+    setAlbumGroupingActive((prev) => !prev)
   }
 
   function handleRowMouseDown(e: React.MouseEvent, idx: number): void {
@@ -736,6 +749,14 @@ export function QueuePanel(): React.JSX.Element {
               }}
             >
               <span>NEXT UP{albumGroupingActive ? ' — ALBUM VIEW' : ''}</span>
+              <button
+                className={`queue-album-toggle${albumGroupingActive ? ' queue-album-toggle--active' : ''}`}
+                onClick={toggleAlbumGrouping}
+                title="Album view"
+                aria-pressed={albumGroupingActive}
+              >
+                <GoToAlbumIcon size={14} />
+              </button>
             </div>
             <ol
               ref={listRef}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -752,7 +752,7 @@ export function QueuePanel(): React.JSX.Element {
               <button
                 className={`queue-album-toggle${albumGroupingActive ? ' queue-album-toggle--active' : ''}`}
                 onClick={toggleAlbumGrouping}
-                title="Album view"
+                {...tooltip(TOOLTIPS.QUEUE_ALBUM_VIEW)}
                 aria-pressed={albumGroupingActive}
               >
                 <GoToAlbumIcon size={14} />

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -19,6 +19,7 @@ export const TOOLTIPS = {
 
   // Queue panel
   QUEUE_CLOSE: 'Close queue',
+  QUEUE_ALBUM_VIEW: 'Album Queue',
 
   // Panel management / preferences
   PREFERENCES: 'Preferences',


### PR DESCRIPTION
## Summary

Queue album view (grouping the Next Up rail by album) was only reachable via the secret `Alt` keydown shortcut — undiscoverable for ordinary users. This adds a visible record-icon toggle to the **NEXT UP** section header, and persists the on/off state across app launches.

- Record-icon toggle button (`GoToAlbumIcon`, a concentric-circle vinyl glyph) at the right edge of the NEXT UP header, styled to match the existing history toggle. Active state shows the accent color.
- State now reads from / writes to `localStorage` under `kamp:album-view`, so it survives relaunch. Default remains off on first launch.
- A single `useEffect` keyed on the state persists every toggle path — the new button, the `Alt` shortcut, and `Escape`-to-exit — without duplicating logic.
- Existing `Alt` shortcut and `Escape` behavior are unchanged.

## Test plan

- [ ] Toggle button appears in the NEXT UP header with the record icon and "Album view" tooltip.
- [ ] Clicking it turns album view on/off; the icon reflects the state (accent when on).
- [ ] `Alt` still toggles album view, and the button appearance updates to match.
- [ ] `Escape` still exits album view; button reflects off.
- [ ] Turn on, quit + relaunch → still on. Turn off, relaunch → still off. Fresh state defaults to off.

KAMP-492

🤖 Generated with [Claude Code](https://claude.com/claude-code)