### PR TITLE
fix(library): behavior-neutral read-switch onto track_stats/track_sources (KAMP-542)

### DIFF
--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -11,6 +11,21 @@ if TYPE_CHECKING:
 # Field registry
 # ---------------------------------------------------------------------------
 
+# A track's effective (preferred) source, reconstructed from track_sources
+# (KAMP-542). Reproduces post-collapse tracks.source (preferred delivery, mapped
+# file->'local' / stream->'bandcamp'), with a COALESCE fallback to the legacy
+# column for a sourceless row (dropped with the column in KAMP-539). Correlated
+# on `tracks.id` — the magic-playlist evaluation queries alias the row source as
+# `tracks`. Lets `track.source` criteria read track_sources with no value rewrite
+# in stored criteria_json (the compared values stay 'local'/'bandcamp'), so the
+# existing is/is_not/contains operator handling works unchanged.
+_EFFECTIVE_SOURCE_SQL = (
+    "COALESCE((SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
+    " FROM track_sources s WHERE s.track_id = tracks.id"
+    " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1),"
+    " tracks.source)"
+)
+
 # Maps field name → (sql_column_expr, value_type).
 # value_type controls coercion and, for "year", special CAST wrapping on
 # numeric operators.
@@ -28,7 +43,7 @@ _FIELD_MAP: dict[str, tuple[str, str]] = {
     "track.artist": ("tracks.artist", "text"),
     "track.album_artist": ("tracks.album_artist", "text"),
     "track.album": ("tracks.album", "text"),
-    "track.source": ("tracks.source", "text"),
+    "track.source": (_EFFECTIVE_SOURCE_SQL, "text"),
 }
 
 # Fields whose SQL expression references the albums table.

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3346,7 +3346,7 @@ class LibraryIndex:
         attached = 0
         try:
             for t in tracks:
-                uri = _canonical_track_key(t.file_path)
+                uri = _canonical_track_uri(t.file_path)
                 row = self._conn.execute(
                     "SELECT t.id FROM tracks t"
                     " LEFT JOIN albums a ON a.id = t.album_id"
@@ -3807,7 +3807,7 @@ class LibraryIndex:
         )
 
         # Step 3: assign album_id on the track rows we just inserted/updated.
-        file_paths = [_canonical_track_key(t.file_path) for t in named]
+        file_paths = [_canonical_track_uri(t.file_path) for t in named]
 
         # Step 3a (KAMP-523): link provenanced tracks by identity. Resolve each
         # trusted sale_item_id to its album — adopting the existing streaming
@@ -3848,7 +3848,7 @@ class LibraryIndex:
             for t in tracks:
                 if not (_provenanced(t) and t.sale_item_id in prov_targets):
                     continue
