### PR TITLE
fix(ui): widen album lookup predicate to match display_album after rename (KAMP-503)

### DIFF
--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -27,7 +27,10 @@ export function NowPlayingView(): React.JSX.Element {
 
   const currentAlbum = current_track
     ? albums.find(
-        (a) => a.album === current_track.album && a.album_artist === current_track.album_artist
+        (a) =>
+          (a.album === current_track.album || a.display_album === current_track.album) &&
+          (a.album_artist === current_track.album_artist ||
+            a.display_album_artist === current_track.album_artist)
       )
     : undefined
 
@@ -44,8 +47,8 @@ export function NowPlayingView(): React.JSX.Element {
         <span className="now-playing-art-placeholder">♪</span>
         <img
           src={artUrl(
-            current_track.album_artist,
-            current_track.album,
+            currentAlbum?.album_artist ?? current_track.album_artist,
+            currentAlbum?.album ?? current_track.album,
             current_track.album ? '' : current_track.file_path
           )}
           onLoad={() => setArtLoaded(true)}

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -139,7 +139,10 @@ export function QueueContextMenu({
                 className="track-context-menu-item"
                 onClick={() => {
                   const found = albums.find(
-                    (a) => a.album_artist === track.album_artist && a.album === track.album
+                    (a) =>
+                      (a.album === track.album || a.display_album === track.album) &&
+                      (a.album_artist === track.album_artist ||
+                        a.display_album_artist === track.album_artist)
                   ) ?? {
                     album_artist: track.album_artist,
                     album: track.album,

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -41,7 +41,10 @@ export function TransportBar(): React.JSX.Element {
 
   const currentAlbum = current_track
     ? albums.find(
-        (a) => a.album === current_track.album && a.album_artist === current_track.album_artist
+        (a) =>
+          (a.album === current_track.album || a.display_album === current_track.album) &&
+          (a.album_artist === current_track.album_artist ||
+            a.display_album_artist === current_track.album_artist)
       )
     : undefined
 


### PR DESCRIPTION
## Summary

- After renaming a streaming album's display title, `Track.album` carries the display name while `Album.album` stays canonical — causing `albums.find()` to return `undefined` in three components
- Widened the predicate in `NowPlayingView`, `TransportBar`, and `QueueContextMenu` to match on either `album` or `display_album` (and likewise for `album_artist`)
- `NowPlayingView` now also passes the canonical album name to `artUrl()` so art resolves correctly against the server endpoint

## Test plan

- [ ] Edit a streaming album display title (e.g. "The Ecstatic (Deluxe)" → "The Ecstatic")
- [ ] Queue the album; right-click a queue item → "Go to album" → should navigate to the correct album page (not blank)
- [ ] Play the album; open Now Playing view → album art should appear (not placeholder)
- [ ] Verify transport bar "go to album" button also navigates correctly
- [ ] Verify the same flows still work for an album with no display override (canonical name unchanged)
- [ ] Verify a local (non-streaming) album is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)