### PR TITLE
fix(bandcamp): track-level provenance so standalone singles are recoverable (KAMP-528)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 40
+_SCHEMA_VERSION = 41
 
 
 class NoStreamableVersionError(Exception):
@@ -197,7 +197,16 @@ CREATE TABLE IF NOT EXISTS tracks (
     -- NULL means "use the canonical value from Bandcamp".
     display_title        TEXT,
     display_album        TEXT,
-    display_album_artist TEXT
+    display_album_artist TEXT,
+    -- Track-level Bandcamp provenance (KAMP-528). Mirrors albums.sale_item_id but
+    -- resolves standalone singles: a purchased single has no album row, so the
+    -- only place to record "this file came from sale_item_id X" is here. Written
+    -- from the KAMP_SALE_ITEM_ID file tag on upsert (valid_sids only, FK-safe).
+    -- The supporting index (tracks_sale_item_id_idx) is created by
+    -- _create_tracks_sale_item_id_index(), NOT here: on an upgrade, executescript
+    -- runs the whole _DDL before the v41 migration adds this column, so a
+    -- CREATE INDEX in _DDL would reference a not-yet-existing column and fail.
+    sale_item_id         TEXT    REFERENCES bandcamp_collection(sale_item_id)
 );
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
@@ -726,6 +735,7 @@ class LibraryIndex:
             # to create immediately (migrations, which also create it after the
             # heal, do not run for a brand-new DB).
             self._create_sale_item_id_unique_index()
+            self._create_tracks_sale_item_id_index()
             self._conn.execute(
                 "INSERT INTO schema_version (version) VALUES (?)", (_SCHEMA_VERSION,)
             )
@@ -1550,7 +1560,74 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 40")
             self._conn.commit()
-            version = 40  # noqa: F841
+            version = 40
+
+        if version < 41:
+            # v40 → v41: add track-level Bandcamp provenance (KAMP-528). Standalone
+            # singles have no album row, so albums.sale_item_id cannot record their
+            # origin; tracks.sale_item_id can. The KAMP_SALE_ITEM_ID file tag is
+            # already read into Track.sale_item_id — this column lets it persist.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if "sale_item_id" not in track_cols:
+                # Default is NULL, so SQLite accepts an added REFERENCES column
+                # even under foreign_keys=ON (a non-NULL default would be rejected).
+                self._conn.execute(
+                    "ALTER TABLE tracks ADD COLUMN sale_item_id TEXT"
+                    " REFERENCES bandcamp_collection(sale_item_id)"
+                )
+            self._create_tracks_sale_item_id_index()
+            # The backfill/re-read below touch albums.sale_item_id, tracks.album_id
+            # and tracks.source. Real DBs gain all of these by v24/v20; only the
+            # narrow migration unit tests build a partial schema without them, so
+            # guard on presence (mirrors the v40 block).
+            album_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(albums)").fetchall()
+            }
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if "sale_item_id" in album_cols and "album_id" in track_cols:
+                # Backfill album → track: copy each provenanced album's sale_item_id
+                # down onto its tracks. FK-safe (album sids already satisfy the
+                # albums→collection FK) and idempotent (only fills NULLs).
+                self._conn.execute("""
+                    UPDATE tracks SET sale_item_id = (
+                        SELECT a.sale_item_id FROM albums a WHERE a.id = tracks.album_id
+                    )
+                    WHERE album_id IS NOT NULL
+                      AND sale_item_id IS NULL
+                      AND (SELECT a.sale_item_id FROM albums a
+                           WHERE a.id = tracks.album_id) IS NOT NULL
+                    """)
+            # A pre-existing standalone single (no album row) can't be reached by the
+            # backfill above. It is not force-re-read here: nulling file_mtime for all
+            # album-less local tracks would re-scan every loose file for the sake of a
+            # rare historical case. Such singles recover via link_track_to_sale_item_id
+            # or a natural re-scan; newly downloaded singles are always scanned fresh
+            # and stamped by upsert_many.
+            self._conn.execute("UPDATE schema_version SET version = 41")
+            self._conn.commit()
+            version = 41  # noqa: F841
+
+    def _create_tracks_sale_item_id_index(self) -> None:
+        """Create the lookup index on tracks.sale_item_id (KAMP-528).
+
+        Kept out of _DDL: executescript runs the whole _DDL before the v41
+        migration adds the column, so a CREATE INDEX there would reference a
+        not-yet-existing column on an upgrading DB. Guarded on column presence so
+        the narrow migration unit tests (which build a partial schema) don't fail.
+        """
+        track_cols = {
+            r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
+        if "sale_item_id" not in track_cols:
+            return
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS tracks_sale_item_id_idx"
+            " ON tracks(sale_item_id)"
+        )
 
     def _create_sale_item_id_unique_index(self) -> None:
         """Enforce one album per sale_item_id via a partial UNIQUE index (KAMP-523).
@@ -2295,19 +2372,48 @@ class LibraryIndex:
 
         Used by the server layer to obtain track IDs for the playing-guard check
         and to collect file paths for deletion before calling remove_download().
+
+        Honors provenance at BOTH levels (KAMP-528): a track whose album carries
+        the sale_item_id, OR a track that carries it directly (a standalone single
+        with no album row). LEFT JOIN so a NULL-album single still matches, and
+        DISTINCT so a track that satisfies both arms after the album→track backfill
+        is not returned twice.
         """
         rows = self._conn.execute(
             """
-            SELECT t.* FROM tracks t
-            JOIN albums a ON a.id = t.album_id
-            WHERE a.sale_item_id = ?
+            SELECT DISTINCT t.* FROM tracks t
+            LEFT JOIN albums a ON a.id = t.album_id
+            WHERE (a.sale_item_id = ? OR t.sale_item_id = ?)
               AND t.file_path NOT LIKE 'bandcamp://%'
               AND t.file_path NOT LIKE 'bandcamp:\\%'
             ORDER BY t.disc_number, t.track_number
             """,
-            (sale_item_id,),
+            (sale_item_id, sale_item_id),
         ).fetchall()
         return [_row_to_track(r) for r in rows]
