### PR TITLE
feat(queue): show now-playing album card in album view (KAMP-493)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -394,6 +394,14 @@
   opacity: 0.4;
 }
 
+.queue-album-card--read-only {
+  cursor: default;
+}
+
+.queue-album-card--read-only:hover {
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
+}
+
 .queue-album-card.drag-over {
   border-top: 2px solid var(--accent);
 }

--- a/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
@@ -40,11 +40,15 @@ export function QueueAlbumCard({
     <li
       className={`queue-album-card${isDragging ? ' queue-album-card--dragging' : ''}${readOnly ? ' queue-album-card--read-only' : ''}`}
       data-drop-idx={readOnly ? undefined : trackIndices[0]}
-      onPointerDown={readOnly ? undefined : (e) => {
-        if (e.button !== 0) return
-        e.preventDefault()
-        onPointerDown!(trackIndices, e.clientX, e.clientY)
-      }}
+      onPointerDown={
+        readOnly
+          ? undefined
+          : (e) => {
+              if (e.button !== 0) return
+              e.preventDefault()
+              onPointerDown!(trackIndices, e.clientX, e.clientY)
+            }
+      }
       onContextMenu={readOnly ? undefined : onContextMenu}
       onDragOver={readOnly ? undefined : onDragOver}
       onDragLeave={readOnly ? undefined : onDragLeave}

--- a/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
@@ -8,8 +8,9 @@ interface QueueAlbumCardProps {
   tracks: Track[]
   trackIndices: number[]
   isDragging: boolean
-  onPointerDown: (trackIndices: number[], startX: number, startY: number) => void
-  onContextMenu: (e: React.MouseEvent) => void
+  readOnly?: boolean
+  onPointerDown?: (trackIndices: number[], startX: number, startY: number) => void
+  onContextMenu?: (e: React.MouseEvent) => void
   // HTML5 drop handlers so external drags (library album/track/files) can target the card,
   // mirroring the track-row drop wiring. The card is drop-target only — it never sets draggable.
   onDragOver?: React.DragEventHandler<HTMLLIElement>
@@ -23,6 +24,7 @@ export function QueueAlbumCard({
   tracks,
   trackIndices,
   isDragging,
+  readOnly,
   onPointerDown,
   onContextMenu,
   onDragOver,
@@ -36,17 +38,17 @@ export function QueueAlbumCard({
 
   return (
     <li
-      className={`queue-album-card${isDragging ? ' queue-album-card--dragging' : ''}`}
-      data-drop-idx={trackIndices[0]}
-      onPointerDown={(e) => {
+      className={`queue-album-card${isDragging ? ' queue-album-card--dragging' : ''}${readOnly ? ' queue-album-card--read-only' : ''}`}
+      data-drop-idx={readOnly ? undefined : trackIndices[0]}
+      onPointerDown={readOnly ? undefined : (e) => {
         if (e.button !== 0) return
         e.preventDefault()
-        onPointerDown(trackIndices, e.clientX, e.clientY)
+        onPointerDown!(trackIndices, e.clientX, e.clientY)
       }}
-      onContextMenu={onContextMenu}
-      onDragOver={onDragOver}
-      onDragLeave={onDragLeave}
-      onDrop={onDrop}
+      onContextMenu={readOnly ? undefined : onContextMenu}
+      onDragOver={readOnly ? undefined : onDragOver}
+      onDragLeave={readOnly ? undefined : onDragLeave}
+      onDrop={readOnly ? undefined : onDrop}
     >
       <div className="queue-album-card-art">
         {!artError && (

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -204,6 +204,36 @@ export function QueuePanel(): React.JSX.Element {
     return result
   }, [albumGroupingActive, tracks, position])
 
+  // Straddle group for the Now Playing album card: contiguous run of tracks around
+  // `position` that share the same album key. Used only in album view.
+  const nowPlayingAlbumCard = useMemo(():
+    | { albumArtist: string; album: string; tracks: Track[]; trackIndices: number[] }
+    | null => {
+    if (!albumGroupingActive || position < 0) return null
+    const nowPlayingTrack = tracks[position]
+    if (!nowPlayingTrack) return null
+    const key = `${nowPlayingTrack.album_artist}\0${nowPlayingTrack.album}`
+
+    let start = position
+    while (start > 0 && `${tracks[start - 1].album_artist}\0${tracks[start - 1].album}` === key) {
+      start--
+    }
+    let end = position
+    while (
+      end + 1 < tracks.length &&
+      `${tracks[end + 1].album_artist}\0${tracks[end + 1].album}` === key
+    ) {
+      end++
+    }
+
+    return {
+      albumArtist: nowPlayingTrack.album_artist,
+      album: nowPlayingTrack.album,
+      tracks: tracks.slice(start, end + 1),
+      trackIndices: Array.from({ length: end - start + 1 }, (_, i) => start + i)
+    }
+  }, [albumGroupingActive, tracks, position])
+
   function clearAlbumDropIndicators(): void {
     const el = activeDropIndicatorRef.current
     if (el) {
@@ -791,6 +821,17 @@ export function QueuePanel(): React.JSX.Element {
               <span>NOW PLAYING</span>
             </div>
             <ol ref={nowPlayingListRef} className="queue-now-playing-list">
+              {albumGroupingActive && nowPlayingAlbumCard && (
+                <QueueAlbumCard
+                  key={`now-playing-album:${nowPlayingAlbumCard.albumArtist}\0${nowPlayingAlbumCard.album}`}
+                  albumArtist={nowPlayingAlbumCard.albumArtist}
+                  album={nowPlayingAlbumCard.album}
+                  tracks={nowPlayingAlbumCard.tracks}
+                  trackIndices={nowPlayingAlbumCard.trackIndices}
+                  isDragging={false}
+                  readOnly
+                />
+              )}
               {renderTrackRow(tracks[position], position)}
             </ol>
           </div>

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -206,9 +206,12 @@ export function QueuePanel(): React.JSX.Element {
 
   // Straddle group for the Now Playing album card: contiguous run of tracks around
   // `position` that share the same album key. Used only in album view.
-  const nowPlayingAlbumCard = useMemo(():
-    | { albumArtist: string; album: string; tracks: Track[]; trackIndices: number[] }
-    | null => {
+  const nowPlayingAlbumCard = useMemo((): {
+    albumArtist: string
+    album: string
+    tracks: Track[]
+    trackIndices: number[]
+  } | null => {
     if (!albumGroupingActive || position < 0) return null
     const nowPlayingTrack = tracks[position]
     if (!nowPlayingTrack) return null


### PR DESCRIPTION
## Summary

- When album grouping is active, a read-only `QueueAlbumCard` appears above the current track row in the Now Playing section
- The card covers the full contiguous straddle run (tracks before, at, and after `position` that share the same album key), providing accurate art and track count
- `QueueAlbumCard` gains a `readOnly` prop that suppresses `onPointerDown`, `onContextMenu`, and all HTML5 drag handlers; adds a `--read-only` CSS modifier that removes the hover highlight and sets `cursor: default`

## Test plan

- [ ] Enable album view; verify the now-playing album card appears above the current track row in the Now Playing section
- [ ] Confirm card shows correct art, album name, artist, and track count
- [ ] Hover — no highlight or grab cursor
- [ ] Attempt drag — card is not draggable
- [ ] Right-click — no context menu
- [ ] Advance track within the same album — card stays, count updates correctly
- [ ] Advance to a different album — card updates to the new album
- [ ] Toggle album view off — card disappears, track row remains
- [ ] Verify Next Up section is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)