### PR TITLE
fix(config): add release_date to ui.sort_order allowed values

### DIFF
--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -180,7 +180,9 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
     ),
     "bandcamp.collection_mode": frozenset({"stream", "download"}),
     "ui.active_view": frozenset({"library", "now-playing", "home"}),
-    "ui.sort_order": frozenset({"album_artist", "album", "date_added", "last_played"}),
+    "ui.sort_order": frozenset(
+        {"album_artist", "album", "date_added", "last_played", "release_date"}
+    ),
     "ui.sort_dir": frozenset({"asc", "desc"}),
 }
 


### PR DESCRIPTION
## Summary

- `release_date` was added as a sort option in KAMP-513 but was never added to the `_CONFIG_KEY_CHOICES` allowlist in `kamp_daemon/config.py`, causing a 500 on `POST /api/v1/ui/sort-order` whenever the UI tried to persist that sort selection.

## Test plan

- [ ] Pre-existing test `TestUiStateEndpoints::test_set_sort_order_release_date_returns_200` now passes (was failing before this fix)
- [ ] Sort by Release Date in the UI and confirm it persists across page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)