+
+    def link_track_to_sale_item_id(self, track_id: int, sale_item_id: str) -> bool:
+        """Attach Bandcamp provenance to a single track by id (KAMP-528).
+
+        The recovery path for a standalone single that has no album row: there is
+        nowhere to record its origin except tracks.sale_item_id. Validates that
+        *sale_item_id* exists in bandcamp_collection first — both for a clear
+        caller-facing failure and to keep the FK to bandcamp_collection satisfied
+        (a bare UPDATE with an unknown sid would raise IntegrityError). Returns
+        True if the track was found and linked, False otherwise.
+        """
+        known = self._conn.execute(
+            "SELECT 1 FROM bandcamp_collection WHERE sale_item_id = ?",
+            (sale_item_id,),
+        ).fetchone()
+        if known is None:
+            return False
+        cur = self._conn.execute(
+            "UPDATE tracks SET sale_item_id = ? WHERE id = ?",
+            (sale_item_id, track_id),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
 
     def streaming_track_for_local_id(self, local_track_id: int) -> "Track | None":
         """Return the streaming (bandcamp://) equivalent of a local track.
@@ -2502,7 +2608,17 @@ class LibraryIndex:
         self._conn.commit()
 
     def clear_bandcamp_collection(self) -> None:
-        """Delete all rows from bandcamp_collection (called on logout)."""
+        """Delete all rows from bandcamp_collection (explicit account reset).
+
+        No longer called on logout — logout preserves the ledger (the file→purchase
+        provenance map) so the next sync reconciles rather than rebuilds. This
+        remains for an explicit account switch/reset. Null the child provenance
+        FKs first (albums AND tracks, KAMP-528): with foreign_keys=ON, deleting a
+        parent row still referenced by a provenanced album or track raises
+        IntegrityError — which is exactly what used to make logout crash.
+        """
+        self._conn.execute("UPDATE albums SET sale_item_id = NULL")
+        self._conn.execute("UPDATE tracks SET sale_item_id = NULL")
         self._conn.execute("DELETE FROM bandcamp_collection")
         self._conn.commit()
 
@@ -2893,6 +3009,23 @@ class LibraryIndex:
                 self._conn.execute(
                     "UPDATE tracks SET album_id = ? WHERE file_path = ?",
                     (prov_targets[t.sale_item_id], fp),
+                )
+
+        # Step 3a' (KAMP-528): persist track-level provenance for EVERY provenanced
+        # track, independent of whether an album link resolved above. This is the
+        # standalone-single case: a nameless single has no album row (so it is
+        # absent from prov_targets) yet must still record its origin — the only
+        # place that can is tracks.sale_item_id. Gated on valid_sids so the FK to
+        # bandcamp_collection can never be violated; only set, never clear (mirrors
+        # album_id linking and the ON CONFLICT clause, which leaves it untouched).
+        # Canonical key so bandcamp:// / Windows-form paths match their stored row.
+        if valid_sids:
+            for t in tracks:
+                if not _provenanced(t):
+                    continue
+                self._conn.execute(
+                    "UPDATE tracks SET sale_item_id = ? WHERE file_path = ?",
+                    (t.sale_item_id, _canonical_track_key(t.file_path)),
                 )
 
         # Step 3b: link the remaining (un-provenanced) tracks by name. TRIM on
@@ -5233,6 +5366,7 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         stream_url_expires_at=row["stream_url_expires_at"],
         is_available=bool(row["is_available"]),
         duration=row["duration"],
+        sale_item_id=row["sale_item_id"] or "",
     )
 
 

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -562,10 +562,13 @@ class Syncer:
 
 
 def logout() -> None:
-    """Clear the Bandcamp session and collection state from the DB.
+    """Clear the Bandcamp session from the DB, preserving the collection ledger.
 
-    After logout the next sync will re-authenticate interactively and
-    re-examine the full collection.
+    Only the session is cleared. The bandcamp_collection table is the file→purchase
+    provenance map (which local files came from which sale_item_id, KAMP-528), so
+    wiping it on every logout needlessly destroys that mapping — and, with the FK
+    from provenanced albums/tracks, the bare DELETE would raise. The next sync after
+    re-authentication reconciles the ledger instead of rebuilding it from scratch.
     """
     from kamp_core.library import LibraryIndex
 
@@ -576,10 +579,9 @@ def logout() -> None:
         index = LibraryIndex(db_path)
         try:
             index.clear_session("bandcamp")
-            index.clear_bandcamp_collection()
         finally:
             index.close()
-        logger.info("Bandcamp logout: session and collection state cleared.")
+        logger.info("Bandcamp logout: session cleared; collection ledger preserved.")
 
     import shutil
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 40
+        assert version == 41
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1599,7 +1599,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1656,7 +1656,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2251,7 +2251,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert row is not None
         assert row[0] == 0
 
@@ -2706,7 +2706,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2802,7 +2802,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -2983,7 +2983,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3078,7 +3078,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 40
+        assert version == 41
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3086,7 +3086,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 40
+        assert version == 41
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -3963,7 +3963,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 40
+        assert version == 41
 
         index.close()
 
@@ -4654,7 +4654,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 40
+        assert version == 41
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4689,7 +4689,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 40
+        assert version == 41
         index.close()
 
 
@@ -5007,6 +5007,206 @@ class TestBandcampCollection:
         assert row is not None
         assert row["sale_item_id"] == "sale-stream"
 
+    # ------------------------------------------------------------------
+    # KAMP-528: track-level Bandcamp provenance (standalone singles)
+    # ------------------------------------------------------------------
+
+    def test_fresh_db_has_tracks_sale_item_id_column_and_index(
+        self, tmp_path: Path
+    ) -> None:
+        """A brand-new DB carries the tracks.sale_item_id column and its index."""
+        index = LibraryIndex(tmp_path / "library.db")
+        cols = {
+            r[1] for r in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
+        }
+        idx_names = {
+            r[1] for r in index._conn.execute("PRAGMA index_list(tracks)").fetchall()
+        }
+        index.close()
+        assert "sale_item_id" in cols
+        assert "tracks_sale_item_id_idx" in idx_names
+
+    def test_upsert_persists_track_sale_item_id_for_standalone_single(
+        self, tmp_path: Path
+    ) -> None:
+        """A single with a valid sid but no album row records track-level provenance.
+
+        This is the KAMP-528 core case: album == "" so no album row is minted, yet
+        the file's KAMP_SALE_ITEM_ID tag must still persist onto the track.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "single-1", mode="local", band_name="Mndsgn", item_title="SIXUNDRGROUND"
+        )
+        single = _sample_track(tmp_path / "single.mp3")
+        single.album = ""  # standalone single: no album
+        single.album_artist = "Mndsgn"
+        single.sale_item_id = "single-1"
+        index.upsert_many([single])
+
+        row = index._conn.execute(
+            "SELECT sale_item_id, album_id FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "single.mp3"),),
+        ).fetchone()
+        found = index.local_tracks_for_sale_item_id("single-1")
+        index.close()
+
+        assert row is not None
+        assert row["sale_item_id"] == "single-1"
+        assert row["album_id"] is None  # genuinely album-less
+        # It now "drops out of the unmatched set": the purchase resolves to a local file.
+        assert [t.title for t in found] == ["A Song"]
+
+    def test_upsert_ignores_unknown_sale_item_id_tag(self, tmp_path: Path) -> None:
+        """A tag sid absent from the collection ledger is not persisted (FK-safe)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        stray = _sample_track(tmp_path / "stray.mp3")
+        stray.album = ""
+        stray.sale_item_id = "never-purchased"
+        index.upsert_many([stray])  # must not raise on the FK
+        row = index._conn.execute(
+            "SELECT sale_item_id FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "stray.mp3"),),
+        ).fetchone()
+        index.close()
+        assert row["sale_item_id"] is None
+
+    def test_row_to_track_reads_sale_item_id(self, tmp_path: Path) -> None:
+        """Track.sale_item_id round-trips through the DB."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("rt-1", mode="local")
+        t = _sample_track(tmp_path / "rt.mp3")
+        t.album = ""
+        t.sale_item_id = "rt-1"
+        index.upsert_many([t])
+        got = index.get_track_by_path(str(tmp_path / "rt.mp3"))
+        index.close()
+        assert got is not None
+        assert got.sale_item_id == "rt-1"
+
+    def test_link_track_to_sale_item_id_links_and_validates(
+        self, tmp_path: Path
+    ) -> None:
+        """The manual recovery path links a known sid and rejects an unknown one."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("link-1", mode="local")
+        t = _sample_track(tmp_path / "orphan.mp3")
+        t.album = ""
+        index.upsert_many([t])
+        track = index.get_track_by_path(str(tmp_path / "orphan.mp3"))
+        assert track is not None and track.id is not None
+
+        # Unknown sid: rejected, nothing written.
+        assert index.link_track_to_sale_item_id(track.id, "not-in-ledger") is False
+        # Known sid: linked.
+        assert index.link_track_to_sale_item_id(track.id, "link-1") is True
+        # Nonexistent track id with a known sid: no row updated.
+        assert index.link_track_to_sale_item_id(999_999, "link-1") is False
+
+        found = index.local_tracks_for_sale_item_id("link-1")
+        index.close()
+        assert [t.title for t in found] == ["A Song"]
+
+    def test_local_tracks_for_sale_item_id_no_duplicate_for_album_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        """A provenanced album's tracks appear exactly once, not once per match arm.
+
+        After the backfill both a.sale_item_id and t.sale_item_id carry the sid, so
+        a naive OR-join would double-count. DISTINCT must collapse them.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "album-1", mode="local", band_name="The Artist", item_title="The Album"
+        )
+        t1 = _sample_track(tmp_path / "01.mp3")
+        t1.track_number = 1
+        t1.sale_item_id = "album-1"
+        t2 = _sample_track(tmp_path / "02.mp3")
+        t2.track_number = 2
+        t2.title = "Second Song"
+        t2.sale_item_id = "album-1"
+        index.upsert_many([t1, t2])
+
+        found = index.local_tracks_for_sale_item_id("album-1")
+        index.close()
+        assert [t.title for t in found] == ["A Song", "Second Song"]
+
+    def test_clear_bandcamp_collection_fk_safe_with_provenance(
+        self, tmp_path: Path
+    ) -> None:
+        """clear_bandcamp_collection nulls child FKs first so it never raises."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item(
+            "c-1", mode="local", band_name="The Artist", item_title="The Album"
+        )
+        album_track = _sample_track(tmp_path / "album.mp3")
+        album_track.sale_item_id = "c-1"
+        single = _sample_track(tmp_path / "single.mp3")
+        single.album = ""
+        single.sale_item_id = "c-1"
+        index.upsert_many([album_track, single])
+
+        index.clear_bandcamp_collection()  # must not raise on the FK
+
+        assert index.get_collection_state() == {}
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) FROM tracks WHERE sale_item_id IS NOT NULL"
+        ).fetchone()[0]
+        albums_remaining = index._conn.execute(
+            "SELECT COUNT(*) FROM albums WHERE sale_item_id IS NOT NULL"
+        ).fetchone()[0]
+        index.close()
+        assert remaining == 0
+        assert albums_remaining == 0
+
+    def test_migration_v41_backfills_album_provenance_to_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        """v41 adds the column and copies albums.sale_item_id down to its tracks."""
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "library.db"
+        seed = LibraryIndex(db_path)
+        seed.close()
+        conn = _sqlite3.connect(str(db_path))
+        # Simulate a pre-v41 DB: drop the new column so the migration must add it.
+        # (SQLite can't DROP COLUMN on old versions, so rebuild is overkill — instead
+        # seed a provenanced album/track and roll the version back to 40.)
+        conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, mode) VALUES ('bf-1', 'local')"
+        )
+        conn.execute(
+            "INSERT INTO albums (id, album_artist, album, sale_item_id, source)"
+            " VALUES (1, 'Artist', 'Album', 'bf-1', 'bandcamp')"
+        )
+        conn.execute(
+            "INSERT INTO tracks (file_path, album, album_id) VALUES ('/a/1.mp3', 'Album', 1)"
+        )
+        conn.execute("UPDATE tracks SET sale_item_id = NULL")
+        conn.execute("UPDATE schema_version SET version = 40")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)  # re-open triggers the v41 migration
+        row = index._conn.execute(
+            "SELECT sale_item_id FROM tracks WHERE file_path = '/a/1.mp3'"
+        ).fetchone()
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        # Idempotent: re-running the migration path (already at 41) changes nothing.
+        index.close()
+        reopened = LibraryIndex(db_path)
+        row2 = reopened._conn.execute(
+            "SELECT sale_item_id FROM tracks WHERE file_path = '/a/1.mp3'"
+        ).fetchone()
+        reopened.close()
+
+        assert row["sale_item_id"] == "bf-1"
+        assert version == 41
+        assert row2["sale_item_id"] == "bf-1"
+
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_collection_item("1", mode="local", synced_at=999.0)
@@ -5137,7 +5337,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 40
+        assert version == 41
 
 
 class TestRemoteTrackSchema:
