### PR TITLE
feat(library): sort by release date (KAMP-512)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -415,6 +415,9 @@ _SORT_CLAUSES: dict[str, str] = {
     "date_added": "sort_date_added {dir}, album_artist COLLATE NOCASE",
     "last_played": "sort_last_played {dir}, album_artist COLLATE NOCASE",
     "most_played": "sort_play_count_avg {dir}, album_artist COLLATE NOCASE",
+    # sort_release_date is NULLIF(year,'') aliased in the UNION ALL branches so
+    # empty strings sort last regardless of direction (NULLS LAST convention).
+    "release_date": "sort_release_date {dir} NULLS LAST, album_artist COLLATE NOCASE",
 }
 
 # Natural default direction per sort key — used when sort_dir is not provided.
@@ -426,6 +429,7 @@ _DEFAULT_SORT_DIR: dict[str, str] = {
     "date_added": "DESC",
     "last_played": "DESC",
     "most_played": "DESC",
+    "release_date": "DESC",
 }
 
 
@@ -3049,6 +3053,7 @@ class LibraryIndex:
                 a.date_added        AS sort_date_added,
                 a.last_played_at    AS sort_last_played,
                 a.play_count_avg    AS sort_play_count_avg,
+                NULLIF(a.year, '')  AS sort_release_date,
                 a.art_version,
                 -- has_art: remote-only albums always have CDN art; others use embedded_art.
                 CASE WHEN a.source = 'bandcamp' THEN 1 ELSE a.embedded_art END AS has_art,
@@ -3090,6 +3095,7 @@ class LibraryIndex:
                 t.date_added        AS sort_date_added,
                 t.last_played       AS sort_last_played,
                 CAST(t.play_count AS REAL) AS sort_play_count_avg,
