### PR TITLE
feat(library): populate track_sources/track_stats + dual-write (KAMP-540)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 44
+_SCHEMA_VERSION = 45
 
 
 class NoStreamableVersionError(Exception):
@@ -1749,7 +1749,50 @@ class LibraryIndex:
             # migration tests, which build a partial tracks table.
             self._conn.execute("UPDATE schema_version SET version = 44")
             self._conn.commit()
-            version = 44  # noqa: F841
+            version = 44
+
+        if version < 45:
+            # v44 → v45: populate track_sources/track_stats from the authoritative
+            # tracks columns (KAMP-540). Additive and behavior-neutral — nothing
+            # reads the children yet (KAMP-542 flips reads). Guarded on the columns
+            # the backfill reads, since the narrow migration-unit-test schemas build
+            # a partial tracks table; when they're absent the tables just stay empty
+            # and we still bump the version. No backup: the backfill only INSERTs
+            # into the (empty) child tables and never touches tracks, so it is
+            # undone by dropping the child rows. Wrapped in try/except so a
+            # pathological uri collision can't brick the DB — the children are left
+            # for KAMP-541's collapse (which re-derives from tracks) to populate.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            needed = {
+                "id",
+                "file_path",
+                "source",
+                "sale_item_id",
+                "favorite",
+                "play_count",
+                "last_played",
+                "ext",
+                "duration",
+                "embedded_art",
+                "file_mtime",
+                "is_available",
+                "stream_url",
+                "stream_url_expires_at",
+            }
+            if needed <= track_cols:
+                try:
+                    self._backfill_canonical_children()
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-540 v45 backfill failed — rolled back; children left"
+                        " for KAMP-541 to populate"
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 45")
+            self._conn.commit()
+            version = 45  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
@@ -1770,6 +1813,69 @@ class LibraryIndex:
         except Exception as exc:  # pragma: no cover - backup is best-effort
             logger.warning("%s: backup failed (%s); skipping heal", label, exc)
             return False