@@ -5471,7 +5671,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5532,7 +5732,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6290,7 +6490,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -6849,7 +7049,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -6927,7 +7127,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7133,7 +7333,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7482,7 +7682,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7579,7 +7779,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7695,7 +7895,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8200,7 +8400,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8315,7 +8515,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8413,7 +8613,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8513,7 +8713,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9020,7 +9220,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 40
+        assert version == 41
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -9864,7 +10064,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 40
+        assert version == 41
         assert "release_date" in cols
         assert "year" not in cols
 

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -651,8 +651,15 @@ class TestSyncAllPurchases:
 
 
 class TestLogout:
-    def test_clears_db_session_and_collection(self, tmp_path: Path) -> None:
-        """logout() clears the DB session row and bandcamp_collection."""
+    def test_clears_session_but_preserves_collection_ledger(
+        self, tmp_path: Path
+    ) -> None:
+        """logout() clears the session row but PRESERVES bandcamp_collection.
+
+        The ledger is the file→purchase provenance map (KAMP-528); wiping it on
+        every logout needlessly destroys that mapping. Only the session is cleared;
+        the next sync reconciles the ledger.
+        """
         from kamp_core.library import LibraryIndex
 
         db_path = tmp_path / "library.db"
@@ -667,7 +674,7 @@ class TestLogout:
                 logout()
 
             assert index.get_session("bandcamp") is None
