### PR TITLE
fix(bandcamp): materialize stream tracks before removing a download (KAMP-527)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -94,6 +94,18 @@ _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 _SCHEMA_VERSION = 40
 
 
+class NoStreamableVersionError(Exception):
+    """Raised by remove_download when the album cannot fall back to streaming.
+
+    Reverting a downloaded album deletes its local track rows; that is only safe
+    when every local track has a matching bandcamp:// stream row to fall back to.
+    When one or more do not (download-mode purchase never streamed, a partial
+    materialization, or a multi-disc download whose disc>1 tracks have no stream
+    counterpart), removal would strand those tracks — so we abort and delete
+    nothing rather than destroy the album (KAMP-527).
+    """
+
+
 @dataclass
 class Condition:
     """A single field-level filter in a magic playlist."""
@@ -547,6 +559,10 @@ class AlbumInfo:
     sale_item_id: str | None = None
     # True when the album is a Bandcamp pre-order (some tracks not yet released).
     is_preorder: bool = False
+    # Number of streamable tracks Bandcamp reports for this purchase (KAMP-527).
+    # 0 means no streamable version exists — "Remove download" would strand the
+    # album, so the UI hides that action. Snapshot; the server re-verifies.
+    num_streamable_tracks: int = 0
     # Bandcamp album page URL — non-empty for streaming/downloaded Bandcamp albums.
     album_url: str = ""
     # Stable integer PK of the albums row; 0 for missing-album virtual entries.
@@ -2317,6 +2333,10 @@ class LibraryIndex:
     def remove_download(self, sale_item_id: str) -> "list[Path]":
         """Revert a downloaded collection item back to streaming state.
 
+        0. Fail-safe guard: raise NoStreamableVersionError (before touching
+           anything) unless every local track has a matching bandcamp:// row to
+           fall back to. The daemon materializes those stream rows on demand
+           first; if it cannot, we must not delete the download (KAMP-527).
         1. Migrates play counts from local track rows to their matching streaming
            counterparts (MAX wins) so counts accumulated during local playback are
            not lost.
@@ -2325,7 +2345,9 @@ class LibraryIndex:
         4. Sets bandcamp_collection.mode = 'remote'.
 
         Returns the list of local file paths that the caller should delete from
-        the filesystem (file deletion is handled in the server layer).
+        the filesystem (file deletion is handled in the server layer). All
+        mutations run under rollback discipline so a mid-flight failure never
+        leaks a partial delete into a later commit on this pooled connection.
         """
         row = self._conn.execute(
             "SELECT id FROM albums WHERE sale_item_id = ?", (sale_item_id,)
@@ -2346,61 +2368,102 @@ class LibraryIndex:
             (album_id,),
         ).fetchall()
 
