### PR TITLE
feat(api): move track identity to canonical id + add sources[] (KAMP-537)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3502,6 +3502,31 @@ class LibraryIndex:
         ).fetchone()
         return row  # type: ignore[no-any-return]
 
+    def sources_for_track_ids(
+        self, track_ids: "list[int]"
+    ) -> "dict[int, list[sqlite3.Row]]":
+        """Return every track_sources row for each id, keyed by track_id (KAMP-537).
+
+        One query for a batch of tracks so serializing a list of TrackOut does not
+        do an N+1. Rows are ordered preferred-first within each track (same order
+        as preferred_source). Ids with no sources are absent — callers default to
+        []. Empty input returns {}. Exposes only the display fields the API needs
+        (kind/provider/uri/is_available/duration).
+        """
+        if not track_ids:
+            return {}
+        placeholders = ",".join("?" * len(track_ids))
+        rows = self._conn.execute(
+            "SELECT track_id, kind, provider, uri, is_available, duration"
+            f" FROM track_sources WHERE track_id IN ({placeholders})"
+            " ORDER BY track_id, is_available DESC, (kind = 'file') DESC, id",
+            track_ids,
+        ).fetchall()
+        result: "dict[int, list[sqlite3.Row]]" = {}
+        for r in rows:
+            result.setdefault(r["track_id"], []).append(r)
+        return result
+
     def update_stream_url_for_source(
         self, source_id: int, stream_url: str, expires_at: float
     ) -> None:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -622,6 +622,10 @@ class AlbumInfo:
     album_url: str = ""
     # Stable integer PK of the albums row; 0 for missing-album virtual entries.
     album_id: int = field(default=0, compare=False)
+    # For a missing-album virtual entry (missing_album=True), the canonical id of
+    # its single track — the stable key the API/UI should use instead of file_path
+    # (KAMP-537). None for real albums.
+    missing_track_id: int | None = field(default=None, compare=False)
     # User-set display overrides for streaming albums (KAMP-467). None means
     # no override; the canonical album/album_artist is the authoritative value.
     display_album: str | None = None
@@ -5106,6 +5110,7 @@ class LibraryIndex:
         rows = self._conn.execute(f"""
             SELECT
                 a.id                AS album_id,
+                NULL                AS missing_track_id,
                 a.album_artist,
                 a.album,
                 a.release_date,
@@ -5150,6 +5155,7 @@ class LibraryIndex:
             -- virtual entry; file_path is the unique identifier for these entries.
             SELECT
                 0                   AS album_id,
+                t.id                AS missing_track_id,
                 t.album_artist,
                 t.title             AS album,
                 t.release_date,
@@ -5180,6 +5186,7 @@ class LibraryIndex:
         return [
             AlbumInfo(
                 album_id=r["album_id"],
+                missing_track_id=r["missing_track_id"],
                 album_artist=r["album_artist"],
                 album=r["album"],
                 release_date=r["release_date"],

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 48
+_SCHEMA_VERSION = 49
 
 
 class NoStreamableVersionError(Exception):
@@ -1956,7 +1956,47 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 48")
             self._conn.commit()
-            version = 48  # noqa: F841
+            version = 48
+
+        if version < 49:
+            # v48 → v49: re-collapse downloaded+streamed forks the epic left
+            # un-merged (KAMP-541/542). The current reconcile merges both fork
+            # directions (verified: a fresh download-after-stream and a sync into a
+            # downloaded album both collapse), so no new forks form — but the v48
+            # heal was one-time and did not reprocess pairs that were not yet in
+            # their final mergeable shape when it ran (e.g. a pair momentarily
+            # accompanied by a duplicate stream row was quarantined as >2 rows;
+            # once the dup was cleaned up a plain file+stream fork remained that no
+            # heal revisited). Re-running the collapse merges each pair (survivor =
+            # the local file row). Idempotent, backup-first, version-last; a no-op
+            # on a library with no sibling buckets.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            needed = {
+                "id",
+                "album_id",
+                "track_number",
+                "disc_number",
+                "sale_item_id",
+                "source",
+            }
+            if (
+                needed <= track_cols
+                and self._has_collapsible_siblings()
+                and self._backup_db("KAMP-541 v49 fork heal")
+            ):
+                try:
+                    self._collapse_canonical_tracks()
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-541 v49 fork heal failed — rolled back; the duplicate"
+                        " rows remain. Restore from the pre-v49 backup if needed."
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 49")
+            self._conn.commit()
+            version = 49  # noqa: F841
 
     def _create_tracks_with_stats_view(self) -> None:
         """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542).

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 50
+_SCHEMA_VERSION = 48
 
 
 class NoStreamableVersionError(Exception):
@@ -828,7 +828,7 @@ class LibraryIndex:
     def _migrate(self) -> None:
         """Create schema and run any pending version migrations."""
         self._conn.executescript(_DDL)
-        # The collapse heals (v46/v48/v49/v50) call _refresh_album_aggregates,
+        # The collapse heals (v46/v48) call _refresh_album_aggregates,
         # which reads the tracks_with_stats view — so the view MUST exist before
         # any heal runs, not only after _migrate returns. Omitting this made every
         # collapse heal on a pre-KAMP-542 upgrade throw "no such table:
@@ -1964,85 +1964,7 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 48")
             self._conn.commit()
