### PR TITLE
fix(queue): correct computeNewOrder insert position for downward drags (KAMP-494)

### DIFF
--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -409,8 +409,12 @@ export function QueuePanel(): React.JSX.Element {
       const sorted: number[] = JSON.parse(multiJson)
       void reorderQueue(computeNewOrder(tracks.length, sorted, dropIdx))
     } else if (queueIdx !== '') {
+      // Route single-track drops through computeNewOrder too (same as the multi branch
+      // above): dropIdx is an insert-before-original-index, but Queue.move() does a
+      // pop-then-insert that lands a downward move one slot too far. reorder takes the
+      // already-corrected permutation and sidesteps that off-by-one.
       const from = Number(queueIdx)
-      if (from !== dropIdx) void moveQueueTrack(from, dropIdx)
+      void reorderQueue(computeNewOrder(tracks.length, [from], dropIdx))
     } else if (trackPath) {
       void insertIntoQueue(trackPath, dropIdx)
     } else if (e.dataTransfer.getData('text/kamp-file-paths')) {

--- a/kamp_ui/src/renderer/src/utils/computeNewOrder.ts
+++ b/kamp_ui/src/renderer/src/utils/computeNewOrder.ts
@@ -13,7 +13,10 @@ export function computeNewOrder(
 ): number[] {
   const selected = new Set(selectedIdxs)
   const unselected = Array.from({ length: trackCount }, (_, i) => i).filter((i) => !selected.has(i))
-  // Math.min handles tail-drop (dropIdx === trackCount) without an off-by-one.
-  const insertPos = Math.min(dropIdx, unselected.length)
+  // Count surviving items that sit before the drop target's original index. This stays
+  // correct when the dragged items precede the target (those removals shift the array left,
+  // which a raw `dropIdx` would ignore) and naturally caps at unselected.length for tail-drop
+  // (dropIdx === trackCount).
+  const insertPos = unselected.filter((i) => i < dropIdx).length
   return [...unselected.slice(0, insertPos), ...selectedIdxs, ...unselected.slice(insertPos)]
 }


### PR DESCRIPTION
## Summary

Fixes drag-to-reorder insert-position bugs in the queue. Two related off-by-ones, both from the same root cause — a drop index that means "insert before this original index" being applied as a post-removal array position:

**1. Album / multi-track drag (`computeNewOrder`)** — dragging an album card from within the straddle zone down to a later boundary dropped it near the end of the queue.

```diff
-const insertPos = Math.min(dropIdx, unselected.length)
+const insertPos = unselected.filter((i) => i < dropIdx).length
```

`insertPos` is now the count of surviving items whose original index is below the target — correct whether the selection is above or below the target, and still caps at `unselected.length` for tail-drop.

**2. Single-track drag (`handleDrop`)** — dragging one track down by one dropped it at "next + 1". This path called `moveQueueTrack(from, dropIdx)` → daemon `Queue.move()`, whose `pop`-then-`insert` shifts the array left on a downward move, landing the track one slot too far. It never went through `computeNewOrder`.

Fix: route the single-track drop through `reorderQueue(computeNewOrder(...))`, identical to the multi-track branch right above it, so both share the corrected insert-before semantics. `moveQueueTrack` stays for tail-drop and the context-menu "play next" slot, which are positionally correct.

## Tests

The renderer has no unit-test runner today, so this is fix-only and validated manually. Follow-up **KAMP-501** sets up vitest with `computeNewOrder` as the first regression suite.

## Test plan

- [ ] Repro 1: album view, queue = A-5 (now playing), A-6, Album N, A-7, A-8, A-9, Album B; drag Album N to the A-9 / Album B boundary → lands between A-9 and Album B.
- [ ] Repro 2: drag a single track down by one row → lands in the next position (not next + 1).
- [ ] Drag a selection **up** (single and multi) → still correct (no regression).
- [ ] Tail drop (single and multi) → still appends to the end.
- [ ] Context-menu "play next" still drops the track immediately after the current one.
- [ ] Multi-select drag down/up in both the queue and a playlist → correct positions.

KAMP-494

🤖 Generated with [Claude Code](https://claude.com/claude-code)