### PR TITLE
fix(queue): unbind Escape from dismissing album grouping mode (KAMP-502)

### DIFF
--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -37,7 +37,6 @@ const GROUPS: Group[] = [
     label: 'Queue',
     shortcuts: [
       { keys: ['Alt'], description: 'Toggle album grouping mode' },
-      { keys: ['Esc'], description: 'Exit album grouping mode' },
       { keys: ['Shift', 'click'], description: 'Range select in Next Up' }
     ]
   },

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -111,11 +111,10 @@ export function QueuePanel(): React.JSX.Element {
     setAnchorIdx(null)
   }, [tracks.length, position])
 
-  // Alt → enter album-grouping mode; Escape → exit it.
+  // Alt → toggle album-grouping mode.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.key === 'Alt') setAlbumGroupingActive(!albumGroupingActive)
-      if (e.key === 'Escape' && albumGroupingActive) setAlbumGroupingActive(false)
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)


### PR DESCRIPTION
## Summary

- Removes the `Escape` key handler that was dismissing queue album grouping mode
- Removes the corresponding `Esc` entry from the keyboard shortcuts overlay
- `Alt` continues to toggle album grouping mode on/off

## Test plan

- [ ] Enter album grouping mode (Alt) — press Escape — mode stays active
- [ ] Open a modal, press Escape — modal still closes normally
- [ ] Open keyboard shortcuts overlay (?), Queue section — Esc no longer listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)