-                fp = _canonical_track_key(t.file_path)
+                fp = _canonical_track_uri(t.file_path)
                 prov_paths.add(fp)
                 prov_album_ids.add(prov_targets[t.sale_item_id])
                 self._conn.execute(
@@ -3870,7 +3870,7 @@ class LibraryIndex:
                     continue
                 self._conn.execute(
                     "UPDATE tracks SET sale_item_id = ? WHERE file_path = ?",
-                    (t.sale_item_id, _canonical_track_key(t.file_path)),
+                    (t.sale_item_id, _canonical_track_uri(t.file_path)),
                 )
 
         # Step 3b: link the remaining (un-provenanced) tracks by name. TRIM on
@@ -3899,7 +3899,7 @@ class LibraryIndex:
         # streaming single-album by identity (local.title == the single-album's
         # album field). Shared with the v42 migration via one helper.
         single_paths = [
-            _canonical_track_key(t.file_path)
+            _canonical_track_uri(t.file_path)
             for t in tracks
             if t.source == "local"
             and not t.album.strip()
@@ -3937,7 +3937,7 @@ class LibraryIndex:
         # this only populates the children for KAMP-541/542.
         src_params: list[tuple[Any, ...]] = []
         for t in tracks:
-            key = _canonical_track_key(t.file_path)
+            key = _canonical_track_uri(t.file_path)
             _uri, kind, provider, provider_item_id = _derive_source_fields(
                 t.file_path, t.source, t.sale_item_id
             )
@@ -4609,7 +4609,7 @@ class LibraryIndex:
         to the normalized uri when nothing matches, leaving the caller's write a
         harmless no-op exactly as before.
         """
-        key = _canonical_track_key(uri)
+        key = _canonical_track_uri(uri)
         if self._conn.execute(
             "SELECT 1 FROM tracks WHERE file_path = ? LIMIT 1", (key,)
         ).fetchone():
@@ -4711,7 +4711,7 @@ class LibraryIndex:
         Orthogonal to record_played: that updates tracks.play_count; this updates artists.play_time.
         For Various Artists albums, credits the track-level artist instead of the album artist.
         """
-        key = _canonical_track_key(file_path)
+        key = _canonical_track_uri(file_path)
         row = self._conn.execute(
             "SELECT artist, album_artist FROM tracks WHERE file_path = ?", (key,)
         ).fetchone()
@@ -5259,7 +5259,7 @@ class LibraryIndex:
             "SELECT t.* FROM track_sources s"
             " JOIN tracks_with_stats t ON t.id = s.track_id"
             " WHERE s.uri = ? AND s.kind = 'stream' LIMIT 1",
-            (_canonical_track_key(key),),
+            (_canonical_track_uri(key),),
         ).fetchone()
         return _row_to_track(src) if src else None
 
@@ -6421,7 +6421,7 @@ _WRITABLE_TRACK_FIELDS: frozenset[str] = frozenset(
 )
 
 
-def _canonical_track_key(path: "Path | str") -> str:
+def _canonical_track_uri(path: "Path | str") -> str:
     """Return the canonical file_path key for *path*.
 
     For bandcamp:// URIs, normalises the single-slash POSIX form (bandcamp:/)
@@ -6461,7 +6461,7 @@ def _derive_source_fields(
     Shared by the v45 backfill and upsert_many so the scan and the migration
     derive identical rows.
     """
-    uri = _canonical_track_key(file_path)
+    uri = _canonical_track_uri(file_path)
     kind = "file" if source == "local" else "stream"
     provider = "bandcamp" if (source == "bandcamp" or sale_item_id) else ""
     provider_item_id = sale_item_id or None
@@ -6500,7 +6500,7 @@ def _track_to_params(
     float,
 ]:
     return (
-        _canonical_track_key(t.file_path),
+        _canonical_track_uri(t.file_path),
         t.title,
         t.artist,
         t.album_artist,
@@ -6549,7 +6549,7 @@ def _row_to_pending_ingest(row: sqlite3.Row) -> PendingIngest:
 def _row_to_track(row: sqlite3.Row) -> Track:
     # DB rows store canonical bandcamp:// form (ensured by _track_to_params and
     # migration v22). Path() on POSIX still collapses the double-slash to single,
-    # but all callers that need a stable string key use _canonical_track_key() or
+    # but all callers that need a stable string key use _canonical_track_uri() or
     # get_track_by_path(str) rather than str(track.file_path), so this is safe.
     return Track(
         id=row["id"],

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -731,6 +731,7 @@ class LibraryIndex:
         if db_path.exists():
             db_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
         self._migrate()
+        self._create_tracks_with_stats_view()
 
     def _make_conn(self) -> sqlite3.Connection:
         """Open a new SQLite connection configured for use in this index."""
@@ -1902,6 +1903,38 @@ class LibraryIndex:
             self._conn.execute("UPDATE schema_version SET version = 48")
             self._conn.commit()
             version = 48  # noqa: F841
+
+    def _create_tracks_with_stats_view(self) -> None:
+        """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542).
+
+        Projects every ``tracks`` column but shadows ``favorite``/``play_count``/
+        ``last_played`` from ``track_stats`` — the authoritative store since the
+        KAMP-540 dual-write — so read paths resolve stats from the child table and
+        KAMP-539 can drop the legacy columns. While both coexist the shadow
+        COALESCEs back to the legacy column, so a track that somehow lacks a
+        ``track_stats`` row still reads its real value rather than a spurious 0;
+        once 539 drops the legacy columns the fallback becomes the type default.
+
+        Built from ``PRAGMA table_info`` and recreated on every open so it always
+        matches the current ``tracks`` schema (survives 539's column drop with no
+        edit here). Read-only by construction: every writer (UPDATE/INSERT/upsert,
+        the ``tracks_fts`` rowid join, the stat mirrors) stays on the base table,
+        whose ``id`` the view preserves so FTS rowid joins still resolve.
+        """
+        cols = [r[1] for r in self._conn.execute("PRAGMA table_info(tracks)")]
+        # column -> SQL default used once the legacy column is dropped (KAMP-539).
+        stats_default = {"favorite": "0", "play_count": "0", "last_played": "NULL"}
+        projected = [f"t.{c}" for c in cols if c not in stats_default]
+        for name, default in stats_default.items():
+            fallback = f"t.{name}" if name in cols else default
+            projected.append(f"COALESCE(ts.{name}, {fallback}) AS {name}")
+        self._conn.executescript(
+            "DROP VIEW IF EXISTS tracks_with_stats;\n"
+            "CREATE VIEW tracks_with_stats AS SELECT "
+            + ", ".join(projected)
+            + " FROM tracks t LEFT JOIN track_stats ts ON ts.track_id = t.id;"
+        )
+        self._conn.commit()
 
     def _backup_db(self, label: str) -> bool:
         """Snapshot the live DB (incl. WAL) before a mutating heal; return success.
@@ -3127,7 +3160,7 @@ class LibraryIndex:
         """
         rows = self._conn.execute(
             """
-            SELECT DISTINCT t.* FROM tracks t
+            SELECT DISTINCT t.* FROM tracks_with_stats t
             LEFT JOIN albums a ON a.id = t.album_id
             WHERE (a.sale_item_id = ? OR t.sale_item_id = ?)
               AND t.file_path NOT LIKE 'bandcamp://%'
@@ -3966,11 +3999,11 @@ class LibraryIndex:
             UPDATE albums SET
                 embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks t WHERE t.album_id = albums.id),
                 date_added     = (SELECT MIN(t.date_added)    FROM tracks t WHERE t.album_id = albums.id),
-                last_played_at = (SELECT MAX(t.last_played)   FROM tracks t WHERE t.album_id = albums.id),
+                last_played_at = (SELECT MAX(t.last_played)   FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 art_version    = (SELECT MAX(CASE WHEN t.source = 'local' THEN t.file_mtime END)
                                   FROM tracks t WHERE t.album_id = albums.id),
                 play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
-                                  FROM tracks t WHERE t.album_id = albums.id),
+                                  FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 source         = (SELECT
                                       CASE WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
                                                 AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
@@ -4550,13 +4583,14 @@ class LibraryIndex:
 
     def all_tracks(self) -> list[Track]:
         """Return all indexed tracks in insertion order."""
-        rows = self._conn.execute("SELECT * FROM tracks").fetchall()
+        rows = self._conn.execute("SELECT * FROM tracks_with_stats").fetchall()
         return [_row_to_track(r) for r in rows]
 
     def top_tracks(self, limit: int) -> list[Track]:
         """Return the top *limit* tracks by play_count descending, excluding unplayed."""
         rows = self._conn.execute(
-            "SELECT * FROM tracks WHERE play_count > 0 ORDER BY play_count DESC LIMIT ?",
+            "SELECT * FROM tracks_with_stats WHERE play_count > 0"
+            " ORDER BY play_count DESC LIMIT ?",
             (limit,),
         ).fetchall()
         return [_row_to_track(r) for r in rows]
@@ -4650,18 +4684,21 @@ class LibraryIndex:
             "UPDATE tracks SET play_count = play_count + 1 WHERE file_path = ?",
             (key,),
         )
+        # Mirror the post-increment absolute value (not a +1) into track_stats
+        # BEFORE recomputing the album average — that recompute now reads
+        # play_count through the tracks_with_stats view (i.e. from track_stats),
+        # so the mirror must land first or the average sees the stale value.
+        self._mirror_track_stats(key, ("play_count",))
         self._conn.execute(
             """
             UPDATE albums SET play_count_avg = (
                 SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
-                FROM tracks t WHERE t.album_id = albums.id
+                FROM tracks_with_stats t WHERE t.album_id = albums.id
             )
             WHERE id = (SELECT album_id FROM tracks WHERE file_path = ?)
             """,
             (key,),
         )
-        # Mirror the post-increment absolute value (not a +1) into track_stats.
-        self._mirror_track_stats(key, ("play_count",))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.play_count"})
@@ -4737,7 +4774,7 @@ class LibraryIndex:
             "SELECT COALESCE(SUM(play_time), 0) FROM artists"
         ).fetchone()[0]
         total_plays = c.execute(
-            "SELECT COALESCE(SUM(play_count), 0) FROM tracks"
+            "SELECT COALESCE(SUM(play_count), 0) FROM tracks_with_stats"
         ).fetchone()[0]
         albums_played = c.execute(
             "SELECT COUNT(*) FROM albums WHERE play_count_avg > 0"
@@ -4973,7 +5010,7 @@ class LibraryIndex:
         )
         self._conn.commit()
         row = self._conn.execute(
-            "SELECT * FROM tracks WHERE id = ?", (track_id,)
+            "SELECT * FROM tracks_with_stats WHERE id = ?", (track_id,)
         ).fetchone()
         return _row_to_track(row) if row else None
 
@@ -5053,7 +5090,7 @@ class LibraryIndex:
                 -- effective album title used for sort-by-album ordering.
                 COALESCE(a.display_album, a.album) AS sort_album
             FROM albums a
-            LEFT JOIN tracks t ON t.album_id = a.id
+            LEFT JOIN tracks_with_stats t ON t.album_id = a.id
             LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id
             GROUP BY a.id
             UNION ALL
@@ -5084,7 +5121,7 @@ class LibraryIndex:
                 NULL                AS display_album,
                 NULL                AS display_album_artist,
                 t.title             AS sort_album
-            FROM tracks t
+            FROM tracks_with_stats t
             WHERE t.album = ''
             ORDER BY {order_by}
             """).fetchall()  # noqa: S608 — order_by is from a whitelist, not user input
@@ -5151,7 +5188,8 @@ class LibraryIndex:
         if album_id is None:
             return []
         rows = self._conn.execute(
-            "SELECT * FROM tracks WHERE album_id = ? ORDER BY disc_number, track_number",
+            "SELECT * FROM tracks_with_stats WHERE album_id = ?"
+            " ORDER BY disc_number, track_number",
             (album_id,),
         ).fetchall()
         return [_row_to_track(r) for r in rows]
@@ -5162,7 +5200,7 @@ class LibraryIndex:
             """
             SELECT t.*
             FROM playlist_tracks pt
-            JOIN tracks t ON t.id = pt.track_id
+            JOIN tracks_with_stats t ON t.id = pt.track_id
             WHERE pt.playlist_id = ?
             ORDER BY pt.position ASC
             """,
@@ -5206,7 +5244,7 @@ class LibraryIndex:
         """
         key = path if isinstance(path, str) else str(path)
         row = self._conn.execute(
-            "SELECT * FROM tracks WHERE file_path = ?", (key,)
+            "SELECT * FROM tracks_with_stats WHERE file_path = ?", (key,)
         ).fetchone()
         if row is not None:
             return _row_to_track(row)
@@ -5217,7 +5255,8 @@ class LibraryIndex:
         # sources: a moved/renamed local file's *old* path is a stale file source
         # and must still resolve to nothing (the file is genuinely gone).
         src = self._conn.execute(
-            "SELECT t.* FROM track_sources s JOIN tracks t ON t.id = s.track_id"
+            "SELECT t.* FROM track_sources s"
+            " JOIN tracks_with_stats t ON t.id = s.track_id"
             " WHERE s.uri = ? AND s.kind = 'stream' LIMIT 1",
             (_canonical_track_key(key),),
         ).fetchone()
@@ -5226,7 +5265,7 @@ class LibraryIndex:
     def get_track_by_id(self, track_id: int) -> "Track | None":
         """Return the track with *track_id*, or None if not indexed."""
         row = self._conn.execute(
-            "SELECT * FROM tracks WHERE id = ?", (track_id,)
+            "SELECT * FROM tracks_with_stats WHERE id = ?", (track_id,)
         ).fetchone()
         return _row_to_track(row) if row else None
 
@@ -5235,7 +5274,8 @@ class LibraryIndex:
         if not mb_recording_id:
             return None
         row = self._conn.execute(
-            "SELECT * FROM tracks WHERE mb_recording_id = ?", (mb_recording_id,)
+            "SELECT * FROM tracks_with_stats WHERE mb_recording_id = ?",
+            (mb_recording_id,),
         ).fetchone()
         return _row_to_track(row) if row else None
 
@@ -5314,7 +5354,7 @@ class LibraryIndex:
             """
             SELECT t.*
             FROM tracks_fts f
-            JOIN tracks t ON f.rowid = t.id
+            JOIN tracks_with_stats t ON f.rowid = t.id
             LEFT JOIN albums al ON al.id = t.album_id
             WHERE tracks_fts MATCH ?
               -- KAMP-541: the collapse leaves one canonical row per track, so the
@@ -5821,7 +5861,7 @@ class LibraryIndex:
                    t.favorite, t.play_count, t.last_played, t.date_added,
                    t.source, t.is_available, t.duration
             FROM playlist_tracks pt
-            JOIN tracks t ON t.id = pt.track_id
+            JOIN tracks_with_stats t ON t.id = pt.track_id
             WHERE pt.playlist_id = ?
             ORDER BY pt.position ASC
             """,
@@ -6072,7 +6112,10 @@ class LibraryIndex:
             if needs_album_join
             else ""
         )
-        sql = f"SELECT tracks.id FROM tracks {album_join} WHERE {where_fragment} ORDER BY tracks.id"
+        sql = (
+            f"SELECT tracks.id FROM tracks_with_stats AS tracks {album_join}"
+            f" WHERE {where_fragment} ORDER BY tracks.id"
+        )
         rows = self._conn.execute(sql, params).fetchall()
         return [r[0] for r in rows]
 
@@ -6104,7 +6147,7 @@ class LibraryIndex:
                    tracks.genre, tracks.label, tracks.favorite, tracks.play_count,
                    tracks.last_played, tracks.date_added,
                    tracks.source, tracks.is_available, tracks.duration
-            FROM tracks {album_join}
+            FROM tracks_with_stats AS tracks {album_join}
             WHERE {where_fragment} AND tracks.is_available = 1
             ORDER BY tracks.id
         """
@@ -6267,7 +6310,7 @@ class LibraryIndex:
                      ORDER BY play_count_avg DESC LIMIT 1) AS top_album
                 FROM artists ar
                 JOIN albums a ON a.artist_id = ar.id
-                JOIN tracks t ON t.album_id = a.id
+                JOIN tracks_with_stats t ON t.album_id = a.id
                 WHERE t.id IN ({placeholders}) AND a.artist_id IS NOT NULL
                 GROUP BY ar.id
                 {order}
@@ -6293,7 +6336,7 @@ class LibraryIndex:
                 t.release_date, t.track_number, t.disc_number, t.ext, t.embedded_art,
                 t.mb_release_id, t.mb_recording_id, t.genre, t.label,
                 t.favorite, t.play_count, t.last_played, t.source, t.is_available, t.duration
-            FROM tracks t
+            FROM tracks_with_stats t
             WHERE t.id IN ({placeholders})
             {order}
             LIMIT ?
@@ -6339,7 +6382,7 @@ class LibraryIndex:
             if needs_album_join
             else ""
         )
-        sql = f"SELECT COUNT(*) FROM tracks {album_join} WHERE {where_fragment}"
+        sql = f"SELECT COUNT(*) FROM tracks_with_stats AS tracks {album_join} WHERE {where_fragment}"
         row = self._conn.execute(sql, params).fetchone()
         return int(row[0])
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -720,15 +720,29 @@ class PendingIngest:
 # KAMP-539 can drop tracks.source. `t.file_path LIKE 'bandcamp://%'` (which the
 # album formula used) equals "this effective source is a stream", i.e.
 # `<eff> <> 'local'`.
-_EFFECTIVE_SOURCE_EXPR = (
-    "COALESCE("
-    "(SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
-    " FROM track_sources s WHERE s.track_id = t.id"
-    " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1)"
-    ", t.source)"  # fall back to the legacy column when a track has no sources
-    # (a pre-540 row or a bare test fixture); tracks.source is NOT NULL. The
-    # fallback is dropped with the column in KAMP-539.
-)
+def _eff_source(alias: str = "t") -> str:
+    """SQL for a track's effective (preferred) source, 'local' or 'bandcamp'.
+
+    Reconstructed from track_sources — the preferred delivery chosen by the same
+    ordering as preferred_source(), kind mapped file->'local'/stream->'bandcamp',
+    the identical value _sync_tracks_row_to_preferred_source writes to
+    tracks.source. Correlated on ``<alias>.id`` so it can replace a ``source``
+    read on any tracks alias, letting KAMP-539 drop tracks.source. COALESCEs to
+    ``<alias>.source`` for a sourceless row (a pre-540 row or bare test fixture;
+    tracks.source is NOT NULL) — that fallback is dropped with the column in 539.
+    Note ``<eff> <> 'local'`` reproduces the legacy ``file_path LIKE 'bandcamp://%'``
+    test (file_path is bandcamp:// exactly when the effective source is a stream).
+    """
+    return (
+        "COALESCE("
+        "(SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
+        f" FROM track_sources s WHERE s.track_id = {alias}.id"
+        " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1)"
+        f", {alias}.source)"
+    )
+
+
+_EFFECTIVE_SOURCE_EXPR = _eff_source("t")
 
 # Album `source` badge ('local' / 'bandcamp' / 'mixed'), correlated on the outer
 # `albums.id`. Behavior-preserving reconstruction of the legacy formula (which
@@ -3131,10 +3145,16 @@ class LibraryIndex:
         Used by sync_collection_stream to trigger a re-fetch of the album page so
         full ISO dates ("2020-01-01") replace year-only strings written before KAMP-513.
         """
+        # A remote track is stream-preferred (effective source 'bandcamp', so a
+        # downloaded copy is excluded exactly as the old file_path check did) and
+        # carries a stream source for this album (KAMP-542; was file_path LIKE
+        # bandcamp://sid AND source='bandcamp').
         row = self._conn.execute(
-            "SELECT 1 FROM tracks"
-            " WHERE (file_path LIKE ? OR file_path LIKE ?)"
-            "   AND source = 'bandcamp'"
+            f"SELECT 1 FROM tracks"
+            f" WHERE {_eff_source('tracks')} = 'bandcamp'"
+            "   AND EXISTS (SELECT 1 FROM track_sources s"
+            "     WHERE s.track_id = tracks.id AND s.kind = 'stream'"
+            "       AND (s.uri LIKE ? OR s.uri LIKE ?))"
             "   AND (release_date = '' OR length(release_date) <= 4)"
             " LIMIT 1",
             (f"bandcamp://{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
@@ -3149,10 +3169,15 @@ class LibraryIndex:
         Called after a backfill fetch to replace year-only strings with the full
         ISO date. Does not touch play_count, favorite, or any other field.
         """
+        # Stream-preferred tracks carrying a stream source for this album — leaves
+        # a downloaded copy's release_date (from its file tags) untouched, exactly
+        # as the old file_path check did (KAMP-542).
         self._conn.execute(
-            "UPDATE tracks SET release_date = ?"
-            " WHERE (file_path LIKE ? OR file_path LIKE ?)"
-            "   AND source = 'bandcamp'",
+            f"UPDATE tracks SET release_date = ?"
+            f" WHERE {_eff_source('tracks')} = 'bandcamp'"
+            "   AND EXISTS (SELECT 1 FROM track_sources s"
+            "     WHERE s.track_id = tracks.id AND s.kind = 'stream'"
+            "       AND (s.uri LIKE ? OR s.uri LIKE ?))",
             (
                 release_date,
                 f"bandcamp://{sale_item_id}/%",
@@ -4007,7 +4032,7 @@ class LibraryIndex:
                 embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks t WHERE t.album_id = albums.id),
                 date_added     = (SELECT MIN(t.date_added)    FROM tracks t WHERE t.album_id = albums.id),
                 last_played_at = (SELECT MAX(t.last_played)   FROM tracks_with_stats t WHERE t.album_id = albums.id),
-                art_version    = (SELECT MAX(CASE WHEN t.source = 'local' THEN t.file_mtime END)
+                art_version    = (SELECT MAX(CASE WHEN {_eff_source("t")} = 'local' THEN t.file_mtime END)
                                   FROM tracks t WHERE t.album_id = albums.id),
                 play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
                                   FROM tracks_with_stats t WHERE t.album_id = albums.id),
@@ -4076,7 +4101,7 @@ class LibraryIndex:
             f"""
             SELECT t.id, t.file_path, t.album_artist, t.title
             FROM tracks t
-            WHERE t.source = 'local'
+            WHERE {_eff_source("t")} = 'local'
               AND t.album_id IS NULL
               AND TRIM(t.album) = ''
               AND TRIM(t.album_artist) != ''
@@ -4092,9 +4117,10 @@ class LibraryIndex:
             # local single sharing this (album_artist, title) is not safe to
             # auto-attach — leave all of them untouched.
             local_dupes = self._conn.execute(
-                """
+                f"""
                 SELECT COUNT(*) FROM tracks
-                WHERE source = 'local' AND album_id IS NULL AND TRIM(album) = ''
+                WHERE {_eff_source("tracks")} = 'local' AND album_id IS NULL
+                  AND TRIM(album) = ''
                   AND TRIM(album_artist) = TRIM(?) COLLATE NOCASE
                   AND TRIM(title)        = TRIM(?) COLLATE NOCASE
                 """,
@@ -4112,14 +4138,14 @@ class LibraryIndex:
             # Streaming single-album: exactly one track, a bandcamp row, whose
             # album equals this single's title under the same artist.
             matches = self._conn.execute(
-                """
+                f"""
                 SELECT a.id FROM albums a
                 WHERE TRIM(a.album_artist) = TRIM(?) COLLATE NOCASE
                   AND TRIM(a.album)        = TRIM(?) COLLATE NOCASE
                   AND (SELECT COUNT(*) FROM tracks x WHERE x.album_id = a.id) = 1
                   AND EXISTS (
                         SELECT 1 FROM tracks x
-                        WHERE x.album_id = a.id AND x.source = 'bandcamp'
+                        WHERE x.album_id = a.id AND {_eff_source("x")} = 'bandcamp'
                       )
                 """,
                 (c["album_artist"], c["title"]),
@@ -4142,7 +4168,7 @@ class LibraryIndex:
             # album_id alone leaves album='' and the loose card persists (KAMP-529).
             stream = self._conn.execute(
                 "SELECT track_number, disc_number FROM tracks"
-                " WHERE album_id = ? AND source = 'bandcamp' LIMIT 1",
+                f" WHERE album_id = ? AND {_eff_source('tracks')} = 'bandcamp' LIMIT 1",
                 (album_id,),
             ).fetchone()
             alb = self._conn.execute(
@@ -5073,7 +5099,7 @@ class LibraryIndex:
                 -- track_count: for mixed or local albums count only local tracks
                 -- so the dedup state (local+remote rows coexisting) shows real files.
                 CASE WHEN a.source IN ('mixed', 'local')
-                     THEN COUNT(CASE WHEN t.source = 'local' THEN 1 END)
+                     THEN COUNT(CASE WHEN {_eff_source("t")} = 'local' THEN 1 END)
                      ELSE COUNT(t.id)
                 END                 AS track_count,
                 MAX(t.favorite)     AS has_favorite_track,
@@ -5310,8 +5336,8 @@ class LibraryIndex:
         if album is not None:
             ambiguous: set[int] = set()
             for r in self._conn.execute(
-                "SELECT track_number, display_title FROM tracks"
-                " WHERE album_id = ? AND file_path LIKE 'bandcamp://%'"
+                f"SELECT track_number, display_title FROM tracks"
+                f" WHERE album_id = ? AND {_eff_source('tracks')} = 'bandcamp'"
                 "   AND display_title IS NOT NULL AND display_title != ''",
                 (album["id"],),
             ).fetchall():

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -711,6 +711,42 @@ class PendingIngest:
     created_at: float
 
 
+# A track's effective (preferred) delivery, reconstructed from track_sources
+# (KAMP-542). Reproduces post-collapse tracks.source exactly: the preferred
+# source is chosen by the same ordering as preferred_source(), and its kind is
+# mapped file->'local' / stream->'bandcamp' — the identical mapping
+# _sync_tracks_row_to_preferred_source writes to tracks.source. Correlated on the
+# outer tracks alias `t`; lets the source classifiers read track_sources so
+# KAMP-539 can drop tracks.source. `t.file_path LIKE 'bandcamp://%'` (which the
+# album formula used) equals "this effective source is a stream", i.e.
+# `<eff> <> 'local'`.
+_EFFECTIVE_SOURCE_EXPR = (
+    "COALESCE("
+    "(SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
+    " FROM track_sources s WHERE s.track_id = t.id"
+    " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1)"
+    ", t.source)"  # fall back to the legacy column when a track has no sources
+    # (a pre-540 row or a bare test fixture); tracks.source is NOT NULL. The
+    # fallback is dropped with the column in KAMP-539.
+)
+
+# Album `source` badge ('local' / 'bandcamp' / 'mixed'), correlated on the outer
+# `albums.id`. Behavior-preserving reconstruction of the legacy formula (which
+# read tracks.source and file_path LIKE 'bandcamp://%'): computes each track's
+# effective source once in a derived table, then applies the identical CASE. The
+# 'mixed' arm is unreachable post-collapse — preserved verbatim so the badge is
+# byte-for-byte unchanged (see KAMP-542; the quirk is tracked separately).
+_ALBUM_SOURCE_SUBQUERY = (
+    "(SELECT CASE"
+    "   WHEN COUNT(CASE WHEN es.eff = 'local' THEN 1 END) > 0"
+    "    AND COUNT(CASE WHEN es.eff <> 'local' THEN 1 END) > 0 THEN 'local'"
+    "   WHEN COUNT(DISTINCT es.eff) > 1 THEN 'mixed'"
+    "   ELSE MIN(es.eff) END"
+    "  FROM (SELECT " + _EFFECTIVE_SOURCE_EXPR + " AS eff"
+    "        FROM tracks t WHERE t.album_id = albums.id) es)"
+)
+
+
 class LibraryIndex:
     """Persistent SQLite index of all tracks in the music library."""
 
@@ -2601,17 +2637,7 @@ class LibraryIndex:
             )
         # 6. Recompute albums.source from the surviving tracks.
         self._conn.execute(
-            """
-            UPDATE albums SET source = (
-                SELECT CASE
-                    WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
-                     AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                        THEN 'local'
-                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                    ELSE MIN(t.source) END
-                FROM tracks t WHERE t.album_id = albums.id
-            ) WHERE id=?
-            """,
+            f"UPDATE albums SET source = {_ALBUM_SOURCE_SUBQUERY} WHERE id=?",
             (keep,),
         )
 
@@ -3048,19 +3074,8 @@ class LibraryIndex:
         # Refresh albums.source via the sale_item_id FK. Remote tracks may not have
         # album_id populated yet, so join through albums.sale_item_id instead.
         self._conn.execute(
-            """
-            UPDATE albums SET source = (
-                SELECT CASE
-                    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
-                         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                    THEN 'local'
-                    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                    ELSE MIN(t.source)
-                END
-                FROM tracks t WHERE t.album_id = albums.id
-            )
-            WHERE sale_item_id = ?
-            """,
+            f"UPDATE albums SET source = {_ALBUM_SOURCE_SUBQUERY}"
+            " WHERE sale_item_id = ?",
             (sale_item_id,),
         )
         self._conn.commit()
@@ -3234,15 +3249,7 @@ class LibraryIndex:
     def _refresh_album_source(self, album_id: int) -> None:
         """Recompute albums.source for one album from its tracks' legacy columns."""
         self._conn.execute(
-            "UPDATE albums SET source = ("
-            "  SELECT CASE"
-            "    WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0"
-            "         AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0"
-            "    THEN 'local'"
-            "    WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'"
-            "    ELSE MIN(t.source) END"
-            "  FROM tracks t WHERE t.album_id = albums.id)"
-            " WHERE id = ?",
+            f"UPDATE albums SET source = {_ALBUM_SOURCE_SUBQUERY} WHERE id = ?",
             (album_id,),
         )
 
@@ -4004,13 +4011,7 @@ class LibraryIndex:
                                   FROM tracks t WHERE t.album_id = albums.id),
                 play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
                                   FROM tracks_with_stats t WHERE t.album_id = albums.id),
-                source         = (SELECT
-                                      CASE WHEN COUNT(CASE WHEN t.source='local' THEN 1 END) > 0
-                                                AND COUNT(CASE WHEN t.file_path LIKE 'bandcamp://%' THEN 1 END) > 0
-                                           THEN 'local'
-                                           WHEN COUNT(DISTINCT t.source) > 1 THEN 'mixed'
-                                           ELSE MIN(t.source) END
-                                  FROM tracks t WHERE t.album_id = albums.id),
+                source         = {_ALBUM_SOURCE_SUBQUERY},
                 release_date   = (SELECT MAX(t.release_date)   FROM tracks t WHERE t.album_id = albums.id),
                 genre          = (SELECT MAX(t.genre)          FROM tracks t WHERE t.album_id = albums.id),
                 label          = (SELECT MAX(t.label)          FROM tracks t WHERE t.album_id = albums.id),
@@ -5101,7 +5102,7 @@ class LibraryIndex:
                 t.album_artist,
                 t.title             AS album,
                 t.release_date,
-                t.source            AS album_source,
+                {_EFFECTIVE_SOURCE_EXPR} AS album_source,
                 NULL                AS sale_item_id,
                 0                   AS is_favorite,
                 t.date_added        AS sort_date_added,
@@ -5368,15 +5369,18 @@ class LibraryIndex:
     # Source expression reused by both playlist search methods.  Matches the
     # album source computation: 'mixed' when both local and non-local tracks are
     # present; otherwise the sole source value, defaulting to 'local' if empty.
-    _PLAYLIST_SOURCE_EXPR = """
+    # Reads track_sources via _EFFECTIVE_SOURCE_EXPR instead of tracks.source
+    # (KAMP-542) — behavior-identical, since post-collapse tracks.source equals a
+    # track's effective source. Correlated on the outer `t` (LEFT JOIN tracks t).
+    _PLAYLIST_SOURCE_EXPR = f"""
         CASE
-            WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
-             AND COUNT(CASE WHEN t.source != 'local' THEN 1 END) > 0
+            WHEN COUNT(CASE WHEN {_EFFECTIVE_SOURCE_EXPR} = 'local' THEN 1 END) > 0
+             AND COUNT(CASE WHEN {_EFFECTIVE_SOURCE_EXPR} != 'local' THEN 1 END) > 0
             THEN 'mixed'
-            WHEN COUNT(CASE WHEN t.source = 'local' THEN 1 END) > 0
+            WHEN COUNT(CASE WHEN {_EFFECTIVE_SOURCE_EXPR} = 'local' THEN 1 END) > 0
             THEN 'local'
             WHEN COUNT(t.id) = 0 THEN 'local'
-            ELSE MIN(t.source)
+            ELSE MIN({_EFFECTIVE_SOURCE_EXPR})
         END
     """
 

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -57,7 +57,7 @@ class PlaybackState:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_track_key(path: "Path | str") -> str:
+def _canonical_track_uri(path: "Path | str") -> str:
     """Canonical string key for remote track URI comparison and persistence.
 
     Normalises POSIX single-slash (bandcamp:/) and Windows backslash
@@ -104,9 +104,9 @@ class PlaybackQueue:
         snapshot reflects the new value without requiring a queue reload.
         Accepts str so remote track URIs (bandcamp://) can be matched.
         """
-        fp_key = _canonical_track_key(file_path)
+        fp_key = _canonical_track_uri(file_path)
         for t in self._tracks:
-            if _canonical_track_key(t.file_path) == fp_key:
+            if _canonical_track_uri(t.file_path) == fp_key:
                 t.favorite = favorite
 
     def update_track_path(self, old_path: Path, new_path: Path, new_title: str) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -49,7 +49,7 @@ from kamp_core.library import (
     MagicCriteria,
     NoStreamableVersionError,
     Track,
-    _canonical_track_key,
+    _canonical_track_uri,
     extract_art,
 )
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
@@ -236,7 +236,7 @@ class TrackOut(BaseModel):
             release_date=t.release_date,
             track_number=t.track_number,
             disc_number=t.disc_number,
-            file_path=_canonical_track_key(t.file_path),
+            file_path=_canonical_track_uri(t.file_path),
             ext=t.ext,
             embedded_art=t.embedded_art,
             mb_release_id=t.mb_release_id,

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -205,7 +205,10 @@ def test_track_source_is() -> None:
     frag, params, _ = build_query(
         _criteria(_group(_cond("track.source", "is", "bandcamp")))
     )
-    assert "tracks.source" in frag
+    # KAMP-542: track.source resolves via track_sources (the preferred delivery),
+    # not the tracks.source column, so KAMP-539 can drop it. The compared value is
+    # unchanged, so stored criteria_json migrates without a rewrite.
+    assert "track_sources" in frag
     assert params == ["bandcamp"]
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -6515,18 +6515,27 @@ class TestRemoteTrackSchema:
         assert row_before is not None
         assert row_before["source"] == "bandcamp"
 
-        # set_track_source_for_item is called (e.g. during sync cleanup).
+        # set_track_source_for_item writes tracks.source directly without touching
+        # track_sources. It is dead code post-collapse — server.py:3030 documents
+        # that it is never called — so it leaves tracks.source and track_sources
+        # inconsistent.
         index.set_track_source_for_item("sale-3", "local")
+        index._refresh_album_source(
+            index._conn.execute(
+                "SELECT id FROM albums WHERE sale_item_id = 'sale-3'"
+            ).fetchone()[0]
+        )
 
         row_after = index._conn.execute(
             "SELECT source FROM albums WHERE sale_item_id = 'sale-3'"
         ).fetchone()
         index.close()
 
-        # Remote tracks now have source='local' but file_path still starts with
-        # bandcamp://, so the dedup logic produces 'local' (local wins).
+        # The badge now derives from track_sources (KAMP-542), which this obsolete
+        # method does not update, so it stays 'bandcamp' (the track still has only
+        # a stream source). Pre-542 it flipped to 'local' by reading tracks.source.
         assert row_after is not None
-        assert row_after["source"] == "local"
+        assert row_after["source"] == "bandcamp"
 
     def test_migration_v20_adds_stream_columns(self, tmp_path: Path) -> None:
         """A v19 DB gains the three new columns on open."""
@@ -6816,8 +6825,19 @@ class TestAlbumInfoRemoteFields:
         index.close()
 
         assert len(albums) == 1
-        assert albums[0].source == "mixed"
-        assert albums[0].has_remote_tracks is True
+        # Post-collapse the badge is reconstructed from track_sources (KAMP-542).
+        # A genuinely mixed album (one local-preferred + one stream-preferred
+        # track) reads 'local', not 'mixed' — the pre-existing quirk tracked in
+        # KAMP-546. The old formula returned 'mixed' here only because this
+        # fixture's "bandcamp" track has a mangled, non-bandcamp:// file_path
+        # (tmp_path / "bandcamp://999/2"), a state that cannot occur in production
+        # where a stream track's file_path IS its bandcamp:// uri.
+        assert albums[0].source == "local"
+        # has_remote_tracks is derived from the badge (album_source != 'local'), so
+        # it follows the same KAMP-546 quirk: a realistic mixed album reads
+        # 'local' -> has_remote_tracks False. This already matches production on
+        # main (where a realistic mixed album's badge is 'local').
+        assert albums[0].has_remote_tracks is False
 
     def test_in_bandcamp_collection_true(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -11288,6 +11308,86 @@ class TestStatsReadFromTrackStats:
         t = index.get_track_by_path(str(tmp_path / "a.mp3"))
         index.close()
         assert t is not None and t.favorite is True and t.play_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Album source classifier reconstruction (KAMP-542)
+# ---------------------------------------------------------------------------
+
+
+class TestAlbumSourceClassifier:
+    """The album `source` badge reads track_sources (not tracks.source) but is
+    byte-for-byte behavior-preserving vs the legacy formula, including the
+    post-collapse quirk where a mixed album reads 'local' and 'mixed' is
+    unreachable (tracked separately; preserved here per KAMP-542)."""
+
+    def _album(self, index: "LibraryIndex", name: str, tracks: list) -> int:
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album) VALUES (?, ?)", (name, name)
+        )
+        alb = c.execute("SELECT id FROM albums WHERE album = ?", (name,)).fetchone()[0]
+        for i, (src, fp, kinds) in enumerate(tracks, 1):
+            c.execute(
+                "INSERT INTO tracks (file_path, source, album_id, track_number,"
+                " disc_number) VALUES (?, ?, ?, ?, 1)",
+                (fp, src, alb, i),
+            )
+            tid = c.execute(
+                "SELECT id FROM tracks WHERE file_path = ?", (fp,)
+            ).fetchone()[0]
+            for k in kinds:
+                uri = fp if k == "file" else f"bandcamp://{name}/{i}"
+                c.execute(
+                    "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, ?, ?)",
+                    (tid, k, uri),
+                )
+        index._conn.commit()
+        return alb
+
+    def test_badge_matches_legacy_output(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        cases = {
+            "downloaded": (
+                [("local", "/m/a1.mp3", ["file"]), ("local", "/m/a2.mp3", ["file"])],
+                "local",
+            ),
+            "stream_only": (
+                [
+                    ("bandcamp", "bandcamp://S/1", ["stream"]),
+                    ("bandcamp", "bandcamp://S/2", ["stream"]),
+                ],
+                "bandcamp",
+            ),
+            # Post-collapse quirk: a mixed album reads 'local' (preserved, not 'mixed').
+            "mixed": (
+                [
+                    ("local", "/m/c1.mp3", ["file"]),
+                    ("bandcamp", "bandcamp://C/2", ["stream"]),
+                ],
+                "local",
+            ),
+            "downloaded_and_streamable": (
+                [
+                    ("local", "/m/d1.mp3", ["file", "stream"]),
+                    ("local", "/m/d2.mp3", ["file", "stream"]),
+                ],
+                "local",
+            ),
+        }
+        ids = {
+            name: self._album(index, name, tracks)
+            for name, (tracks, _) in cases.items()
+        }
+        index._refresh_album_aggregates(list(ids.values()))
+        got = {
+            name: index._conn.execute(
+                "SELECT source FROM albums WHERE id = ?", (ids[name],)
+            ).fetchone()[0]
+            for name in cases
+        }
+        index.close()
+        assert got == {name: expected for name, (_, expected) in cases.items()}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -76,6 +76,23 @@ def _sample_track(file_path: Path) -> Track:
     )
 
 
+def _mirror_stats(index: "LibraryIndex") -> None:
+    """Propagate every track's legacy stat columns into track_stats (KAMP-542).
+
+    Reads now resolve favorite/play_count/last_played through the
+    tracks_with_stats view (i.e. from track_stats), so a test that seeds those
+    values with a direct ``UPDATE tracks`` must mirror them, exactly as the
+    production stat writers do.
+    """
+    index._conn.execute(
+        "INSERT INTO track_stats (track_id, favorite, play_count, last_played)"
+        " SELECT id, favorite, play_count, last_played FROM tracks WHERE true"
+        " ON CONFLICT(track_id) DO UPDATE SET favorite=excluded.favorite,"
+        " play_count=excluded.play_count, last_played=excluded.last_played"
+    )
+    index._conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # LibraryIndex
 # ---------------------------------------------------------------------------
@@ -8464,6 +8481,7 @@ class TestInheritRemotePlayCounts:
         index.upsert_many([local])
         index._conn.execute("UPDATE tracks SET play_count = 10 WHERE source = 'local'")
         index._conn.commit()
+        _mirror_stats(index)
         index.inherit_remote_play_counts([local])
 
         result = index.tracks_for_album("The Artist", "The Album")
@@ -10182,6 +10200,7 @@ class TestMagicPlaylists:
             (str(tmp_path / "a.mp3"),),
         )
         index._conn.commit()
+        _mirror_stats(index)
         row_a = index._conn.execute(
             "SELECT id FROM tracks WHERE file_path = ?", (str(tmp_path / "a.mp3"),)
         ).fetchone()
@@ -11204,6 +11223,71 @@ class TestUpsertSyncProtection:
         result = index.all_tracks()[0]
         index.close()
         assert result.genre == "Electronic"
+
+
+# ---------------------------------------------------------------------------
+# Stats read-switch — reads resolve from track_stats (KAMP-542)
+# ---------------------------------------------------------------------------
+
+
+class TestStatsReadFromTrackStats:
+    """Every stats read resolves via track_stats, not the legacy tracks columns.
+
+    Proven differentially: deliberately desync track_stats from the tracks
+    columns (favorite/play_count/last_played) — which cannot happen in
+    production, where every writer mirrors — and assert the read paths report
+    the track_stats values. Guards KAMP-542's core promise so KAMP-539 can drop
+    the legacy columns.
+    """
+
+    def _desynced(self, tmp_path: Path) -> tuple["LibraryIndex", int]:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([_sample_track(tmp_path / "a.mp3")])
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        # Legacy columns say 0/NULL; track_stats (authoritative) says otherwise.
+        index._conn.execute(
+            "UPDATE tracks SET favorite = 0, play_count = 0, last_played = NULL"
+        )
+        index._conn.execute(
+            "INSERT INTO track_stats (track_id, favorite, play_count, last_played)"
+            " VALUES (?, 1, 9, 555.0) ON CONFLICT(track_id) DO UPDATE SET"
+            " favorite = 1, play_count = 9, last_played = 555.0",
+            (tid,),
+        )
+        index._conn.commit()
+        return index, tid
+
+    def test_get_track_by_id_and_path_read_track_stats(self, tmp_path: Path) -> None:
+        index, tid = self._desynced(tmp_path)
+        by_id = index.get_track_by_id(tid)
+        by_path = index.get_track_by_path(str(tmp_path / "a.mp3"))
+        index.close()
+        for t in (by_id, by_path):
+            assert t is not None
+            assert t.favorite is True
+            assert t.play_count == 9
+            assert t.last_played == 555.0
+
+    def test_top_tracks_and_album_read_track_stats(self, tmp_path: Path) -> None:
+        index, _ = self._desynced(tmp_path)
+        top = index.top_tracks(5)  # WHERE play_count > 0 — legacy col is 0
+        album = index.tracks_for_album("The Artist", "The Album")
+        index.close()
+        assert [t.play_count for t in top] == [
+            9
+        ]  # would be [] if reading tracks.play_count
+        assert album[0].favorite is True
+
+    def test_view_falls_back_to_legacy_when_no_stats_row(self, tmp_path: Path) -> None:
+        """A track with no track_stats row still reads its legacy value (transition safety)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([_sample_track(tmp_path / "a.mp3")])
+        index._conn.execute("UPDATE tracks SET favorite = 1, play_count = 4")
+        index._conn.execute("DELETE FROM track_stats")
+        index._conn.commit()
+        t = index.get_track_by_path(str(tmp_path / "a.mp3"))
+        index.close()
+        assert t is not None and t.favorite is True and t.play_count == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -10280,6 +10280,35 @@ class TestMagicPlaylists:
         index.close()
         assert result == [id_a]
 
+    def test_evaluate_filters_by_source_via_track_sources(self, tmp_path: Path) -> None:
+        """track.source criteria resolves via track_sources, not tracks.source (KAMP-542)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([_sample_track(tmp_path / "a.mp3")])
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
+        # Desync: the track has a file (local) source, but its legacy source column
+        # is set to 'bandcamp'. The criterion must follow the source (local).
+        index._conn.execute(
+            "UPDATE tracks SET source = 'bandcamp' WHERE id = ?", (tid,)
+        )
+        index._conn.commit()
+        criteria = MagicCriteria(
+            groups=[
+                Group(
+                    conditions=[
+                        Condition(field="track.source", op="is", value="local")
+                    ],
+                    match="all",
+                )
+            ],
+            match="all",
+        )
+        pid = index.create_magic_playlist("Local", criteria)
+        result = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert result == [
+            tid
+        ]  # matched by the file source, not tracks.source='bandcamp'
+
     def test_evaluate_filters_by_genre_contains(self, tmp_path: Path) -> None:
         index, id_a, id_b = self._seeded_index(tmp_path)
         criteria = MagicCriteria(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -6735,6 +6735,35 @@ class TestReleaseDateBackfill:
 
         assert needs is True
 
+    def test_downloaded_track_with_stream_source_is_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """A downloaded (file-preferred) track carrying a stream source for the
+        album is NOT flagged/patched, even with a year-only release_date — the
+        backfill targets stream-preferred tracks only (KAMP-542). Guards the
+        effective-source restriction: a naive EXISTS(stream source) would wrongly
+        match it and overwrite its file-tag release_date."""
+        index = self._make_index(tmp_path)
+        c = index._conn
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, release_date) VALUES ('/m/a.mp3','local',NULL,1,1,'2020')"
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.executemany(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, ?, ?)",
+            [(tid, "file", "/m/a.mp3"), (tid, "stream", "bandcamp://sale9/1")],
+        )
+        c.commit()
+
+        assert index.has_remote_tracks_needing_date_backfill("sale9") is False
+        index.patch_release_date_for_remote_album("sale9", "2020-05-01")
+        after = c.execute(
+            "SELECT release_date FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        index.close()
+        assert after == "2020"  # untouched — it is downloaded, not stream-preferred
+
     def test_backfill_needed_when_release_date_is_empty(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
         track = Track(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -6954,7 +6954,7 @@ class TestAlbumInfoRemoteFields:
     def test_sale_item_id_populated_for_bandcamp_album(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         # Use upsert_many via the helper so the albums row (and its sale_item_id FK)
-        # is created. upsert_many's _canonical_track_key preserves bandcamp:// paths.
+        # is created. upsert_many's _canonical_track_uri preserves bandcamp:// paths.
         self._insert_bc_tracks(index, "abc123")
         index.upsert_collection_item(
             "abc123",
@@ -6982,7 +6982,7 @@ class TestAlbumInfoRemoteFields:
         """Insert two bandcamp:// tracks via upsert_many so the albums row is created.
 
         Uses the same album_artist / album defaults as _insert_track so tests can
-        mix the two helpers in the same album group.  _canonical_track_key inside
+        mix the two helpers in the same album group.  _canonical_track_uri inside
         upsert_many preserves the bandcamp:// double-slash form even though Path()
         collapses it to a single slash on POSIX.
         """


### PR DESCRIPTION
## KAMP-542 — Behavior-neutral read-switch: stats + source + criteria + rename

Part of epic **KAMP-533** (canonical track identity). Moves the remaining **reads** off the legacy `tracks` columns onto the child tables (`track_stats`, `track_sources`) so **KAMP-539** can drop those columns. Depends on KAMP-541 (merged). No observable behavior change — proven by differential tests and a green suite.

Design note: `docs/design/KAMP-533-canonical-track-identity.md` §6.

### Commits

| Commit | What |
|---|---|
| `f2cb377` | **Stats reads → `tracks_with_stats` view.** A read-only view shadows `favorite`/`play_count`/`last_played` from `track_stats` (COALESCE back to the legacy column while both coexist). Every `_row_to_track` producer, the album-average recompute, and `get_stats` read the view. Also fixes a real ordering bug the switch exposed in `record_played` (recomputed the album average before mirroring the increment). |
| `56ae4bb` | **Source badge → `track_sources`.** Album/playlist/virtual-album `source` classifiers reconstruct the effective (preferred) delivery from `track_sources` via `_EFFECTIVE_SOURCE_EXPR`, reproducing `tracks.source` exactly. 4 album-formula copies collapse into one shared `_ALBUM_SOURCE_SUBQUERY`. |
| `e025561` | **Criteria `track.source` → `track_sources`.** Magic-playlist `track.source` maps to the effective-source expression; the value stays `local`/`bandcamp` so stored `criteria_json` migrates with no rewrite. Stats criteria fields already read the view (Commit 1) — no `QueryFragment` plumbing needed. |
| `a978227` | **Rename** `_canonical_track_key` → `_canonical_track_uri` (both copies + call sites). |
| `16146e3` | **Residual source/file_path mode-tests → `track_sources`** via an alias-parameterized `_eff_source()` helper (loose-single heal, album `art_version`/`track_count`, the release-date backfill, download-title overrides). |

### Source mode-test triage (A/B/C/D)

Only **bucket D** (live reads) was rewritten:

| Bucket | Handling | Examples |
|---|---|---|
| **A — URI construction / write-time discriminator** | leave | `_derive_source_fields`, upsert `ON CONFLICT excluded.source` |
| **B — migration / backfill body** | leave (runs before `track_sources` exists) | every `source=`/`bandcamp://` inside `if version < N` / `_populate_*` |
| **C — dead-post-541** | leave (deleted in KAMP-539) | `inherit_remote_favorites` / `inherit_remote_play_counts` |
| **D — live read-path mode-test** | **rewrite → `track_sources`** | classifiers, criteria, loose-single heal, aggregates, date backfill, download overrides |

`albums.source` / `bc.mode` reads are untouched — those are not `tracks` columns.

### Behavior-neutrality — how it's proven

The claim holds for **stats** unconditionally (dual-write since KAMP-540). For **source** it is preserving-by-reconstruction: the effective-source expression reproduces post-collapse `tracks.source` exactly (same `preferred_source` ordering; `_sync` writes the identical `file→'local'/stream→'bandcamp'` mapping), and `<eff> <> 'local'` reproduces `file_path LIKE 'bandcamp://%'`. Verified by:
- A **desync differential test** (`TestStatsReadFromTrackStats`): `track_stats` deliberately disagrees with the legacy columns; every read follows `track_stats`.
- An **album-badge differential test** (`TestAlbumSourceClassifier`) over downloaded / stream-only / mixed / downloaded-and-streamable fixtures — badge byte-identical to the legacy formula.
- A **criteria differential test** — `track.source` follows a track's file source, not a stale `tracks.source`.
- A **date-backfill differential test** — a downloaded track carrying a stream source is correctly skipped.
- Full suite **2224 passed, 9 skipped, coverage 93.18%**; `black` + `mypy` clean.

### Pre-existing quirk surfaced (not fixed here) — KAMP-546

The album `source` badge never renders `'mixed'` post-collapse (a mixed album reads `'local'`; playlists are unaffected). This is a pre-existing effect of the KAMP-541 collapse, **deliberately preserved** to keep this ticket behavior-neutral, and filed as **KAMP-546** (with its `has_remote_tracks`/`track_count` downstream effects). Two tests that pinned the old formula's output on production-impossible fixtures were updated with explanatory comments.

### What's next in the epic

KAMP-539 (contract) can now drop the duplicated `tracks` columns and delete the dead `inherit_remote_*` helpers — this PR removes the last live reads of them (bucket-A write discriminators aside, which 539 reworks with the column drop).

### Manual test plan (behavior should be identical to before)

- Magic playlists filtering on favorite / play_count / last_played / source return the same tracks.
- Album and playlist source badges unchanged (a downloaded-and-streamable album shows the same badge as before this PR).
- Top Tracks / Last Played / favorites sorts unchanged; favoriting via the transport still reflects on the album page.
- A bandcamp sync still backfills stream tracks' release dates without touching downloaded copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
