### PR TITLE
refactor(playback): identify queued tracks by track_id (KAMP-536)

### DIFF
--- a/docs/design/KAMP-533-canonical-track-identity.md
+++ b/docs/design/KAMP-533-canonical-track-identity.md
@@ -371,17 +371,17 @@ unaccounted for.
 
 | Site | Stores | Phase |
 |------|--------|-------|
-| `tracks.file_path` (UNIQUE, identity) | URI | v44 (535) — moves to `track_sources.uri` |
-| `tracks.sale_item_id` | provenance | v44 (535) — moves to `track_sources.provider_item_id` |
-| `tracks.favorite/play_count/last_played` | stats | v44 (535) — move to `track_stats` |
-| per-source cols on `tracks` | delivery | v44 (535) — move to `track_sources` |
-| `playlist_tracks.track_id` (FK CASCADE) | id | v44 repoint (535) |
-| `deferred_ops.track_id` (UNIQUE) | id | v44 repoint (535) |
-| `tracks_fts` rowid = id | id | v44 repoint (535) |
-| `player_state.track_path` | path | v44 rewrite → id (535) |
-| `queue_state.tracks` (JSON paths) | paths | v44 rewrite → id (535); runtime queue-by-id (536) |
-| `criteria.py` `_FIELD_MAP` stats fields | column refs | core (536) — JOIN `track_stats` |
-| `criteria.py` `track.source` | column ref | core (536) — EXISTS value-map + `criteria_json` compat |
+| `tracks.file_path` (UNIQUE, identity) | URI | populate → `track_sources.uri` (540); dropped (539) |
+| `tracks.sale_item_id` | provenance | populate → `track_sources.provider_item_id` (540); dropped (539) |
+| `tracks.favorite/play_count/last_played` | stats | populate + dual-write → `track_stats` (540); reads switch (542); dropped (539) |
+| per-source cols on `tracks` | delivery | populate → `track_sources` (540); reads switch (541/542); dropped (539) |
+| `playlist_tracks.track_id` (FK CASCADE) | id | collapse repoint (541) |
+| `deferred_ops.track_id` (UNIQUE) | id | collapse repoint (541) |
+| `tracks_fts` rowid = id | id | collapse repoint (541) |
+| `player_state.track_path` | path | rewrite → id (536 queue-by-id); collapse repoint by id (541) |
+| `queue_state.tracks` (JSON paths) | paths | rewrite → ids (536 queue-by-id); collapse repoint by id (541) |
+| `criteria.py` `_FIELD_MAP` stats fields | column refs | read-switch (542) — JOIN `track_stats` |
+| `criteria.py` `track.source` | column ref | read-switch (542) — EXISTS value-map + `criteria_json` compat |
 | `server.py` `TrackOut` + siblings (`file_path` identity) | field | API (537) — key on id; `file_path` computed then removed (539) |
 | UI (~24 files) React key / favorite-target | field | UI (538) |
 | `extension_audit_log.track_mbid` | mb id | no change — protected by COALESCE-non-empty on `mb_recording_id` |
@@ -391,24 +391,38 @@ unaccounted for.
 
 ## 10. Phase routing
 
+The "core rewrite" was decomposed (after two reviews found a single collapse PR mis-scoped
+and irreversible) into a linear sequence of **independently-shippable** tickets — each
+merges to a working `main` on its own, no integration branch. Doing the two behavior-neutral
+pieces first (queue-by-id, populate+dual-write) shrinks the irreversible collapse and removes
+its couplings.
+
 | Phase | Ticket | Owns |
 |-------|--------|------|
 | Design spike | KAMP-534 | this note |
 | Schema (expand) | KAMP-535 | §2 tables created **empty** in `_DDL` + version bump; no backfill/collapse |
