### PR TITLE
fix(library): prune empty local albums when their files are deleted (KAMP-522)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 39
+_SCHEMA_VERSION = 40
 
 
 @dataclass
@@ -1509,7 +1509,32 @@ class LibraryIndex:
             self._create_sale_item_id_unique_index()
             self._conn.execute("UPDATE schema_version SET version = 39")
             self._conn.commit()
-            version = 39  # noqa: F841
+            version = 39
+
+        if version < 40:
+            # v39 → v40: heal albums orphaned by filesystem deletion of their
+            # tracks (KAMP-522). Before the scan learned to prune, deleting an
+            # album folder left a zero-track ghost row behind; sweep those once
+            # on upgrade. Inlined (not via prune_empty_albums) so the migration's
+            # behaviour stays frozen if that method later changes. The
+            # sale_item_id guard preserves Bandcamp preorder/streaming rows.
+            album_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+            }
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            # Real DBs gain these columns in the v24 albums migration; only the
+            # narrow migration unit tests build a partial schema without them.
+            if "sale_item_id" in album_cols and "album_id" in track_cols:
+                self._conn.execute(
+                    "DELETE FROM albums WHERE sale_item_id IS NULL"
+                    " AND NOT EXISTS"
+                    " (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 40")
+            self._conn.commit()
+            version = 40  # noqa: F841
 
     def _create_sale_item_id_unique_index(self) -> None:
         """Enforce one album per sale_item_id via a partial UNIQUE index (KAMP-523).
@@ -3211,6 +3236,26 @@ class LibraryIndex:
                 }
             )
 
+    def prune_empty_albums(self) -> int:
+        """Delete purely-local album rows that no longer have any tracks (KAMP-522).
+
+        When the user deletes an album folder from disk, the scan removes the
+        track rows but leaves the parent ``albums`` row orphaned; it then shows
+        up in the UI as a ghost card with zero tracks. This sweeps those rows.
+
+        The ``sale_item_id IS NULL`` guard is load-bearing: Bandcamp-backed rows
+        (preorders, fetch-failed streaming albums, downloaded purchases) can
+        legitimately have zero *local* tracks and must survive — a forked album
+        also keeps its ``bandcamp://`` rows, so ``NOT EXISTS`` protects it too.
+        Returns the number of album rows removed.
+        """
+        cur = self._conn.execute(
+            "DELETE FROM albums WHERE sale_item_id IS NULL"
+            " AND NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)"
+        )
+        self._conn.commit()
+        return cur.rowcount
+
     def all_tracks(self) -> list[Track]:
         """Return all indexed tracks in insertion order."""
         rows = self._conn.execute("SELECT * FROM tracks").fetchall()
@@ -3339,7 +3384,13 @@ class LibraryIndex:
         # are synthesised at query time from tracks with empty album tags — they are
         # not stored here, so no filter is required.
         album_count = c.execute("SELECT COUNT(*) FROM albums").fetchone()[0]
-        artist_count = c.execute("SELECT COUNT(*) FROM artists").fetchone()[0]
+        # Count distinct album_artist values, matching the user-visible artists()
+        # list — a pruned album's artist row lingers in the artists table (its
+        # play_time still feeds total_play_seconds), so counting that table would
+        # drift above the shown artist list after a deletion (KAMP-522).
+        artist_count = c.execute(
+            "SELECT COUNT(DISTINCT album_artist) FROM albums"
+        ).fetchone()[0]
         total_seconds = c.execute(
             "SELECT COALESCE(SUM(play_time), 0) FROM artists"
         ).fetchone()[0]
@@ -5639,6 +5690,15 @@ class LibraryScanner:
             if path not in reconciled_old_paths:
                 self._index.remove_track(path)
                 removed += 1
+
+        # A removal may have emptied an album; prune the now-orphaned local
+        # rows so a deleted album folder disappears entirely (KAMP-522) rather
+        # than lingering as a zero-track ghost. Only when something was removed
+        # — idle scans never touch the albums table.
+        if removed:
+            pruned = self._index.prune_empty_albums()
+            if pruned:
+                logger.info("Pruned %d empty album(s) after scan removals", pruned)
 
         unchanged = len(on_disk & in_index) - len(to_update)
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 39
+        assert version == 40
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -824,6 +824,116 @@ class TestLibraryScanner:
         assert result.removed == 1
         assert tracks == []
 
+    def test_scan_removes_orphaned_local_album(self, tmp_path: Path) -> None:
+        """Deleting every file of a local album prunes the album row too (KAMP-522).
+
+        Otherwise the album lingers with zero tracks and surfaces in the UI as
+        a ghost card with track_count == 0.
+        """
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3", title="One", album="Ghost", album_artist="Spectre")
+        _make_mp3(lib / "02.mp3", title="Two", album="Ghost", album_artist="Spectre")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+        assert any(a.album == "Ghost" for a in index.albums())
+
+        (lib / "01.mp3").unlink()
+        (lib / "02.mp3").unlink()
+        scanner.scan(lib)
+        albums = index.albums()
+        index.close()
+
+        assert not any(a.album == "Ghost" for a in albums)
+
+    def test_scan_keeps_album_with_remaining_track(self, tmp_path: Path) -> None:
+        """Deleting only some files leaves the album with its surviving tracks."""
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3", title="One", album="Half", album_artist="Band")
+        _make_mp3(lib / "02.mp3", title="Two", album="Half", album_artist="Band")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+        (lib / "02.mp3").unlink()
+        scanner.scan(lib)
+        albums = [a for a in index.albums() if a.album == "Half"]
+        index.close()
+
+        assert len(albums) == 1
+        assert albums[0].track_count == 1
+
+    def test_prune_empty_albums_keeps_bandcamp_backed_album(
+        self, tmp_path: Path
+    ) -> None:
+        """A sale_item_id-bearing album with zero tracks survives the prune.
+
+        Preorders and fetch-failed streaming albums legitimately have no
+        tracks; only purely-local (sale_item_id IS NULL) orphans are removed.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        conn = index._conn
+        # A local orphan (no tracks, no provenance) — should be pruned.
+        conn.execute(
+            "INSERT INTO albums (album_artist, album) VALUES ('Local', 'Orphan')"
+        )
+        # A Bandcamp preorder-shaped row (sale_item_id set, zero tracks) — kept.
+        conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, mode) VALUES ('sid-1', 'preorder')"
+        )
+        conn.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id, source)"
+            " VALUES ('Artist', 'Preorder', 'sid-1', 'bandcamp')"
+        )
+        conn.commit()
+
+        removed = index.prune_empty_albums()
+        remaining = {a.album for a in index.albums()}
+        index.close()
+
+        assert removed == 1
+        assert "Orphan" not in remaining
+        assert "Preorder" in remaining
+
+    def test_scan_keeps_fork_with_remote_track(self, tmp_path: Path) -> None:
+        """A downloaded purchase reverts to streaming when its local files vanish.
+
+        The album carries sale_item_id and still has a bandcamp:// row, so it
+        must not be pruned when the local file is deleted.
+        """
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "01.mp3", title="One", album="Fork", album_artist="Artist")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+        conn = index._conn
+        # Stamp the scanned album with provenance and add a streaming sibling row.
+        conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, mode) VALUES ('sid-9', 'local')"
+        )
+        conn.execute("UPDATE albums SET sale_item_id = 'sid-9' WHERE album = 'Fork'")
+        album_id = conn.execute(
+            "SELECT id FROM albums WHERE album = 'Fork'"
+        ).fetchone()["id"]
+        conn.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, source, album_id)"
+            " VALUES ('bandcamp://sid-9/1', 'One', 'Fork', 'Artist', 'bandcamp', ?)",
+            (album_id,),
+        )
+        conn.commit()
+
+        (lib / "01.mp3").unlink()
+        scanner.scan(lib)
+        albums = {a.album for a in index.albums()}
+        index.close()
+
+        assert "Fork" in albums
+
     def test_scan_reads_m4a_tags(self, tmp_path: Path) -> None:
         lib = tmp_path / "music"
         lib.mkdir()