-            version = 48
-
-        if version < 49:
-            # v48 → v49: re-collapse downloaded+streamed forks the epic left
-            # un-merged (KAMP-541/542). The current reconcile merges both fork
-            # directions (verified: a fresh download-after-stream and a sync into a
-            # downloaded album both collapse), so no new forks form — but the v48
-            # heal was one-time and did not reprocess pairs that were not yet in
-            # their final mergeable shape when it ran (e.g. a pair momentarily
-            # accompanied by a duplicate stream row was quarantined as >2 rows;
-            # once the dup was cleaned up a plain file+stream fork remained that no
-            # heal revisited). Re-running the collapse merges each pair (survivor =
-            # the local file row). Idempotent, backup-first, version-last; a no-op
-            # on a library with no sibling buckets.
-            track_cols = {
-                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
-            }
-            needed = {
-                "id",
-                "album_id",
-                "track_number",
-                "disc_number",
-                "sale_item_id",
-                "source",
-            }
-            if (
-                needed <= track_cols
-                and self._has_collapsible_siblings()
-                and self._backup_db("KAMP-541 v49 fork heal")
-            ):
-                try:
-                    self._collapse_canonical_tracks()
-                except Exception:
-                    self._conn.rollback()
-                    logger.exception(
-                        "KAMP-541 v49 fork heal failed — rolled back; the duplicate"
-                        " rows remain. Restore from the pre-v49 backup if needed."
-                    )
-            self._conn.execute("UPDATE schema_version SET version = 49")
-            self._conn.commit()
-            version = 49
-
-        if version < 50:
-            # v49 → v50: actually run the collapse. The v46/v48/v49 heals had been
-            # SILENTLY FAILING on every pre-KAMP-542 upgrade — _collapse_canonical_
-            # tracks -> _refresh_album_aggregates reads the tracks_with_stats view,
-            # which was only created AFTER _migrate, so each heal threw "no such
-            # table: tracks_with_stats", rolled back, and left the two-row fork
-            # model (KAMP-532 dupes) while the version still bumped. The view is now
-            # created before the heals (top of _migrate), so this re-run finally
-            # collapses the forks stranded at v49. Same backup-first / one-txn /
-            # version-last discipline; a no-op on a library with no sibling buckets.
-            track_cols = {
-                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
-            }
-            needed = {
-                "id",
-                "album_id",
-                "track_number",
-                "disc_number",
-                "sale_item_id",
-                "source",
-            }
-            if (
-                needed <= track_cols
-                and self._has_collapsible_siblings()
-                and self._backup_db("KAMP-541 v50 fork heal")
-            ):
-                try:
-                    self._collapse_canonical_tracks()
-                except Exception:
-                    self._conn.rollback()
-                    logger.exception(
-                        "KAMP-541 v50 fork heal failed — rolled back; the duplicate"
-                        " rows remain. Restore from the pre-v50 backup if needed."
-                    )
-            self._conn.execute("UPDATE schema_version SET version = 50")
-            self._conn.commit()
-            version = 50  # noqa: F841
+            version = 48  # noqa: F841
 
     def _create_tracks_with_stats_view(self) -> None:
         """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542).

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 49
+_SCHEMA_VERSION = 50
 
 
 class NoStreamableVersionError(Exception):
@@ -828,6 +828,14 @@ class LibraryIndex:
     def _migrate(self) -> None:
         """Create schema and run any pending version migrations."""
         self._conn.executescript(_DDL)
+        # The collapse heals (v46/v48/v49/v50) call _refresh_album_aggregates,
+        # which reads the tracks_with_stats view — so the view MUST exist before
+        # any heal runs, not only after _migrate returns. Omitting this made every
+        # collapse heal on a pre-KAMP-542 upgrade throw "no such table:
+        # tracks_with_stats", roll back, and leave the two-row fork model intact
+        # (the version still bumped). track_stats + tracks exist by now (_DDL), so
+        # the view builds; it is rebuilt with final columns after _migrate.
+        self._create_tracks_with_stats_view()
         row = self._conn.execute("SELECT version FROM schema_version").fetchone()
         if row is None:
             # Brand-new database — stamp current version and populate FTS.
@@ -1996,7 +2004,45 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 49")
             self._conn.commit()
-            version = 49  # noqa: F841
+            version = 49
+
+        if version < 50:
+            # v49 → v50: actually run the collapse. The v46/v48/v49 heals had been
+            # SILENTLY FAILING on every pre-KAMP-542 upgrade — _collapse_canonical_
+            # tracks -> _refresh_album_aggregates reads the tracks_with_stats view,
+            # which was only created AFTER _migrate, so each heal threw "no such
+            # table: tracks_with_stats", rolled back, and left the two-row fork
+            # model (KAMP-532 dupes) while the version still bumped. The view is now
+            # created before the heals (top of _migrate), so this re-run finally
+            # collapses the forks stranded at v49. Same backup-first / one-txn /
+            # version-last discipline; a no-op on a library with no sibling buckets.
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            needed = {
+                "id",
+                "album_id",
+                "track_number",
+                "disc_number",
+                "sale_item_id",
+                "source",
+            }
+            if (
+                needed <= track_cols
+                and self._has_collapsible_siblings()
+                and self._backup_db("KAMP-541 v50 fork heal")
+            ):
+                try:
+                    self._collapse_canonical_tracks()
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-541 v50 fork heal failed — rolled back; the duplicate"
+                        " rows remain. Restore from the pre-v50 backup if needed."
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 50")
+            self._conn.commit()
+            version = 50  # noqa: F841
 
     def _create_tracks_with_stats_view(self) -> None:
         """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542).

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -378,8 +378,10 @@ class PlayPlaylistRequest(BaseModel):
 
 
 class PlayFilesRequest(BaseModel):
-    file_paths: list[str]
+    file_paths: list[str] = []
     start_index: int = 0
+    # KAMP-537: canonical ids, preferred over file_paths when non-empty.
+    ids: list[int] | None = None
 
 
 class SeekRequest(BaseModel):