+                NULLIF(t.year, '')  AS sort_release_date,
                 t.file_mtime        AS art_version,
                 t.embedded_art      AS has_art,
                 1                   AS missing_album,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2707,7 +2707,7 @@ def create_app(
         return {"ok": True}
 
     _VALID_SORT_ORDERS = frozenset(
-        {"album_artist", "album", "date_added", "last_played"}
+        {"album_artist", "album", "date_added", "last_played", "release_date"}
     )
 
     @app.post("/api/v1/ui/sort-order")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -324,7 +324,13 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
 
 export type UiState = {
   active_view: 'library' | 'now-playing' | 'home'
-  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date'
+  sort_order:
+    | 'album_artist'
+    | 'album'
+    | 'date_added'
+    | 'last_played'
+    | 'most_played'
+    | 'release_date'
   sort_dir: 'asc' | 'desc'
   queue_panel_open: boolean
 }
@@ -334,7 +340,13 @@ export const setActiveViewApi = (
   view: 'library' | 'now-playing' | 'home'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date',
+  sortOrder:
+    | 'album_artist'
+    | 'album'
+    | 'date_added'
+    | 'last_played'
+    | 'most_played'
+    | 'release_date',
   sortDir: 'asc' | 'desc'
 ): Promise<{ ok: boolean }> =>
   post('/api/v1/ui/sort-order', { sort_order: sortOrder, sort_dir: sortDir })

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -324,7 +324,7 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
 
 export type UiState = {
   active_view: 'library' | 'now-playing' | 'home'
-  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+  sort_order: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date'
   sort_dir: 'asc' | 'desc'
   queue_panel_open: boolean
 }
@@ -334,7 +334,7 @@ export const setActiveViewApi = (
   view: 'library' | 'now-playing' | 'home'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played',
+  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date',
   sortDir: 'asc' | 'desc'
 ): Promise<{ ok: boolean }> =>
   post('/api/v1/ui/sort-order', { sort_order: sortOrder, sort_dir: sortDir })

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -14,7 +14,8 @@ const ALBUM_SORT_OPTIONS = [
   { key: 'album', label: 'Album' },
   { key: 'date_added', label: 'Date Added' },
   { key: 'last_played', label: 'Last Played' },
-  { key: 'most_played', label: 'Most Played' }
+  { key: 'most_played', label: 'Most Played' },
+  { key: 'release_date', label: 'Release Date' }
 ]
 
 export function AlbumGrid(): React.JSX.Element {

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -34,7 +34,8 @@ const TRACK_SORT_OPTIONS = [
   { key: 'duration', label: 'Duration' },
   { key: 'last_played', label: 'Last Played' },
   { key: 'most_played', label: 'Most Played' },
-  { key: 'date_added', label: 'Date Added' }
+  { key: 'date_added', label: 'Date Added' },
+  { key: 'release_date', label: 'Release Date' }
 ]
 
 type TrackSortOrder =
@@ -46,6 +47,7 @@ type TrackSortOrder =
   | 'last_played'
   | 'most_played'
   | 'date_added'
+  | 'release_date'
 
 function sortKey(playlistId: number): string {
   return `kamp:playlist:${playlistId}:sort`
@@ -116,6 +118,16 @@ function applySortToTracks(
         if (aD === null) return 1
         if (bD === null) return -1
         cmp = aD - bD
+        break
+      }
+      case 'release_date': {
+        // Tracks with no year always sort last regardless of direction.
+        const aY = a.year || null
+        const bY = b.year || null
+        if (aY === null && bY === null) return 0
+        if (aY === null) return 1
+        if (bY === null) return -1
+        cmp = parseInt(aY, 10) - parseInt(bY, 10)
         break
       }
     }

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -73,7 +73,8 @@ const SEARCH_SORT_OPTIONS = [
   { key: 'album', label: 'Album' },
   { key: 'date_added', label: 'Date Added' },
   { key: 'last_played', label: 'Last Played' },
-  { key: 'most_played', label: 'Most Played' }
+  { key: 'most_played', label: 'Most Played' },
+  { key: 'release_date', label: 'Release Date' }
 ]
 
 export function SearchView(): React.JSX.Element {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -96,7 +96,7 @@ type PlayerStore = {
   albumEditMode: boolean
   albumMetaExpanded: boolean
   albumRenameProgress: { done: number; total: number } | null
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date'
   sortDir: 'asc' | 'desc'
   libraryFilter: string[]
   searchQuery: string
@@ -120,7 +120,7 @@ type PlayerStore = {
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (
-    sort: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played'
+    sort: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date'
   ) => Promise<void>
   setSortDir: (dir: 'asc' | 'desc') => Promise<void>
   setLibraryFilter: (filters: string[]) => void
@@ -441,7 +441,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setSortOrder: async (sort) => {
     // Reset direction to the natural default for the new sort key so the
     // results make intuitive sense (e.g. "Date Added" → newest first).
-    const naturalDir: 'asc' | 'desc' = ['date_added', 'last_played', 'most_played'].includes(sort)
+    const naturalDir: 'asc' | 'desc' = ['date_added', 'last_played', 'most_played', 'release_date'].includes(sort)
       ? 'desc'
       : 'asc'
     set({ sortOrder: sort, sortDir: naturalDir })

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -96,7 +96,13 @@ type PlayerStore = {
   albumEditMode: boolean
   albumMetaExpanded: boolean
   albumRenameProgress: { done: number; total: number } | null
-  sortOrder: 'album_artist' | 'album' | 'date_added' | 'last_played' | 'most_played' | 'release_date'
+  sortOrder:
+    | 'album_artist'
+    | 'album'
+    | 'date_added'
+    | 'last_played'
+    | 'most_played'
+    | 'release_date'
   sortDir: 'asc' | 'desc'
   libraryFilter: string[]
   searchQuery: string
@@ -441,7 +447,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setSortOrder: async (sort) => {
     // Reset direction to the natural default for the new sort key so the
     // results make intuitive sense (e.g. "Date Added" → newest first).
-    const naturalDir: 'asc' | 'desc' = ['date_added', 'last_played', 'most_played', 'release_date'].includes(sort)
+    const naturalDir: 'asc' | 'desc' = [
+      'date_added',
+      'last_played',
+      'most_played',
+      'release_date'
+    ].includes(sort)
       ? 'desc'
       : 'asc'
     set({ sortOrder: sort, sortDir: naturalDir })

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1745,6 +1745,88 @@ class TestAlbumsSort:
         index.close()
         assert [a.album for a in albums_default] == [a.album for a in albums_none]
 
+    def test_sort_by_release_date_newest_first(self, tmp_path: Path) -> None:
+        """Default release_date sort is DESC (newest year first)."""
+        index = self._make_index(tmp_path)
+        albums = index.albums(sort="release_date")
+        index.close()
+        # years: Foley Room=2007, Apostrophe=1974, Hot Rats=1969
+        assert [a.album for a in albums] == ["Foley Room", "Apostrophe", "Hot Rats"]
+
+    def test_sort_by_release_date_asc_oldest_first(self, tmp_path: Path) -> None:
+        """sort_dir='asc' on release_date yields oldest year first."""
+        index = self._make_index(tmp_path)
+        albums = index.albums(sort="release_date", sort_dir="asc")
+        index.close()
+        assert [a.album for a in albums] == ["Hot Rats", "Apostrophe", "Foley Room"]
+
+    def test_sort_by_release_date_empty_year_sorts_last(self, tmp_path: Path) -> None:
+        """Albums with no year sort after dated albums regardless of direction."""
+        index = LibraryIndex(tmp_path / "rd.db")
+        p1 = tmp_path / "rd1.mp3"
+        p2 = tmp_path / "rd2.mp3"
+        p3 = tmp_path / "rd3.mp3"
+        _make_mp3(
+            p1, artist="A", album_artist="A", album="Alpha", year="2020", title="T1"
+        )
+        _make_mp3(p2, artist="B", album_artist="B", album="Beta", year="", title="T2")
+        _make_mp3(
+            p3, artist="C", album_artist="C", album="Gamma", year="1990", title="T3"
+        )
+        index.upsert_many(
+            [
+                Track(
+                    file_path=p1,
+                    title="T1",
+                    artist="A",
+                    album_artist="A",
+                    album="Alpha",
+                    year="2020",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                ),
+                Track(
+                    file_path=p2,
+                    title="T2",
+                    artist="B",
+                    album_artist="B",
+                    album="Beta",
+                    year="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                ),
+                Track(
+                    file_path=p3,
+                    title="T3",
+                    artist="C",
+                    album_artist="C",
+                    album="Gamma",
+                    year="1990",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                ),
+            ]
+        )
+        desc_albums = index.albums(sort="release_date")
+        asc_albums = index.albums(sort="release_date", sort_dir="asc")
+        index.close()
+        # DESC: 2020, 1990, then empty-year last
+        assert [a.album for a in desc_albums] == ["Alpha", "Gamma", "Beta"]
+        # ASC: 1990, 2020, then empty-year last
+        assert [a.album for a in asc_albums] == ["Gamma", "Alpha", "Beta"]
+
 
 class TestRecordPlayed:
     """Tests for LibraryIndex.record_played()."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1875,6 +1875,10 @@ class TestUiStateEndpoints:
         resp = client.post("/api/v1/ui/sort-order", json={"sort_order": "bogus"})
         assert resp.status_code == 422
 
+    def test_set_sort_order_release_date_returns_200(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/ui/sort-order", json={"sort_order": "release_date"})
+        assert resp.status_code == 200
+
     def test_set_sort_order_calls_callback(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds **Release Date** as a sort option in both the library view (AlbumGrid) and playlist view (PlaylistView)
- Backend: new `"release_date"` key in `_SORT_CLAUSES` (SQL: `sort_release_date NULLS LAST`) and `_DEFAULT_SORT_DIR` (DESC), added to `_VALID_SORT_ORDERS`
- Frontend: TypeScript union types updated in `client.ts` and `store.ts`; `naturalDir` list includes `'release_date'` so it defaults to newest-first; UI option added to AlbumGrid and PlaylistView sort dropdowns
- Empty `year` values sort last in both directions — matches the `NULLS LAST` convention used for `last_played`

## Test plan

- [ ] Open library view — "Release Date" appears in the sort dropdown
- [ ] Select Release Date — albums reorder newest year first by default
- [ ] Click direction toggle — oldest first; albums with no year appear last in both directions
- [ ] Open a playlist — "Release Date" appears; selecting it sorts tracks by year, empty-year tracks last
- [ ] Set sort to Release Date, reload app — selection persists
- [ ] Confirm existing sorts (Album Artist, Album, Date Added, Last Played, Most Played) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)