### PR TITLE
fix(bandcamp): identity-based provenance so downloads re-attach to origin (KAMP-523)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1491,7 +1491,19 @@ class LibraryIndex:
             # LEFT UNTOUCHED — auto-merging them risks collapsing genuinely
             # distinct releases (self-titled EPs, VA comps). A one-time DB backup
             # is taken before any merge, and every merge is logged at INFO.
-            self._heal_forked_albums()
+            #
+            # Defense in depth: a heal failure must never brick the DB. If any
+            # merge raises unexpectedly, roll the heal back and continue — the
+            # fork stays un-healed (identity linking still resolves it at runtime
+            # via LIMIT 1) but the database always opens.
+            try:
+                self._heal_forked_albums()
+            except Exception:
+                self._conn.rollback()
+                logger.exception(
+                    "KAMP-523 heal failed — rolled back; forks left for runtime"
+                    " identity linking to resolve"
+                )
             self._create_sale_item_id_unique_index()
             self._conn.execute("UPDATE schema_version SET version = 39")
             self._conn.commit()
@@ -1554,8 +1566,15 @@ class LibraryIndex:
             for drop in ids[1:]:
                 merge_into[drop] = keep
 
-        # (b) A local row that normalizes onto a sale_item_id-bearing row whose
-        #     collection band/title also matches — the classic whitespace fork.
+        # (b) A row WITH NO sale_item_id of its own that normalizes onto a
+        #     sale_item_id-bearing row whose collection band/title also matches —
+        #     the classic whitespace fork (the old code minted an un-provenanced
+        #     local album next to the streaming origin).
+        #
+        # `loc.sale_item_id IS NULL` is load-bearing: a row that carries its OWN
+        # non-null id is a distinct release (Bandcamp ids are 1:1 with releases),
+        # so it must never be folded into a different id's album — doing so would
+        # collapse two genuinely-different purchases that merely share a name.
         # Guarded on the settled band_name/item_title columns (older
         # bandcamp_collection schemas predate them), mirroring the v24 migration.
         bcc_cols = {
@@ -1573,7 +1592,7 @@ class LibraryIndex:
              AND TRIM(loc.album_artist) = TRIM(org.album_artist) COLLATE NOCASE
              AND TRIM(loc.album)        = TRIM(org.album)        COLLATE NOCASE
             JOIN bandcamp_collection bc ON bc.sale_item_id = org.sale_item_id
-            WHERE (loc.sale_item_id IS NULL OR loc.sale_item_id != org.sale_item_id)
+            WHERE loc.sale_item_id IS NULL
               AND TRIM(loc.album_artist) = TRIM(bc.band_name)  COLLATE NOCASE
               AND TRIM(loc.album)        = TRIM(bc.item_title) COLLATE NOCASE
             """).fetchall() if {"band_name", "item_title"} <= bcc_cols else []):
@@ -1611,7 +1630,7 @@ class LibraryIndex:
         whitespace), and recompute albums.source.
         """
         keep_row = self._conn.execute(
-            "SELECT album_artist, artist_id FROM albums WHERE id=?", (keep,)
+            "SELECT album_artist, album, artist_id FROM albums WHERE id=?", (keep,)
         ).fetchone()
         drop_row = self._conn.execute(
             "SELECT artist_id FROM albums WHERE id=?", (drop,)
@@ -1619,6 +1638,7 @@ class LibraryIndex:
         if keep_row is None or drop_row is None:  # pragma: no cover - defensive
             return
         canon = keep_row["album_artist"].strip()
+        keep_album = keep_row["album"]
         keep_artist = keep_row["artist_id"]
         drop_artist = drop_row["artist_id"]
 
@@ -1654,25 +1674,45 @@ class LibraryIndex:
                 (drop_artist, drop_artist),
             )
         # 4. Normalize the surviving names to canonical (trimmed) form so the
-        #    whitespace divergence that forked them cannot recur.
-        self._conn.execute("UPDATE albums SET album_artist=? WHERE id=?", (canon, keep))
-        self._conn.execute(
-            "UPDATE tracks SET album_artist=?, artist=? WHERE album_id=?",
-            (canon, canon, keep),
-        )
-        if keep_artist:
+        #    whitespace divergence that forked them cannot recur — BUT only if no
+        #    other album already occupies the (canon, keep_album) slot. A distinct
+        #    release that legitimately shares this name (different sale_item_id)
+        #    would otherwise trip UNIQUE(album_artist, album) and abort the whole
+        #    migration, bricking the DB. When a collision looms we keep the
+        #    current name; the sale_item_id link preserves identity regardless.
+        collision = self._conn.execute(
+            "SELECT 1 FROM albums WHERE album_artist=? AND album=? AND id!=?",
+            (canon, keep_album, keep),
+        ).fetchone()
+        if collision is None and canon != keep_row["album_artist"]:
             self._conn.execute(
-                "UPDATE artists SET name=? WHERE id=?"
-                " AND NOT EXISTS (SELECT 1 FROM artists WHERE name=? AND id!=?)",
-                (canon, keep_artist, canon, keep_artist),
+                "UPDATE albums SET album_artist=? WHERE id=?", (canon, keep)
             )
-        # 5. Keep bandcamp_collection.band_name consistent with the canonical name.
-        self._conn.execute(
-            "UPDATE bandcamp_collection SET band_name=?"
-            " WHERE sale_item_id = (SELECT sale_item_id FROM albums WHERE id=?)"
-            "   AND sale_item_id IS NOT NULL",
-            (canon, keep),
-        )
+            self._conn.execute(
+                "UPDATE tracks SET album_artist=?, artist=? WHERE album_id=?",
+                (canon, canon, keep),
+            )
+            if keep_artist:
+                self._conn.execute(
+                    "UPDATE artists SET name=? WHERE id=?"
+                    " AND NOT EXISTS (SELECT 1 FROM artists WHERE name=? AND id!=?)",
+                    (canon, keep_artist, canon, keep_artist),
+                )
+            # Keep bandcamp_collection.band_name consistent with the canonical name.
+            self._conn.execute(
+                "UPDATE bandcamp_collection SET band_name=?"
+                " WHERE sale_item_id = (SELECT sale_item_id FROM albums WHERE id=?)"
+                "   AND sale_item_id IS NOT NULL",
+                (canon, keep),
+            )
+        elif collision is not None:
+            logger.warning(
+                "KAMP-523 heal: album %d kept name %r (canonical %r collides with a"
+                " distinct release) — merge completed without rename",
+                keep,
+                keep_row["album_artist"],
+                canon,
+            )
         # 6. Recompute albums.source from the surviving tracks.
         self._conn.execute(
             """

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -609,11 +609,13 @@ class DeferredOp:
 
 @dataclass
 class DownloadOverrides:
-    """User-set display overrides to apply to a Bandcamp download (KAMP-523).
+    """Effective album names + user title edits for a Bandcamp download (KAMP-523).
 
-    Empty strings / an empty dict mean "no override" — the pipeline keeps the
-    file's own (Bandcamp-provided) tag in that case. ``titles`` is keyed by
-    track_number and only contains entries the user actually edited.
+    ``album_artist`` / ``album`` are the *effective* names to stamp on the
+    downloaded files (user display override, else synced canonical, else the
+    collection ledger) so a download matches its streaming origin — empty only
+    when the item is entirely unknown. ``titles`` is keyed by track_number and
+    holds only the tracks the user actually renamed.
     """
 
     album_artist: str
@@ -2577,7 +2579,12 @@ class LibraryIndex:
         # are actually present in bandcamp_collection are trusted (a stale tag on
         # a file the user moved elsewhere falls back to the string match, and the
         # FK on albums.sale_item_id can never be violated).
-        prov_sids = {t.sale_item_id for t in named if t.sale_item_id}
+        # ALL tracks, not just `named`: a standalone single ships with no album
+        # tag (album == ""), so it is excluded from `named` — but it still
+        # carries a provenance stamp and must re-attach to its streaming origin
+        # by identity (KAMP-523 single case). Its empty album just means it links
+        # to an *existing* album row rather than minting one.
+        prov_sids = {t.sale_item_id for t in tracks if t.sale_item_id}
         valid_sids: set[str] = set()
         existing_album_by_sid: dict[str, int] = {}
         if prov_sids:
@@ -2724,13 +2731,22 @@ class LibraryIndex:
         # album where present, else stamping the id onto the newly-created
         # name-keyed row so the download and its origin share one album row.
         prov_paths: set[str] = set()
+        prov_album_ids: set[int] = set()
         if valid_sids:
             prov_targets: dict[str, int] = {}
             for sid in prov_sids & valid_sids:
                 if sid in existing_album_by_sid:
                     prov_targets[sid] = existing_album_by_sid[sid]
                     continue
-                rep = next(t for t in named if t.sale_item_id == sid)
+                # No album carries this id yet. We can only mint/adopt one from a
+                # track that HAS a name; a nameless single (album == "") with no
+                # existing album row is left unlinked rather than creating a blank
+                # album — in practice its streaming origin row already exists.
+                rep = next(
+                    (t for t in tracks if t.sale_item_id == sid and t.album), None
+                )
+                if rep is None:
+                    continue
                 # Stamp the id onto the just-inserted name-keyed row (or an
                 # existing un-provenanced local row with the same names).
                 self._conn.execute(
@@ -2745,11 +2761,13 @@ class LibraryIndex:
                 ).fetchone()
                 if row is not None:
                     prov_targets[sid] = row["id"]
-            for t in named:
+            # Link every provenanced track (named or nameless) to its album.
+            for t in tracks:
                 if not (_provenanced(t) and t.sale_item_id in prov_targets):
                     continue
                 fp = _canonical_track_key(t.file_path)
                 prov_paths.add(fp)
+                prov_album_ids.add(prov_targets[t.sale_item_id])
                 self._conn.execute(
                     "UPDATE tracks SET album_id = ? WHERE file_path = ?",
                     (prov_targets[t.sale_item_id], fp),
@@ -2775,15 +2793,24 @@ class LibraryIndex:
             )
 
         # Step 4: refresh denormalized aggregate columns on the touched album rows.
-        # Run once per batch (not per track) using a correlated subquery.
+        # Run once per batch (not per track) using a correlated subquery. Include
+        # albums reached only through provenance linking (prov_album_ids) — a
+        # nameless single's target album is not in file_paths (built from named),
+        # yet its source/aggregates must be recomputed now that a local track
+        # attached to it.
+        touched_album_ids: set[int] = set(prov_album_ids)
         if file_paths:
             all_placeholders = ",".join("?" * len(file_paths))
-            album_ids_rows = self._conn.execute(
-                f"SELECT DISTINCT album_id FROM tracks"
-                f" WHERE file_path IN ({all_placeholders}) AND album_id IS NOT NULL",
-                file_paths,
-            ).fetchall()
-            album_ids = [r[0] for r in album_ids_rows]
+            touched_album_ids.update(
+                r[0]
+                for r in self._conn.execute(
+                    f"SELECT DISTINCT album_id FROM tracks"
+                    f" WHERE file_path IN ({all_placeholders}) AND album_id IS NOT NULL",
+                    file_paths,
+                ).fetchall()
+            )
+        if touched_album_ids:
+            album_ids = list(touched_album_ids)
             if album_ids:
                 id_placeholders = ",".join("?" * len(album_ids))
                 self._conn.execute(
@@ -3808,43 +3835,64 @@ class LibraryIndex:
         return _row_to_track(row) if row else None
 
     def download_overrides_for_sale_item(self, sale_item_id: str) -> DownloadOverrides:
-        """Return the user's display overrides for a Bandcamp item (KAMP-523).
+        """Return the effective album names + user title edits for a download (KAMP-523).
 
-        Used by the ingest pipeline to honour edits the user made on the
-        streaming version (renamed album/artist/tracks) instead of re-deriving
-        those fields. Returns empty overrides when nothing was edited or the
-        album has not been synced — the caller then keeps the file's own tags.
+        The ingest pipeline applies these to the downloaded files so a download
+        carries the same (album_artist, album) as its streaming origin — using
+        the metadata we already have instead of re-deriving it. album_artist and
+        album are the *effective* names: the user's display_* override if set,
+        else the synced album row's canonical value, else the bandcamp_collection
+        band_name/item_title (which always exists for a download). This is what
+        gives a standalone single its album name (Bandcamp singles ship with no
+        album tag, so the file would otherwise land album-less and fork off a
+        second card — KAMP-523 single case).
 
-        titles collapses on track_number; a track_number that appears on more
-        than one disc is dropped (ambiguous) rather than risk mis-applying a
-        title across discs.
+        titles carries per-track user renames keyed by track_number; a
+        track_number appearing on more than one disc is dropped (ambiguous)
+        rather than risk mis-applying a title across discs.
+
+        Returns empty names only when the item is unknown (no album row and no
+        collection row) — the caller then keeps the file's own tags.
         """
         album = self._conn.execute(
-            "SELECT id, display_album, display_album_artist FROM albums"
+            "SELECT id, album, album_artist, display_album, display_album_artist"
+            " FROM albums WHERE sale_item_id = ?",
+            (sale_item_id,),
+        ).fetchone()
+
+        titles: dict[int, str] = {}
+        if album is not None:
+            ambiguous: set[int] = set()
+            for r in self._conn.execute(
+                "SELECT track_number, display_title FROM tracks"
+                " WHERE album_id = ? AND file_path LIKE 'bandcamp://%'"
+                "   AND display_title IS NOT NULL AND display_title != ''",
+                (album["id"],),
+            ).fetchall():
+                tno = r["track_number"]
+                if tno in titles:
+                    ambiguous.add(tno)
+                titles[tno] = r["display_title"]
+            for tno in ambiguous:
+                titles.pop(tno, None)
+            return DownloadOverrides(
+                album_artist=album["display_album_artist"] or album["album_artist"],
+                album=album["display_album"] or album["album"],
+                titles=titles,
+            )
+
+        # No synced album row (downloaded without syncing streaming rows): fall
+        # back to the collection ledger, which the downloader always wrote.
+        bc = self._conn.execute(
+            "SELECT band_name, item_title FROM bandcamp_collection"
             " WHERE sale_item_id = ?",
             (sale_item_id,),
         ).fetchone()
-        if album is None:
+        if bc is None:
             return DownloadOverrides(album_artist="", album="", titles={})
-
-        titles: dict[int, str] = {}
-        ambiguous: set[int] = set()
-        for r in self._conn.execute(
-            "SELECT track_number, display_title FROM tracks"
-            " WHERE album_id = ? AND file_path LIKE 'bandcamp://%'"
-            "   AND display_title IS NOT NULL AND display_title != ''",
-            (album["id"],),
-        ).fetchall():
-            tno = r["track_number"]
-            if tno in titles:
-                ambiguous.add(tno)
-            titles[tno] = r["display_title"]
-        for tno in ambiguous:
-            titles.pop(tno, None)
-
         return DownloadOverrides(
-            album_artist=(album["display_album_artist"] or "").strip(),
-            album=(album["display_album"] or "").strip(),
+            album_artist=(bc["band_name"] or "").strip(),
+            album=(bc["item_title"] or "").strip(),
             titles=titles,
         )
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 38
+_SCHEMA_VERSION = 39
 
 
 @dataclass
@@ -329,6 +329,24 @@ CREATE TABLE IF NOT EXISTS download_queue (
     queued_at    REAL    NOT NULL DEFAULT (unixepoch())
 );
 
+-- Download → pipeline provenance handoff (KAMP-523). When the Bandcamp
+-- downloader drops an artifact (album ZIP or bare single) in the watch folder,
+-- it records the artifact path -> sale_item_id here. The ingest pipeline runs
+-- in a spawn subprocess that only receives (path, config); it looks this row up
+-- to (a) write the metadata we already own instead of re-deriving it via
+-- MusicBrainz and (b) stamp a durable provenance tag so the scan re-attaches the
+-- files to their streaming origin by identity, not by fragile tag matching.
+-- UNIQUE(artifact_path) makes a re-download idempotent. The row is deleted when
+-- the pipeline finishes (success or quarantine); a startup sweep clears rows
+-- whose artifact no longer exists (crash/restart mid-flight).
+CREATE TABLE IF NOT EXISTS pending_ingest (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    artifact_path TEXT    NOT NULL UNIQUE,
+    sale_item_id  TEXT    NOT NULL,
+    tralbum_id    TEXT    NOT NULL DEFAULT '',
+    created_at    REAL    NOT NULL
+);
+
 -- User-defined playlists (KAMP-441). Local-only; Bandcamp playlist sync is future work.
 CREATE TABLE IF NOT EXISTS playlists (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -478,6 +496,11 @@ class Track:
     # Runtime flag; not persisted to DB. False for stub tracks created during
     # queue restore when the DB row is missing (e.g. after a DB wipe).
     reachable: bool = field(default=True, compare=False)
+    # Bandcamp provenance stamp read from the file's KAMP_SALE_ITEM_ID tag
+    # (KAMP-523). Runtime-only: it is NOT stored on the tracks table — it is
+    # consumed by upsert_many to link the file to its album by identity, and the
+    # link persists via album_id, so a later re-scan re-reads it from the file.
+    sale_item_id: str = field(default="", compare=False)
 
     @property
     def is_remote(self) -> bool:
@@ -584,6 +607,37 @@ class DeferredOp:
     last_error: str | None
 
 
+@dataclass
+class DownloadOverrides:
+    """User-set display overrides to apply to a Bandcamp download (KAMP-523).
+
+    Empty strings / an empty dict mean "no override" — the pipeline keeps the
+    file's own (Bandcamp-provided) tag in that case. ``titles`` is keyed by
+    track_number and only contains entries the user actually edited.
+    """
+
+    album_artist: str
+    album: str
+    titles: dict[int, str]
+
+
+@dataclass
+class PendingIngest:
+    """A download → pipeline provenance handoff row (KAMP-523).
+
+    Maps a watch-folder artifact (album ZIP or bare single) to the Bandcamp
+    identity the downloader knew at download time, so the ingest pipeline can
+    write known metadata and stamp a provenance tag instead of re-deriving
+    identity from tags via MusicBrainz.
+    """
+
+    id: int
+    artifact_path: str
+    sale_item_id: str
+    tralbum_id: str
+    created_at: float
+
+
 class LibraryIndex:
     """Persistent SQLite index of all tracks in the music library."""
 
@@ -650,6 +704,10 @@ class LibraryIndex:
         if row is None:
             # Brand-new database — stamp current version and populate FTS.
             self._rebuild_fts()
+            # Fresh DBs have no forks, so the identity-uniqueness index is safe
+            # to create immediately (migrations, which also create it after the
+            # heal, do not run for a brand-new DB).
+            self._create_sale_item_id_unique_index()
             self._conn.execute(
                 "INSERT INTO schema_version (version) VALUES (?)", (_SCHEMA_VERSION,)
             )
@@ -1418,7 +1476,218 @@ class LibraryIndex:
             )
             self._conn.execute("UPDATE schema_version SET version = 38")
             self._conn.commit()
-            version = 38  # noqa: F841
+            version = 38
+
+        if version < 39:
+            # v38 → v39: heal albums forked by tag divergence (KAMP-523) and
+            # enforce one album per sale_item_id.
+            #
+            # Only the *provably-same-release* forks are merged automatically:
+            #   (a) two album rows carrying the same non-null sale_item_id, and
+            #   (b) a source='local' row whose TRIM/NOCASE (album_artist, album)
+            #       collapses onto a sale_item_id-bearing row AND matches that
+            #       id's bandcamp_collection band/title.
+            # Ambiguous string-only forks (no sale_item_id on either side) are
+            # LEFT UNTOUCHED — auto-merging them risks collapsing genuinely
+            # distinct releases (self-titled EPs, VA comps). A one-time DB backup
+            # is taken before any merge, and every merge is logged at INFO.
+            self._heal_forked_albums()
+            self._create_sale_item_id_unique_index()
+            self._conn.execute("UPDATE schema_version SET version = 39")
+            self._conn.commit()
+            version = 39  # noqa: F841
+
+    def _create_sale_item_id_unique_index(self) -> None:
+        """Enforce one album per sale_item_id via a partial UNIQUE index (KAMP-523).
+
+        Defensive: if a duplicate somehow survives the heal, log and continue
+        rather than aborting the migration (identity linking still resolves
+        deterministically via LIMIT 1) — a failed migration would make the DB
+        unopenable, which is far worse than a missing guard index.
+        """
+        album_cols = {
+            r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+        }
+        if "sale_item_id" not in album_cols:
+            # Minimal/partial schema (only seen in narrow migration unit tests);
+            # a real DB gains the column in the v24 albums migration.
+            return
+        try:
+            self._conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS albums_sale_item_id_uidx"
+                " ON albums(sale_item_id) WHERE sale_item_id IS NOT NULL"
+            )
+        except sqlite3.IntegrityError:  # pragma: no cover - defensive
+            logger.warning(
+                "Could not create UNIQUE index on albums.sale_item_id — duplicate"
+                " sale_item_ids remain; identity linking falls back to"
+                " deterministic LIMIT-1 resolution."
+            )
+
+    def _heal_forked_albums(self) -> None:
+        """Merge albums forked by tag divergence, for the provably-same subset.
+
+        See the v39 migration comment for the safety rationale. This backs the DB
+        up before any merge and logs every merge at INFO. Generalizes the
+        human-in-the-loop scripts/merge_forked_album.sh for the identity-provable
+        pairs only.
+        """
+        album_cols = {
+            r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+        }
+        if "sale_item_id" not in album_cols:
+            # Minimal/partial schema (narrow migration unit tests only); a real
+            # DB gains sale_item_id in the v24 albums migration, so there is
+            # nothing Bandcamp-linked to heal here.
+            return
+
+        merge_into: dict[int, int] = {}
+
+        # (a) Multiple album rows carrying the same non-null sale_item_id.
+        for r in self._conn.execute(
+            "SELECT sale_item_id, GROUP_CONCAT(id) AS ids, COUNT(*) AS n"
+            " FROM albums WHERE sale_item_id IS NOT NULL"
+            " GROUP BY sale_item_id HAVING n > 1"
+        ).fetchall():
+            ids = sorted(int(x) for x in r["ids"].split(","))
+            keep = ids[0]
+            for drop in ids[1:]:
+                merge_into[drop] = keep
+
+        # (b) A local row that normalizes onto a sale_item_id-bearing row whose
+        #     collection band/title also matches — the classic whitespace fork.
+        # Guarded on the settled band_name/item_title columns (older
+        # bandcamp_collection schemas predate them), mirroring the v24 migration.
+        bcc_cols = {
+            r[1]
+            for r in self._conn.execute(
+                "PRAGMA table_info(bandcamp_collection)"
+            ).fetchall()
+        }
+        for r in (self._conn.execute("""
+            SELECT loc.id AS drop_id, org.id AS keep_id
+            FROM albums loc
+            JOIN albums org
+              ON org.sale_item_id IS NOT NULL
+             AND loc.id != org.id
+             AND TRIM(loc.album_artist) = TRIM(org.album_artist) COLLATE NOCASE
+             AND TRIM(loc.album)        = TRIM(org.album)        COLLATE NOCASE
+            JOIN bandcamp_collection bc ON bc.sale_item_id = org.sale_item_id
+            WHERE (loc.sale_item_id IS NULL OR loc.sale_item_id != org.sale_item_id)
+              AND TRIM(loc.album_artist) = TRIM(bc.band_name)  COLLATE NOCASE
+              AND TRIM(loc.album)        = TRIM(bc.item_title) COLLATE NOCASE
+            """).fetchall() if {"band_name", "item_title"} <= bcc_cols else []):
+            keep, drop = r["keep_id"], r["drop_id"]
+            if drop != keep and drop not in merge_into:
+                merge_into[drop] = keep
+
+        if not merge_into:
+            return
+
+        # Back up before mutating. Connection.backup copies the live DB (incl.
+        # WAL) consistently — a plain file copy could miss un-checkpointed WAL.
+        ts = _time.strftime("%Y%m%d-%H%M%S")
+        backup_path = self._db_path.with_name(f"{self._db_path.name}.bak-{ts}")
+        try:
+            dest = sqlite3.connect(str(backup_path))
+            with dest:
+                self._conn.backup(dest)
+            dest.close()
+            logger.info("KAMP-523 heal: backed up library to %s", backup_path)
+        except Exception as exc:  # pragma: no cover - backup is best-effort
+            logger.warning("KAMP-523 heal: backup failed (%s); aborting heal", exc)
+            return
+
+        for drop, keep in merge_into.items():
+            self._merge_album_pair(keep, drop)
+        logger.info("KAMP-523 heal: merged %d forked album row(s)", len(merge_into))
+
+    def _merge_album_pair(self, keep: int, drop: int) -> None:
+        """Fold album *drop* into *keep*, merging the duplicate artist too.
+
+        Mirrors scripts/merge_forked_album.sh: move tracks, merge artists
+        (preserving play_time), delete the orphan album, normalize the surviving
+        names to their trimmed canonical form (so the pair can't re-fork on
+        whitespace), and recompute albums.source.
+        """
+        keep_row = self._conn.execute(
+            "SELECT album_artist, artist_id FROM albums WHERE id=?", (keep,)
+        ).fetchone()
+        drop_row = self._conn.execute(
+            "SELECT artist_id FROM albums WHERE id=?", (drop,)
+        ).fetchone()
+        if keep_row is None or drop_row is None:  # pragma: no cover - defensive
+            return
+        canon = keep_row["album_artist"].strip()
+        keep_artist = keep_row["artist_id"]
+        drop_artist = drop_row["artist_id"]
+
+        logger.info(
+            "KAMP-523 heal: merging album %d into %d (canonical artist %r)",
+            drop,
+            keep,
+            canon,
+        )
+
+        # 1. Move the drop album's tracks onto keep.
+        self._conn.execute(
+            "UPDATE tracks SET album_id=? WHERE album_id=?", (keep, drop)
+        )
+        # 2. Delete the now-empty duplicate album.
+        self._conn.execute("DELETE FROM albums WHERE id=?", (drop,))
+        # 3. Merge the duplicate artist: fold play_time into the survivor,
+        #    repoint album refs, delete the loser if nothing else references it.
+        if keep_artist and drop_artist and keep_artist != drop_artist:
+            self._conn.execute(
+                "UPDATE artists SET play_time = play_time"
+                " + (SELECT IFNULL(play_time,0) FROM artists WHERE id=?)"
+                " WHERE id=?",
+                (drop_artist, keep_artist),
+            )
+            self._conn.execute(
+                "UPDATE albums SET artist_id=? WHERE artist_id=?",
+                (keep_artist, drop_artist),
+            )
+            self._conn.execute(
+                "DELETE FROM artists WHERE id=?"
+                " AND NOT EXISTS (SELECT 1 FROM albums WHERE artist_id=?)",
+                (drop_artist, drop_artist),
+            )
+        # 4. Normalize the surviving names to canonical (trimmed) form so the
+        #    whitespace divergence that forked them cannot recur.
+        self._conn.execute("UPDATE albums SET album_artist=? WHERE id=?", (canon, keep))
+        self._conn.execute(
+            "UPDATE tracks SET album_artist=?, artist=? WHERE album_id=?",
+            (canon, canon, keep),
+        )
+        if keep_artist:
+            self._conn.execute(
+                "UPDATE artists SET name=? WHERE id=?"
+                " AND NOT EXISTS (SELECT 1 FROM artists WHERE name=? AND id!=?)",
+                (canon, keep_artist, canon, keep_artist),
+            )
+        # 5. Keep bandcamp_collection.band_name consistent with the canonical name.
+        self._conn.execute(
+            "UPDATE bandcamp_collection SET band_name=?"
+            " WHERE sale_item_id = (SELECT sale_item_id FROM albums WHERE id=?)"
+            "   AND sale_item_id IS NOT NULL",
+            (canon, keep),
+        )
+        # 6. Recompute albums.source from the surviving tracks.
+        self._conn.execute(
+            """
+            UPDATE albums SET source = (
+                SELECT CASE
+                    WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
+                     AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
+                        THEN 'local'
+                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                    ELSE MIN(t.source) END
+                FROM tracks t WHERE t.album_id = albums.id
+            ) WHERE id=?
+            """,
+            (keep,),
+        )
 
     def _rebuild_fts(self) -> None:
         """Rebuild the FTS index from the current contents of the tracks table.
@@ -2258,14 +2527,57 @@ class LibraryIndex:
         if not tracks:
             return
 
+        named = [t for t in tracks if t.album]
+
+        # KAMP-523: resolve Bandcamp provenance up front. A track carrying a
+        # KAMP_SALE_ITEM_ID tag (written by the download pipeline) links to its
+        # album by *identity*, never by the fragile (album_artist, album) string
+        # match — so a downloaded album re-attaches to its streaming origin even
+        # when the tagger rewrote the names beyond whitespace/case. Only ids that
+        # are actually present in bandcamp_collection are trusted (a stale tag on
+        # a file the user moved elsewhere falls back to the string match, and the
+        # FK on albums.sale_item_id can never be violated).
+        prov_sids = {t.sale_item_id for t in named if t.sale_item_id}
+        valid_sids: set[str] = set()
+        existing_album_by_sid: dict[str, int] = {}
+        if prov_sids:
+            sid_list = list(prov_sids)
+            sid_ph = ",".join("?" * len(sid_list))
+            valid_sids = {
+                r[0]
+                for r in self._conn.execute(
+                    "SELECT sale_item_id FROM bandcamp_collection"
+                    f" WHERE sale_item_id IN ({sid_ph})",
+                    sid_list,
+                ).fetchall()
+            }
+            for r in self._conn.execute(
+                f"SELECT id, sale_item_id FROM albums WHERE sale_item_id IN ({sid_ph})",
+                sid_list,
+            ).fetchall():
+                # setdefault: the partial UNIQUE index makes this at most one row
+                # per id post-migration; if an un-healed fork still has two, the
+                # lowest id wins deterministically.
+                existing_album_by_sid.setdefault(r["sale_item_id"], r["id"])
+
+        def _provenanced(t: Track) -> bool:
+            return bool(t.sale_item_id) and t.sale_item_id in valid_sids
+
+        # A provenanced track whose album already exists by identity must NOT
+        # spawn a name-keyed album row — that duplicate album (and its duplicate
+        # artist row) is exactly the fork this ticket prevents.
+        def _needs_name_album(t: Track) -> bool:
+            return not (_provenanced(t) and t.sale_item_id in existing_album_by_sid)
+
         # Step 1: upsert parent album rows for named albums. INSERT OR IGNORE so
         # existing album metadata (e.g. favorite flag) is never overwritten here.
-        named = [t for t in tracks if t.album]
         seen: set[tuple[str, str]] = set()
         album_params: list[
             tuple[str, str, str, int, str, str, str, str, float | None]
         ] = []
         for t in named:
+            if not _needs_name_album(t):
+                continue
             key = (t.album_artist.lower(), t.album.lower())
             if key not in seen:
                 seen.add(key)
@@ -2366,27 +2678,69 @@ class LibraryIndex:
 
         # Step 3: assign album_id on the track rows we just inserted/updated.
         file_paths = [_canonical_track_key(t.file_path) for t in named]
-        if file_paths:
-            placeholders = ",".join("?" * len(file_paths))
+
+        # Step 3a (KAMP-523): link provenanced tracks by identity. Resolve each
+        # trusted sale_item_id to its album — adopting the existing streaming
+        # album where present, else stamping the id onto the newly-created
+        # name-keyed row so the download and its origin share one album row.
+        prov_paths: set[str] = set()
+        if valid_sids:
+            prov_targets: dict[str, int] = {}
+            for sid in prov_sids & valid_sids:
+                if sid in existing_album_by_sid:
+                    prov_targets[sid] = existing_album_by_sid[sid]
+                    continue
+                rep = next(t for t in named if t.sale_item_id == sid)
+                # Stamp the id onto the just-inserted name-keyed row (or an
+                # existing un-provenanced local row with the same names).
+                self._conn.execute(
+                    "UPDATE albums SET sale_item_id = ?"
+                    " WHERE album_artist = ? COLLATE NOCASE"
+                    "   AND album        = ? COLLATE NOCASE"
+                    "   AND (sale_item_id IS NULL OR sale_item_id = ?)",
+                    (sid, rep.album_artist, rep.album, sid),
+                )
+                row = self._conn.execute(
+                    "SELECT id FROM albums WHERE sale_item_id = ?", (sid,)
+                ).fetchone()
+                if row is not None:
+                    prov_targets[sid] = row["id"]
+            for t in named:
+                if not (_provenanced(t) and t.sale_item_id in prov_targets):
+                    continue
+                fp = _canonical_track_key(t.file_path)
+                prov_paths.add(fp)
+                self._conn.execute(
+                    "UPDATE tracks SET album_id = ? WHERE file_path = ?",
+                    (prov_targets[t.sale_item_id], fp),
+                )
+
+        # Step 3b: link the remaining (un-provenanced) tracks by name. TRIM on
+        # both sides folds the leading/trailing-whitespace divergence that used
+        # to fork albums (belt-and-suspenders behind the identity link above).
+        plain_paths = [fp for fp in file_paths if fp not in prov_paths]
+        if plain_paths:
+            placeholders = ",".join("?" * len(plain_paths))
             self._conn.execute(
                 f"""
                 UPDATE tracks SET album_id = (
                     SELECT a.id FROM albums a
-                    WHERE a.album_artist = tracks.album_artist COLLATE NOCASE
-                      AND a.album        = tracks.album        COLLATE NOCASE
+                    WHERE TRIM(a.album_artist) = TRIM(tracks.album_artist) COLLATE NOCASE
+                      AND TRIM(a.album)        = TRIM(tracks.album)        COLLATE NOCASE
                 )
                 WHERE file_path IN ({placeholders})
                   AND album != ''
                 """,
-                file_paths,
+                plain_paths,
             )
 
         # Step 4: refresh denormalized aggregate columns on the touched album rows.
         # Run once per batch (not per track) using a correlated subquery.
         if file_paths:
+            all_placeholders = ",".join("?" * len(file_paths))
             album_ids_rows = self._conn.execute(
                 f"SELECT DISTINCT album_id FROM tracks"
-                f" WHERE file_path IN ({placeholders}) AND album_id IS NOT NULL",
+                f" WHERE file_path IN ({all_placeholders}) AND album_id IS NOT NULL",
                 file_paths,
             ).fetchall()
             album_ids = [r[0] for r in album_ids_rows]
@@ -2640,6 +2994,68 @@ class LibraryIndex:
             "SELECT id, track_id FROM deferred_ops ORDER BY id ASC"
         ).fetchall()
         return [{"op_id": r["id"], "track_id": r["track_id"]} for r in rows]
+
+    # ------------------------------------------------------------------
+    # Pending ingest — download → pipeline provenance handoff (KAMP-523)
+    # ------------------------------------------------------------------
+
+    def add_pending_ingest(
+        self, artifact_path: str, sale_item_id: str, tralbum_id: str = ""
+    ) -> None:
+        """Record that *artifact_path* is a Bandcamp download of *sale_item_id*.
+
+        INSERT OR REPLACE on the UNIQUE(artifact_path) so a re-download of the
+        same artifact path refreshes the identity rather than erroring.
+        """
+        import time as _t
+
+        self._conn.execute(
+            "INSERT OR REPLACE INTO pending_ingest"
+            " (artifact_path, sale_item_id, tralbum_id, created_at) VALUES (?,?,?,?)",
+            (artifact_path, sale_item_id, tralbum_id, _t.time()),
+        )
+        self._conn.commit()
+
+    def pending_ingest_for_path(self, artifact_path: str) -> PendingIngest | None:
+        """Return the pending-ingest row for *artifact_path*, or None.
+
+        The pipeline receives the watch-folder path it was triggered on; this
+        looks the provenance up before any extraction/move mutates the path.
+        """
+        row = self._conn.execute(
+            "SELECT * FROM pending_ingest WHERE artifact_path=?",
+            (artifact_path,),
+        ).fetchone()
+        return _row_to_pending_ingest(row) if row is not None else None
+
+    def clear_pending_ingest(self, artifact_path: str) -> None:
+        """Delete the pending-ingest row for *artifact_path* (idempotent).
+
+        Called from the pipeline's finally/quarantine paths so a completed or
+        failed ingest never leaves a stale handoff behind.
+        """
+        self._conn.execute(
+            "DELETE FROM pending_ingest WHERE artifact_path=?", (artifact_path,)
+        )
+        self._conn.commit()
+
+    def sweep_orphan_pending_ingest(self) -> int:
+        """Delete pending-ingest rows whose artifact no longer exists on disk.
+
+        Guards against rows left behind by a crash/restart between download and
+        ingest. Returns the number of rows removed. Called once at daemon start.
+        """
+        rows = self._conn.execute(
+            "SELECT id, artifact_path FROM pending_ingest"
+        ).fetchall()
+        stale = [r["id"] for r in rows if not Path(r["artifact_path"]).exists()]
+        if stale:
+            placeholders = ",".join("?" * len(stale))
+            self._conn.execute(
+                f"DELETE FROM pending_ingest WHERE id IN ({placeholders})", stale
+            )
+            self._conn.commit()
+        return len(stale)
 
     # ------------------------------------------------------------------
     # Download queue (KAMP-408)
@@ -3350,6 +3766,47 @@ class LibraryIndex:
             "SELECT * FROM tracks WHERE mb_recording_id = ?", (mb_recording_id,)
         ).fetchone()
         return _row_to_track(row) if row else None
+
+    def download_overrides_for_sale_item(self, sale_item_id: str) -> DownloadOverrides:
+        """Return the user's display overrides for a Bandcamp item (KAMP-523).
+
+        Used by the ingest pipeline to honour edits the user made on the
+        streaming version (renamed album/artist/tracks) instead of re-deriving
+        those fields. Returns empty overrides when nothing was edited or the
+        album has not been synced — the caller then keeps the file's own tags.
+
+        titles collapses on track_number; a track_number that appears on more
+        than one disc is dropped (ambiguous) rather than risk mis-applying a
+        title across discs.
+        """
+        album = self._conn.execute(
+            "SELECT id, display_album, display_album_artist FROM albums"
+            " WHERE sale_item_id = ?",
+            (sale_item_id,),
+        ).fetchone()
+        if album is None:
+            return DownloadOverrides(album_artist="", album="", titles={})
+
+        titles: dict[int, str] = {}
+        ambiguous: set[int] = set()
+        for r in self._conn.execute(
+            "SELECT track_number, display_title FROM tracks"
+            " WHERE album_id = ? AND file_path LIKE 'bandcamp://%'"
+            "   AND display_title IS NOT NULL AND display_title != ''",
+            (album["id"],),
+        ).fetchall():
+            tno = r["track_number"]
+            if tno in titles:
+                ambiguous.add(tno)
+            titles[tno] = r["display_title"]
+        for tno in ambiguous:
+            titles.pop(tno, None)
+
+        return DownloadOverrides(
+            album_artist=(album["display_album_artist"] or "").strip(),
+            album=(album["display_album"] or "").strip(),
+            titles=titles,
+        )
 
     def search(self, query: str) -> list[Track]:
         """Full-text search across title, artist, album_artist, and album.
@@ -4492,6 +4949,16 @@ def _row_to_deferred_op(row: sqlite3.Row) -> DeferredOp:
     )
 
 
+def _row_to_pending_ingest(row: sqlite3.Row) -> PendingIngest:
+    return PendingIngest(
+        id=row["id"],
+        artifact_path=row["artifact_path"],
+        sale_item_id=row["sale_item_id"],
+        tralbum_id=row["tralbum_id"],
+        created_at=row["created_at"],
+    )
+
+
 def _row_to_track(row: sqlite3.Row) -> Track:
     # DB rows store canonical bandcamp:// form (ensured by _track_to_params and
     # migration v22). Path() on POSIX still collapses the double-slash to single,
@@ -4644,6 +5111,7 @@ def _read_mp3_tags(path: Path) -> Track:
         genre=_str("TCON"),
         label=_str("TPUB"),
         duration=duration,
+        sale_item_id=_str("TXXX:KAMP_SALE_ITEM_ID"),
     )
 
 
@@ -4691,6 +5159,7 @@ def _read_m4a_tags(path: Path) -> Track:
         genre=_s("\xa9gen"),
         label=_s("----:com.apple.iTunes:LABEL"),
         duration=duration,
+        sale_item_id=_s("----:com.apple.iTunes:KAMP_SALE_ITEM_ID"),
     )
 
 
@@ -4741,6 +5210,7 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
         genre=_s("GENRE"),
         label=_s("LABEL") or _s("ORGANIZATION"),
         duration=duration,
+        sale_item_id=_s("KAMP_SALE_ITEM_ID"),
     )
 
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -567,6 +567,13 @@ def _cmd_daemon(
 
     index = LibraryIndex(db_path)
 
+    # KAMP-523: clear any download → ingest provenance rows whose artifact no
+    # longer exists (crash/restart between download and ingest), so a stale row
+    # can never be replayed against an unrelated file at the same path.
+    _swept = index.sweep_orphan_pending_ingest()
+    if _swept:
+        _logger.info("Cleared %d orphaned pending-ingest row(s) at startup", _swept)
+
     # Migrate legacy bandcamp_session.json → sessions DB table (one-time).
     # After migration the file is deleted so subsequent starts skip this block.
     _legacy_session = _state_dir() / "bandcamp_session.json"

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -415,6 +415,12 @@ def sync_new_purchases(
                 added_at=_parse_purchased(item.get("purchased")),
                 num_streamable_tracks=api_streamable,
             )
+            # KAMP-523: hand the download's identity to the ingest pipeline so it
+            # writes the metadata we already own and stamps a provenance tag,
+            # instead of re-deriving identity from tags via MusicBrainz.
+            index.add_pending_ingest(
+                str(path), str(sid), str(item.get("tralbum_id", ""))
+            )
             logger.info(
                 "Downloaded: %s (mode=%s, streamable_tracks=%d)",
                 path.name,
@@ -647,6 +653,9 @@ def download_single_album(
     # by the file watcher will add local tracks, and the albums/tracks queries
     # deduplicate by preferring non-bandcamp:// records when both exist.
     index.set_collection_item_mode(sale_item_id, "local")
+    # KAMP-523: record the download → pipeline provenance handoff (see
+    # sync_new_purchases for the rationale).
+    index.add_pending_ingest(str(dest), sale_item_id, str(item.get("tralbum_id", "")))
 
     if status_callback:
         status_callback("")

--- a/kamp_daemon/pipeline.py
+++ b/kamp_daemon/pipeline.py
@@ -59,6 +59,7 @@ def _pipeline_worker(
 
         import musicbrainzngs
 
+        from .config import _state_dir
         from .pipeline_impl import run
 
         # The subprocess starts with a clean interpreter — set_useragent must be
@@ -76,6 +77,9 @@ def _pipeline_worker(
             _on_directory=lambda d: stage_q.put(f"{_DIR_SENTINEL}{d}"),
             stage_callback=lambda s: stage_q.put(s),
             notify_callback=lambda s: stage_q.put(s),
+            # KAMP-523: the live DB path so the pipeline can consume the
+            # download → ingest provenance handoff (see pipeline_impl.run).
+            index_path=_state_dir() / "library.db",
         )
         result_q.put(("ok", None))
     except Exception as exc:  # noqa: BLE001

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -330,6 +330,12 @@ def _tag_known_bandcamp(
 
     total = len(audio_files)
     for audio_file, track in zip(audio_files, tracks):
+        # A standalone single ships with no track number (track_number == 0),
+        # but KAMP-526 numbers the streaming single as track 1. Align them so the
+        # scanner's favorite/play-count inheritance and the title override below —
+        # all keyed on (album_id, track_number, disc_number) — actually match.
+        if total == 1 and track.track_number == 0:
+            track.track_number = 1
         if overrides is not None:
             if overrides.album_artist:
                 track.album_artist = overrides.album_artist

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -13,6 +13,10 @@ import logging
 import shutil
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kamp_core.library import DownloadOverrides, LibraryIndex, PendingIngest
 
 from .artwork import ArtworkError, _detect_mime, _embed, find_local_artwork
 from .config import Config
@@ -27,6 +31,7 @@ from .tagger import (
     is_tagged,
     read_release_mbids,
     read_track_metadata_from_file,
+    write_sale_item_id,
     write_tags_from_track_metadata,
 )
 
@@ -72,6 +77,7 @@ def run(
     _on_directory: Callable[[Path], None] | None = None,
     stage_callback: Callable[[str], None] | None = None,
     notify_callback: Callable[[str], None] | None = None,
+    index_path: Path | None = None,
 ) -> None:
     """Process a single watch folder item (ZIP or directory) end-to-end.
 
@@ -89,6 +95,30 @@ def run(
     assert config.paths.library is not None
     watch_folder: Path = config.paths.watch_folder
     library: Path = config.paths.library
+
+    # KAMP-523: if the downloader recorded this artifact's Bandcamp identity, we
+    # own its metadata and must re-attach it to its streaming origin. Look the
+    # handoff up now, on the original artifact path, before extraction mutates
+    # it. Best-effort: any failure falls back to the normal MusicBrainz path.
+    # index_path is None for a bare directory drop or in unit tests — provenance
+    # only applies to downloads recorded by the daemon, which passes the real DB
+    # path. Keeping it a parameter (rather than deriving _state_dir() here) keeps
+    # the pipeline from ever touching the live DB under test.
+    index: "LibraryIndex | None" = None
+    provenance: "PendingIngest | None" = None
+    overrides: "DownloadOverrides | None" = None
+    if index_path is not None:
+        try:
+            from kamp_core.library import LibraryIndex  # noqa: PLC0415
+
+            index = LibraryIndex(index_path)
+            provenance = index.pending_ingest_for_path(str(path))
+            if provenance is not None:
+                overrides = index.download_overrides_for_sale_item(
+                    provenance.sale_item_id
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Provenance lookup failed (non-fatal): %s", exc)
 
     try:
         # --- 1. Extract -------------------------------------------------------
@@ -131,7 +161,16 @@ def run(
         # is untagged, run the full pass for the whole directory to stay consistent.
         if stage_callback:
             stage_callback("Tagging")
-        if all(is_tagged(f) for f in audio_files):
+        if provenance is not None:
+            # KAMP-523: we already own this release's identity and metadata.
+            # Keep the file's Bandcamp tags, overlay the user's display edits,
+            # stamp the provenance tag, and record an MBID best-effort — never
+            # let MusicBrainz rewrite the names (that divergence is the bug).
+            # This branch wins over the is_tagged skip below by design.
+            mbid, rg_mbid, title = _tag_known_bandcamp(
+                audio_files, provenance, overrides, ctx
+            )
+        elif all(is_tagged(f) for f in audio_files):
             logger.info("All files already tagged — skipping MusicBrainz lookup")
             mbid, rg_mbid = read_release_mbids(audio_files[0])
             title = "(already tagged)"
@@ -203,6 +242,10 @@ def run(
                     min_dimension=config.artwork.min_dimension,
                     max_bytes=config.artwork.max_bytes,
                     save_format=config.artwork.save_format,
+                    # KAMP-523: for a Bandcamp download, prefer the artwork we
+                    # already have (the cover bundled in the ZIP) and don't reach
+                    # out to the MusicBrainz Cover Art Archive.
+                    skip_network=provenance is not None,
                 )
         except ArtworkError as exc:
             # Artwork failure is non-fatal: log and continue.
@@ -246,6 +289,65 @@ def run(
         # quarantine, or unexpected error.
         if stage_callback:
             stage_callback("")
+        # KAMP-523: drop the provenance handoff whether we succeeded or
+        # quarantined — it has served its purpose and must never be replayed
+        # against a later, unrelated file at the same path.
+        if index is not None:
+            try:
+                if provenance is not None:
+                    index.clear_pending_ingest(str(path))
+            finally:
+                index.close()
+
+
+def _tag_known_bandcamp(
+    audio_files: list[Path],
+    provenance: "PendingIngest",
+    overrides: "DownloadOverrides | None",
+    ctx: KampGround,
+) -> tuple[str, str, str]:
+    """Tag a Bandcamp download from metadata we already own (KAMP-523).
+
+    Keeps each file's Bandcamp-provided tags, overlays the user's display edits
+    (renamed album/artist/tracks), stamps the KAMP_SALE_ITEM_ID provenance tag,
+    and records a release MBID best-effort. The MusicBrainz name output is never
+    applied — that divergence is exactly what forks a downloaded album from its
+    streaming origin. Returns (release_mbid, release_group_mbid, title).
+    """
+    tracks = [read_track_metadata_from_file(f) for f in audio_files]
+
+    # Best-effort MBID only: run the tagger but ignore its names, and never let
+    # a lookup failure quarantine the download (Bandcamp self-releases are often
+    # absent from MusicBrainz).
+    mbid, rg_mbid = "", ""
+    try:
+        enriched = KampMusicBrainzTagger(ctx).tag_release(tracks)
+        if enriched:
+            mbid = enriched[0].release_mbid
+            rg_mbid = enriched[0].release_group_mbid
+    except Exception as exc:
+        logger.warning("MBID lookup for Bandcamp download failed (non-fatal): %s", exc)
+
+    total = len(audio_files)
+    for audio_file, track in zip(audio_files, tracks):
+        if overrides is not None:
+            if overrides.album_artist:
+                track.album_artist = overrides.album_artist
+            if overrides.album:
+                track.album = overrides.album
+            edited_title = overrides.titles.get(track.track_number)
+            if edited_title:
+                track.title = edited_title
+        track.release_mbid = mbid
+        track.release_group_mbid = rg_mbid
+        write_tags_from_track_metadata(audio_file, track, total_tracks=total)
+        write_sale_item_id(audio_file, provenance.sale_item_id)
+
+    if overrides is not None and overrides.album:
+        title = overrides.album
+    else:
+        title = tracks[0].album if tracks else ""
+    return mbid, rg_mbid, title
 
 
 def _fetch_and_embed_via_extension(
@@ -257,6 +359,7 @@ def _fetch_and_embed_via_extension(
     min_dimension: int,
     max_bytes: int,
     save_format: str = "embedded",
+    skip_network: bool = False,
 ) -> tuple[bytes, str] | None:
     """Fetch cover art via KampCoverArtArchive extension and embed in audio files.
 
@@ -269,6 +372,11 @@ def _fetch_and_embed_via_extension(
     ``(image_bytes, mime_type)`` tuple is returned so the caller can write a
     cover file after the audio files have been moved to the library.
     Returns ``None`` when no qualifying art was found or when art was embedded.
+
+    When *skip_network* is True (Bandcamp downloads, KAMP-523), only the bundled
+    local image is used — the MusicBrainz Cover Art Archive is never queried, so
+    we keep the artwork we already own rather than fetching a possibly-different
+    one.
     """
     from .artwork import _load_local_artwork, has_embedded_art
 
@@ -282,6 +390,12 @@ def _fetch_and_embed_via_extension(
         if image_bytes is not None:
             logger.info("Using bundled artwork from %s", local)
             mime_type = _detect_mime(image_bytes)
+
+    if image_bytes is None and skip_network:
+        logger.info(
+            "Bandcamp download: no bundled art found — skipping Cover Art Archive"
+        )
+        return None
 
     if image_bytes is None:
         # Skip the Cover Art Archive network call when all files already have

--- a/kamp_daemon/tagger.py
+++ b/kamp_daemon/tagger.py
@@ -505,6 +505,55 @@ def _write_ogg_tags_from_metadata(
     logger.debug("Wrote metadata tags to OGG %s", path)
 
 
+# KAMP-523: the private tag that carries Bandcamp provenance. The scanner reads
+# it back (kamp_core.library._read_*_tags) and links the file to its album by
+# identity, so a download re-attaches to its streaming origin even when the
+# descriptive tags diverge.
+_SALE_ITEM_ID_MP3 = "TXXX:KAMP_SALE_ITEM_ID"
+_SALE_ITEM_ID_M4A = "----:com.apple.iTunes:KAMP_SALE_ITEM_ID"
+_SALE_ITEM_ID_VORBIS = "KAMP_SALE_ITEM_ID"
+
+
+def write_sale_item_id(path: Path, sale_item_id: str) -> None:
+    """Stamp *sale_item_id* into a file's KAMP_SALE_ITEM_ID private tag.
+
+    Written per codec, mirroring the MusicBrainz-ID tag conventions. A no-op
+    for an empty id or an unsupported format (logged, not raised).
+    """
+    if not sale_item_id:
+        return
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        try:
+            tags = id3.ID3(str(path))
+        except Exception:
+            tags = id3.ID3()
+        tags[_SALE_ITEM_ID_MP3] = id3.TXXX(
+            encoding=3, desc="KAMP_SALE_ITEM_ID", text=sale_item_id
+        )
+        tags.save(str(path))
+    elif suffix == ".m4a":
+        audio = mutagen.mp4.MP4(str(path))
+        if audio.tags is None:
+            audio.add_tags()
+        assert audio.tags is not None
+        audio.tags[_SALE_ITEM_ID_M4A] = [mutagen.mp4.MP4FreeForm(sale_item_id.encode())]
+        audio.save()
+    elif suffix in (".flac", ".ogg"):
+        audio = (
+            mutagen.flac.FLAC(str(path))
+            if suffix == ".flac"
+            else mutagen.oggvorbis.OggVorbis(str(path))
+        )
+        if audio.tags is None:
+            audio.add_tags()
+        assert audio.tags is not None
+        audio.tags[_SALE_ITEM_ID_VORBIS] = [sale_item_id]
+        audio.save()
+    else:
+        logger.warning("Unsupported format for provenance tag: %s", path)
+
+
 def _lookup_release_by_acoustid(
     audio_files: list[Path],
 ) -> tuple[ReleaseInfo, dict[Path, str]]:

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/scripts/merge_forked_album.sh
+++ b/scripts/merge_forked_album.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# merge_forked_album.sh — heal a "forked" album in a kamp library.db.
+#
+# A fork is two `albums` rows that are really the same release, split because a
+# metadata mismatch (classically a trailing space in album_artist, but also any
+# tag divergence: "A & B" vs "A / B", punctuation, etc.) defeated kamp's
+# match-by-(album_artist, album) join. The download path then minted a second
+# local album + artist instead of merging the downloaded files into the
+# Bandcamp album that carries sale_item_id.
+#
+# This script reassigns the DROP album's tracks onto the KEEP album, deletes the
+# orphan album, merges the duplicate artist (preserving play_time), normalizes
+# the surviving names to a canonical string, recomputes albums.source, and
+# verifies. It runs in ONE transaction after a timestamped backup.
+#
+# Pick KEEP = the album that carries sale_item_id (the Bandcamp origin) so the
+# merged album stays linked to its collection item. kamp's tracks_for_album()
+# hides the bandcamp:// rows whenever local tracks exist under the same
+# album_id, so after the merge you see one album playing the downloaded files.
+#
+# Usage:
+#   merge_forked_album.sh <db> <keep_album_id> <drop_album_id> [canonical_album_artist]
+#
+# If canonical_album_artist is omitted it defaults to TRIM() of the KEEP album's
+# current album_artist. Pass it explicitly when the divergence is not just
+# whitespace (e.g. unify "Homeboy Sandman / Edan" -> "Homeboy Sandman & Edan").
+#
+# Find candidates first (albums that collapse to the same trimmed/lowered key):
+#   sqlite3 library.db "
+#     SELECT TRIM(LOWER(album_artist)) k, TRIM(LOWER(album)) a,
+#            GROUP_CONCAT(id) ids, COUNT(*) n
+#     FROM albums GROUP BY k, a HAVING n > 1;"
+#
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed '1d'  # print the header as help
+  exit 2
+fi
+
+DB=$1
+KEEP=$2
+DROP=$3
+CANON=${4:-}
+
+q() { sqlite3 "$DB" "$@"; }
+
+[[ -f $DB ]] || { echo "no such db: $DB" >&2; exit 1; }
+[[ "$KEEP" =~ ^[0-9]+$ && "$DROP" =~ ^[0-9]+$ ]] || { echo "album ids must be integers" >&2; exit 1; }
+[[ "$KEEP" != "$DROP" ]] || { echo "keep and drop are the same album" >&2; exit 1; }
+
+# Resolve the two album rows up front; bail if either is missing. One query per
+# field — packing fields into a delimited string and splitting in the shell is
+# fragile (delimiter bytes don't reliably round-trip through read/IFS).
+[[ $(q "SELECT COUNT(*) FROM albums WHERE id=$KEEP;") == 1 ]] || { echo "keep album $KEEP not found" >&2; exit 1; }
+[[ $(q "SELECT COUNT(*) FROM albums WHERE id=$DROP;") == 1 ]] || { echo "drop album $DROP not found" >&2; exit 1; }
+
+keep_aa=$(q "SELECT album_artist FROM albums WHERE id=$KEEP;")
+keep_alb=$(q "SELECT album FROM albums WHERE id=$KEEP;")
+keep_artist=$(q "SELECT IFNULL(artist_id,'') FROM albums WHERE id=$KEEP;")
+keep_sale=$(q "SELECT IFNULL(sale_item_id,'') FROM albums WHERE id=$KEEP;")
+drop_aa=$(q "SELECT album_artist FROM albums WHERE id=$DROP;")
+drop_alb=$(q "SELECT album FROM albums WHERE id=$DROP;")
+drop_artist=$(q "SELECT IFNULL(artist_id,'') FROM albums WHERE id=$DROP;")
+
+# Default canonical artist = trimmed KEEP album_artist (computed in SQL so the
+# shell never has to quote the raw name).
+if [[ -z $CANON ]]; then
+  CANON=$(q "SELECT TRIM(album_artist) FROM albums WHERE id=$KEEP;")
+fi
+canon_sql=$(printf '%s' "$CANON" | sed "s/'/''/g")  # single-quote-escaped for SQL
+
+echo "DB:    $DB"
+echo "KEEP:  album $KEEP  [$keep_aa] / [$keep_alb]  artist_id=$keep_artist  sale_item_id=${keep_sale:-<none>}"
+echo "DROP:  album $DROP  [$drop_aa] / [$drop_alb]  artist_id=$drop_artist"
+echo "CANON: [$CANON]"
+[[ -n $keep_sale ]] || echo "WARNING: KEEP album has no sale_item_id — confirm it is the Bandcamp origin." >&2
+
+# --- Decide the surviving artist (keep the one with more play_time) -----------
+# artists are referenced only by albums.artist_id (tracks store a plain string).
+art_keep=$keep_artist
+art_drop=$drop_artist
+art_survivor=""
+art_loser=""
+if [[ -n $art_keep && -n $art_drop && $art_keep != "$art_drop" ]]; then
+  pt_keep=$(q "SELECT IFNULL(play_time,0) FROM artists WHERE id=$art_keep;")
+  pt_drop=$(q "SELECT IFNULL(play_time,0) FROM artists WHERE id=$art_drop;")
+  # string-safe float compare via sqlite
+  if [[ $(q "SELECT ($pt_drop > $pt_keep);") == 1 ]]; then
+    art_survivor=$art_drop; art_loser=$art_keep
+  else
+    art_survivor=$art_keep; art_loser=$art_drop
+  fi
+  echo "ARTIST: survivor=$art_survivor (sum play_time), loser=$art_loser (deleted)"
+fi
+
+# --- Backup -------------------------------------------------------------------
+ts=$(q "SELECT strftime('%Y%m%d-%H%M%S','now');")
+bak="$DB.bak-$ts"
+cp "$DB" "$bak"
+echo "backup: $bak"
+
+# --- Merge (single transaction) ----------------------------------------------
+sqlite3 "$DB" <<SQL
+BEGIN;
+
+-- 1. Move the DROP album's tracks onto the KEEP album.
+UPDATE tracks SET album_id = $KEEP WHERE album_id = $DROP;
+
+-- 2. Drop the now-empty duplicate album (frees the UNIQUE(album_artist,album) slot).
+DELETE FROM albums WHERE id = $DROP;
+
+-- 3. Merge artists: fold loser play_time into survivor, repoint refs, delete loser.
+$( [[ -n $art_survivor && -n $art_loser ]] && cat <<ART
+UPDATE artists SET play_time = play_time
+  + (SELECT IFNULL(play_time,0) FROM artists WHERE id = $art_loser)
+  WHERE id = $art_survivor;
+UPDATE albums SET artist_id = $art_survivor WHERE artist_id = $art_loser;
+DELETE FROM artists WHERE id = $art_loser
+  AND NOT EXISTS (SELECT 1 FROM albums WHERE artist_id = $art_loser);
+ART
+)
+
+-- 4. Normalize names to the canonical string (no collision now that DROP is gone).
+UPDATE albums SET album_artist = '$canon_sql' WHERE id = $KEEP;
+UPDATE tracks SET album_artist = '$canon_sql', artist = '$canon_sql' WHERE album_id = $KEEP;
+$( [[ -n $art_survivor ]] && echo "UPDATE artists SET name = '$canon_sql' WHERE id = $art_survivor;" )
+
+-- 5. Recompute albums.source from the surviving tracks (local present => 'local').
+UPDATE albums SET source = (
+  SELECT CASE
+    WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0 THEN 'local'
+    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+    ELSE MIN(t.source) END
+  FROM tracks t WHERE t.album_id = albums.id
+) WHERE id = $KEEP;
+
+-- 6. Keep bandcamp_collection.band_name consistent (no-op if unlinked).
+UPDATE bandcamp_collection SET band_name = '$canon_sql'
+  WHERE sale_item_id = (SELECT sale_item_id FROM albums WHERE id = $KEEP)
+    AND sale_item_id IS NOT NULL;
+
+COMMIT;
+SQL
+
+# --- Verify -------------------------------------------------------------------
+echo "--- result ---"
+sqlite3 -header -column "$DB" "
+  SELECT id, album_artist, album, source, IFNULL(sale_item_id,'<none>') sale_item_id, artist_id
+  FROM albums WHERE id = $KEEP;"
+sqlite3 -header -column "$DB" "
+  SELECT CASE WHEN file_path LIKE 'bandcamp://%' THEN 'stream' ELSE 'local' END kind,
+         COUNT(*) n FROM tracks WHERE album_id = $KEEP GROUP BY kind;"
+drop_left=$(q "SELECT COUNT(*) FROM albums WHERE id=$DROP;")
+echo "drop album rows remaining: $drop_left (expect 0)"
+echo "integrity: $(q 'PRAGMA integrity_check;')"
+echo "If the kamp server is running, restart it (or rescan) to refresh its cached album list."

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10035,6 +10035,31 @@ class TestProvenanceLinking:
         assert albums[0]["source"] == "local"
         index.close()
 
+    def test_single_favorite_inherits_once_track_number_aligned(
+        self, tmp_path: Path
+    ) -> None:
+        # With the streaming single favorited and the downloaded single aligned to
+        # track 1 (as the pipeline now does), inherit_remote_favorites carries the
+        # favorite across. Regression for the Ohm Foam "Gush" favorite loss.
+        index = LibraryIndex(tmp_path / "library.db")
+        self._seed_streaming_album(index, "S1", "Ohm Foam", "Gush")
+        stream = index.get_track_by_path("bandcamp://S1/1")
+        assert stream is not None
+        index._conn.execute("UPDATE tracks SET favorite = 1 WHERE id = ?", (stream.id,))
+        index._conn.commit()
+
+        dl = _download_track(tmp_path / "gush.mp3", "Ohm Foam", "Gush", "S1", n=1)
+        dl.title = "Gush"
+        index.upsert_many([dl])
+        index.inherit_remote_favorites([dl])
+
+        fav = index._conn.execute(
+            "SELECT favorite FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "gush.mp3"),),
+        ).fetchone()[0]
+        assert fav == 1
+        index.close()
+
     def test_unprovenanced_files_still_match_by_trimmed_name(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10237,3 +10237,53 @@ class TestHealForkedAlbums:
         healed = LibraryIndex(db)
         assert len(_album_rows(healed)) == 1
         healed.close()
+
+    def test_canonical_rename_collision_does_not_brick_db(self, tmp_path: Path) -> None:
+        # A distinct release (different sale_item_id) legitimately shares the
+        # canonical (album_artist, album) that a merge would rename onto. The
+        # rename must be skipped, the merge must still complete, and BOTH albums
+        # must survive — the DB must open, not crash-loop on UNIQUE. (Reality
+        # Checker P0 regression.)
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        # SX: origin with a trailing-space name (canonical would be "Artist").
+        index.upsert_collection_item(
+            "SX", mode="local", band_name="Artist ", item_title="Album"
+        )
+        index.upsert_many([_prov_stream_track("SX", "Artist ", "Album")])
+        # SY: a genuinely different release already occupying "Artist"/"Album".
+        index.upsert_collection_item(
+            "SY", mode="local", band_name="Artist", item_title="Album"
+        )
+        index.upsert_many([_prov_stream_track("SY", "Artist", "Album")])
+        index.close()
+
+        # Inject a second row sharing SX's sale_item_id → forces a pass-(a) merge
+        # whose canonical rename ("Artist ") -> ("Artist") would collide with SY.
+        self._downgrade_to_v38(db)
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "INSERT INTO albums (album_artist, album, source, sale_item_id)"
+            " VALUES ('Artist Dup', 'Album', 'local', 'SX')"
+        )
+        conn.commit()
+        conn.close()
+
+        healed = LibraryIndex(db)  # must not raise
+        by_sid = {
+            r["sale_item_id"]: r["album_artist"]
+            for r in healed._conn.execute(
+                "SELECT sale_item_id, album_artist FROM albums"
+                " WHERE sale_item_id IS NOT NULL"
+            ).fetchall()
+        }
+        # Both releases survive distinctly; SX kept its (un-renamed) name.
+        assert by_sid == {"SX": "Artist ", "SY": "Artist"}
+        # The duplicate SX row was merged away (one row per sale_item_id).
+        assert (
+            healed._conn.execute(
+                "SELECT COUNT(*) FROM albums WHERE sale_item_id = 'SX'"
+            ).fetchone()[0]
+            == 1
+        )
+        healed.close()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 38
+        assert version == 39
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1489,7 +1489,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1546,7 +1546,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2141,7 +2141,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert row is not None
         assert row[0] == 0
 
@@ -2565,7 +2565,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2661,7 +2661,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2842,7 +2842,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2937,7 +2937,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 38
+        assert version == 39
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2945,7 +2945,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 38
+        assert version == 39
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3822,7 +3822,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 38
+        assert version == 39
 
         index.close()
 
@@ -4513,7 +4513,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 38
+        assert version == 39
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4548,7 +4548,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 38
+        assert version == 39
         index.close()
 
 
@@ -4996,7 +4996,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 38
+        assert version == 39
 
 
 class TestRemoteTrackSchema:
@@ -5330,7 +5330,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5391,7 +5391,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6149,7 +6149,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -6466,7 +6466,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -6544,7 +6544,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6750,7 +6750,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7099,7 +7099,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7196,7 +7196,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7312,7 +7312,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7817,7 +7817,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7932,7 +7932,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8030,7 +8030,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8130,7 +8130,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -8637,7 +8637,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 38
+        assert version == 39
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -9481,7 +9481,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 38
+        assert version == 39
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -9863,3 +9863,377 @@ class TestGetStats:
         assert len(stats.top_tracks) == 2
         assert stats.top_tracks[0].file_path == pb
         assert stats.top_tracks[1].file_path == pa
+
+
+# ---------------------------------------------------------------------------
+# KAMP-523: identity-based provenance (download re-attaches to streaming origin)
+# ---------------------------------------------------------------------------
+
+
+def _prov_stream_track(sid: str, artist: str, album: str, n: int = 1) -> Track:
+    """A streaming (bandcamp://) track row for *sid*."""
+    return Track(
+        file_path=Path(f"bandcamp://{sid}/{n}"),
+        title=f"Track {n}",
+        artist=artist,
+        album_artist=artist,
+        album=album,
+        release_date="",
+        track_number=n,
+        disc_number=1,
+        ext="",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+        source="bandcamp",
+    )
+
+
+def _download_track(path: Path, artist: str, album: str, sid: str, n: int = 1) -> Track:
+    """A local downloaded file carrying a KAMP_SALE_ITEM_ID provenance stamp."""
+    t = Track(
+        file_path=path,
+        title=f"Track {n}",
+        artist=artist,
+        album_artist=artist,
+        album=album,
+        release_date="2020",
+        track_number=n,
+        disc_number=1,
+        ext="mp3",
+        embedded_art=False,
+        mb_release_id="",
+        mb_recording_id="",
+    )
+    t.sale_item_id = sid
+    return t
+
+
+def _album_rows(index: LibraryIndex) -> list[sqlite3.Row]:
+    return index._conn.execute(
+        "SELECT id, album_artist, album, source, sale_item_id FROM albums"
+    ).fetchall()
+
+
+class TestProvenanceLinking:
+    def _seed_streaming_album(
+        self,
+        index: LibraryIndex,
+        sid: str,
+        band_name: str,
+        item_title: str,
+    ) -> int:
+        """Create a bandcamp_collection item + its streaming album row."""
+        index.upsert_collection_item(
+            sid, mode="local", band_name=band_name, item_title=item_title
+        )
+        index.upsert_many([_prov_stream_track(sid, band_name, item_title)])
+        row = index._conn.execute(
+            "SELECT id FROM albums WHERE sale_item_id = ?", (sid,)
+        ).fetchone()
+        assert row is not None, "streaming album should carry sale_item_id"
+        return row["id"]
+
+    def test_download_reattaches_despite_trailing_whitespace(
+        self, tmp_path: Path
+    ) -> None:
+        # The reported bug: Bandcamp delivered a trailing space in band_name; the
+        # downloaded files were tagged clean. Identity linking must still merge.
+        index = LibraryIndex(tmp_path / "library.db")
+        origin = self._seed_streaming_album(
+            index, "S1", "Homeboy Sandman & Edan ", "Humble Pi"
+        )
+
+        dl = _download_track(
+            tmp_path / "hp.mp3", "Homeboy Sandman & Edan", "Humble Pi", "S1"
+        )
+        index.upsert_many([dl])
+
+        albums = _album_rows(index)
+        assert len(albums) == 1, f"expected one album, got {albums}"
+        assert albums[0]["id"] == origin
+        assert albums[0]["sale_item_id"] == "S1"
+        # exactly one artist row
+        n_artists = index._conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
+        assert n_artists == 1
+        # the local file is linked to the origin album
+        linked = index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "hp.mp3"),),
+        ).fetchone()[0]
+        assert linked == origin
+        index.close()
+
+    def test_download_reattaches_despite_punctuation_divergence(
+        self, tmp_path: Path
+    ) -> None:
+        # A divergence no amount of TRIM/NOCASE could fix: "/" vs "&".
+        index = LibraryIndex(tmp_path / "library.db")
+        origin = self._seed_streaming_album(
+            index, "S2", "Homeboy Sandman / Edan", "Humble Pi"
+        )
+        dl = _download_track(
+            tmp_path / "hp.mp3", "Homeboy Sandman & Edan", "Humble Pi", "S2"
+        )
+        index.upsert_many([dl])
+        albums = _album_rows(index)
+        assert len(albums) == 1
+        assert albums[0]["id"] == origin
+        index.close()
+
+    def test_download_stamps_id_when_origin_album_absent(self, tmp_path: Path) -> None:
+        # Downloaded without ever syncing streaming rows: still exactly one album,
+        # and it carries the sale_item_id.
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "S3", mode="local", band_name="Artist", item_title="Album"
+        )
+        dl = _download_track(tmp_path / "a.mp3", "Artist", "Album", "S3")
+        index.upsert_many([dl])
+        albums = _album_rows(index)
+        assert len(albums) == 1
+        assert albums[0]["sale_item_id"] == "S3"
+        index.close()
+
+    def test_stale_sale_item_id_falls_back_to_name_match(self, tmp_path: Path) -> None:
+        # A file carrying a sale_item_id not present in bandcamp_collection (e.g.
+        # moved in from elsewhere) must NOT link by identity — it falls back to
+        # the name match, and never violates the FK.
+        index = LibraryIndex(tmp_path / "library.db")
+        dl = _download_track(tmp_path / "a.mp3", "Local Artist", "Local Album", "GHOST")
+        index.upsert_many([dl])
+        albums = _album_rows(index)
+        assert len(albums) == 1
+        assert albums[0]["sale_item_id"] is None
+        assert albums[0]["album_artist"] == "Local Artist"
+        index.close()
+
+    def test_unprovenanced_files_still_match_by_trimmed_name(
+        self, tmp_path: Path
+    ) -> None:
+        # Two genuinely-local files whose album_artist differs only by a trailing
+        # space collapse to one album via the TRIM fallback.
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "1.mp3")
+        t2 = _sample_track(tmp_path / "2.mp3")
+        t2.album_artist = t1.album_artist + " "
+        index.upsert_many([t1, t2])
+        albums = _album_rows(index)
+        # One album row already existed for the trimmed name; the spaced variant
+        # links to it rather than forking (COLLATE NOCASE lets both names coexist
+        # as rows, but the track links via the TRIM match).
+        linked = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT album_id FROM tracks WHERE album_id IS NOT NULL"
+            ).fetchall()
+        }
+        assert len(linked) == 1
+        index.close()
+
+
+class TestDownloadOverrides:
+    def test_empty_when_album_not_synced(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        ov = index.download_overrides_for_sale_item("NOPE")
+        assert ov.album_artist == "" and ov.album == "" and ov.titles == {}
+        index.close()
+
+    def test_returns_user_edits(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("S1", mode="local", band_name="A", item_title="B")
+        index.upsert_many([_prov_stream_track("S1", "A", "B", n=1)])
+        index.update_album_display("A", "B", "Disp Album", "Disp Artist")
+        t1 = index.get_track_by_path("bandcamp://S1/1")
+        assert t1 is not None
+        index.update_track_display_title(t1.id, "Edited Title")
+        ov = index.download_overrides_for_sale_item("S1")
+        assert ov.album_artist == "Disp Artist"
+        assert ov.album == "Disp Album"
+        assert ov.titles == {1: "Edited Title"}
+        index.close()
+
+    def test_ambiguous_track_number_across_discs_is_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        # Two discs both have a track 1 with a display title → ambiguous, so no
+        # per-track override is offered for track 1 (avoids cross-disc misapply).
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("S1", mode="local", band_name="A", item_title="B")
+        d1 = _prov_stream_track("S1", "A", "B", n=1)
+        d2 = _prov_stream_track("S1", "A", "B", n=1)
+        d2.file_path = Path("bandcamp://S1/2")
+        d2.disc_number = 2
+        index.upsert_many([d1, d2])
+        for uri in ("bandcamp://S1/1", "bandcamp://S1/2"):
+            t = index.get_track_by_path(uri)
+            assert t is not None
+            index.update_track_display_title(t.id, "Edited")
+        ov = index.download_overrides_for_sale_item("S1")
+        assert 1 not in ov.titles
+        index.close()
+
+
+class TestPendingIngest:
+    def test_add_get_clear_roundtrip(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.add_pending_ingest("/watch/a.zip", "S1", "T1")
+        row = index.pending_ingest_for_path("/watch/a.zip")
+        assert row is not None
+        assert row.sale_item_id == "S1"
+        assert row.tralbum_id == "T1"
+        assert index.pending_ingest_for_path("/watch/missing.zip") is None
+        index.clear_pending_ingest("/watch/a.zip")
+        assert index.pending_ingest_for_path("/watch/a.zip") is None
+        index.close()
+
+    def test_add_is_idempotent_on_repeat_download(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.add_pending_ingest("/watch/a.zip", "S1")
+        index.add_pending_ingest("/watch/a.zip", "S2")  # re-download same path
+        row = index.pending_ingest_for_path("/watch/a.zip")
+        assert row is not None and row.sale_item_id == "S2"
+        n = index._conn.execute("SELECT COUNT(*) FROM pending_ingest").fetchone()[0]
+        assert n == 1
+        index.close()
+
+    def test_sweep_removes_only_orphans(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        real = tmp_path / "real.zip"
+        real.write_bytes(b"zip")
+        index.add_pending_ingest(str(real), "S1")
+        index.add_pending_ingest(str(tmp_path / "gone.zip"), "S2")
+        removed = index.sweep_orphan_pending_ingest()
+        assert removed == 1
+        assert index.pending_ingest_for_path(str(real)) is not None
+        assert index.pending_ingest_for_path(str(tmp_path / "gone.zip")) is None
+        index.close()
+
+
+class TestHealForkedAlbums:
+    def _downgrade_to_v38(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP INDEX IF EXISTS albums_sale_item_id_uidx")
+        conn.execute("UPDATE schema_version SET version = 38")
+        conn.commit()
+        conn.close()
+
+    def test_whitespace_fork_with_sale_item_id_collapses(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        # Origin streaming album (spaced name + sale_item_id).
+        index.upsert_collection_item(
+            "S1", mode="local", band_name="Artist X ", item_title="Album Y"
+        )
+        index.upsert_many([_prov_stream_track("S1", "Artist X ", "Album Y")])
+        index.close()
+
+        # Inject the fork the OLD code would have minted: a local album with the
+        # trimmed name, its own duplicate artist row (linked), and a local track.
+        # Done after the downgrade so the UNIQUE index isn't in the way.
+        self._downgrade_to_v38(db)
+        conn = sqlite3.connect(str(db))
+        conn.execute("INSERT INTO artists (name) VALUES ('Artist X')")
+        fork_artist = conn.execute(
+            "SELECT id FROM artists WHERE name = 'Artist X'"
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO albums (album_artist, album, source, artist_id)"
+            " VALUES ('Artist X', 'Album Y', 'local', ?)",
+            (fork_artist,),
+        )
+        fork_id = conn.execute(
+            "SELECT id FROM albums WHERE album_artist = 'Artist X' AND sale_item_id IS NULL"
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO tracks (file_path, album_artist, album, source, album_id)"
+            " VALUES ('/lib/x.mp3', 'Artist X', 'Album Y', 'local', ?)",
+            (fork_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        healed = LibraryIndex(db)  # triggers v39 heal
+        albums = _album_rows(healed)
+        assert len(albums) == 1, f"fork not healed: {albums}"
+        assert albums[0]["sale_item_id"] == "S1"
+        # local track moved under the surviving album
+        moved = healed._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = '/lib/x.mp3'"
+        ).fetchone()[0]
+        assert moved == albums[0]["id"]
+        # duplicate artist merged away
+        n_artists = healed._conn.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
+        assert n_artists == 1
+        # a backup was written
+        assert any(p.name.startswith("library.db.bak-") for p in tmp_path.iterdir())
+        healed.close()
+
+    def test_two_rows_sharing_sale_item_id_collapse(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index.upsert_collection_item(
+            "S9", mode="local", band_name="Band", item_title="Rec"
+        )
+        index.upsert_many([_prov_stream_track("S9", "Band", "Rec")])
+        index.close()
+
+        # A second album row illegally carrying the same sale_item_id (injected
+        # after the downgrade so the UNIQUE index isn't in the way).
+        self._downgrade_to_v38(db)
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "INSERT INTO albums (album_artist, album, source, sale_item_id)"
+            " VALUES ('Band', 'Rec (Deluxe)', 'local', 'S9')"
+        )
+        conn.commit()
+        conn.close()
+
+        healed = LibraryIndex(db)
+        rows = healed._conn.execute(
+            "SELECT COUNT(*) FROM albums WHERE sale_item_id = 'S9'"
+        ).fetchone()[0]
+        assert rows == 1
+        healed.close()
+
+    def test_string_only_fork_without_id_left_untouched(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        # Two distinct local albums that merely normalize alike, neither linked
+        # to Bandcamp — must NOT be merged (could be genuinely different).
+        index._conn.execute(
+            "INSERT INTO albums (album_artist, album, source) VALUES ('S T', 'EP', 'local')"
+        )
+        index._conn.execute(
+            "INSERT INTO albums (album_artist, album, source) VALUES ('S T ', 'EP', 'local')"
+        )
+        index._conn.commit()
+        index.close()
+
+        self._downgrade_to_v38(db)
+        healed = LibraryIndex(db)
+        n = healed._conn.execute("SELECT COUNT(*) FROM albums").fetchone()[0]
+        assert n == 2, "string-only forks must be left untouched"
+        # No backup taken when nothing merges.
+        assert not any(p.name.startswith("library.db.bak-") for p in tmp_path.iterdir())
+        healed.close()
+
+    def test_heal_is_idempotent(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index.upsert_collection_item(
+            "S1", mode="local", band_name="Artist X ", item_title="Album Y"
+        )
+        index.upsert_many([_prov_stream_track("S1", "Artist X ", "Album Y")])
+        index._conn.execute(
+            "INSERT INTO albums (album_artist, album, source) VALUES ('Artist X', 'Album Y', 'local')"
+        )
+        index._conn.commit()
+        index.close()
+
+        self._downgrade_to_v38(db)
+        LibraryIndex(db).close()  # first heal
+        # Re-open again: version is 39, migration does not re-run; still one album.
+        healed = LibraryIndex(db)
+        assert len(_album_rows(healed)) == 1
+        healed.close()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10008,6 +10008,33 @@ class TestProvenanceLinking:
         assert albums[0]["album_artist"] == "Local Artist"
         index.close()
 
+    def test_empty_album_single_links_to_origin_by_identity(
+        self, tmp_path: Path
+    ) -> None:
+        # A standalone Bandcamp single ships with no album tag (album == ""), so
+        # it is excluded from `named` — but it carries a provenance stamp and must
+        # still re-attach to its streaming single (which KAMP-526 gives an album
+        # name = title). Regression for the Ohm Foam "Gush" duplicate card.
+        index = LibraryIndex(tmp_path / "library.db")
+        origin = self._seed_streaming_album(index, "S1", "Ohm Foam", "Gush")
+
+        dl = _download_track(tmp_path / "gush.mp3", "Ohm Foam", "", "S1")
+        dl.title = "Gush"
+        index.upsert_many([dl])
+
+        albums = _album_rows(index)
+        assert len(albums) == 1, f"nameless single forked: {albums}"
+        assert albums[0]["id"] == origin
+        linked = index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "gush.mp3"),),
+        ).fetchone()[0]
+        assert linked == origin
+        # The album now holds a local file, so it reads as a local (downloaded)
+        # release rather than a stream.
+        assert albums[0]["source"] == "local"
+        index.close()
+
     def test_unprovenanced_files_still_match_by_trimmed_name(
         self, tmp_path: Path
     ) -> None:
@@ -10033,10 +10060,38 @@ class TestProvenanceLinking:
 
 
 class TestDownloadOverrides:
-    def test_empty_when_album_not_synced(self, tmp_path: Path) -> None:
+    def test_empty_when_item_unknown(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         ov = index.download_overrides_for_sale_item("NOPE")
         assert ov.album_artist == "" and ov.album == "" and ov.titles == {}
+        index.close()
+
+    def test_effective_canonical_names_without_user_edits(self, tmp_path: Path) -> None:
+        # No display edits: return the synced album row's canonical names so the
+        # download is stamped to match its origin (this is what gives a nameless
+        # single its album name).
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "S1", mode="local", band_name="Ohm Foam", item_title="Gush"
+        )
+        index.upsert_many([_prov_stream_track("S1", "Ohm Foam", "Gush")])
+        ov = index.download_overrides_for_sale_item("S1")
+        assert ov.album_artist == "Ohm Foam"
+        assert ov.album == "Gush"
+        index.close()
+
+    def test_falls_back_to_collection_when_album_row_absent(
+        self, tmp_path: Path
+    ) -> None:
+        # Downloaded without syncing streaming rows: the collection ledger still
+        # supplies the names (band_name / item_title).
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "S1", mode="local", band_name="Ohm Foam ", item_title="Gush"
+        )
+        ov = index.download_overrides_for_sale_item("S1")
+        assert ov.album_artist == "Ohm Foam"  # trimmed
+        assert ov.album == "Gush"
         index.close()
 
     def test_returns_user_edits(self, tmp_path: Path) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1103,6 +1103,59 @@ class TestKnownBandcampBranch:
         assert str(tags["TXXX:MusicBrainz Album Id"]) == "rel-77"
         assert str(tags["TXXX:KAMP_SALE_ITEM_ID"]) == "S7"
 
+    def test_nameless_single_gets_album_name_and_provenance(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        # A Bandcamp single arrives with no album tag; the pipeline must stamp the
+        # known album name (= the item title) so it doesn't ingest album-less and
+        # fork off a second card. Ohm Foam "Gush" regression.
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+
+        from kamp_core.library import LibraryIndex, Track
+
+        idx = LibraryIndex(db)
+        idx.upsert_collection_item(
+            "SG", mode="local", band_name="Ohm Foam", item_title="Gush"
+        )
+        idx.upsert_many(
+            [
+                Track(
+                    file_path=Path("bandcamp://SG/1"),
+                    title="Gush",
+                    artist="Ohm Foam",
+                    album_artist="Ohm Foam",
+                    album="Gush",
+                    release_date="",
+                    track_number=1,
+                    disc_number=1,
+                    ext="",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+        extracted = config.paths.watch_folder / "single"
+        extracted.mkdir()
+        gush = extracted / "Gush.mp3"
+        _make_bandcamp_mp3(gush, "Ohm Foam", "", "Gush", 1)  # no album tag
+        idx.add_pending_ingest(str(extracted), "SG", "TG")
+        idx.close()
+
+        with patch("kamp_daemon.pipeline_impl.KampMusicBrainzTagger") as mock_tagger:
+            mock_tagger.return_value.tag_release.side_effect = Exception("no network")
+            run(extracted, config, index_path=db)
+
+        moved = list(config.paths.library.rglob("*.mp3"))
+        assert len(moved) == 1
+        tags = id3.ID3(str(moved[0]))
+        assert str(tags["TALB"]) == "Gush"  # album name filled from known metadata
+        assert str(tags["TPE2"]) == "Ohm Foam"
+        assert str(tags["TXXX:KAMP_SALE_ITEM_ID"]) == "SG"
+
     def test_pending_ingest_cleared_on_quarantine(
         self, tmp_path: Path, config: Config
     ) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -953,3 +953,177 @@ class TestFetchAndEmbedViaExtension:
             )
 
         mock_embed.assert_called_once_with(mp3, image_data)
+
+
+# ---------------------------------------------------------------------------
+# KAMP-523: known-Bandcamp ingest branch (provenance)
+# ---------------------------------------------------------------------------
+
+
+def _make_bandcamp_mp3(
+    path: Path, artist: str, album: str, title: str, track: int
+) -> None:
+    path.write_bytes(b"\xff\xfb" * 64)
+    tags = id3.ID3()
+    tags["TPE1"] = id3.TPE1(encoding=3, text=artist)
+    tags["TPE2"] = id3.TPE2(encoding=3, text=artist)
+    tags["TALB"] = id3.TALB(encoding=3, text=album)
+    tags["TIT2"] = id3.TIT2(encoding=3, text=title)
+    tags["TRCK"] = id3.TRCK(encoding=3, text=str(track))
+    tags.save(str(path))
+
+
+class TestKnownBandcampBranch:
+    def _seed_db(self, db_path: Path) -> None:
+        from kamp_core.library import LibraryIndex, Track
+
+        idx = LibraryIndex(db_path)
+        idx.upsert_collection_item(
+            "S1", mode="local", band_name="Artist X ", item_title="Album Y"
+        )
+        # Streaming rows for the album (so display overrides have somewhere to live).
+        streaming = [
+            Track(
+                file_path=Path(f"bandcamp://S1/{n}"),
+                title=f"Track {n}",
+                artist="Artist X ",
+                album_artist="Artist X ",
+                album="Album Y",
+                release_date="",
+                track_number=n,
+                disc_number=1,
+                ext="",
+                embedded_art=False,
+                mb_release_id="",
+                mb_recording_id="",
+                source="bandcamp",
+            )
+            for n in (1, 2)
+        ]
+        idx.upsert_many(streaming)
+        # User edits on the streaming version.
+        idx.update_album_display(
+            "Artist X ", "Album Y", "Display Album", "Display Artist"
+        )
+        t1 = idx.get_track_by_path("bandcamp://S1/1")
+        assert t1 is not None
+        idx.update_track_display_title(t1.id, "Renamed Track 1")
+        idx.close()
+
+    def test_writes_known_metadata_and_provenance_without_musicbrainz(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+        self._seed_db(db)
+
+        extracted = config.paths.watch_folder / "album"
+        extracted.mkdir()
+        f1 = extracted / "01.mp3"
+        f2 = extracted / "02.mp3"
+        _make_bandcamp_mp3(f1, "Artist X", "Album Y", "Track 1", 1)
+        _make_bandcamp_mp3(f2, "Artist X", "Album Y", "Track 2", 2)
+
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(db)
+        idx.add_pending_ingest(str(extracted), "S1", "T1")
+        idx.close()
+
+        # MusicBrainz must never be required — make any lookup blow up and prove
+        # the download still ingests (best-effort MBID, non-fatal).
+        with patch("kamp_daemon.pipeline_impl.KampMusicBrainzTagger") as mock_tagger:
+            mock_tagger.return_value.tag_release.side_effect = Exception("no network")
+            run(extracted, config, index_path=db)
+
+        moved = list(config.paths.library.rglob("*.mp3"))
+        assert len(moved) == 2
+        # Track 1 carries the user's edits + the provenance stamp; MB names never
+        # applied.
+        track1 = next(p for p in moved if p.name.startswith("01"))
+        tags = id3.ID3(str(track1))
+        assert str(tags["TPE2"]) == "Display Artist"
+        assert str(tags["TALB"]) == "Display Album"
+        assert str(tags["TIT2"]) == "Renamed Track 1"
+        assert str(tags["TXXX:KAMP_SALE_ITEM_ID"]) == "S1"
+
+        # Provenance handoff consumed.
+        idx = LibraryIndex(db)
+        assert idx.pending_ingest_for_path(str(extracted)) is None
+        idx.close()
+
+    def test_records_mbid_and_keeps_bandcamp_names_without_overrides(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        # No user edits synced (empty overrides): keep the file's Bandcamp names,
+        # but still record the release MBID a successful lookup returns.
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(db)
+        idx.upsert_collection_item(
+            "S7", mode="local", band_name="Bandcamp Artist", item_title="Bandcamp Album"
+        )
+        extracted = config.paths.watch_folder / "album"
+        extracted.mkdir()
+        f1 = extracted / "01.mp3"
+        _make_bandcamp_mp3(f1, "Bandcamp Artist", "Bandcamp Album", "Real Title", 1)
+        idx.add_pending_ingest(str(extracted), "S7", "T7")
+        idx.close()
+
+        enriched = [
+            TrackMetadata(
+                title="MB Title",  # deliberately different — must NOT be applied
+                artist="MB Artist",
+                album="MB Album",
+                album_artist="MB Artist",
+                release_date="1999",
+                track_number=1,
+                mbid="rec-1",
+                release_mbid="rel-77",
+                release_group_mbid="rg-77",
+            )
+        ]
+        with patch("kamp_daemon.pipeline_impl.KampMusicBrainzTagger") as mock_tagger:
+            mock_tagger.return_value.tag_release.return_value = enriched
+            run(extracted, config, index_path=db)
+
+        moved = list(config.paths.library.rglob("*.mp3"))
+        assert len(moved) == 1
+        tags = id3.ID3(str(moved[0]))
+        # Bandcamp names kept; MB names ignored.
+        assert str(tags["TPE2"]) == "Bandcamp Artist"
+        assert str(tags["TALB"]) == "Bandcamp Album"
+        assert str(tags["TIT2"]) == "Real Title"
+        # MBID recorded, provenance stamped.
+        assert str(tags["TXXX:MusicBrainz Album Id"]) == "rel-77"
+        assert str(tags["TXXX:KAMP_SALE_ITEM_ID"]) == "S7"
+
+    def test_pending_ingest_cleared_on_quarantine(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+        self._seed_db(db)
+
+        # A directory with no audio files quarantines during extraction.
+        empty = config.paths.watch_folder / "album"
+        empty.mkdir()
+        (empty / "notes.txt").write_text("no audio here")
+
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(db)
+        idx.add_pending_ingest(str(empty), "S1", "T1")
+        idx.close()
+
+        run(empty, config, index_path=db)
+
+        idx = LibraryIndex(db)
+        assert idx.pending_ingest_for_path(str(empty)) is None
+        idx.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -27,6 +27,7 @@ from kamp_daemon.pipeline_impl import (
     _quarantine,
     run,
 )
+from kamp_core.library import _read_mp3_tags
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1155,6 +1156,11 @@ class TestKnownBandcampBranch:
         assert str(tags["TALB"]) == "Gush"  # album name filled from known metadata
         assert str(tags["TPE2"]) == "Ohm Foam"
         assert str(tags["TXXX:KAMP_SALE_ITEM_ID"]) == "SG"
+        # Aligned to the streaming single's track number (1) so favorite /
+        # play-count inheritance matches on (album_id, track_number, disc_number).
+        # Written "1/1" (track/total); the scanner parses the leading number.
+        assert str(tags["TRCK"]) == "1/1"
+        assert _read_mp3_tags(moved[0]).track_number == 1
 
     def test_pending_ingest_cleared_on_quarantine(
         self, tmp_path: Path, config: Config

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -31,8 +31,10 @@ from kamp_daemon.tagger import (
     read_release_mbids,
     read_track_metadata_from_file,
     tag_directory,
+    write_sale_item_id,
     write_tags_from_track_metadata,
 )
+from kamp_core.library import _read_mp3_tags
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -2160,3 +2162,68 @@ class TestLookupReleasesFromTracks:
 
         # Only one call — the empty-title track is skipped.
         assert mock_rec.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# KAMP-523: provenance tag (write_sale_item_id)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSaleItemId:
+    def test_mp3_roundtrip_through_scanner(self, tmp_path: Path) -> None:
+        # End-to-end proof: what the tagger stamps is what the scanner reads back
+        # into Track.sale_item_id and uses to link by identity.
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        write_sale_item_id(mp3, "389857692")
+        assert _read_mp3_tags(mp3).sale_item_id == "389857692"
+
+    def test_empty_id_is_noop(self, tmp_path: Path) -> None:
+        mp3 = tmp_path / "01.mp3"
+        _make_mp3(mp3)
+        write_sale_item_id(mp3, "")
+        assert _read_mp3_tags(mp3).sale_item_id == ""
+
+    def test_m4a_sets_freeform_key(self, tmp_path: Path) -> None:
+        m4a = tmp_path / "01.m4a"
+        _make_m4a(m4a)
+        mock_mp4 = MagicMock()
+        mock_mp4.tags = {}
+        with patch("kamp_daemon.tagger.mutagen.mp4.MP4", return_value=mock_mp4):
+            write_sale_item_id(m4a, "S1")
+        stored = mock_mp4.tags["----:com.apple.iTunes:KAMP_SALE_ITEM_ID"][0]
+        assert bytes(stored) == b"S1"
+        mock_mp4.save.assert_called_once()
+
+    def test_flac_sets_vorbis_key(self, tmp_path: Path) -> None:
+        flac = tmp_path / "01.flac"
+        flac.write_bytes(b"fLaC")
+        mock_audio = MagicMock()
+        mock_audio.tags = {}
+        with patch("kamp_daemon.tagger.mutagen.flac.FLAC", return_value=mock_audio):
+            write_sale_item_id(flac, "S2")
+        assert mock_audio.tags["KAMP_SALE_ITEM_ID"] == ["S2"]
+        mock_audio.save.assert_called_once()
+
+    def test_ogg_sets_vorbis_key(self, tmp_path: Path) -> None:
+        ogg = tmp_path / "01.ogg"
+        ogg.write_bytes(b"OggS")
+        mock_audio = MagicMock()
+        mock_audio.tags = None  # exercise the add_tags() branch
+
+        def _add_tags() -> None:
+            mock_audio.tags = {}
+
+        mock_audio.add_tags.side_effect = _add_tags
+        with patch(
+            "kamp_daemon.tagger.mutagen.oggvorbis.OggVorbis", return_value=mock_audio
+        ):
+            write_sale_item_id(ogg, "S3")
+        assert mock_audio.tags["KAMP_SALE_ITEM_ID"] == ["S3"]
+        mock_audio.add_tags.assert_called_once()
+
+    def test_unsupported_format_warns(self, tmp_path: Path) -> None:
+        wav = tmp_path / "01.wav"
+        wav.write_bytes(b"RIFF")
+        # Should not raise — just logs a warning.
+        write_sale_item_id(wav, "S4")


### PR DESCRIPTION
## What

Matures the streaming→download pipeline from "drop it in the watch folder and pray the tags match" to "every album/single is its own entity with a stable identity, whether streaming or local."

Downloading a Bandcamp purchase used to fork into a duplicate album + artist row because the scan linked local files to albums by matching descriptive tags `(album_artist, album)` under `COLLATE NOCASE` — which folds case but not whitespace/punctuation — and the MusicBrainz tag step rewrote the names. Any divergence minted a new album instead of merging into the streaming album carrying `sale_item_id`.

## How

- **Identity handoff:** the downloader records a `pending_ingest` row (`artifact_path → sale_item_id`) for album ZIPs *and* bare single tracks.
- **Known-metadata ingest:** when the pipeline sees a handoff it writes the metadata we already own (Bandcamp tags + the user's `display_*` edits), records an MBID best-effort (non-fatal), keeps the bundled/cached Bandcamp art instead of querying the Cover Art Archive, and stamps a `KAMP_SALE_ITEM_ID` private tag — **never** letting MusicBrainz rewrite the names.
- **Identity-first linking:** the scanner reads that tag; `upsert_many` links by `sale_item_id` first, falling back to a `TRIM`-normalized name match only for un-provenanced local files. A stale id absent from `bandcamp_collection` is ignored (FK-safe).
- **Invariant:** a partial `UNIQUE(sale_item_id)` index enforces one album per purchase.
- **Heal migration v39:** merges already-forked rows for the *provably-same* subset only (shared `sale_item_id`, or a local row that normalizes onto a `sale_item_id`-bearing row's collection band/title), taking a DB backup first and logging every merge; ambiguous string-only forks are left untouched. Idempotent.
- Daemon sweeps orphaned `pending_ingest` rows at startup; the tested `merge_forked_album.sh` moves into `scripts/`.

## Design notes

The original sidecar-manifest + auto-destructive-migration design was rejected by a Reality Checker pass (orphan/mismatch lifecycle, irreversible over-merge). This uses a DB transport table (modeled on `deferred_ops`) + an embedded provenance tag instead, and a non-destructive backup-guarded heal.

## Tests

25+ new behavioural tests: whitespace- and punctuation-divergent downloads each yield one album + one artist; stale/absent id falls back to name match; heal collapses seeded forks (whitespace + shared-id), leaves string-only forks untouched, is idempotent; provenance tag write→scan round-trip per codec; pipeline writes known metadata + provenance without MusicBrainz, records MBID on success, and clears the handoff on success and on quarantine.

Full suite green (2150 passed), black + mypy clean, coverage above threshold.

## Manual Test Plan

Albums
- [x] **Whitespace fork (the reported bug):** an album whose Bandcamp `band_name` has a trailing space — download it and confirm **one** album card + one artist, linked via `sale_item_id`, streaming rows hidden once local files exist.
- [x] **Punctuation divergence** (`A / B` vs `A & B`, or a MusicBrainz-style rewrite): download and confirm it still merges to one album by identity.
- [x] **User edits honoured:** rename a streaming album's artist/album (and a track title) via the UI, then download — the downloaded files reflect the display names, not raw Bandcamp/MB strings.
- [ ] **Regression:** a genuinely-local (non-Bandcamp) folder drop still tags via MusicBrainz and indexes normally.

Singles (KAMP-526 path)
- [x] **No duplicate card:** download a standalone single (e.g. Ohm Foam "Gush") → exactly one card, linked to its streaming origin; the file gets its album name filled in.
- [x] **Favorite persists:** favorite the streaming single, download it, confirm the favorite carries onto the local file (track number aligned to 1). Same for play count on a previously-streamed single.

Resilience
- [ ] **MBID non-fatal:** with no network / MB miss, the download still completes and links (no quarantine).
- [ ] **Quarantine / orphan:** interrupt a download (or force a pipeline failure) and confirm no orphaned `pending_ingest` row is left behind (startup sweep clears stale ones).

Heal migration (already-forked libraries)
- [x] On a DB with a known fork (e.g. Homeboy Sandman & Edan / Humble Pi, sale_item_id 389857692), confirm the v39 heal collapses it to one album, writes a `library.db.bak-*`, logs the merge, and passes integrity — and that re-running is a no-op.
- [x] Confirm a genuinely-distinct same-name release (different `sale_item_id`) is **not** merged.

> Note: verified end-to-end so far — Humble Pi (healed) and Ohm Foam "Gush" (single card + favorite). Remaining boxes are for wider coverage before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