@@ -449,8 +451,9 @@ _FORBIDDEN_LIBRARY_ROOTS: frozenset[Path] = frozenset(
 
 
 class FavoriteRequest(BaseModel):
-    file_path: str
+    file_path: str = ""
     favorite: bool
+    id: int | None = None  # KAMP-537: preferred over file_path when present
 
 
 class AlbumFavoriteRequest(BaseModel):
@@ -473,7 +476,8 @@ class QueueOut(BaseModel):
 
 
 class AddToQueueRequest(BaseModel):
-    file_path: str
+    file_path: str = ""
+    id: int | None = None  # KAMP-537: preferred over file_path when present
 
 
 class MoveQueueRequest(BaseModel):
@@ -486,8 +490,9 @@ class ReorderQueueRequest(BaseModel):
 
 
 class InsertQueueRequest(BaseModel):
-    file_path: str
+    file_path: str = ""
     index: int
+    id: int | None = None  # KAMP-537: preferred over file_path when present
 
 
 class AlbumQueueRequest(BaseModel):
@@ -717,6 +722,7 @@ class AddTrackToPlaylistRequest(BaseModel):
     file_path: str | None = None
     album_artist: str | None = None
     album: str | None = None
+    id: int | None = None  # KAMP-537: preferred over file_path when present
 
 
 class ReorderPlaylistRequest(BaseModel):
@@ -850,6 +856,27 @@ def _track_out(index: LibraryIndex, track: Track) -> TrackOut:
     return TrackOut.from_track(
         track, index.sources_for_track_ids([track.id]).get(track.id, [])
     )
+
+
+def _resolve_track(
+    index: LibraryIndex,
+    *,
+    track_id: int | None,
+    file_path: str,
+    library_path: Path | None,
+) -> Track | None:
+    """Dual-accept track resolution (KAMP-537): the canonical `id` wins when
+    present (even if file_path is also sent); otherwise fall back to the
+    file_path via the KAMP-541 source-uri bridge. Returns None (caller 404s) when
+    neither resolves. Both the file_path request fields and this fallback are
+    removed in KAMP-539."""
+    if track_id is not None:
+        return index.get_track_by_id(track_id)
+    if not file_path:
+        return None
+    if _is_remote_uri(file_path):
+        return index.get_track_by_path(file_path)
+    return index.get_track_by_path(_validate_library_path(file_path, library_path))
 
 
 def _validate_proxy_url(url: str) -> str:
@@ -1505,21 +1532,21 @@ def create_app(
 
     @app.post("/api/v1/tracks/favorite")
     def set_track_favorite(req: FavoriteRequest) -> dict[str, Any]:
-        if _is_remote_uri(req.file_path):
-            track = index.get_track_by_path(req.file_path)
-            if track is None:
-                raise HTTPException(status_code=404, detail="Track not found")
-            index.set_favorite(req.file_path, req.favorite)
-            queue.update_favorite(req.file_path, req.favorite)
-        else:
-            p = _validate_library_path(req.file_path, _state["library_path"])
-            track = index.get_track_by_path(p)
-            if track is None:
-                raise HTTPException(status_code=404, detail="Track not found")
-            index.set_favorite(p, req.favorite)
-            # Keep the in-memory queue in sync so the next player-state snapshot
-            # reflects the new favorite value without requiring a queue reload.
-            queue.update_favorite(p, req.favorite)
+        track = _resolve_track(
+            index,
+            track_id=req.id,
+            file_path=req.file_path,
+            library_path=_state["library_path"],
+        )
+        if track is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        # Feed the resolved track's canonical uri to the (still file_path-keyed)
+        # stat/queue writers; KAMP-539 makes these id-native (KAMP-537).
+        key = _canonical_track_uri(track.file_path)
+        index.set_favorite(key, req.favorite)
+        # Keep the in-memory queue in sync so the next player-state snapshot
+        # reflects the new favorite value without requiring a queue reload.
+        queue.update_favorite(key, req.favorite)
         return {"ok": True}
 
     @app.post("/api/v1/albums/favorite")
@@ -3312,9 +3339,15 @@ def create_app(
         Used when the client holds an ordered list (e.g. a sorted playlist
         view) that differs from the stored playlist order.
         """
-        tracks = [
-            t for p in req.file_paths if (t := index.get_track_by_path(p)) is not None
-        ]
+        # KAMP-537: ids preferred over file_paths when provided.
+        if req.ids is not None:
+            tracks = [t for i in req.ids if (t := index.get_track_by_id(i)) is not None]
+        else:
+            tracks = [
+                t
+                for p in req.file_paths
+                if (t := index.get_track_by_path(p)) is not None
+            ]
         if not tracks:
             return {"ok": True}
         old_current = queue.current()
@@ -3410,11 +3443,12 @@ def create_app(
 
     @app.post("/api/v1/player/queue/add")
     def queue_add(req: AddToQueueRequest) -> dict[str, Any]:
-        if _is_remote_uri(req.file_path):
-            track = index.get_track_by_path(req.file_path)
-        else:
-            p = _validate_library_path(req.file_path, _state["library_path"])
-            track = index.get_track_by_path(p)
+        track = _resolve_track(
+            index,
+            track_id=req.id,
+            file_path=req.file_path,
+            library_path=_state["library_path"],
+        )
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         was_stopped = queue.current() is None
@@ -3430,11 +3464,12 @@ def create_app(
 
     @app.post("/api/v1/player/queue/play-next")
     def queue_play_next(req: AddToQueueRequest) -> dict[str, Any]:
-        if _is_remote_uri(req.file_path):
-            track = index.get_track_by_path(req.file_path)
-        else:
-            p = _validate_library_path(req.file_path, _state["library_path"])
-            track = index.get_track_by_path(p)
+        track = _resolve_track(
+            index,
+            track_id=req.id,
+            file_path=req.file_path,
+            library_path=_state["library_path"],
+        )
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         was_stopped = queue.current() is None
@@ -3450,11 +3485,12 @@ def create_app(
 
     @app.post("/api/v1/player/queue/insert")
     def queue_insert(req: InsertQueueRequest) -> dict[str, Any]:
-        if _is_remote_uri(req.file_path):
-            track = index.get_track_by_path(req.file_path)
-        else:
-            p = _validate_library_path(req.file_path, _state["library_path"])
-            track = index.get_track_by_path(p)
+        track = _resolve_track(
+            index,
+            track_id=req.id,
+            file_path=req.file_path,
+            library_path=_state["library_path"],
+        )
         if track is None:
             raise HTTPException(status_code=404, detail="Track not found")
         queue.insert_at(track, req.index)
@@ -3805,7 +3841,14 @@ def create_app(
     ) -> dict[str, Any]:
         if index.get_playlist(playlist_id) is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
-        if req.file_path:
+        if req.id is not None:  # KAMP-537: id preferred over file_path
+            track = index.get_track_by_id(req.id)
+            if track is None:
+                raise HTTPException(status_code=404, detail="Track not found")
+            index.add_track_to_playlist(
+                playlist_id, _canonical_track_uri(track.file_path)
+            )
+        elif req.file_path:
             index.add_track_to_playlist(playlist_id, req.file_path)
         elif req.album_artist is not None and req.album is not None:
             tracks = index.tracks_for_album(req.album_artist, req.album)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -324,6 +324,9 @@ class AlbumOut(BaseModel):
     # Non-empty only when missing_album=True; used as the unique lookup key
     # instead of (album_artist, album) for tracks without an album tag.
     file_path: str = ""
+    # KAMP-537: for a missing-album card, the canonical id of its single track —
+    # the stable key to use instead of file_path. None for real albums.
+    track_id: int | None = None
     # MAX(file_mtime) across the album's tracks — appended to art URLs as ?v=
     # so the browser caches images by URL and only re-fetches when files change.
     art_version: float | None = None
@@ -370,6 +373,7 @@ class PlayRequest(BaseModel):
     album: str
     track_index: int = 0
     file_path: str = ""  # non-empty for missing-album tracks
+    id: int | None = None  # KAMP-537: missing-album track id, preferred over file_path
 
 
 class PlayPlaylistRequest(BaseModel):
@@ -499,6 +503,7 @@ class AlbumQueueRequest(BaseModel):
     album_artist: str
     album: str
     file_path: str = ""  # non-empty for missing-album tracks
+    id: int | None = None  # KAMP-537: missing-album track id, preferred over file_path
 
 
 class InsertAlbumQueueRequest(BaseModel):
@@ -506,6 +511,7 @@ class InsertAlbumQueueRequest(BaseModel):
     album: str
     index: int
     file_path: str = ""  # non-empty for missing-album tracks
+    id: int | None = None  # KAMP-537: missing-album track id, preferred over file_path
 
 
 class RemoveFromQueueRequest(BaseModel):
@@ -1313,6 +1319,7 @@ def create_app(
                 has_art=a.has_art,
                 missing_album=a.missing_album,
                 file_path=a.file_path,
+                track_id=a.missing_track_id,
                 art_version=a.art_version,
                 added_at=a.added_at,
                 last_played_at=a.last_played_at,
@@ -2409,6 +2416,7 @@ def create_app(
                     has_art=a.has_art,
                     missing_album=a.missing_album,
                     file_path=a.file_path,
+                    track_id=a.missing_track_id,
                     art_version=a.art_version,
                     added_at=a.added_at,
                     last_played_at=a.last_played_at,
@@ -2539,6 +2547,7 @@ def create_app(
                     has_art=a.has_art,
                     missing_album=a.missing_album,
                     file_path=a.file_path,
+                    track_id=a.missing_track_id,
                     art_version=a.art_version,
                     added_at=a.added_at,
                     last_played_at=a.last_played_at,
@@ -2699,6 +2708,7 @@ def create_app(
                 has_art=a.has_art,
                 missing_album=a.missing_album,
                 file_path=a.file_path,
+                track_id=a.missing_track_id,
                 art_version=a.art_version,
                 added_at=a.added_at,
                 last_played_at=a.last_played_at,
@@ -3264,7 +3274,10 @@ def create_app(
     def play(req: PlayRequest) -> dict[str, Any]:
         old_current = queue.current()
         old_lookahead = queue.peek_next()
-        if req.file_path and _is_remote_uri(req.file_path):
+        if req.id is not None:  # KAMP-537: missing-album track id, preferred
+            track = index.get_track_by_id(req.id)
+            tracks = [track] if track else []
+        elif req.file_path and _is_remote_uri(req.file_path):
             track = index.get_track_by_path(req.file_path)
             tracks = [track] if track else []
         elif req.file_path:
@@ -3499,7 +3512,10 @@ def create_app(
 
     @app.post("/api/v1/player/queue/add-album")
     def queue_add_album(req: AlbumQueueRequest) -> dict[str, Any]:
-        if req.file_path:
+        if req.id is not None:  # KAMP-537: missing-album track id, preferred
+            track = index.get_track_by_id(req.id)
+            tracks = [track] if track else []
+        elif req.file_path:
             p = _validate_library_path(req.file_path, _state["library_path"])
             track = index.get_track_by_path(p)
             tracks = [track] if track else []
@@ -3549,7 +3565,10 @@ def create_app(
 
     @app.post("/api/v1/player/queue/insert-album")
     def queue_insert_album(req: InsertAlbumQueueRequest) -> dict[str, Any]:
-        if req.file_path:
+        if req.id is not None:  # KAMP-537: missing-album track id, preferred
+            track = index.get_track_by_id(req.id)
+            tracks = [track] if track else []
+        elif req.file_path:
             track = index.get_track_by_path(Path(req.file_path))
             tracks = [track] if track else []
         else:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -202,6 +202,30 @@ def resolve_playback_uri(
 # ---------------------------------------------------------------------------
 
 
+class SourceOut(BaseModel):
+    """One delivery of a track (KAMP-537), for display only — local/stream badge,
+    offline state, remove-download affordance. Ordered preferred-first. NOT the
+    client's playability signal: playback is server-resolved and a legacy row can
+    be playable with an empty sources list, so TrackOut.is_available/duration
+    (the preferred source) remain authoritative."""
+
+    kind: str  # 'file' | 'stream'
+    provider: str
+    uri: str
+    is_available: bool
+    duration: float
+
+    @classmethod
+    def from_row(cls, row: Any) -> "SourceOut":
+        return cls(
+            kind=row["kind"],
+            provider=row["provider"] or "",
+            uri=row["uri"],
+            is_available=bool(row["is_available"]),
+            duration=float(row["duration"] or 0.0),
+        )
+
+
 class TrackOut(BaseModel):
     id: int
     title: str
@@ -224,9 +248,10 @@ class TrackOut(BaseModel):
     reachable: bool = True
     is_available: bool = True
     duration: float = 0.0
+    sources: list[SourceOut] = []
 
     @classmethod
-    def from_track(cls, t: Track) -> "TrackOut":
+    def from_track(cls, t: Track, sources: "list[Any] | None" = None) -> "TrackOut":
         return cls(
             id=t.id,
             title=t.title,
@@ -249,6 +274,7 @@ class TrackOut(BaseModel):
             reachable=t.reachable,
             is_available=t.is_available,
             duration=t.duration,
+            sources=[SourceOut.from_row(r) for r in (sources or [])],
         )
 
 
@@ -274,7 +300,7 @@ class StatsOut(BaseModel):
     top_tracks: list[TrackOut]
 
     @classmethod
-    def from_stats(cls, s: LibraryStats) -> "StatsOut":
+    def from_stats(cls, s: LibraryStats, top_tracks_out: list[TrackOut]) -> "StatsOut":
         return cls(
             track_count=s.track_count,
             album_count=s.album_count,
@@ -284,7 +310,7 @@ class StatsOut(BaseModel):
             albums_played=s.albums_played,
             top_artist_name=s.top_artist_name,
             top_artist_seconds=s.top_artist_seconds,
-            top_tracks=[TrackOut.from_track(t) for t in s.top_tracks],
+            top_tracks=top_tracks_out,
         )
 
 
@@ -666,6 +692,7 @@ class PlaylistTrackOut(BaseModel):
     source: str
     is_available: bool
     duration: float
+    sources: list[SourceOut] = []
 
 
 class CreatePlaylistRequest(BaseModel):
@@ -805,6 +832,24 @@ def _is_remote_uri(s: str) -> bool:
     """True for scheme-prefixed remote URIs (bandcamp://, etc.) that must bypass
     library-path validation."""
     return "://" in s or s.startswith("bandcamp:")
+
+
+def _tracks_out(index: LibraryIndex, tracks: "list[Track]") -> list[TrackOut]:
+    """Serialize a list of tracks to TrackOut with sources batch-fetched (KAMP-537).
+
+    One sources_for_track_ids call for the whole list (no N+1). Synthetic queue
+    restore stubs (id=0) are excluded from the batch and get an empty sources
+    list. Use this instead of a bare `[TrackOut.from_track(t) for t in ...]`.
+    """
+    src_map = index.sources_for_track_ids([t.id for t in tracks if t.id])
+    return [TrackOut.from_track(t, src_map.get(t.id, [])) for t in tracks]
+
+
+def _track_out(index: LibraryIndex, track: Track) -> TrackOut:
+    """Serialize a single track to TrackOut with its sources (KAMP-537)."""
+    return TrackOut.from_track(
+        track, index.sources_for_track_ids([track.id]).get(track.id, [])
+    )
 
 
 def _validate_proxy_url(url: str) -> str:
@@ -1219,8 +1264,8 @@ def create_app(
             position=pos,
             duration=engine.state.duration,
             volume=engine.state.volume,
-            current_track=TrackOut.from_track(current) if current else None,
-            next_track=TrackOut.from_track(nxt) if nxt else None,
+            current_track=_track_out(index, current) if current else None,
+            next_track=_track_out(index, nxt) if nxt else None,
             buffering=_state["buffering"],
         )
 
@@ -1261,7 +1306,8 @@ def create_app(
 
     @app.get("/api/v1/stats", response_model=StatsOut)
     def get_stats(top_tracks: int = 3) -> StatsOut:
-        return StatsOut.from_stats(index.get_stats(top_tracks_limit=top_tracks))
+        s = index.get_stats(top_tracks_limit=top_tracks)
+        return StatsOut.from_stats(s, _tracks_out(index, s.top_tracks))
 
     @app.get("/api/v1/artists/top", response_model=list[ArtistOut])
     def get_top_artists(limit: int = 10) -> list[ArtistOut]:
@@ -1273,7 +1319,7 @@ def create_app(
 
     @app.get("/api/v1/tracks/top", response_model=list[TrackOut])
     def get_top_tracks(limit: int = 10) -> list[TrackOut]:
-        return [TrackOut.from_track(t) for t in index.top_tracks(limit)]
+        return _tracks_out(index, index.top_tracks(limit))
 
     @app.get("/api/v1/tracks", response_model=list[TrackOut])
     def get_tracks(
@@ -1286,10 +1332,8 @@ def create_app(
         if file_path:
             p = _validate_library_path(file_path, _state["library_path"])
             track = index.get_track_by_path(p)
-            return [TrackOut.from_track(track)] if track else []
-        return [
-            TrackOut.from_track(t) for t in index.tracks_for_album(album_artist, album)
-        ]
+            return [_track_out(index, track)] if track else []
+        return _tracks_out(index, index.tracks_for_album(album_artist, album))
 
     @app.patch("/api/v1/tracks/{track_id}/tags")
     def patch_track_tags(track_id: int, req: "TrackTagsRequest") -> Any:
@@ -1373,7 +1417,7 @@ def create_app(
             queue.update_track_path(old_path, old_path, req.title)
             _notify_library_changed()
             updated = index.get_track_by_id(track_id)
-            return TrackOut.from_track(updated)  # type: ignore[arg-type]
+            return _track_out(index, updated)  # type: ignore[arg-type]
 
         # is_case_only was computed before the lock check so it is available
         # for both the deferred-op payload and the immediate rename path.
@@ -1422,7 +1466,7 @@ def create_app(
 
         _notify_library_changed()
         updated = index.get_track_by_id(track_id)
-        return TrackOut.from_track(updated)  # type: ignore[arg-type]
+        return _track_out(index, updated)  # type: ignore[arg-type]
 
     @app.patch("/api/v1/tracks/{track_id}/meta")
     def patch_track_meta(track_id: int, req: "TrackMetaRequest") -> "TrackOut":
@@ -1452,7 +1496,7 @@ def create_app(
 
         updated = index.update_track_mb_recording_id(track_id, req.mb_recording_id)
         _notify_library_changed()
-        return TrackOut.from_track(updated)  # type: ignore[arg-type]
+        return _track_out(index, updated)  # type: ignore[arg-type]
 
     @app.get("/api/v1/deferred-ops")
     def get_deferred_ops() -> list[dict[str, Any]]:
@@ -1645,7 +1689,7 @@ def create_app(
                     )
                     updated = index.get_track_by_id(track.id)
                     if updated is not None:
-                        moved.append(TrackOut.from_track(updated))
+                        moved.append(_track_out(index, updated))
                 except Exception as exc:
                     logger.exception("tag write failed for %s", old_path)
                     failed.append(
@@ -1746,7 +1790,7 @@ def create_app(
                         )
                         updated = index.get_track_by_id(track.id)
                         if updated is not None:
-                            moved.append(TrackOut.from_track(updated))
+                            moved.append(_track_out(index, updated))
                     except Exception as exc:
                         logger.exception("album per-file move failed for %s", old_path)
                         failed.append(
@@ -1858,7 +1902,7 @@ def create_app(
                     if tag_write_ok:
                         updated = index.get_track_by_id(track.id)
                         if updated is not None:
-                            moved.append(TrackOut.from_track(updated))
+                            moved.append(_track_out(index, updated))
 
                 try:
                     index.rename_album_tracks_bulk(
@@ -1958,7 +2002,7 @@ def create_app(
                     )
                     updated = index.get_track_by_id(track.id)
                     if updated is not None:
-                        moved.append(TrackOut.from_track(updated))
+                        moved.append(_track_out(index, updated))
                 except Exception as exc:
                     logger.exception(
                         "album merge failed for track %d (%s)", track.id, old_path
@@ -2023,7 +2067,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="Track not found")
         updated = index.update_track_display_title(track_id, req.display_title)
         _notify_library_changed()
-        return TrackOut.from_track(updated)  # type: ignore[arg-type]
+        return _track_out(index, updated)  # type: ignore[arg-type]
 
     @app.patch("/api/v1/albums/display", response_model=AlbumOut)
     def patch_album_display(req: "AlbumDisplayRequest") -> AlbumOut:
@@ -2118,7 +2162,7 @@ def create_app(
             mb_release_id=req.mb_release_id,
         )
         _notify_library_changed()
-        return AlbumMetaOut(tracks=[TrackOut.from_track(t) for t in updated])
+        return AlbumMetaOut(tracks=_tracks_out(index, updated))
 
     @app.get("/api/v1/albums/musicbrainz", response_model=MusicBrainzLookupOut)
     async def get_album_musicbrainz(
@@ -2662,7 +2706,7 @@ def create_app(
 
         return SearchOut(
             albums=albums,
-            tracks=[TrackOut.from_track(t) for t in fts_tracks],
+            tracks=_tracks_out(index, fts_tracks),
             playlists=playlists,
         )
 
@@ -3171,7 +3215,7 @@ def create_app(
     def get_queue() -> QueueOut:
         tracks, pos = queue.queue_tracks()
         return QueueOut(
-            tracks=[TrackOut.from_track(t) for t in tracks],
+            tracks=_tracks_out(index, tracks),
             position=pos,
             shuffle=queue.shuffle,
             repeat=queue.repeat,
@@ -3708,8 +3752,17 @@ def create_app(
         if index.get_playlist(playlist_id) is None:
             raise HTTPException(status_code=404, detail="Playlist not found")
         if index.get_magic_playlist_criteria(playlist_id) is not None:
-            return index.get_magic_playlist_tracks(playlist_id)
-        return index.get_playlist_tracks(playlist_id)
+            rows = index.get_magic_playlist_tracks(playlist_id)
+        else:
+            rows = index.get_playlist_tracks(playlist_id)
+        # These rows are hand-rolled dicts (not via TrackOut.from_track), so attach
+        # sources here in the response layer (KAMP-537).
+        src_map = index.sources_for_track_ids([r["id"] for r in rows if r.get("id")])
+        for r in rows:
+            r["sources"] = [
+                SourceOut.from_row(s).model_dump() for s in src_map.get(r["id"], [])
+            ]
+        return rows
 
     @app.put("/api/v1/playlists/{playlist_id}/criteria", response_model=PlaylistOut)
     def update_playlist_criteria(

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1256,6 +1256,8 @@ class TestLibraryIndex:
         assert albums[0].missing_album is True
         assert albums[0].album == "Standalone Track"  # title used as display name
         assert albums[0].file_path == str(tmp_path / "standalone.mp3")
+        # KAMP-537: the entry carries its single track's canonical id.
+        assert albums[0].missing_track_id is not None and albums[0].missing_track_id > 0
 
     def test_two_missing_album_tracks_each_get_own_entry(self, tmp_path: Path) -> None:
         """Each track without an album tag should be its own entry, not grouped."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -151,7 +151,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 50
+        assert version == 48
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -258,7 +258,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -351,7 +351,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 50
+        assert version == 48
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -843,75 +843,17 @@ class TestLibraryIndex:
         assert surv == file_id  # survivor is the local download
         assert kinds == ["file", "stream"]  # stream re-parented onto it
 
-    def test_v49_heals_leftover_download_stream_fork(self, tmp_path: Path) -> None:
-        """v49 re-collapses a file+stream fork the one-time v48 heal never revisited.
-
-        Reproduces the residue KAMP-537 found: a previously-downloaded track and its
-        stream sit as two un-merged rows at v48 (the current reconcile merges new
-        downloads, but nothing reprocesses a pair left forked during the epic's
-        development). Opening at v48 runs the v49 heal and collapses them.
-        """
-        db = tmp_path / "library.db"
-        index = LibraryIndex(db)
-        c = index._conn
-        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid49')")
-        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
-        alb = c.execute("SELECT id FROM albums").fetchone()[0]
-        c.execute(
-            "INSERT INTO tracks (file_path, source, album_id, track_number,"
-            " disc_number, sale_item_id) VALUES ('/m/a.mp3','local',?,1,1,'sid49')",
-            (alb,),
-        )
-        file_id = c.execute("SELECT id FROM tracks").fetchone()[0]
-        c.execute(
-            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/a.mp3')",
-            (file_id,),
-        )
-        c.execute(
-            "INSERT INTO tracks (file_path, source, album_id, track_number,"
-            " disc_number, sale_item_id)"
-            " VALUES ('bandcamp://sid49/1','bandcamp',?,1,1,'sid49')",
-            (alb,),
-        )
-        stream_id = c.execute(
-            "SELECT id FROM tracks WHERE id != ?", (file_id,)
-        ).fetchone()[0]
-        c.execute(
-            "INSERT INTO track_sources (track_id, kind, uri)"
-            " VALUES (?, 'stream', 'bandcamp://sid49/1')",
-            (stream_id,),
-        )
-        c.execute("UPDATE schema_version SET version = 48")
-        c.commit()
-        index.close()
-
-        healed = LibraryIndex(db)  # runs the v49 heal
-        hc = healed._conn
-        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-        kinds = sorted(
-            r["kind"]
-            for r in hc.execute(
-                "SELECT kind FROM track_sources WHERE track_id = ?", (file_id,)
-            )
-        )
-        surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
-        ver = hc.execute("SELECT version FROM schema_version").fetchone()[0]
-        healed.close()
-        assert ver == 50
-        assert n_tracks == 1  # the fork is gone
-        assert surv == file_id  # survivor is the local download
-        assert kinds == ["file", "stream"]  # stream re-parented onto it
-
     def test_collapse_heal_works_without_preexisting_view(self, tmp_path: Path) -> None:
         """A collapse heal must build the tracks_with_stats view before running.
 
-        Regression for the KAMP-542 view-timing bug: the collapse calls
-        _refresh_album_aggregates, which reads tracks_with_stats. On a pre-542
-        upgrade the view did not exist yet, so every heal threw 'no such table:
-        tracks_with_stats', rolled back, and left the two-row fork model while the
-        version still bumped. This drops the view before a heal runs and asserts
-        the collapse still succeeds (the view is now created at the top of
-        _migrate).
+        Regression for the KAMP-542 view-timing bug (root cause of the persistent
+        Snail Mail - Lush dupes): the v46 collapse calls _refresh_album_aggregates,
+        which reads tracks_with_stats. On a pre-542 upgrade the view did not exist
+        yet, so the collapse threw 'no such table: tracks_with_stats', the whole
+        one-transaction heal rolled back, and the two-row fork model survived while
+        the version still bumped. This drops the view and rewinds to v45 so the v46
+        collapse runs, and asserts the fork collapses (the view is now created at
+        the top of _migrate, before any heal).
         """
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
@@ -943,17 +885,26 @@ class TestLibraryIndex:
             " VALUES (?, 'stream', 'bandcamp://sidv/1')",
             (stream_id,),
         )
-        # Simulate a pre-KAMP-542 DB: no view, and a version that triggers a heal.
+        # Simulate a pre-KAMP-542 DB: no view, rewound to before the v46 collapse.
         c.execute("DROP VIEW IF EXISTS tracks_with_stats")
-        c.execute("UPDATE schema_version SET version = 49")
+        c.execute("UPDATE schema_version SET version = 45")
         c.commit()
         index.close()
 
-        healed = LibraryIndex(db)  # v50 heal must build the view, then collapse
+        healed = LibraryIndex(db)  # v46 collapse must build the view, then collapse
         hc = healed._conn
         n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in hc.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (file_id,)
+            )
+        )
+        surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
         healed.close()
         assert n_tracks == 1  # collapse ran (would be 2 if the heal had thrown)
+        assert surv == file_id  # survivor is the local download
+        assert kinds == ["file", "stream"]  # stream re-parented onto it
 
     def test_all_downloads_streamable(self, tmp_path: Path) -> None:
         """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
@@ -2667,7 +2618,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2724,7 +2675,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3319,7 +3270,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert row is not None
         assert row[0] == 0
 
@@ -3774,7 +3725,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3870,7 +3821,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4051,7 +4002,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4146,7 +4097,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 50
+        assert version == 48
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4154,7 +4105,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 50
+        assert version == 48
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5031,7 +4982,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 50
+        assert version == 48
 
         index.close()
 
@@ -5722,7 +5673,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 50
+        assert version == 48
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5757,7 +5708,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 50
+        assert version == 48
         index.close()
 
 
@@ -6272,7 +6223,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 50
+        assert version == 48
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6405,7 +6356,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 50
+        assert version == 48
 
 
 class TestRemoteTrackSchema:
@@ -6748,7 +6699,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6809,7 +6760,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7607,7 +7558,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8166,7 +8117,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -8244,7 +8195,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8450,7 +8401,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8800,7 +8751,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8897,7 +8848,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9013,7 +8964,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9518,7 +9469,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9633,7 +9584,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9731,7 +9682,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9831,7 +9782,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10338,7 +10289,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 50
+        assert version == 48
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11212,7 +11163,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 50
+        assert version == 48
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12328,7 +12279,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 50
+        assert version == 48
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -12348,7 +12299,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 50
+        assert version == 48
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -12390,7 +12341,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 50
+        assert version == 48
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -151,7 +151,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 49
+        assert version == 50
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -258,7 +258,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -351,7 +351,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 49
+        assert version == 50
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -897,10 +897,63 @@ class TestLibraryIndex:
         surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
         ver = hc.execute("SELECT version FROM schema_version").fetchone()[0]
         healed.close()
-        assert ver == 49
+        assert ver == 50
         assert n_tracks == 1  # the fork is gone
         assert surv == file_id  # survivor is the local download
         assert kinds == ["file", "stream"]  # stream re-parented onto it
+
+    def test_collapse_heal_works_without_preexisting_view(self, tmp_path: Path) -> None:
+        """A collapse heal must build the tracks_with_stats view before running.
+
+        Regression for the KAMP-542 view-timing bug: the collapse calls
+        _refresh_album_aggregates, which reads tracks_with_stats. On a pre-542
+        upgrade the view did not exist yet, so every heal threw 'no such table:
+        tracks_with_stats', rolled back, and left the two-row fork model while the
+        version still bumped. This drops the view before a heal runs and asserts
+        the collapse still succeeds (the view is now created at the top of
+        _migrate).
+        """
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidv')")
+        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, sale_item_id) VALUES ('/m/a.mp3','local',?,1,1,'sidv')",
+            (alb,),
+        )
+        file_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/a.mp3')",
+            (file_id,),
+        )
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, sale_item_id)"
+            " VALUES ('bandcamp://sidv/1','bandcamp',?,1,1,'sidv')",
+            (alb,),
+        )
+        stream_id = c.execute(
+            "SELECT id FROM tracks WHERE id != ?", (file_id,)
+        ).fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri)"
+            " VALUES (?, 'stream', 'bandcamp://sidv/1')",
+            (stream_id,),
+        )
+        # Simulate a pre-KAMP-542 DB: no view, and a version that triggers a heal.
+        c.execute("DROP VIEW IF EXISTS tracks_with_stats")
+        c.execute("UPDATE schema_version SET version = 49")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # v50 heal must build the view, then collapse
+        hc = healed._conn
+        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        healed.close()
+        assert n_tracks == 1  # collapse ran (would be 2 if the heal had thrown)
 
     def test_all_downloads_streamable(self, tmp_path: Path) -> None:
         """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
@@ -2614,7 +2667,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2671,7 +2724,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3266,7 +3319,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         assert row[0] == 0
 
@@ -3721,7 +3774,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3817,7 +3870,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3998,7 +4051,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4093,7 +4146,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4101,7 +4154,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4978,7 +5031,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
 
         index.close()
 
@@ -5669,7 +5722,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5704,7 +5757,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
         index.close()
 
 
@@ -6219,7 +6272,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 49
+        assert version == 50
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6352,7 +6405,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 49
+        assert version == 50
 
 
 class TestRemoteTrackSchema:
@@ -6695,7 +6748,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6756,7 +6809,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7554,7 +7607,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8113,7 +8166,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -8191,7 +8244,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8397,7 +8450,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8747,7 +8800,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8844,7 +8897,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8960,7 +9013,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9465,7 +9518,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9580,7 +9633,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9678,7 +9731,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9778,7 +9831,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10285,7 +10338,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11159,7 +11212,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 49
+        assert version == 50
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12275,7 +12328,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 49
+        assert version == 50
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -12295,7 +12348,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -12337,7 +12390,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 49
+        assert version == 50
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -151,7 +151,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 48
+        assert version == 49
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -258,7 +258,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -351,7 +351,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 48
+        assert version == 49
         assert n_src == 0
 
     def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
@@ -840,6 +840,65 @@ class TestLibraryIndex:
         surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
         healed.close()
         assert n_tracks == 1  # the forked stream row is gone
+        assert surv == file_id  # survivor is the local download
+        assert kinds == ["file", "stream"]  # stream re-parented onto it
+
+    def test_v49_heals_leftover_download_stream_fork(self, tmp_path: Path) -> None:
+        """v49 re-collapses a file+stream fork the one-time v48 heal never revisited.
+
+        Reproduces the residue KAMP-537 found: a previously-downloaded track and its
+        stream sit as two un-merged rows at v48 (the current reconcile merges new
+        downloads, but nothing reprocesses a pair left forked during the epic's
+        development). Opening at v48 runs the v49 heal and collapses them.
+        """
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        c = index._conn
+        c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid49')")
+        c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, sale_item_id) VALUES ('/m/a.mp3','local',?,1,1,'sid49')",
+            (alb,),
+        )
+        file_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri) VALUES (?, 'file', '/m/a.mp3')",
+            (file_id,),
+        )
+        c.execute(
+            "INSERT INTO tracks (file_path, source, album_id, track_number,"
+            " disc_number, sale_item_id)"
+            " VALUES ('bandcamp://sid49/1','bandcamp',?,1,1,'sid49')",
+            (alb,),
+        )
+        stream_id = c.execute(
+            "SELECT id FROM tracks WHERE id != ?", (file_id,)
+        ).fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri)"
+            " VALUES (?, 'stream', 'bandcamp://sid49/1')",
+            (stream_id,),
+        )
+        c.execute("UPDATE schema_version SET version = 48")
+        c.commit()
+        index.close()
+
+        healed = LibraryIndex(db)  # runs the v49 heal
+        hc = healed._conn
+        n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in hc.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (file_id,)
+            )
+        )
+        surv = hc.execute("SELECT id FROM tracks").fetchone()[0]
+        ver = hc.execute("SELECT version FROM schema_version").fetchone()[0]
+        healed.close()
+        assert ver == 49
+        assert n_tracks == 1  # the fork is gone
         assert surv == file_id  # survivor is the local download
         assert kinds == ["file", "stream"]  # stream re-parented onto it
 