@@ -1489,7 +1599,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1546,7 +1656,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2141,7 +2251,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert row is not None
         assert row[0] == 0
 
@@ -2303,6 +2413,37 @@ class TestTopArtists:
         assert len(result) == 1
         assert result[0].name == "Bach"
         assert result[0].play_time == pytest.approx(960.0)
+
+    def test_migration_v40_heals_orphaned_local_album(self, tmp_path: Path) -> None:
+        """v40 sweeps pre-existing zero-track local albums, keeping Bandcamp rows."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        seed = LibraryIndex(db_path)
+        seed.close()
+        conn = _sqlite3.connect(str(db_path))
+        # A local orphan left behind by the old (pre-fix) deletion behaviour.
+        conn.execute(
+            "INSERT INTO albums (album_artist, album) VALUES ('Local', 'Orphan')"
+        )
+        # A Bandcamp preorder-shaped row that legitimately has zero tracks.
+        conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, mode) VALUES ('sid-1', 'preorder')"
+        )
+        conn.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id, source)"
+            " VALUES ('Artist', 'Preorder', 'sid-1', 'bandcamp')"
+        )
+        conn.execute("UPDATE schema_version SET version = 39")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)  # re-open triggers the v40 migration
+        albums = {a.album for a in index.albums()}
+        index.close()
+
+        assert "Orphan" not in albums
+        assert "Preorder" in albums
 
     def test_top_artists_returns_artist_info_instances(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -2565,7 +2706,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2661,7 +2802,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2842,7 +2983,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -2937,7 +3078,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 39
+        assert version == 40
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -2945,7 +3086,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 39
+        assert version == 40
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3822,7 +3963,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 39
+        assert version == 40
 
         index.close()
 
@@ -4513,7 +4654,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 39
+        assert version == 40
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4548,7 +4689,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 39
+        assert version == 40
         index.close()
 
 
@@ -4996,7 +5137,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 39
+        assert version == 40
 
 
 class TestRemoteTrackSchema:
@@ -5330,7 +5471,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5391,7 +5532,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6149,7 +6290,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -6466,7 +6607,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -6544,7 +6685,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -6750,7 +6891,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7099,7 +7240,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7196,7 +7337,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7312,7 +7453,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -7817,7 +7958,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -7932,7 +8073,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8030,7 +8171,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8130,7 +8271,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -8637,7 +8778,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 39
+        assert version == 40
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -9481,7 +9622,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 39
+        assert version == 40
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -9763,6 +9904,31 @@ class TestGetStats:
         assert stats.track_count == 3
         assert stats.album_count == 2
         assert stats.artist_count == 2
+
+    def test_artist_count_matches_artists_list_after_prune(
+        self, tmp_path: Path
+    ) -> None:
+        """artist_count stays consistent with artists() once an album is pruned.
+
+        Pruning leaves the artists-table row behind, so counting that table
+        would over-report; the stat derives from albums to match the UI list.
+        """
+        lib = tmp_path / "music"
+        lib.mkdir()
+        _make_mp3(lib / "a.mp3", title="A", album="Solo", album_artist="Gone")
+        _make_mp3(lib / "b.mp3", title="B", album="Stay", album_artist="Kept")
+
+        index = LibraryIndex(tmp_path / "library.db")
+        scanner = LibraryScanner(index)
+        scanner.scan(lib)
+        (lib / "a.mp3").unlink()
+        scanner.scan(lib)
+        stats = index.get_stats()
+        artists = index.artists()
+        index.close()
+
+        assert stats.artist_count == len(artists)
+        assert "Gone" not in artists
 
     def test_total_play_seconds(self, tmp_path: Path) -> None:
         """total_play_seconds accumulates from artists.play_time via record_play_time."""
@@ -10280,12 +10446,26 @@ class TestHealForkedAlbums:
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
         # Two distinct local albums that merely normalize alike, neither linked
-        # to Bandcamp — must NOT be merged (could be genuinely different).
-        index._conn.execute(
+        # to Bandcamp — must NOT be merged (could be genuinely different). Each
+        # gets a linked track so they are real albums rather than empty rows the
+        # v40 prune would (correctly) sweep — the point here is the v39 heal.
+        cur = index._conn.execute(
             "INSERT INTO albums (album_artist, album, source) VALUES ('S T', 'EP', 'local')"
         )
-        index._conn.execute(
+        a1 = cur.lastrowid
+        cur = index._conn.execute(
             "INSERT INTO albums (album_artist, album, source) VALUES ('S T ', 'EP', 'local')"
+        )
+        a2 = cur.lastrowid
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, source, album_id)"
+            " VALUES ('/m/1.mp3', 'x', 'EP', 'S T', 'local', ?)",
+            (a1,),
+        )
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, source, album_id)"
+            " VALUES ('/m/2.mp3', 'y', 'EP', 'S T ', 'local', ?)",
+            (a2,),
         )
         index._conn.commit()
         index.close()


### PR DESCRIPTION
## Problem

Deleting an album folder from the library through the file system (Finder/Explorer) left the album in the library showing zero tracks instead of disappearing. The file watcher fired a rescan and the scan removed the missing track rows, but the parent `albums` row was left orphaned — and `albums()` reads the `albums` table `LEFT JOIN tracks`, so the zero-track row still surfaced as a ghost card in the UI.

## Fix

- **`prune_empty_albums()`** — after a scan removes tracks, delete purely-local (`sale_item_id IS NULL`) album rows that have no remaining tracks. Runs at the scan tail, only when a removal happened.
- **Why not inside `remove_track`** — its two non-scan callers in `server.py` remove the *conflicting* entry during an overwrite-rename; pruning there could destroy album metadata (favorite/art/display overrides) when overwriting an album's last track.
- **Bandcamp-safe** — preorders, streaming, and downloaded purchases always carry `sale_item_id`, so they're never pruned even at zero *local* tracks. A forked album keeps its `bandcamp://` rows, so `NOT EXISTS` protects it too.
- **v40 migration** heals libraries that already accumulated ghost albums (guarded for the narrow partial-schema migration unit tests); `_SCHEMA_VERSION` → 40.
- **`stats().artist_count`** now derives from `COUNT(DISTINCT album_artist) FROM albums`, keeping it consistent with the visible `artists()` list after a prune (the artists-table row lingers and still feeds `total_play_seconds`).

## Tests

New behavioral tests: orphaned-album removal, partial-deletion survival, Bandcamp/preorder guard, fork survival, v40 migration heal, and artist-count consistency. Existing "migrated to current version" assertions bumped 39 → 40.

Full suite: **2162 passed, 9 skipped**; black + mypy clean; coverage 93.07% (passes the 93 floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)