-        # Migrate play counts (MAX wins) and favorites (OR wins) to streaming rows.
-        for r in local_rows:
-            self._conn.execute(
-                """
-                UPDATE tracks
-                SET play_count = MAX(play_count, ?),
-                    favorite   = MAX(favorite, ?)
-                WHERE album_id = ?
-                  AND track_number = ?
-                  AND disc_number = ?
-                  AND (file_path LIKE 'bandcamp://%' OR file_path LIKE 'bandcamp:\\%')
-                """,
-                (
-                    r["play_count"],
-                    r["favorite"],
-                    album_id,
-                    r["track_number"],
-                    r["disc_number"],
-                ),
+        # KAMP-527 fail-safe: refuse to delete unless EVERY local track has a
+        # bandcamp:// counterpart (matched on track_number + disc_number) to fall
+        # back to. Checked before any mutation so an abort touches nothing. This
+        # covers the download-mode case (no stream rows at all), a partial
+        # materialization, and multi-disc downloads whose disc>1 tracks have no
+        # stream row. Without it the album would be deleted with no way back.
+        uncovered = self._conn.execute(
+            """
+            SELECT COUNT(*) AS n FROM tracks l
+            WHERE l.album_id = ?
+              AND l.file_path NOT LIKE 'bandcamp://%'
+              AND l.file_path NOT LIKE 'bandcamp:\\%'
+              AND NOT EXISTS (
+                  SELECT 1 FROM tracks s
+                  WHERE s.album_id = l.album_id
+                    AND s.track_number = l.track_number
+                    AND s.disc_number = l.disc_number
+                    AND (s.file_path LIKE 'bandcamp://%'
+                         OR s.file_path LIKE 'bandcamp:\\%')
+              )
+            """,
+            (album_id,),
+        ).fetchone()["n"]
+        if uncovered > 0:
+            raise NoStreamableVersionError(
+                f"{uncovered} track(s) for sale_item_id={sale_item_id} have no "
+                "streamable counterpart; refusing to delete the download."
             )
 
         file_paths = [Path(r["file_path"]) for r in local_rows]
 
-        # Remove local track rows.
-        self._conn.execute(
-            """
-            DELETE FROM tracks
-            WHERE album_id = ?
-              AND file_path NOT LIKE 'bandcamp://%'
-              AND file_path NOT LIKE 'bandcamp:\\%'
-            """,
-            (album_id,),
-        )
+        # All mutations run under a single transaction guarded by rollback: a
+        # mid-flight failure must NOT leave a partial delete uncommitted on this
+        # thread-local connection, or the next unrelated commit() would flush it
+        # and silently destroy the local tracks (KAMP-527 deferred-commit bug).
+        try:
+            # Migrate play counts (MAX wins) and favorites (OR wins) to streaming rows.
+            for r in local_rows:
+                self._conn.execute(
+                    """
+                    UPDATE tracks
+                    SET play_count = MAX(play_count, ?),
+                        favorite   = MAX(favorite, ?)
+                    WHERE album_id = ?
+                      AND track_number = ?
+                      AND disc_number = ?
+                      AND (file_path LIKE 'bandcamp://%' OR file_path LIKE 'bandcamp:\\%')
+                    """,
+                    (
+                        r["play_count"],
+                        r["favorite"],
+                        album_id,
+                        r["track_number"],
+                        r["disc_number"],
+                    ),
+                )
 
-        # Refresh albums.source — same subquery pattern as set_track_source_for_item.
-        self._conn.execute(
-            """
-            UPDATE albums SET source = (
-                SELECT CASE
-                    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
-                         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                    THEN 'local'
-                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                    ELSE MIN(t.source)
-                END
-                FROM tracks t WHERE t.album_id = albums.id
+            # Remove local track rows.
+            self._conn.execute(
+                """
+                DELETE FROM tracks
+                WHERE album_id = ?
+                  AND file_path NOT LIKE 'bandcamp://%'
+                  AND file_path NOT LIKE 'bandcamp:\\%'
+                """,
+                (album_id,),
             )
-            WHERE id = ?
-            """,
-            (album_id,),
-        )
 
-        self.set_collection_item_mode(sale_item_id, "remote")
-        self._rebuild_fts()
-        self._conn.commit()
+            # Refresh albums.source — same subquery pattern as set_track_source_for_item.
+            self._conn.execute(
+                """
+                UPDATE albums SET source = (
+                    SELECT CASE
+                        WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+                             AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
+                        THEN 'local'
+                        WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                        ELSE MIN(t.source)
+                    END
+                    FROM tracks t WHERE t.album_id = albums.id
+                )
+                WHERE id = ?
+                """,
+                (album_id,),
+            )
+
+            self._conn.execute(
+                "UPDATE bandcamp_collection SET mode = 'remote', synced_at = NULL"
+                " WHERE sale_item_id = ?",
+                (sale_item_id,),
+            )
+            self._rebuild_fts()
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
         if self.on_fields_changed:
             self.on_fields_changed(
                 {
@@ -2412,6 +2475,26 @@ class LibraryIndex:
             )
 
         return file_paths
+
+    def materialize_stream_tracks(
+        self, sale_item_id: str, tracks: "list[Track]"
+    ) -> int:
+        """Upsert on-demand bandcamp:// stream rows for a downloaded album.
+
+        Used by the DELETE-download endpoint (KAMP-527) to create the streamable
+        representation a download-mode album never had, so remove_download has
+        something to fall back to. Stamps *sale_item_id* on each Track so
+        upsert_many links them by identity to the EXISTING album row rather than
+        forking a new name-keyed album (KAMP-523 identity path). upsert_many
+        already carries rollback discipline, so a mid-flight failure leaves no
+        partial writes on this connection. Returns the number of tracks upserted.
+        """
+        if not tracks:
+            return 0
+        for t in tracks:
+            t.sale_item_id = str(sale_item_id)
+        self.upsert_many(tracks)
+        return len(tracks)
 
     def reset_collection_sync_state(self) -> None:
         """Set synced_at = NULL for all rows so the next sync re-downloads everything."""
@@ -2590,10 +2673,24 @@ class LibraryIndex:
         self.upsert_many([track])
 
     def upsert_many(self, tracks: list[Track]) -> None:
-        """Insert or replace multiple tracks in a single transaction."""
+        """Insert or replace multiple tracks in a single transaction.
+
+        Wrapped in rollback discipline: a mid-flight failure (FK violation, a
+        locked database after the busy timeout, disk error) must not leave the
+        partial writes uncommitted on this thread-local connection, or the next
+        unrelated commit() would flush them (the KAMP-527 deferred-commit bug,
+        also fixed in remove_download).
+        """
         if not tracks:
             return
+        try:
+            self._upsert_many(tracks)
+        except Exception:
+            self._conn.rollback()
+            raise
 
+    def _upsert_many(self, tracks: list[Track]) -> None:
+        """Body of upsert_many; see the wrapper for rollback discipline."""
         named = [t for t in tracks if t.album]
 
         # KAMP-523: resolve Bandcamp provenance up front. A track carrying a
@@ -3698,6 +3795,8 @@ class LibraryIndex:
                 CASE WHEN bc.mode = 'local' THEN 1 ELSE 0 END AS in_bc,
                 -- is_preorder: True when the album is a Bandcamp pre-order (KAMP-423).
                 CASE WHEN bc.mode = 'preorder' THEN 1 ELSE 0 END AS is_preorder,
+                -- num_streamable_tracks: 0 => no streamable version (KAMP-527).
+                COALESCE(bc.num_streamable_tracks, 0) AS num_streamable_tracks,
                 -- album_url: Bandcamp page URL for sharing (KAMP-367).
                 COALESCE(bc.album_url, '') AS album_url,
                 -- display overrides for streaming albums (KAMP-467).
@@ -3732,6 +3831,7 @@ class LibraryIndex:
                 t.favorite          AS has_favorite_track,
                 0                   AS in_bc,
                 0                   AS is_preorder,
+                0                   AS num_streamable_tracks,
                 ''                  AS album_url,
                 NULL                AS display_album,
                 NULL                AS display_album_artist,
@@ -3760,6 +3860,7 @@ class LibraryIndex:
                 has_remote_tracks=r["album_source"] != "local",
                 in_bandcamp_collection=bool(r["in_bc"]),
                 is_preorder=bool(r["is_preorder"]),
+                num_streamable_tracks=r["num_streamable_tracks"],
                 album_url=r["album_url"] or "",
                 sale_item_id=r["sale_item_id"],
                 display_album=r["display_album"],

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -47,6 +47,7 @@ from kamp_core.library import (
     LibraryScanner,
     LibraryStats,
     MagicCriteria,
+    NoStreamableVersionError,
     Track,
     _canonical_track_key,
     extract_art,
@@ -293,6 +294,9 @@ class AlbumOut(BaseModel):
     sale_item_id: str | None = None
     # True when the album is a Bandcamp pre-order (some tracks not yet released).
     is_preorder: bool = False
+    # Streamable-track count Bandcamp reports; 0 => no streamable version, so the
+    # UI hides "Remove download" (KAMP-527). Snapshot; the server re-verifies.
+    num_streamable_tracks: int = 0
     # Bandcamp album page URL — non-empty for Bandcamp albums (KAMP-367).
     album_url: str = ""
     # User-set display overrides for streaming albums (KAMP-467). None means no override.
@@ -788,6 +792,61 @@ def _validate_proxy_url(url: str) -> str:
     return url
 
 
+def _materialize_stream_tracks_or_422(
+    index: LibraryIndex,
+    item: dict[str, Any],
+    get_bandcamp_session: "Callable[[], dict[str, Any] | None] | None",
+) -> None:
+    """Fetch + upsert bandcamp:// stream rows for a download-mode album (KAMP-527).
+
+    Called from the DELETE-download endpoint before any deletion so a downloaded
+    album gains the streamable representation it never had. Any failure — no
+    session, no album_url, network/parse error, or an empty result (Bandcamp has
+    no streamable version) — raises HTTP 422 so the caller deletes nothing. The
+    underlying upsert carries its own rollback discipline.
+    """
+    album_url = item.get("album_url") or ""
+    sale_item_id = str(item.get("sale_item_id") or "")
+    session_data = get_bandcamp_session() if get_bandcamp_session else None
+    if not session_data or not album_url:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Log in to Bandcamp to revert this download — a streamable "
+                "version must be fetched before the local files are removed."
+            ),
+        )
+    from kamp_daemon.bandcamp import (  # noqa: PLC0415
+        _make_requests_session,
+        fetch_album_tracks,
+    )
+
+    try:
+        session = _make_requests_session(session_data)
+        tracks = fetch_album_tracks(
+            album_url,
+            int(sale_item_id),
+            item.get("band_name") or "",
+            item.get("item_title") or "",
+            session,
+        )
+    except Exception as exc:  # network, parse, or auth failure
+        raise HTTPException(
+            status_code=422,
+            detail="Could not fetch the streamable version from Bandcamp.",
+        ) from exc
+
+    if not tracks:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "No streamable version available for this album. Removing the "
+                "download would remove it from your library, so it was kept."
+            ),
+        )
+    index.materialize_stream_tracks(sale_item_id, tracks)
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -1167,6 +1226,7 @@ def create_app(
                 has_remote_tracks=a.has_remote_tracks,
                 sale_item_id=a.sale_item_id,
                 is_preorder=a.is_preorder,
+                num_streamable_tracks=a.num_streamable_tracks,
                 album_url=a.album_url,
                 display_album=a.display_album,
                 display_album_artist=a.display_album_artist,
@@ -1975,6 +2035,7 @@ def create_app(
             has_remote_tracks=result.has_remote_tracks,
             sale_item_id=result.sale_item_id,
             is_preorder=result.is_preorder,
+            num_streamable_tracks=result.num_streamable_tracks,
             album_url=result.album_url,
             display_album=result.display_album,
             display_album_artist=result.display_album_artist,
@@ -2262,6 +2323,7 @@ def create_app(
                     has_remote_tracks=a.has_remote_tracks,
                     sale_item_id=a.sale_item_id,
                     is_preorder=a.is_preorder,
+                    num_streamable_tracks=a.num_streamable_tracks,
                     album_url=a.album_url,
                     display_album=a.display_album,
                     display_album_artist=a.display_album_artist,
@@ -2391,6 +2453,7 @@ def create_app(
                     has_remote_tracks=a.has_remote_tracks,
                     sale_item_id=a.sale_item_id,
                     is_preorder=a.is_preorder,
+                    num_streamable_tracks=a.num_streamable_tracks,
                     album_url=a.album_url,
                     display_album=a.display_album,
                     display_album_artist=a.display_album_artist,
@@ -2550,6 +2613,7 @@ def create_app(
                 has_remote_tracks=a.has_remote_tracks,
                 sale_item_id=a.sale_item_id,
                 is_preorder=a.is_preorder,
+                num_streamable_tracks=a.num_streamable_tracks,
                 album_url=a.album_url,
                 display_album=a.display_album,
                 display_album_artist=a.display_album_artist,
@@ -2966,8 +3030,12 @@ def create_app(
 
         Returns 404 if the item is not in the collection.
         Returns 409 if a track from this album is currently playing.
+        Returns 422 if no streamable version can be produced (logged out,
+        network/parse failure, or no streamable tracks) — in which case nothing
+        is deleted.
         """
-        if not index.get_collection_item(sale_item_id):
+        item = index.get_collection_item(sale_item_id)
+        if not item:
             raise HTTPException(status_code=404, detail="Collection item not found")
 
         local_tracks = index.local_tracks_for_sale_item_id(sale_item_id)
@@ -2987,6 +3055,16 @@ def create_app(
                 ),
             )
 
+        # KAMP-527: download-mode albums have no bandcamp:// stream rows to fall
+        # back to. Materialize them on demand (a network call) BEFORE the queue
+        # swap and delete — this is why the daemon-side endpoint owns it rather
+        # than the pure LibraryIndex method. If we cannot (logged out, fetch
+        # fails, or Bandcamp has no streamable version), abort with 422 and
+        # delete nothing; remove_download's own per-track guard is the final
+        # safety net that still refuses to strand any local track.
+        if not index.has_remote_album_tracks(sale_item_id):
+            _materialize_stream_tracks_or_422(index, item, get_bandcamp_session)
+
         # Swap every local track in the queue to its streaming equivalent so
         # that on restart the queue can be fully restored from the DB.  Without
         # this, only the swapped current/next entries survive; all other queue
@@ -3001,7 +3079,18 @@ def create_app(
             # is released before we delete the file from disk.
             engine.unload()
 
-        file_paths = index.remove_download(sale_item_id)
+        try:
+            file_paths = index.remove_download(sale_item_id)
+        except NoStreamableVersionError as exc:
+            # The per-track guard refused: at least one local track has no stream
+            # counterpart (e.g. a multi-disc download). Nothing was deleted.
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "No streamable version available for this album. Removing the "
+                    "download would remove it from your library, so it was kept."
+                ),
+            ) from exc
 
         for fp in file_paths:
             try:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -60,6 +60,9 @@ export type Album = {
   sale_item_id?: string
   // True when this album is a Bandcamp pre-order (some tracks not yet released).
   is_preorder?: boolean
+  // Streamable-track count Bandcamp reports; 0 => no streamable version, so
+  // "Remove download" is hidden (it would strand the album) — KAMP-527.
+  num_streamable_tracks?: number
   // Bandcamp album page URL — non-empty for Bandcamp albums; used for sharing.
   album_url?: string
   // User-set display overrides for streaming albums (KAMP-467). Undefined means no override.

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -224,27 +224,29 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
               Download this album
             </button>
           )}
-          {album.source === 'local' && album.sale_item_id && (
-            <button
-              className="track-context-menu-item track-context-menu-item--action"
-              onClick={() => {
-                void removeDownload(album.sale_item_id!)
-                onClose()
-              }}
-            >
-              <span
-                style={{
-                  marginRight: 6,
-                  verticalAlign: 'middle',
-                  flexShrink: 0,
-                  display: 'inline-flex'
+          {album.source === 'local' &&
+            album.sale_item_id &&
+            (album.num_streamable_tracks ?? 0) > 0 && (
+              <button
+                className="track-context-menu-item track-context-menu-item--action"
+                onClick={() => {
+                  void removeDownload(album.sale_item_id!)
+                  onClose()
                 }}
               >
-                <RemoveFromQueueIcon size={12} />
-              </span>
-              Remove download
-            </button>
-          )}
+                <span
+                  style={{
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                    flexShrink: 0,
+                    display: 'inline-flex'
+                  }}
+                >
+                  <RemoveFromQueueIcon size={12} />
+                </span>
+                Remove download
+              </button>
+            )}
           {album.source === 'local' && (
             <button
               className="track-context-menu-item"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -6550,6 +6550,248 @@ class TestRemoveDownload:
 
         assert result == []
 
+    # --- KAMP-527: fail-safe guard when no streamable representation exists ---
+
+    def _setup_download_only_album(self, tmp_path: Path) -> LibraryIndex:
+        """A downloaded album with local tracks but NO bandcamp:// stream rows.
+
+        This is the download-mode population from KAMP-527: provenance is linked
+        (albums.sale_item_id set) but the streaming Track rows were never created
+        because the user bought+downloaded rather than streamed.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "sid99",
+            mode="local",
+            band_name="The Artist",
+            item_title="The Album",
+            album_url="https://the-artist.bandcamp.com/album/the-album",
+            num_streamable_tracks=2,
+            synced_at=1.0,
+        )
+
+        local1 = _sample_track(tmp_path / "track1.mp3")
+        local1.track_number = 1
+        local2 = _sample_track(tmp_path / "track2.mp3")
+        local2.track_number = 2
+        index.upsert_many([local1, local2])
+
+        index._conn.execute(
+            "UPDATE albums SET sale_item_id = 'sid99', source = 'local'"
+            " WHERE album = 'The Album'"
+        )
+        index._conn.commit()
+        return index
+
+    def test_remove_download_raises_when_no_stream_rows(self, tmp_path: Path) -> None:
+        from kamp_core.library import NoStreamableVersionError
+
+        index = self._setup_download_only_album(tmp_path)
+        with pytest.raises(NoStreamableVersionError):
+            index.remove_download("sid99")
+
+        # Nothing was deleted — the two local tracks remain.
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        index.close()
+        assert remaining == 2
+
+    def test_remove_download_no_stream_rows_deferred_commit_safe(
+        self, tmp_path: Path
+    ) -> None:
+        """The aborted removal must roll back so a LATER unrelated commit on the
+        same (thread-local) connection does not flush a partial deletion.
+        """
+        from kamp_core.library import NoStreamableVersionError
+
+        index = self._setup_download_only_album(tmp_path)
+        with pytest.raises(NoStreamableVersionError):
+            index.remove_download("sid99")
+
+        # Simulate the next unrelated write + commit on the same connection.
+        index._conn.execute(
+            "UPDATE bandcamp_collection SET synced_at = 2.0 WHERE sale_item_id = 'sid99'"
+        )
+        index._conn.commit()
+
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        index.close()
+        assert remaining == 2
+
+    def test_remove_download_partial_stream_rows_raises(self, tmp_path: Path) -> None:
+        """A stream counterpart for only some local tracks is still unsafe: the
+        uncovered local track would be lost, so the whole op aborts.
+        """
+        from kamp_core.library import NoStreamableVersionError
+
+        index = self._setup_download_only_album(tmp_path)
+        # Materialize a stream row for track 1 only.
+        streaming1 = _sample_track(Path("bandcamp://sid99/1"))
+        streaming1.track_number = 1
+        streaming1.source = "bandcamp"
+        streaming1.sale_item_id = "sid99"
+        index.upsert_many([streaming1])
+
+        with pytest.raises(NoStreamableVersionError):
+            index.remove_download("sid99")
+
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        index.close()
+        assert remaining == 2
+
+    def test_remove_download_multidisc_local_without_stream_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A local disc-2 track has no stream counterpart (fetch_album_tracks only
+        ever yields disc 1), so removal must abort rather than silently lose it.
+        """
+        from kamp_core.library import NoStreamableVersionError
+
+        index = self._setup_download_only_album(tmp_path)
+        # Give the album a matching stream row for disc 1 tracks…
+        for n in (1, 2):
+            s = _sample_track(Path(f"bandcamp://sid99/{n}"))
+            s.track_number = n
+            s.source = "bandcamp"
+            s.sale_item_id = "sid99"
+            index.upsert_many([s])
+        # …then add a disc-2 local track with no stream counterpart.
+        d2 = _sample_track(tmp_path / "disc2track1.mp3")
+        d2.track_number = 1
+        d2.disc_number = 2
+        index.upsert_many([d2])
+        index._conn.execute(
+            "UPDATE albums SET sale_item_id = 'sid99', source = 'local'"
+            " WHERE album = 'The Album'"
+        )
+        index._conn.commit()
+
+        with pytest.raises(NoStreamableVersionError):
+            index.remove_download("sid99")
+
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        index.close()
+        assert remaining == 3
+
+    def test_materialize_stream_tracks_attaches_to_existing_album(
+        self, tmp_path: Path
+    ) -> None:
+        """Materialized stream rows link by identity to the existing album row
+        (no fork) so remove_download can then migrate + revert cleanly.
+        """
+        index = self._setup_download_only_album(tmp_path)
+        album_id = index._conn.execute(
+            "SELECT id FROM albums WHERE sale_item_id = 'sid99'"
+        ).fetchone()["id"]
+
+        s1 = _sample_track(Path("bandcamp://sid99/1"))
+        s1.track_number = 1
+        s1.source = "bandcamp"
+        s2 = _sample_track(Path("bandcamp://sid99/2"))
+        s2.track_number = 2
+        s2.source = "bandcamp"
+        n = index.materialize_stream_tracks("sid99", [s1, s2])
+
+        # No duplicate album row, and the stream rows joined the existing album.
+        album_count = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM albums WHERE sale_item_id = 'sid99'"
+        ).fetchone()["n"]
+        stream_album_ids = [
+            r["album_id"]
+            for r in index._conn.execute(
+                "SELECT album_id FROM tracks WHERE file_path LIKE 'bandcamp://sid99/%'"
+            ).fetchall()
+        ]
+        index.close()
+        assert n == 2
+        assert album_count == 1
+        assert stream_album_ids == [album_id, album_id]
+
+    def test_remove_download_succeeds_after_materialize(self, tmp_path: Path) -> None:
+        """End-to-end: materialize then remove_download reverts to streaming."""
+        index = self._setup_download_only_album(tmp_path)
+        s1 = _sample_track(Path("bandcamp://sid99/1"))
+        s1.track_number = 1
+        s1.source = "bandcamp"
+        s2 = _sample_track(Path("bandcamp://sid99/2"))
+        s2.track_number = 2
+        s2.source = "bandcamp"
+        index.materialize_stream_tracks("sid99", [s1, s2])
+
+        paths = index.remove_download("sid99")
+
+        local_remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        source = index._conn.execute(
+            "SELECT source FROM albums WHERE sale_item_id = 'sid99'"
+        ).fetchone()["source"]
+        index.close()
+        assert len(paths) == 2
+        assert local_remaining == 0
+        assert source == "bandcamp"
+
+    def test_materialize_stream_tracks_empty_is_noop(self, tmp_path: Path) -> None:
+        index = self._setup_download_only_album(tmp_path)
+        assert index.materialize_stream_tracks("sid99", []) == 0
+        index.close()
+
+    def test_remove_download_rolls_back_on_mid_transaction_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """If a mutation fails after the guard passes, the partial delete must be
+        rolled back so a later unrelated commit cannot flush it (KAMP-527).
+        """
+        index = self._setup_downloaded_album(tmp_path)  # has stream + local rows
+
+        # Force a failure late in the transaction, after the DELETE has run.
+        def _boom() -> None:
+            raise RuntimeError("simulated failure during remove_download")
+
+        with patch.object(index, "_rebuild_fts", _boom):
+            with pytest.raises(RuntimeError):
+                index.remove_download("sid42")
+
+        # The next unrelated write + commit must NOT flush the aborted delete.
+        index._conn.execute(
+            "UPDATE bandcamp_collection SET synced_at = 9.0 WHERE sale_item_id = 'sid42'"
+        )
+        index._conn.commit()
+
+        local_remaining = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM tracks WHERE file_path NOT LIKE 'bandcamp://%'"
+        ).fetchone()["n"]
+        index.close()
+        assert local_remaining == 2
+
+    def test_upsert_many_rolls_back_on_mid_transaction_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """upsert_many carries the same rollback discipline: a mid-flight failure
+        leaves no partial writes to leak into the next commit (KAMP-527).
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        t1 = _sample_track(tmp_path / "a.mp3")
+        t1.track_number = 1
+
+        with patch.object(index, "_rebuild_fts", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                index.upsert_many([t1])
+
+        # Nothing from the aborted upsert should survive a later commit.
+        index._conn.execute("PRAGMA user_version = 1")  # any harmless write
+        index._conn.commit()
+        n = index._conn.execute("SELECT COUNT(*) AS n FROM tracks").fetchone()["n"]
+        index.close()
+        assert n == 0
+
 
 class TestMigrationV23:
     """v22 → v23: download_queue table created on upgrade from v22."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3118,6 +3118,154 @@ class TestBandcampRemoveDownload:
         assert not album_dir.exists()
         assert artist_dir.exists()  # kept — other album still present
 
+    # --- KAMP-527: on-demand stream materialization for download-mode albums ---
+
+    def _download_only_item(self) -> dict[str, Any]:
+        return {
+            "sale_item_id": "42",
+            "mode": "local",
+            "band_name": "Artist",
+            "item_title": "Album",
+            "album_url": "https://artist.bandcamp.com/album/album",
+            "num_streamable_tracks": 2,
+        }
+
+    def test_materializes_stream_tracks_when_missing(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """A download-mode album with no stream rows fetches + materializes them
+        before remove_download runs."""
+        mock_index.get_collection_item.return_value = self._download_only_item()
+        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.remove_download.return_value = []
+        mock_engine.state.playing = False
+
+        fetched = [MagicMock(name="track1"), MagicMock(name="track2")]
+        with (
+            patch(
+                "kamp_daemon.bandcamp.fetch_album_tracks", return_value=fetched
+            ) as fat,
+            patch("kamp_daemon.bandcamp._make_requests_session"),
+        ):
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                get_bandcamp_session=lambda: {"cookies": []},
+            )
+            resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 200
+        fat.assert_called_once()
+        mock_index.materialize_stream_tracks.assert_called_once_with("42", fetched)
+        mock_index.remove_download.assert_called_once_with("42")
+
+    def test_returns_422_when_no_session_for_materialization(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_collection_item.return_value = self._download_only_item()
+        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_engine.state.playing = False
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            get_bandcamp_session=lambda: None,
+        )
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 422
+        mock_index.materialize_stream_tracks.assert_not_called()
+        mock_index.remove_download.assert_not_called()
+
+    def test_returns_422_when_no_streamable_version_available(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """fetch_album_tracks returning nothing => no streamable version; abort."""
+        mock_index.get_collection_item.return_value = self._download_only_item()
+        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_engine.state.playing = False
+
+        with (
+            patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=[]),
+            patch("kamp_daemon.bandcamp._make_requests_session"),
+        ):
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                get_bandcamp_session=lambda: {"cookies": []},
+            )
+            resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 422
+        mock_index.materialize_stream_tracks.assert_not_called()
+        mock_index.remove_download.assert_not_called()
+
+    def test_returns_422_when_fetch_raises(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.get_collection_item.return_value = self._download_only_item()
+        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_engine.state.playing = False
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp.fetch_album_tracks",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("kamp_daemon.bandcamp._make_requests_session"),
+        ):
+            app = create_app(
+                index=mock_index,
+                engine=mock_engine,
+                queue=mock_queue,
+                get_bandcamp_session=lambda: {"cookies": []},
+            )
+            resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 422
+        mock_index.remove_download.assert_not_called()
+
+    def test_returns_422_when_remove_download_reports_no_streamable(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Stream rows appear present (skip materialize) but remove_download's own
+        per-track guard rejects the removal => surface a clean 422."""
+        from kamp_core.library import NoStreamableVersionError
+
+        mock_index.get_collection_item.return_value = self._download_only_item()
+        mock_index.has_remote_album_tracks.return_value = True
+        mock_index.local_tracks_for_sale_item_id.return_value = []
+        mock_index.streaming_track_for_local_id.return_value = None
+        mock_index.remove_download.side_effect = NoStreamableVersionError("nope")
+        mock_engine.state.playing = False
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
+
+        assert resp.status_code == 422
+
 
 # Bandcamp session-cookies endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## KAMP-527: "Remove download" no longer destroys download-mode albums

### Problem
"Remove download" reverts a downloaded Bandcamp album to stream-only state. It worked for stream-mode users (whose albums already have `bandcamp://` track rows) but **broke for download-mode users**, whose albums have no stream rows to fall back to. On such albums the action:

1. **500'd** — `remove_download()` deleted the only (local) tracks, then `MIN(t.source)` over an empty set set `albums.source` to `NULL`, tripping `NOT NULL constraint failed`.
2. **Risked silent data loss** — the aborted transaction was never rolled back, so the next unrelated `commit()` on the same pooled (`threading.local`) worker connection could flush the partial `DELETE` and leave a zero-track ghost album.

~84% of the maintainer's provenance-linked library was in this state.

### Fix
Treat downloaded albums as "downloaded streams": **materialize the streamable representation before destroying the local one**, and make the operation fail-safe.

- **`remove_download` (kamp_core/library.py)** — per-track fail-safe guard: refuse (raise `NoStreamableVersionError`, before any mutation) unless *every* local track has a matching `bandcamp://` counterpart. All mutations now run under `try/except → rollback` so a mid-flight failure can never leak a partial delete into a later commit. The collection-mode flip is folded into the same transaction for atomicity.
- **`upsert_many`** — wrapped in the same rollback discipline (it had the identical deferred-commit landmine on the materialization path).
- **`materialize_stream_tracks`** — new thin index method that stamps `sale_item_id` on fetched tracks so they attach to the *existing* album row by identity (no fork), then upserts them.
- **DELETE endpoint (kamp_core/server.py)** — owns the network call: when an album has no stream rows it fetches them via `fetch_album_tracks` and materializes before the queue-swap/delete. Logged out / fetch failure / no streamable version → **HTTP 422, nothing deleted** (surfaced to the UI as a toast). Catches `NoStreamableVersionError` from `remove_download` → 422.
- **UI** — `num_streamable_tracks` is surfaced through `AlbumInfo`/`AlbumOut`/the `Album` type, and the "Remove download" menu item is hidden when it's 0 (defense-in-depth; the server remains authoritative).

Multi-disc downloads whose disc>1 tracks have no stream counterpart now fail cleanly rather than silently losing those tracks — a documented, safe limitation.

### Tests
- `tests/test_library.py` — download-only album raises + deletes nothing; deferred-commit regression (a later commit does not flush the aborted delete); partial and multi-disc cases; `remove_download`/`upsert_many` rollback on mid-transaction failure; `materialize_stream_tracks` identity attach (no fork) + end-to-end revert.
- `tests/test_server.py` — DELETE endpoint materialize success; 422 on no-session, empty fetch, fetch raises, and `NoStreamableVersionError`; existing 200/409 paths still pass.
- Full suite green; black + mypy clean; UI typecheck + eslint clean.

### Manual test plan
On a copy of a download-mode DB:
1. Downloaded album with `num_streamable_tracks > 0` → Remove download reverts to a streamable, playable album; play count + favorites preserved; local files removed.
2. Logged out → action fails with a toast; album and local files untouched.
3. `num_streamable_tracks == 0` → the menu item is hidden.
4. Multi-disc download → fails cleanly, nothing deleted.
5. Stream-mode downloaded album → works exactly as before.
6. After any failed removal, keep using the app and confirm the album still has all its local tracks (no deferred-commit corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