@@ -2555,7 +2614,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2612,7 +2671,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3207,7 +3266,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         assert row[0] == 0
 
@@ -3662,7 +3721,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3758,7 +3817,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3939,7 +3998,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4034,7 +4093,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4042,7 +4101,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4919,7 +4978,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
 
         index.close()
 
@@ -5610,7 +5669,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5645,7 +5704,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
         index.close()
 
 
@@ -6160,7 +6219,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 48
+        assert version == 49
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6293,7 +6352,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 48
+        assert version == 49
 
 
 class TestRemoteTrackSchema:
@@ -6636,7 +6695,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6697,7 +6756,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7495,7 +7554,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8054,7 +8113,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -8132,7 +8191,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8338,7 +8397,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8688,7 +8747,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8785,7 +8844,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8901,7 +8960,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9406,7 +9465,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9521,7 +9580,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9619,7 +9678,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9719,7 +9778,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10226,7 +10285,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11100,7 +11159,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 48
+        assert version == 49
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12216,7 +12275,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 48
+        assert version == 49
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -12236,7 +12295,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -12278,7 +12337,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 48
+        assert version == 49
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -438,6 +438,37 @@ class TestLibraryIndex:
         assert pref["kind"] == "stream"
         assert pref["uri"] == "bandcamp://9/1"
 
