### PR TITLE
fix(bandcamp): support standalone single-track purchases (index, playback, download) — KAMP-526

### DIFF
--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1318,7 +1318,10 @@ def _download_item(
         )
 
     safe_name = re.sub(r'[<>:"/\\|?*]', "_", f"{band_name} - {item_title}")
-    dest = watch_dir / f"{safe_name}.zip"
+    # No extension yet: full-album purchases download as .zip, standalone
+    # single-track purchases as a bare audio file.  _download_file sniffs the
+    # payload and appends the correct extension (KAMP-526).
+    dest_base = watch_dir / safe_name
 
     logger.info("Downloading %r by %r…", item_title, band_name)
     cdn_url = _get_cdn_url(redownload_url, bc_config.format, session)
@@ -1327,31 +1330,71 @@ def _download_item(
         # Dev mode: the requests.Session carries Bandcamp cookies.
         # popplers5 requires cookies to serve the ZIP; pass the authenticated
         # session directly so requests follows any redirect automatically.
-        _download_file(cdn_url, dest, session)
-    else:
-        # Frozen mode: Electron's net.fetch carries cookies and follows the
-        # popplers5 → bcbits.com redirect via the proxy HEAD call.
-        # Download from bcbits.com directly — its pre-signed URLs need no cookies.
-        final_url = _resolve_cdn_redirect(cdn_url, session)
-        dl_session = _requests.Session()
-        dl_session.headers["User-Agent"] = _UA
-        _download_file(final_url, dest, dl_session)
-    return dest
+        return _download_file(cdn_url, dest_base, session, bc_config.format)
+    # Frozen mode: Electron's net.fetch carries cookies and follows the
+    # popplers5 → bcbits.com redirect via the proxy HEAD call.
+    # Download from bcbits.com directly — its pre-signed URLs need no cookies.
+    final_url = _resolve_cdn_redirect(cdn_url, session)
+    dl_session = _requests.Session()
+    dl_session.headers["User-Agent"] = _UA
+    return _download_file(final_url, dest_base, dl_session, bc_config.format)
+
+
+# Content-Type → file extension for bare audio downloads (single tracks).
+_AUDIO_CONTENT_TYPE_EXT = {
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/flac": ".flac",
+    "audio/x-flac": ".flac",
+    "audio/mp4": ".m4a",
+    "audio/x-m4a": ".m4a",
+    "audio/aac": ".m4a",
+    "audio/ogg": ".ogg",
+    "audio/vorbis": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+}
+
+# Configured download format → file extension, used as a fallback when the
+# Content-Type header is missing or unrecognised.
+_FORMAT_EXT = {
+    "mp3-v0": ".mp3",
+    "mp3-320": ".mp3",
+    "flac": ".flac",
+    "aac-hi": ".m4a",
+    "alac": ".m4a",
+    "vorbis": ".ogg",
+    "wav": ".wav",
+}
+
+
+def _audio_extension(content_type: str, fmt: str) -> str:
+    """Pick the file extension for a bare-audio download from its Content-Type,
+    falling back to the configured format, then to ``.mp3``."""
+    ct = content_type.split(";")[0].strip().lower()
+    return _AUDIO_CONTENT_TYPE_EXT.get(ct) or _FORMAT_EXT.get(fmt) or ".mp3"
 
 
 def _download_file(
     cdn_url: str,
-    dest: Path,
+    dest_base: Path,
     session: _requests.Session,
-) -> None:
-    """Stream *cdn_url* to *dest*, following redirects.
+    fmt: str,
+) -> Path:
+    """Stream *cdn_url* to a file under *dest_base*, following redirects.
+
+    Full-album purchases arrive as a ZIP; standalone single-track purchases are
+    served as a bare audio file (KAMP-526).  The payload type is detected from
+    the magic bytes and Content-Type, and the file is saved with the matching
+    extension (``.zip`` for albums, ``.mp3``/``.flac``/… for single tracks) so
+    the watch-folder pipeline ingests it correctly.  Returns the final path.
 
     Downloads to a ``*.part`` sibling first, then renames atomically on
     completion.  This keeps the watch-folder watcher from picking up the
     file mid-download — ``.part`` is not a watched extension, so only the
     finished file triggers the ingest pipeline.
     """
-    tmp = dest.with_suffix(dest.suffix + ".part")
+    tmp = dest_base.with_name(dest_base.name + ".part")
     try:
         with session.get(
             cdn_url, stream=True, timeout=300, allow_redirects=True
@@ -1368,18 +1411,33 @@ def _download_file(
                 for chunk in resp.iter_content(chunk_size=1024 * 1024):
                     fh.write(chunk)
 
-        # Guard against CDN returning an HTML error page with HTTP 200.
-        # ZIP files always start with the PK local-file magic (0x50 0x4B 0x03 0x04).
         with open(tmp, "rb") as fh:
             magic = fh.read(4)
-        if not magic.startswith(b"PK"):
+        ct = content_type.split(";")[0].strip().lower()
+        if magic.startswith(b"PK"):
+            # ZIP local-file magic (0x50 0x4B 0x03 0x04) — a full-album download.
+            final = dest_base.with_name(dest_base.name + ".zip")
+        elif (
+            ct.startswith("audio/")
+            or magic[:3] == b"ID3"
+            or magic[:4] == b"fLaC"
+            or magic[:1] == b"\xff"
+        ):
+            # Bare audio file — a standalone single-track purchase.
+            final = dest_base.with_name(
+                dest_base.name + _audio_extension(content_type, fmt)
+            )
+        else:
+            # Neither ZIP nor audio: the CDN served an HTML error page with
+            # HTTP 200 (e.g. missing cookies on popplers5).
             raise BandcampAPIError(
-                f"CDN response is not a ZIP file "
+                f"CDN response is neither a ZIP nor audio "
                 f"(first-bytes={magic!r}, content-type={content_type!r}) — "
                 f"url={cdn_url}"
             )
 
-        tmp.rename(dest)
+        tmp.rename(final)
+        return final
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1045,8 +1045,14 @@ def fetch_stream_url(
     tralbum: dict[str, Any] = json.loads(html_lib.unescape(match.group(1)))
     tracks: list[dict[str, Any]] = tralbum.get("trackinfo") or []
 
+    # A standalone single-track page exposes its lone track with track_num=None;
+    # it is indexed as #1 by fetch_album_tracks, so match it the same way here
+    # (KAMP-526).  The is_single guard keeps multi-track album track 1 unaffected.
+    is_single = tralbum.get("item_type") == "track"
+
     for t in tracks:
-        if t.get("track_num") == track_number:
+        page_track_num = t.get("track_num") or (1 if is_single else None)
+        if page_track_num == track_number:
             files: dict[str, Any] = t.get("file") or {}
             url = files.get("mp3-v0") or files.get("mp3-128")
             if not url:
@@ -1102,8 +1108,18 @@ def fetch_album_tracks(
     tralbum: dict[str, Any] = json.loads(html_lib.unescape(match.group(1)))
     trackinfo: list[dict[str, Any]] = tralbum.get("trackinfo") or []
 
+    # Standalone single-track purchases (item_type='track') expose their lone
+    # track with track_num=None and carry the release date under current rather
+    # than album_release_date.  Normalise both so the track is indexed as #1 and
+    # dated correctly instead of being silently dropped (KAMP-526).
+    is_single_track = tralbum.get("item_type") == "track"
+
     # Parse the release date string (e.g. "01 Jan 2020 00:00:00 GMT") to ISO form.
-    raw_release_date = str(tralbum.get("album_release_date") or "")
+    raw_release_date = str(
+        tralbum.get("album_release_date")
+        or (tralbum.get("current") or {}).get("release_date")
+        or ""
+    )
     parsed_date = email.utils.parsedate(raw_release_date)
     if parsed_date:
         release_date_iso = time.strftime("%Y-%m-%d", parsed_date)
@@ -1113,7 +1129,7 @@ def fetch_album_tracks(
 
     result: list[Track] = []
     for t in trackinfo:
-        track_num = t.get("track_num")
+        track_num = t.get("track_num") or (1 if is_single_track else None)
         if not track_num:
             continue
         # Per-track artist field is set on compilations/splits; fall back to band_name.

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -1537,9 +1537,8 @@ class TestDownloadItem:
             with patch("kamp_daemon.bandcamp._resolve_cdn_redirect") as mock_resolve:
                 with patch(
                     "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess: (
-                        calls.append((url, sess)),
-                        dest.write_bytes(b"fake"),
+                    side_effect=lambda url, dest, sess, fmt: (
+                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
                     ),
                 ):
                     _download_item(
@@ -1567,9 +1566,8 @@ class TestDownloadItem:
             ) as mock_resolve:
                 with patch(
                     "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess: (
-                        calls.append((url, sess)),
-                        dest.write_bytes(b"fake"),
+                    side_effect=lambda url, dest, sess, fmt: (
+                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
                     ),
                 ):
                     _download_item(
@@ -1616,7 +1614,9 @@ class TestDownloadItem:
             ):
                 with patch(
                     "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess: dest.write_bytes(b"x"),
+                    side_effect=lambda url, dest, sess, fmt: dest.with_name(
+                        dest.name + ".zip"
+                    ),
                 ):
                     path = _download_item(
                         item, _bc_config(tmp_path), watch_folder, MagicMock()
@@ -1642,13 +1642,16 @@ class TestDownloadFile:
         return resp
 
     def test_writes_chunked_response_to_dest(self, tmp_path: Path) -> None:
-        dest = tmp_path / "album.zip"
+        dest_base = tmp_path / "album"
         session = MagicMock()
         session.get.return_value = self._make_resp([_FAKE_ZIP])
 
-        _download_file("https://cdn.example.com/f.zip", dest, session)
+        final = _download_file(
+            "https://cdn.example.com/f.zip", dest_base, session, "mp3-v0"
+        )
 
-        assert dest.read_bytes() == _FAKE_ZIP
+        assert final == tmp_path / "album.zip"
+        assert final.read_bytes() == _FAKE_ZIP
         session.get.assert_called_once_with(
             "https://cdn.example.com/f.zip",
             stream=True,
@@ -1658,18 +1661,52 @@ class TestDownloadFile:
 
     def test_renames_from_part_file(self, tmp_path: Path) -> None:
         """Download writes to .part first, then renames — no partial file visible."""
-        dest = tmp_path / "album.zip"
+        dest_base = tmp_path / "album"
         session = MagicMock()
         session.get.return_value = self._make_resp([_FAKE_ZIP])
 
-        _download_file("https://cdn.example.com/f.zip", dest, session)
+        _download_file("https://cdn.example.com/f.zip", dest_base, session, "mp3-v0")
 
-        assert dest.exists()
-        assert not (tmp_path / "album.zip.part").exists()
+        assert (tmp_path / "album.zip").exists()
+        assert not (tmp_path / "album.part").exists()
+
+    def test_single_track_saved_as_audio_file(self, tmp_path: Path) -> None:
+        """A bare audio response (single-track purchase) is saved with an audio
+        extension, not .zip (KAMP-526)."""
+        dest_base = tmp_path / "Ohm Foam - Gush"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"ID3\x03\x00\x00\x00" + b"\x00" * 16], content_type="audio/mpeg"
+        )
+
+        final = _download_file(
+            "https://cdn.example.com/track?enc=mp3-v0", dest_base, session, "mp3-v0"
+        )
+
+        assert final == tmp_path / "Ohm Foam - Gush.mp3"
+        assert final.exists()
+        assert not (tmp_path / "Ohm Foam - Gush.part").exists()
+
+    def test_single_track_extension_from_format_when_content_type_generic(
+        self, tmp_path: Path
+    ) -> None:
+        """When the audio Content-Type is unrecognised, the configured format
+        drives the extension (KAMP-526)."""
+        dest_base = tmp_path / "Artist - Song"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"fLaC\x00\x00\x00\x22"], content_type="application/octet-stream"
+        )
+
+        final = _download_file(
+            "https://cdn.example.com/track?enc=flac", dest_base, session, "flac"
+        )
+
+        assert final == tmp_path / "Artist - Song.flac"
 
     def test_cleans_up_part_file_on_error(self, tmp_path: Path) -> None:
         """On download failure the .part file is removed."""
-        dest = tmp_path / "album.zip"
+        dest_base = tmp_path / "album"
         resp = MagicMock()
         resp.__enter__ = lambda s: s
         resp.__exit__ = MagicMock(return_value=False)
@@ -1679,25 +1716,31 @@ class TestDownloadFile:
         session.get.return_value = resp
 
         with pytest.raises(RuntimeError):
-            _download_file("https://cdn.example.com/f.zip", dest, session)
+            _download_file(
+                "https://cdn.example.com/f.zip", dest_base, session, "mp3-v0"
+            )
 
-        assert not dest.exists()
-        assert not (tmp_path / "album.zip.part").exists()
+        assert not (tmp_path / "album.zip").exists()
+        assert not (tmp_path / "album.part").exists()
 
-    def test_raises_when_cdn_returns_non_zip(self, tmp_path: Path) -> None:
-        """Non-ZIP CDN response (e.g. HTML error page) raises BandcampAPIError."""
-        dest = tmp_path / "album.zip"
+    def test_raises_when_cdn_returns_neither_zip_nor_audio(
+        self, tmp_path: Path
+    ) -> None:
+        """An HTML error page (neither ZIP nor audio) raises BandcampAPIError."""
+        dest_base = tmp_path / "album"
         html_body = b"<html>Error: access denied</html>"
         session = MagicMock()
         session.get.return_value = self._make_resp(
             [html_body], content_type="text/html"
         )
 
-        with pytest.raises(BandcampAPIError, match="not a ZIP"):
-            _download_file("https://cdn.example.com/f.zip", dest, session)
+        with pytest.raises(BandcampAPIError, match="neither a ZIP nor audio"):
+            _download_file(
+                "https://cdn.example.com/f.zip", dest_base, session, "mp3-v0"
+            )
 
-        assert not dest.exists()
-        assert not (tmp_path / "album.zip.part").exists()
+        assert not (tmp_path / "album.zip").exists()
+        assert not (tmp_path / "album.part").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -100,9 +100,16 @@ def _item(
 
 def _stream_album_page_html(
     tracks: list[dict[str, Any]] | None = None,
-    release_date: str = "01 Jan 2020 00:00:00 GMT",
+    release_date: str | None = "01 Jan 2020 00:00:00 GMT",
+    item_type: str | None = None,
+    current: dict[str, Any] | None = None,
 ) -> str:
-    """Build fake album page HTML with data-tralbum for fetch_album_tracks tests."""
+    """Build fake album page HTML with data-tralbum for fetch_album_tracks tests.
+
+    ``item_type='track'`` plus ``current`` model a standalone single-track page,
+    where ``trackinfo`` carries one entry with ``track_num=None`` and the release
+    date lives in ``current.release_date`` rather than ``album_release_date``.
+    """
     import html as _html
     import json as _json
 
@@ -111,7 +118,14 @@ def _stream_album_page_html(
             {"title": f"Track {i}", "track_num": i, "artist": None, "duration": 200.0}
             for i in range(1, 4)
         ]
-    tralbum = {"trackinfo": tracks, "album_release_date": release_date}
+    tralbum: dict[str, Any] = {
+        "trackinfo": tracks,
+        "album_release_date": release_date,
+    }
+    if item_type is not None:
+        tralbum["item_type"] = item_type
+    if current is not None:
+        tralbum["current"] = current
     encoded = _html.escape(_json.dumps(tralbum), quote=True)
     return f'<html><body data-tralbum="{encoded}"></body></html>'
 
@@ -2034,12 +2048,18 @@ class TestResolveCdnRedirect:
 # ---------------------------------------------------------------------------
 
 
-def _album_page_html(tracks: list[dict]) -> str:
-    """Build fake Bandcamp album page HTML with data-tralbum attribute."""
+def _album_page_html(tracks: list[dict], item_type: str | None = None) -> str:
+    """Build fake Bandcamp album page HTML with data-tralbum attribute.
+
+    Pass ``item_type='track'`` to model a standalone single-track page, whose
+    lone ``trackinfo`` entry carries ``track_num=None``.
+    """
     import html as html_lib
     import json
 
-    tralbum = {"trackinfo": tracks}
+    tralbum: dict[str, Any] = {"trackinfo": tracks}
+    if item_type is not None:
+        tralbum["item_type"] = item_type
     encoded = html_lib.escape(json.dumps(tralbum))
     return f'<html><body><div data-tralbum="{encoded}"></div></body></html>'
 
@@ -2117,6 +2137,21 @@ class TestFetchStreamUrl:
 
         with pytest.raises(BandcampAPIError, match="track_num=99 not found"):
             fetch_stream_url(self._album_url, 99, sess)
+
+    def test_resolves_single_track_page_with_null_track_num(self) -> None:
+        """A standalone /track/ page's lone entry has track_num=None; playing the
+        track (indexed as number 1) must still resolve its CDN URL (KAMP-526)."""
+        track_data = [
+            {"track_num": None, "file": {"mp3-v0": "https://cdn.example.com/gush.mp3"}}
+        ]
+        html = _album_page_html(track_data, item_type="track")
+        sess = MagicMock()
+        sess.get.return_value = MagicMock(status_code=200, text=html)
+        sess.get.return_value.raise_for_status = MagicMock()
+
+        url, _ = fetch_stream_url("https://ohmfoam.bandcamp.com/track/gush", 1, sess)
+
+        assert url == "https://cdn.example.com/gush.mp3"
 
     def test_uses_ts_plus_24h_as_expires_at(self) -> None:
         """ts= is the URL creation time; expiry is ts + 86400 (Bandcamp's ~24h window)."""
@@ -2867,6 +2902,61 @@ class TestFetchAlbumTracks:
         )
         assert len(result) == 1
         assert result[0].title == "Good"
+
+    def test_single_track_page_indexes_one_track_as_number_1(self) -> None:
+        """A standalone /track/ page (item_type='track') has one trackinfo entry
+        with track_num=None; it must be indexed as track_number 1, not skipped
+        (KAMP-526)."""
+        tracks = [
+            {
+                "title": "Gush",
+                "track_num": None,
+                "artist": None,
+                "duration": 410.9,
+                "file": {"mp3-128": "https://cdn.example.com/gush.mp3"},
+            }
+        ]
+        html = _stream_album_page_html(
+            tracks=tracks,
+            release_date=None,
+            item_type="track",
+            current={"release_date": "29 Jun 2026 00:00:00 GMT"},
+        )
+        result = fetch_album_tracks(
+            "https://ohmfoam.bandcamp.com/track/gush",
+            390616303,
+            "Ohm Foam",
+            "Gush",
+            self._make_session(html),
+        )
+        assert len(result) == 1
+        assert result[0].title == "Gush"
+        assert result[0].track_number == 1
+        # Virtual path carries sale_item_id and the normalised track number.
+        assert "390616303" in str(result[0].file_path)
+        assert str(result[0].file_path).endswith("/1")
+        assert result[0].is_available is True
+
+    def test_single_track_release_date_falls_back_to_current(self) -> None:
+        """When album_release_date is absent, the date comes from
+        current.release_date (KAMP-526)."""
+        tracks = [
+            {"title": "Gush", "track_num": None, "artist": None, "file": {"x": "y"}}
+        ]
+        html = _stream_album_page_html(
+            tracks=tracks,
+            release_date=None,
+            item_type="track",
+            current={"release_date": "29 Jun 2026 00:00:00 GMT"},
+        )
+        result = fetch_album_tracks(
+            "https://x.bandcamp.com/track/gush",
+            1,
+            "B",
+            "Gush",
+            self._make_session(html),
+        )
+        assert result[0].release_date == "2026-06-29"
 
     def test_is_available_true_when_file_present(self) -> None:
         """Tracks with a file entry are marked available (KAMP-423)."""

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2976,8 +2976,11 @@ class TestFetchAlbumTracks:
         assert result[0].title == "Gush"
         assert result[0].track_number == 1
         # Virtual path carries sale_item_id and the normalised track number.
-        assert "390616303" in str(result[0].file_path)
-        assert str(result[0].file_path).endswith("/1")
+        # Path renders bandcamp://.../1 with backslashes on Windows, which
+        # resolve_playback_uri also normalises before parsing — do the same here.
+        normalised_fp = str(result[0].file_path).replace("\\", "/")
+        assert "390616303" in normalised_fp
+        assert normalised_fp.endswith("/1")
         assert result[0].is_available is True
 
     def test_single_track_release_date_falls_back_to_current(self) -> None:


### PR DESCRIPTION
## Summary

Fixes [KAMP-526](https://eightyeighteyes.atlassian.net/browse/KAMP-526). Standalone Bandcamp **single-track** purchases (`item_type='track'`, `album_url` ending `/track/...`) were broken end to end. This PR makes them work across all three code paths: stream indexing, playback, and download.

Root of it all: a standalone `/track/` page exposes its lone track with `track_num = None` (album listings number from 1), and Bandcamp serves the download as a bare audio file rather than a ZIP.

## 1. Stream indexing — `fetch_album_tracks`

The indexer skipped any track with a falsy `track_num`, so the single track was dropped → no album/track rows → invisible in the app. Now, when `item_type == 'track'`, a null `track_num` defaults to `1`. Also falls back to `current.release_date` when `album_release_date` is absent (single-track pages carry the date under `current`).

Data confirmed the shape: every remote `/album/` item had tracks (67/67); the lone `/track/` item had none (0/1).

## 2. Playback — `fetch_stream_url`

`fetch_stream_url` matched `t.get("track_num") == track_number`. The indexed track is number 1 but the page's `track_num` is `None`, so without a change the track would be **visible but unplayable**. Applies the same `is_single`-gated normalisation (recomputed locally) so track 1 resolves its CDN URL. The guard keeps multi-track album track 1 unaffected.

## 3. Download — `_download_file`

Bandcamp serves a single track as a bare audio file (`ID3…`, `Content-Type: audio/mpeg`), not a ZIP. The downloader hardcoded a `.zip` destination and rejected any payload not starting with the `PK` ZIP magic — single-track downloads failed with `CDN response is not a ZIP file (first-bytes=b'ID3\x03')`. Now `_download_file` detects the payload from magic bytes + Content-Type and saves with the matching extension (`.zip` for albums, `.mp3`/`.flac`/… for single tracks). The watch-folder pipeline already ingests bare audio files (watcher triggers on `AUDIO_EXTENSIONS`; extractor moves a lone audio file into a folder), so no pipeline change was needed. The HTML-error-page guard is preserved.

## Self-healing

No manual DB edit needed: `sync_collection_stream` re-fetches remote items with zero tracks, so the next Bandcamp sync heals existing broken items once this ships.

## Known pre-existing edge (out of scope)

If a downloaded single's MP3 lacks a `TRCK` tag, the tagger defaults `track_number=0` while the remote row is `1`, so favorite/play-count inheritance and queue-swap-on-delete (keyed on `album_id, track_number, disc_number`) would miss. That belongs to the download/tagger path, not this fix — worth a follow-up only if hit in practice.

## Testing

- Index/playback (red→green): single-track page indexes one track as #1; release date from `current.release_date`; `fetch_stream_url` resolves a page whose `track_num` is `None`.
- Download (red→green): bare-audio response saved as `.mp3`; extension derived from configured format when Content-Type is generic; ZIP still saved as `.zip`; neither-ZIP-nor-audio still raises.
- Regression: multi-track album indexing, playback, and ZIP download unchanged.
- Full suite: 2126 passed, 9 skipped; black + mypy clean; coverage gate met.

## Manual verification (for reviewer)

1. Trigger a Bandcamp stream sync → *Ohm Foam – Gush* appears in the grid.
2. **Play it** (remote) — confirm it streams.
3. **Download it** — confirm the `.mp3` lands in the watch folder, gets ingested, and plays locally.
4. Confirm existing multi-track albums (stream + download) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAMP-526]: https://eightyeighteyes.atlassian.net/browse/KAMP-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