+
+    def _backfill_canonical_children(self) -> None:
+        """Populate track_sources/track_stats from existing tracks rows (KAMP-540).
+
+        One track_sources row and one track_stats row per tracks row that has no
+        source row yet (the NOT EXISTS guard makes re-runs a no-op). Derives the
+        source fields via _derive_source_fields so the migration and the scan path
+        produce identical rows. Additive only — never mutates tracks.
+        """
+        rows = self._conn.execute(
+            "SELECT id, file_path, source, sale_item_id, ext, duration,"
+            " embedded_art, file_mtime, is_available, stream_url,"
+            " stream_url_expires_at, favorite, play_count, last_played"
+            " FROM tracks"
+            " WHERE NOT EXISTS"
+            " (SELECT 1 FROM track_sources s WHERE s.track_id = tracks.id)"
+        ).fetchall()
+        source_params: list[tuple[Any, ...]] = []
+        stats_params: list[tuple[Any, ...]] = []
+        for r in rows:
+            uri, kind, provider, provider_item_id = _derive_source_fields(
+                r["file_path"], r["source"], r["sale_item_id"]
+            )
+            source_params.append(
+                (
+                    r["id"],
+                    kind,
+                    provider,
+                    provider_item_id,
+                    uri,
+                    r["ext"],
+                    r["duration"],
+                    r["embedded_art"],
+                    r["file_mtime"],
+                    r["is_available"],
+                    r["stream_url"],
+                    r["stream_url_expires_at"],
+                )
+            )
+            stats_params.append(
+                (r["id"], r["favorite"], r["play_count"], r["last_played"])
+            )
+        if source_params:
+            self._conn.executemany(
+                "INSERT INTO track_sources"
+                " (track_id, kind, provider, provider_item_id, uri, ext, duration,"
+                "  embedded_art, file_mtime, is_available, stream_url,"
+                "  stream_url_expires_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                source_params,
+            )
+        if stats_params:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO track_stats"
+                " (track_id, favorite, play_count, last_played)"
+                " VALUES (?, ?, ?, ?)",
+                stats_params,
+            )
+        if source_params:
+            logger.info(
+                "KAMP-540 v45 backfill: populated %d track_sources/track_stats rows",
+                len(source_params),
+            )
 
     def _create_tracks_sale_item_id_index(self) -> None:
         """Create the lookup index on tracks.sale_item_id (KAMP-528).
@@ -3244,6 +3350,48 @@ class LibraryIndex:
         if touched_album_ids:
             self._refresh_album_aggregates(list(touched_album_ids))
 
+        # Step 5 (KAMP-540): keep the canonical child tables in sync. Every
+        # upserted track gets a refreshed track_sources row (per-source cols read
+        # back from the now-current tracks row) and, if it has none yet, a
+        # track_stats row mirroring its stats (INSERT OR IGNORE so a re-scan never
+        # resets favorite/play_count). Reads still use the old tracks columns —
+        # this only populates the children for KAMP-541/542.
+        src_params: list[tuple[Any, ...]] = []
+        for t in tracks:
+            key = _canonical_track_key(t.file_path)
+            _uri, kind, provider, provider_item_id = _derive_source_fields(
+                t.file_path, t.source, t.sale_item_id
+            )
+            src_params.append((kind, provider, provider_item_id, key))
+        if src_params:
+            self._conn.executemany(
+                "INSERT INTO track_sources"
+                " (track_id, kind, provider, provider_item_id, uri, ext, duration,"
+                "  embedded_art, file_mtime, is_available, stream_url,"
+                "  stream_url_expires_at)"
+                " SELECT id, ?, ?, ?, file_path, ext, duration, embedded_art,"
+                "        file_mtime, is_available, stream_url, stream_url_expires_at"
+                " FROM tracks WHERE file_path = ?"
+                " ON CONFLICT(uri) DO UPDATE SET"
+                "   track_id = excluded.track_id, kind = excluded.kind,"
+                "   provider = excluded.provider,"
+                "   provider_item_id = excluded.provider_item_id,"
+                "   ext = excluded.ext, duration = excluded.duration,"
+                "   embedded_art = excluded.embedded_art,"
+                "   file_mtime = excluded.file_mtime,"
+                "   is_available = excluded.is_available,"
+                "   stream_url = excluded.stream_url,"
+                "   stream_url_expires_at = excluded.stream_url_expires_at",
+                src_params,
+            )
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO track_stats"
+                " (track_id, favorite, play_count, last_played)"
+                " SELECT id, favorite, play_count, last_played"
+                " FROM tracks WHERE file_path = ?",
+                [(p[3],) for p in src_params],
+            )
+
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()
         self._conn.commit()
@@ -3820,6 +3968,28 @@ class LibraryIndex:
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
+    def _mirror_track_stats(self, key: str, cols: "tuple[str, ...]") -> None:
+        """Mirror stat column(s) from the tracks row at *key* into track_stats.
+
+        Absolute-value dual-write (KAMP-540): reads the *post-update* value(s)
+        from tracks and upserts them into track_stats keyed by track_id — never a
+        relative delta, so it survives the KAMP-541 collapse. No-op when *key*
+        matches no track. Creates the track_stats row (mirroring current tracks
+        values) if the v45 backfill / a scan hasn't yet. *cols* are internal
+        column-name literals, never user input.
+        """
+        import time
+
+        col_list = ", ".join(cols)
+        assigns = ", ".join(f"{c} = excluded.{c}" for c in cols)
+        self._conn.execute(
+            f"INSERT INTO track_stats (track_id, {col_list}, updated_at)"
+            f" SELECT id, {col_list}, ? FROM tracks WHERE file_path = ?"
+            f" ON CONFLICT(track_id) DO UPDATE SET {assigns},"
+            f" updated_at = excluded.updated_at",
+            (time.time(), key),
+        )
+
     def record_track_started(self, file_path: Path) -> None:
         """Record the current time as last_played for the track at *file_path*.
 
@@ -3845,6 +4015,7 @@ class LibraryIndex:
             """,
             (now, key, now),
         )
+        self._mirror_track_stats(key, ("last_played",))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.last_played"})
@@ -3871,6 +4042,8 @@ class LibraryIndex:
             """,
             (key,),
         )
+        # Mirror the post-increment absolute value (not a +1) into track_stats.
+        self._mirror_track_stats(key, ("play_count",))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.play_count"})
@@ -3980,6 +4153,7 @@ class LibraryIndex:
             "UPDATE tracks SET favorite = ? WHERE file_path = ?",
             (int(favorite), key),
         )
+        self._mirror_track_stats(key, ("favorite",))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.favorite"})
@@ -5607,6 +5781,36 @@ def _canonical_track_key(path: "Path | str") -> str:
         rest = s.split("bandcamp:", 1)[1].lstrip("/\\").replace("\\", "/")
         return "bandcamp://" + rest
     return s
