### PR TITLE
feat(library): add track_sources + track_stats tables (KAMP-535)

### DIFF
--- a/docs/design/KAMP-533-canonical-track-identity.md
+++ b/docs/design/KAMP-533-canonical-track-identity.md
@@ -217,11 +217,28 @@ it later, not in v44.
 
 ---
 
-## 7. Migration v44 — spec
+## 7. Migration — spec
 
-All of the following land in **one migration**. The items under "one-way doors" change
-the *shape* of the tables v44 creates and the *site list* KAMP-536/537 sweep; deferring
-any one guarantees a second migration + re-sweep.
+> **Sequencing (expand/contract) — refined during KAMP-535.** Dropping columns from
+> `tracks` breaks every reader (`Track`, `_row_to_track`, the ~62 `bandcamp://` sites,
+> `TrackOut`, `criteria.py`), and that rewrite is KAMP-536 — so the transform cannot land
+> in a single migration that also ships to a working `main`. It is split across the
+> phases as expand → migrate → contract:
+> - **v44 / KAMP-535 (expand):** create `track_sources` + `track_stats` **empty** (in
+>   `_DDL`), bump the schema version. No backfill, no collapse, no drops. Provably
+>   zero behavior change; the old `tracks` columns stay authoritative.
+> - **KAMP-536 (collapse + read switch):** a later migration performs the collapse/merge
+>   below and the code switches reads/writes to the new tables (dual-writing the old
+>   columns as a safety net). The old columns remain the source the collapse reads from.
+> - **KAMP-539 (contract):** drop the now-duplicated columns from `tracks` once nothing
+>   reads them.
+>
+> Everything below (matching, survivor-id, merge, repoint, crash-safety) is the
+> **collapse migration** and lands in KAMP-536, not v44. v44 itself is only the empty-
+> table creation + version bump.
+
+All of the following land in **one migration** (the KAMP-536 collapse). The items under
+"one-way doors" fix the *shape* of the tables and the *site list* the rewrite sweeps.
 
 ### One-way doors (must all be in v44)
 - Two-axis `track_sources` (`kind` + `provider`), soft `(provider, provider_item_id)`
@@ -377,11 +394,17 @@ unaccounted for.
 | Phase | Ticket | Owns |
 |-------|--------|------|
 | Design spike | KAMP-534 | this note |
-| Schema + v44 migration | KAMP-535 | §2 tables, §7 migration, repoints, quarantine report |
-| Core rewrite | KAMP-536 | reads/writes vs. `track_sources`/`track_stats`; queue-by-id; `criteria.py`; rename `_canonical_track_key` → `_canonical_track_uri` (both copies) |
+| Schema (expand) | KAMP-535 | §2 tables created **empty** in `_DDL` + version bump; no backfill/collapse |
+| Core rewrite + collapse | KAMP-536 | the §7 collapse migration (matching, repoints, quarantine report); reads/writes vs. `track_sources`/`track_stats`; queue-by-id; `criteria.py`; rename `_canonical_track_key` → `_canonical_track_uri` (both copies); dual-write old columns |
 | Server API | KAMP-537 | `TrackOut` on id + `sources`; computed `file_path` |
 | UI | KAMP-538 | React key / favorite-target → id |
-| Cleanup + regression | KAMP-539 | remove reconcile helpers; delete computed `file_path`; full regression |
+| Cleanup + contract + regression | KAMP-539 | drop duplicated `tracks` columns; remove reconcile helpers; delete computed `file_path`; full regression |
+
+> **Hand-off invariant (KAMP-535 → KAMP-536):** after the expand phase the child tables
+> are **empty**, and there is **no** 1:1 guarantee — a fresh install and any track scanned
+> between 535 and 536 have no child row. KAMP-536 must derive from the old `tracks`
+> columns, **LEFT JOIN** the children (never inner-join and silently drop tracks), and
+> dual-write the old columns as the safety net until KAMP-539 contracts.
 
 > **Note for KAMP-535/536/537:** their current Jira descriptions were written against the
 > earlier *two-table* `mode`-enum proposal. Reconcile them to this three-table,

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 43
+_SCHEMA_VERSION = 44
 
 
 class NoStreamableVersionError(Exception):
