### PR TITLE
fix(library): dedupe local files against streaming collection rows (KAMP-529)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4197,6 +4197,19 @@ class LibraryIndex:
             JOIN tracks t ON f.rowid = t.id
             LEFT JOIN albums al ON al.id = t.album_id
             WHERE tracks_fts MATCH ?
+              -- KAMP-529: local-wins collapse. Hide a streaming (bandcamp) row
+              -- when its album also holds a local track, so a downloaded track
+              -- surfaces once in search instead of doubling. Same album-level
+              -- rule as tracks_for_album; keyed on album_id (NULL-safe) and
+              -- source (Windows path-form safe), not on track_number.
+              AND NOT (
+                    t.source = 'bandcamp'
+                    AND t.album_id IS NOT NULL
+                    AND EXISTS (
+                        SELECT 1 FROM tracks x
+                        WHERE x.album_id = t.album_id AND x.source = 'local'
+                    )
+                  )
             ORDER BY (t.favorite OR COALESCE(al.favorite, 0)) DESC, f.rank
             """,
             (fts_expr,),

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3047,13 +3047,30 @@ class LibraryIndex:
                 plain_paths,
             )
 
+        # Step 3c (KAMP-529): attach un-provenanced loose local singles. A
+        # standalone single's local file has an empty album tag, so Step 3b
+        # skips it (album != '') and it has no album row to sid-link — it lingers
+        # as a loose track duplicating the streaming single. Re-link it to its
+        # streaming single-album by identity (local.title == the single-album's
+        # album field). Shared with the v42 migration via one helper.
+        single_paths = [
+            _canonical_track_key(t.file_path)
+            for t in tracks
+            if t.source == "local"
+            and not t.album.strip()
+            and t.album_artist.strip()
+            and t.title.strip()
+            and not _provenanced(t)
+        ]
+        touched_from_singles = self._attach_loose_local_singles(single_paths)
+
         # Step 4: refresh denormalized aggregate columns on the touched album rows.
         # Run once per batch (not per track) using a correlated subquery. Include
-        # albums reached only through provenance linking (prov_album_ids) — a
-        # nameless single's target album is not in file_paths (built from named),
-        # yet its source/aggregates must be recomputed now that a local track
-        # attached to it.
-        touched_album_ids: set[int] = set(prov_album_ids)
+        # albums reached only through provenance linking (prov_album_ids) and
+        # single re-linking (touched_from_singles) — a nameless single's target
+        # album is not in file_paths (built from named), yet its source/aggregates
+        # must be recomputed now that a local track attached to it.
+        touched_album_ids: set[int] = set(prov_album_ids) | touched_from_singles
         if file_paths:
             all_placeholders = ",".join("?" * len(file_paths))
             touched_album_ids.update(
@@ -3124,6 +3141,126 @@ class LibraryIndex:
                     "track.year",
                 }
             )
+
+    def _attach_loose_local_singles(
+        self, file_paths: "list[str] | None" = None
+    ) -> set[int]:
+        """Attach un-provenanced loose local singles to their streaming single-album (KAMP-529).
+
+        A standalone Bandcamp single's local file carries an empty album tag, so
+        the (album_artist, album) name-match in ``_upsert_many`` (Step 3b) skips
+        it and it has no album row to sid-link — it lingers as a loose track that
+        duplicates the streaming single kamp indexes for the same purchase. The
+        streaming single is a 1-track album whose ``album`` field equals the item
+        title, so the match key already lives there: ``local.title`` ==
+        ``streaming_single_album.album``.
+
+        Attach only on an *unambiguous* identity match: non-empty
+        album_artist/title, the streaming side is a genuine 1-track ``bandcamp``
+        single, and exactly one candidate exists on each side of the
+        (album_artist, title) pair — otherwise skip and log. ``sale_item_id`` is
+        deliberately NOT stamped on the local row: the album already carries it,
+        and stamping a never-downloaded row would create a second claimant for
+        the KAMP-523 download re-attach path. Shared by the scan path and the v42
+        migration so the two never drift.
+
+        When *file_paths* is given, only those local rows are considered (scan
+        path); ``None`` scans every loose local single (one-shot migration).
+        Idempotent: an attached single gains an album_id and drops out of the
+        candidate set. Returns the set of album_ids that gained a track.
+        """
+        params: list[Any] = []
+        scope = ""
+        if file_paths is not None:
+            if not file_paths:
+                return set()
+            scope = f" AND t.file_path IN ({','.join('?' * len(file_paths))})"
+            params = list(file_paths)
+        candidates = self._conn.execute(
+            f"""
+            SELECT t.id, t.file_path, t.album_artist, t.title
+            FROM tracks t
+            WHERE t.source = 'local'
+              AND t.album_id IS NULL
+              AND TRIM(t.album) = ''
+              AND TRIM(t.album_artist) != ''
+              AND TRIM(t.title) != ''
+              {scope}
+            """,
+            params,
+        ).fetchall()
+
+        touched: set[int] = set()
+        for c in candidates:
+            # Ambiguity guard (DB-wide, not batch-scoped): more than one loose
+            # local single sharing this (album_artist, title) is not safe to
+            # auto-attach — leave all of them untouched.
+            local_dupes = self._conn.execute(
+                """
+                SELECT COUNT(*) FROM tracks
+                WHERE source = 'local' AND album_id IS NULL AND TRIM(album) = ''
+                  AND TRIM(album_artist) = TRIM(?) COLLATE NOCASE
+                  AND TRIM(title)        = TRIM(?) COLLATE NOCASE
+                """,
+                (c["album_artist"], c["title"]),
+            ).fetchone()[0]
+            if local_dupes != 1:
+                logger.info(
+                    "KAMP-529 single-attach: skipping ambiguous local single"
+                    " (%s - %s): %d loose candidates",
+                    c["album_artist"],
+                    c["title"],
+                    local_dupes,
+                )
+                continue
+            # Streaming single-album: exactly one track, a bandcamp row, whose
+            # album equals this single's title under the same artist.
+            matches = self._conn.execute(
+                """
+                SELECT a.id FROM albums a
+                WHERE TRIM(a.album_artist) = TRIM(?) COLLATE NOCASE
+                  AND TRIM(a.album)        = TRIM(?) COLLATE NOCASE
+                  AND (SELECT COUNT(*) FROM tracks x WHERE x.album_id = a.id) = 1
+                  AND EXISTS (
+                        SELECT 1 FROM tracks x
+                        WHERE x.album_id = a.id AND x.source = 'bandcamp'
+                      )
+                """,
+                (c["album_artist"], c["title"]),
+            ).fetchall()
+            if len(matches) != 1:
+                if len(matches) > 1:
+                    logger.info(
+                        "KAMP-529 single-attach: skipping ambiguous streaming"
+                        " match for (%s - %s): %d candidate albums",
+                        c["album_artist"],
+                        c["title"],
+                        len(matches),
+                    )
+                continue
+            album_id = matches[0]["id"]
+            # Align track_number/disc to the streaming track so per-track joins
+            # (favorite/play-count inheritance, remove_download) line up.
+            stream = self._conn.execute(
+                "SELECT track_number, disc_number FROM tracks"
+                " WHERE album_id = ? AND source = 'bandcamp' LIMIT 1",
+                (album_id,),
+            ).fetchone()
+            self._conn.execute(
+                "UPDATE tracks SET album_id = ?, track_number = ?, disc_number = ?"
+                " WHERE id = ?",
+                (album_id, stream["track_number"], stream["disc_number"], c["id"]),
+            )
+            touched.add(album_id)
+            logger.info(
+                "KAMP-529 single-attach: linked local single '%s - %s'"
+                " (track id %d) to streaming album %d",
+                c["album_artist"],
+                c["title"],
+                c["id"],
+                album_id,
+            )
+        return touched
 
     def move_track(
         self,

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 42
+_SCHEMA_VERSION = 43
 
 
 class NoStreamableVersionError(Exception):
@@ -1646,7 +1646,49 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 42")
             self._conn.commit()
-            version = 42  # noqa: F841
+            version = 42
+
+        if version < 43:
+            # v42 → v43: an earlier v42 build attached loose singles by setting
+            # album_id but left their album tag empty, so they kept rendering as
+            # duplicate "missing album" grid cards (albums() keys that branch on
+            # album='') and their album source was never refreshed. A DB already
+            # advanced to 42 by that build is gated out of the fixed v42 heal, so
+            # re-stamp the album name onto any local track carrying an album_id but
+            # no album tag, then refresh aggregates. A DB healed correctly by the
+            # fixed v42 (or a fresh upgrade) has no such rows and this is a no-op.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if {"album_id", "album", "album_artist", "source"} <= track_cols:
+                touched = [
+                    r[0]
+                    for r in self._conn.execute(
+                        "SELECT DISTINCT t.album_id FROM tracks t"
+                        " JOIN albums a ON a.id = t.album_id"
+                        " WHERE t.source = 'local' AND t.album_id IS NOT NULL"
+                        " AND TRIM(t.album) = '' AND TRIM(a.album) != ''"
+                    ).fetchall()
+                ]
+                if touched and self._backup_db("KAMP-529 v43 heal"):
+                    self._conn.execute(
+                        "UPDATE tracks SET"
+                        " album = (SELECT a.album FROM albums a WHERE a.id = tracks.album_id),"
+                        " album_artist = (SELECT a.album_artist FROM albums a WHERE a.id = tracks.album_id)"
+                        " WHERE source = 'local' AND album_id IS NOT NULL"
+                        " AND TRIM(album) = ''"
+                        " AND (SELECT TRIM(a.album) FROM albums a WHERE a.id = tracks.album_id) != ''"
+                    )
+                    self._refresh_album_aggregates(touched)
+                    self._rebuild_fts()
+                    logger.info(
+                        "KAMP-529 v43 heal: re-stamped album name on attached"
+                        " singles in %d album(s)",
+                        len(touched),
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 43")
+            self._conn.commit()
+            version = 43  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 41
+_SCHEMA_VERSION = 42
 
 
 class NoStreamableVersionError(Exception):
@@ -1609,7 +1609,57 @@ class LibraryIndex:
             # and stamped by upsert_many.
             self._conn.execute("UPDATE schema_version SET version = 41")
             self._conn.commit()
-            version = 41  # noqa: F841
+            version = 41
+
+        if version < 42:
+            # v41 → v42: re-link un-provenanced loose local singles to their
+            # streaming single-album (KAMP-529). A pre-existing standalone single
+            # (empty album tag, no album row) duplicates the streaming single kamp
+            # indexes for the same purchase. upsert_many Step 3c handles this going
+            # forward, but an unchanged file is never re-scanned, so heal the rows
+            # already on disk once. Guarded on the columns the helper needs (the
+            # narrow migration-unit-test schemas build a partial tracks table).
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if {"album_id", "source", "album", "album_artist", "title"} <= track_cols:
+                has_loose = self._conn.execute(
+                    "SELECT 1 FROM tracks WHERE source = 'local' AND album_id IS NULL"
+                    " AND TRIM(album) = '' AND TRIM(album_artist) != ''"
+                    " AND TRIM(title) != '' LIMIT 1"
+                ).fetchone()
+                # Back up only when there is something to touch (mirrors the v39
+                # heal); abort the heal if the snapshot fails.
+                if has_loose and self._backup_db("KAMP-529 heal"):
+                    touched = self._attach_loose_local_singles()
+                    logger.info(
+                        "KAMP-529 heal: re-linked loose local singles into"
+                        " %d album(s)",
+                        len(touched),
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 42")
+            self._conn.commit()
+            version = 42  # noqa: F841
+
+    def _backup_db(self, label: str) -> bool:
+        """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
+
+        Connection.backup copies consistently where a plain file copy could miss
+        un-checkpointed WAL. Best-effort: on failure, log and return False so the
+        caller can abort the mutation rather than run it without a restore point.
+        """
+        ts = _time.strftime("%Y%m%d-%H%M%S")
+        backup_path = self._db_path.with_name(f"{self._db_path.name}.bak-{ts}")
+        try:
+            dest = sqlite3.connect(str(backup_path))
+            with dest:
+                self._conn.backup(dest)
+            dest.close()
+            logger.info("%s: backed up library to %s", label, backup_path)
+            return True
+        except Exception as exc:  # pragma: no cover - backup is best-effort
+            logger.warning("%s: backup failed (%s); skipping heal", label, exc)
+            return False
 
     def _create_tracks_sale_item_id_index(self) -> None:
         """Create the lookup index on tracks.sale_item_id (KAMP-528).

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1632,6 +1632,13 @@ class LibraryIndex:
                 # heal); abort the heal if the snapshot fails.
                 if has_loose and self._backup_db("KAMP-529 heal"):
                     touched = self._attach_loose_local_singles()