+
+
+def _derive_source_fields(
+    file_path: "Path | str", source: str, sale_item_id: "str | None"
+) -> "tuple[str, str, str, str | None]":
+    """Map a legacy tracks row onto its canonical track_sources fields (KAMP-540).
+
+    Returns (uri, kind, provider, provider_item_id) per design note §3:
+    - uri: the canonical file_path (bandcamp:// slash forms normalised).
+    - kind: 'file' for a local file, else 'stream'.
+    - provider: 'bandcamp' for a streamed row or a download-provenanced local
+      file (has a sale_item_id); '' for an unaffiliated rip.
+    - provider_item_id: the sale_item_id; for a pure streaming row (which stores
+      the id only in its bandcamp://<sid>/<n> URI, not tracks.sale_item_id) the
+      id is parsed back out of the URI.
+
+    Shared by the v45 backfill and upsert_many so the scan and the migration
+    derive identical rows.
+    """
+    uri = _canonical_track_key(file_path)
+    kind = "file" if source == "local" else "stream"
+    provider = "bandcamp" if (source == "bandcamp" or sale_item_id) else ""
+    provider_item_id = sale_item_id or None
+    if (
+        provider == "bandcamp"
+        and not provider_item_id
+        and uri.startswith("bandcamp://")
+    ):
+        provider_item_id = uri[len("bandcamp://") :].split("/", 1)[0] or None
+    return uri, kind, provider, provider_item_id
 
 
 def _track_to_params(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 44
+        assert version == 45
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -199,13 +199,8 @@ class TestLibraryIndex:
         index.upsert_track(_sample_track(tmp_path / "01.mp3"))
         track_id = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
 
-        index._conn.execute(
-            "INSERT INTO track_stats (track_id, favorite, play_count) VALUES (?, 1, 3)",
-            (track_id,),
-        )
-        index._conn.commit()
-
-        # track_id is the PRIMARY KEY: a second row for the same track is rejected.
+        # upsert already created the track's track_stats row (KAMP-540 Step 5);
+        # track_id is the PRIMARY KEY, so a second row for the same track is rejected.
         with pytest.raises(sqlite3.IntegrityError):
             index._conn.execute(
                 "INSERT INTO track_stats (track_id, favorite) VALUES (?, 0)",
@@ -246,8 +241,157 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert {"track_sources", "track_stats"} <= tables
+
+    def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
+        """v45 backfills track_sources/track_stats from tracks per design §3 (KAMP-540)."""
+        db_path = tmp_path / "library.db"
+        LibraryIndex(db_path).close()  # full current schema
+        conn = sqlite3.connect(str(db_path))
+        # Rewind to the pre-backfill state: empty children, version 44, raw rows.
+        conn.execute("DELETE FROM track_sources")
+        conn.execute("DELETE FROM track_stats")
+        conn.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid1')")
+        conn.executemany(
+            "INSERT INTO tracks (file_path, source, sale_item_id, favorite,"
+            " play_count, last_played, ext, duration, embedded_art, is_available)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("/music/rip.mp3", "local", None, 1, 3, 111.0, "mp3", 200.0, 1, 1),
+                ("/music/dl.mp3", "local", "sid1", 0, 5, 222.0, "mp3", 210.0, 1, 1),
+                ("bandcamp://sid2/7", "bandcamp", None, 1, 2, 333.0, "", 0.0, 0, 1),
+            ],
+        )
+        conn.execute("UPDATE schema_version SET version = 44")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)  # runs the v45 backfill
+        src = {
+            r["file_path"]: (r["kind"], r["provider"], r["provider_item_id"], r["uri"])
+            for r in index._conn.execute(
+                "SELECT t.file_path, s.kind, s.provider, s.provider_item_id, s.uri"
+                " FROM track_sources s JOIN tracks t ON t.id = s.track_id"
+            )
+        }
+        stats = {
+            r["file_path"]: (r["favorite"], r["play_count"], r["last_played"])
+            for r in index._conn.execute(
+                "SELECT t.file_path, st.favorite, st.play_count, st.last_played"
+                " FROM track_stats st JOIN tracks t ON t.id = st.track_id"
+            )
+        }
+        index.close()
+
+        # unaffiliated rip → file / no provider; download → file + bandcamp provenance;
+        # pure stream → stream + provider_item_id parsed from the URI.
+        assert src["/music/rip.mp3"] == ("file", "", None, "/music/rip.mp3")
+        assert src["/music/dl.mp3"] == ("file", "bandcamp", "sid1", "/music/dl.mp3")
+        assert src["bandcamp://sid2/7"] == (
+            "stream",
+            "bandcamp",
+            "sid2",
+            "bandcamp://sid2/7",
+        )
+        assert stats["/music/dl.mp3"] == (0, 5, 222.0)
+        assert stats["bandcamp://sid2/7"] == (1, 2, 333.0)
+
+    def test_v45_backfill_is_idempotent(self, tmp_path: Path) -> None:
+        """Re-running the backfill inserts no duplicate child rows (KAMP-540)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('/m/a.mp3', 'local')"
+        )
+        index._conn.commit()
+        index._backfill_canonical_children()
+        index._backfill_canonical_children()  # second run must be a no-op
+        n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
+        n_stats = index._conn.execute("SELECT COUNT(*) FROM track_stats").fetchone()[0]
+        index.close()
+        assert n_src == 1
+        assert n_stats == 1
+
+    def test_v45_backfill_guard_skips_partial_schema(self, tmp_path: Path) -> None:
+        """A partial-schema DB migrates to v45 without error; children stay empty."""
+        db_path = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version VALUES (44)")
+        # Missing sale_item_id/is_available/duration/… → backfill guard must skip.
+        conn.execute(
+            "CREATE TABLE tracks (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, source TEXT DEFAULT 'local',"
+            " favorite INTEGER DEFAULT 0, play_count INTEGER DEFAULT 0)"
+        )
+        conn.execute("INSERT INTO tracks (file_path) VALUES ('/a.mp3')")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
+        index.close()
+        assert version == 45
+        assert n_src == 0
+
+    def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
+        """set_favorite/record_played/record_track_started mirror into track_stats (KAMP-540)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        fp = tmp_path / "s.mp3"
+        index.upsert_many([_sample_track(fp)])
+        key = str(fp)
+        index.set_favorite(key, True)
+        index.record_played(fp)
+        index.record_played(fp)  # relative +1 twice → absolute 2, not off-by-one
+        index.record_track_started(fp)
+
+        st = index._conn.execute(
+            "SELECT st.favorite, st.play_count, st.last_played FROM track_stats st"
+            " JOIN tracks t ON t.id = st.track_id WHERE t.file_path = ?",
+            (key,),
+        ).fetchone()
+        tr = index._conn.execute(
+            "SELECT favorite, play_count, last_played FROM tracks WHERE file_path = ?",
+            (key,),
+        ).fetchone()
+        index.close()
+
+        assert st["favorite"] == 1 == tr["favorite"]
+        assert st["play_count"] == 2 == tr["play_count"]
+        assert st["last_played"] == tr["last_played"] and st["last_played"] is not None
+
+    def test_upsert_maintains_children_without_resetting_stats(
+        self, tmp_path: Path
+    ) -> None:
+        """Scan creates a source + stats row; a re-scan refreshes source, keeps stats."""
+        index = LibraryIndex(tmp_path / "library.db")
+        fp = tmp_path / "s.mp3"
+        index.upsert_many([_sample_track(fp)])
+        key = str(fp)
+        index.set_favorite(key, True)  # user favorites after the first scan
+
+        rescanned = _sample_track(fp)
+        rescanned.duration = 99.0  # a per-source col changed on disk
+        index.upsert_many([rescanned])
+
+        src = index._conn.execute(
+            "SELECT s.kind, s.uri, s.duration FROM track_sources s"
+            " JOIN tracks t ON t.id = s.track_id WHERE t.file_path = ?",
+            (key,),
+        ).fetchone()
+        fav = index._conn.execute(
+            "SELECT st.favorite FROM track_stats st"
+            " JOIN tracks t ON t.id = st.track_id WHERE t.file_path = ?",
+            (key,),
+        ).fetchone()["favorite"]
+        index.close()
+
+        assert src["kind"] == "file" and src["uri"] == key
+        assert src["duration"] == 99.0  # source refreshed
+        assert fav == 1  # stats preserved across the re-scan (INSERT OR IGNORE)
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -1782,7 +1926,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -1839,7 +1983,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2434,7 +2578,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert row is not None
         assert row[0] == 0
 
