### PR TITLE
feat(queue): album-aware shuffle in album view (KAMP-499)

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -231,7 +231,7 @@ class PlaybackQueue:
         # Clamp _pos in case it pointed past the new end.
         self._pos = min(self._pos, len(self._order) - 1)
 
-    def set_shuffle(self, shuffle: bool) -> None:
+    def set_shuffle(self, shuffle: bool, album_mode: bool = False) -> None:
         if shuffle == self._shuffle:
             return
         self._shuffle = shuffle
@@ -239,7 +239,10 @@ class PlaybackQueue:
             return
         current_track_idx = self._order[self._pos] if self._pos >= 0 else -1
         if shuffle:
-            self._shuffled_order(current_track_idx)
+            if album_mode:
+                self._album_shuffled_order(current_track_idx)
+            else:
+                self._shuffled_order(current_track_idx)
             self._pos = 0
         else:
             # Restore original order; keep current track as reference point
@@ -481,6 +484,56 @@ class PlaybackQueue:
             remaining.remove(pick)
             prev_artist = self._tracks[pick].artist
             prev_album = self._tracks[pick].album
+
+        self._order = result
+
+    def _album_shuffled_order(self, anchor_idx: int) -> None:
+        """Shuffle _order keeping album runs intact; maximises album_artist diversity.
+
+        Groups self._tracks into contiguous (album_artist, album) runs. The run
+        containing anchor_idx is placed first with anchor at position 0, followed
+        by the rest of that album. The remaining runs (plus any pre-anchor tracks
+        of the anchor's album, treated as their own run) are then shuffled using
+        the same greedy artist-diversity heuristic as _shuffled_order.
+        """
+        # Build contiguous (album_artist, album) runs over all tracks
+        runs: list[list[int]] = []
+        for i in range(len(self._tracks)):
+            key = (self._tracks[i].album_artist, self._tracks[i].album)
+            if runs:
+                last = runs[-1][-1]
+                if (self._tracks[last].album_artist, self._tracks[last].album) == key:
+                    runs[-1].append(i)
+                    continue
+            runs.append([i])
+
+        if anchor_idx < 0:
+            random.shuffle(runs)
+            self._order = [idx for run in runs for idx in run]
+            return
+
+        # Separate the anchor's run; split it at the anchor position
+        anchor_run_pos = next(r for r, run in enumerate(runs) if anchor_idx in run)
+        anchor_run = runs.pop(anchor_run_pos)
+        split = anchor_run.index(anchor_idx)
+        pre_anchor = anchor_run[:split]
+        post_anchor = anchor_run[split + 1 :]
+
+        # Anchor first, then remaining tracks of its album; pre-anchor portion
+        # is shuffled in with other albums as its own run.
+        result: list[int] = [anchor_idx] + post_anchor
+        if pre_anchor:
+            runs.append(pre_anchor)
+
+        prev_artist: str | None = self._tracks[anchor_idx].album_artist
+        while runs:
+            preferred = [
+                r for r in runs if self._tracks[r[0]].album_artist != prev_artist
+            ]
+            pick = random.choice(preferred if preferred else runs)
+            result.extend(pick)
+            prev_artist = self._tracks[pick[0]].album_artist
+            runs.remove(pick)
 
         self._order = result
 

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -239,11 +239,13 @@ class PlaybackQueue:
             return
         current_track_idx = self._order[self._pos] if self._pos >= 0 else -1
         if shuffle:
-            if album_mode:
+            if album_mode and current_track_idx >= 0:
+                # _album_shuffled_order preserves _pos — the straddled album
+                # stays in place and only complete Next Up albums are shuffled.
                 self._album_shuffled_order(current_track_idx)
             else:
                 self._shuffled_order(current_track_idx)
-            self._pos = 0
+                self._pos = 0
         else:
             # Restore original order; keep current track as reference point
             self._order = list(range(len(self._tracks)))
@@ -488,54 +490,67 @@ class PlaybackQueue:
         self._order = result
 
     def _album_shuffled_order(self, anchor_idx: int) -> None:
-        """Shuffle _order keeping album runs intact; maximises album_artist diversity.
+        """Shuffle Next Up albums as units; exempt the straddled album.
 