+                    if touched:
+                        # Recompute album source/aggregates and rebuild FTS so the
+                        # grid and search immediately reflect the attached tracks —
+                        # the scan path gets this via upsert_many, the migration
+                        # must do it explicitly.
+                        self._refresh_album_aggregates(list(touched))
+                        self._rebuild_fts()
                     logger.info(
                         "KAMP-529 heal: re-linked loose local singles into"
                         " %d album(s)",
@@ -3132,51 +3139,7 @@ class LibraryIndex:
                 ).fetchall()
             )
         if touched_album_ids:
-            album_ids = list(touched_album_ids)
-            if album_ids:
-                id_placeholders = ",".join("?" * len(album_ids))
-                self._conn.execute(
-                    f"""
-                    UPDATE albums SET
-                        embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks t WHERE t.album_id = albums.id),
-                        date_added     = (SELECT MIN(t.date_added)    FROM tracks t WHERE t.album_id = albums.id),
-                        last_played_at = (SELECT MAX(t.last_played)   FROM tracks t WHERE t.album_id = albums.id),
-                        art_version    = (SELECT MAX(CASE WHEN t.source = 'local' THEN t.file_mtime END)
-                                          FROM tracks t WHERE t.album_id = albums.id),
-                        play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
-                                          FROM tracks t WHERE t.album_id = albums.id),
-                        source         = (SELECT
-                                              CASE WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
-                                                        AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                                                   THEN 'local'
-                                                   WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                                                   ELSE MIN(t.source) END
-                                          FROM tracks t WHERE t.album_id = albums.id),
-                        release_date   = (SELECT MAX(t.release_date)   FROM tracks t WHERE t.album_id = albums.id),
-                        genre          = (SELECT MAX(t.genre)          FROM tracks t WHERE t.album_id = albums.id),
-                        label          = (SELECT MAX(t.label)          FROM tracks t WHERE t.album_id = albums.id),
-                        mb_release_id  = (SELECT MAX(t.mb_release_id)  FROM tracks t WHERE t.album_id = albums.id)
-                    WHERE id IN ({id_placeholders})
-                    """,
-                    album_ids,
-                )
-                # Backfill sale_item_id from bandcamp_collection for albums that were
-                # just inserted without it. This covers the streaming-sync order where
-                # upsert_collection_item fires before upsert_many, so the UPDATE inside
-                # upsert_collection_item is a no-op (no albums row yet at that point).
-                self._conn.execute(
-                    f"""
-                    UPDATE albums SET sale_item_id = (
-                        SELECT bc.sale_item_id FROM bandcamp_collection bc
-                        WHERE bc.band_name  = albums.album_artist COLLATE NOCASE
-                          AND bc.item_title = albums.album        COLLATE NOCASE
-                        LIMIT 1
-                    )
-                    WHERE id IN ({id_placeholders})
-                      AND sale_item_id IS NULL
-                    """,
-                    album_ids,
-                )
+            self._refresh_album_aggregates(list(touched_album_ids))
 
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()
@@ -3191,6 +3154,61 @@ class LibraryIndex:
                     "track.year",
                 }
             )
