### PR TITLE
fix(base-kamp): give magic playlist random re-shuffle a cooldown (KAMP-530)

### DIFF
--- a/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { getMagicPlaylistModuleContent, artUrl } from '../../api/client'
 import type { Album, Artist, PlaylistTrack } from '../../api/client'
 import { useStore } from '../../store'
@@ -377,12 +377,32 @@ export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): Re
   const [tracks, setTracks] = useState<PlaylistTrack[]>([])
   const [loading, setLoading] = useState(true)
   const [randomTick, setRandomTick] = useState(0)
+  // Hover guard for the random re-shuffle: refs (not state) so hovering never
+  // forces a re-render. A tick that fires while the cursor is over the module is
+  // deferred and applied on mouse-leave, so items never change under the user.
+  const hoveredRef = useRef(false)
+  const pendingShuffleRef = useRef(false)
 
   useEffect(() => {
     if (config.sort !== 'random') return
-    const id = setInterval(() => setRandomTick((n) => n + 1), 60 * 60 * 1000)
-    return () => clearInterval(id)
+    // Re-shuffle every 5 minutes, but hold back a tick while the module is
+    // hovered — the deferred shuffle is applied by onMouseLeave below.
+    const timer = setInterval(
+      () => {
+        if (hoveredRef.current) {
+          pendingShuffleRef.current = true
+        } else {
+          setRandomTick((n) => n + 1)
+        }
+      },
+      5 * 60 * 1000
+    )
+    return () => clearInterval(timer)
   }, [config.sort])
+
+  // Random modules refresh only on their own timer (randomTick), not on every
+  // library event; deterministic sorts still update when the library changes.
+  const libraryTrigger = config.sort === 'random' ? 0 : magicPlaylistVersion
 
   useEffect(() => {
     if (serverStatus !== 'connected' || config.playlistId == null) return
@@ -410,40 +430,64 @@ export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): Re
     config.sort,
     config.items,
     serverStatus,
-    magicPlaylistVersion,
+    libraryTrigger,
     randomTick
   ])
 
-  if (config.playlistId == null) {
-    return <div className="module-empty">Choose a playlist in the settings above.</div>
-  }
+  const renderBody = (): React.JSX.Element => {
+    if (config.playlistId == null) {
+      return <div className="module-empty">Choose a playlist in the settings above.</div>
+    }
 
-  if (loading) {
-    return (
-      <div className="module-skeleton-row">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="module-skeleton-card" />
-        ))}
-      </div>
-    )
-  }
+    if (loading) {
+      return (
+        <div className="module-skeleton-row">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="module-skeleton-card" />
+          ))}
+        </div>
+      )
+    }
 
-  // Albums
-  if (config.contents === 'albums') {
-    if (albums.length === 0) return <div className="module-empty">No albums found.</div>
-    if (displayStyle === 'list') return <ListView albums={albums} />
-    if (displayStyle === 'grid') return <GridView albums={albums} />
-    return <ShelfView albums={albums} />
-  }
+    // Albums
+    if (config.contents === 'albums') {
+      if (albums.length === 0) return <div className="module-empty">No albums found.</div>
+      if (displayStyle === 'list') return <ListView albums={albums} />
+      if (displayStyle === 'grid') return <GridView albums={albums} />
+      return <ShelfView albums={albums} />
+    }
 