-| Core rewrite + collapse | KAMP-536 | the §7 collapse migration (matching, repoints, quarantine report); reads/writes vs. `track_sources`/`track_stats`; queue-by-id; `criteria.py`; rename `_canonical_track_key` → `_canonical_track_uri` (both copies); dual-write old columns |
+| Queue-by-id | KAMP-536 | queue identity path→`track_id` (persistence + in-memory + daemon restore); behavior-neutral. Turns the collapse's `queue_state` repoint into a plain id update |
+| Populate + dual-write | KAMP-540 | backfill one `track_sources`+`track_stats` row per `tracks` row; writers dual-write stats as an **absolute mirror**; `upsert_many` maintains children on scan; reads stay on old columns; behavior-neutral |
+| Collapse + source reads + delete-download | KAMP-541 | the §7 collapse migration (matching, survivor-id, repoints **by id**, quarantine, backup-first, one txn); preferred-source playback + stream-refresh reads; rework `remove_download`/`materialize_stream_tracks` and delete the `streaming_track_for_local_id` swap. **Fixes KAMP-532.** Atomic/irreversible |
+| Read-switch | KAMP-542 | remaining stats reads → `track_stats`; ~62 `bandcamp://`/`source=` sites → `track_sources` EXISTS; `criteria.py` JOIN + `track.source` value-map; rename `_canonical_track_key`→`_canonical_track_uri`; behavior-neutral |
 | Server API | KAMP-537 | `TrackOut` on id + `sources`; computed `file_path` |
 | UI | KAMP-538 | React key / favorite-target → id |
-| Cleanup + contract + regression | KAMP-539 | drop duplicated `tracks` columns; remove reconcile helpers; delete computed `file_path`; full regression |
+| Contract + regression | KAMP-539 | drop duplicated `tracks` columns; delete now-dead reconcile helpers + computed `file_path`; full regression |
 
-> **Hand-off invariant (KAMP-535 → KAMP-536):** after the expand phase the child tables
-> are **empty**, and there is **no** 1:1 guarantee — a fresh install and any track scanned
-> between 535 and 536 have no child row. KAMP-536 must derive from the old `tracks`
-> columns, **LEFT JOIN** the children (never inner-join and silently drop tracks), and
-> dual-write the old columns as the safety net until KAMP-539 contracts.
+Order: **535 → 536 → 540 → 541 → 542 → (537/538) → 539.**
 
-> **Note for KAMP-535/536/537:** their current Jira descriptions were written against the
-> earlier *two-table* `mode`-enum proposal. Reconcile them to this three-table,
-> `kind`+`provider`, `track_stats` design before starting each.
+> **Hand-off invariant (populate → collapse):** the child tables are **empty** until KAMP-540,
+> and there is **no** 1:1 guarantee — a fresh install and any track scanned before KAMP-540
+> has no child row. KAMP-541 must derive from the old `tracks` columns, **LEFT JOIN** the
+> children (never inner-join and silently drop tracks), and rely on dual-write keeping the old
+> columns authoritative until KAMP-539 contracts.
+
+> **Why the delete-download helpers moved out of KAMP-539:** the collapse *breaks* (not just
+> orphans) `remove_download`/`materialize_stream_tracks`/`streaming_track_for_local_id` —
+> they assume two rows per track and are live-called by delete-download (would 422 on every
+> removal). So their rework lands with the collapse (KAMP-541), and one `UNIQUE file_path`
+> column can't represent a track that is both local and streamable, so source/URI reads move
+> with the collapse too — only pure-stats reads defer to KAMP-542.
 
 ---
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4608,8 +4608,14 @@ class LibraryIndex:
         ).fetchall()
         return [_playlist_row_to_dict(r) for r in rows]
 
-    def save_player_state(self, track_path: "str | Path", position: float) -> None:
-        """Persist the current track path and playback position."""
+    def save_player_state(self, track_id: int, position: float) -> None:
+        """Persist the current track id and playback position.
+
+        The value is stored in the (legacy-named) track_path column as the
+        stringified track id (KAMP-536 queue-by-id). load_player_state() reads
+        it back and callers resolve it via get_track_by_id; a legacy path value
+        written by an older build is still resolvable via get_track_by_path.
+        """
         self._conn.execute(
             """
             INSERT INTO player_state (id, track_path, position) VALUES (1, ?, ?)
@@ -4617,7 +4623,7 @@ class LibraryIndex:
                 track_path = excluded.track_path,
                 position   = excluded.position
             """,
-            (str(track_path), position),
+            (str(track_id), position),
         )
         self._conn.commit()
 