+
+    def _refresh_album_aggregates(self, album_ids: list[int]) -> None:
+        """Recompute denormalized album columns from the album's tracks.
+
+        Refreshes source/art/counts/dates and backfills sale_item_id from
+        bandcamp_collection. Shared by upsert_many Step 4 and the v42
+        single-attach migration: without this an album whose source was
+        'bandcamp' keeps reading as remote after a local track attaches, so the
+        grid never reflects the newly-owned copy.
+        """
+        if not album_ids:
+            return
+        id_placeholders = ",".join("?" * len(album_ids))
+        self._conn.execute(
+            f"""
+            UPDATE albums SET
+                embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks t WHERE t.album_id = albums.id),
+                date_added     = (SELECT MIN(t.date_added)    FROM tracks t WHERE t.album_id = albums.id),
+                last_played_at = (SELECT MAX(t.last_played)   FROM tracks t WHERE t.album_id = albums.id),
+                art_version    = (SELECT MAX(CASE WHEN t.source = 'local' THEN t.file_mtime END)
+                                  FROM tracks t WHERE t.album_id = albums.id),
+                play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
+                                  FROM tracks t WHERE t.album_id = albums.id),
+                source         = (SELECT
+                                      CASE WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
+                                                AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
+                                           THEN 'local'
+                                           WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
+                                           ELSE MIN(t.source) END
+                                  FROM tracks t WHERE t.album_id = albums.id),
+                release_date   = (SELECT MAX(t.release_date)   FROM tracks t WHERE t.album_id = albums.id),
+                genre          = (SELECT MAX(t.genre)          FROM tracks t WHERE t.album_id = albums.id),
+                label          = (SELECT MAX(t.label)          FROM tracks t WHERE t.album_id = albums.id),
+                mb_release_id  = (SELECT MAX(t.mb_release_id)  FROM tracks t WHERE t.album_id = albums.id)
+            WHERE id IN ({id_placeholders})
+            """,
+            album_ids,
+        )
+        # Backfill sale_item_id from bandcamp_collection for albums that were just
+        # inserted without it. Covers the streaming-sync order where
+        # upsert_collection_item fires before upsert_many, so the UPDATE inside
+        # upsert_collection_item is a no-op (no albums row yet at that point).
+        self._conn.execute(
+            f"""
+            UPDATE albums SET sale_item_id = (
+                SELECT bc.sale_item_id FROM bandcamp_collection bc
+                WHERE bc.band_name  = albums.album_artist COLLATE NOCASE
+                  AND bc.item_title = albums.album        COLLATE NOCASE
+                LIMIT 1
+            )
+            WHERE id IN ({id_placeholders})
+              AND sale_item_id IS NULL
+            """,
+            album_ids,
+        )
 
     def _attach_loose_local_singles(
         self, file_paths: "list[str] | None" = None
@@ -3290,16 +3308,29 @@ class LibraryIndex:
                 continue
             album_id = matches[0]["id"]
             # Align track_number/disc to the streaming track so per-track joins
-            # (favorite/play-count inheritance, remove_download) line up.
+            # (favorite/play-count inheritance, remove_download) line up, and stamp
+            # the album's canonical name onto the (previously album-less) single so
+            # it stops rendering as its own "missing album" grid card — setting
+            # album_id alone leaves album='' and the loose card persists (KAMP-529).
             stream = self._conn.execute(
                 "SELECT track_number, disc_number FROM tracks"
                 " WHERE album_id = ? AND source = 'bandcamp' LIMIT 1",
                 (album_id,),
             ).fetchone()
+            alb = self._conn.execute(
+                "SELECT album_artist, album FROM albums WHERE id = ?", (album_id,)
+            ).fetchone()
             self._conn.execute(
-                "UPDATE tracks SET album_id = ?, track_number = ?, disc_number = ?"
-                " WHERE id = ?",
-                (album_id, stream["track_number"], stream["disc_number"], c["id"]),
+                "UPDATE tracks SET album_id = ?, track_number = ?, disc_number = ?,"
+                " album = ?, album_artist = ? WHERE id = ?",
+                (
+                    album_id,
+                    stream["track_number"],
+                    stream["disc_number"],
+                    alb["album"],
+                    alb["album_artist"],
+                    c["id"],
+                ),
             )
             touched.add(album_id)
             logger.info(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 41
+        assert version == 42
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1673,7 +1673,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1730,7 +1730,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2325,7 +2325,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert row is not None
         assert row[0] == 0
 
@@ -2780,7 +2780,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2876,7 +2876,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3057,7 +3057,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3152,7 +3152,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 41
+        assert version == 42
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3160,7 +3160,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 41
+        assert version == 42
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4037,7 +4037,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 41
+        assert version == 42
 
         index.close()
 
@@ -4728,7 +4728,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 41
+        assert version == 42
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4763,7 +4763,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 41
+        assert version == 42
         index.close()
 
 
@@ -5278,7 +5278,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 41
+        assert version == 42
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -5411,7 +5411,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 41
+        assert version == 42
 
 
 class TestRemoteTrackSchema:
@@ -5745,7 +5745,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5806,7 +5806,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6564,7 +6564,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7123,7 +7123,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7201,7 +7201,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7407,7 +7407,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7756,7 +7756,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7853,7 +7853,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7969,7 +7969,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8474,7 +8474,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8589,7 +8589,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8687,7 +8687,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8787,7 +8787,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9294,7 +9294,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 41
+        assert version == 42
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10138,7 +10138,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 41
+        assert version == 42
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11061,6 +11061,58 @@ class TestLooseSingleAttach:
             == 2
         )
         index.close()
+
+    def test_v42_migration_relinks_preexisting_loose_single(
+        self, tmp_path: Path
+    ) -> None:
+        """A loose single already on disk (indexed before this fix, so never
+        attached by Step 3c) is re-linked on upgrade by the v42 heal, which also
+        snapshots the DB first."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index.upsert_many([self._stream_single("300", "Megahit", "Celebrity")])
+        stream_album = index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = 'bandcamp://300/1'"
+        ).fetchone()[0]
+        # Insert the loose local single by raw SQL so Step 3c does NOT run on it,
+        # reproducing a row indexed by an older build. Then downgrade to v41.
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+            " track_number, source) VALUES (?, 'Celebrity', 'Megahit', 'Megahit',"
+            " '', 0, 'local')",
+            (str(tmp_path / "celebrity.flac"),),
+        )
+        index._conn.execute("UPDATE schema_version SET version = 41")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        row = reopened._conn.execute(
+            "SELECT album_id, track_number FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "celebrity.flac"),),
+        ).fetchone()
+        version = reopened._conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0]
+        reopened.close()
+
+        assert version == 42
+        assert row["album_id"] == stream_album
+        assert row["track_number"] == 1
+        # The heal took a backup snapshot before mutating.
+        assert list(tmp_path.glob("library.db.bak-*"))
+
+    def test_v42_migration_no_backup_when_nothing_to_heal(self, tmp_path: Path) -> None:
+        """A fresh DB (or one with no loose singles) is stamped current without a
+        wasteful backup snapshot."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        index.close()
+        assert version == 42
+        assert not list(tmp_path.glob("library.db.bak-*"))
 
 
 class TestHealForkedAlbums:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10872,6 +10872,197 @@ class TestPendingIngest:
         index.close()
 
 
+class TestLooseSingleAttach:
+    """KAMP-529 Step 3c: an un-provenanced loose local single (empty album tag)
+    re-links by identity to its streaming single-album, so the two stop
+    duplicating. Negative cases assert we never merge on an ambiguous key."""
+
+    def _stream_single(
+        self,
+        sid: str,
+        artist: str,
+        album_title: str,
+        title: "str | None" = None,
+    ) -> Track:
+        """A 1-track streaming (bandcamp) single-album whose album == item title."""
+        return Track(
+            file_path=Path(f"bandcamp://{sid}/1"),
+            title=title or album_title,
+            artist=artist,
+            album_artist=artist,
+            album=album_title,
+            release_date="",
+            track_number=1,
+            disc_number=1,
+            ext="",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+
+    def _loose_local(self, path: Path, artist: str, title: str) -> Track:
+        """A user's loose local single: empty album tag, track_number 0."""
+        return Track(
+            file_path=path,
+            title=title,
+            artist=artist,
+            album_artist=artist,
+            album="",
+            release_date="",
+            track_number=0,
+            disc_number=1,
+            ext="flac",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="local",
+        )
+
+    def _album_id_of(self, index: LibraryIndex, path: Path) -> "int | None":
+        return index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = ?", (str(path),)
+        ).fetchone()[0]
+
+    def test_loose_single_attaches_to_streaming_album(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._stream_single("100", "Megahit", "Celebrity")])
+        stream_album = index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = 'bandcamp://100/1'"
+        ).fetchone()[0]
+
+        local = self._loose_local(tmp_path / "celebrity.flac", "Megahit", "Celebrity")
+        index.upsert_many([local])
+
+        # The local single now shares the streaming album and inherits track_number.
+        row = index._conn.execute(
+            "SELECT album_id, track_number FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "celebrity.flac"),),
+        ).fetchone()
+        assert row["album_id"] == stream_album
+        assert row["track_number"] == 1
+        # One album, and it no longer shows as a separate loose card.
+        assert len(_album_rows(index)) == 1
+        # Collapses everywhere: album view + search return the local row only.
+        detail = index.tracks_for_album("Megahit", "Celebrity")
+        assert len(detail) == 1 and detail[0].source == "local"
+        results = index.search("celebrity")
+        assert len(results) == 1 and results[0].source == "local"
+        index.close()
+
+    def test_prefix_titled_streaming_single_still_matches(self, tmp_path: Path) -> None:
+        """Bandcamp prefixes some single titles with 'Artist - '; the album field
+        stays clean, so matching on album (not track title) still links."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._stream_single(
+                    "101",
+                    "Neon Nox, Powernerd",
+                    "Duality",
+                    title="Neon Nox, Powernerd - Duality",
+                )
+            ]
+        )
+        local = self._loose_local(
+            tmp_path / "duality.flac", "Neon Nox, Powernerd", "Duality"
+        )
+        index.upsert_many([local])
+        assert self._album_id_of(index, tmp_path / "duality.flac") is not None
+        assert len(index.tracks_for_album("Neon Nox, Powernerd", "Duality")) == 1
+        index.close()
+
+    def test_no_attach_when_album_is_multitrack(self, tmp_path: Path) -> None:
+        """album.album == local.title but the album is NOT a single (>1 track):
+        the local file must not be absorbed into a multi-track album."""
+        index = LibraryIndex(tmp_path / "library.db")
+        # Two bandcamp tracks under one album titled "Celebrity" → a 2-track album,
+        # not a single. Track 2 gets a distinct path/number.
+        track2 = Track(
+            file_path=Path("bandcamp://102/2"),
+            title="Another",
+            artist="Various",
+            album_artist="Various",
+            album="Celebrity",
+            release_date="",
+            track_number=2,
+            disc_number=1,
+            ext="",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        index.upsert_many([self._stream_single("102", "Various", "Celebrity"), track2])
+        local = self._loose_local(tmp_path / "c.flac", "Various", "Celebrity")
+        index.upsert_many([local])
+        assert self._album_id_of(index, tmp_path / "c.flac") is None
+        index.close()
+
+    def test_no_attach_when_album_artist_blank(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._stream_single("103", "", "Untitled")])
+        local = self._loose_local(tmp_path / "u.flac", "", "Untitled")
+        index.upsert_many([local])
+        assert self._album_id_of(index, tmp_path / "u.flac") is None
+        index.close()
+
+    def test_no_attach_when_two_loose_singles_share_identity(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._stream_single("104", "Megahit", "Celebrity")])
+        a = self._loose_local(tmp_path / "a.flac", "Megahit", "Celebrity")
+        b = self._loose_local(tmp_path / "b.flac", "Megahit", "Celebrity")
+        index.upsert_many([a, b])
+        assert self._album_id_of(index, tmp_path / "a.flac") is None
+        assert self._album_id_of(index, tmp_path / "b.flac") is None
+        index.close()
+
+    def test_no_attach_when_two_streaming_singles_match(self, tmp_path: Path) -> None:
+        """Two streaming single-albums TRIM/NOCASE-match the same title (they differ
+        only by trailing whitespace, which the albums UNIQUE index permits): the
+        match is ambiguous, so the loose single is left untouched."""
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid, album_name in (("200", "Celebrity"), ("201", "Celebrity ")):
+            index._conn.execute(
+                "INSERT INTO albums (album_artist, album, source) VALUES ('Megahit', ?, 'bandcamp')",
+                (album_name,),
+            )
+            aid = index._conn.execute(
+                "SELECT id FROM albums ORDER BY id DESC LIMIT 1"
+            ).fetchone()[0]
+            index._conn.execute(
+                "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+                " track_number, source, album_id) VALUES (?, 'Celebrity', 'Megahit',"
+                " 'Megahit', ?, 1, 'bandcamp', ?)",
+                (f"bandcamp://{sid}/1", album_name, aid),
+            )
+        index._conn.commit()
+        local = self._loose_local(tmp_path / "c.flac", "Megahit", "Celebrity")
+        index.upsert_many([local])
+        assert self._album_id_of(index, tmp_path / "c.flac") is None
+        index.close()
+
+    def test_attach_is_idempotent(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._stream_single("105", "Megahit", "Celebrity")])
+        local = self._loose_local(tmp_path / "celebrity.flac", "Megahit", "Celebrity")
+        index.upsert_many([local])
+        first = self._album_id_of(index, tmp_path / "celebrity.flac")
+        # A second pass (helper directly) must not move it or inflate the album.
+        touched = index._attach_loose_local_singles()
+        assert touched == set()
+        assert self._album_id_of(index, tmp_path / "celebrity.flac") == first
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) FROM tracks WHERE album_id = ?", (first,)
+            ).fetchone()[0]
+            == 2
+        )
+        index.close()
+
+
 class TestHealForkedAlbums:
     def _downgrade_to_v38(self, db_path: Path) -> None:
         conn = sqlite3.connect(str(db_path))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10934,13 +10934,15 @@ class TestLooseSingleAttach:
         local = self._loose_local(tmp_path / "celebrity.flac", "Megahit", "Celebrity")
         index.upsert_many([local])
 
-        # The local single now shares the streaming album and inherits track_number.
+        # The local single now shares the streaming album, inherits track_number,
+        # and is stamped with the album name so it stops being "album-less".
         row = index._conn.execute(
-            "SELECT album_id, track_number FROM tracks WHERE file_path = ?",
+            "SELECT album_id, track_number, album FROM tracks WHERE file_path = ?",
             (str(tmp_path / "celebrity.flac"),),
         ).fetchone()
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
+        assert row["album"] == "Celebrity"
         # One album, and it no longer shows as a separate loose card.
         assert len(_album_rows(index)) == 1
         # Collapses everywhere: album view + search return the local row only.
@@ -10948,6 +10950,13 @@ class TestLooseSingleAttach:
         assert len(detail) == 1 and detail[0].source == "local"
         results = index.search("celebrity")
         assert len(results) == 1 and results[0].source == "local"
+        # And the GRID shows exactly one "Celebrity" card, not a duplicate loose
+        # missing-album entry alongside the album card. The album now reads as
+        # owned (source flips off 'bandcamp').
+        cards = [a for a in index.albums() if a.album == "Celebrity"]
+        assert len(cards) == 1
+        assert cards[0].missing_album is False
+        assert cards[0].source in ("local", "mixed")
         index.close()
 
     def test_prefix_titled_streaming_single_still_matches(self, tmp_path: Path) -> None:
@@ -11094,6 +11103,8 @@ class TestLooseSingleAttach:
         version = reopened._conn.execute(
             "SELECT version FROM schema_version"
         ).fetchone()[0]
+        # Capture the grid before closing the connection.
+        cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
         assert version == 42
@@ -11101,6 +11112,11 @@ class TestLooseSingleAttach:
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
         assert list(tmp_path.glob("library.db.bak-*"))
+        # The grid no longer shows a duplicate: one "Celebrity" card, not a loose
+        # missing-album entry beside the album card, and the album reads as owned.
+        assert len(cards) == 1
+        assert cards[0].missing_album is False
+        assert cards[0].source in ("local", "mixed")
 
     def test_v42_migration_no_backup_when_nothing_to_heal(self, tmp_path: Path) -> None:
         """A fresh DB (or one with no loose singles) is stamped current without a

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1553,6 +1553,80 @@ class TestSearch:
         assert results[0].album_artist == "ArtistB"
         assert results[1].album_artist == "ArtistA"
 