+    def test_sources_for_track_ids_batches_preferred_first(
+        self, tmp_path: Path
+    ) -> None:
+        """sources_for_track_ids returns all sources per track, preferred-first (KAMP-537)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO tracks (file_path, source) VALUES ('a', 'local')")
+        c.execute("INSERT INTO tracks (file_path, source) VALUES ('b', 'bandcamp')")
+        t1, t2 = [r[0] for r in c.execute("SELECT id FROM tracks ORDER BY id")]
+        c.executemany(
+            "INSERT INTO track_sources (track_id, kind, provider, uri, is_available,"
+            " duration) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (t1, "stream", "bandcamp", "bandcamp://9/1", 1, 100.0),
+                (t1, "file", "local", "/m/a.mp3", 1, 101.0),
+                (t2, "stream", "bandcamp", "bandcamp://9/2", 1, 200.0),
+            ],
+        )
+        c.commit()
+        out = index.sources_for_track_ids([t1, t2, 999])
+        index.close()
+        # t1: file preferred-first over stream; t2: its one stream; 999: absent.
+        assert [r["kind"] for r in out[t1]] == ["file", "stream"]
+        assert [r["kind"] for r in out[t2]] == ["stream"]
+        assert 999 not in out
+
+    def test_sources_for_track_ids_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.sources_for_track_ids([]) == {}
+        index.close()
+
     def test_remove_track_keeps_track_with_surviving_stream(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -306,6 +306,75 @@ class TestAlbumsEndpoint:
         mock_index.albums.assert_called_with(sort="album_artist", sort_dir=None)
 
 
+class TestTrackSources:
+    """TrackOut/PlaylistTrackOut carry a sources[] list wired from the index (KAMP-537)."""
+
+    _SRCS = {
+        1: [
+            {
+                "kind": "file",
+                "provider": "local",
+                "uri": "/m/a.mp3",
+                "is_available": 1,
+                "duration": 101.0,
+            },
+            {
+                "kind": "stream",
+                "provider": "bandcamp",
+                "uri": "bandcamp://9/1",
+                "is_available": 1,
+                "duration": 100.0,
+            },
+        ]
+    }
+
+    def test_get_tracks_includes_sources(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.id = 1
+        mock_index.tracks_for_album.return_value = [track]
+        mock_index.sources_for_track_ids.return_value = self._SRCS
+        c = TestClient(
+            create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        )
+        res = c.get("/api/v1/tracks?album_artist=Artist&album=Album")
+        assert res.status_code == 200
+        srcs = res.json()[0]["sources"]
+        assert [s["kind"] for s in srcs] == ["file", "stream"]
+        assert srcs[1]["uri"] == "bandcamp://9/1"
+
+    def test_queue_includes_sources(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        # The queue path bypasses TrackOut.from_track's usual list builders — assert
+        # it still gets sources (Reality-Checker risk #1).
+        track = _track(1)
+        track.id = 1
+        mock_queue.queue_tracks.return_value = ([track], 0)
+        mock_index.sources_for_track_ids.return_value = self._SRCS
+        c = TestClient(
+            create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        )
+        res = c.get("/api/v1/player/queue")
+        assert res.status_code == 200
+        assert [s["kind"] for s in res.json()["tracks"][0]["sources"]] == [
+            "file",
+            "stream",
+        ]
+
+    def test_sourceless_track_has_empty_sources(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        mock_index.sources_for_track_ids.return_value = {}  # legacy row, no sources
+        c = TestClient(
+            create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        )
+        res = c.get("/api/v1/tracks?album_artist=Artist&album=Album")
+        assert res.json()[0]["sources"] == []
+
+
 class TestAlbumArtEndpoint:
     def test_returns_art_bytes_when_embedded(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2110,6 +2110,53 @@ class TestFavoriteEndpoint:
         assert resp.status_code == 404
 
 
+class TestApiIdContract:
+    """Freezes the KAMP-537 track-shape contract handed to KAMP-538, and the exact
+    set of response shapes still carrying file_path — the KAMP-539 removal checklist.
+    A drift (a shape gains/loses id, sources, or file_path) fails here."""
+
+    def test_source_out_fields(self) -> None:
+        from kamp_core.server import SourceOut
+
+        assert set(SourceOut.model_fields) == {
+            "kind",
+            "provider",
+            "uri",
+            "is_available",
+            "duration",
+        }
+
+    def test_track_shapes_carry_id_and_sources(self) -> None:
+        from kamp_core.server import PlaylistTrackOut, TrackOut
+
+        assert {"id", "sources", "file_path"} <= set(TrackOut.model_fields)
+        assert {"id", "sources", "file_path"} <= set(PlaylistTrackOut.model_fields)
+
+    def test_album_out_exposes_missing_track_id(self) -> None:
+        from kamp_core.server import AlbumOut
+
+        assert {"track_id", "file_path", "missing_album"} <= set(AlbumOut.model_fields)
+
+    def test_file_path_carrying_out_shapes_are_the_539_checklist(self) -> None:
+        import inspect
+
+        from pydantic import BaseModel
+
+        from kamp_core import server
+
+        carriers = {
+            name
+            for name, obj in inspect.getmembers(server, inspect.isclass)
+            if issubclass(obj, BaseModel)
+            and obj.__module__ == server.__name__
+            and name.endswith("Out")
+            and "file_path" in obj.model_fields
+        }
+        # KAMP-539 deletes file_path from exactly these response shapes (plus the
+        # request bodies). Update this set — and 539 — together if it changes.
+        assert carriers == {"TrackOut", "PlaylistTrackOut", "AlbumOut"}
+
+
 class TestDualAcceptId:
     """Track-keyed endpoints resolve the canonical id, preferred over file_path (KAMP-537)."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2030,13 +2030,11 @@ class TestFavoriteEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