-            assert index.get_collection_state() == {}
+            assert index.get_collection_state() == {"999": "local"}
         finally:
             index.close()
 


### PR DESCRIPTION
## Summary

Bandcamp provenance (which purchase a file came from) was stored **only at the album level** (`albums.sale_item_id`). A purchased **standalone single** has no album row — empty `album`, `NULL album_id` — so there was nowhere to record which `sale_item_id` it came from. Such a purchase stayed permanently flagged "not in your library" and could only be dismissed, never linked or recovered (KAMP-528; surfaced by purchase `338769505` — Mndsgn "SIXUNDRGROUND" → track 1437).

The plumbing was already in place: `Track.sale_item_id` exists, the ingest pipeline stamps a `KAMP_SALE_ITEM_ID` file tag, and `_read_*_tags` reads it into `Track.sale_item_id`. It was simply **dropped on the way into the DB** because there was no column. This adds the column and persists it end to end.

## Changes

- **Schema v40 → v41** — add `tracks.sale_item_id TEXT REFERENCES bandcamp_collection(sale_item_id)` + `tracks_sale_item_id_idx`. Migration: guarded `ALTER`, create index, and **backfill** `albums.sale_item_id` down onto each album's tracks (idempotent, FK-safe). The index is created via `_create_tracks_sale_item_id_index()` rather than `_DDL` because `executescript` runs the whole DDL before the migration adds the column on an upgrading DB.
- **Persist on upsert** — `_upsert_many` stamps `tracks.sale_item_id` for **every** provenanced track (valid sids only, canonical key), independent of whether an album link resolved — the standalone-single case. `_row_to_track` reads it back.
- **`link_track_to_sale_item_id(track_id, sale_item_id)`** — the manual recovery path (`UPDATE tracks SET sale_item_id=? WHERE id=?`), validating the sid exists in `bandcamp_collection` first for a clear failure and FK-safety.
- **`local_tracks_for_sale_item_id`** — now honors provenance at **both** levels (album OR track) via `LEFT JOIN` + `DISTINCT`, so a standalone single is found and album tracks aren't double-counted after backfill. This is how a linked single "drops out of the unmatched set."
- **Logout preserves the ledger** — `logout()` previously did `DELETE FROM bandcamp_collection`, which **already raised `IntegrityError`** whenever a provenanced album existed (`foreign_keys=ON`, reproduced empirically). It now clears only the session and preserves the ledger (the file→purchase map the next sync reconciles). `clear_bandcamp_collection` is kept for an explicit account reset and made FK-safe (nulls child sids first).