+    def test_search_hides_streaming_twin_when_local_in_same_album(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-529: when a local track and its bandcamp:// streaming twin share an
+        album, search returns only the local row — mirroring the album detail
+        view's local-wins collapse so downloaded tracks don't double in search."""
+        index = LibraryIndex(tmp_path / "library.db")
+        streaming = Track(
+            file_path=Path("bandcamp://555/1"),
+            title="Adrenaline",
+            artist="MAGNAVOLT",
+            album_artist="MAGNAVOLT",
+            album="EDGEZONE FM",
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        local = Track(
+            file_path=tmp_path / "adrenaline.flac",
+            title="Adrenaline",
+            artist="MAGNAVOLT",
+            album_artist="MAGNAVOLT",
+            album="EDGEZONE FM",
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="flac",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="local",
+        )
+        index.upsert_many([streaming, local])
+        results = index.search("adrenaline")
+        index.close()
+        assert len(results) == 1
+        assert results[0].source == "local"
+        assert not str(results[0].file_path).startswith("bandcamp://")
+
+    def test_search_keeps_streaming_row_when_album_has_no_local(
+        self, tmp_path: Path
+    ) -> None:
+        """A purely-streaming album (no local twin) still surfaces its bandcamp://
+        row in search — the collapse must not hide un-downloaded tracks."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=Path("bandcamp://556/1"),
+                    title="Streaming Only",
+                    artist="MAGNAVOLT",
+                    album_artist="MAGNAVOLT",
+                    album="Remote Album",
+                    release_date="2020",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                )
+            ]
+        )
+        results = index.search("streaming only")
+        index.close()
+        assert len(results) == 1
+        assert results[0].source == "bandcamp"
+
     def test_v1_database_migrated_to_current(self, tmp_path: Path) -> None:
         """Existing v1 databases are fully migrated (FTS + date columns) on open."""
         import sqlite3 as _sqlite3

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 42
+        assert version == 43
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1673,7 +1673,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1730,7 +1730,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2325,7 +2325,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert row is not None
         assert row[0] == 0
 
