### PR TITLE
feat(queue): album card double-click, straddle track drag, toggle relocation (KAMP-498)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -40,6 +40,12 @@
   flex-shrink: 0;
 }
 
+.queue-panel-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .queue-panel-label {
   font-size: 11px;
   font-weight: 600;

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -78,6 +78,7 @@ export function QueuePanel(): React.JSX.Element {
   const nowPlayingListRef = useRef<HTMLOListElement>(null)
   // Tracks the currently highlighted drop-indicator element to avoid a DOM query on clear.
   const activeDropIndicatorRef = useRef<HTMLElement | null>(null)
+  const lastAlbumTapRef = useRef<{ idx: number; time: number } | null>(null)
 
   // Stabilise via useMemo so the ?? [] fallback never produces a new array reference
   // on renders where queue is null, which would otherwise invalidate nextUpItems every render.
@@ -334,6 +335,15 @@ export function QueuePanel(): React.JSX.Element {
         if (dropIdx !== null) {
           void reorderQueue(computeNewOrder(tracks.length, trackIndices, dropIdx))
         }
+      } else {
+        const now = Date.now()
+        const last = lastAlbumTapRef.current
+        if (last && now - last.time < 300 && last.idx === trackIndices[0]) {
+          lastAlbumTapRef.current = null
+          void skipToQueueTrack(trackIndices[0])
+        } else {
+          lastAlbumTapRef.current = { idx: trackIndices[0], time: now }
+        }
       }
     }
 
@@ -398,8 +408,6 @@ export function QueuePanel(): React.JSX.Element {
 
   function handleRowMouseDown(e: React.MouseEvent, idx: number): void {
     if (e.button !== 0) return
-    // While grouping mode is active, individual track rows are non-interactive.
-    if (albumGroupingActive) return
     if (e.shiftKey && anchorIdx !== null) {
       const lo = Math.min(anchorIdx, idx)
       const hi = Math.max(anchorIdx, idx)
@@ -573,7 +581,7 @@ export function QueuePanel(): React.JSX.Element {
         ]
           .filter(Boolean)
           .join(' ')}
-        draggable={!isCurrent && !albumGroupingActive}
+        draggable={!isCurrent}
         onMouseDown={(e) => handleRowMouseDown(e, idx)}
         onMouseUp={() => handleRowMouseUp(idx)}
         onDragStart={(e) => {

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -747,7 +747,17 @@ export function QueuePanel(): React.JSX.Element {
         onDoubleClick={handleResizeDoubleClick}
       />
       <div className="queue-panel-header">
-        <span className="queue-panel-label">QUEUE</span>
+        <div className="queue-panel-header-left">
+          <span className="queue-panel-label">QUEUE</span>
+          <button
+            className={`queue-album-toggle${albumGroupingActive ? ' queue-album-toggle--active' : ''}`}
+            onClick={toggleAlbumGrouping}
+            {...tooltip(TOOLTIPS.QUEUE_ALBUM_VIEW)}
+            aria-pressed={albumGroupingActive}
+          >
+            <GoToAlbumIcon size={14} />
+          </button>
+        </div>
         <button
           className="queue-close-btn"
           onClick={toggleQueuePanel}
@@ -857,15 +867,7 @@ export function QueuePanel(): React.JSX.Element {
                 e.preventDefault()
               }}
             >
-              <span>NEXT UP{albumGroupingActive ? ' — ALBUM VIEW' : ''}</span>
-              <button
-                className={`queue-album-toggle${albumGroupingActive ? ' queue-album-toggle--active' : ''}`}
-                onClick={toggleAlbumGrouping}
-                {...tooltip(TOOLTIPS.QUEUE_ALBUM_VIEW)}
-                aria-pressed={albumGroupingActive}
-              >
-                <GoToAlbumIcon size={14} />
-              </button>
+              <span>NEXT UP</span>
             </div>
             <ol
               ref={listRef}


### PR DESCRIPTION
## Summary

- Double-clicking a `QueueAlbumCard` in the Next Up rail now calls `skipToQueueTrack(trackIndices[0])`, advancing playback to the first track of that album. Because `onPointerDown` calls `e.preventDefault()` (which suppresses native `dblclick`), detection is implemented via a `lastAlbumTapRef` timestamp ref inside `handleAlbumCardPointerDown` — two non-drag taps on the same card within 300 ms triggers the skip.
- Straddle track rows in album view are now fully interactive: the `!albumGroupingActive` gate on `draggable` and the early-return guard in `handleRowMouseDown` are removed, enabling drag-reordering and selection (single, shift, cmd-click) for tracks that span album boundaries.
- Album view toggle button moved from the NEXT UP section header to the main queue panel header (right of the QUEUE label); the "— ALBUM VIEW" suffix on the NEXT UP label is removed.

## Test plan

- [ ] Double-click an album card in Next Up → queue jumps to that album's first track
- [ ] Single click on album card → no accidental skip
- [ ] Drag a straddle track to a new position → queue reorders correctly
- [ ] Single / shift / cmd-click straddle tracks → selection highlights as in flat view
- [ ] Drag a complete album card → still works alongside straddle track drag
- [ ] Toggle album view off → flat-view double-click on individual track still works
- [ ] Album toggle button appears in the queue header next to QUEUE label; active state (accent color) still shows when album view is on
- [ ] Now-playing album card (read-only) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)