@@ -4627,10 +4633,12 @@ class LibraryIndex:
         self._conn.commit()
 
     def load_player_state(self) -> "tuple[str, float] | None":
-        """Return (track_path, position) from the last session, or None.
+        """Return (track_ref, position) from the last session, or None.
 
-        Returns the raw string stored in the DB — callers must not wrap it in
-        Path() since it may be a remote URI (bandcamp://) that Path normalizes.
+        *track_ref* is the current track's id as a string (KAMP-536); a legacy
+        build may have stored a path/URI instead. Returned raw so the caller can
+        resolve it (digit string → get_track_by_id, otherwise get_track_by_path)
+        without Path() normalizing a remote bandcamp:// URI.
         """
         row = self._conn.execute(
             "SELECT track_path, position FROM player_state WHERE id = 1"
@@ -4639,16 +4647,20 @@ class LibraryIndex:
 
     def save_queue_state(
         self,
-        tracks: "Sequence[Path | str]",
+        track_ids: "Sequence[int]",
         order: list[int],
         pos: int,
         shuffle: bool,
         repeat: str,
     ) -> None:
-        """Persist the queue in original load order with playback permutation."""
+        """Persist the queue in original load order with playback permutation.
+
+        *track_ids* are track ids in original load order (KAMP-536 queue-by-id);
+        the later collapse migration repoints these with a plain id update.
+        """
         import json
 
-        payload = json.dumps([str(p) for p in tracks])
+        payload = json.dumps([int(t) for t in track_ids])
         order_payload = json.dumps(order)
         self._conn.execute(
             """
@@ -4667,11 +4679,14 @@ class LibraryIndex:
 
     def load_queue_state(
         self,
-    ) -> "tuple[list[str], list[int], int, bool, str] | None":
-        """Return (tracks_in_original_order, order, pos, shuffle, repeat_mode) or None.
+    ) -> "tuple[list[int | str], list[int], int, bool, str] | None":
+        """Return (entries_in_original_order, order, pos, shuffle, repeat_mode) or None.
 
-        Tracks are returned as raw strings (not Path objects) so remote URIs
-        (bandcamp://) are not corrupted by Path normalization.
+        *entries* are track ids (KAMP-536 queue-by-id). A DB last written by an
+        older build yields legacy path strings instead; entries are returned as
+        parsed JSON (ints or strs) so the caller resolves each by type — int via
+        get_track_by_id, str via get_track_by_path (protecting bandcamp:// URIs
+        from Path normalization).
         """
         import json
 
@@ -4680,16 +4695,16 @@ class LibraryIndex:
         ).fetchone()
         if not row:
             return None
-        paths: list[str] = list(json.loads(row["tracks"]))
+        entries: list[int | str] = list(json.loads(row["tracks"]))
         raw_order = row["order_json"]
         order: list[int] = (
-            json.loads(raw_order) if raw_order else list(range(len(paths)))
+            json.loads(raw_order) if raw_order else list(range(len(entries)))
         )
         raw_repeat = row["repeat"]
         repeat: str = (
             raw_repeat if raw_repeat in ("off", "queue", "album", "single") else "off"
         )
-        return paths, order, row["pos"], bool(row["shuffle"]), repeat
+        return entries, order, row["pos"], bool(row["shuffle"]), repeat
 
     def clear_queue_state(self) -> None:
         """Remove the persisted queue state (e.g. after the queue is exhausted)."""

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -323,18 +323,20 @@ class PlaybackQueue:
         """
         return [self._tracks[i] for i in self._order], self._pos
 
-    def get_state(self) -> tuple[list[str], list[int], int, bool, str]:
-        """Return (original_paths, order, pos, shuffle, repeat_mode) for persistence.
+    def get_state(self) -> tuple[list[int], list[int], int, bool, str]:
+        """Return (original_ids, order, pos, shuffle, repeat_mode) for persistence.
 
-        *original_paths* is _tracks in load order; *order* is the index
-        permutation (_order) so the shuffled sequence can be faithfully
+        *original_ids* is _tracks in load order (track ids); *order* is the
+        index permutation (_order) so the shuffled sequence can be faithfully
         restored and toggling shuffle off recovers the true original order.
-        Paths are returned as strings to match load_queue_state()'s list[str].
+        Persisting track ids rather than paths (KAMP-536) keeps the queue stable
+        across the canonical-track refactor: the later collapse repoints the
+        saved queue with a plain id update instead of rewriting path strings.
         """
 
-        original_paths = [_canonical_track_key(t.file_path) for t in self._tracks]
+        original_ids = [t.id for t in self._tracks]
         return (
-            original_paths,
+            original_ids,
             list(self._order),
             self._pos,
             self._shuffle,

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -602,21 +602,23 @@ def _cmd_daemon(
     saved_queue = index.load_queue_state()
     saved_player = index.load_player_state()
     if saved_queue and saved_player:
-        saved_paths, q_order, q_pos, q_shuffle, q_repeat = saved_queue
+        saved_entries, q_order, q_pos, q_shuffle, q_repeat = saved_queue
         _, saved_position = saved_player
-        # Resolve original-order paths → Track objects.
-        # Remote tracks that can't be found in the DB (e.g. after a DB wipe) are
-        # kept as minimal stub Tracks with reachable=False so they remain visible
-        # in the queue UI rather than silently disappearing.  Local tracks that
-        # aren't found (deleted files) are still dropped.
+
+        # Resolve original-order entries → Track objects (KAMP-536 queue-by-id).
+        # Entries are track ids; a DB last written by an older build yields legacy
+        # path strings, resolved by path. Remote tracks missing from the DB (e.g.
+        # a legacy bandcamp: path after a DB wipe) are kept as minimal stub Tracks
+        # with reachable=False so they remain visible in the queue UI rather than
+        # silently disappearing. Ids/local paths not found (deleted) are dropped.
         # Build a mapping old_index → new_index so the playback permutation
         # (q_order) can be remapped to the compacted resolved list.
-        resolved: list[Any] = []
-        old_to_new: dict[int, int] = {}
-        for i, p in enumerate(saved_paths):
+        def _resolve_saved_entry(entry: "int | str") -> "Track | None":
+            if isinstance(entry, int):
+                return index.get_track_by_id(entry)
+            p = str(entry)
             t = index.get_track_by_path(p)
             if t is None and p.startswith("bandcamp:"):
-                # Remote track missing from DB — keep as unreachable stub.
                 t = Track(
                     file_path=Path(p),
                     title=p.split("/")[-1] or p,
@@ -633,6 +635,12 @@ def _cmd_daemon(
                     source="bandcamp",
                     reachable=False,
                 )
+            return t
+
+        resolved: list[Any] = []
+        old_to_new: dict[int, int] = {}
+        for i, entry in enumerate(saved_entries):
+            t = _resolve_saved_entry(entry)
             if t is not None:
                 old_to_new[i] = len(resolved)
                 resolved.append(t)
@@ -663,8 +671,12 @@ def _cmd_daemon(
                 engine.load_paused(current.playback_uri, saved_position)
     elif saved_player:
         # Fallback: no queue state — restore single track (pre-TASK-47 behaviour).
-        saved_path, saved_position = saved_player
-        track = index.get_track_by_path(saved_path)
+        saved_ref, saved_position = saved_player
+        track = (
+            index.get_track_by_id(int(saved_ref))
+            if saved_ref.lstrip("-").isdigit()
+            else index.get_track_by_path(saved_ref)
+        )
         if track:
             queue.load([track], 0)
             engine.load_paused(track.playback_uri, saved_position)
@@ -815,9 +827,9 @@ def _cmd_daemon(
                 _et_prev_pos[0] = pos
                 _et_playing[0] = playing
                 if tick % 5 == 0:
-                    index.save_player_state(current.file_path, engine.state.position)
-                    q_paths, q_order, q_pos, q_shuffle, q_repeat = queue.get_state()
-                    index.save_queue_state(q_paths, q_order, q_pos, q_shuffle, q_repeat)
+                    index.save_player_state(current.id, engine.state.position)
+                    q_ids, q_order, q_pos, q_shuffle, q_repeat = queue.get_state()
+                    index.save_queue_state(q_ids, q_order, q_pos, q_shuffle, q_repeat)
             elif _et_path[0] is not None:
                 # Queue became empty — flush any accumulated time.
                 _flush_elapsed()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -607,14 +607,14 @@ class TestLibraryIndex:
 
     def test_save_and_load_player_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_player_state(tmp_path / "track.mp3", 42.5)
+        index.save_player_state(7, 42.5)
         result = index.load_player_state()
         index.close()
 
         assert result is not None
-        path, position = result
-        assert isinstance(path, str)
-        assert path == str(tmp_path / "track.mp3")
+        ref, position = result
+        assert isinstance(ref, str)
+        assert ref == "7"  # track id stored as text (KAMP-536)
         assert position == 42.5
 
     def test_load_player_state_returns_none_when_empty(self, tmp_path: Path) -> None:
@@ -626,7 +626,7 @@ class TestLibraryIndex:
 
     def test_clear_player_state_removes_saved_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_player_state(tmp_path / "track.mp3", 42.5)
+        index.save_player_state(7, 42.5)
         index.clear_player_state()
         result = index.load_player_state()
         index.close()
@@ -635,30 +635,30 @@ class TestLibraryIndex:
 
     def test_save_player_state_overwrites_previous(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_player_state(tmp_path / "first.mp3", 10.0)
-        index.save_player_state(tmp_path / "second.mp3", 99.0)
+        index.save_player_state(1, 10.0)
+        index.save_player_state(2, 99.0)
         result = index.load_player_state()
         index.close()
 
         assert result is not None
-        path, position = result
-        assert isinstance(path, str)
-        assert path == str(tmp_path / "second.mp3")
+        ref, position = result
+        assert isinstance(ref, str)
+        assert ref == "2"
         assert position == 99.0
 
     def test_save_and_load_queue_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        tracks = [tmp_path / "a.mp3", tmp_path / "b.mp3", tmp_path / "c.mp3"]
+        track_ids = [10, 20, 30]
         index.save_queue_state(
-            tracks, order=[2, 0, 1], pos=1, shuffle=True, repeat=False
+            track_ids, order=[2, 0, 1], pos=1, shuffle=True, repeat=False
         )
         result = index.load_queue_state()
         index.close()
 
         assert result is not None
-        paths, order, pos, shuffle, repeat = result
-        assert all(isinstance(p, str) for p in paths)
-        assert paths == [str(t) for t in tracks]
+        entries, order, pos, shuffle, repeat = result
+        assert all(isinstance(e, int) for e in entries)
+        assert entries == [10, 20, 30]
         assert order == [2, 0, 1]
         assert pos == 1
         assert shuffle is True
@@ -673,11 +673,9 @@ class TestLibraryIndex:
 
     def test_save_queue_state_overwrites_previous(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
+        index.save_queue_state([10], order=[0], pos=0, shuffle=False, repeat=False)
         index.save_queue_state(
-            [tmp_path / "a.mp3"], order=[0], pos=0, shuffle=False, repeat=False
-        )
-        index.save_queue_state(
-            [tmp_path / "b.mp3", tmp_path / "c.mp3"],
+            [20, 30],
             order=[1, 0],
             pos=1,
             shuffle=True,
@@ -687,8 +685,8 @@ class TestLibraryIndex:
         index.close()
 
         assert result is not None
-        paths, order, pos, shuffle, repeat = result
-        assert paths == [str(tmp_path / "b.mp3"), str(tmp_path / "c.mp3")]
+        entries, order, pos, shuffle, repeat = result
+        assert entries == [20, 30]
         assert order == [1, 0]
         assert pos == 1
         assert shuffle is True
@@ -696,9 +694,7 @@ class TestLibraryIndex:
 
     def test_clear_queue_state(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_queue_state(
-            [tmp_path / "a.mp3"], order=[0], pos=0, shuffle=False, repeat=False
-        )
+        index.save_queue_state([10], order=[0], pos=0, shuffle=False, repeat=False)
         index.clear_queue_state()
         result = index.load_queue_state()
         index.close()
@@ -6447,56 +6443,64 @@ class TestIndexedPathsExcludesRemote:
 class TestQueuePlayerStateStr:
     def test_load_player_state_returns_str(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_player_state(tmp_path / "track.mp3", 10.0)
+        index.save_player_state(5, 10.0)
         result = index.load_player_state()
         index.close()
 
         assert result is not None
-        path, _ = result
-        assert isinstance(path, str)
+        ref, _ = result
+        assert isinstance(ref, str)
+        assert ref == "5"
 
-    def test_load_player_state_preserves_remote_uri(self, tmp_path: Path) -> None:
+    def test_load_player_state_preserves_legacy_path(self, tmp_path: Path) -> None:
+        # Back-compat: a pre-queue-by-id build stored a raw path/URI in
+        # player_state.track_path; load returns it unchanged so the daemon can
+        # resolve it by path (KAMP-536).
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_player_state("bandcamp://999/3", 22.5)
+        index._conn.execute(
+            "INSERT INTO player_state (id, track_path, position) VALUES (1, ?, ?)",
+            ("bandcamp://999/3", 22.5),
+        )
+        index._conn.commit()
         result = index.load_player_state()
         index.close()
 
         assert result is not None
-        path, position = result
-        assert path == "bandcamp://999/3"
+        ref, position = result
+        assert ref == "bandcamp://999/3"
         assert position == 22.5
 
-    def test_load_queue_state_returns_list_of_str(self, tmp_path: Path) -> None:
+    def test_load_queue_state_returns_list_of_int(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.save_queue_state(
-            [tmp_path / "a.mp3", tmp_path / "b.mp3"],
-            order=[0, 1],
-            pos=0,
-            shuffle=False,
-            repeat="off",
+            [11, 22], order=[0, 1], pos=0, shuffle=False, repeat="off"
         )
         result = index.load_queue_state()
         index.close()
 
         assert result is not None
-        paths, _, _, _, _ = result
-        assert all(isinstance(p, str) for p in paths)
+        entries, _, _, _, _ = result
+        assert all(isinstance(e, int) for e in entries)
+        assert entries == [11, 22]
 
-    def test_load_queue_state_preserves_remote_uri(self, tmp_path: Path) -> None:
+    def test_load_queue_state_preserves_legacy_paths(self, tmp_path: Path) -> None:
+        # Back-compat: a pre-queue-by-id DB stored JSON path strings; load returns
+        # them unchanged so the daemon resolves each by path (KAMP-536).
+        import json
+
         index = LibraryIndex(tmp_path / "library.db")
-        index.save_queue_state(
-            ["bandcamp://999/1", "bandcamp://999/2"],
-            order=[0, 1],
-            pos=0,
-            shuffle=False,
-            repeat="off",
+        index._conn.execute(
+            "INSERT INTO queue_state (id, tracks, order_json, pos, shuffle, repeat) "
+            "VALUES (1, ?, ?, 0, 0, 'off')",
+            (json.dumps(["bandcamp://999/1", "bandcamp://999/2"]), json.dumps([0, 1])),
         )
+        index._conn.commit()
         result = index.load_queue_state()
         index.close()
 
         assert result is not None
-        paths, _, _, _, _ = result
-        assert paths == ["bandcamp://999/1", "bandcamp://999/2"]
+        entries, _, _, _, _ = result
+        assert entries == ["bandcamp://999/1", "bandcamp://999/2"]
 
     def test_get_track_by_path_accepts_str(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -38,6 +38,7 @@ def _track(n: int) -> Track:
         embedded_art=False,
         mb_release_id="",
         mb_recording_id="",
+        id=n + 1,  # distinct track id (queue persists by id, KAMP-536)
     )
 
 
@@ -76,6 +77,7 @@ def _remote_track(sale_id: str = "123456", track_num: int = 1) -> Track:
         source="bandcamp",
         stream_url="https://cdn.bcbits.com/stream/track.mp3",
         stream_url_expires_at=9999999999.0,
+        id=900 + track_num,  # distinct track id (queue persists by id, KAMP-536)
     )
 
 
@@ -494,25 +496,25 @@ class TestPlaybackQueue:
         assert tracks == []
         assert pos == -1
 
-    def test_get_state_returns_original_paths_and_order(self) -> None:
+    def test_get_state_returns_original_ids_and_order(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(3)]
         q.load(tracks)
-        paths, order, pos, shuffle, repeat = q.get_state()
-        assert paths == [str(t.file_path) for t in tracks]
+        ids, order, pos, shuffle, repeat = q.get_state()
+        assert ids == [t.id for t in tracks]
         assert order == [0, 1, 2]
         assert pos == 0
         assert shuffle is False
         assert repeat == "off"
 
-    def test_get_state_with_shuffle_returns_original_paths(self) -> None:
+    def test_get_state_with_shuffle_returns_original_ids(self) -> None:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(5)]
         q.load(tracks)
         q.set_shuffle(True)
-        paths, order, pos, shuffle, repeat = q.get_state()
-        # paths must be in ORIGINAL load order, not shuffled
-        assert paths == [str(t.file_path) for t in tracks]
+        ids, order, pos, shuffle, repeat = q.get_state()
+        # ids must be in ORIGINAL load order, not shuffled
+        assert ids == [t.id for t in tracks]
         # order[0] must be the original index of the currently playing track (0)
         assert order[0] == 0
         assert set(order) == {0, 1, 2, 3, 4}
@@ -521,18 +523,18 @@ class TestPlaybackQueue:
 
     def test_get_state_empty_queue(self) -> None:
         q = PlaybackQueue()
-        paths, order, pos, shuffle, repeat = q.get_state()
-        assert paths == []
+        ids, order, pos, shuffle, repeat = q.get_state()
+        assert ids == []
         assert order == []
         assert pos == -1
 
-    def test_get_state_remote_track_canonical_uri(self) -> None:
-        """Remote tracks serialise as bandcamp:// (double-slash) even on POSIX."""
+    def test_get_state_remote_track_returns_id(self) -> None:
+        """Remote tracks persist by track id like any other (KAMP-536)."""
         q = PlaybackQueue()
         remote = _remote_track(sale_id="999", track_num=3)
         q.load([remote])
-        paths, _, _, _, _ = q.get_state()
-        assert paths == ["bandcamp://999/3"]
+        ids, _, _, _, _ = q.get_state()
+        assert ids == [remote.id]
 
     def test_update_favorite_str_path_matches_remote_track(self) -> None:
         """update_favorite accepts a str URI so remote tracks can be matched."""
@@ -547,7 +549,7 @@ class TestPlaybackQueue:
         tracks = [_track(i) for i in range(3)]
         q.restore(tracks, order=[2, 0, 1], pos=0, shuffle=True, repeat="queue")
         assert q.current() == tracks[2]
-        paths, order, pos, shuffle, repeat = q.get_state()
+        _ids, order, pos, shuffle, repeat = q.get_state()
         assert pos == 0
         assert shuffle is True
         assert repeat == "queue"
@@ -556,8 +558,8 @@ class TestPlaybackQueue:
         q = PlaybackQueue()
         q.restore([], order=[], pos=0, shuffle=False, repeat="off")
         assert q.current() is None
-        paths, order, pos, shuffle, repeat = q.get_state()
-        assert paths == []
+        ids, order, pos, shuffle, repeat = q.get_state()
+        assert ids == []
         assert order == []
         assert pos == -1
 
@@ -580,10 +582,11 @@ class TestPlaybackQueue:
         q.next()
         before_toggle = q.current()
 
-        # Simulate save/restore (what happens across a quit/restart).
-        paths, order, pos, shuffle, repeat = q.get_state()
+        # Simulate save/restore (what happens across a quit/restart): the queue
+        # persists track ids, and the daemon resolves each id back to a Track.
+        ids, order, pos, shuffle, repeat = q.get_state()
         q2 = PlaybackQueue()
-        resolved = [next(t for t in tracks if str(t.file_path) == p) for p in paths]
+        resolved = [next(t for t in tracks if t.id == i) for i in ids]
         q2.restore(resolved, order=order, pos=pos, shuffle=shuffle, repeat=repeat)
 
         assert q2.current() == before_toggle


### PR DESCRIPTION
## KAMP-536 — queue-by-id

First piece of the **decomposed** canonical-track core rewrite (epic KAMP-533). Behavior-neutral: the queue's persisted identity moves from file paths to `track_id`.

Design note: `docs/design/KAMP-533-canonical-track-identity.md` (§5, §10).

### Why this exists / why first
The original single "core rewrite" (KAMP-536) was found mis-scoped by two reviews and decomposed into a linear sequence of independently-shippable tickets: **536 (queue-by-id) → 540 (populate+dual-write) → 541 (collapse, fixes KAMP-532) → 542 (read-switch) → 539 (contract)**. Doing queue-by-id first turns the later collapse migration's `queue_state` repoint from fragile JSON-path-string surgery into a plain `UPDATE ... SET track_id = survivor`, and removes the in-memory `file_path` coupling. It needs neither the collapse nor the new child tables, so it ships to a working `main` on its own.

### Changes
- `kamp_core/playback.py` — `Queue.get_state()` returns track ids in load order (was canonicalized paths).
- `kamp_core/library.py` — `save/load_queue_state` and `save/load_player_state` persist/read ids. Loaders tolerate **legacy path payloads** from a pre-queue-by-id DB (resolved by path on the first restore) so upgrades don't drop the restored queue.
- `kamp_daemon/__main__.py` — restore resolves ids → `Track` via `get_track_by_id`, keeping the legacy path + `bandcamp:`-stub path for old DBs; save loop stores `current.id`.
- `docs/design/…` — §9/§10 updated to the decomposition + hand-off invariants.

### Behavior-neutral
Same tracks restore in the same order across restart; nothing user-visible changes. `queue_state`/`player_state` schema is unchanged (ids stored in the existing TEXT/JSON columns).

### Verification
- Full suite: **2200 passed, 9 skipped**; coverage **93.18%** (above gate). `black` + `mypy` clean.
- New/updated tests: id round-trips for `queue_state`/`player_state`; two explicit **legacy-path back-compat** tests (raw-insert path payload → load returns it for daemon path-resolution); `test_playback` get_state/restore round-trip now asserts the id contract.
- The daemon restore loop is coverage-excluded (CLI/lifecycle glue) — validated via the manual test plan below.

### Manual test plan
- [ ] Play an album, queue several tracks (mix of local + streaming), skip to the middle, quit and relaunch → same queue and current track restore in the same order; playback resumes at the right position.
- [ ] Relaunch against a DB last written by the **old** (path-based) build → queue still restores (legacy path-payload back-compat).
- [ ] Remove a queued track from the library, relaunch → queue restore skips it cleanly (no crash, no phantom entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)