### PR TITLE
feat: collapse to canonical track identity — fixes KAMP-532 (KAMP-541)

### DIFF
--- a/docs/design/KAMP-533-canonical-track-identity.md
+++ b/docs/design/KAMP-533-canonical-track-identity.md
@@ -261,7 +261,27 @@ All of the following land in **one migration** (the KAMP-536 collapse). The item
 - Rows with no `provider_item_id` and no `album_id` each stay their own canonical track.
 
 ### Survivor id + repoint-before-delete
-- Survivor = the **lower `tracks.id`** (deterministic).
+- Survivor selection differs by context (both deterministic):
+  - **Offline migration (v46 collapse + v48 heal):** prefer the **file row**, then the
+    lower `tracks.id`. No live clients reference ids during a startup migration, and the
+    downloaded copy carries the better content/art/tags to keep as the canonical.
+  - **Runtime reconcile (`_reconcile_scanned_tracks`, KAMP-541):** keep the **incumbent**
+    (the sibling that existed before this upsert batch), merging the just-upserted
+    delivery into it. A live queue / open album view already holds the incumbent's id and
+    uri; surviving it keeps those references valid. The reconcile is **symmetric** — it
+    attaches a downloaded FILE to a streamed sibling **and** a synced STREAM to a
+    downloaded sibling (the download-only-then-first-stream case). Skipping the stream
+    direction re-forks a stream-only row beside the local canonical and re-creates
+    KAMP-532; the **v48 heal** re-collapses any such forks already on disk, and
+    `has_remote_album_tracks` was made collapse-aware (checks `track_sources` stream uris,
+    not just `bandcamp://` `tracks.file_path`) so the incremental sync stops re-fetching a
+    stream that now lives as a source on the canonical.
+  - **Resolve-by-source-uri bridge:** because `file_path` is now mutable (it realigns to
+    the preferred source on collapse), a client holding a stale `bandcamp://` stream uri
+    still resolves to the surviving row via `track_sources` (`get_track_by_path` +
+    `set_favorite`/`record_*`), and the three rename sites keep the file source uri in
+    lock-step with `tracks.file_path`. This holds the line until KAMP-537/542 move the
+    API onto ids.
 - Every reference to the dropped id is repointed **in the same transaction, before the
   delete**:
   - `playlist_tracks.track_id` — `REFERENCES tracks(id) ON DELETE CASCADE`; a naive

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2168,8 +2168,11 @@ class LibraryIndex:
             else:
                 continue
             if len(cands) == 1:
-                other = cands[0]["id"]
-                self._merge_track_into(min(row["id"], other), max(row["id"], other))
+                # *row* is the just-scanned local file (it has the file source);
+                # *other* is the stream-only canonical. Prefer the file row as the
+                # survivor (consistent with the collapse) so the canonical keeps
+                # the owned copy's content and metadata.
+                self._merge_track_into(row["id"], cands[0]["id"])
 
     def _heal_collapse_art(self) -> None:
         """Re-sync every track's legacy per-source columns from its preferred source.
@@ -2221,7 +2224,8 @@ class LibraryIndex:
         disc_number) with agreeing sale_item_id; loose singles by sale_item_id
         only; everything else solo), quarantines ambiguous buckets (>2 rows, or a
         duplicate (provider,kind)), and merges each mergeable bucket into its
-        lower-id survivor. Caller wraps this in a transaction + backup.
+        survivor — the local file row if present, else the lowest id. Caller wraps
+        this in a transaction + backup.
         """
         rows = self._conn.execute(
             "SELECT id, album_id, track_number, disc_number, sale_item_id, source"
@@ -2258,7 +2262,11 @@ class LibraryIndex:
             if len(bucket) > 2 or len(distinct_sids) > 1 or len(set(pks)) != len(pks):
                 quarantined += 1
                 continue
-            ordered = sorted(bucket, key=lambda r: r["id"])
+            # Survivor = the local file row if present, else the lowest id. The
+            # file row already carries the content we keep (art, mtime, path, and
+            # the user's tags), so the merge transplants less and the canonical
+            # defaults to the owned copy's metadata rather than the stream's.
+            ordered = sorted(bucket, key=lambda r: (r["source"] != "local", r["id"]))
             survivor_id = ordered[0]["id"]
             for r in ordered:
                 if r["album_id"] is not None:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2169,10 +2169,17 @@ class LibraryIndex:
                 continue
             if len(cands) == 1:
                 # *row* is the just-scanned local file (it has the file source);
-                # *other* is the stream-only canonical. Prefer the file row as the
-                # survivor (consistent with the collapse) so the canonical keeps
-                # the owned copy's content and metadata.
-                self._merge_track_into(row["id"], cands[0]["id"])
+                # *cands[0]* is the pre-existing stream-only canonical. Keep the
+                # INCUMBENT as survivor (opposite of the offline migration, which
+                # prefers the file row): at runtime a live queue / open album view
+                # already references the incumbent's id and its bandcamp:// uri, and
+                # the merge deletes the loser — so surviving the incumbent keeps
+                # those references valid (preferred_source still resolves the newly
+                # attached file for playback, and the stale bandcamp:// uri still
+                # resolves to the survivor via resolve_track_id). Content and art
+                # are realigned onto the survivor by _sync_tracks_row_to_preferred_
+                # source inside the merge, so nothing owned is lost.
+                self._merge_track_into(cands[0]["id"], row["id"])
 
     def _heal_collapse_art(self) -> None:
         """Re-sync every track's legacy per-source columns from its preferred source.
@@ -4064,6 +4071,23 @@ class LibraryIndex:
             )
         return touched
 
+    def _rename_file_source(
+        self, old_path: "Path | str", new_path: "Path | str"
+    ) -> None:
+        """Repoint a track's file track_sources.uri after its file moves on disk.
+
+        The scanner reads indexed file paths from track_sources (kind='file',
+        KAMP-541), so a tag-edit / album rename that physically moved a file must
+        update its file source uri in lock-step with tracks.file_path. Otherwise
+        the next scan sees the old uri as a vanished file (remove_track drops the
+        source — deleting a local-only track and its stats) and the new path as
+        unindexed (re-fork). Caller owns the commit.
+        """
+        self._conn.execute(
+            "UPDATE track_sources SET uri = ? WHERE kind = 'file' AND uri = ?",
+            (str(new_path), str(old_path)),
+        )
+
     def move_track(
         self,
         old_path: Path,
@@ -4075,12 +4099,14 @@ class LibraryIndex:
 
         Called by the tag-edit endpoint after a file is physically moved on
         disk.  The row's primary stats (date_added, play_count, last_played,
-        favorite, mb IDs) are intentionally unchanged.
+        favorite, mb IDs) are intentionally unchanged. The track's file source
+        uri is repointed alongside file_path (see _rename_file_source).
         """
         self._conn.execute(
             "UPDATE tracks SET file_path = ?, title = ?, file_mtime = ? WHERE file_path = ?",
             (str(new_path), new_title, new_mtime, str(old_path)),
         )
+        self._rename_file_source(old_path, new_path)
         self._rebuild_fts()
         self._conn.commit()
 
@@ -4104,6 +4130,7 @@ class LibraryIndex:
                WHERE file_path = ?""",
             (str(new_path), new_album, new_album_artist, new_mtime, str(old_path)),
         )
+        self._rename_file_source(old_path, new_path)
         self._rebuild_fts()
         self._conn.commit()
 
@@ -4158,6 +4185,7 @@ class LibraryIndex:
                         str(old_path),
                     ),
                 )
+                self._rename_file_source(old_path, new_path)
             # Update the albums row. The UNIQUE (album_artist, album) COLLATE NOCASE
             # constraint raises IntegrityError if the new name already exists.
             if album_id is not None:
@@ -4467,6 +4495,31 @@ class LibraryIndex:
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
+    def _canonical_key_for(self, uri: "Path | str") -> str:
+        """Translate *uri* to the tracks.file_path of the row it addresses.
+
+        A track is addressable by its own file_path OR by any of its
+        track_sources uris. After the KAMP-541 collapse a live client can still
+        hold a delivery uri — e.g. a queued bandcamp:// stream uri — for a track
+        that has since collapsed onto its downloaded local file, so that uri is
+        now the track's *stream source* while file_path has realigned to the
+        local path. Direct-match first (the common case); only when the uri is
+        not itself a file_path do we redirect through track_sources. Falls back
+        to the normalized uri when nothing matches, leaving the caller's write a
+        harmless no-op exactly as before.
+        """
+        key = _canonical_track_key(uri)
+        if self._conn.execute(
+            "SELECT 1 FROM tracks WHERE file_path = ? LIMIT 1", (key,)
+        ).fetchone():
+            return key
+        row = self._conn.execute(
+            "SELECT t.file_path FROM track_sources s JOIN tracks t"
+            " ON t.id = s.track_id WHERE s.uri = ? AND s.kind = 'stream' LIMIT 1",
+            (key,),
+        ).fetchone()
+        return str(row["file_path"]) if row is not None else key
+
     def _mirror_track_stats(self, key: str, cols: "tuple[str, ...]") -> None:
         """Mirror stat column(s) from the tracks row at *key* into track_stats.
 
@@ -4500,7 +4553,7 @@ class LibraryIndex:
         import time
 
         now = time.time()
-        key = _canonical_track_key(file_path)
+        key = self._canonical_key_for(file_path)
         self._conn.execute(
             "UPDATE tracks SET last_played = ? WHERE file_path = ?",
             (now, key),
@@ -4526,7 +4579,7 @@ class LibraryIndex:
         updated here; last_played is managed exclusively by record_track_started().
         Also refreshes the parent album's play_count_avg.
         """
-        key = _canonical_track_key(file_path)
+        key = self._canonical_key_for(file_path)
         self._conn.execute(
             "UPDATE tracks SET play_count = play_count + 1 WHERE file_path = ?",
             (key,),
@@ -4644,10 +4697,12 @@ class LibraryIndex:
     def set_favorite(self, file_path: "Path | str", favorite: bool) -> None:
         """Set or clear the favorite flag for the track at *file_path*.
 
-        Accepts str so remote track URIs (bandcamp://) are not corrupted
-        by Path normalization on POSIX (// → /).
+        *file_path* may be a track's own file_path or any of its delivery uris
+        (a queued bandcamp:// stream uri whose track has since collapsed onto its
+        local file); _canonical_key_for redirects the latter to the surviving
+        row so the favorite lands on the canonical track (KAMP-541).
         """
-        key = file_path if isinstance(file_path, str) else str(file_path)
+        key = self._canonical_key_for(file_path)
         self._conn.execute(
             "UPDATE tracks SET favorite = ? WHERE file_path = ?",
             (int(favorite), key),
@@ -5087,7 +5142,20 @@ class LibraryIndex:
         row = self._conn.execute(
             "SELECT * FROM tracks WHERE file_path = ?", (key,)
         ).fetchone()
-        return _row_to_track(row) if row else None
+        if row is not None:
+            return _row_to_track(row)
+        # Fall back to a stream delivery uri: after the KAMP-541 collapse a client
+        # may hold a track's bandcamp:// stream uri while file_path has realigned
+        # to its downloaded local file. Resolve through track_sources so the stale
+        # uri still finds the surviving canonical row. Restricted to stream
+        # sources: a moved/renamed local file's *old* path is a stale file source
+        # and must still resolve to nothing (the file is genuinely gone).
+        src = self._conn.execute(
+            "SELECT t.* FROM track_sources s JOIN tracks t ON t.id = s.track_id"
+            " WHERE s.uri = ? AND s.kind = 'stream' LIMIT 1",
+            (_canonical_track_key(key),),
+        ).fetchone()
+        return _row_to_track(src) if src else None
 
     def get_track_by_id(self, track_id: int) -> "Track | None":
         """Return the track with *track_id*, or None if not indexed."""

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 47
+_SCHEMA_VERSION = 48
 
 
 class NoStreamableVersionError(Exception):
@@ -1862,7 +1862,46 @@ class LibraryIndex:
                         )
             self._conn.execute("UPDATE schema_version SET version = 47")
             self._conn.commit()
-            version = 47  # noqa: F841
+            version = 47
+
+        if version < 48:
+            # v47 → v48: heal stream-only duplicate rows the bandcamp sync forked
+            # for already-downloaded albums. Before the symmetric _reconcile_scanned_
+            # tracks fix, a stream synced for a download-only album (its bandcamp://
+            # tracks row was absent, so has_remote_album_tracks returned False) was
+            # upserted as a SEPARATE stream-only row beside the local canonical,
+            # re-creating the KAMP-532 split. Re-running the collapse merges each
+            # such pair (survivor = the local file row) — idempotent, and a no-op on
+            # a library with no sibling buckets. Same backup-first / one-transaction
+            # / version-last discipline as v46.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            needed = {
+                "id",
+                "album_id",
+                "track_number",
+                "disc_number",
+                "sale_item_id",
+                "source",
+            }
+            if (
+                needed <= track_cols
+                and self._has_collapsible_siblings()
+                and self._backup_db("KAMP-541 v48 sync-fork heal")
+            ):
+                try:
+                    self._collapse_canonical_tracks()
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-541 v48 sync-fork heal failed — rolled back; the"
+                        " duplicate stream rows remain. Restore from the pre-v48"
+                        " backup if needed."
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 48")
+            self._conn.commit()
+            version = 48  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
@@ -2121,16 +2160,24 @@ class LibraryIndex:
         self._sync_tracks_row_to_preferred_source(survivor_id)
 
     def _reconcile_scanned_tracks(self, canonical_keys: "list[str]") -> None:
-        """Attach a newly-scanned file to its existing canonical track (KAMP-541).
+        """Attach a newly-upserted delivery to its existing canonical (KAMP-541).
 
-        For each just-upserted file that is a sibling of exactly ONE canonical
-        track that has no file source of its own (i.e. a stream-only row — the
-        common "download a streamed album" case), merge the freshly-forked row
-        into the lower-id survivor via _merge_track_into, so the download attaches
-        as a source rather than resurrecting the two-row duplicate. Conservative:
-        matches by (album_id, track_number, disc_number) with agreeing sale_item_id
-        or, for a loose single, by sale_item_id; a >1 or ambiguous match is left
-        alone (the migration quarantines those). Caller owns the commit.
+        Symmetric in the two directions a fork can arrive:
+          - a downloaded FILE for an album that was streamed (the file scanner's
+            "download a streamed album" case), and
+          - a synced STREAM for an album that was already downloaded (bandcamp
+            sync bringing a stream in for the first time — otherwise upsert_many
+            forks a stream-only row next to the local canonical, re-creating the
+            KAMP-532 duplicate).
+
+        For each just-upserted row, find the ONE sibling that lacks the kind this
+        row supplies (a stream-only sibling for a file row; a file-only sibling
+        for a stream row) and merge into it, keeping the INCUMBENT (the sibling
+        that existed before this upsert batch) as survivor so live references
+        stay valid. Matches by (album_id, track_number, disc_number) with
+        agreeing sale_item_id, or by sale_item_id for a loose single; a >1 or
+        ambiguous match is left alone (the migration quarantines those). Caller
+        owns the commit.
         """
         for key in canonical_keys:
             row = self._conn.execute(
@@ -2140,16 +2187,23 @@ class LibraryIndex:
             ).fetchone()
             if row is None:
                 continue
-            no_file_src = (
+            # The sibling must be missing the kind this row supplies, so the merge
+            # yields a clean file+stream canonical rather than a duplicate kind.
+            row_has_file = self._conn.execute(
+                "SELECT 1 FROM track_sources WHERE track_id = ? AND kind = 'file'",
+                (row["id"],),
+            ).fetchone()
+            missing_kind = "file" if row_has_file else "stream"
+            no_kind_src = (
                 " AND NOT EXISTS (SELECT 1 FROM track_sources s"
-                " WHERE s.track_id = t.id AND s.kind = 'file')"
+                f" WHERE s.track_id = t.id AND s.kind = '{missing_kind}')"
             )
             if row["album_id"] is not None:
                 cands = self._conn.execute(
                     "SELECT t.id FROM tracks t WHERE t.id != ? AND t.album_id = ?"
                     " AND t.track_number = ? AND t.disc_number = ?"
                     " AND (t.sale_item_id IS NULL OR ? IS NULL OR t.sale_item_id = ?)"
-                    + no_file_src,
+                    + no_kind_src,
                     (
                         row["id"],
                         row["album_id"],
@@ -2162,22 +2216,21 @@ class LibraryIndex:
             elif row["sale_item_id"]:
                 cands = self._conn.execute(
                     "SELECT t.id FROM tracks t WHERE t.id != ? AND t.album_id IS NULL"
-                    " AND t.sale_item_id = ?" + no_file_src,
+                    " AND t.sale_item_id = ?" + no_kind_src,
                     (row["id"], row["sale_item_id"]),
                 ).fetchall()
             else:
                 continue
             if len(cands) == 1:
-                # *row* is the just-scanned local file (it has the file source);
-                # *cands[0]* is the pre-existing stream-only canonical. Keep the
-                # INCUMBENT as survivor (opposite of the offline migration, which
-                # prefers the file row): at runtime a live queue / open album view
-                # already references the incumbent's id and its bandcamp:// uri, and
-                # the merge deletes the loser — so surviving the incumbent keeps
-                # those references valid (preferred_source still resolves the newly
-                # attached file for playback, and the stale bandcamp:// uri still
-                # resolves to the survivor via resolve_track_id). Content and art
-                # are realigned onto the survivor by _sync_tracks_row_to_preferred_
+                # *row* is the just-upserted delivery; *cands[0]* is the
+                # pre-existing sibling. Keep the INCUMBENT as survivor (opposite
+                # of the offline migration, which prefers the file row): a live
+                # queue / open album view already references the incumbent's id
+                # and uri, and the merge deletes the loser — so surviving the
+                # incumbent keeps those references valid (preferred_source still
+                # resolves the file for playback, and a stale bandcamp:// uri
+                # still resolves via resolve_track_id). Content and art are
+                # realigned onto the survivor by _sync_tracks_row_to_preferred_
                 # source inside the merge, so nothing owned is lost.
                 self._merge_track_into(cands[0]["id"], row["id"])
 
@@ -3000,14 +3053,27 @@ class LibraryIndex:
         return [dict(r) for r in rows]
 
     def has_remote_album_tracks(self, sale_item_id: str) -> bool:
-        """Return True if the tracks table already has entries for this remote album.
+        """Return True if this remote album's stream tracks are already present.
 
-        Checks canonical bandcamp:// (POSIX) and Windows bandcamp:\\ path forms so
-        incremental stream syncs can skip album-page fetches for existing albums.
+        Checks legacy bandcamp:// (POSIX) and Windows bandcamp:\\ tracks.file_path
+        forms AND (post-KAMP-541 collapse) stream track_sources whose uri encodes
+        this sale_item_id. After the collapse the stream lives as a source on the
+        downloaded canonical rather than as its own tracks row, so a file_path-only
+        check would miss it and make the incremental sync re-fetch and re-insert a
+        duplicate stream row.
         """
         row = self._conn.execute(
-            "SELECT 1 FROM tracks WHERE file_path LIKE ? OR file_path LIKE ? LIMIT 1",
-            (f"bandcamp://{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
+            "SELECT 1 FROM tracks WHERE file_path LIKE ? OR file_path LIKE ?"
+            " UNION ALL"
+            " SELECT 1 FROM track_sources WHERE kind = 'stream'"
+            "   AND (uri LIKE ? OR uri LIKE ?)"
+            " LIMIT 1",
+            (
+                f"bandcamp://{sale_item_id}/%",
+                f"bandcamp:\\{sale_item_id}\\%",
+                f"bandcamp://{sale_item_id}/%",
+                f"bandcamp:\\{sale_item_id}\\%",
+            ),
         ).fetchone()
         return row is not None
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2971,6 +2971,33 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def _sync_tracks_row_to_preferred_source(self, track_id: int) -> None:
+        """Realign a track's legacy columns to its preferred source (KAMP-541).
+
+        Keeps `tracks.file_path`/`source`/per-source columns coherent with
+        `track_sources` while both coexist (the columns are dropped in KAMP-539),
+        e.g. after a local file is removed and the track reverts to its stream
+        source. Caller commits. No-op if the track has no sources.
+        """
+        src = self.preferred_source(track_id)
+        if src is None:
+            return
+        self._conn.execute(
+            "UPDATE tracks SET file_path = ?, source = ?, ext = ?, duration = ?,"
+            " is_available = ?, stream_url = ?, stream_url_expires_at = ?"
+            " WHERE id = ?",
+            (
+                src["uri"],
+                "local" if src["kind"] == "file" else "bandcamp",
+                src["ext"],
+                src["duration"],
+                src["is_available"],
+                src["stream_url"],
+                src["stream_url_expires_at"],
+                track_id,
+            ),
+        )
+
     def update_track_display_title(
         self, track_id: int, display_title: str | None
     ) -> "Track | None":
@@ -3949,8 +3976,37 @@ class LibraryIndex:
         self._conn.commit()
 
     def remove_track(self, file_path: Path) -> None:
-        """Remove the track with the given file path from the index."""
-        self._conn.execute("DELETE FROM tracks WHERE file_path = ?", (str(file_path),))
+        """Remove a local file from the index (KAMP-541).
+
+        Drops the file's `track_sources` row. The canonical `tracks` row is
+        deleted only when no source remains — a track that still has a stream
+        source survives (reverting to stream-only) instead of being cascade-
+        deleted along with its stream source and stats (the KAMP-527 data-loss
+        class). Legacy fallback: a pre-collapse row with no source is deleted by
+        `file_path` as before.
+        """
+        uri = str(file_path)
+        src = self._conn.execute(
+            "SELECT track_id FROM track_sources WHERE uri = ? AND kind = 'file'",
+            (uri,),
+        ).fetchone()
+        if src is not None:
+            track_id = src["track_id"]
+            self._conn.execute(
+                "DELETE FROM track_sources WHERE uri = ? AND kind = 'file'", (uri,)
+            )
+            remaining = self._conn.execute(
+                "SELECT COUNT(*) FROM track_sources WHERE track_id = ?", (track_id,)
+            ).fetchone()[0]
+            if remaining == 0:
+                self._conn.execute("DELETE FROM tracks WHERE id = ?", (track_id,))
+            else:
+                # Keep the track; realign its legacy columns to a surviving source
+                # so file_path/source reads stay coherent and the freed local path
+                # can be re-added later without a UNIQUE collision.
+                self._sync_tracks_row_to_preferred_source(track_id)
+        else:
+            self._conn.execute("DELETE FROM tracks WHERE file_path = ?", (uri,))
         # Sync FTS — rebuilding is simpler than per-row deletes with FTS5 content tables.
         self._rebuild_fts()
         self._conn.commit()
@@ -4599,24 +4655,29 @@ class LibraryIndex:
     def indexed_paths(self) -> set[Path]:
         """Return the set of local file paths currently in the index.
 
-        Remote tracks (source != 'local') are excluded so the scanner never
-        tries to stat a bandcamp:// URI or treats it as a missing file.
+        KAMP-541: reads the `kind='file'` sources from track_sources, not
+        `tracks WHERE source='local'`. After a track is collapsed its local file
+        lives as a source of a canonical row whose `tracks.file_path` may be the
+        streaming uri — enumerating file sources keeps that path "indexed" so the
+        scanner does not re-fork a duplicate row for it. Stream sources are
+        excluded (their uri is not a real filesystem path).
         """
         rows = self._conn.execute(
-            "SELECT file_path FROM tracks WHERE source = 'local'"
+            "SELECT uri FROM track_sources WHERE kind = 'file'"
         ).fetchall()
-        return {Path(r["file_path"]) for r in rows}
+        return {Path(r["uri"]) for r in rows}
 
     def indexed_paths_with_mtime(self) -> dict[Path, float | None]:
         """Return a mapping of local indexed file paths to their stored file_mtime.
 
-        Remote tracks (source != 'local') are excluded for the same reason as
-        indexed_paths() — their URI is not a real filesystem path.
+        KAMP-541: reads `kind='file'` sources from track_sources (see
+        indexed_paths). Stream sources are excluded — their URI is not a real
+        filesystem path.
         """
         rows = self._conn.execute(
-            "SELECT file_path, file_mtime FROM tracks WHERE source = 'local'"
+            "SELECT uri, file_mtime FROM track_sources WHERE kind = 'file'"
         ).fetchall()
-        return {Path(r["file_path"]): r["file_mtime"] for r in rows}
+        return {Path(r["uri"]): r["file_mtime"] for r in rows}
 
     def get_track_by_path(self, path: "str | Path") -> "Track | None":
         """Return the track for *path*, or None if not indexed.

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 45
+_SCHEMA_VERSION = 46
 
 
 class NoStreamableVersionError(Exception):
@@ -1792,7 +1792,47 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 45")
             self._conn.commit()
-            version = 45  # noqa: F841
+            version = 45
+
+        if version < 46:
+            # v45 → v46: collapse each track's streaming+local sibling rows into
+            # ONE canonical tracks row (KAMP-541, design §7). Irreversible — take a
+            # backup first (mirrors the v39 heal), run the whole collapse in one
+            # transaction, and bump the version LAST so a crash rolls back cleanly.
+            # Guarded on the columns the bucketing reads (narrow migration-unit-test
+            # schemas build a partial tracks table). On any failure, roll back and
+            # leave the two-row model intact rather than brick the DB.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            needed = {
+                "id",
+                "album_id",
+                "track_number",
+                "disc_number",
+                "sale_item_id",
+                "source",
+            }
+            # Only back up + collapse when there is actually a sibling pair to
+            # merge — a library with no downloaded-streaming duplicates needs
+            # neither the backup nor the work.
+            if (
+                needed <= track_cols
+                and self._has_collapsible_siblings()
+                and self._backup_db("KAMP-541 v46 collapse")
+            ):
+                try:
+                    self._collapse_canonical_tracks()
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-541 v46 collapse failed — rolled back; the two-row"
+                        " model is preserved. Restore from the pre-v46 backup if"
+                        " needed."
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 46")
+            self._conn.commit()
+            version = 46  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
@@ -1875,6 +1915,260 @@ class LibraryIndex:
             logger.info(
                 "KAMP-540 v45 backfill: populated %d track_sources/track_stats rows",
                 len(source_params),
+            )
+
+    # ------------------------------------------------------------------
+    # KAMP-541 canonical-track collapse (shared by the v46 migration and the
+    # scan-time reconcile in upsert_many)
+    # ------------------------------------------------------------------
+
+    def _ensure_track_source(self, track_id: int) -> None:
+        """Derive a track_sources row from the tracks columns if one is missing.
+
+        Honours the KAMP-540 hand-off invariant: a track scanned before 540 (or
+        whose 540 backfill was skipped) may have no source row. Never bare-merge
+        assuming it exists. Skips on a uri-UNIQUE collision (slash-form dup).
+        """
+        if self._conn.execute(
+            "SELECT 1 FROM track_sources WHERE track_id = ? LIMIT 1", (track_id,)
+        ).fetchone():
+            return
+        r = self._conn.execute(
+            "SELECT file_path, source, sale_item_id, ext, duration, embedded_art,"
+            " file_mtime, is_available, stream_url, stream_url_expires_at"
+            " FROM tracks WHERE id = ?",
+            (track_id,),
+        ).fetchone()
+        if r is None:
+            return
+        uri, kind, provider, provider_item_id = _derive_source_fields(
+            r["file_path"], r["source"], r["sale_item_id"]
+        )
+        if self._conn.execute(
+            "SELECT 1 FROM track_sources WHERE uri = ?", (uri,)
+        ).fetchone():
+            return  # slash-form dup already present under another track — skip
+        self._conn.execute(
+            "INSERT INTO track_sources (track_id, kind, provider, provider_item_id,"
+            " uri, ext, duration, embedded_art, file_mtime, is_available, stream_url,"
+            " stream_url_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                track_id,
+                kind,
+                provider,
+                provider_item_id,
+                uri,
+                r["ext"],
+                r["duration"],
+                r["embedded_art"],
+                r["file_mtime"],
+                r["is_available"],
+                r["stream_url"],
+                r["stream_url_expires_at"],
+            ),
+        )
+
+    def _repoint_track_refs(self, loser_id: int, survivor_id: int) -> None:
+        """Repoint every reference from *loser_id* to *survivor_id* (KAMP-541).
+
+        playlist_tracks (no UNIQUE — dedupe within a playlist by hand), deferred_ops
+        (UNIQUE track_id — keep the survivor's op, drop the loser's), and the id-
+        keyed player_state / queue_state (KAMP-536). Callers commit.
+        """
+        import json
+
+        c = self._conn
+        # playlist_tracks: drop the loser's entry in any playlist that already
+        # holds the survivor (would otherwise become a phantom duplicate — no
+        # UNIQUE constraint to catch it), then repoint the rest. Position gaps are
+        # harmless (reads ORDER BY position).
+        c.execute(
+            "DELETE FROM playlist_tracks WHERE track_id = ? AND playlist_id IN"
+            " (SELECT playlist_id FROM playlist_tracks WHERE track_id = ?)",
+            (loser_id, survivor_id),
+        )
+        c.execute(
+            "UPDATE playlist_tracks SET track_id = ? WHERE track_id = ?",
+            (survivor_id, loser_id),
+        )
+        # deferred_ops: UNIQUE(track_id) — a blind UPDATE would abort if both have
+        # a pending op. Keep the survivor's, drop the loser's; else repoint.
+        if c.execute(
+            "SELECT 1 FROM deferred_ops WHERE track_id = ?", (survivor_id,)
+        ).fetchone():
+            c.execute("DELETE FROM deferred_ops WHERE track_id = ?", (loser_id,))
+        else:
+            c.execute(
+                "UPDATE deferred_ops SET track_id = ? WHERE track_id = ?",
+                (survivor_id, loser_id),
+            )
+        # player_state.track_path stores the id as text (KAMP-536).
+        c.execute(
+            "UPDATE player_state SET track_path = ? WHERE track_path = ?",
+            (str(survivor_id), str(loser_id)),
+        )
+        # queue_state.tracks is a JSON array of ids (KAMP-536).
+        qrow = c.execute("SELECT tracks FROM queue_state WHERE id = 1").fetchone()
+        if qrow is not None:
+            try:
+                ids = json.loads(qrow["tracks"])
+            except (ValueError, TypeError):
+                ids = []
+            if isinstance(ids, list) and loser_id in ids:
+                ids = [survivor_id if x == loser_id else x for x in ids]
+                c.execute(
+                    "UPDATE queue_state SET tracks = ? WHERE id = 1", (json.dumps(ids),)
+                )
+
+    def _merge_track_into(self, survivor_id: int, loser_id: int) -> None:
+        """Merge the loser track row into the survivor (KAMP-541, design §7).
+
+        Both must be the same logical track. Combines stats onto the survivor's
+        tracks columns (MAX/MAX/latest — so reads still on those columns converge,
+        fixing KAMP-532), COALESCE-merges identity (streaming display_* win;
+        non-empty mb/genre/label win), re-parents track_sources, repoints refs,
+        deletes the loser, re-derives track_stats from the merged columns, and
+        realigns the survivor's legacy columns to its preferred source. Caller
+        owns the transaction/commit.
+        """
+        c = self._conn
+        self._ensure_track_source(survivor_id)
+        self._ensure_track_source(loser_id)
+        # Stats onto the survivor's tracks columns.
+        c.execute(
+            "UPDATE tracks SET"
+            " favorite = MAX(favorite, COALESCE((SELECT favorite FROM tracks WHERE id=?),0)),"
+            " play_count = MAX(play_count, COALESCE((SELECT play_count FROM tracks WHERE id=?),0)),"
+            " last_played = NULLIF(MAX(COALESCE(last_played,0),"
+            "     COALESCE((SELECT last_played FROM tracks WHERE id=?),0)), 0)"
+            " WHERE id=?",
+            (loser_id, loser_id, loser_id, survivor_id),
+        )
+        # Identity: streaming display_* win if the survivor's is NULL; non-empty
+        # mb/genre/label fill a blank survivor field from the loser.
+        c.execute(
+            "UPDATE tracks SET"
+            " mb_release_id = CASE WHEN mb_release_id != '' THEN mb_release_id"
+            "   ELSE (SELECT mb_release_id FROM tracks WHERE id=?) END,"
+            " mb_recording_id = CASE WHEN mb_recording_id != '' THEN mb_recording_id"
+            "   ELSE (SELECT mb_recording_id FROM tracks WHERE id=?) END,"
+            " genre = CASE WHEN genre != '' THEN genre"
+            "   ELSE (SELECT genre FROM tracks WHERE id=?) END,"
+            " label = CASE WHEN label != '' THEN label"
+            "   ELSE (SELECT label FROM tracks WHERE id=?) END,"
+            " display_title = COALESCE(display_title, (SELECT display_title FROM tracks WHERE id=?)),"
+            " display_album = COALESCE(display_album, (SELECT display_album FROM tracks WHERE id=?)),"
+            " display_album_artist = COALESCE(display_album_artist,"
+            "   (SELECT display_album_artist FROM tracks WHERE id=?))"
+            " WHERE id=?",
+            (
+                loser_id,
+                loser_id,
+                loser_id,
+                loser_id,
+                loser_id,
+                loser_id,
+                loser_id,
+                survivor_id,
+            ),
+        )
+        # Re-parent the loser's sources onto the survivor.
+        c.execute(
+            "UPDATE track_sources SET track_id = ? WHERE track_id = ?",
+            (survivor_id, loser_id),
+        )
+        self._repoint_track_refs(loser_id, survivor_id)
+        # Delete the loser (its sources are re-parented; its stats cascade away).
+        c.execute("DELETE FROM tracks WHERE id = ?", (loser_id,))
+        # Re-derive the survivor's track_stats from the merged tracks columns.
+        c.execute(
+            "INSERT INTO track_stats (track_id, favorite, play_count, last_played)"
+            " SELECT id, favorite, play_count, last_played FROM tracks WHERE id=?"
+            " ON CONFLICT(track_id) DO UPDATE SET favorite=excluded.favorite,"
+            " play_count=excluded.play_count, last_played=excluded.last_played",
+            (survivor_id,),
+        )
+        self._sync_tracks_row_to_preferred_source(survivor_id)
+
+    def _has_collapsible_siblings(self) -> bool:
+        """True if any bucket would hold >1 tracks row (KAMP-541 pre-flight).
+
+        Cheap existence check so the v46 collapse skips the backup + work on a
+        library that has no downloaded-streaming duplicates. Over-triggers only on
+        buckets that later quarantine — acceptable (a backup is never wrong).
+        """
+        return (
+            self._conn.execute(
+                "SELECT 1 WHERE"
+                " EXISTS (SELECT 1 FROM tracks WHERE album_id IS NOT NULL"
+                "   GROUP BY album_id, track_number, disc_number HAVING COUNT(*) > 1)"
+                " OR EXISTS (SELECT 1 FROM tracks"
+                "   WHERE album_id IS NULL AND sale_item_id IS NOT NULL"
+                "   GROUP BY sale_item_id HAVING COUNT(*) > 1)"
+            ).fetchone()
+            is not None
+        )
+
+    def _collapse_canonical_tracks(self) -> None:
+        """Merge every streaming+local sibling pair into one canonical track.
+
+        Buckets sibling tracks rows (album rows by (album_id, track_number,
+        disc_number) with agreeing sale_item_id; loose singles by sale_item_id
+        only; everything else solo), quarantines ambiguous buckets (>2 rows, or a
+        duplicate (provider,kind)), and merges each mergeable bucket into its
+        lower-id survivor. Caller wraps this in a transaction + backup.
+        """
+        rows = self._conn.execute(
+            "SELECT id, album_id, track_number, disc_number, sale_item_id, source"
+            " FROM tracks"
+        ).fetchall()
+
+        def _kind(r: sqlite3.Row) -> str:
+            return "file" if r["source"] == "local" else "stream"
+
+        def _provider(r: sqlite3.Row) -> str:
+            return (
+                "bandcamp" if (r["source"] == "bandcamp" or r["sale_item_id"]) else ""
+            )
+
+        buckets: dict[tuple[Any, ...], list[sqlite3.Row]] = {}
+        for r in rows:
+            if r["album_id"] is None:
+                key = (
+                    ("sid", r["sale_item_id"])
+                    if r["sale_item_id"]
+                    else ("solo", r["id"])
+                )
+            else:
+                key = ("album", r["album_id"], r["track_number"], r["disc_number"])
+            buckets.setdefault(key, []).append(r)
+
+        touched_album_ids: set[int] = set()
+        quarantined = 0
+        for bucket in buckets.values():
+            if len(bucket) < 2:
+                continue
+            distinct_sids = {r["sale_item_id"] for r in bucket if r["sale_item_id"]}
+            pks = [(_provider(r), _kind(r)) for r in bucket]
+            if len(bucket) > 2 or len(distinct_sids) > 1 or len(set(pks)) != len(pks):
+                quarantined += 1
+                continue
+            ordered = sorted(bucket, key=lambda r: r["id"])
+            survivor_id = ordered[0]["id"]
+            for r in ordered:
+                if r["album_id"] is not None:
+                    touched_album_ids.add(r["album_id"])
+            for loser in ordered[1:]:
+                self._merge_track_into(survivor_id, loser["id"])
+
+        if touched_album_ids:
+            self._refresh_album_aggregates(list(touched_album_ids))
+        self._rebuild_fts()
+        if quarantined:
+            logger.warning(
+                "KAMP-541 collapse: %d ambiguous bucket(s) quarantined (left"
+                " un-merged; resolve manually)",
+                quarantined,
             )
 
     def _create_tracks_sale_item_id_index(self) -> None:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 46
+_SCHEMA_VERSION = 47
 
 
 class NoStreamableVersionError(Exception):
@@ -1832,7 +1832,37 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 46")
             self._conn.commit()
-            version = 46  # noqa: F841
+            version = 46
+
+        if version < 47:
+            # v46 → v47: heal album art lost by the KAMP-541 collapse. The collapse
+            # kept the streaming survivor's embedded_art=0 / file_mtime=NULL instead
+            # of the downloaded file's, so downloaded-and-streamed albums (art comes
+            # from tracks.embedded_art / file_mtime aggregates) showed no cover.
+            # Re-sync every track's legacy columns from its preferred source (now
+            # including embedded_art + file_mtime) and refresh album art. Gated on
+            # the exact symptom so a clean DB does no work + takes no backup.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            if {"embedded_art", "file_mtime", "file_path", "source"} <= track_cols:
+                symptom = self._conn.execute(
+                    "SELECT 1 FROM tracks t"
+                    " JOIN track_sources s ON s.track_id = t.id AND s.kind = 'file'"
+                    " WHERE s.embedded_art != t.embedded_art LIMIT 1"
+                ).fetchone()
+                if symptom is not None and self._backup_db("KAMP-541 v47 art heal"):
+                    try:
+                        self._heal_collapse_art()
+                    except Exception:
+                        self._conn.rollback()
+                        logger.exception(
+                            "KAMP-541 v47 art heal failed — rolled back; album art"
+                            " may still be missing on collapsed albums."
+                        )
+            self._conn.execute("UPDATE schema_version SET version = 47")
+            self._conn.commit()
+            version = 47  # noqa: F841
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
@@ -2140,6 +2170,30 @@ class LibraryIndex:
             if len(cands) == 1:
                 other = cands[0]["id"]
                 self._merge_track_into(min(row["id"], other), max(row["id"], other))
+
+    def _heal_collapse_art(self) -> None:
+        """Re-sync every track's legacy per-source columns from its preferred source.
+
+        The KAMP-541 v46 collapse omitted embedded_art/file_mtime when realigning a
+        merged track to its preferred (file) source, so downloaded-and-streamed
+        albums lost their cover art. Re-running the (now-fixed) sync over every
+        track restores embedded_art + file_mtime, then album aggregates are
+        refreshed. Idempotent — a single-source track syncs to itself. Caller owns
+        the transaction/commit.
+        """
+        ids = [
+            r[0]
+            for r in self._conn.execute(
+                "SELECT DISTINCT track_id FROM track_sources"
+            ).fetchall()
+        ]
+        for tid in ids:
+            self._sync_tracks_row_to_preferred_source(tid)
+        album_ids = [
+            r[0] for r in self._conn.execute("SELECT id FROM albums").fetchall()
+        ]
+        self._refresh_album_aggregates(album_ids)
+        self._rebuild_fts()
 
     def _has_collapsible_siblings(self) -> bool:
         """True if any bucket would hold >1 tracks row (KAMP-541 pre-flight).
@@ -3294,7 +3348,7 @@ class LibraryIndex:
         """
         row = self._conn.execute(
             "SELECT id, kind, provider, provider_item_id, uri, ext, duration,"
-            " is_available, stream_url, stream_url_expires_at"
+            " embedded_art, file_mtime, is_available, stream_url, stream_url_expires_at"
             " FROM track_sources WHERE track_id = ?"
             " ORDER BY is_available DESC, (kind = 'file') DESC, id"
             " LIMIT 1",
@@ -3326,13 +3380,15 @@ class LibraryIndex:
             return
         self._conn.execute(
             "UPDATE tracks SET file_path = ?, source = ?, ext = ?, duration = ?,"
-            " is_available = ?, stream_url = ?, stream_url_expires_at = ?"
-            " WHERE id = ?",
+            " embedded_art = ?, file_mtime = ?, is_available = ?, stream_url = ?,"
+            " stream_url_expires_at = ? WHERE id = ?",
             (
                 src["uri"],
                 "local" if src["kind"] == "file" else "bandcamp",
                 src["ext"],
                 src["duration"],
+                src["embedded_art"],
+                src["file_mtime"],
                 src["is_available"],
                 src["stream_url"],
                 src["stream_url_expires_at"],

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2938,6 +2938,39 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def preferred_source(self, track_id: int) -> "sqlite3.Row | None":
+        """Return the preferred track_sources row for playback (KAMP-541, design §3).
+
+        Prefers an available source, then a local file over a stream, then the
+        lowest source id. None if the track has no source rows (shouldn't happen
+        after KAMP-540; callers fall back to the legacy Track columns). Once a
+        collapsed track has both a file and a stream source, this selects the
+        local file when it is available and falls through to the stream when the
+        file is not (e.g. an unmounted drive) — availability is the primary key so
+        the fallback actually happens (design §3; note the §3 draft listed
+        kind before is_available, which would never fall through).
+        """
+        row = self._conn.execute(
+            "SELECT id, kind, provider, provider_item_id, uri, ext, duration,"
+            " is_available, stream_url, stream_url_expires_at"
+            " FROM track_sources WHERE track_id = ?"
+            " ORDER BY is_available DESC, (kind = 'file') DESC, id"
+            " LIMIT 1",
+            (track_id,),
+        ).fetchone()
+        return row  # type: ignore[no-any-return]
+
+    def update_stream_url_for_source(
+        self, source_id: int, stream_url: str, expires_at: float
+    ) -> None:
+        """Persist a refreshed CDN stream URL onto a track_sources row (KAMP-541)."""
+        self._conn.execute(
+            "UPDATE track_sources SET stream_url = ?, stream_url_expires_at = ?"
+            " WHERE id = ?",
+            (stream_url, expires_at, source_id),
+        )
+        self._conn.commit()
+
     def update_track_display_title(
         self, track_id: int, display_title: str | None
     ) -> "Track | None":

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2090,6 +2090,57 @@ class LibraryIndex:
         )
         self._sync_tracks_row_to_preferred_source(survivor_id)
 
+    def _reconcile_scanned_tracks(self, canonical_keys: "list[str]") -> None:
+        """Attach a newly-scanned file to its existing canonical track (KAMP-541).
+
+        For each just-upserted file that is a sibling of exactly ONE canonical
+        track that has no file source of its own (i.e. a stream-only row — the
+        common "download a streamed album" case), merge the freshly-forked row
+        into the lower-id survivor via _merge_track_into, so the download attaches
+        as a source rather than resurrecting the two-row duplicate. Conservative:
+        matches by (album_id, track_number, disc_number) with agreeing sale_item_id
+        or, for a loose single, by sale_item_id; a >1 or ambiguous match is left
+        alone (the migration quarantines those). Caller owns the commit.
+        """
+        for key in canonical_keys:
+            row = self._conn.execute(
+                "SELECT id, album_id, track_number, disc_number, sale_item_id"
+                " FROM tracks WHERE file_path = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                continue
+            no_file_src = (
+                " AND NOT EXISTS (SELECT 1 FROM track_sources s"
+                " WHERE s.track_id = t.id AND s.kind = 'file')"
+            )
+            if row["album_id"] is not None:
+                cands = self._conn.execute(
+                    "SELECT t.id FROM tracks t WHERE t.id != ? AND t.album_id = ?"
+                    " AND t.track_number = ? AND t.disc_number = ?"
+                    " AND (t.sale_item_id IS NULL OR ? IS NULL OR t.sale_item_id = ?)"
+                    + no_file_src,
+                    (
+                        row["id"],
+                        row["album_id"],
+                        row["track_number"],
+                        row["disc_number"],
+                        row["sale_item_id"],
+                        row["sale_item_id"],
+                    ),
+                ).fetchall()
+            elif row["sale_item_id"]:
+                cands = self._conn.execute(
+                    "SELECT t.id FROM tracks t WHERE t.id != ? AND t.album_id IS NULL"
+                    " AND t.sale_item_id = ?" + no_file_src,
+                    (row["id"], row["sale_item_id"]),
+                ).fetchall()
+            else:
+                continue
+            if len(cands) == 1:
+                other = cands[0]["id"]
+                self._merge_track_into(min(row["id"], other), max(row["id"], other))
+
     def _has_collapsible_siblings(self) -> bool:
         """True if any bucket would hold >1 tracks row (KAMP-541 pre-flight).
 
@@ -2975,26 +3026,57 @@ class LibraryIndex:
         self._conn.commit()
         return cur.rowcount > 0
 
-    def streaming_track_for_local_id(self, local_track_id: int) -> "Track | None":
-        """Return the streaming (bandcamp://) equivalent of a local track.
+    def _file_sources_for_item(self, sale_item_id: str) -> "list[sqlite3.Row]":
+        """Rows (track_id, src_id, uri, album_id) for file sources of a download.
 
-        Joins on (album_id, track_number, disc_number) to find the bandcamp://
-        row that corresponds to the given local track ID.  Used to swap a queue
-        entry to its streaming counterpart before deleting the local file.
+        A downloaded track is a canonical track with a kind='file' track_sources
+        row tied to *sale_item_id* — by the source's provider_item_id, or via the
+        album/track sale_item_id provenance (KAMP-528). (KAMP-541.)
+        """
+        return self._conn.execute(
+            "SELECT DISTINCT t.id AS track_id, fs.id AS src_id, fs.uri AS uri,"
+            " t.album_id AS album_id"
+            " FROM tracks t"
+            " JOIN track_sources fs ON fs.track_id = t.id AND fs.kind = 'file'"
+            " LEFT JOIN albums a ON a.id = t.album_id"
+            " WHERE fs.provider_item_id = ? OR a.sale_item_id = ? OR t.sale_item_id = ?"
+            " ORDER BY t.disc_number, t.track_number",
+            (sale_item_id, sale_item_id, sale_item_id),
+        ).fetchall()
+
+    def all_downloads_streamable(self, sale_item_id: str) -> bool:
+        """True if every downloaded track for *sale_item_id* has a stream source.
+
+        The KAMP-541 replacement for the has_remote_album_tracks gate in the
+        delete-download flow: when False, the server materializes the missing
+        stream sources before removing the download.
         """
         row = self._conn.execute(
-            """
-            SELECT s.* FROM tracks s
-            JOIN tracks l ON l.album_id = s.album_id
-                          AND l.track_number = s.track_number
-                          AND l.disc_number = s.disc_number
-            WHERE l.id = ?
-              AND (s.file_path LIKE 'bandcamp://%' OR s.file_path LIKE 'bandcamp:\\%')
-            LIMIT 1
-            """,
-            (local_track_id,),
+            "SELECT 1 FROM tracks t"
+            " JOIN track_sources fs ON fs.track_id = t.id AND fs.kind = 'file'"
+            " LEFT JOIN albums a ON a.id = t.album_id"
+            " WHERE (fs.provider_item_id = ? OR a.sale_item_id = ? OR t.sale_item_id = ?)"
+            "   AND NOT EXISTS (SELECT 1 FROM track_sources s"
+            "     WHERE s.track_id = t.id AND s.kind = 'stream')"
+            " LIMIT 1",
+            (sale_item_id, sale_item_id, sale_item_id),
         ).fetchone()
-        return _row_to_track(row) if row is not None else None
+        return row is None
+
+    def _refresh_album_source(self, album_id: int) -> None:
+        """Recompute albums.source for one album from its tracks' legacy columns."""
+        self._conn.execute(
+            "UPDATE albums SET source = ("
+            "  SELECT CASE"
+            "    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0"
+            "         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0"
+            "    THEN 'local'"
+            "    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'"
+            "    ELSE MIN(t.source) END"
+            "  FROM tracks t WHERE t.album_id = albums.id)"
+            " WHERE id = ?",
+            (album_id,),
+        )
 
     def remove_download(self, sale_item_id: str) -> "list[Path]":
         """Revert a downloaded collection item back to streaming state.
@@ -3015,111 +3097,41 @@ class LibraryIndex:
         mutations run under rollback discipline so a mid-flight failure never
         leaks a partial delete into a later commit on this pooled connection.
         """
-        row = self._conn.execute(
-            "SELECT id FROM albums WHERE sale_item_id = ?", (sale_item_id,)
-        ).fetchone()
-        if row is None:
+        rows = self._file_sources_for_item(sale_item_id)
+        if not rows:
             return []
-        album_id: int = row["id"]
 
-        # Fetch local tracks before deletion so we can migrate play counts and favorites.
-        local_rows = self._conn.execute(
-            """
-            SELECT file_path, play_count, favorite, track_number, disc_number
-            FROM tracks
-            WHERE album_id = ?
-              AND file_path NOT LIKE 'bandcamp://%'
-              AND file_path NOT LIKE 'bandcamp:\\%'
-            """,
-            (album_id,),
-        ).fetchall()
-
-        # KAMP-527 fail-safe: refuse to delete unless EVERY local track has a
-        # bandcamp:// counterpart (matched on track_number + disc_number) to fall
-        # back to. Checked before any mutation so an abort touches nothing. This
-        # covers the download-mode case (no stream rows at all), a partial
-        # materialization, and multi-disc downloads whose disc>1 tracks have no
-        # stream row. Without it the album would be deleted with no way back.
-        uncovered = self._conn.execute(
-            """
-            SELECT COUNT(*) AS n FROM tracks l
-            WHERE l.album_id = ?
-              AND l.file_path NOT LIKE 'bandcamp://%'
-              AND l.file_path NOT LIKE 'bandcamp:\\%'
-              AND NOT EXISTS (
-                  SELECT 1 FROM tracks s
-                  WHERE s.album_id = l.album_id
-                    AND s.track_number = l.track_number
-                    AND s.disc_number = l.disc_number
-                    AND (s.file_path LIKE 'bandcamp://%'
-                         OR s.file_path LIKE 'bandcamp:\\%')
-              )
-            """,
-            (album_id,),
-        ).fetchone()["n"]
-        if uncovered > 0:
-            raise NoStreamableVersionError(
-                f"{uncovered} track(s) for sale_item_id={sale_item_id} have no "
-                "streamable counterpart; refusing to delete the download."
-            )
-
-        file_paths = [Path(r["file_path"]) for r in local_rows]
-
-        # All mutations run under a single transaction guarded by rollback: a
-        # mid-flight failure must NOT leave a partial delete uncommitted on this
-        # thread-local connection, or the next unrelated commit() would flush it
-        # and silently destroy the local tracks (KAMP-527 deferred-commit bug).
-        try:
-            # Migrate play counts (MAX wins) and favorites (OR wins) to streaming rows.
-            for r in local_rows:
+        # KAMP-527 fail-safe: refuse unless EVERY downloaded track retains a stream
+        # source after we drop its file source. Checked before any mutation so an
+        # abort touches nothing (the daemon materializes missing streams first).
+        for r in rows:
+            if (
                 self._conn.execute(
-                    """
-                    UPDATE tracks
-                    SET play_count = MAX(play_count, ?),
-                        favorite   = MAX(favorite, ?)
-                    WHERE album_id = ?
-                      AND track_number = ?
-                      AND disc_number = ?
-                      AND (file_path LIKE 'bandcamp://%' OR file_path LIKE 'bandcamp:\\%')
-                    """,
-                    (
-                        r["play_count"],
-                        r["favorite"],
-                        album_id,
-                        r["track_number"],
-                        r["disc_number"],
-                    ),
+                    "SELECT 1 FROM track_sources WHERE track_id = ? AND kind = 'stream'"
+                    " LIMIT 1",
+                    (r["track_id"],),
+                ).fetchone()
+                is None
+            ):
+                raise NoStreamableVersionError(
+                    f"track {r['track_id']} for sale_item_id={sale_item_id} has no "
+                    "stream source; refusing to remove the download."
                 )
 
-            # Remove local track rows.
-            self._conn.execute(
-                """
-                DELETE FROM tracks
-                WHERE album_id = ?
-                  AND file_path NOT LIKE 'bandcamp://%'
-                  AND file_path NOT LIKE 'bandcamp:\\%'
-                """,
-                (album_id,),
-            )
+        file_paths = [Path(r["uri"]) for r in rows]
+        album_ids = {r["album_id"] for r in rows if r["album_id"] is not None}
 
-            # Refresh albums.source — same subquery pattern as set_track_source_for_item.
-            self._conn.execute(
-                """
-                UPDATE albums SET source = (
-                    SELECT CASE
-                        WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
-                             AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                        THEN 'local'
-                        WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                        ELSE MIN(t.source)
-                    END
-                    FROM tracks t WHERE t.album_id = albums.id
+        # All mutations under a single rollback-guarded transaction (KAMP-527
+        # deferred-commit discipline).
+        try:
+            # Drop each file source and revert the track to its stream source.
+            for r in rows:
+                self._conn.execute(
+                    "DELETE FROM track_sources WHERE id = ?", (r["src_id"],)
                 )
-                WHERE id = ?
-                """,
-                (album_id,),
-            )
-
+                self._sync_tracks_row_to_preferred_source(r["track_id"])
+            for aid in album_ids:
+                self._refresh_album_source(aid)
             self._conn.execute(
                 "UPDATE bandcamp_collection SET mode = 'remote', synced_at = NULL"
                 " WHERE sale_item_id = ?",
@@ -3145,22 +3157,58 @@ class LibraryIndex:
     def materialize_stream_tracks(
         self, sale_item_id: str, tracks: "list[Track]"
     ) -> int:
-        """Upsert on-demand bandcamp:// stream rows for a downloaded album.
+        """Attach an on-demand stream source to each downloaded track (KAMP-541/527).
 
-        Used by the DELETE-download endpoint (KAMP-527) to create the streamable
-        representation a download-mode album never had, so remove_download has
-        something to fall back to. Stamps *sale_item_id* on each Track so
-        upsert_many links them by identity to the EXISTING album row rather than
-        forking a new name-keyed album (KAMP-523 identity path). upsert_many
-        already carries rollback discipline, so a mid-flight failure leaves no
-        partial writes on this connection. Returns the number of tracks upserted.
+        Used by the DELETE-download endpoint to give a download-mode album (bought
+        + downloaded, never streamed) the streamable fallback remove_download
+        needs. *tracks* are streaming Track objects (bandcamp:// file_path); each
+        is matched to its existing canonical track by (this item + track_number +
+        disc_number) and a kind='stream' track_sources row is inserted when the
+        track has none yet. Rollback-guarded. Returns the number attached.
         """
         if not tracks:
             return 0
-        for t in tracks:
-            t.sale_item_id = str(sale_item_id)
-        self.upsert_many(tracks)
-        return len(tracks)
+        attached = 0
+        try:
+            for t in tracks:
+                uri = _canonical_track_key(t.file_path)
+                row = self._conn.execute(
+                    "SELECT t.id FROM tracks t"
+                    " LEFT JOIN albums a ON a.id = t.album_id"
+                    " WHERE (a.sale_item_id = ? OR t.sale_item_id = ?)"
+                    "   AND t.track_number = ? AND t.disc_number = ?"
+                    "   AND NOT EXISTS (SELECT 1 FROM track_sources s"
+                    "     WHERE s.track_id = t.id AND s.kind = 'stream')"
+                    " LIMIT 1",
+                    (sale_item_id, sale_item_id, t.track_number, t.disc_number),
+                ).fetchone()
+                if row is None:
+                    continue
+                if self._conn.execute(
+                    "SELECT 1 FROM track_sources WHERE uri = ?", (uri,)
+                ).fetchone():
+                    continue  # uri already present
+                self._conn.execute(
+                    "INSERT INTO track_sources (track_id, kind, provider,"
+                    " provider_item_id, uri, ext, duration, stream_url,"
+                    " stream_url_expires_at) VALUES (?, 'stream', 'bandcamp', ?, ?,"
+                    " ?, ?, ?, ?)",
+                    (
+                        row["id"],
+                        str(sale_item_id),
+                        uri,
+                        t.ext,
+                        t.duration,
+                        t.stream_url,
+                        t.stream_url_expires_at,
+                    ),
+                )
+                attached += 1
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        return attached
 
     def reset_collection_sync_state(self) -> None:
         """Set synced_at = NULL for all rows so the next sync re-downloads everything."""
@@ -3745,6 +3793,10 @@ class LibraryIndex:
                 " FROM tracks WHERE file_path = ?",
                 [(p[3],) for p in src_params],
             )
+            # Step 6 (KAMP-541): attach a newly-scanned file to its existing
+            # canonical track (merging the fork) instead of leaving a duplicate
+            # streaming+local pair. No-op when there is no stream-only sibling.
+            self._reconcile_scanned_tracks([p[3] for p in src_params])
 
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()
@@ -4906,29 +4958,16 @@ class LibraryIndex:
     def tracks_for_album(self, album_artist: str, album: str) -> list[Track]:
         """Return tracks for a given album sorted by disc then track number.
 
-        When local (non-bandcamp://) tracks exist alongside remote bandcamp://
-        tracks for the same album, only the local tracks are returned. This
-        prevents duplicate-track display after a Bandcamp album is downloaded
-        and the local files have been scanned in alongside the old remote rows.
+        KAMP-541: after the collapse there is one canonical row per track (its
+        local file and stream both live in track_sources), so the old local-wins
+        de-dup filter is gone — every album row is returned.
         """
         album_id = self._album_id(album_artist, album)
         if album_id is None:
             return []
         rows = self._conn.execute(
-            """
-            SELECT * FROM tracks
-            WHERE album_id = ?
-              AND (
-                file_path NOT LIKE 'bandcamp://%'
-                OR NOT EXISTS (
-                    SELECT 1 FROM tracks t2
-                    WHERE t2.album_id = ?
-                      AND t2.file_path NOT LIKE 'bandcamp://%'
-                )
-              )
-            ORDER BY disc_number, track_number
-            """,
-            (album_id, album_id),
+            "SELECT * FROM tracks WHERE album_id = ? ORDER BY disc_number, track_number",
+            (album_id,),
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 
@@ -5080,19 +5119,8 @@ class LibraryIndex:
             JOIN tracks t ON f.rowid = t.id
             LEFT JOIN albums al ON al.id = t.album_id
             WHERE tracks_fts MATCH ?
-              -- KAMP-529: local-wins collapse. Hide a streaming (bandcamp) row
-              -- when its album also holds a local track, so a downloaded track
-              -- surfaces once in search instead of doubling. Same album-level
-              -- rule as tracks_for_album; keyed on album_id (NULL-safe) and
-              -- source (Windows path-form safe), not on track_number.
-              AND NOT (
-                    t.source = 'bandcamp'
-                    AND t.album_id IS NOT NULL
-                    AND EXISTS (
-                        SELECT 1 FROM tracks x
-                        WHERE x.album_id = t.album_id AND x.source = 'local'
-                    )
-                  )
+              -- KAMP-541: the collapse leaves one canonical row per track, so the
+              -- KAMP-529 local-wins de-dup filter is no longer needed.
             ORDER BY (t.favorite OR COALESCE(al.favorite, 0)) DESC, f.rank
             """,
             (fts_expr,),

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -75,19 +75,41 @@ def resolve_playback_uri(
 
     A brief validation delay is far better than silently skipping a track.
     """
-    if not track.is_remote:
-        return track.playback_uri
+    # Resolve the preferred delivery via track_sources (KAMP-541): a collapsed
+    # track has both a file and a stream source, and the preferred-source rule
+    # picks the local file when present/available and falls through to the stream
+    # otherwise. On the pre-collapse DB each track has exactly one source, so this
+    # is behaviour-neutral. A track with no source row (pre-KAMP-540 / a synthetic
+    # queue-restore stub) falls back to the legacy Track columns.
+    _src = index.preferred_source(track.id) if track.id else None
+    _cached_url: str | None
+    _cached_expires: float | None
+    _source_id: int | None
+    if _src is not None:
+        _kind = str(_src["kind"])
+        _src_uri = str(_src["uri"])
+        _cached_url = _src["stream_url"]
+        _cached_expires = _src["stream_url_expires_at"]
+        _source_id = int(_src["id"])
+    else:
+        _kind = "stream" if track.is_remote else "file"
+        _src_uri = str(track.file_path)
+        _cached_url = track.stream_url
+        _cached_expires = track.stream_url_expires_at
+        _source_id = None
+
+    if _kind == "file":
+        return _src_uri
 
     import time as _t
 
     _now = _t.time()
 
-    # Parse bandcamp://sale_id/track_num upfront — needed by both the
+    # Parse bandcamp://sale_id/track_num from the source uri — needed by both the
     # proactive-expiry path and the HEAD-triggered forced-refresh path.
     # Path() mutates the URI differently per platform (POSIX collapses //,
     # Windows converts to \\), so split on the scheme literal instead.
-    _fp = str(track.file_path)
-    _after_scheme = _fp.split("bandcamp:", 1)
+    _after_scheme = _src_uri.split("bandcamp:", 1)
     _canonical_fp: str | None = None
     _album_url: str = ""
     _track_num: int = 0
@@ -122,7 +144,12 @@ def resolve_playback_uri(
         result = refresh_stream_url(_album_url, _track_num)
         if result is not None:
             new_url, expires_at = result
-            index.update_stream_url(_canonical_fp, new_url, expires_at)
+            # Persist onto the source row when we resolved one, else the legacy
+            # tracks column (pre-KAMP-540 fallback).
+            if _source_id is not None:
+                index.update_stream_url_for_source(_source_id, new_url, expires_at)
+            else:
+                index.update_stream_url(_canonical_fp, new_url, expires_at)
             logger.info(
                 "resolve_playback_uri: stream URL refreshed for %s "
                 "(new expires_at=%.0f)",
@@ -137,19 +164,17 @@ def resolve_playback_uri(
         return None
 
     # Step 1 — proactive refresh when the cached URL is near or past expiry.
-    url = track.playback_uri
-    needs_refresh = (
-        track.stream_url_expires_at is None or track.stream_url_expires_at < _now + 60
-    )
+    url = _cached_url or _src_uri
+    needs_refresh = _cached_expires is None or _cached_expires < _now + 60
     if needs_refresh:
-        refreshed = _do_refresh(f"expires_at={track.stream_url_expires_at}")
+        refreshed = _do_refresh(f"expires_at={_cached_expires}")
         if refreshed is not None:
             url = refreshed
     else:
         logger.debug(
             "resolve_playback_uri: cached stream URL for %s (expires in %.0fs)",
-            track.file_path,
-            (track.stream_url_expires_at or 0) - _now,
+            _canonical_fp or _src_uri,
+            (_cached_expires or 0) - _now,
         )
 
     # Step 2 — HEAD request to verify the URL is live before handing to mpv.

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3087,17 +3087,17 @@ def create_app(
         # fails, or Bandcamp has no streamable version), abort with 422 and
         # delete nothing; remove_download's own per-track guard is the final
         # safety net that still refuses to strand any local track.
-        if not index.has_remote_album_tracks(sale_item_id):
+        # KAMP-541: a downloaded track keeps its stream as a track_sources row, so
+        # "has a stream to fall back to" is a source check. When some track lacks
+        # one (download-mode album never streamed), materialize the stream sources
+        # on demand (a network call) before removing; if that fails, abort with 422.
+        if not index.all_downloads_streamable(sale_item_id):
             _materialize_stream_tracks_or_422(index, item, get_bandcamp_session)
 
-        # Swap every local track in the queue to its streaming equivalent so
-        # that on restart the queue can be fully restored from the DB.  Without
-        # this, only the swapped current/next entries survive; all other queue
-        # positions point at local paths that no longer exist after deletion.
-        for local_track in local_tracks:
-            streaming = index.streaming_track_for_local_id(local_track.id)
-            if streaming is not None:
-                queue.update_track_by_id(local_track.id, streaming)
+        # No queue swap needed (KAMP-541 + queue-by-id): the canonical track
+        # survives the removal — its file source is dropped and it reverts to its
+        # stream source with the SAME track id — so the id-keyed queue entries
+        # stay valid across a restart.
 
         if locked:
             # Current track's file is loaded in mpv — unload it so the handle

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 45
+        assert version == 46
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -241,7 +241,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -334,7 +334,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 45
+        assert version == 46
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -470,6 +470,94 @@ class TestLibraryIndex:
         n = index._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
         index.close()
         assert n == 0
+
+    def test_v46_collapse_merges_siblings_and_repoints(self, tmp_path: Path) -> None:
+        """v46 collapses a stream+local sibling pair into one track (KAMP-541)."""
+        import json
+
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album, source) VALUES ('A','Alb','bandcamp')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid9')")
+        # Stream row first (lower id → survivor), favorite=1 pc=2; local second, pc=5.
+        c.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, source,"
+            " album_id, track_number, disc_number, sale_item_id, favorite, play_count)"
+            " VALUES ('bandcamp://sid9/1','T','Alb','A','bandcamp',?,1,1,'sid9',1,2)",
+            (alb,),
+        )
+        stream_id = c.execute(
+            "SELECT id FROM tracks WHERE source='bandcamp'"
+        ).fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, source,"
+            " album_id, track_number, disc_number, sale_item_id, favorite, play_count)"
+            " VALUES ('/m/1.mp3','T','Alb','A','local',?,1,1,'sid9',0,5)",
+            (alb,),
+        )
+        local_id = c.execute("SELECT id FROM tracks WHERE source='local'").fetchone()[0]
+        c.executemany(
+            "INSERT INTO track_sources (track_id, kind, provider, provider_item_id, uri)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                (stream_id, "stream", "bandcamp", "sid9", "bandcamp://sid9/1"),
+                (local_id, "file", "bandcamp", "sid9", "/m/1.mp3"),
+            ],
+        )
+        c.executemany(
+            "INSERT INTO track_stats (track_id, favorite, play_count) VALUES (?, ?, ?)",
+            [(stream_id, 1, 2), (local_id, 0, 5)],
+        )
+        c.execute(
+            "INSERT INTO playlists (title, created_at, updated_at) VALUES ('P',0,0)"
+        )
+        pl = c.execute("SELECT id FROM playlists").fetchone()[0]
+        c.execute(
+            "INSERT INTO playlist_tracks (playlist_id, track_id, position) VALUES (?,?,0)",
+            (pl, local_id),
+        )
+        c.execute(
+            "INSERT INTO queue_state (id, tracks, order_json, pos, shuffle, repeat)"
+            " VALUES (1, ?, '[0]', 0, 0, 'off')",
+            (json.dumps([local_id]),),
+        )
+        c.execute("UPDATE schema_version SET version = 45")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # runs the v46 collapse
+        hc = healed._conn
+        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        surv = hc.execute(
+            "SELECT id, favorite, play_count, file_path FROM tracks"
+        ).fetchone()
+        n_src = hc.execute(
+            "SELECT COUNT(*) FROM track_sources WHERE track_id = ?", (surv["id"],)
+        ).fetchone()[0]
+        st = hc.execute(
+            "SELECT favorite, play_count FROM track_stats WHERE track_id = ?",
+            (surv["id"],),
+        ).fetchone()
+        pl_tid = hc.execute("SELECT track_id FROM playlist_tracks").fetchone()[
+            "track_id"
+        ]
+        q = json.loads(
+            hc.execute("SELECT tracks FROM queue_state WHERE id=1").fetchone()["tracks"]
+        )
+        healed.close()
+
+        assert n_tracks == 1
+        assert surv["id"] == stream_id  # lower id survives
+        assert (surv["favorite"], surv["play_count"]) == (1, 5)  # MAX merge
+        assert (st["favorite"], st["play_count"]) == (1, 5)  # track_stats re-derived
+        assert n_src == 2  # both sources re-parented onto the survivor
+        assert surv["file_path"] == "/m/1.mp3"  # realigned to preferred (file) source
+        assert pl_tid == stream_id  # playlist repointed loser→survivor
+        assert q == [stream_id]  # queue repointed
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -2004,7 +2092,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2061,7 +2149,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2656,7 +2744,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert row is not None
         assert row[0] == 0
 
@@ -3111,7 +3199,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3207,7 +3295,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3388,7 +3476,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3483,7 +3571,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 45
+        assert version == 46
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3491,7 +3579,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 45
+        assert version == 46
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4368,7 +4456,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 45
+        assert version == 46
 
         index.close()
 
@@ -5059,7 +5147,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 45
+        assert version == 46
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5094,7 +5182,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 45
+        assert version == 46
         index.close()
 
 
@@ -5609,7 +5697,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 45
+        assert version == 46
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -5742,7 +5830,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 45
+        assert version == 46
 
 
 class TestRemoteTrackSchema:
@@ -6076,7 +6164,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6137,7 +6225,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -6903,7 +6991,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7462,7 +7550,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7540,7 +7628,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -7746,7 +7834,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8095,7 +8183,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8192,7 +8280,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8308,7 +8396,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -8813,7 +8901,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -8928,7 +9016,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9026,7 +9114,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9126,7 +9214,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9633,7 +9721,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 45
+        assert version == 46
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10477,7 +10565,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 45
+        assert version == 46
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11446,7 +11534,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 45
+        assert version == 46
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11466,7 +11554,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 45
+        assert version == 46
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -11508,7 +11596,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 45
+        assert version == 46
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -613,6 +613,80 @@ class TestLibraryIndex:
         assert c.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0] == 1
         index.close()
 
+    def test_all_downloads_streamable(self, tmp_path: Path) -> None:
+        """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidS')")
+        c.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id) VALUES ('A','Alb','sidS')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('/m/s.mp3','local',?,1,1)",
+            (alb,),
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/s.mp3')",
+            (tid,),
+        )
+        c.commit()
+        assert index.all_downloads_streamable("sidS") is False  # no stream yet
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'stream', 'bandcamp://sidS/1')",
+            (tid,),
+        )
+        c.commit()
+        assert index.all_downloads_streamable("sidS") is True
+        index.close()
+
+    def test_materialize_skips_when_no_matching_track(self, tmp_path: Path) -> None:
+        """materialize_stream_tracks attaches nothing when no track matches (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid99')")
+        c.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id) VALUES ('A','Alb','sid99')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('/m/1.mp3','local',?,1,1)",
+            (alb,),
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/1.mp3')",
+            (tid,),
+        )
+        c.commit()
+
+        phantom = _sample_track(Path("bandcamp://sid99/9"))
+        phantom.track_number = 9  # no local track has track_number 9
+        phantom.source = "bandcamp"
+        n = index.materialize_stream_tracks("sid99", [phantom])
+        streams = c.execute(
+            "SELECT COUNT(*) FROM track_sources WHERE kind = 'stream'"
+        ).fetchone()[0]
+        index.close()
+        assert n == 0 and streams == 0
+
+    def test_sync_to_preferred_noop_without_sources(self, tmp_path: Path) -> None:
+        """_sync_tracks_row_to_preferred_source is a no-op for a sourceless track (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('/m/n.mp3', 'local')"
+        )
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        index._sync_tracks_row_to_preferred_source(tid)  # must not raise
+        fp = index._conn.execute(
+            "SELECT file_path FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        index.close()
+        assert fp == "/m/n.mp3"  # unchanged
+
     def test_remove_track_legacy_row_without_source(self, tmp_path: Path) -> None:
         """A pre-collapse tracks row with no source is removed by file_path (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -471,6 +471,160 @@ class TestLibraryIndex:
         index.close()
         assert n == 0
 
+    def test_v46_collapse_quarantines_ambiguous_bucket(self, tmp_path: Path) -> None:
+        """A bucket with >2 rows is left un-merged (KAMP-541 quarantine)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        # Three rows sharing (album, track, disc) — ambiguous, must not collapse.
+        for i, (fp, src) in enumerate(
+            [
+                ("bandcamp://x/1", "bandcamp"),
+                ("/m/a.mp3", "local"),
+                ("/m/b.flac", "local"),
+            ]
+        ):
+            c.execute(
+                "INSERT INTO tracks (file_path, source, album_id, track_number,"
+                " disc_number) VALUES (?, ?, ?, 1, 1)",
+                (fp, src, alb),
+            )
+        c.execute("UPDATE schema_version SET version = 45")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # v46 runs, quarantines
+        n = healed._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        healed.close()
+        assert n == 3  # all left in place
+
+    def test_v46_collapse_derives_missing_source_and_dedupes_deferred_op(
+        self, tmp_path: Path
+    ) -> None:
+        """Collapse derives an absent source and keeps the survivor's deferred op (KAMP-541)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('bandcamp://y/1','bandcamp',?,1,1)",
+            (alb,),
+        )
+        stream_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('/m/y.mp3','local',?,1,1)",
+            (alb,),
+        )
+        local_id = c.execute("SELECT id FROM tracks WHERE source='local'").fetchone()[0]
+        # Intentionally NO track_sources rows (simulate a pre-540 skip) -> collapse
+        # must derive them. Both rows carry a pending deferred op (UNIQUE track_id).
+        c.executemany(
+            "INSERT INTO deferred_ops (op_type, track_id, payload_json, created_at)"
+            " VALUES ('track_retag', ?, '{}', ?)",
+            [(stream_id, 1.0), (local_id, 2.0)],
+        )
+        c.execute("UPDATE schema_version SET version = 45")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)
+        hc = healed._conn
+        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        n_src = hc.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
+        n_ops = hc.execute("SELECT COUNT(*) FROM deferred_ops").fetchone()[0]
+        op_tid = hc.execute("SELECT track_id FROM deferred_ops").fetchone()["track_id"]
+        healed.close()
+        assert n_tracks == 1  # merged
+        assert n_src == 2  # both sources derived + re-parented
+        assert n_ops == 1 and op_tid == stream_id  # survivor's op kept, loser's dropped
+
+    def test_upsert_attaches_new_download_to_existing_canonical(
+        self, tmp_path: Path
+    ) -> None:
+        """A downloaded file for an existing stream track attaches as a source (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album) VALUES ('The Artist','The Album')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+            " source, album_id, track_number, disc_number)"
+            " VALUES ('bandcamp://z/1','A Song','The Artist','The Artist','The Album',"
+            " 'bandcamp',?,1,1)",
+            (alb,),
+        )
+        stream_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, provider, uri)"
+            " VALUES (?, 'stream', 'bandcamp', 'bandcamp://z/1')",
+            (stream_id,),
+        )
+        c.commit()
+
+        # Scan a local file for the same album+track: it must attach, not fork.
+        index.upsert_many([_sample_track(tmp_path / "track1.mp3")])
+
+        n_tracks = c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in c.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (stream_id,)
+            )
+        )
+        index.close()
+        assert n_tracks == 1
+        assert kinds == ["file", "stream"]
+
+    def test_remove_download_refuses_when_no_stream_source(
+        self, tmp_path: Path
+    ) -> None:
+        """remove_download refuses if a track would be left with no stream (KAMP-527)."""
+        from kamp_core.library import NoStreamableVersionError
+
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidX')")
+        c.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id) VALUES ('A','Alb','sidX')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('/m/x.mp3','local',?,1,1)",
+            (alb,),
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, provider, provider_item_id, uri)"
+            " VALUES (?, 'file', 'bandcamp', 'sidX', '/m/x.mp3')",
+            (tid,),
+        )
+        c.commit()
+
+        with pytest.raises(NoStreamableVersionError):
+            index.remove_download("sidX")
+        assert c.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0] == 1
+        index.close()
+
+    def test_remove_track_legacy_row_without_source(self, tmp_path: Path) -> None:
+        """A pre-collapse tracks row with no source is removed by file_path (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('/m/legacy.mp3', 'local')"
+        )
+        index._conn.commit()
+        index.remove_track(Path("/m/legacy.mp3"))
+        n = index._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        index.close()
+        assert n == 0
+
     def test_v46_collapse_merges_siblings_and_repoints(self, tmp_path: Path) -> None:
         """v46 collapses a stream+local sibling pair into one track (KAMP-541)."""
         import json
@@ -6588,18 +6742,10 @@ class TestAlbumInfoRemoteFields:
         assert albums[0].source == "local"
         assert albums[0].has_remote_tracks is False
 
-    def test_tracks_for_album_excludes_bc_rows_when_local_tracks_exist(
-        self, tmp_path: Path
-    ) -> None:
-        """tracks_for_album returns only local tracks when both exist."""
-        index = LibraryIndex(tmp_path / "library.db")
-        self._insert_bc_tracks(index, "555")
-        self._insert_track(index, tmp_path, "t1.mp3", source="local")
-        tracks = index.tracks_for_album("The Artist", "The Album")
-        index.close()
-
-        assert len(tracks) == 1
-        assert "bandcamp:" not in str(tracks[0].file_path)
+    # (KAMP-541) The old "tracks_for_album excludes bandcamp rows when a local
+    # sibling exists" test is removed: the local-wins filter is gone because the
+    # collapse leaves one canonical row per track. De-dup is covered by the
+    # collapse migration + scan-reconcile tests.
 
     def test_tracks_for_album_returns_bc_rows_when_no_local_tracks(
         self, tmp_path: Path
@@ -7094,8 +7240,10 @@ class TestRemoveDownload:
             "UPDATE tracks SET play_count = 7 WHERE file_path = ?",
             (str(tmp_path / "track1.mp3"),),
         )
+        # Post-KAMP-541 the stream+local rows collapse into one canonical track
+        # holding the MAX play_count (track2: stream 5 > local 3 -> 5).
         index._conn.execute(
-            "UPDATE tracks SET play_count = 3 WHERE file_path = ?",
+            "UPDATE tracks SET play_count = 5 WHERE file_path = ?",
             (str(tmp_path / "track2.mp3"),),
         )
         index._conn.commit()
@@ -7226,15 +7374,19 @@ class TestRemoveDownload:
     def test_remove_download_preserves_existing_streaming_favorite(
         self, tmp_path: Path
     ) -> None:
-        """Favorite already set on the streaming row is kept even if local is unfavorited."""
+        """A favorite on the canonical track is kept when the download is removed."""
         index = self._setup_downloaded_album(tmp_path)
+        # Post-KAMP-541 there is one canonical track (file_path = local path until
+        # the download is removed); favorite it there.
         index._conn.execute(
-            "UPDATE tracks SET favorite = 1 WHERE file_path = 'bandcamp://sid42/2'"
+            "UPDATE tracks SET favorite = 1 WHERE file_path = ?",
+            (str(tmp_path / "track2.mp3"),),
         )
         index._conn.commit()
 
         index.remove_download("sid42")
 
+        # After removal the track reverts to its stream source (file_path).
         row = index._conn.execute(
             "SELECT favorite FROM tracks WHERE file_path = 'bandcamp://sid42/2'"
         ).fetchone()
@@ -7384,13 +7536,10 @@ class TestRemoveDownload:
     def test_materialize_stream_tracks_attaches_to_existing_album(
         self, tmp_path: Path
     ) -> None:
-        """Materialized stream rows link by identity to the existing album row
-        (no fork) so remove_download can then migrate + revert cleanly.
+        """Materialize attaches a stream source to each existing canonical track
+        (no fork, no duplicate album) so remove_download can then revert cleanly (KAMP-541).
         """
         index = self._setup_download_only_album(tmp_path)
-        album_id = index._conn.execute(
-            "SELECT id FROM albums WHERE sale_item_id = 'sid99'"
-        ).fetchone()["id"]
 
         s1 = _sample_track(Path("bandcamp://sid99/1"))
         s1.track_number = 1
@@ -7400,20 +7549,17 @@ class TestRemoveDownload:
         s2.source = "bandcamp"
         n = index.materialize_stream_tracks("sid99", [s1, s2])
 
-        # No duplicate album row, and the stream rows joined the existing album.
         album_count = index._conn.execute(
             "SELECT COUNT(*) AS n FROM albums WHERE sale_item_id = 'sid99'"
         ).fetchone()["n"]
-        stream_album_ids = [
-            r["album_id"]
-            for r in index._conn.execute(
-                "SELECT album_id FROM tracks WHERE file_path LIKE 'bandcamp://sid99/%'"
-            ).fetchall()
-        ]
+        stream_srcs = index._conn.execute(
+            "SELECT COUNT(*) FROM track_sources WHERE kind = 'stream'"
+        ).fetchone()[0]
         index.close()
         assert n == 2
         assert album_count == 1
-        assert stream_album_ids == [album_id, album_id]
+        # Attached as sources of the two existing canonical tracks, not as rows.
+        assert stream_srcs == 2
 
     def test_remove_download_succeeds_after_materialize(self, tmp_path: Path) -> None:
         """End-to-end: materialize then remove_download reverts to streaming."""
@@ -11490,11 +11636,13 @@ class TestLooseSingleAttach:
         touched = index._attach_loose_local_singles()
         assert touched == set()
         assert self._album_id_of(index, tmp_path / "celebrity.flac") == first
+        # Post-KAMP-541 the loose local single and its stream twin collapse into
+        # one canonical track (file + stream sources), so the album holds 1 row.
         assert (
             index._conn.execute(
                 "SELECT COUNT(*) FROM tracks WHERE album_id = ?", (first,)
             ).fetchone()[0]
-            == 2
+            == 1
         )
         index.close()
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -393,6 +393,34 @@ class TestLibraryIndex:
         assert src["duration"] == 99.0  # source refreshed
         assert fav == 1  # stats preserved across the re-scan (INSERT OR IGNORE)
 
+    def test_preferred_source_prefers_file_then_available(self, tmp_path: Path) -> None:
+        """preferred_source picks a local file, falling through to a stream (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('canon', 'bandcamp')"
+        )
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        index._conn.executemany(
+            "INSERT INTO track_sources (track_id, kind, uri, is_available)"
+            " VALUES (?, ?, ?, ?)",
+            [
+                (tid, "stream", "bandcamp://9/1", 1),
+                (tid, "file", "/m/a.mp3", 1),
+            ],
+        )
+        index._conn.commit()
+
+        assert index.preferred_source(tid)["kind"] == "file"  # file wins
+        # An unavailable file falls through to the stream.
+        index._conn.execute(
+            "UPDATE track_sources SET is_available = 0 WHERE kind = 'file'"
+        )
+        index._conn.commit()
+        pref = index.preferred_source(tid)
+        index.close()
+        assert pref["kind"] == "stream"
+        assert pref["uri"] == "bandcamp://9/1"
+
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_track(_sample_track(tmp_path / "01.mp3"))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 46
+        assert version == 47
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -241,7 +241,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -334,7 +334,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 46
+        assert version == 47
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -615,6 +615,50 @@ class TestLibraryIndex:
             index.remove_download("sidX")
         assert c.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0] == 1
         index.close()
+
+    def test_v47_heals_collapse_art(self, tmp_path: Path) -> None:
+        """v47 restores embedded_art/file_mtime lost by the v46 collapse (KAMP-541)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album, embedded_art) VALUES ('A','Alb',0)"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        # A collapsed track: the stream survivor left embedded_art=0 / file_mtime
+        # NULL on the row even though its file source carries the art.
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, embedded_art) VALUES ('bandcamp://a/1','bandcamp',?,1,1,0)",
+            (alb,),
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.executemany(
+            "INSERT INTO track_sources (track_id, kind, uri, embedded_art, file_mtime)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                (tid, "stream", "bandcamp://a/1", 0, None),
+                (tid, "file", "/m/a.mp3", 1, 123.0),
+            ],
+        )
+        c.execute("UPDATE schema_version SET version = 46")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # runs the v47 heal
+        hc = healed._conn
+        t = hc.execute(
+            "SELECT embedded_art, file_mtime, source, file_path FROM tracks WHERE id=?",
+            (tid,),
+        ).fetchone()
+        a_art = hc.execute(
+            "SELECT embedded_art FROM albums WHERE id=?", (alb,)
+        ).fetchone()[0]
+        healed.close()
+        assert t["embedded_art"] == 1  # synced from the file source
+        assert t["file_mtime"] == 123.0
+        assert t["source"] == "local" and t["file_path"] == "/m/a.mp3"
+        assert a_art == 1  # album cover restored
 
     def test_all_downloads_streamable(self, tmp_path: Path) -> None:
         """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
@@ -2324,7 +2368,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2381,7 +2425,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -2976,7 +3020,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert row is not None
         assert row[0] == 0
 
@@ -3431,7 +3475,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3527,7 +3571,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3708,7 +3752,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3803,7 +3847,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 46
+        assert version == 47
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3811,7 +3855,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 46
+        assert version == 47
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4688,7 +4732,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 46
+        assert version == 47
 
         index.close()
 
@@ -5379,7 +5423,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 46
+        assert version == 47
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5414,7 +5458,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 46
+        assert version == 47
         index.close()
 
 
@@ -5929,7 +5973,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 46
+        assert version == 47
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6062,7 +6106,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 46
+        assert version == 47
 
 
 class TestRemoteTrackSchema:
@@ -6396,7 +6440,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6457,7 +6501,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7215,7 +7259,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7774,7 +7818,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7852,7 +7896,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8058,7 +8102,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8407,7 +8451,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8504,7 +8548,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8620,7 +8664,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9125,7 +9169,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9240,7 +9284,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9338,7 +9382,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9438,7 +9482,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -9945,7 +9989,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 46
+        assert version == 47
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10789,7 +10833,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 46
+        assert version == 47
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11760,7 +11804,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 46
+        assert version == 47
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11780,7 +11824,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 46
+        assert version == 47
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -11822,7 +11866,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 46
+        assert version == 47
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -134,7 +134,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 47
+        assert version == 48
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -241,7 +241,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -334,7 +334,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 47
+        assert version == 48
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -603,6 +603,66 @@ class TestLibraryIndex:
         )
         index.close()
 
+    def test_sync_attaches_stream_to_downloaded_canonical(self, tmp_path: Path) -> None:
+        """A synced stream for an already-downloaded album attaches, not forks (KAMP-541).
+
+        The reverse of test_upsert_attaches_new_download_to_existing_canonical:
+        the local file exists first (download-only album) and the bandcamp sync
+        brings its stream in for the first time. Without the symmetric reconcile
+        the stream is upserted as a separate stream-only row, re-creating the
+        KAMP-532 duplicate.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('s7')")
+        c.execute(
+            "INSERT INTO albums (album_artist, album, sale_item_id)"
+            " VALUES ('The Artist','The Album','s7')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        # A downloaded, never-streamed canonical (file source only).
+        local = _sample_track(tmp_path / "track1.mp3")
+        local.sale_item_id = "s7"
+        index.upsert_track(local)
+        c.execute("UPDATE tracks SET album_id = ?, sale_item_id = 's7'", (alb,))
+        file_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.commit()
+
+        # The sync upserts the streaming track for the same album+track.
+        stream = Track(
+            file_path="bandcamp://s7/1",
+            title="A Song",
+            artist="The Artist",
+            album_artist="The Artist",
+            album="The Album",
+            release_date="",
+            track_number=local.track_number,
+            disc_number=local.disc_number,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        stream.source = "bandcamp"  # a streamed delivery -> stream track_source
+        index.upsert_many([stream])
+
+        n_tracks = c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in c.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (file_id,)
+            )
+        )
+        # One row survives — the incumbent local file — now carrying both sources.
+        assert n_tracks == 1
+        assert kinds == ["file", "stream"]
+        assert c.execute("SELECT id FROM tracks").fetchone()[0] == file_id
+        assert index.preferred_source(file_id)["kind"] == "file"
+        # has_remote_album_tracks now sees the attached stream source (collapse-aware),
+        # so a subsequent sync skips re-fetching and re-forking it.
+        assert index.has_remote_album_tracks("s7") is True
+        index.close()
+
     def test_remove_download_refuses_when_no_stream_source(
         self, tmp_path: Path
     ) -> None:
@@ -677,6 +737,63 @@ class TestLibraryIndex:
         assert t["file_mtime"] == 123.0
         assert t["source"] == "local" and t["file_path"] == "/m/a.mp3"
         assert a_art == 1  # album cover restored
+
+    def test_v48_heals_sync_forked_stream_duplicate(self, tmp_path: Path) -> None:
+        """v48 merges a stream-only row the sync forked beside a download (KAMP-541).
+
+        Reproduces the download-only album whose stream arrived via a later sync
+        as a SEPARATE stream-only tracks row (before the symmetric reconcile). The
+        heal re-runs the collapse: survivor is the local file, the stream re-parents
+        as a source, the duplicate row is gone.
+        """
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid48')")
+        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        # Downloaded canonical (file source, sale_item_id) + a forked stream-only row.
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, sale_item_id) VALUES ('/m/a.mp3','local',?,1,1,'sid48')",
+            (alb,),
+        )
+        file_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/a.mp3')",
+            (file_id,),
+        )
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number, disc_number)"
+            " VALUES ('bandcamp://sid48/1','bandcamp',?,1,1)",
+            (alb,),
+        )
+        stream_id = c.execute(
+            "SELECT id FROM tracks WHERE id != ?", (file_id,)
+        ).fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri)"
+            " VALUES (?, 'stream', 'bandcamp://sid48/1')",
+            (stream_id,),
+        )
+        c.execute("UPDATE schema_version SET version = 47")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # runs the v48 heal
+        hc = healed._conn
+        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in hc.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (file_id,)
+            )
+        )
+        surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
+        healed.close()
+        assert n_tracks == 1  # the forked stream row is gone
+        assert surv == file_id  # survivor is the local download
+        assert kinds == ["file", "stream"]  # stream re-parented onto it
 
     def test_all_downloads_streamable(self, tmp_path: Path) -> None:
         """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
@@ -2388,7 +2505,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2445,7 +2562,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3040,7 +3157,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert row is not None
         assert row[0] == 0
 
@@ -3495,7 +3612,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3591,7 +3708,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3772,7 +3889,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -3867,7 +3984,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 47
+        assert version == 48
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -3875,7 +3992,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 47
+        assert version == 48
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4752,7 +4869,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 47
+        assert version == 48
 
         index.close()
 
@@ -5443,7 +5560,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 47
+        assert version == 48
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5478,7 +5595,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 47
+        assert version == 48
         index.close()
 
 
@@ -5993,7 +6110,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 47
+        assert version == 48
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6126,7 +6243,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 47
+        assert version == 48
 
 
 class TestRemoteTrackSchema:
@@ -6460,7 +6577,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6521,7 +6638,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7279,7 +7396,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -7838,7 +7955,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -7916,7 +8033,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8122,7 +8239,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8471,7 +8588,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8568,7 +8685,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8684,7 +8801,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9189,7 +9306,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9304,7 +9421,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9402,7 +9519,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9502,7 +9619,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10009,7 +10126,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 47
+        assert version == 48
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -10853,7 +10970,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 47
+        assert version == 48
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -11824,7 +11941,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 47
+        assert version == 48
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -11844,7 +11961,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 47
+        assert version == 48
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -11886,7 +12003,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 47
+        assert version == 48
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -583,11 +583,25 @@ class TestLibraryIndex:
                 "SELECT kind FROM track_sources WHERE track_id = ?", (surviving_id,)
             )
         )
-        index.close()
+        # The runtime reconcile keeps the INCUMBENT (the pre-existing canonical a
+        # live queue / open album view already references) rather than the file
+        # row the offline migration prefers — see _reconcile_scanned_tracks.
         assert n_tracks == 1
         assert kinds == ["file", "stream"]
-        # Prefer-file: the local (new) row survives; the stream row is merged away.
-        assert surviving_id != stream_id
+        assert surviving_id == stream_id
+        # The stale queued stream uri still resolves to the survivor, and its
+        # preferred source is now the downloaded file (KAMP-541 regression guard:
+        # a favorite via the transport 404'd and a queue jump replayed the stream).
+        assert index.get_track_by_path("bandcamp://z/1").id == stream_id
+        assert index.preferred_source(stream_id)["kind"] == "file"
+        index.set_favorite("bandcamp://z/1", True)
+        assert (
+            c.execute(
+                "SELECT favorite FROM track_stats WHERE track_id = ?", (stream_id,)
+            ).fetchone()["favorite"]
+            == 1
+        )
+        index.close()
 
     def test_remove_download_refuses_when_no_stream_source(
         self, tmp_path: Path

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -544,7 +544,8 @@ class TestLibraryIndex:
         healed.close()
         assert n_tracks == 1  # merged
         assert n_src == 2  # both sources derived + re-parented
-        assert n_ops == 1 and op_tid == stream_id  # survivor's op kept, loser's dropped
+        # Prefer-file: the local row survives, so its deferred op is kept.
+        assert n_ops == 1 and op_tid == local_id
 
     def test_upsert_attaches_new_download_to_existing_canonical(
         self, tmp_path: Path
@@ -575,15 +576,18 @@ class TestLibraryIndex:
         index.upsert_many([_sample_track(tmp_path / "track1.mp3")])
 
         n_tracks = c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        surviving_id = c.execute("SELECT id FROM tracks").fetchone()[0]
         kinds = sorted(
             r["kind"]
             for r in c.execute(
-                "SELECT kind FROM track_sources WHERE track_id = ?", (stream_id,)
+                "SELECT kind FROM track_sources WHERE track_id = ?", (surviving_id,)
             )
         )
         index.close()
         assert n_tracks == 1
         assert kinds == ["file", "stream"]
+        # Prefer-file: the local (new) row survives; the stream row is merged away.
+        assert surviving_id != stream_id
 
     def test_remove_download_refuses_when_no_stream_source(
         self, tmp_path: Path
@@ -759,7 +763,9 @@ class TestLibraryIndex:
         )
         alb = c.execute("SELECT id FROM albums").fetchone()[0]
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid9')")
-        # Stream row first (lower id → survivor), favorite=1 pc=2; local second, pc=5.
+        # Stream row first (lower id), favorite=1 pc=2; local second, pc=5. Under
+        # prefer-file the LOCAL row survives; the playlist/queue point at the stream
+        # (loser) so the repoint is exercised.
         c.execute(
             "INSERT INTO tracks (file_path, title, album, album_artist, source,"
             " album_id, track_number, disc_number, sale_item_id, favorite, play_count)"
@@ -794,12 +800,12 @@ class TestLibraryIndex:
         pl = c.execute("SELECT id FROM playlists").fetchone()[0]
         c.execute(
             "INSERT INTO playlist_tracks (playlist_id, track_id, position) VALUES (?,?,0)",
-            (pl, local_id),
+            (pl, stream_id),
         )
         c.execute(
             "INSERT INTO queue_state (id, tracks, order_json, pos, shuffle, repeat)"
             " VALUES (1, ?, '[0]', 0, 0, 'off')",
-            (json.dumps([local_id]),),
+            (json.dumps([stream_id]),),
         )
         c.execute("UPDATE schema_version SET version = 45")
         c.commit()
@@ -827,13 +833,13 @@ class TestLibraryIndex:
         healed.close()
 
         assert n_tracks == 1
-        assert surv["id"] == stream_id  # lower id survives
+        assert surv["id"] == local_id  # prefer-file: the local row survives
         assert (surv["favorite"], surv["play_count"]) == (1, 5)  # MAX merge
         assert (st["favorite"], st["play_count"]) == (1, 5)  # track_stats re-derived
         assert n_src == 2  # both sources re-parented onto the survivor
         assert surv["file_path"] == "/m/1.mp3"  # realigned to preferred (file) source
-        assert pl_tid == stream_id  # playlist repointed loser→survivor
-        assert q == [stream_id]  # queue repointed
+        assert pl_tid == local_id  # playlist repointed loser→survivor
+        assert q == [local_id]  # queue repointed
 
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -421,6 +421,56 @@ class TestLibraryIndex:
         assert pref["kind"] == "stream"
         assert pref["uri"] == "bandcamp://9/1"
 
+    def test_remove_track_keeps_track_with_surviving_stream(
+        self, tmp_path: Path
+    ) -> None:
+        """Removing a local file drops its source but keeps a track that still streams (KAMP-541 C2)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('/m/a.mp3', 'local')"
+        )
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        index._conn.executemany(
+            "INSERT INTO track_sources (track_id, kind, uri, is_available)"
+            " VALUES (?, ?, ?, ?)",
+            [(tid, "file", "/m/a.mp3", 1), (tid, "stream", "bandcamp://9/1", 1)],
+        )
+        index._conn.commit()
+
+        index.remove_track(Path("/m/a.mp3"))
+
+        track_still_there = index._conn.execute(
+            "SELECT id FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()
+        srcs = [
+            r["kind"]
+            for r in index._conn.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (tid,)
+            )
+        ]
+        index.close()
+        assert track_still_there is not None  # track survives
+        assert srcs == ["stream"]  # only the stream source remains
+
+    def test_remove_track_deletes_sourceless_track(self, tmp_path: Path) -> None:
+        """Removing the only (file) source deletes the canonical track (KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index._conn.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('/m/solo.mp3', 'local')"
+        )
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        index._conn.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/solo.mp3')",
+            (tid,),
+        )
+        index._conn.commit()
+
+        index.remove_track(Path("/m/solo.mp3"))
+
+        n = index._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        index.close()
+        assert n == 0
+
     def test_upsert_adds_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         index.upsert_track(_sample_track(tmp_path / "01.mp3"))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -426,18 +426,20 @@ class TestLibraryIndex:
     ) -> None:
         """Removing a local file drops its source but keeps a track that still streams (KAMP-541 C2)."""
         index = LibraryIndex(tmp_path / "library.db")
+        # Use a real platform path so str(fp) matches the stored uri on Windows too.
+        fp = tmp_path / "a.mp3"
         index._conn.execute(
-            "INSERT INTO tracks (file_path, source) VALUES ('/m/a.mp3', 'local')"
+            "INSERT INTO tracks (file_path, source) VALUES (?, 'local')", (str(fp),)
         )
         tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
         index._conn.executemany(
             "INSERT INTO track_sources (track_id, kind, uri, is_available)"
             " VALUES (?, ?, ?, ?)",
-            [(tid, "file", "/m/a.mp3", 1), (tid, "stream", "bandcamp://9/1", 1)],
+            [(tid, "file", str(fp), 1), (tid, "stream", "bandcamp://9/1", 1)],
         )
         index._conn.commit()
 
-        index.remove_track(Path("/m/a.mp3"))
+        index.remove_track(fp)
 
         track_still_there = index._conn.execute(
             "SELECT id FROM tracks WHERE id = ?", (tid,)
@@ -455,17 +457,18 @@ class TestLibraryIndex:
     def test_remove_track_deletes_sourceless_track(self, tmp_path: Path) -> None:
         """Removing the only (file) source deletes the canonical track (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        fp = tmp_path / "solo.mp3"
         index._conn.execute(
-            "INSERT INTO tracks (file_path, source) VALUES ('/m/solo.mp3', 'local')"
+            "INSERT INTO tracks (file_path, source) VALUES (?, 'local')", (str(fp),)
         )
         tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
         index._conn.execute(
-            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/solo.mp3')",
-            (tid,),
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', ?)",
+            (tid, str(fp)),
         )
         index._conn.commit()
 
-        index.remove_track(Path("/m/solo.mp3"))
+        index.remove_track(fp)
 
         n = index._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
         index.close()
@@ -690,11 +693,12 @@ class TestLibraryIndex:
     def test_remove_track_legacy_row_without_source(self, tmp_path: Path) -> None:
         """A pre-collapse tracks row with no source is removed by file_path (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        fp = tmp_path / "legacy.mp3"
         index._conn.execute(
-            "INSERT INTO tracks (file_path, source) VALUES ('/m/legacy.mp3', 'local')"
+            "INSERT INTO tracks (file_path, source) VALUES (?, 'local')", (str(fp),)
         )
         index._conn.commit()
-        index.remove_track(Path("/m/legacy.mp3"))
+        index.remove_track(fp)
         n = index._conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
         index.close()
         assert n == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4887,6 +4887,43 @@ class TestResolvePlaybackUri:
             "bandcamp://777/2", "https://cdn.example.com/new.mp3", 9999.0
         )
 
+    def test_resolves_via_stream_source_and_refreshes_onto_source(
+        self, tmp_path: Path
+    ) -> None:
+        """A track with a stream source resolves+refreshes via track_sources (KAMP-541)."""
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(tmp_path / "l.db")
+        c = idx._conn
+        c.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, album_url)"
+            " VALUES ('sid', 'https://a.bandcamp.com/album/x')"
+        )
+        c.execute(
+            "INSERT INTO tracks (file_path, source) VALUES ('bandcamp://sid/2', 'bandcamp')"
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, provider, provider_item_id, uri,"
+            " stream_url, stream_url_expires_at)"
+            " VALUES (?, 'stream', 'bandcamp', 'sid', 'bandcamp://sid/2',"
+            " 'https://cdn/old.mp3', 0.0)",
+            (tid,),
+        )
+        c.commit()
+        track = idx.get_track_by_id(tid)
+        refresh_fn = MagicMock(return_value=("https://cdn/new.mp3", 9999.0))
+
+        result = resolve_playback_uri(track, idx, refresh_fn)
+
+        refresh_fn.assert_called_once_with("https://a.bandcamp.com/album/x", 2)
+        persisted = c.execute(
+            "SELECT stream_url FROM track_sources WHERE track_id = ?", (tid,)
+        ).fetchone()[0]
+        idx.close()
+        assert result == "https://cdn/new.mp3"
+        assert persisted == "https://cdn/new.mp3"  # written onto the source row
+
     def test_head_check_passes_returns_cached_url(self) -> None:
         """If HEAD returns 2xx, no refresh is triggered and the cached URL is used."""
         import time

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2843,146 +2843,6 @@ class TestBandcampRemoveDownload:
         resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
         assert resp.status_code == 409
 
-    def test_swaps_queue_to_streaming_when_stopped(
-        self,
-        mock_index: MagicMock,
-        mock_engine: MagicMock,
-        mock_queue: MagicMock,
-    ) -> None:
-        """When the local track is queued but transport is stopped, swap the
-        queue entry to the streaming equivalent and proceed without a 409."""
-        from kamp_core.library import Track
-        from pathlib import Path as _Path
-
-        mock_index.get_collection_item.return_value = {
-            "sale_item_id": "42",
-            "mode": "local",
-        }
-        local_track = Track(
-            file_path=_Path("/music/Artist/Album/01.flac"),
-            title="Track",
-            artist="Artist",
-            album_artist="Artist",
-            album="Album",
-            release_date="2024",
-            track_number=1,
-            disc_number=1,
-            ext="flac",
-            embedded_art=False,
-            mb_release_id="",
-            mb_recording_id="",
-        )
-        local_track.id = 77
-        local_track.album_id = 5
-
-        streaming_track = Track(
-            file_path=_Path("bandcamp://42/1"),
-            title="Track",
-            artist="Artist",
-            album_artist="Artist",
-            album="Album",
-            release_date="2024",
-            track_number=1,
-            disc_number=1,
-            ext="mp3",
-            embedded_art=False,
-            mb_release_id="",
-            mb_recording_id="",
-        )
-        streaming_track.id = 78
-
-        mock_index.local_tracks_for_sale_item_id.return_value = [local_track]
-        mock_index.streaming_track_for_local_id.return_value = streaming_track
-        mock_index.remove_download.return_value = []
-        mock_queue.current.return_value = local_track
-        mock_queue.peek_next.return_value = None
-        mock_engine.state.playing = False
-
-        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
-        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
-
-        assert resp.status_code == 200
-        mock_queue.update_track_by_id.assert_called_once_with(77, streaming_track)
-        mock_engine.unload.assert_called_once()
-
-    def test_swaps_all_queued_tracks_not_just_current(
-        self,
-        mock_index: MagicMock,
-        mock_engine: MagicMock,
-        mock_queue: MagicMock,
-    ) -> None:
-        """All local tracks in the queue are swapped, not just current/next.
-
-        Without this, tracks beyond 'next' survive in memory but point at local
-        paths that no longer exist in the DB after deletion, so they are silently
-        dropped when the queue is restored on the next restart."""
-        from kamp_core.library import Track
-        from pathlib import Path as _Path
-
-        mock_index.get_collection_item.return_value = {
-            "sale_item_id": "42",
-            "mode": "local",
-        }
-
-        def _make_local(n: int) -> Track:
-            t = Track(
-                file_path=_Path(f"/music/Artist/Album/0{n}.flac"),
-                title=f"Track {n}",
-                artist="Artist",
-                album_artist="Artist",
-                album="Album",
-                release_date="2024",
-                track_number=n,
-                disc_number=1,
-                ext="flac",
-                embedded_art=False,
-                mb_release_id="",
-                mb_recording_id="",
-            )
-            t.id = 100 + n
-            return t
-
-        def _make_streaming(n: int) -> Track:
-            t = Track(
-                file_path=_Path(f"bandcamp://42/{n}"),
-                title=f"Track {n}",
-                artist="Artist",
-                album_artist="Artist",
-                album="Album",
-                release_date="2024",
-                track_number=n,
-                disc_number=1,
-                ext="mp3",
-                embedded_art=False,
-                mb_release_id="",
-                mb_recording_id="",
-            )
-            t.id = 200 + n
-            return t
-
-        local_tracks = [_make_local(i) for i in range(1, 5)]
-        streaming_tracks = {100 + i: _make_streaming(i) for i in range(1, 5)}
-
-        mock_index.local_tracks_for_sale_item_id.return_value = local_tracks
-        mock_index.streaming_track_for_local_id.side_effect = (
-            lambda tid: streaming_tracks.get(tid)
-        )
-        mock_index.remove_download.return_value = []
-        # Only track 1 is current; tracks 2–4 are further in the queue (not locked).
-        mock_queue.current.return_value = local_tracks[0]
-        mock_queue.peek_next.return_value = local_tracks[1]
-        mock_engine.state.playing = False
-
-        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
-        resp = TestClient(app).delete("/api/v1/bandcamp/collection/42/download")
-
-        assert resp.status_code == 200
-        # All four tracks must have been swapped.
-        swapped_ids = {
-            call.args[0] for call in mock_queue.update_track_by_id.call_args_list
-        }
-        assert swapped_ids == {101, 102, 103, 104}
-
     def test_returns_200_and_broadcasts_removed(
         self,
         mock_index: MagicMock,
@@ -3139,7 +2999,7 @@ class TestBandcampRemoveDownload:
         """A download-mode album with no stream rows fetches + materializes them
         before remove_download runs."""
         mock_index.get_collection_item.return_value = self._download_only_item()
-        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.all_downloads_streamable.return_value = False
         mock_index.local_tracks_for_sale_item_id.return_value = []
         mock_index.remove_download.return_value = []
         mock_engine.state.playing = False
@@ -3171,7 +3031,7 @@ class TestBandcampRemoveDownload:
         mock_queue: MagicMock,
     ) -> None:
         mock_index.get_collection_item.return_value = self._download_only_item()
-        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.all_downloads_streamable.return_value = False
         mock_index.local_tracks_for_sale_item_id.return_value = []
         mock_engine.state.playing = False
 
@@ -3195,7 +3055,7 @@ class TestBandcampRemoveDownload:
     ) -> None:
         """fetch_album_tracks returning nothing => no streamable version; abort."""
         mock_index.get_collection_item.return_value = self._download_only_item()
-        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.all_downloads_streamable.return_value = False
         mock_index.local_tracks_for_sale_item_id.return_value = []
         mock_engine.state.playing = False
 
@@ -3222,7 +3082,7 @@ class TestBandcampRemoveDownload:
         mock_queue: MagicMock,
     ) -> None:
         mock_index.get_collection_item.return_value = self._download_only_item()
-        mock_index.has_remote_album_tracks.return_value = False
+        mock_index.all_downloads_streamable.return_value = False
         mock_index.local_tracks_for_sale_item_id.return_value = []
         mock_engine.state.playing = False
 
@@ -3255,9 +3115,8 @@ class TestBandcampRemoveDownload:
         from kamp_core.library import NoStreamableVersionError
 
         mock_index.get_collection_item.return_value = self._download_only_item()
-        mock_index.has_remote_album_tracks.return_value = True
+        mock_index.all_downloads_streamable.return_value = True
         mock_index.local_tracks_for_sale_item_id.return_value = []
-        mock_index.streaming_track_for_local_id.return_value = None
         mock_index.remove_download.side_effect = NoStreamableVersionError("nope")
         mock_engine.state.playing = False
 

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -173,6 +173,10 @@ class TestLibraryIndexTagEdit:
         # Stats preserved.
         assert updated.id == original.id
         assert updated.mb_recording_id == original.mb_recording_id
+        # The file source uri follows the rename (KAMP-541): the scanner reads
+        # indexed paths from track_sources, so a stale old uri would make the
+        # next scan drop this track and re-fork the moved file.
+        assert list(index.indexed_paths()) == [new_path]
         index.close()
 
     def test_move_track_preserves_stats(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## KAMP-541 — the atomic core of the canonical-track refactor

Collapses each track's streaming + local sibling rows into ONE canonical `tracks` row (both deliveries move to `track_sources`), and switches the source/ingest/playback/removal paths onto `track_sources`. **This fixes KAMP-532.** Epic KAMP-533; design note `docs/design/KAMP-533-canonical-track-identity.md` §3/§5/§7. Order: 535 ✅ 536 ✅ 540 ✅ → **541** → 542 → 537/538 → 539.

### Why collapse + ingest switch had to ship together
A Reality-Checker pass proved the collapse can't ship alone: the scanner keyed on `tracks.file_path`/`source='local'`, so post-collapse it would **self-revert** (re-fork a deleted row on the next scan) or **strand a track** (cascade-delete a surviving stream + stats when a local file goes missing). So this PR bundles the collapse with the scanner/ingest/removal read-write switch.

### What's in it (staged commits)
1. **Preferred-source playback** — `resolve_playback_uri` selects file-over-stream via `track_sources` (availability first, so a missing local file falls through to the stream); refreshed CDN url cached on the source row.
2. **Scanner read/remove** — `indexed_paths*` and `remove_track` operate on `track_sources` (fixes self-revert + strand-a-track).
3. **v46 collapse migration + merge machinery** — buckets siblings (album tuple w/ agreeing `sale_item_id`; loose singles by `sale_item_id`; else solo), quarantines ambiguous buckets, MAX-merges stats onto the survivor, COALESCE-merges identity, re-parents sources, repoints playlists/queue/`deferred_ops`, refreshes aggregates. Backup-first, one transaction, `schema_version` bumped last, rollback-on-failure, gated so a library with no duplicates does no work.
4. **Ingest + delete-download rework** — `upsert_many` attaches a new download as a source of the existing canonical track (no re-fork); `remove_download` drops file sources and reverts to stream (KAMP-527 fail-safe = "every track keeps a stream source"); `materialize_stream_tracks` attaches stream sources; `streaming_track_for_local_id` + the queue-swap deleted (queue-by-id makes them unnecessary); `tracks_for_album`/`search` drop the local-wins filter.

### Verification
- Full suite: **2211 passed, 9 skipped**; `black` + `mypy` clean; coverage **93.00%** (at the gate — see note below).
- New automated coverage of the plan's verify scenarios: collapse merges + repoints; scan after collapse does not re-fork; a new download attaches as a source (no fork); remove-download post-collapse keeps a playable stream and never strands a track; the KAMP-527 fail-safe refuses when no stream remains; missing-local → stream fallback; collapse quarantines ambiguous buckets; derive-missing-source + `deferred_ops` dedupe.

### Notes / follow-ups
- **Coverage is exactly 93.00%** (baseline was 93.18%; this PR adds a lot of new code). It clears the gate but has no margin — a few more branch tests would be prudent. Flagging rather than burying it.
- Still deferred to later tickets: **KAMP-542** (pure-stats reads → `track_stats` + `criteria.py`), **537/538** (API/UI on `id`), **539** (drop the now-duplicated `tracks` columns + delete the dead reconcile helpers). Until 539, the legacy `tracks` columns are kept coherent with the preferred source.

### Manual test plan (you drive the app; your DB is backed up)
- [x] The KAMP-532 repro: favorite a track via the transport after downloading its album → shows favorited on the album page.
- [x] Play a track whose local file is missing → falls back to the stream.
- [x] Remove a download → album flips to streaming, still plays; queue survives a restart.
- [ ] Run a library scan → no duplicate rows appear; re-download an album → attaches, no dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)