### PR TITLE
feat(ui): zoom shortcuts, view menu cleanup, and display scaling constraints (KAMP-516)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -574,10 +574,13 @@ function buildAppMenu(): void {
             ]
           : []),
         { role: 'resetZoom' as const, accelerator: 'CommandOrControl+0' },
+        // Custom click handler (not role) so the [-3, +3] clamp applies. The
+        // native accelerator is kept without registerAccelerator:false so macOS
+        // captures Cmd+= at the menu level, which prevents Chromium's built-in
+        // zoom shortcut from also firing and double-stepping.
         {
           label: 'Zoom In',
           accelerator: 'CommandOrControl+=',
-          registerAccelerator: false,
           click: (_, win) => {
             const bw = win as BrowserWindow | undefined
             if (bw) bw.webContents.setZoomLevel(Math.min(3, bw.webContents.getZoomLevel() + 1))
@@ -650,19 +653,16 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
-  // Zoom-out via before-input-event: 'CommandOrControl+-' doesn't parse
-  // reliably in all Electron versions (the parser can treat '-' as a
-  // separator). Physical key codes are unambiguous. Zoom in is also handled
-  // here so both directions share the same [-3, +3] clamp.
+  // Zoom-out: 'CommandOrControl+-' doesn't register reliably (Electron parser
+  // ambiguity on '-'), so intercept via physical key code instead.
+  // Zoom-in uses a native menu accelerator whose OS-level capture prevents
+  // Chromium's built-in Cmd+= from also firing — so no before-input-event
+  // handling needed (and adding it would double-step).
   mainWindow.webContents.on('before-input-event', (_event, input) => {
     if (input.type !== 'keyDown' || input.shift || input.alt) return
     const cmdOrCtrl = process.platform === 'darwin' ? input.meta : input.control
-    if (!cmdOrCtrl) return
-    const level = mainWindow.webContents.getZoomLevel()
-    if (input.code === 'Minus') {
-      mainWindow.webContents.setZoomLevel(Math.max(-3, level - 1))
-    } else if (input.code === 'Equal') {
-      mainWindow.webContents.setZoomLevel(Math.min(3, level + 1))
+    if (cmdOrCtrl && input.code === 'Minus') {
+      mainWindow.webContents.setZoomLevel(Math.max(-3, mainWindow.webContents.getZoomLevel() - 1))
     }
   })
 

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -564,15 +564,22 @@ function buildAppMenu(): void {
     {
       label: 'View',
       submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
+        // Dev tools are only useful during development — hide them in the packaged app.
+        ...(!app.isPackaged
+          ? [
+              { role: 'reload' as const },
+              { role: 'forceReload' as const },
+              { role: 'toggleDevTools' as const },
+              { type: 'separator' as const }
+            ]
+          : []),
+        // Explicit accelerators override Electron's built-ins and ensure the
+        // shortcuts fire consistently across macOS keyboard layouts.
+        { role: 'resetZoom' as const, accelerator: 'CommandOrControl+0' },
+        { role: 'zoomIn' as const, accelerator: 'CommandOrControl+=' },
+        { role: 'zoomOut' as const, accelerator: 'CommandOrControl+-' },
+        { type: 'separator' as const },
+        { role: 'togglefullscreen' as const }
       ]
     },
     {

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -577,6 +577,7 @@ function buildAppMenu(): void {
         {
           label: 'Zoom In',
           accelerator: 'CommandOrControl+=',
+          registerAccelerator: false,
           click: (_, win) => {
             const bw = win as BrowserWindow | undefined
             if (bw) bw.webContents.setZoomLevel(Math.min(3, bw.webContents.getZoomLevel() + 1))

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -574,11 +574,25 @@ function buildAppMenu(): void {
             ]
           : []),
         { role: 'resetZoom' as const, accelerator: 'CommandOrControl+0' },
-        { role: 'zoomIn' as const, accelerator: 'CommandOrControl+=' },
-        // Electron's accelerator parser treats '-' as a separator in some
-        // versions, so 'CommandOrControl+-' never registers. The shortcut is
-        // handled via before-input-event in createWindow() instead.
-        { role: 'zoomOut' as const, accelerator: 'CommandOrControl+-', registerAccelerator: false },
+        {
+          label: 'Zoom In',
+          accelerator: 'CommandOrControl+=',
+          click: (_, win) => {
+            const bw = win as BrowserWindow | undefined
+            if (bw) bw.webContents.setZoomLevel(Math.min(3, bw.webContents.getZoomLevel() + 1))
+          }
+        },
+        // Zoom-out keyboard shortcut is handled via before-input-event (see
+        // createWindow) because 'CommandOrControl+-' doesn't parse reliably.
+        {
+          label: 'Zoom Out',
+          accelerator: 'CommandOrControl+-',
+          registerAccelerator: false,
+          click: (_, win) => {
+            const bw = win as BrowserWindow | undefined
+            if (bw) bw.webContents.setZoomLevel(Math.max(-3, bw.webContents.getZoomLevel() - 1))
+          }
+        },
         { type: 'separator' as const },
         { role: 'togglefullscreen' as const }
       ]
@@ -635,14 +649,19 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
-  // Electron's accelerator parser is ambiguous when the key itself is '-'
-  // (the separator character in some parser paths). Register zoom-out via
-  // before-input-event so the physical key code is matched unambiguously.
+  // Zoom-out via before-input-event: 'CommandOrControl+-' doesn't parse
+  // reliably in all Electron versions (the parser can treat '-' as a
+  // separator). Physical key codes are unambiguous. Zoom in is also handled
+  // here so both directions share the same [-3, +3] clamp.
   mainWindow.webContents.on('before-input-event', (_event, input) => {
     if (input.type !== 'keyDown' || input.shift || input.alt) return
     const cmdOrCtrl = process.platform === 'darwin' ? input.meta : input.control
-    if (cmdOrCtrl && input.code === 'Minus') {
-      mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() - 1)
+    if (!cmdOrCtrl) return
+    const level = mainWindow.webContents.getZoomLevel()
+    if (input.code === 'Minus') {
+      mainWindow.webContents.setZoomLevel(Math.max(-3, level - 1))
+    } else if (input.code === 'Equal') {
+      mainWindow.webContents.setZoomLevel(Math.min(3, level + 1))
     }
   })
 

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -573,11 +573,12 @@ function buildAppMenu(): void {
               { type: 'separator' as const }
             ]
           : []),
-        // Explicit accelerators override Electron's built-ins and ensure the
-        // shortcuts fire consistently across macOS keyboard layouts.
         { role: 'resetZoom' as const, accelerator: 'CommandOrControl+0' },
         { role: 'zoomIn' as const, accelerator: 'CommandOrControl+=' },
-        { role: 'zoomOut' as const, accelerator: 'CommandOrControl+-' },
+        // Electron's accelerator parser treats '-' as a separator in some
+        // versions, so 'CommandOrControl+-' never registers. The shortcut is
+        // handled via before-input-event in createWindow() instead.
+        { role: 'zoomOut' as const, accelerator: 'CommandOrControl+-', registerAccelerator: false },
         { type: 'separator' as const },
         { role: 'togglefullscreen' as const }
       ]
@@ -632,6 +633,17 @@ function createWindow(): void {
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }
+  })
+
+  // Electron's accelerator parser is ambiguous when the key itself is '-'
+  // (the separator character in some parser paths). Register zoom-out via
+  // before-input-event so the physical key code is matched unambiguously.
+  mainWindow.webContents.on('before-input-event', (_event, input) => {
+    if (input.type !== 'keyDown' || input.shift || input.alt) return
+    const cmdOrCtrl = process.platform === 'darwin' ? input.meta : input.control
+    if (cmdOrCtrl && input.code === 'Minus') {
+      mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() - 1)
+    }
   })
 
   // HMR for renderer base on electron-vite cli.

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -41,6 +41,14 @@ const GROUPS: Group[] = [
     ]
   },
   {
+    label: 'View',
+    shortcuts: [
+      { keys: [mod, '+'], description: 'Zoom in' },
+      { keys: [mod, '-'], description: 'Zoom out' },
+      { keys: [mod, '0'], description: 'Actual size' }
+    ]
+  },
+  {
     label: 'Help',
     shortcuts: [
       { keys: ['?'], description: 'Show / hide keyboard shortcuts' },


### PR DESCRIPTION
## Summary

- Hide Reload, Force Reload, and Toggle Developer Tools from the View menu in packaged builds — these are dev-only and should not be visible to end users
- Add explicit keyboard shortcuts for Zoom In (`Cmd/Ctrl+=`), Zoom Out (`Cmd/Ctrl+-`), and Actual Size (`Cmd/Ctrl+0`) that work reliably on macOS and Windows
- Clamp zoom level to `[-3, +3]` (≈58%–173%) so the UI stays readable
- Document zoom shortcuts in the keyboard shortcuts overlay (`?`)

## Implementation notes

`Cmd+-` (zoom out) never registered reliably — Electron's accelerator parser treats `-` ambiguously when `+` is the separator. Fixed via `before-input-event` on the webContents, matching the physical `Minus` key code instead.

`Cmd+=` (zoom in) uses a native menu accelerator with a custom click handler (no `registerAccelerator: false`). macOS captures the shortcut at the menu level, which suppresses Chromium's built-in zoom shortcut from also firing — the only safe way to avoid double-stepping while still enforcing the clamp.

## Test plan

- [ ] Dev mode: View menu shows Reload, Force Reload, Toggle Developer Tools
- [ ] Packaged build: View menu shows only Actual Size, Zoom In, Zoom Out, Toggle Full Screen
- [ ] `Cmd+-` zooms out one step; stops at level −3
- [ ] `Cmd+=` zooms in one step; stops at level +3
- [ ] `Cmd+0` resets to actual size
- [ ] Clicking Zoom In / Zoom Out in the View menu works and respects the clamp
- [ ] Keyboard shortcuts overlay (`?`) shows a View group with Cmd +, -, 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)