## Scope notes

- The KAMP-525 review UI and a remove-download rewrite for standalone singles are intentionally **out of scope** (no UI exists yet, so nothing ships a dead button).
- A pre-existing standalone single that was already indexed before this change is **not** force-re-read on upgrade (nulling `file_mtime` for all album-less local tracks would re-scan every loose file for a rare historical case). Such singles recover via `link_track_to_sale_item_id` or a natural re-scan; **newly downloaded singles are always scanned fresh and stamped by `upsert_many`.**

## Test plan

Automated (all green locally — 2184 passed, black, mypy clean, coverage 93.14% ≥ fail_under):
- Fresh DB has the column + index.
- Standalone single (no album row) persists track-level provenance and resolves via `local_tracks_for_sale_item_id`.
- Unknown tag sid is not persisted (FK-safe, no raise); `Track.sale_item_id` round-trips.
- `link_track_to_sale_item_id`: links a known sid, rejects an unknown sid, no-ops on a missing track.
- Multi-track provenanced album returns each track exactly once (dedup).
- `clear_bandcamp_collection` is FK-safe with provenanced album + single present.
- v41 migration backfills album→track and is idempotent.
- `logout()` clears the session but preserves the collection ledger.

Manual (for reviewer):
- Upgrade a pre-v41 DB with a downloaded album → migration runs once, backfills, idempotent on re-open.
- Download a standalone single, let it scan → `tracks.sale_item_id` populated.
- Log out of Bandcamp → no crash; ledger + provenance links remain; re-login + sync reconciles.

Closes KAMP-528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)