@@ -2889,7 +3033,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -2985,7 +3129,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3166,7 +3310,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3261,7 +3405,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 44
+        assert version == 45
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3269,7 +3413,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 44
+        assert version == 45
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4146,7 +4290,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 44
+        assert version == 45
 
         index.close()
 
@@ -4837,7 +4981,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 44
+        assert version == 45
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -4872,7 +5016,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 44
+        assert version == 45
         index.close()
 
 
@@ -5387,7 +5531,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 44
+        assert version == 45
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -5520,7 +5664,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 44
+        assert version == 45
 
 
 class TestRemoteTrackSchema:
@@ -5854,7 +5998,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -5915,7 +6059,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6681,7 +6825,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7240,7 +7384,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7318,7 +7462,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7524,7 +7668,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -7873,7 +8017,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -7970,7 +8114,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8086,7 +8230,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8591,7 +8735,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8706,7 +8850,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -8804,7 +8948,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -8904,7 +9048,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9411,7 +9555,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 44
+        assert version == 45
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10255,7 +10399,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 44
+        assert version == 45
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11224,7 +11368,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 44
+        assert version == 45
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11244,7 +11388,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 44
+        assert version == 45
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -11286,7 +11430,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 44
+        assert version == 45
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1


### PR DESCRIPTION
## KAMP-540 — populate + dual-write