-        Groups self._tracks into contiguous (album_artist, album) runs. The run
-        containing anchor_idx is placed first with anchor at position 0, followed
-        by the rest of that album. The remaining runs (plus any pre-anchor tracks
-        of the anchor's album, treated as their own run) are then shuffled using
-        the same greedy artist-diversity heuristic as _shuffled_order.
+        Splits _order at _pos into history (unchanged) and future (anchor
+        onwards). The anchor's album is exempted from shuffling — its tracks
+        stay at the front of the future slice in their current order. All
+        other complete albums in the future slice are shuffled with the same
+        greedy album_artist-diversity heuristic as _shuffled_order. _pos is
+        not modified; the anchor remains the now-playing track after the call.
         """
-        # Build contiguous (album_artist, album) runs over all tracks
-        runs: list[list[int]] = []
-        for i in range(len(self._tracks)):
-            key = (self._tracks[i].album_artist, self._tracks[i].album)
-            if runs:
-                last = runs[-1][-1]
-                if (self._tracks[last].album_artist, self._tracks[last].album) == key:
-                    runs[-1].append(i)
+        anchor_album_key = (
+            self._tracks[anchor_idx].album_artist,
+            self._tracks[anchor_idx].album,
+        )
+
+        # Keep history (before _pos) exactly as-is; only reshuffle the future.
+        history_order = self._order[: self._pos]
+        future_order = self._order[self._pos :]  # future_order[0] == anchor_idx
+
+        # Exempt the straddled album: its tracks in the future slice stay in place.
+        straddle_future = [
+            idx
+            for idx in future_order
+            if (self._tracks[idx].album_artist, self._tracks[idx].album)
+            == anchor_album_key
+        ]
+        other_future = [
+            idx
+            for idx in future_order
+            if (self._tracks[idx].album_artist, self._tracks[idx].album)
+            != anchor_album_key
+        ]
+
+        # Group other_future into contiguous album runs (preserving adjacency
+        # from the current order, not from _tracks load order).
+        other_runs: list[list[int]] = []
+        for idx in other_future:
+            key = (self._tracks[idx].album_artist, self._tracks[idx].album)
+            if other_runs:
+                last_run_last = other_runs[-1][-1]
+                if (
+                    self._tracks[last_run_last].album_artist,
+                    self._tracks[last_run_last].album,
+                ) == key:
+                    other_runs[-1].append(idx)
                     continue
-            runs.append([i])
+            other_runs.append([idx])
 
-        if anchor_idx < 0:
-            random.shuffle(runs)
-            self._order = [idx for run in runs for idx in run]
-            return
-
-        # Separate the anchor's run; split it at the anchor position
-        anchor_run_pos = next(r for r, run in enumerate(runs) if anchor_idx in run)
-        anchor_run = runs.pop(anchor_run_pos)
-        split = anchor_run.index(anchor_idx)
-        pre_anchor = anchor_run[:split]
-        post_anchor = anchor_run[split + 1 :]
-
-        # Anchor first, then remaining tracks of its album; pre-anchor portion
-        # is shuffled in with other albums as its own run.
-        result: list[int] = [anchor_idx] + post_anchor
-        if pre_anchor:
-            runs.append(pre_anchor)
-
+        # Shuffle other_runs with album_artist diversity.
         prev_artist: str | None = self._tracks[anchor_idx].album_artist
-        while runs:
+        shuffled: list[int] = []
+        while other_runs:
             preferred = [
-                r for r in runs if self._tracks[r[0]].album_artist != prev_artist
+                r for r in other_runs if self._tracks[r[0]].album_artist != prev_artist
             ]
-            pick = random.choice(preferred if preferred else runs)
-            result.extend(pick)
+            pick = random.choice(preferred if preferred else other_runs)
+            shuffled.extend(pick)
             prev_artist = self._tracks[pick[0]].album_artist
-            runs.remove(pick)
+            other_runs.remove(pick)
 
-        self._order = result
+        # _pos is preserved: anchor stays at index self._pos in the new order.
+        self._order = history_order + straddle_future + shuffled
 
 
 # ---------------------------------------------------------------------------

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -337,6 +337,7 @@ class VolumeRequest(BaseModel):
 
 class ShuffleRequest(BaseModel):
     shuffle: bool
+    album_shuffle: bool = False
 
 
 class RepeatRequest(BaseModel):
@@ -3395,7 +3396,7 @@ def create_app(
 
     @app.post("/api/v1/player/shuffle")
     def set_shuffle(req: ShuffleRequest) -> dict[str, Any]:
-        queue.set_shuffle(req.shuffle)
+        queue.set_shuffle(req.shuffle, album_mode=req.album_shuffle)
         engine.preload_next(queue.peek_next())
         return {"ok": True}
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -424,8 +424,8 @@ export const setVolume = (volume: number): Promise<unknown> =>
   post('/api/v1/player/volume', { volume })
 export const nextTrack = (): Promise<unknown> => post('/api/v1/player/next')
 export const prevTrack = (): Promise<unknown> => post('/api/v1/player/prev')
-export const setShuffle = (shuffle: boolean): Promise<unknown> =>
-  post('/api/v1/player/shuffle', { shuffle })
+export const setShuffle = (shuffle: boolean, albumShuffle = false): Promise<unknown> =>
+  post('/api/v1/player/shuffle', { shuffle, album_shuffle: albumShuffle })
 export const setRepeat = (repeat: boolean): Promise<unknown> =>
   post('/api/v1/player/repeat', { repeat })
 export const addAlbumToQueue = (

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -72,9 +72,8 @@ export function QueuePanel(): React.JSX.Element {
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(QUEUE_WIDTH_DEFAULT)
   const didDragRef = useRef(false)
-  const [albumGroupingActive, setAlbumGroupingActive] = useState(
-    () => localStorage.getItem('kamp:album-view') === 'true'
-  )
+  const albumGroupingActive = useStore((s) => s.albumGroupingActive)
+  const setAlbumGroupingActive = useStore((s) => s.setAlbumGroupingActive)
   const nowPlayingListRef = useRef<HTMLOListElement>(null)
   // Tracks the currently highlighted drop-indicator element to avoid a DOM query on clear.
   const activeDropIndicatorRef = useRef<HTMLElement | null>(null)
@@ -112,21 +111,15 @@ export function QueuePanel(): React.JSX.Element {
     setAnchorIdx(null)
   }, [tracks.length, position])
 
-  // Persist album-view state so it survives app relaunch. A single effect keyed on
-  // the state covers every toggle path — the header button, the Alt shortcut, and Escape.
-  useEffect(() => {
-    localStorage.setItem('kamp:album-view', String(albumGroupingActive))
-  }, [albumGroupingActive])
-
   // Alt → enter album-grouping mode; Escape → exit it.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Alt') setAlbumGroupingActive((prev) => !prev)
+      if (e.key === 'Alt') setAlbumGroupingActive(!albumGroupingActive)
       if (e.key === 'Escape' && albumGroupingActive) setAlbumGroupingActive(false)
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [albumGroupingActive])
+  }, [albumGroupingActive, setAlbumGroupingActive])
 
   // Clamp width to 33% when the window shrinks.
   useEffect(() => {
@@ -403,7 +396,7 @@ export function QueuePanel(): React.JSX.Element {
 
   // Persistence is handled by the localStorage effect keyed on albumGroupingActive.
   function toggleAlbumGrouping(): void {
-    setAlbumGroupingActive((prev) => !prev)
+    setAlbumGroupingActive(!albumGroupingActive)
   }
 
   function handleRowMouseDown(e: React.MouseEvent, idx: number): void {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -103,6 +103,7 @@ type PlayerStore = {
   artistPanelVisible: boolean
   artistPanelSnapshot: boolean | null // saved visibility before entering Now Playing
   queue: QueueState | null
+  albumGroupingActive: boolean
   downloadingAlbumIds: Set<string>
   queuedAlbumIds: Set<string>
   flashToast: string | null
@@ -200,6 +201,7 @@ type PlayerStore = {
   prev: () => Promise<void>
   seek: (position: number) => Promise<void>
   setVolume: (volume: number) => Promise<void>
+  setAlbumGroupingActive: (active: boolean) => void
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: (repeat: boolean) => Promise<void>
   addAlbumToQueue: (albumArtist: string, album: string, filePath?: string) => Promise<void>
@@ -393,6 +395,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   artistPanelVisible: localStorage.getItem('kamp:artist-panel-visible') !== 'false',
   artistPanelSnapshot: null,
   queue: null,
+  albumGroupingActive: localStorage.getItem('kamp:album-view') === 'true',
   downloadingAlbumIds: new Set<string>(),
   queuedAlbumIds: new Set<string>(),
   flashToast: null,
@@ -1004,8 +1007,13 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set((s) => ({ player: { ...s.player, volume } }))
   },
 
+  setAlbumGroupingActive: (active) => {
+    localStorage.setItem('kamp:album-view', String(active))
+    set({ albumGroupingActive: active })
+  },
+
   setShuffle: async (shuffle) => {
-    await api.setShuffle(shuffle)
+    await api.setShuffle(shuffle, get().albumGroupingActive)
     void get().loadQueue()
   },
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1212,23 +1212,55 @@ class TestAlbumShuffleOrder:
         assert ordered[1:] == [tracks[1], tracks[2], tracks[3]]
 
     def test_mid_album_anchor(self) -> None:
-        # Anchor at track 1 of AlbumA (0-indexed): tracks[2] (AlbumA idx 2) follows anchor;
-        # tracks[0] (AlbumA idx 0, pre-anchor) ends up somewhere later.
+        # Straddled album is exempt: tracks[0] stays in history, anchor and
+        # rest of its album stay in place, other albums shuffle after.
         tracks = [_track_for(i, "ArtistA", "AlbumA") for i in range(3)] + [
             _track_for(i, "ArtistB", "AlbumB") for i in range(2)
         ]
         q = PlaybackQueue()
         q.load(tracks)
-        q.next()  # advance to AlbumA track 1 (idx=1)
-        anchor = q.current()
-        assert anchor == tracks[1]
+        q.next()  # advance to AlbumA track 1, _pos = 1
+        assert q.current() == tracks[1]
         q.set_shuffle(True, album_mode=True)
-        ordered, _ = q.queue_tracks()
-        assert ordered[0] == tracks[1]  # anchor first
-        assert ordered[1] == tracks[2]  # rest of AlbumA after anchor
+        ordered, pos = q.queue_tracks()
+        # _pos is preserved
+        assert pos == 1
+        assert q.current() == tracks[1]
+        # Pre-anchor history stays at position 0
+        assert ordered[0] == tracks[0]
+        # Anchor and rest of its album stay at positions 1-2
+        assert ordered[1] == tracks[1]
+        assert ordered[2] == tracks[2]
+        # AlbumB shuffled in after
         assert len(ordered) == 5
-        # tracks[0] (pre-anchor) appears somewhere
-        assert tracks[0] in ordered
+        assert {t.album for t in ordered[3:]} == {"AlbumB"}
+
+    def test_straddled_album_exempt_pos_preserved(self) -> None:
+        # Scenario from KAMP-499: A-1..A-4 in history, A-5 now playing (pos=4),
+        # A-6..A-10 in next up. Albums B and C are complete in next up.
+        # After album shuffle, Now Playing stays at queue position 5 (index 4).
+        tracks = (
+            [_track_for(i, "ArtistA", "AlbumA") for i in range(10)]
+            + [_track_for(i, "ArtistB", "AlbumB") for i in range(3)]
+            + [_track_for(i, "ArtistC", "AlbumC") for i in range(3)]
+        )
+        q = PlaybackQueue()
+        q.load(tracks)
+        for _ in range(4):
+            q.next()  # advance to tracks[4] (A-5), _pos = 4
+        assert q.current() == tracks[4]
+        q.set_shuffle(True, album_mode=True)
+        ordered, pos = q.queue_tracks()
+        # _pos preserved — Now Playing is still at index 4
+        assert pos == 4
+        assert q.current() == tracks[4]
+        # History (A-1..A-4) unchanged at positions 0-3
+        assert ordered[:4] == tracks[:4]
+        # Straddled album continues: A-5..A-10 at positions 4-9
+        assert ordered[4:10] == tracks[4:10]
+        # Albums B and C shuffled in after
+        assert len(ordered) == 16
+        assert {t.album for t in ordered[10:]} == {"AlbumB", "AlbumC"}
 
     def test_album_mode_false_unchanged(self) -> None:
         # album_mode=False (default) must behave exactly as before: tracks shuffled individually.

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1129,6 +1129,125 @@ class TestShuffleArtistDiversity:
 
 
 # ---------------------------------------------------------------------------
+# Album shuffle
+# ---------------------------------------------------------------------------
+
+
+class TestAlbumShuffleOrder:
+    """Tests for _album_shuffled_order via set_shuffle(album_mode=True)."""
+
+    def _load_multi_album(self) -> tuple[PlaybackQueue, list]:
+        """3-track Album A, 2-track Album B, 1-track Album C — 3 artists."""
+        tracks = (
+            [_track_for(i, "ArtistA", "AlbumA") for i in range(3)]
+            + [_track_for(i, "ArtistB", "AlbumB") for i in range(2)]
+            + [_track_for(i, "ArtistC", "AlbumC") for i in range(1)]
+        )
+        q = PlaybackQueue()
+        q.load(tracks)
+        return q, tracks
+
+    def test_album_runs_kept_intact(self) -> None:
+        # All tracks of each album must appear consecutively in the shuffled order.
+        q, tracks = self._load_multi_album()
+        for _ in range(30):
+            q.set_shuffle(False)
+            q.set_shuffle(True, album_mode=True)
+            ordered, _ = q.queue_tracks()
+            seen_albums: list[str] = []
+            for t in ordered:
+                if not seen_albums or seen_albums[-1] != t.album:
+                    seen_albums.append(t.album)
+            # No album should appear more than once in the album sequence
+            assert len(seen_albums) == len(
+                set(seen_albums)
+            ), f"album run broken: {[t.album for t in ordered]}"
+
+    def test_all_tracks_appear_exactly_once(self) -> None:
+        q, tracks = self._load_multi_album()
+        q.set_shuffle(True, album_mode=True)
+        ordered, _ = q.queue_tracks()
+        assert sorted(t.title for t in ordered) == sorted(t.title for t in tracks)
+
+    def test_current_track_is_first(self) -> None:
+        q, tracks = self._load_multi_album()
+        first = q.current()
+        q.set_shuffle(True, album_mode=True)
+        assert q.current() == first
+
+    def test_artist_diversity_at_album_level(self) -> None:
+        # 2 albums by ArtistA, 2 albums by ArtistB — never need consecutive same artist.
+        tracks = (
+            [_track_for(i, "ArtistA", "AlbumA1") for i in range(2)]
+            + [_track_for(i, "ArtistB", "AlbumB1") for i in range(2)]
+            + [_track_for(i, "ArtistA", "AlbumA2") for i in range(2)]
+            + [_track_for(i, "ArtistB", "AlbumB2") for i in range(2)]
+        )
+        q = PlaybackQueue()
+        q.load(tracks)
+        for _ in range(50):
+            q.set_shuffle(False)
+            q.set_shuffle(True, album_mode=True)
+            ordered, _ = q.queue_tracks()
+            # Extract album sequence (deduplicated consecutive)
+            album_seq = []
+            for t in ordered:
+                if not album_seq or album_seq[-1] != (t.album_artist, t.album):
+                    album_seq.append((t.album_artist, t.album))
+            for (a1, _), (a2, _) in zip(album_seq, album_seq[1:]):
+                assert (
+                    a1 != a2
+                ), f"consecutive same artist albums after shuffle: {album_seq}"
+
+    def test_single_album_queue(self) -> None:
+        # One album only — should not raise; all tracks in original order after anchor.
+        tracks = [_track_for(i, "ArtistA", "AlbumA") for i in range(4)]
+        q = PlaybackQueue()
+        q.load(tracks)
+        q.set_shuffle(True, album_mode=True)
+        ordered, _ = q.queue_tracks()
+        assert len(ordered) == 4
+        assert ordered[0] == tracks[0]  # anchor first
+        # Rest of album follows anchor in original order
+        assert ordered[1:] == [tracks[1], tracks[2], tracks[3]]
+
+    def test_mid_album_anchor(self) -> None:
+        # Anchor at track 1 of AlbumA (0-indexed): tracks[2] (AlbumA idx 2) follows anchor;
+        # tracks[0] (AlbumA idx 0, pre-anchor) ends up somewhere later.
+        tracks = [_track_for(i, "ArtistA", "AlbumA") for i in range(3)] + [
+            _track_for(i, "ArtistB", "AlbumB") for i in range(2)
+        ]
+        q = PlaybackQueue()
+        q.load(tracks)
+        q.next()  # advance to AlbumA track 1 (idx=1)
+        anchor = q.current()
+        assert anchor == tracks[1]
+        q.set_shuffle(True, album_mode=True)
+        ordered, _ = q.queue_tracks()
+        assert ordered[0] == tracks[1]  # anchor first
+        assert ordered[1] == tracks[2]  # rest of AlbumA after anchor
+        assert len(ordered) == 5
+        # tracks[0] (pre-anchor) appears somewhere
+        assert tracks[0] in ordered
+
+    def test_album_mode_false_unchanged(self) -> None:
+        # album_mode=False (default) must behave exactly as before: tracks shuffled individually.
+        tracks = [_track_for(i, "ArtistA", "AlbumA") for i in range(10)]
+        q = PlaybackQueue()
+        q.load(tracks)
+        for _ in range(20):
+            q.set_shuffle(False)
+            q.set_shuffle(True, album_mode=False)
+            ordered, _ = q.queue_tracks()
+            assert len(ordered) == 10
+
+    def test_no_tracks_album_mode_no_raise(self) -> None:
+        q = PlaybackQueue()
+        q.set_shuffle(True, album_mode=True)
+        assert q.current() is None
+
+
+# ---------------------------------------------------------------------------
 # MpvPlaybackEngine
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1005,7 +1005,16 @@ class TestPlayerControlEndpoints:
     def test_set_shuffle(self, client: TestClient, mock_queue: MagicMock) -> None:
         response = client.post("/api/v1/player/shuffle", json={"shuffle": True})
         assert response.status_code == 200
-        mock_queue.set_shuffle.assert_called_once_with(True)
+        mock_queue.set_shuffle.assert_called_once_with(True, album_mode=False)
+
+    def test_set_shuffle_album_mode(
+        self, client: TestClient, mock_queue: MagicMock
+    ) -> None:
+        response = client.post(
+            "/api/v1/player/shuffle", json={"shuffle": True, "album_shuffle": True}
+        )
+        assert response.status_code == 200
+        mock_queue.set_shuffle.assert_called_once_with(True, album_mode=True)
 
     def test_set_repeat(self, client: TestClient, mock_queue: MagicMock) -> None:
         response = client.post("/api/v1/player/repeat", json={"repeat": True})


### PR DESCRIPTION
## Summary

- When shuffle is enabled while album view is active, albums shuffle as units rather than individual tracks. Track order within each album is preserved.
- The straddled album (the one spanning History and Now Playing) is exempt from shuffling — its tracks stay exactly in place. Now Playing remains at its original queue position (e.g. position 5, not position 1) after shuffle is enabled.
- Complete albums in the Next Up section are shuffled using the same greedy `album_artist`-diversity heuristic as the existing per-track shuffle.
- `albumGroupingActive` lifted from local `QueuePanel` state into the Zustand store so the shuffle action can read it without prop threading or localStorage reads.

## How it works

`PlaybackQueue._album_shuffled_order` splits `_order` at `_pos`:
- History slice (`_order[:_pos]`) is left untouched.
- The straddled album's tracks in the future slice stay in their current positions.
- All other complete albums in the future slice are shuffled into a new order.
- `_pos` is not modified — the now-playing track stays where it was.

The daemon receives `album_shuffle: bool` in `ShuffleRequest` and selects the algorithm accordingly. The UI store reads `albumGroupingActive` and forwards it with every shuffle toggle.

## Test plan

- [ ] Enable album view; shuffle on → Next Up albums reorder as whole units (track order within each album preserved)
- [ ] With a straddled album (A-1..A-4 in History, A-5 Now Playing, A-6..A-10 in Next Up): shuffle on → Now Playing stays at queue position 5, A-6..A-10 stay right after it, other albums shuffle in beyond that
- [ ] Artist diversity: multiple albums by same artist interleaved with other artists after shuffle
- [ ] Shuffle off → original order restores
- [ ] Album view off → individual-track shuffle works as before
- [ ] Single-album queue: shuffle on in album view → no error, tracks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)