-  // Artists
-  if (config.contents === 'artists') {
-    if (artists.length === 0) return <div className="module-empty">No artists found.</div>
+    // Artists
+    if (config.contents === 'artists') {
+      if (artists.length === 0) return <div className="module-empty">No artists found.</div>
+      if (displayStyle === 'list') {
+        return (
+          <div className="module-list">
+            {artists.map((artist) => (
+              <MagicArtistListRow key={artist.name} artist={artist} />
+            ))}
+          </div>
+        )
+      }
+      if (displayStyle === 'grid') {
+        return (
+          <div className="album-grid module-grid">
+            {artists.map((artist) => (
+              <MagicArtistCard key={artist.name} artist={artist} />
+            ))}
+          </div>
+        )
+      }
+      return <MagicArtistShelf artists={artists} />
+    }
+
+    // Tracks
+    if (tracks.length === 0) return <div className="module-empty">No tracks found.</div>
     if (displayStyle === 'list') {
       return (
         <div className="module-list">
-          {artists.map((artist) => (
-            <MagicArtistListRow key={artist.name} artist={artist} />
+          {tracks.map((track) => (
+            <MagicTrackListRow key={track.id} track={track} />
           ))}
         </div>
       )
@@ -451,34 +495,33 @@ export function MagicPlaylistModule({ displayStyle, moduleId }: ModuleProps): Re
     if (displayStyle === 'grid') {
       return (
         <div className="album-grid module-grid">
-          {artists.map((artist) => (
-            <MagicArtistCard key={artist.name} artist={artist} />
+          {tracks.map((track) => (
+            <MagicTrackCard key={track.id} track={track} />
           ))}
         </div>
       )
     }
-    return <MagicArtistShelf artists={artists} />
+    return <MagicTrackShelf tracks={tracks} />
   }
 
-  // Tracks
-  if (tracks.length === 0) return <div className="module-empty">No tracks found.</div>
-  if (displayStyle === 'list') {
-    return (
-      <div className="module-list">
-        {tracks.map((track) => (
-          <MagicTrackListRow key={track.id} track={track} />
-        ))}
-      </div>
-    )
-  }
-  if (displayStyle === 'grid') {
-    return (
-      <div className="album-grid module-grid">
-        {tracks.map((track) => (
-          <MagicTrackCard key={track.id} track={track} />
-        ))}
-      </div>
-    )
-  }
-  return <MagicTrackShelf tracks={tracks} />
+  // Wrapper carries the hover guard for the random re-shuffle. It's a plain
+  // block that passes width through, so it does not affect the shelf/grid/list
+  // layouts inside .base-kamp-module-body.
+  return (
+    <div
+      className="magic-playlist-module-body"
+      onMouseEnter={() => {
+        hoveredRef.current = true
+      }}
+      onMouseLeave={() => {
+        hoveredRef.current = false
+        if (pendingShuffleRef.current) {
+          pendingShuffleRef.current = false
+          setRandomTick((n) => n + 1)
+        }
+      }}
+    >
+      {renderBody()}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

A magic playlist module set to **sort = random** on the base kamp page re-shuffled its display on *every* `magic_playlist.updated` WebSocket event — file adds/removes, play-count bumps, favorites, a song finishing. During an album download (many library updates) the module reshuffled constantly. This gives the random re-shuffle a cooldown and a hover guard.

Fixes KAMP-530.

## Changes

All in `kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx`:

- **Decouple library events from the random re-fetch.** The fetch effect depended on the global `magicPlaylistVersion` counter, which is bumped for every magic-playlist WS event. Now a derived `libraryTrigger` is constant (`0`) for random sort and equal to `magicPlaylistVersion` otherwise. Random modules refresh only on their own timer plus explicit config changes; deterministic sorts (`most_played`, `last_played`, `recently_added`) still update on library change.
- **Interval 60 min → 5 min.** The re-shuffle timer was `60 * 60 * 1000`; now `5 * 60 * 1000`.
- **Hover guard.** A scheduled re-shuffle is suppressed while the cursor is over the module (tracked with refs, so hovering causes no re-render) and applied on mouse-leave, so displayed items never change while the user is acting on one.

Server-side playlist evaluation and the WS broadcast are untouched — magic playlists still receive updates; only the base-kamp module's display refresh is throttled.

## Test plan

kamp_ui has no unit-test runner; verified via `npm run lint` and `npm run typecheck` (both clean) plus manual QA:

1. Base kamp → create a magic playlist module, set **Sort = Random**.
2. Download an album (many library updates). Displayed items do **not** reshuffle during the download.
3. Favorite a track / let a song finish while the random module is visible → no reshuffle.
4. Leave the random module visible ~5 min with the cursor away → it reshuffles once on the timer.
5. Park the cursor on the random module across a 5-min boundary → no reshuffle while hovered; it reshuffles once, immediately, when the cursor leaves.
6. Switch to **Sort = Most Played** (or Recently Added) and trigger a library change → the module updates to reflect the new order.
7. Change a random module's config (items count, contents) → it re-fetches immediately regardless of hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)