Second piece of the decomposed canonical-track core rewrite (epic KAMP-533), after #630 (queue-by-id). **Additive and behavior-neutral** — reads still use the old `tracks` columns; this populates the new child tables and keeps them fresh so KAMP-541's collapse reads clean, already-populated data.

Design note: `docs/design/KAMP-533-canonical-track-identity.md` §2/§3. Order: 535 ✅ → 536 ✅ → **540** → 541 → 542 → 537/538 → 539.

### Changes (`kamp_core/library.py`)
- **`_derive_source_fields()`** — shared mapping of a `tracks` row → `(uri, kind, provider, provider_item_id)` per design §3. `kind='file'` for local else `'stream'`; `provider='bandcamp'` for a stream or a download-provenanced local file; **parses the sid from the `bandcamp://<sid>/n` URI** for pure streams (whose `tracks.sale_item_id` is NULL). Reused by the backfill and the scan path so they produce identical rows.
- **v45 backfill migration** — one `track_sources` + one `track_stats` row per existing `tracks` row. Idempotent (`NOT EXISTS` guard), **PRAGMA-guarded** on the full read-set (narrow migration-test schemas skip cleanly), additive-only so **no backup needed**, wrapped in try/except+rollback so a pathological `uri` collision can't brick the DB (children left for 541).
- **`_mirror_track_stats()`** — absolute-value dual-write (never a relative `+1`), wired into `set_favorite`, `record_played` (after the increment), `record_track_started`.
- **`upsert_many` Step 5** — refreshes the `track_sources` row and `INSERT OR IGNORE`s a `track_stats` row on scan (a re-scan never resets `favorite`/`play_count`).

### Deliberate scope call
Does **not** dual-write `inherit_remote_favorites`/`inherit_remote_play_counts`/`remove_download`'s MAX-merge — they operate only on the two-row sibling model that KAMP-541 collapses (post-collapse the first two are dead; `remove_download` is reworked). **KAMP-541 re-derives `track_stats` from the authoritative `tracks` columns at collapse**, and no read switches to the children until KAMP-542. Documented on KAMP-541.

### Behavior-neutral
Nothing reads `track_sources`/`track_stats` yet. No `tracks` column is mutated by the backfill. Existing favorite/play_count/album/scan tests unchanged and green.

### Verification
- Full suite: **2205 passed, 9 skipped**; coverage **93.19%** (above gate). `black` + `mypy` clean.
- New tests: backfill row-shape derivation (local rip / bandcamp download / pure stream), backfill idempotency, backfill guard (partial schema), absolute-mirror dual-write (incl. `record_played` twice → 2, not off-by-one), and scan maintains children without resetting stats.

### Manual test plan
Automated-heavy. Optional spot-check: favorite a track, play one to completion, run a scan → app behaves exactly as before; `sqlite3 <lib.db> "SELECT COUNT(*) FROM tracks; SELECT COUNT(*) FROM track_sources; SELECT COUNT(*) FROM track_stats;"` → counts reconcile (sources = tracks; stats = tracks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)