@@ -2780,7 +2780,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2876,7 +2876,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3057,7 +3057,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3152,7 +3152,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 42
+        assert version == 43
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3160,7 +3160,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 42
+        assert version == 43
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4037,7 +4037,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 42
+        assert version == 43
 
         index.close()
 
@@ -4728,7 +4728,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 42
+        assert version == 43
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4763,7 +4763,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 42
+        assert version == 43
         index.close()
 
 
@@ -5278,7 +5278,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 42
+        assert version == 43
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -5411,7 +5411,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 42
+        assert version == 43
 
 
 class TestRemoteTrackSchema:
@@ -5745,7 +5745,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5806,7 +5806,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6564,7 +6564,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7123,7 +7123,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7201,7 +7201,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7407,7 +7407,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7756,7 +7756,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7853,7 +7853,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7969,7 +7969,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8474,7 +8474,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8589,7 +8589,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8687,7 +8687,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8787,7 +8787,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9294,7 +9294,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 42
+        assert version == 43
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10138,7 +10138,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 42
+        assert version == 43
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11107,7 +11107,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 42
+        assert version == 43
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11127,8 +11127,55 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 42
+        assert version == 43
         assert not list(tmp_path.glob("library.db.bak-*"))
+
+    def test_v43_migration_restamps_attached_but_unstamped_single(
+        self, tmp_path: Path
+    ) -> None:
+        """The first v42 build attached a single (set album_id) but left its album
+        tag empty, so it kept showing as a duplicate loose grid card. A DB already
+        at v42 is gated out of the fixed v42 heal, so v43 re-stamps it in place —
+        the tester upgrades without reverting."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index.upsert_many([self._stream_single("400", "Megahit", "Celebrity")])
+        album_id = index._conn.execute(
+            "SELECT album_id FROM tracks WHERE file_path = 'bandcamp://400/1'"
+        ).fetchone()[0]
+        # Reproduce the buggy v42 state: album_id set, album tag empty, and the
+        # album row still reads 'bandcamp' (aggregates never refreshed).
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+            " track_number, source, album_id) VALUES (?, 'Celebrity', 'Megahit',"
+            " 'Megahit', '', 1, 'local', ?)",
+            (str(tmp_path / "celebrity.flac"), album_id),
+        )
+        index._conn.execute(
+            "UPDATE albums SET source = 'bandcamp' WHERE id = ?", (album_id,)
+        )
+        index._conn.execute("UPDATE schema_version SET version = 42")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        stamped = reopened._conn.execute(
+            "SELECT album FROM tracks WHERE file_path = ?",
+            (str(tmp_path / "celebrity.flac"),),
+        ).fetchone()[0]
+        version = reopened._conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0]
+        cards = [a for a in reopened.albums() if a.album == "Celebrity"]
+        reopened.close()
+
+        assert version == 43
+        assert stamped == "Celebrity"
+        # No duplicate loose card, and the album now reads as owned.
+        assert len(cards) == 1
+        assert cards[0].missing_album is False
+        assert cards[0].source in ("local", "mixed")
+        assert list(tmp_path.glob("library.db.bak-*"))
 
 
 class TestHealForkedAlbums:


### PR DESCRIPTION
## What & why

A beta tester's library showed duplicates everywhere: their local audio files of Bandcamp purchases sit alongside the streaming (`bandcamp://`) rows kamp indexes from their collection. kamp's existing name-match already reconciles multi-track albums, but two gaps remained (KAMP-529):

- **Part A — standalone singles.** A single's local file carries an *empty* album tag, so the `(album_artist, album)` name-match in `upsert_many` skips it and it has no album row to sid-link. It lingers as a loose track duplicating the streaming single kamp indexes for the same purchase (surfaced for every single by KAMP-526). The streaming single is a 1-track album whose `album` field equals the item title, so the match key already lives there: `local.title == streaming_single_album.album` (robust to Bandcamp's `Artist - Title` track-title prefix, which the album field omits).
- **Part B — search doubling.** The album detail view already hides a `bandcamp://` row when its album holds a local track (`tracks_for_album` local-wins), but `search()` returned both, so every downloaded track doubled in search. This affects **every** kamp user who downloads, not just this tester.

A third pattern — an album-title mismatch where the local rip and Bandcamp titled the *album* differently (e.g. local "ODEO 3035 (Anime & Nightcore)" vs Bandcamp "ODEO 3035 (Nightcore Mix)"; also the tester's "Sunset Strip" filed under a "16bit Blessings" album) — is **out of scope** here and tracked for a follow-up: it needs a destructive album merge with a forward-path rule.

## Changes

1. **`search()` local-wins collapse** — hide a `bandcamp` row when its album also holds a local track. Keyed on `album_id` (NULL-safe) and `source` (Windows path-form safe), mirroring the detail view. Pure display, no data mutation.
2. **`_attach_loose_local_singles()` + Step 3c in `upsert_many`** — attach a loose local single to its streaming single-album on an *unambiguous* identity match: non-empty album_artist/title, a genuine 1-track `bandcamp` single, and exactly one candidate on each side (else skip + log). Aligns `track_number`/`disc` to the streaming row; deliberately does **not** stamp `sale_item_id` on the local row (the album carries it; stamping a never-downloaded row would create a second claimant for the KAMP-523 download re-attach).
3. **v41 → v42 migration** — re-links loose singles already on disk (an unchanged file is never re-scanned, so Step 3c alone can't reach them). Snapshots the DB first (shared `_backup_db`, mirroring the v39 heal), backs up only when there's a loose single to touch, idempotent. Reuses the same helper as the scan path so the two never drift.

## Verification against the tester's DB (`domin-library.db`, a copy)

Opening it runs migrations **v38 → v42**:

- 10 loose local singles → **9 re-linked** to their streaming single-albums; the 10th ("Inertia") correctly untouched (no streaming twin).
- `search("adrenaline")`, `search("celebrity")`, `search("duality")` → **1 result each** (was 2). Prefix-titled "Duality" matches via the album field.
- Album/artist counts unchanged (93 / 67); backup snapshot written.
- **"Sunset Strip" is not fixed here** — it's the deferred album-title-mismatch pattern (local tagged into "16bit Blessings"), not an empty-album single. It joins the ODEO 3035 case for the follow-up ticket.

## Tests

- `search()` collapse + guard (streaming-only album still surfaces).
- Single-attach happy path, prefix-titled match, and the load-bearing **negatives**: multi-track album (not a single), blank album_artist, two ambiguous local singles, two ambiguous streaming matches, idempotency.
- v42 migration re-links a pre-existing loose single + snapshots; fresh DB stamps current with no wasteful backup.
- Full suite green (2195 passed); coverage 93.18% (patch is coverage-positive; every new line/branch covered).

## Manual test plan (visual)

- [ ] Grid: the 9 singles show once (as local/downloaded), not as separate loose cards.
- [ ] Search each of those titles → single result.
- [ ] Search a coexistence-album track (e.g. "Adrenaline") → single result.
- [ ] Play an attached single → the local file plays.
- [ ] Expected residual: "Sunset Strip" and "ODEO 3035" still show two cards (deferred Pattern C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