@@ -207,6 +207,52 @@ CREATE TABLE IF NOT EXISTS tracks (
     -- runs the whole _DDL before the v41 migration adds this column, so a
     -- CREATE INDEX in _DDL would reference a not-yet-existing column and fail.
     sale_item_id         TEXT    REFERENCES bandcamp_collection(sale_item_id)
+);
+
+-- Canonical-track model, expand phase (KAMP-535, epic KAMP-533). A track's
+-- identity (tracks) is being split from the per-delivery sources that provide
+-- its bytes (track_sources) and its mutable listener stats (track_stats), so the
+-- streaming and downloaded copies of one track stop diverging (KAMP-532). These
+-- two child tables are created EMPTY here; nothing reads or writes them yet.
+-- KAMP-536 populates them (collapsing sibling rows) and switches reads over;
+-- KAMP-539 drops the now-duplicated columns from tracks. Both tables reference
+-- tracks(id) — no FK points back the other way — so existing INSERT/DELETE paths
+-- on tracks are unaffected while these stay empty. See
+-- docs/design/KAMP-533-canonical-track-identity.md §2.
+--
+-- track_sources: one row per way-to-get-the-bytes. Two orthogonal axes replace
+-- the old tracks.source enum — kind (how bytes arrive) and provider (which
+-- catalog/adapter). provider_item_id generalizes sale_item_id with NO hard FK
+-- (adapter-validated). Only uri is UNIQUE: .mp3+.flac of one track and the same
+-- track streamable from two providers are legitimate plural sources.
+CREATE TABLE IF NOT EXISTS track_sources (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id              INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    kind                  TEXT    NOT NULL CHECK (kind IN ('file', 'stream')),
+    provider              TEXT    NOT NULL DEFAULT '',
+    provider_item_id      TEXT,
+    uri                   TEXT    NOT NULL UNIQUE,
+    ext                   TEXT    NOT NULL DEFAULT '',
+    duration              REAL    NOT NULL DEFAULT 0,
+    embedded_art          INTEGER NOT NULL DEFAULT 0,
+    file_mtime            REAL,
+    is_available          INTEGER NOT NULL DEFAULT 1,
+    stream_url            TEXT,
+    stream_url_expires_at REAL
+);
+CREATE INDEX IF NOT EXISTS track_sources_track_idx    ON track_sources(track_id);
+CREATE INDEX IF NOT EXISTS track_sources_provider_idx ON track_sources(provider, provider_item_id);
+
+-- track_stats: mutable listener state, separated so identity stays immutable and
+-- multi-client (single-listener endpoint fanout) writes have one home. No
+-- profile_id — stats are one row per track. updated_at is a last-writer-wins
+-- timestamp for concurrent edits from multiple devices.
+CREATE TABLE IF NOT EXISTS track_stats (
+    track_id    INTEGER PRIMARY KEY REFERENCES tracks(id) ON DELETE CASCADE,
+    favorite    INTEGER NOT NULL DEFAULT 0,
+    play_count  INTEGER NOT NULL DEFAULT 0,
+    last_played REAL,
+    updated_at  REAL
 );
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
@@ -1688,7 +1734,22 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 43")
             self._conn.commit()
