### PR TITLE
feat(ui): hover-to-favorite button on track rows (KAMP-509)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -155,6 +155,27 @@
   color: var(--accent);
 }
 
+.queue-track-fav-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.queue-track-row:hover .queue-track-fav-btn,
+.queue-track-fav-btn.active {
+  opacity: 1;
+}
+
+.queue-panel--resizing .queue-track-row:hover .queue-track-fav-btn {
+  opacity: 0;
+}
+
 .queue-track-num {
   grid-row: 1 / 3;
   align-self: center;

--- a/kamp_ui/src/renderer/src/assets/search.css
+++ b/kamp_ui/src/renderer/src/assets/search.css
@@ -142,6 +142,23 @@
   color: var(--accent);
 }
 
+.search-track-fav-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.search-track-row:hover .search-track-fav-btn,
+.search-track-fav-btn.active {
+  opacity: 1;
+}
+
 .search-track-title {
   font-size: 13px;
   white-space: nowrap;

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -713,6 +713,23 @@
   color: var(--accent);
 }
 
+.track-row-fav-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.track-row:hover .track-row-fav-btn,
+.track-row-fav-btn.active {
+  opacity: 1;
+}
+
 .track-row-num {
   display: flex;
   align-items: center;

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -147,6 +147,7 @@ export function PlaylistView(): React.JSX.Element | null {
   const reorderPlaylistTracks = useStore((s) => s.reorderPlaylistTracks)
   const removeTrackFromPlaylist = useStore((s) => s.removeTrackFromPlaylist)
   const setPlaylistFavorite = useStore((s) => s.setPlaylistFavorite)
+  const setFavorite = useStore((s) => s.setFavorite)
   const renamePlaylist = useStore((s) => s.renamePlaylist)
   const currentTrack = useStore((s) => s.player.current_track)
   const playing = useStore((s) => s.player.playing)
@@ -829,7 +830,17 @@ export function PlaylistView(): React.JSX.Element | null {
                   }}
                 >
                   <span className="track-row-fav">
-                    {track.favorite && <FavoriteIcon active size={10} />}
+                    <button
+                      className={`track-row-fav-btn${track.favorite ? ' active' : ''}`}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        void setFavorite(track, !track.favorite)
+                      }}
+                      aria-label={track.favorite ? 'Remove from favorites' : 'Add to favorites'}
+                      aria-pressed={track.favorite}
+                    >
+                      <FavoriteIcon active={track.favorite} size={10} />
+                    </button>
                   </span>
                   <span className="track-row-num">{i + 1}</span>
                   <span className="track-row-title-cell">

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -46,6 +46,7 @@ export function QueuePanel(): React.JSX.Element {
   const insertIntoQueue = useStore((s) => s.insertIntoQueue)
   const insertAlbumAt = useStore((s) => s.insertAlbumAt)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
+  const setFavorite = useStore((s) => s.setFavorite)
   const insertArtistAt = useStore((s) => s.insertArtistAt)
   const loadPlaylistTracks = useStore((s) => s.loadPlaylistTracks)
   const configValues = useStore((s) => s.configValues)
@@ -651,7 +652,17 @@ export function QueuePanel(): React.JSX.Element {
         }}
       >
         <span className="queue-track-fav">
-          {track.favorite && <FavoriteIcon active size={10} />}
+          <button
+            className={`queue-track-fav-btn${track.favorite ? ' active' : ''}`}
+            onClick={(e) => {
+              e.stopPropagation()
+              void setFavorite(track, !track.favorite)
+            }}
+            aria-label={track.favorite ? 'Remove from favorites' : 'Add to favorites'}
+            aria-pressed={track.favorite}
+          >
+            <FavoriteIcon active={track.favorite} size={10} />
+          </button>
         </span>
         <span className="queue-track-num">{idx + 1}</span>
         <span className="queue-track-title">

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -20,6 +20,7 @@ function SearchTrackRow({
 }): React.JSX.Element {
   const playTrack = useStore((s) => s.playTrack)
   const setSearchQuery = useStore((s) => s.setSearchQuery)
+  const setFavorite = useStore((s) => s.setFavorite)
 
   const handleClick = (): void => {
     // Pass file_path for tracks with no album so the server can look them up
@@ -47,7 +48,17 @@ function SearchTrackRow({
       }}
     >
       <span className="search-track-fav">
-        {track.favorite && <FavoriteIcon active size={10} />}
+        <button
+          className={`search-track-fav-btn${track.favorite ? ' active' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation()
+            void setFavorite(track, !track.favorite)
+          }}
+          aria-label={track.favorite ? 'Remove from favorites' : 'Add to favorites'}
+          aria-pressed={track.favorite}
+        >
+          <FavoriteIcon active={track.favorite} size={10} />
+        </button>
       </span>
       <span className="search-track-title">{track.title}</span>
       <span className="search-track-meta">

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -92,6 +92,7 @@ export function TrackList(): React.JSX.Element | null {
   const playTrack = useStore((s) => s.playTrack)
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const setAlbumFavorite = useStore((s) => s.setAlbumFavorite)
+  const setFavorite = useStore((s) => s.setFavorite)
   const addAlbumToQueue = useStore((s) => s.addAlbumToQueue)
   const playAlbumNext = useStore((s) => s.playAlbumNext)
 
@@ -747,7 +748,17 @@ export function TrackList(): React.JSX.Element | null {
                 }}
               >
                 <span className="track-row-fav">
-                  {track.favorite && <FavoriteIcon active size={10} />}
+                  <button
+                    className={`track-row-fav-btn${track.favorite ? ' active' : ''}`}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      void setFavorite(track, !track.favorite)
+                    }}
+                    aria-label={track.favorite ? 'Remove from favorites' : 'Add to favorites'}
+                    aria-pressed={track.favorite}
+                  >
+                    <FavoriteIcon active={track.favorite} size={10} />
+                  </button>
                 </span>
                 <span className="track-row-num">
                   {isRemoteTrack && !isCurrent && (


### PR DESCRIPTION
## Summary

- Replaces the conditional solid-heart icon in track rows with an always-rendered `<button>` wrapping `<FavoriteIcon active={track.favorite} />`
- Button is hidden by default (`opacity: 0`) and revealed on row hover; favorited tracks keep it visible via an `.active` class
- Clicking calls `setFavorite(track, !track.favorite)` with `stopPropagation()` to avoid triggering play
- Applied across all four track list surfaces: album track list, playlist view, search results, and queue panel

## Test plan

- [ ] Album track list: hover unfavorited track — hollow heart appears; click it — becomes solid
- [ ] Album track list: hover favorited track — solid heart always visible; click to un-favorite
- [ ] Playlist view: same two cases
- [ ] Search results: same two cases; double-click on row still plays track
- [ ] Queue panel: same two cases; heart hidden during panel resize (resizing guard)
- [ ] Context menu favorite/unfavorite still works alongside the new button

🤖 Generated with [Claude Code](https://claude.com/claude-code)