### PR TITLE
feat(ui): address tracks by canonical id, not file_path (KAMP-538)

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -52,27 +52,6 @@ class PlaybackState:
 
 
 # ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _canonical_track_uri(path: "Path | str") -> str:
-    """Canonical string key for remote track URI comparison and persistence.
-
-    Normalises POSIX single-slash (bandcamp:/) and Windows backslash
-    (bandcamp:\\) forms to the canonical double-slash form (bandcamp://)
-    so DB lookups and in-queue comparisons are consistent across platforms.
-    Local paths are returned as-is via str().
-    """
-    s = str(path)
-    if s.startswith("bandcamp:"):
-        rest = s.split("bandcamp:", 1)[1].lstrip("/\\").replace("\\", "/")
-        return "bandcamp://" + rest
-    return s
-
-
-# ---------------------------------------------------------------------------
 # PlaybackQueue
 # ---------------------------------------------------------------------------
 
@@ -97,16 +76,21 @@ class PlaybackQueue:
         else:
             self._pos = start_index if tracks else -1
 
-    def update_favorite(self, file_path: Path | str, favorite: bool) -> None:
-        """Update the favorite flag on any queued tracks matching *file_path*.
+    def update_favorite(self, track_id: int, favorite: bool) -> None:
+        """Update the favorite flag on any queued track with the canonical *track_id*.
 
