### PR TITLE
fix(queue): album cards accept external drops between albums (KAMP-490)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -394,6 +394,10 @@
   opacity: 0.4;
 }
 
+.queue-album-card.drag-over {
+  border-top: 2px solid var(--accent);
+}
+
 .queue-album-card-art {
   flex-shrink: 0;
   width: 36px;

--- a/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
@@ -10,6 +10,11 @@ interface QueueAlbumCardProps {
   isDragging: boolean
   onPointerDown: (trackIndices: number[], startX: number, startY: number) => void
   onContextMenu: (e: React.MouseEvent) => void
+  // HTML5 drop handlers so external drags (library album/track/files) can target the card,
+  // mirroring the track-row drop wiring. The card is drop-target only — it never sets draggable.
+  onDragOver?: React.DragEventHandler<HTMLLIElement>
+  onDragLeave?: React.DragEventHandler<HTMLLIElement>
+  onDrop?: React.DragEventHandler<HTMLLIElement>
 }
 
 export function QueueAlbumCard({
@@ -19,7 +24,10 @@ export function QueueAlbumCard({
   trackIndices,
   isDragging,
   onPointerDown,
-  onContextMenu
+  onContextMenu,
+  onDragOver,
+  onDragLeave,
+  onDrop
 }: QueueAlbumCardProps): React.JSX.Element {
   const [artLoaded, setArtLoaded] = useState(false)
   const [artError, setArtError] = useState(false)
@@ -36,6 +44,9 @@ export function QueueAlbumCard({
         onPointerDown(trackIndices, e.clientX, e.clientY)
       }}
       onContextMenu={onContextMenu}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
     >
       <div className="queue-album-card-art">
         {!artError && (

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -623,6 +623,52 @@ export function QueuePanel(): React.JSX.Element {
     )
   }
 
+  // Mirrors renderTrackRow: keeping the album-card JSX (and its ref-reading drop
+  // handlers) inside a named function rather than inline in the render map keeps
+  // the react-hooks/refs lint rule from flagging handleDrop's listRef access.
+  function renderAlbumCard(item: Extract<NextUpItem, { kind: 'album' }>): React.JSX.Element {
+    return (
+      <QueueAlbumCard
+        key={`album:${item.albumArtist}\0${item.album}`}
+        albumArtist={item.albumArtist}
+        album={item.album}
+        tracks={item.tracks}
+        trackIndices={item.trackIndices}
+        isDragging={false}
+        onPointerDown={handleAlbumCardPointerDown}
+        onDragOver={(e) => {
+          if (!isQueueDrop(e.dataTransfer.types)) return
+          e.preventDefault()
+          e.stopPropagation()
+          e.currentTarget.classList.add('drag-over')
+          listRef.current?.classList.remove('queue-tail-drop')
+        }}
+        onDragLeave={(e) => {
+          e.stopPropagation()
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            e.currentTarget.classList.remove('drag-over')
+          }
+        }}
+        onDrop={(e) => handleDrop(e, item.trackIndices[0])}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setMenu({
+            x: e.clientX,
+            y: e.clientY,
+            // clear_remaining keeps through trackIdx and removes
+            // everything after — pass the last track of the album so
+            // the full album is kept and everything beyond is cleared.
+            trackIdx: item.trackIndices[item.trackIndices.length - 1],
+            track: item.tracks[0],
+            selectedTracks: item.tracks,
+            unplayedSelectedIndices: item.trackIndices
+          })
+        }}
+      />
+    )
+  }
+
   const listContextMenu = (e: React.MouseEvent): void => {
     e.preventDefault()
     setMenu({
@@ -778,34 +824,9 @@ export function QueuePanel(): React.JSX.Element {
             >
               {albumGroupingActive
                 ? nextUpItems.map((item) =>
-                    item.kind === 'track' ? (
-                      renderTrackRow(item.track, item.queueIdx)
-                    ) : (
-                      <QueueAlbumCard
-                        key={`album:${item.albumArtist}\0${item.album}`}
-                        albumArtist={item.albumArtist}
-                        album={item.album}
-                        tracks={item.tracks}
-                        trackIndices={item.trackIndices}
-                        isDragging={false}
-                        onPointerDown={handleAlbumCardPointerDown}
-                        onContextMenu={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          setMenu({
-                            x: e.clientX,
-                            y: e.clientY,
-                            // clear_remaining keeps through trackIdx and removes
-                            // everything after — pass the last track of the album so
-                            // the full album is kept and everything beyond is cleared.
-                            trackIdx: item.trackIndices[item.trackIndices.length - 1],
-                            track: item.tracks[0],
-                            selectedTracks: item.tracks,
-                            unplayedSelectedIndices: item.trackIndices
-                          })
-                        }}
-                      />
-                    )
+                    item.kind === 'track'
+                      ? renderTrackRow(item.track, item.queueIdx)
+                      : renderAlbumCard(item)
                   )
                 : tracks
                     .slice(position + 1)


### PR DESCRIPTION
## Summary

In album view, dragging an album card from the library (or base kamp) into the Next Up rail offered no drop target *between* album cards — the drag could only land at the tail or between individual track rows.

Root cause: `QueueAlbumCard` rendered an `<li data-drop-idx={trackIndices[0]}>` with no HTML5 drag handlers, so external album drags (`text/kamp-album`) bubbled past the card to the `<ol>`'s tail-drop handler.

## Changes

- `QueueAlbumCard` gains optional `onDragOver` / `onDragLeave` / `onDrop` props, spread onto its `<li>`. The card stays presentational and drop-target only (it never sets `draggable`).
- At the render site, the handlers mirror the track-row pattern and delegate to the existing `handleDrop(e, trackIndices[0])` — which already resolves every external drag type (album, track, file list, artist, playlist) and queue-internal moves to the correct insert index.
- New `.queue-album-card.drag-over` style shows the same top-border indicator track rows use.
- The album-card JSX was extracted into a `renderAlbumCard` helper (mirroring `renderTrackRow`) so `handleDrop`'s `listRef` access isn't flagged by the `react-hooks/refs` lint rule when called from the render map.

Internal album reordering is pointer-events based (KAMP-458) and unaffected — these HTML5 handlers only catch external drags.

## Test plan

- [ ] Enable album view; drag a library album card over the Next Up rail — a top-border drop indicator appears on the album card under the pointer.
- [ ] Drop between two albums → the album inserts at that position (not the tail).
- [ ] No double-insert (tail drop does not also fire).
- [ ] Dragging a single track / multiple files / an artist / a playlist onto an album card inserts at that position.
- [ ] Internal album-card reordering (pointer drag) still works.
- [ ] Tail drop still appends; with album view off, track-row drops behave as before.

KAMP-490

🤖 Generated with [Claude Code](https://claude.com/claude-code)