-            version = 43  # noqa: F841
+            version = 43
+
+        if version < 44:
+            # v43 → v44: canonical-track model, expand phase (KAMP-535, epic
+            # KAMP-533). track_sources and track_stats are created empty by _DDL
+            # (executescript runs it before this block, and on a fresh DB the
+            # row-is-None branch stamps the current version so no block runs) —
+            # both fresh installs and upgrades converge on the empty tables. This
+            # block only bumps the version; there is deliberately NO backfill (the
+            # v7/v8 no-op pattern). KAMP-536 populates the tables from the still-
+            # authoritative tracks columns and switches reads over. A backfill here
+            # would be thrown away by that collapse and would crash the narrow
+            # migration tests, which build a partial tracks table.
+            self._conn.execute("UPDATE schema_version SET version = 44")
+            self._conn.commit()
+            version = 44  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,120 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 43
+        assert version == 44
+
+    def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
+        """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        tables = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        n_sources = index._conn.execute(
+            "SELECT COUNT(*) FROM track_sources"
+        ).fetchone()[0]
+        n_stats = index._conn.execute("SELECT COUNT(*) FROM track_stats").fetchone()[0]
+        index.close()
+
+        assert {"track_sources", "track_stats"} <= tables
+        # Expand phase only: created empty, nothing populates them until KAMP-536.
+        assert n_sources == 0
+        assert n_stats == 0
+
+    def test_track_sources_constraints_enforced(self, tmp_path: Path) -> None:
+        """track_sources enforces kind CHECK, uri UNIQUE, and FK cascade (KAMP-535)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_track(_sample_track(tmp_path / "01.mp3"))
+        track_id = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+
+        index._conn.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', ?)",
+            (track_id, "/music/01.mp3"),
+        )
+        index._conn.commit()
+
+        # Invalid kind is rejected by the CHECK constraint.
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'bogus', ?)",
+                (track_id, "/music/other.mp3"),
+            )
+        index._conn.rollback()
+
+        # Duplicate uri is rejected by the UNIQUE constraint.
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'stream', ?)",
+                (track_id, "/music/01.mp3"),
+            )
+        index._conn.rollback()
+
+        # Deleting the track cascades to its sources (foreign_keys=ON).
+        index._conn.execute("DELETE FROM tracks WHERE id = ?", (track_id,))
+        index._conn.commit()
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) FROM track_sources WHERE track_id = ?", (track_id,)
+        ).fetchone()[0]
+        index.close()
+        assert remaining == 0
+
+    def test_track_stats_pk_and_cascade(self, tmp_path: Path) -> None:
+        """track_stats is one row per track (PK) and cascades on track delete (KAMP-535)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_track(_sample_track(tmp_path / "01.mp3"))
+        track_id = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+
+        index._conn.execute(
+            "INSERT INTO track_stats (track_id, favorite, play_count) VALUES (?, 1, 3)",
+            (track_id,),
+        )
+        index._conn.commit()
+
+        # track_id is the PRIMARY KEY: a second row for the same track is rejected.
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "INSERT INTO track_stats (track_id, favorite) VALUES (?, 0)",
+                (track_id,),
+            )
+        index._conn.rollback()
+
+        index._conn.execute("DELETE FROM tracks WHERE id = ?", (track_id,))
+        index._conn.commit()
+        remaining = index._conn.execute(
+            "SELECT COUNT(*) FROM track_stats WHERE track_id = ?", (track_id,)
+        ).fetchone()[0]
+        index.close()
+        assert remaining == 0
+
+    def test_migration_v43_to_v44_creates_child_tables(self, tmp_path: Path) -> None:
+        """A pre-v44 DB (full schema, no child tables) gains them on open (KAMP-535)."""
+        db_path = tmp_path / "library.db"
+        # Build a complete current DB, then rewind it to the pre-44 state: drop the
+        # two new tables and stamp version 43, so opening exercises the v44 upgrade.
+        LibraryIndex(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP TABLE track_sources")
+        conn.execute("DROP TABLE track_stats")
+        conn.execute("UPDATE schema_version SET version = 43")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        tables = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        index.close()
+
+        assert version == 44
+        assert {"track_sources", "track_stats"} <= tables
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1673,7 +1786,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1730,7 +1843,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2325,7 +2438,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert row is not None
         assert row[0] == 0
 
@@ -2780,7 +2893,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2876,7 +2989,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3057,7 +3170,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3152,7 +3265,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 43
+        assert version == 44
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3160,7 +3273,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 43
+        assert version == 44
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4037,7 +4150,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 43
+        assert version == 44
 
         index.close()
 
@@ -4728,7 +4841,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 43
+        assert version == 44
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4763,7 +4876,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 43
+        assert version == 44
         index.close()
 
 
@@ -5278,7 +5391,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 43
+        assert version == 44
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -5411,7 +5524,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 43
+        assert version == 44
 
 
 class TestRemoteTrackSchema:
@@ -5745,7 +5858,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5806,7 +5919,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6564,7 +6677,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7123,7 +7236,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7201,7 +7314,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7407,7 +7520,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7756,7 +7869,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7853,7 +7966,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7969,7 +8082,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8474,7 +8587,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8589,7 +8702,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8687,7 +8800,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8787,7 +8900,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9294,7 +9407,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 43
+        assert version == 44
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10138,7 +10251,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 43
+        assert version == 44
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11107,7 +11220,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 43
+        assert version == 44
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11127,7 +11240,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 43
+        assert version == 44
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -11169,7 +11282,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 43
+        assert version == 44
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1


### PR DESCRIPTION
## KAMP-535 — schema expand phase

First code phase of epic **KAMP-533** (canonical track identity). Creates the two new child tables **empty** and bumps the schema to v44. Deliberately additive — **zero behavior change**.

Design note: `docs/design/KAMP-533-canonical-track-identity.md` (§2 schema, §7/§10 sequencing).

### Why this is minimal (resliced from the original 2xLP)
The design note originally put the whole transform (collapse siblings, drop `tracks` columns, repoint refs) in one v44 migration. But dropping columns breaks every reader (`Track`, `_row_to_track`, ~62 `bandcamp://` sites, `TrackOut`, `criteria.py`) — and that rewrite is KAMP-536. Two independent reviews (data-safety + Fable maintainability) led to an **expand/contract** split:
- **This PR (expand):** create `track_sources` + `track_stats` empty, bump version. No backfill, no collapse, no drops.
- **KAMP-536 (collapse + read switch):** populate the tables from the still-authoritative old columns, switch reads/writes, dual-write old columns.
- **KAMP-539 (contract):** drop the duplicated `tracks` columns.

### Changes
- `kamp_core/library.py`: two `CREATE TABLE IF NOT EXISTS` (+ two indexes) in `_DDL` after `tracks`; `_SCHEMA_VERSION` 43→44; a no-op `if version < 44:` bump block (v7/v8 pattern). Both fresh installs and upgrades get the tables from `_DDL`.
- `docs/design/KAMP-533-canonical-track-identity.md`: §7/§10 amended for the expand/contract sequencing + the 535→536 hand-off invariant.
- `tests/test_library.py`: new shape/constraint/upgrade tests; terminal-version assertions bumped 43→44.

### Why it's safe (zero behavior change)
No FK points *from* `tracks` to the children, so every existing INSERT/DELETE/`set_favorite`/scan/prune path is unaffected while the children stay empty. Nothing reads the new tables yet.

### Verification
- Full suite: **2200 passed, 9 skipped**; coverage **93.18%** (above the 93% gate; repo baseline). `black` clean, `mypy` clean.
- New tests: fresh-DB table shape + constraints (`kind` CHECK, `uri` UNIQUE, FK `ON DELETE CASCADE`, `track_stats` PK); v43→v44 upgrade creates both tables.

### Manual test plan
- [ ] Open the app against an existing library DB → opens cleanly; library/albums/playback/favorites unchanged.
- [ ] `sqlite3 <lib.db> ".schema track_sources"` / `".schema track_stats"` show the tables; `SELECT COUNT(*)` = 0 on each; `SELECT version FROM schema_version` = 44.
- [ ] Fresh install starts at v44 with both tables present and empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)