-        Called after a favorite is toggled so that the next player-state
-        snapshot reflects the new value without requiring a queue reload.
-        Accepts str so remote track URIs (bandcamp://) can be matched.
+        Called after a favorite is toggled so that the next player-state snapshot
+        reflects the new value without requiring a queue reload. Matched by
+        canonical id (KAMP-538/532), not file_path: a queued track's delivery uri
+        can diverge from the favorited row's preferred source — e.g. a stream
+        queued before its album was downloaded, whose preferred source has since
+        flipped to the local file — while the canonical id stays stable. Matching
+        by uri missed that case, so the 4 Hz player-state poll kept overwriting the
+        UI's optimistic patch with a stale favorite=False (self-healing only on
+        restart, when the queue reloads from the DB).
         """
-        fp_key = _canonical_track_uri(file_path)
         for t in self._tracks:
-            if _canonical_track_uri(t.file_path) == fp_key:
+            if t.id == track_id:
                 t.favorite = favorite
 
     def update_track_path(self, old_path: Path, new_path: Path, new_title: str) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1552,8 +1552,11 @@ def create_app(
         key = _canonical_track_uri(track.file_path)
         index.set_favorite(key, req.favorite)
         # Keep the in-memory queue in sync so the next player-state snapshot
-        # reflects the new favorite value without requiring a queue reload.
-        queue.update_favorite(key, req.favorite)
+        # reflects the new favorite value without requiring a queue reload. Keyed
+        # on the canonical id (KAMP-538/532): the queued track's delivery uri may
+        # have diverged from `key` (post-download preferred-source flip), which a
+        # uri match would miss, reverting the UI on the next 4 Hz state poll.
+        queue.update_favorite(track.id, req.favorite)
         return {"ok": True}
 
     @app.post("/api/v1/albums/favorite")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -491,7 +491,8 @@ export const clearRemainingQueue = (position: number): Promise<unknown> =>
 export const removeFromQueue = (indices: number[]): Promise<unknown> =>
   post('/api/v1/player/queue/remove', { indices })
 export const setTrackFavorite = (track: Track, favorite: boolean): Promise<unknown> =>
-  post('/api/v1/tracks/favorite', { file_path: track.file_path, favorite })
+  // KAMP-538: identify the track by its canonical id (server is id-preferred).
+  post('/api/v1/tracks/favorite', { id: track.id, favorite })
 
 export type TrackTagsCollision = {
   collision: true
@@ -889,8 +890,9 @@ export async function applyPlaylistArtLocal(playlistId: number, file: File): Pro
 export const playPlaylist = (playlistId: number, startIndex = 0): Promise<void> =>
   post('/api/v1/player/play-playlist', { playlist_id: playlistId, start_index: startIndex })
 
-export const playFiles = (filePaths: string[], startIndex = 0): Promise<void> =>
-  post('/api/v1/player/play-files', { file_paths: filePaths, start_index: startIndex })
+export const playFiles = (trackIds: number[], startIndex = 0): Promise<void> =>
+  // KAMP-538: play-files by canonical track ids (server accepts `ids`, id-preferred).
+  post('/api/v1/player/play-files', { ids: trackIds, start_index: startIndex })
 
 export const getPlaylists = (): Promise<Playlist[]> => get('/api/v1/playlists')
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -918,8 +918,9 @@ export const deletePlaylist = (id: number): Promise<void> => del(`/api/v1/playli
 export const getPlaylistTracks = (id: number): Promise<PlaylistTrack[]> =>
   get(`/api/v1/playlists/${id}/tracks`)
 
-export const addTrackToPlaylist = (id: number, filePath: string): Promise<void> =>
-  post(`/api/v1/playlists/${id}/tracks`, { file_path: filePath })
+export const addTrackToPlaylist = (playlistId: number, trackId: number): Promise<void> =>
+  // KAMP-538: add by canonical track id (server is id-preferred).
+  post(`/api/v1/playlists/${playlistId}/tracks`, { id: trackId })
 
 export const addAlbumToPlaylist = (id: number, albumArtist: string, album: string): Promise<void> =>
   post(`/api/v1/playlists/${id}/tracks`, { album_artist: albumArtist, album })

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -473,12 +473,19 @@ export const insertAlbumAt = (
     index,
     file_path: filePath
   })
-export const addToQueue = (filePath: string): Promise<unknown> =>
-  post('/api/v1/player/queue/add', { file_path: filePath })
-export const insertIntoQueue = (filePath: string, index: number): Promise<unknown> =>
-  post('/api/v1/player/queue/insert', { file_path: filePath, index })
-export const playNext = (filePath: string): Promise<unknown> =>
-  post('/api/v1/player/queue/play-next', { file_path: filePath })
+// KAMP-538: a track is addressed by its canonical id. A file_path fallback
+// remains only for album-granularity drags whose per-track ids are not loaded
+// (removed with the rest of file_path in KAMP-539). id wins server-side.
+export type TrackRef = { id: number } | { filePath: string }
+const trackRefBody = (ref: TrackRef): Record<string, unknown> =>
+  'id' in ref ? { id: ref.id } : { file_path: ref.filePath }
+
+export const addToQueue = (ref: TrackRef): Promise<unknown> =>
+  post('/api/v1/player/queue/add', trackRefBody(ref))
+export const insertIntoQueue = (ref: TrackRef, index: number): Promise<unknown> =>
+  post('/api/v1/player/queue/insert', { ...trackRefBody(ref), index })
+export const playNext = (ref: TrackRef): Promise<unknown> =>
+  post('/api/v1/player/queue/play-next', trackRefBody(ref))
 export const moveQueueTrack = (fromIndex: number, toIndex: number): Promise<unknown> =>
   post('/api/v1/player/queue/move', { from_index: fromIndex, to_index: toIndex })
 export const reorderQueue = (order: number[]): Promise<unknown> =>

--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -26,8 +26,8 @@ interface Props {
 type DuplicateModalState = {
   playlistId: number
   playlistName: string
-  allPaths: string[]
-  uniquePaths: string[]
+  allIds: number[]
+  uniqueIds: number[]
 }
 
 export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Element {
@@ -46,27 +46,27 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
 
   const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
 
-  // Fetch tracks client-side so the full file_path list is available.
-  // This handles missing-album tracks (keyed by file_path, not album_artist+album)
-  // and avoids the server-side tracks_for_album path which has no file_path fallback.
+  // Fetch tracks client-side so the album's per-track ids are available (the
+  // album card itself carries no track ids). This also handles missing-album
+  // tracks, which are looked up by album.file_path (a separate album-identity key).
   const handleAddToPlaylist = (playlistId: number): void => {
     const pl = playlists.find((p) => p.id === playlistId)
     void (async () => {
       const albumTracks = await getTracksForAlbum(album.album_artist, album.album, album.file_path)
-      const allPaths = albumTracks.map((t) => t.file_path)
+      const allIds = albumTracks.map((t) => t.id)
       const existing = await getPlaylistTracks(playlistId)
-      const existingSet = new Set(existing.map((t) => t.file_path))
-      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
-      if (uniquePaths.length === allPaths.length) {
-        for (const fp of allPaths) await addTrackToPlaylist(playlistId, fp)
+      const existingSet = new Set(existing.map((t) => t.id))
+      const uniqueIds = allIds.filter((id) => !existingSet.has(id))
+      if (uniqueIds.length === allIds.length) {
+        for (const id of allIds) await addTrackToPlaylist(playlistId, id)
         if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
         onClose()
       } else {
         setDuplicateModal({
           playlistId,
           playlistName: pl?.title ?? '',
-          allPaths,
-          uniquePaths
+          allIds,
+          uniqueIds
         })
       }
     })()
@@ -74,9 +74,9 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
 
   const handleDuplicateConfirmAll = (): void => {
     if (!duplicateModal) return
-    const { playlistId, allPaths, playlistName } = duplicateModal
+    const { playlistId, allIds, playlistName } = duplicateModal
     void (async () => {
-      for (const fp of allPaths) await addTrackToPlaylist(playlistId, fp)
+      for (const id of allIds) await addTrackToPlaylist(playlistId, id)
       showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     })()
     setDuplicateModal(null)
@@ -85,9 +85,9 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
 
   const handleDuplicateConfirmUnique = (): void => {
     if (!duplicateModal) return
-    const { playlistId, uniquePaths, playlistName } = duplicateModal
+    const { playlistId, uniqueIds, playlistName } = duplicateModal
     void (async () => {
-      for (const fp of uniquePaths) await addTrackToPlaylist(playlistId, fp)
+      for (const id of uniqueIds) await addTrackToPlaylist(playlistId, id)
       showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     })()
     setDuplicateModal(null)
@@ -108,7 +108,7 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
       await selectPlaylist(pl)
       const albumTracks = await getTracksForAlbum(album.album_artist, album.album, album.file_path)
       for (const t of albumTracks) {
-        await addTrackToPlaylist(pl.id, t.file_path)
+        await addTrackToPlaylist(pl.id, t.id)
       }
     })()
   }
@@ -283,7 +283,7 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
       {duplicateModal && (
         <DuplicatePlaylistTrackModal
           playlistName={duplicateModal.playlistName}
-          hasMixed={duplicateModal.uniquePaths.length > 0}
+          hasMixed={duplicateModal.uniqueIds.length > 0}
           onAddAll={handleDuplicateConfirmAll}
           onAddUnique={handleDuplicateConfirmUnique}
           onCancel={handleDuplicateCancel}

--- a/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistContextMenu.tsx
@@ -33,8 +33,8 @@ export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.J
           onClose()
           void (async () => {
             await loadPlaylistTracks(playlist.id)
-            const paths = useStore.getState().library.playlistTracks.map((t) => t.file_path)
-            for (let i = paths.length - 1; i >= 0; i--) await playNext(paths[i])
+            const ids = useStore.getState().library.playlistTracks.map((t) => t.id)
+            for (let i = ids.length - 1; i >= 0; i--) await playNext({ id: ids[i] })
           })()
         }}
       >
@@ -49,8 +49,8 @@ export function PlaylistContextMenu({ x, y, playlist, onClose }: Props): React.J
           onClose()
           void (async () => {
             await loadPlaylistTracks(playlist.id)
-            const paths = useStore.getState().library.playlistTracks.map((t) => t.file_path)
-            for (const p of paths) await addToQueue(p)
+            const ids = useStore.getState().library.playlistTracks.map((t) => t.id)
+            for (const id of ids) await addToQueue({ id })
           })()
         }}
       >

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -440,13 +440,13 @@ export function PlaylistView(): React.JSX.Element | null {
     if (playlistTracks.length === 0) return
     void (async () => {
       for (let i = playlistTracks.length - 1; i >= 0; i--) {
-        await playNext(playlistTracks[i].file_path)
+        await playNext({ id: playlistTracks[i].id })
       }
     })()
   }
 
   const isCurrentPlaylist =
-    currentTrack !== null && playlistTracks.some((t) => t.file_path === currentTrack.file_path)
+    currentTrack !== null && playlistTracks.some((t) => t.id === currentTrack.id)
 
   // If a playlist track is already in the queue: couple to transport (pause/resume).
   // Otherwise: replace the queue with this playlist's tracks and start playing.
@@ -462,7 +462,7 @@ export function PlaylistView(): React.JSX.Element | null {
   const handleAddToQueue = (): void => {
     void (async () => {
       for (const t of playlistTracks) {
-        await addToQueue(t.file_path)
+        await addToQueue({ id: t.id })
       }
     })()
   }
@@ -506,8 +506,8 @@ export function PlaylistView(): React.JSX.Element | null {
     const isMulti = selectedIndices.has(idx) && selectedIndices.size > 1
     if (isMulti) {
       const sorted = [...selectedIndices].sort((a, b) => a - b)
-      const paths = sorted.map((i) => displayTracks[i].file_path)
-      e.dataTransfer.setData('text/kamp-file-paths', JSON.stringify(paths))
+      const ids = sorted.map((i) => displayTracks[i].id)
+      e.dataTransfer.setData('text/kamp-track-ids', JSON.stringify(ids))
       if (isDragEnabled) {
         e.dataTransfer.setData('text/kamp-playlist-track-idx', String(idx))
         e.dataTransfer.setData('text/kamp-playlist-multi', JSON.stringify(sorted))
@@ -522,7 +522,7 @@ export function PlaylistView(): React.JSX.Element | null {
     } else {
       setSelectedIndices(new Set())
       setAnchorIdx(null)
-      e.dataTransfer.setData('text/kamp-track-path', displayTracks[idx].file_path)
+      e.dataTransfer.setData('text/kamp-track-id', String(displayTracks[idx].id))
       if (isDragEnabled) {
         e.dataTransfer.setData('text/kamp-playlist-track-idx', String(idx))
       }
@@ -767,7 +767,7 @@ export function PlaylistView(): React.JSX.Element | null {
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const i = virtualRow.index
               const track = displayTracks[i]
-              const isCurrent = currentTrack?.file_path === track.file_path
+              const isCurrent = currentTrack?.id === track.id
               const isRemote = track.source !== 'local'
               const isOffline = isRemote && !connected
               const isSelected = selectedIndices.has(i)

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -809,7 +809,7 @@ export function PlaylistView(): React.JSX.Element | null {
                     } else {
                       // Sorted view — queue in display order so the right track plays
                       void playFiles(
-                        displayTracks.map((t) => t.file_path),
+                        displayTracks.map((t) => t.id),
                         i
                       )
                       void recordPlaylistPlayed(playlist.id)
@@ -824,7 +824,7 @@ export function PlaylistView(): React.JSX.Element | null {
                       void playPlaylist(playlist.id, i)
                     } else {
                       void playFiles(
-                        displayTracks.map((t) => t.file_path),
+                        displayTracks.map((t) => t.id),
                         i
                       )
                       void recordPlaylistPlayed(playlist.id)

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -29,8 +29,8 @@ interface Props {
 type DuplicateModalState = {
   playlistId: number
   playlistName: string
-  allPaths: string[]
-  uniquePaths: string[]
+  allIds: number[]
+  uniqueIds: number[]
 }
 
 export function QueueContextMenu({
@@ -70,21 +70,21 @@ export function QueueContextMenu({
 
   const handleAddToPlaylist = (playlistId: number): void => {
     const pl = playlists.find((p) => p.id === playlistId)
-    const allPaths = playlistTargets.map((t) => t.file_path)
+    const allIds = playlistTargets.map((t) => t.id)
     void (async () => {
       const existing = await getPlaylistTracks(playlistId)
-      const existingSet = new Set(existing.map((t) => t.file_path))
-      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
-      if (uniquePaths.length === allPaths.length) {
-        allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+      const existingSet = new Set(existing.map((t) => t.id))
+      const uniqueIds = allIds.filter((id) => !existingSet.has(id))
+      if (uniqueIds.length === allIds.length) {
+        allIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
         if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
         onClose()
       } else {
         setDuplicateModal({
           playlistId,
           playlistName: pl?.title ?? '',
-          allPaths,
-          uniquePaths
+          allIds,
+          uniqueIds
         })
       }
     })()
@@ -92,8 +92,8 @@ export function QueueContextMenu({
 
   const handleDuplicateConfirmAll = (): void => {
     if (!duplicateModal) return
-    const { playlistId, allPaths, playlistName } = duplicateModal
-    allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    const { playlistId, allIds, playlistName } = duplicateModal
+    allIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
     showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     setDuplicateModal(null)
     onClose()
@@ -101,8 +101,8 @@ export function QueueContextMenu({
 
   const handleDuplicateConfirmUnique = (): void => {
     if (!duplicateModal) return
-    const { playlistId, uniquePaths, playlistName } = duplicateModal
-    uniquePaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    const { playlistId, uniqueIds, playlistName } = duplicateModal
+    uniqueIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
     showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     setDuplicateModal(null)
     onClose()
@@ -121,7 +121,7 @@ export function QueueContextMenu({
       setCollectionType('playlists')
       await selectPlaylist(pl)
       for (const t of playlistTargets) {
-        await addTrackToPlaylist(pl.id, t.file_path)
+        await addTrackToPlaylist(pl.id, t.id)
       }
     })()
   }
@@ -319,7 +319,7 @@ export function QueueContextMenu({
       {duplicateModal && (
         <DuplicatePlaylistTrackModal
           playlistName={duplicateModal.playlistName}
-          hasMixed={duplicateModal.uniquePaths.length > 0}
+          hasMixed={duplicateModal.uniqueIds.length > 0}
           onAddAll={handleDuplicateConfirmAll}
           onAddUnique={handleDuplicateConfirmUnique}
           onCancel={handleDuplicateCancel}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -16,7 +16,8 @@ const QUEUE_WIDTH_KEY = 'kamp:queue-width'
 const QUEUE_WIDTH_DEFAULT = 280
 
 const QUEUE_DROP_TYPES = new Set([
-  'text/kamp-track-path',
+  'text/kamp-track-id',
+  'text/kamp-track-ids',
   'text/kamp-file-paths',
   'text/kamp-album',
   'text/kamp-artist',
@@ -437,7 +438,7 @@ export function QueuePanel(): React.JSX.Element {
     listRef.current?.classList.remove('queue-tail-drop')
     const multiJson = e.dataTransfer.getData('text/kamp-queue-multi')
     const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
-    const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+    const trackId = e.dataTransfer.getData('text/kamp-track-id')
     const albumJson = e.dataTransfer.getData('text/kamp-album')
     if (multiJson !== '') {
       const sorted: number[] = JSON.parse(multiJson)
@@ -449,13 +450,25 @@ export function QueuePanel(): React.JSX.Element {
       // already-corrected permutation and sidesteps that off-by-one.
       const from = Number(queueIdx)
       void reorderQueue(computeNewOrder(tracks.length, [from], dropIdx))
-    } else if (trackPath) {
-      void insertIntoQueue(trackPath, dropIdx)
+    } else if (trackId !== '') {
+      void insertIntoQueue({ id: Number(trackId) }, dropIdx)
+    } else if (e.dataTransfer.getData('text/kamp-track-ids')) {
+      try {
+        const ids: number[] = JSON.parse(e.dataTransfer.getData('text/kamp-track-ids'))
+        void (async () => {
+          for (let i = 0; i < ids.length; i++) await insertIntoQueue({ id: ids[i] }, dropIdx + i)
+        })()
+      } catch {
+        // malformed — ignore
+      }
     } else if (e.dataTransfer.getData('text/kamp-file-paths')) {
+      // Album-granularity drag (AlbumCard) still carries file paths — no per-track
+      // ids are loaded on the card. Path fallback until KAMP-539 (album migration).
       try {
         const paths: string[] = JSON.parse(e.dataTransfer.getData('text/kamp-file-paths'))
         void (async () => {
-          for (let i = 0; i < paths.length; i++) await insertIntoQueue(paths[i], dropIdx + i)
+          for (let i = 0; i < paths.length; i++)
+            await insertIntoQueue({ filePath: paths[i] }, dropIdx + i)
         })()
       } catch {
         // malformed — ignore
@@ -487,8 +500,8 @@ export function QueuePanel(): React.JSX.Element {
       if (playlistIdStr) {
         void (async () => {
           await loadPlaylistTracks(Number(playlistIdStr))
-          const paths = useStore.getState().library.playlistTracks.map((t) => t.file_path)
-          for (let i = 0; i < paths.length; i++) await insertIntoQueue(paths[i], dropIdx + i)
+          const ids = useStore.getState().library.playlistTracks.map((t) => t.id)
+          for (let i = 0; i < ids.length; i++) await insertIntoQueue({ id: ids[i] }, dropIdx + i)
         })()
       }
     }
@@ -500,7 +513,7 @@ export function QueuePanel(): React.JSX.Element {
     e.currentTarget.classList.remove('queue-tail-drop')
     const multiJson = e.dataTransfer.getData('text/kamp-queue-multi')
     const queueIdx = e.dataTransfer.getData('text/kamp-queue-idx')
-    const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+    const trackId = e.dataTransfer.getData('text/kamp-track-id')
     const albumJson = e.dataTransfer.getData('text/kamp-album')
     if (multiJson !== '') {
       const sorted: number[] = JSON.parse(multiJson)
@@ -510,13 +523,23 @@ export function QueuePanel(): React.JSX.Element {
       const from = Number(queueIdx)
       const last = tracks.length - 1
       if (from !== last) void moveQueueTrack(from, last)
-    } else if (trackPath) {
-      void addToQueue(trackPath)
+    } else if (trackId !== '') {
+      void addToQueue({ id: Number(trackId) })
+    } else if (e.dataTransfer.getData('text/kamp-track-ids')) {
+      try {
+        const ids: number[] = JSON.parse(e.dataTransfer.getData('text/kamp-track-ids'))
+        void (async () => {
+          for (const id of ids) await addToQueue({ id })
+        })()
+      } catch {
+        // malformed — ignore
+      }
     } else if (e.dataTransfer.getData('text/kamp-file-paths')) {
+      // Album-granularity drag (AlbumCard) — path fallback until KAMP-539.
       try {
         const paths: string[] = JSON.parse(e.dataTransfer.getData('text/kamp-file-paths'))
         void (async () => {
-          for (const p of paths) await addToQueue(p)
+          for (const p of paths) await addToQueue({ filePath: p })
         })()
       } catch {
         // malformed — ignore
@@ -548,8 +571,8 @@ export function QueuePanel(): React.JSX.Element {
       if (playlistIdStr) {
         void (async () => {
           await loadPlaylistTracks(Number(playlistIdStr))
-          const paths = useStore.getState().library.playlistTracks.map((t) => t.file_path)
-          for (const p of paths) await addToQueue(p)
+          const ids = useStore.getState().library.playlistTracks.map((t) => t.id)
+          for (const id of ids) await addToQueue({ id })
         })()
       }
     }
@@ -777,10 +800,10 @@ export function QueuePanel(): React.JSX.Element {
             e.preventDefault()
           }}
           onDrop={(e) => {
-            const trackPath = e.dataTransfer.getData('text/kamp-track-path')
+            const trackId = e.dataTransfer.getData('text/kamp-track-id')
             const albumJson = e.dataTransfer.getData('text/kamp-album')
-            if (trackPath) {
-              void addToQueue(trackPath)
+            if (trackId !== '') {
+              void addToQueue({ id: Number(trackId) })
             } else if (albumJson) {
               try {
                 const {

--- a/kamp_ui/src/renderer/src/components/SearchView.tsx
+++ b/kamp_ui/src/renderer/src/components/SearchView.tsx
@@ -43,7 +43,7 @@ function SearchTrackRow({
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       onContextMenu={(e) => onContextMenu(e, track)}
       onDragStart={(e) => {
-        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.setData('text/kamp-track-id', String(track.id))
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -128,7 +128,7 @@ export function TrackContextMenu({
             onClick={() => {
               onClose()
               void (async () => {
-                for (let i = targets.length - 1; i >= 0; i--) await playNext(targets[i].file_path)
+                for (let i = targets.length - 1; i >= 0; i--) await playNext({ id: targets[i].id })
               })()
             }}
           >
@@ -149,7 +149,7 @@ export function TrackContextMenu({
             onClick={() => {
               onClose()
               void (async () => {
-                for (const t of targets) await addToQueue(t.file_path)
+                for (const t of targets) await addToQueue({ id: t.id })
               })()
             }}
           >

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -29,8 +29,8 @@ interface Props {
 type DuplicateModalState = {
   playlistId: number
   playlistName: string
-  allPaths: string[]
-  uniquePaths: string[]
+  allIds: number[]
+  uniqueIds: number[]
 }
 
 export function TrackContextMenu({
@@ -64,21 +64,21 @@ export function TrackContextMenu({
 
   const handleAddToPlaylist = (playlistId: number): void => {
     const pl = playlists.find((p) => p.id === playlistId)
-    const allPaths = targets.map((t) => t.file_path)
+    const allIds = targets.map((t) => t.id)
     void (async () => {
       const existing = await getPlaylistTracks(playlistId)
-      const existingSet = new Set(existing.map((t) => t.file_path))
-      const uniquePaths = allPaths.filter((p) => !existingSet.has(p))
-      if (uniquePaths.length === allPaths.length) {
-        allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+      const existingSet = new Set(existing.map((t) => t.id))
+      const uniqueIds = allIds.filter((id) => !existingSet.has(id))
+      if (uniqueIds.length === allIds.length) {
+        allIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
         if (pl) showFlashToast(`Added to ${truncateTitle(pl.title, 35)}`)
         onClose()
       } else {
         setDuplicateModal({
           playlistId,
           playlistName: pl?.title ?? '',
-          allPaths,
-          uniquePaths
+          allIds,
+          uniqueIds
         })
       }
     })()
@@ -86,8 +86,8 @@ export function TrackContextMenu({
 
   const handleDuplicateConfirmAll = (): void => {
     if (!duplicateModal) return
-    const { playlistId, allPaths, playlistName } = duplicateModal
-    allPaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    const { playlistId, allIds, playlistName } = duplicateModal
+    allIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
     showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     setDuplicateModal(null)
     onClose()
@@ -95,8 +95,8 @@ export function TrackContextMenu({
 
   const handleDuplicateConfirmUnique = (): void => {
     if (!duplicateModal) return
-    const { playlistId, uniquePaths, playlistName } = duplicateModal
-    uniquePaths.forEach((fp) => void addTrackToPlaylist(playlistId, fp))
+    const { playlistId, uniqueIds, playlistName } = duplicateModal
+    uniqueIds.forEach((id) => void addTrackToPlaylist(playlistId, id))
     showFlashToast(`Added to ${truncateTitle(playlistName, 35)}`)
     setDuplicateModal(null)
     onClose()
@@ -114,7 +114,7 @@ export function TrackContextMenu({
       setCollectionType('playlists')
       await selectPlaylist(pl)
       for (const t of targets) {
-        await addTrackToPlaylist(pl.id, t.file_path)
+        await addTrackToPlaylist(pl.id, t.id)
       }
     })()
   }
@@ -299,7 +299,7 @@ export function TrackContextMenu({
       {duplicateModal && (
         <DuplicatePlaylistTrackModal
           playlistName={duplicateModal.playlistName}
-          hasMixed={duplicateModal.uniquePaths.length > 0}
+          hasMixed={duplicateModal.uniqueIds.length > 0}
           onAddAll={handleDuplicateConfirmAll}
           onAddUnique={handleDuplicateConfirmUnique}
           onCancel={handleDuplicateCancel}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -390,8 +390,8 @@ export function TrackList(): React.JSX.Element | null {
     const isMulti = selectedIndices.has(idx) && selectedIndices.size > 1
     if (isMulti) {
       const sorted = [...selectedIndices].sort((a, b) => a - b)
-      const paths = sorted.map((i) => tracks[i].file_path)
-      e.dataTransfer.setData('text/kamp-file-paths', JSON.stringify(paths))
+      const ids = sorted.map((i) => tracks[i].id)
+      e.dataTransfer.setData('text/kamp-track-ids', JSON.stringify(ids))
       const ghost = document.createElement('div')
       ghost.textContent = `${sorted.length} tracks`
       ghost.style.cssText =
@@ -400,7 +400,7 @@ export function TrackList(): React.JSX.Element | null {
       e.dataTransfer.setDragImage(ghost, 0, 0)
       requestAnimationFrame(() => document.body.removeChild(ghost))
     } else {
-      e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+      e.dataTransfer.setData('text/kamp-track-id', String(track.id))
     }
     e.dataTransfer.effectAllowed = 'copy'
   }

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -107,10 +107,10 @@ export function TransportBar(): React.JSX.Element {
   // value in state and compare during render. Avoids the useEffect cascade
   // warning and runs synchronously so the very first render after a track
   // change already shows the server position.
-  const currentPath = current_track?.file_path ?? null
-  const [prevPath, setPrevPath] = useState<string | null>(currentPath)
-  if (prevPath !== currentPath) {
-    setPrevPath(currentPath)
+  const currentTrackId = current_track?.id ?? null
+  const [prevTrackId, setPrevTrackId] = useState<number | null>(currentTrackId)
+  if (prevTrackId !== currentTrackId) {
+    setPrevTrackId(currentTrackId)
     setScrubPos(null)
     // pointerDown.current is intentionally not touched here — a fresh
     // onPointerDown will set it true again, and pointerUp/pointerCancel
@@ -209,7 +209,7 @@ export function TransportBar(): React.JSX.Element {
               // Pin pointer events to the slider so pointerup is guaranteed to
               // fire here even if the user releases the pointer outside the
               // slider bounds. Without this, scrubPos can wedge — the
-              // track-change reset above (currentPath comparison) is the
+              // track-change reset above (currentTrackId comparison) is the
               // escape hatch for any wedge that still slips through.
               try {
                 e.currentTarget.setPointerCapture(e.pointerId)

--- a/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/MagicPlaylistModule.tsx
@@ -269,7 +269,7 @@ function MagicTrackCard({ track }: { track: PlaylistTrack }): React.JSX.Element 
         setMenu({ x: e.clientX, y: e.clientY, track })
       }}
       onDragStart={(e) => {
-        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.setData('text/kamp-track-id', String(track.id))
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >
@@ -320,7 +320,7 @@ function MagicTrackListRow({ track }: { track: PlaylistTrack }): React.JSX.Eleme
         setMenu({ x: e.clientX, y: e.clientY, track })
       }}
       onDragStart={(e) => {
-        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.setData('text/kamp-track-id', String(track.id))
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >

--- a/kamp_ui/src/renderer/src/components/modules/TopTracksModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopTracksModule.tsx
@@ -49,7 +49,7 @@ function TrackCard({ track }: { track: Track }): React.JSX.Element {
         setMenu({ x: e.clientX, y: e.clientY, track })
       }}
       onDragStart={(e) => {
-        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.setData('text/kamp-track-id', String(track.id))
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >
@@ -104,7 +104,7 @@ function TrackListRow({ track }: { track: Track }): React.JSX.Element {
         setMenu({ x: e.clientX, y: e.clientY, track })
       }}
       onDragStart={(e) => {
-        e.dataTransfer.setData('text/kamp-track-path', track.file_path)
+        e.dataTransfer.setData('text/kamp-track-id', String(track.id))
         e.dataTransfer.effectAllowed = 'copy'
       }}
     >
@@ -210,7 +210,7 @@ export function TopTracksConfig(): React.JSX.Element {
 
 export function TopTracksModule({ displayStyle }: ModuleProps): React.JSX.Element {
   const count = useStore((s) => s.topTracksCount)
-  const currentFilePath = useStore((s) => s.player?.current_track?.file_path ?? null)
+  const currentTrackId = useStore((s) => s.player?.current_track?.id ?? null)
   const serverStatus = useStore((s) => s.serverStatus)
   const [tracks, setTracks] = useState<Track[]>([])
   const [loading, setLoading] = useState(true)
@@ -221,7 +221,7 @@ export function TopTracksModule({ displayStyle }: ModuleProps): React.JSX.Elemen
       .then(setTracks)
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [count, currentFilePath, serverStatus])
+  }, [count, currentTrackId, serverStatus])
 
   if (loading) {
     return (

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -225,9 +225,9 @@ type PlayerStore = {
     index: number,
     filePath?: string
   ) => Promise<void>
-  addToQueue: (filePath: string) => Promise<void>
-  insertIntoQueue: (filePath: string, index: number) => Promise<void>
-  playNext: (filePath: string) => Promise<void>
+  addToQueue: (ref: api.TrackRef) => Promise<void>
+  insertIntoQueue: (ref: api.TrackRef, index: number) => Promise<void>
+  playNext: (ref: api.TrackRef) => Promise<void>
   moveQueueTrack: (fromIndex: number, toIndex: number) => Promise<void>
   reorderQueue: (order: number[]) => Promise<void>
   skipToQueueTrack: (position: number) => Promise<void>
@@ -1073,18 +1073,18 @@ export const useStore = create<PlayerStore>((set, get) => ({
     void get().loadQueue()
   },
 
-  addToQueue: async (filePath) => {
-    await api.addToQueue(filePath)
+  addToQueue: async (ref) => {
+    await api.addToQueue(ref)
     void get().loadQueue()
   },
 
-  insertIntoQueue: async (filePath, index) => {
-    await api.insertIntoQueue(filePath, index)
+  insertIntoQueue: async (ref, index) => {
+    await api.insertIntoQueue(ref, index)
     void get().loadQueue()
   },
 
-  playNext: async (filePath) => {
-    await api.playNext(filePath)
+  playNext: async (ref) => {
+    await api.playNext(ref)
     void get().loadQueue()
   },
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -188,7 +188,7 @@ type PlayerStore = {
   updateMagicPlaylistCriteria: (id: number, criteria: CriteriaDoc) => Promise<Playlist>
   selectPlaylist: (playlist: Playlist | null) => Promise<void>
   loadPlaylistTracks: (playlistId: number) => Promise<void>
-  addTrackToPlaylist: (playlistId: number, filePath: string) => Promise<void>
+  addTrackToPlaylist: (playlistId: number, trackId: number) => Promise<void>
   addAlbumToPlaylist: (playlistId: number, albumArtist: string, album: string) => Promise<void>
   removeTrackFromPlaylist: (playlistId: number, playlistTrackId: number) => Promise<void>
   reorderPlaylistTracks: (playlistId: number, trackIds: number[]) => Promise<void>
@@ -909,8 +909,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }))
   },
 
-  addTrackToPlaylist: async (playlistId, filePath) => {
-    await api.addTrackToPlaylist(playlistId, filePath)
+  addTrackToPlaylist: async (playlistId, trackId) => {
+    await api.addTrackToPlaylist(playlistId, trackId)
     if (get().library.selectedPlaylist?.id === playlistId) {
       await get().loadPlaylistTracks(playlistId)
     }
@@ -1155,17 +1155,21 @@ export const useStore = create<PlayerStore>((set, get) => ({
           }
         : s.searchResults
     }))
-    // Patch playlist track list so the heart updates without a reload.
+    // Patch the open album track list and the playlist track list in place, keyed
+    // on the canonical id — which never diverges between the streaming and
+    // downloaded views (KAMP-538 fixes KAMP-532). A favorite never adds or removes
+    // a row, so the old refreshOpenAlbum() refetch was both unnecessary and racy:
+    // for a freshly-downloaded track it could read back a not-yet-committed value
+    // and clobber this optimistic patch (the very reload race KAMP-532 describes).
     set((s) => ({
       library: {
         ...s.library,
+        tracks: s.library.tracks.map((t) => (t.id === track.id ? { ...t, favorite } : t)),
         playlistTracks: s.library.playlistTracks.map((t) =>
           t.id === track.id ? { ...t, favorite } : t
         )
       }
     }))
-    // Reload the open album track list so the heart in track rows updates.
-    await get().refreshOpenAlbum()
   },
 
   setFavorites: async (tracks, favorite) => {
@@ -1201,12 +1205,12 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set((s) => ({
       library: {
         ...s.library,
+        tracks: s.library.tracks.map((t) => (ids.has(t.id) ? { ...t, favorite } : t)),
         playlistTracks: s.library.playlistTracks.map((t) =>
           ids.has(t.id) ? { ...t, favorite } : t
         )
       }
     }))
-    await get().refreshOpenAlbum()
   },
 
   patchTrackTitle: async (trackId, title, overwrite = false) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -180,7 +180,7 @@ type PlayerStore = {
   loadTracks: (albumArtist: string, album: string, filePath?: string) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
   playPlaylist: (playlistId: number, startIndex?: number) => Promise<void>
-  playFiles: (filePaths: string[], startIndex?: number) => Promise<void>
+  playFiles: (trackIds: number[], startIndex?: number) => Promise<void>
   recordPlaylistPlayed: (playlistId: number) => Promise<void>
   loadPlaylists: () => Promise<void>
   createPlaylist: (title: string) => Promise<Playlist>
@@ -836,8 +836,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
     void get().loadPlaylists()
   },
 
-  playFiles: async (filePaths, startIndex = 0) => {
-    await api.playFiles(filePaths, startIndex)
+  playFiles: async (trackIds, startIndex = 0) => {
+    await api.playFiles(trackIds, startIndex)
     void get().loadQueue()
   },
 
@@ -1171,11 +1171,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setFavorites: async (tracks, favorite) => {
     // allSettled so a partial 404 doesn't silently mis-patch state for succeeded tracks
     const results = await Promise.allSettled(tracks.map((t) => api.setTrackFavorite(t, favorite)))
-    const succeededPaths = new Set(
-      tracks.filter((_, i) => results[i].status === 'fulfilled').map((t) => t.file_path)
-    )
-    if (succeededPaths.size === 0) return
-    const ids = new Set(tracks.filter((t) => succeededPaths.has(t.file_path)).map((t) => t.id))
+    // KAMP-538: key the patch set directly on the canonical id of each succeeded track.
+    const ids = new Set(tracks.filter((_, i) => results[i].status === 'fulfilled').map((t) => t.id))
+    if (ids.size === 0) return
     if (get().player.current_track && ids.has(get().player.current_track!.id)) {
       set((s) => ({
         player: {

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -363,7 +363,7 @@ class TestPlaybackQueue:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(3)]
         q.load(tracks)
-        q.update_favorite(tracks[1].file_path, True)
+        q.update_favorite(tracks[1].id, True)
         assert q._tracks[0].favorite is False
         assert q._tracks[1].favorite is True
         assert q._tracks[2].favorite is False
@@ -372,7 +372,7 @@ class TestPlaybackQueue:
         q = PlaybackQueue()
         tracks = [_track(i) for i in range(2)]
         q.load(tracks)
-        q.update_favorite(Path("/nonexistent.mp3"), True)  # should not raise
+        q.update_favorite(999999, True)  # unknown id — should not raise
         assert all(not t.favorite for t in q._tracks)
 
     def test_update_track_path_patches_matching_track(self) -> None:
@@ -536,12 +536,21 @@ class TestPlaybackQueue:
         ids, _, _, _, _ = q.get_state()
         assert ids == [remote.id]
 
-    def test_update_favorite_str_path_matches_remote_track(self) -> None:
-        """update_favorite accepts a str URI so remote tracks can be matched."""
+    def test_update_favorite_matches_by_id_not_uri(self) -> None:
+        """KAMP-538/532: a queued track is favorited by its canonical id, so the
+        match holds even when the queued track's delivery uri differs from the
+        favorited row's preferred source (e.g. a stream queued before its album was
+        downloaded, whose preferred source has since flipped to the local file).
+
+        Regression: matching by uri (`_canonical_track_uri(id)` vs the queued
+        `bandcamp://` uri) missed this, so the 4 Hz player-state poll reverted the
+        UI's optimistic favorite to False — self-healing only on a queue reload.
+        """
         q = PlaybackQueue()
-        remote = _remote_track()
-        q.load([remote])
-        q.update_favorite("bandcamp:/123456/1", True)
+        # Queued as the stream (bandcamp:// uri); the favorite arrives by id only.
+        streamed = _remote_track()  # id=901, file_path=bandcamp://123456/1
+        q.load([streamed])
+        q.update_favorite(streamed.id, True)
         assert q._tracks[0].favorite is True
 
     def test_restore_sets_all_fields(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2022,7 +2022,9 @@ class TestFavoriteEndpoint:
     def test_set_favorite_endpoint(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
-        mock_index.get_track_by_path.return_value = _track(1)
+        track = _track(1)
+        track.id = 42
+        mock_index.get_track_by_path.return_value = track
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         resp = TestClient(app).post(
             "/api/v1/tracks/favorite",
@@ -2030,15 +2032,14 @@ class TestFavoriteEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
-        # KAMP-537: favorite resolves the track first, then keys on its canonical
-        # uri (the stored preferred-source path), not the raw request path.
+        # KAMP-537: favorite resolves the track first, then keys the DB write on its
+        # canonical uri (the stored preferred-source path), not the raw request path.
         mock_index.set_favorite.assert_called_once_with(
             str(Path("/music/01.mp3")), True
         )
-        # Queue must also be updated so the next player-state snapshot is correct.
-        mock_queue.update_favorite.assert_called_once_with(
-            str(Path("/music/01.mp3")), True
-        )
+        # KAMP-538/532: the in-memory queue is patched by canonical id so the next
+        # player-state snapshot is correct even if the queued uri has diverged.
+        mock_queue.update_favorite.assert_called_once_with(42, True)
 
     def test_set_favorite_returns_404_for_unknown_track(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -2090,7 +2091,9 @@ class TestFavoriteEndpoint:
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
         remote_uri = "bandcamp://999/3"
-        mock_index.get_track_by_path.return_value = _track(1)
+        track = _track(1)
+        track.id = 42
+        mock_index.get_track_by_path.return_value = track
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         resp = TestClient(app).post(
             "/api/v1/tracks/favorite",
@@ -2098,13 +2101,12 @@ class TestFavoriteEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
-        # KAMP-537: keys on the resolved track's canonical uri, not the request uri.
+        # KAMP-537: DB write keys on the resolved track's canonical uri, not the
+        # request uri. KAMP-538/532: the queue is patched by canonical id.
         mock_index.set_favorite.assert_called_once_with(
             str(Path("/music/01.mp3")), True
         )
-        mock_queue.update_favorite.assert_called_once_with(
-            str(Path("/music/01.mp3")), True
-        )
+        mock_queue.update_favorite.assert_called_once_with(42, True)
 
     def test_set_favorite_remote_track_returns_404_when_not_found(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## KAMP-538: UI — address tracks by canonical id, not file_path

Migrates the renderer's **track** identity from the mutable `file_path` to the canonical numeric `id`, matching the id-native API from KAMP-537 (#634, merged). This is the UI half of the KAMP-533 canonical-track-identity epic and it fixes **KAMP-532** (the favorite/stat reload race between the streaming and downloaded views).

Since `id` never diverges between a track's streaming row and its downloaded row (they collapsed to one canonical row in KAMP-541), keying the UI on `id` makes the streaming-vs-local divergence disappear by construction.

### What changed (3 commits)

**1 — favorite + play-files wrappers → id**
- `setTrackFavorite` posts `{ id }`; `playFiles` posts `{ ids }`.
- `setFavorites` builds its optimistic-patch id-set directly (dropped a redundant `file_path→id` round-trip).

**2 — drag payload + queue wrappers → id**
- `addToQueue` / `insertIntoQueue` / `playNext` take a `TrackRef` (`{ id } | { filePath }`); all Track-object callers pass `{ id }`.
- New drag MIME types `text/kamp-track-id` (single) and `text/kamp-track-ids` (multi-select) replace `text/kamp-track-path`. Consumers guard every `getData` against `''` before `Number()`. A new MIME name means a stale producer fails closed instead of feeding a path into an id parse.
- True track-vs-track "currently playing" checks now compare `id` (PlaylistView row + `isCurrentPlaylist`, TopTracks refetch trigger, TransportBar scrub-reset).

**3 — add-to-playlist + dedupe → id, and the KAMP-532 fix**
- `addTrackToPlaylist` posts the track `id`; the "already in this playlist" dedupe builds its Sets from ids on both sides (incl. AlbumContextMenu's client-side `getTracksForAlbum` fetch).
- **KAMP-532:** `setFavorite`/`setFavorites` now patch the open album track list (`library.tracks`) **in place by id** instead of calling `refreshOpenAlbum()`. The old refetch was racy — for a freshly-downloaded track it could read back a not-yet-committed favorite and clobber the optimistic patch.

**4 — server: queue favorite by id (the other half of KAMP-532)**
- Favoriting from the album list flashed then reverted in the queue/transport: the client polls player-state at 4 Hz, and each snapshot serves `current_track.favorite` from the **in-memory queue track** (never re-read from the DB). That flag was updated by `queue.update_favorite` matching on **URI**, but the favorite is resolved by **id** — when a queued track's delivery URI has diverged from the favorited row's preferred source (a stream queued before its album was downloaded), the URI match missed and the poll overwrote the optimistic patch with a stale `favorite:false` (healed only on restart). Now `update_favorite` matches by canonical **id**. Red/green regression test included.

### Deliberately left on `file_path` (separate album-identity axis, its own KAMP-539 follow-up)
Album-scoped wrappers (`addAlbumToQueue`/`playAlbumNext`/`insertAlbumAt`/`getTracksForAlbum`/`artUrl`), album React keys, the `missing_album` "album is playing" checks (`Album` has no `id`), the AlbumCard album-drag payload (`text/kamp-file-paths` — album cards hold no per-track ids), plus non-identity path uses (Bandcamp provenance parsing, Show-in-Folder, art lookup). No `sources[]` type field and no `shared/kampAPI.ts` (extension SDK) change — deferred to where a real consumer pins the shape.

### Verification
CI gates green locally: `npm run typecheck`, `npm run lint`, `npm run build`. `kamp_ui` has no unit-test runner, so behavior is verified manually.

Manual test plan:
1. **KAMP-532 core:** download an album, favorite one of its tracks from the transport → the album-page heart lights immediately, no reload race. Toggle off clears immediately.
2. Play a track a few times; play_count/last_played match between album page and transport.
3. Favorite from every surface: album row, transport, multi-select, search result, playlist row.
4. Queue by id: add-to-queue / play-next from a track row, search result, playlist row; drag a single track and a multi-select into the queue.
5. Album-drag still works (path fallback): drag a whole album card (missing_album + normal) into the queue.
6. Add-to-playlist dedupe: add tracks (single, multi, whole album) to a playlist that already contains some → dupes skipped, new added.
7. Currently-playing highlight follows the right row in PlaylistView + Top Tracks; transport scrub resets on track change.
8. Freshly-downloaded / not-yet-indexed track: favorite + queue it and confirm no "acts on track 0" behavior.
9. Untouched path uses still work: Show in Folder, Bandcamp album-URL actions, art for album-less tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