-        mock_index.set_favorite.assert_called_once_with(
-            Path("/music/01.mp3").resolve(), True
-        )
+        # KAMP-537: favorite resolves the track first, then keys on its canonical
+        # uri (the stored preferred-source path), not the raw request path.
+        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
         # Queue must also be updated so the next player-state snapshot is correct.
-        mock_queue.update_favorite.assert_called_once_with(
-            Path("/music/01.mp3").resolve(), True
-        )
+        mock_queue.update_favorite.assert_called_once_with("/music/01.mp3", True)
 
     def test_set_favorite_returns_404_for_unknown_track(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2096,8 +2094,9 @@ class TestFavoriteEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
-        mock_index.set_favorite.assert_called_once_with(remote_uri, True)
-        mock_queue.update_favorite.assert_called_once_with(remote_uri, True)
+        # KAMP-537: keys on the resolved track's canonical uri, not the request uri.
+        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
+        mock_queue.update_favorite.assert_called_once_with("/music/01.mp3", True)
 
     def test_set_favorite_remote_track_returns_404_when_not_found(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2109,6 +2108,61 @@ class TestFavoriteEndpoint:
             json={"file_path": "bandcamp://999/3", "favorite": True},
         )
         assert resp.status_code == 404
+
+
+class TestDualAcceptId:
+    """Track-keyed endpoints resolve the canonical id, preferred over file_path (KAMP-537)."""
+
+    def test_favorite_by_id(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.id = 5
+        mock_index.get_track_by_id.return_value = track
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite", json={"id": 5, "favorite": True}
+        )
+        assert resp.status_code == 200
+        mock_index.get_track_by_id.assert_called_once_with(5)
+        mock_index.get_track_by_path.assert_not_called()
+        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
+
+    def test_favorite_id_wins_when_both_sent(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.id = 5
+        mock_index.get_track_by_id.return_value = track
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/tracks/favorite",
+            json={"id": 5, "file_path": "/music/other.mp3", "favorite": True},
+        )
+        assert resp.status_code == 200
+        # id wins — no 400, file_path ignored.
+        mock_index.get_track_by_id.assert_called_once_with(5)
+        mock_index.get_track_by_path.assert_not_called()
+
+    def test_favorite_neither_id_nor_file_path_is_404(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post("/api/v1/tracks/favorite", json={"favorite": True})
+        assert resp.status_code == 404
+
+    def test_queue_add_by_id(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        track = _track(1)
+        track.id = 7
+        mock_index.get_track_by_id.return_value = track
+        mock_queue.current.return_value = None
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post("/api/v1/player/queue/add", json={"id": 7})
+        assert resp.status_code == 200
+        mock_index.get_track_by_id.assert_called_once_with(7)
+        mock_queue.add_to_queue.assert_called_once_with(track)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2032,9 +2032,13 @@ class TestFavoriteEndpoint:
         assert resp.json() == {"ok": True}
         # KAMP-537: favorite resolves the track first, then keys on its canonical
         # uri (the stored preferred-source path), not the raw request path.
-        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
+        mock_index.set_favorite.assert_called_once_with(
+            str(Path("/music/01.mp3")), True
+        )
         # Queue must also be updated so the next player-state snapshot is correct.
-        mock_queue.update_favorite.assert_called_once_with("/music/01.mp3", True)
+        mock_queue.update_favorite.assert_called_once_with(
+            str(Path("/music/01.mp3")), True
+        )
 
     def test_set_favorite_returns_404_for_unknown_track(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2095,8 +2099,12 @@ class TestFavoriteEndpoint:
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
         # KAMP-537: keys on the resolved track's canonical uri, not the request uri.
-        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
-        mock_queue.update_favorite.assert_called_once_with("/music/01.mp3", True)
+        mock_index.set_favorite.assert_called_once_with(
+            str(Path("/music/01.mp3")), True
+        )
+        mock_queue.update_favorite.assert_called_once_with(
+            str(Path("/music/01.mp3")), True
+        )
 
     def test_set_favorite_remote_track_returns_404_when_not_found(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2173,7 +2181,9 @@ class TestDualAcceptId:
         assert resp.status_code == 200
         mock_index.get_track_by_id.assert_called_once_with(5)
         mock_index.get_track_by_path.assert_not_called()
-        mock_index.set_favorite.assert_called_once_with("/music/01.mp3", True)
+        mock_index.set_favorite.assert_called_once_with(
+            str(Path("/music/01.mp3")), True
+        )
 
     def test_favorite_id_wins_when_both_sent(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## KAMP-537 — Server API: move track identity off file_path to canonical id

Part of epic **KAMP-533**. Moves the server API onto the stable canonical track `id` so KAMP-539 can delete the mutable `file_path`, and adds a per-track `sources[]` list the KAMP-538 UI will consume. Additive + dual-accept, so **no behavior change for the current UI**. Design note §4.

### Commits

| Commit | What |
|---|---|
| `2619792` | **`sources[]` on every track shape.** `SourceOut` (kind/provider/uri/is_available/duration) added to `TrackOut` + `PlaylistTrackOut`, populated in the response layer via one batch `LibraryIndex.sources_for_track_ids(ids)` per list — including the two shapes that bypass `TrackOut.from_track` (the queue path with its `id=0` stubs, and the hand-rolled playlist dicts). Display-only: a sourceless row yields `[]` yet stays playable, so top-level `is_available`/`duration` remain authoritative. |
| `2e4d297` | **Dual-accept `id` on track-keyed request bodies** (favorite, queue add/play-next/insert, play-files, add-to-playlist). `id` wins when present — even if `file_path` is also sent (no 400); else the file_path bridge; neither → 404. A shared `_resolve_track` centralizes it. |
| `4e6ea64` | **Missing-album cards/actions keyed on the track id.** `AlbumInfo`/`AlbumOut` expose the single track's `missing_track_id`/`track_id` (threaded through the `albums()` UNION); the album-shaped play/queue requests accept `id`. Real albums keep their `(album_artist, album)` key — album-level file_paths are deliberately not swept in. |
| `cac4036` | **Contract tests** freezing the track-shape fields and the exact set of `*Out` shapes still carrying `file_path` (`{TrackOut, PlaylistTrackOut, AlbumOut}` — the 539 removal checklist). |

### Transition tactic (§4)

`TrackOut.file_path` stays a **computed** preferred-source uri through this ticket, so KAMP-538 migrates the ~24 UI files' keys/favorite-target from `file_path` to `id` incrementally. The file_path request/response fields and the KAMP-541 stream-uri bridge are deleted in KAMP-539.

### Hazard to flag for KAMP-538

`file_path` is **unstable across download add/remove** — it's the preferred-source uri (a local path once downloaded), and the KAMP-541 `get_track_by_path` fallback is stream-only. So a UI that stores `file_path` as a key/favorite-target, then removes the download, will find the old local path resolves to nothing. This is the concrete reason 538 must migrate keys to `id`.

### Verification

- **Dual-accept round-trip** (favorite/queue-add by `id` select the same track as by `file_path`; `id` wins when both sent; neither → 404).
- **sources plumbing** wired through the tracks + queue (bypass shape) endpoints; sourceless row → `[]`.
- **`sources_for_track_ids`** batches preferred-first.
- **Missing-album** entry exposes its track id and resolves by it.
- **Contract/checklist tests** freeze the shapes for 538 and the 539 file_path removal set.
- Full suite **2237 passed, 9 skipped, coverage 93.05%**; `black` + `mypy` clean.

### Next in the epic

KAMP-538 (UI migrates keys to `id`, consumes `sources[]`) then KAMP-539 (drop `file_path`/`source`/legacy stat columns, delete `inherit_remote_*` + the file_path fallback + the stream bridge). This PR's checklist test is the 539 starting point.

Manual verification (user drives; UI checks land in 538): favorite/queue/play a track by the existing flows and confirm identical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
