### PR TITLE
feat(library)!: drop the duplicated per-source/stat columns from tracks (KAMP-539)

### DIFF
--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -23,7 +23,7 @@ _EFFECTIVE_SOURCE_SQL = (
     "COALESCE((SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
     " FROM track_sources s WHERE s.track_id = tracks.id"
     " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1),"
-    " tracks.source)"
+    " 'local')"  # KAMP-539: tracks.source dropped; default matches its old DEFAULT
 )
 
 # Maps field name → (sql_column_expr, value_type).

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 48
+_SCHEMA_VERSION = 49
 
 
 class NoStreamableVersionError(Exception):
@@ -176,23 +176,17 @@ CREATE TABLE IF NOT EXISTS tracks (
     release_date     TEXT    NOT NULL DEFAULT '',
     track_number     INTEGER NOT NULL DEFAULT 0,
     disc_number      INTEGER NOT NULL DEFAULT 1,
-    ext              TEXT    NOT NULL DEFAULT '',
-    embedded_art     INTEGER NOT NULL DEFAULT 0,
     mb_release_id    TEXT    NOT NULL DEFAULT '',
     mb_recording_id  TEXT    NOT NULL DEFAULT '',
     date_added       REAL,    -- file birthtime/ctime at first scan (Unix timestamp)
-    last_played      REAL,    -- Unix timestamp of last natural EOF; NULL until played
-    favorite         INTEGER NOT NULL DEFAULT 0,
-    play_count       INTEGER NOT NULL DEFAULT 0,
-    file_mtime       REAL,    -- st_mtime at last scan; NULL until v6 migration backfill
     genre                TEXT    NOT NULL DEFAULT '',
     label                TEXT    NOT NULL DEFAULT '',
-    source               TEXT    NOT NULL DEFAULT 'local',
-    stream_url           TEXT,
-    stream_url_expires_at REAL,
     album_id             INTEGER REFERENCES albums(id),
-    is_available         INTEGER NOT NULL DEFAULT 1,
-    duration             REAL    NOT NULL DEFAULT 0,
+    -- KAMP-539: per-source columns (ext/embedded_art/file_mtime/source/stream_url/
+    -- stream_url_expires_at/is_available/duration) live in track_sources, and the
+    -- mutable stats (favorite/play_count/last_played) live in track_stats. Reads go
+    -- through the tracks_with_stats view, which derives them. file_path and
+    -- sale_item_id are retained (their removal is a separate follow-up).
     -- User-set display overrides for streaming tracks (KAMP-467).
     -- NULL means "use the canonical value from Bandcamp".
     display_title        TEXT,
@@ -731,9 +725,9 @@ def _eff_source(alias: str = "t") -> str:
     ordering as preferred_source(), kind mapped file->'local'/stream->'bandcamp',
     the identical value _sync_tracks_row_to_preferred_source writes to
     tracks.source. Correlated on ``<alias>.id`` so it can replace a ``source``
-    read on any tracks alias, letting KAMP-539 drop tracks.source. COALESCEs to
-    ``<alias>.source`` for a sourceless row (a pre-540 row or bare test fixture;
-    tracks.source is NOT NULL) — that fallback is dropped with the column in 539.
+    read on any tracks alias (tracks.source was dropped in KAMP-539). COALESCEs to
+    the ``'local'`` default for a sourceless row (a pre-540 row or bare test
+    fixture), matching the old tracks.source NOT NULL DEFAULT 'local'.
     Note ``<eff> <> 'local'`` reproduces the legacy ``file_path LIKE 'bandcamp://%'``
     test (file_path is bandcamp:// exactly when the effective source is a stream).
     """
@@ -742,7 +736,7 @@ def _eff_source(alias: str = "t") -> str:
         "(SELECT CASE WHEN s.kind = 'file' THEN 'local' ELSE 'bandcamp' END"
         f" FROM track_sources s WHERE s.track_id = {alias}.id"
         " ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1)"
-        f", {alias}.source)"
+        ", 'local')"
     )
 
 
@@ -1964,7 +1958,56 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 48")
             self._conn.commit()
-            version = 48  # noqa: F841
+            version = 48
+
+        if version < 49:
+            # v48 -> v49 (KAMP-539 contract): drop the now-duplicated columns from
+            # tracks. Reads derive them from track_sources/track_stats through the
+            # tracks_with_stats view, and every writer targets the child tables, so
+            # they are dead weight. Per-column ALTER TABLE DROP COLUMN — all 11 are
+            # unconstrained (file_path/sale_item_id are UNIQUE/indexed and deferred).
+            # The view names every column, so drop it first and rebuild it after (the
+            # `finally` rebuilds it to match the schema whether the drop succeeds or
+            # rolls back). Irreversible, so backup-first (v46/v47/v48 template);
+            # version-last; idempotent via the presence check so a partial run
+            # completes on the next open.
+            drop_cols = [
+                "ext",
+                "embedded_art",
+                "file_mtime",
+                "source",
+                "stream_url",
+                "stream_url_expires_at",
+                "is_available",
+                "duration",
+                "favorite",
+                "play_count",
+                "last_played",
+            ]
+            track_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(tracks)").fetchall()
+            }
+            present = [c for c in drop_cols if c in track_cols]
+            if not present:
+                self._conn.execute("UPDATE schema_version SET version = 49")
+                self._conn.commit()
+                version = 49  # noqa: F841
+            elif self._backup_db("KAMP-539 v49 drop legacy columns"):
+                try:
+                    self._conn.execute("DROP VIEW IF EXISTS tracks_with_stats")
+                    for col in present:
+                        self._conn.execute(f"ALTER TABLE tracks DROP COLUMN {col}")
+                    self._conn.execute("UPDATE schema_version SET version = 49")
+                    self._conn.commit()
+                    version = 49  # noqa: F841
+                except Exception:
+                    self._conn.rollback()
+                    logger.exception(
+                        "KAMP-539 v49 column drop failed — rolled back; the legacy"
+                        " columns remain. Restore from the pre-v49 backup if needed."
+                    )
+                finally:
+                    self._create_tracks_with_stats_view()
 
     def _create_tracks_with_stats_view(self) -> None:
         """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542/539).
@@ -3125,15 +3168,21 @@ class LibraryIndex:
         self._conn.commit()
 
     def set_track_source_for_item(self, sale_item_id: str, source: str) -> int:
-        """Set source on every track whose file_path belongs to *sale_item_id*.
+        """Refresh albums.source for a sale item's tracks; return the match count.
 
-        Matches canonical bandcamp:// (POSIX) and Windows bandcamp:\\ path forms.
-        Returns the number of rows updated. Also refreshes albums.source so the
-        album entity stays consistent without waiting for the next full rescan.
+        The track-level ``source`` is derived from track_sources now (KAMP-539), so
+        this no longer writes ``tracks.source`` — it recomputes the album entity's
+        source badge and returns the number of matching tracks. Matches canonical
+        bandcamp:// (POSIX) and Windows bandcamp:\\ path forms. No production
+        callers (a download add/remove changes the track's sources, which the view
+        derives from directly); retained for coverage of the album-badge refresh.
         """
-        cur = self._conn.execute(
-            "UPDATE tracks SET source = ? WHERE file_path LIKE ? OR file_path LIKE ?",
-            (source, f"bandcamp://{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
+        count = int(
+            self._conn.execute(
+                "SELECT COUNT(*) FROM tracks"
+                " WHERE file_path LIKE ? OR file_path LIKE ?",
+                (f"bandcamp://{sale_item_id}/%", f"bandcamp:\\{sale_item_id}\\%"),
+            ).fetchone()[0]
         )
         # Refresh albums.source via the sale_item_id FK. Remote tracks may not have
         # album_id populated yet, so join through albums.sale_item_id instead.
@@ -3143,7 +3192,7 @@ class LibraryIndex:
             (sale_item_id,),
         )
         self._conn.commit()
-        return cur.rowcount
+        return count
 
     def set_collection_item_mode(self, sale_item_id: str, mode: str) -> bool:
         """Update mode for a collection item and clear synced_at so the next sync picks it up.
@@ -3860,42 +3909,33 @@ class LibraryIndex:
             """
             INSERT INTO tracks
                 (file_path, title, artist, album_artist, album, release_date,
-                 track_number, disc_number, ext, embedded_art,
-                 mb_release_id, mb_recording_id, date_added, file_mtime,
-                 genre, label, source, stream_url, stream_url_expires_at,
-                 is_available, duration)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 track_number, disc_number, mb_release_id, mb_recording_id,
+                 date_added, genre, label)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(file_path) DO UPDATE SET
                 title                 = excluded.title,
                 artist                = excluded.artist,
                 album_artist          = excluded.album_artist,
                 album                 = excluded.album,
-                -- For streaming tracks, preserve user-edited release_date/genre/label if the
-                -- incoming sync value is empty (Bandcamp never sends these fields).
-                release_date          = CASE WHEN excluded.source = 'bandcamp'
+                -- For streaming tracks (file_path is a bandcamp:// uri), preserve
+                -- user-edited release_date/genre/label if the incoming sync value is
+                -- empty (Bandcamp never sends these fields). KAMP-539: keyed on
+                -- file_path since the source column is gone.
+                release_date          = CASE WHEN excluded.file_path LIKE 'bandcamp://%'
                                              THEN COALESCE(NULLIF(excluded.release_date, ''), release_date)
                                              ELSE excluded.release_date END,
                 track_number          = excluded.track_number,
                 disc_number           = excluded.disc_number,
-                ext                   = excluded.ext,
-                embedded_art          = excluded.embedded_art,
                 mb_release_id         = excluded.mb_release_id,
                 mb_recording_id       = excluded.mb_recording_id,
-                file_mtime            = excluded.file_mtime,
-                genre                 = CASE WHEN excluded.source = 'bandcamp'
+                genre                 = CASE WHEN excluded.file_path LIKE 'bandcamp://%'
                                              THEN COALESCE(NULLIF(excluded.genre, ''), genre)
                                              ELSE excluded.genre END,
-                label                 = CASE WHEN excluded.source = 'bandcamp'
+                label                 = CASE WHEN excluded.file_path LIKE 'bandcamp://%'
                                              THEN COALESCE(NULLIF(excluded.label, ''), label)
-                                             ELSE excluded.label END,
-                source                = excluded.source,
-                -- Preserve the cached CDN URL if the incoming row has none.
-                -- fetch_album_tracks never populates stream_url; without this
-                -- COALESCE a sync run would wipe every cached stream URL.
-                stream_url            = COALESCE(excluded.stream_url, stream_url),
-                stream_url_expires_at = COALESCE(excluded.stream_url_expires_at, stream_url_expires_at),
-                is_available          = excluded.is_available,
-                duration              = excluded.duration
+                                             ELSE excluded.label END
+                -- Per-source columns (ext/embedded_art/file_mtime/source/stream_url*/
+                -- is_available/duration) now live in track_sources (KAMP-539).
                 -- date_added intentionally omitted: preserve original scan date on re-scan
                 -- last_played intentionally omitted: managed exclusively by record_played()
             """,
@@ -4282,20 +4322,23 @@ class LibraryIndex:
         return touched
 
     def _rename_file_source(
-        self, old_path: "Path | str", new_path: "Path | str"
+        self, old_path: "Path | str", new_path: "Path | str", new_mtime: float
     ) -> None:
-        """Repoint a track's file track_sources.uri after its file moves on disk.
+        """Repoint a track's file track_sources.uri (and mtime) after it moves on disk.
 
         The scanner reads indexed file paths from track_sources (kind='file',
         KAMP-541), so a tag-edit / album rename that physically moved a file must
         update its file source uri in lock-step with tracks.file_path. Otherwise
         the next scan sees the old uri as a vanished file (remove_track drops the
         source — deleting a local-only track and its stats) and the new path as
-        unindexed (re-fork). Caller owns the commit.
+        unindexed (re-fork). Also carries the post-move file_mtime, which the
+        callers used to write to tracks.file_mtime (dropped in KAMP-539). Caller
+        owns the commit.
         """
         self._conn.execute(
-            "UPDATE track_sources SET uri = ? WHERE kind = 'file' AND uri = ?",
-            (str(new_path), str(old_path)),
+            "UPDATE track_sources SET uri = ?, file_mtime = ?"
+            " WHERE kind = 'file' AND uri = ?",
+            (str(new_path), new_mtime, str(old_path)),
         )
 
     def move_track(
@@ -4313,10 +4356,10 @@ class LibraryIndex:
         uri is repointed alongside file_path (see _rename_file_source).
         """
         self._conn.execute(
-            "UPDATE tracks SET file_path = ?, title = ?, file_mtime = ? WHERE file_path = ?",
-            (str(new_path), new_title, new_mtime, str(old_path)),
+            "UPDATE tracks SET file_path = ?, title = ? WHERE file_path = ?",
+            (str(new_path), new_title, str(old_path)),
         )
-        self._rename_file_source(old_path, new_path)
+        self._rename_file_source(old_path, new_path, new_mtime)
         self._rebuild_fts()
         self._conn.commit()
 
@@ -4336,11 +4379,11 @@ class LibraryIndex:
         """
         self._conn.execute(
             """UPDATE tracks
-               SET file_path = ?, album = ?, album_artist = ?, file_mtime = ?
+               SET file_path = ?, album = ?, album_artist = ?
                WHERE file_path = ?""",
-            (str(new_path), new_album, new_album_artist, new_mtime, str(old_path)),
+            (str(new_path), new_album, new_album_artist, str(old_path)),
         )
-        self._rename_file_source(old_path, new_path)
+        self._rename_file_source(old_path, new_path, new_mtime)
         self._rebuild_fts()
         self._conn.commit()
 
@@ -4381,8 +4424,7 @@ class LibraryIndex:
                        SET file_path = ?,
                            album = ?,
                            album_artist = ?,
-                           artist = CASE WHEN ? IS NOT NULL AND artist = ? THEN ? ELSE artist END,
-                           file_mtime = ?
+                           artist = CASE WHEN ? IS NOT NULL AND artist = ? THEN ? ELSE artist END
                        WHERE file_path = ?""",
                     (
                         str(new_path),
@@ -4391,11 +4433,10 @@ class LibraryIndex:
                         old_album_artist,
                         old_album_artist,
                         new_album_artist,
-                        new_mtime,
                         str(old_path),
                     ),
                 )
-                self._rename_file_source(old_path, new_path)
+                self._rename_file_source(old_path, new_path, new_mtime)
             # Update the albums row. The UNIQUE (album_artist, album) COLLATE NOCASE
             # constraint raises IntegrityError if the new name already exists.
             if album_id is not None:
@@ -4600,9 +4641,13 @@ class LibraryIndex:
     ) -> None:
         """Update a single track's path + album tags after a deferred album_retag drains."""
         self._conn.execute(
-            "UPDATE tracks SET file_path=?, album=?, album_artist=?, file_mtime=?"
-            " WHERE id=?",
-            (str(new_path), album, album_artist, mtime, track_id),
+            "UPDATE tracks SET file_path=?, album=?, album_artist=? WHERE id=?",
+            (str(new_path), album, album_artist, track_id),
+        )
+        # file_mtime lives in track_sources now (KAMP-539); update the file source.
+        self._conn.execute(
+            "UPDATE track_sources SET file_mtime=? WHERE kind='file' AND track_id=?",
+            (mtime, track_id),
         )
         if new_artist is not None:
             self._conn.execute(
@@ -5738,7 +5783,8 @@ class LibraryIndex:
         (AC #2).
         """
         row = self._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", (mbid,)
+            "SELECT embedded_art FROM tracks_with_stats WHERE mb_recording_id = ?",
+            (mbid,),
         ).fetchone()
         old_embedded_art: bool | None = bool(row["embedded_art"]) if row else None
 
@@ -5758,7 +5804,9 @@ class LibraryIndex:
         )
         if row:
             self._conn.execute(
-                "UPDATE tracks SET embedded_art = 1 WHERE mb_recording_id = ?",
+                "UPDATE track_sources SET embedded_art = 1"
+                " WHERE kind = 'file' AND track_id IN"
+                " (SELECT id FROM tracks WHERE mb_recording_id = ?)",
                 (mbid,),
             )
         self._conn.commit()
@@ -5807,7 +5855,9 @@ class LibraryIndex:
                 embedded_art = old.get("embedded_art")
                 if embedded_art is not None:
                     self._conn.execute(
-                        "UPDATE tracks SET embedded_art = ? WHERE mb_recording_id = ?",
+                        "UPDATE track_sources SET embedded_art = ?"
+                        " WHERE kind = 'file' AND track_id IN"
+                        " (SELECT id FROM tracks WHERE mb_recording_id = ?)",
                         (int(embedded_art), mbid),
                     )
             reverted += 1
@@ -6596,19 +6646,14 @@ def _track_to_params(
     int,
     int,
     str,
-    int,
-    str,
     str,
     float | None,
-    float | None,
     str,
     str,
-    str,
-    str | None,
-    float | None,
-    int,
-    float,
 ]:
+    # Identity/catalog columns only — the per-source columns (ext/embedded_art/
+    # file_mtime/source/stream_url*/is_available/duration) live in track_sources
+    # and were dropped from tracks in KAMP-539; the upsert populates them there.
     return (
         _canonical_track_uri(t.file_path),
         t.title,
@@ -6618,19 +6663,11 @@ def _track_to_params(
         t.release_date,
         t.track_number,
         t.disc_number,
-        t.ext,
-        int(t.embedded_art),
         t.mb_release_id,
         t.mb_recording_id,
         t.date_added,
-        t.file_mtime,
         t.genre,
         t.label,
-        t.source,
-        t.stream_url,
-        t.stream_url_expires_at,
-        int(t.is_available),
-        t.duration,
     )
 
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2231,18 +2231,25 @@ class LibraryIndex:
         realigns the survivor's legacy columns to its preferred source. Caller
         owns the transaction/commit.
         """
+        import time
+
         c = self._conn
         self._ensure_track_source(survivor_id)
         self._ensure_track_source(loser_id)
-        # Stats onto the survivor's tracks columns.
+        # Merge the loser's stats into the survivor's track_stats — the sole stat
+        # store (KAMP-539): MAX favorite/play_count, latest last_played, read from
+        # both track_stats rows now, before the loser (and its cascading stats row)
+        # is deleted below. Fixes KAMP-532 without touching the legacy tracks columns.
         c.execute(
-            "UPDATE tracks SET"
-            " favorite = MAX(favorite, COALESCE((SELECT favorite FROM tracks WHERE id=?),0)),"
-            " play_count = MAX(play_count, COALESCE((SELECT play_count FROM tracks WHERE id=?),0)),"
-            " last_played = NULLIF(MAX(COALESCE(last_played,0),"
-            "     COALESCE((SELECT last_played FROM tracks WHERE id=?),0)), 0)"
-            " WHERE id=?",
-            (loser_id, loser_id, loser_id, survivor_id),
+            "INSERT INTO track_stats"
+            " (track_id, favorite, play_count, last_played, updated_at)"
+            " SELECT ?, COALESCE(MAX(favorite), 0), COALESCE(MAX(play_count), 0),"
+            "   NULLIF(COALESCE(MAX(last_played), 0), 0), ?"
+            " FROM track_stats WHERE track_id IN (?, ?)"
+            " ON CONFLICT(track_id) DO UPDATE SET favorite = excluded.favorite,"
+            "   play_count = excluded.play_count, last_played = excluded.last_played,"
+            "   updated_at = excluded.updated_at",
+            (survivor_id, time.time(), survivor_id, loser_id),
         )
         # Identity: streaming display_* win if the survivor's is NULL; non-empty
         # mb/genre/label fill a blank survivor field from the loser.
@@ -2278,16 +2285,11 @@ class LibraryIndex:
             (survivor_id, loser_id),
         )
         self._repoint_track_refs(loser_id, survivor_id)
-        # Delete the loser (its sources are re-parented; its stats cascade away).
+        # Delete the loser (its sources are re-parented; its stats cascade away;
+        # the survivor's merged stats were written to track_stats above).
         c.execute("DELETE FROM tracks WHERE id = ?", (loser_id,))
-        # Re-derive the survivor's track_stats from the merged tracks columns.
-        c.execute(
-            "INSERT INTO track_stats (track_id, favorite, play_count, last_played)"
-            " SELECT id, favorite, play_count, last_played FROM tracks WHERE id=?"
-            " ON CONFLICT(track_id) DO UPDATE SET favorite=excluded.favorite,"
-            " play_count=excluded.play_count, last_played=excluded.last_played",
-            (survivor_id,),
-        )
+        # Realign the survivor's identity file_path to its (now combined) preferred
+        # source so it is found by the local path once a file joins a stream.
         self._sync_tracks_row_to_preferred_source(survivor_id)
 
     def _reconcile_scanned_tracks(self, canonical_keys: "list[str]") -> None:
@@ -3587,32 +3589,22 @@ class LibraryIndex:
         self._conn.commit()
 
     def _sync_tracks_row_to_preferred_source(self, track_id: int) -> None:
-        """Realign a track's legacy columns to its preferred source (KAMP-541).
+        """Realign a track's identity file_path to its preferred source (KAMP-541).
 
-        Keeps `tracks.file_path`/`source`/per-source columns coherent with
-        `track_sources` while both coexist (the columns are dropped in KAMP-539),
-        e.g. after a local file is removed and the track reverts to its stream
-        source. Caller commits. No-op if the track has no sources.
+        `tracks.file_path` is the retained identity/lookup key; keep it coherent
+        with `track_sources` so the track is found by its preferred delivery uri
+        (e.g. after a local file is removed and the track reverts to its stream
+        source, or a download is added and the local file becomes preferred). The
+        per-source/`source` columns that this used to also realign are now derived
+        from `track_sources` by the view and dropped in KAMP-539, so only file_path
+        remains to sync. Caller commits. No-op if the track has no sources.
         """
         src = self.preferred_source(track_id)
         if src is None:
             return
         self._conn.execute(
-            "UPDATE tracks SET file_path = ?, source = ?, ext = ?, duration = ?,"
-            " embedded_art = ?, file_mtime = ?, is_available = ?, stream_url = ?,"
-            " stream_url_expires_at = ? WHERE id = ?",
-            (
-                src["uri"],
-                "local" if src["kind"] == "file" else "bandcamp",
-                src["ext"],
-                src["duration"],
-                src["embedded_art"],
-                src["file_mtime"],
-                src["is_available"],
-                src["stream_url"],
-                src["stream_url_expires_at"],
-                track_id,
-            ),
+            "UPDATE tracks SET file_path = ? WHERE id = ?",
+            (src["uri"], track_id),
         )
 
     def update_track_display_title(
@@ -4102,11 +4094,11 @@ class LibraryIndex:
         self._conn.execute(
             f"""
             UPDATE albums SET
-                embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks t WHERE t.album_id = albums.id),
+                embedded_art   = (SELECT MAX(t.embedded_art)  FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 date_added     = (SELECT MIN(t.date_added)    FROM tracks t WHERE t.album_id = albums.id),
                 last_played_at = (SELECT MAX(t.last_played)   FROM tracks_with_stats t WHERE t.album_id = albums.id),
-                art_version    = (SELECT MAX(CASE WHEN {_eff_source("t")} = 'local' THEN t.file_mtime END)
-                                  FROM tracks t WHERE t.album_id = albums.id),
+                art_version    = (SELECT MAX(CASE WHEN t.source = 'local' THEN t.file_mtime END)
+                                  FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 play_count_avg = (SELECT CAST(SUM(t.play_count) AS REAL) / COUNT(*)
                                   FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 source         = {_ALBUM_SOURCE_SUBQUERY},
@@ -4720,25 +4712,43 @@ class LibraryIndex:
         ).fetchone()
         return str(row["file_path"]) if row is not None else key
 
-    def _mirror_track_stats(self, key: str, cols: "tuple[str, ...]") -> None:
-        """Mirror stat column(s) from the tracks row at *key* into track_stats.
+    def _write_track_stats(self, key: str, **values: "float | int | None") -> None:
+        """Upsert absolute stat value(s) into track_stats for the track at *key*.
 
-        Absolute-value dual-write (KAMP-540): reads the *post-update* value(s)
-        from tracks and upserts them into track_stats keyed by track_id — never a
-        relative delta, so it survives the KAMP-541 collapse. No-op when *key*
-        matches no track. Creates the track_stats row (mirroring current tracks
-        values) if the v45 backfill / a scan hasn't yet. *cols* are internal
-        column-name literals, never user input.
+        Resolves track_id from tracks.file_path and writes track_stats directly —
+        the sole source of truth since KAMP-539 dropped the legacy tracks stat
+        columns. Absolute values (never a relative delta), so it survives the
+        KAMP-541 collapse. No-op when *key* matches no track; creates the
+        track_stats row if a scan/backfill has not yet. *values* keys are internal
+        column-name literals (favorite/last_played), never user input.
         """
         import time
 
+        cols = list(values)
         col_list = ", ".join(cols)
+        value_slots = ", ".join("?" for _ in cols)
         assigns = ", ".join(f"{c} = excluded.{c}" for c in cols)
         self._conn.execute(
             f"INSERT INTO track_stats (track_id, {col_list}, updated_at)"
-            f" SELECT id, {col_list}, ? FROM tracks WHERE file_path = ?"
+            f" SELECT id, {value_slots}, ? FROM tracks WHERE file_path = ?"
             f" ON CONFLICT(track_id) DO UPDATE SET {assigns},"
             f" updated_at = excluded.updated_at",
+            (*values.values(), time.time(), key),
+        )
+
+    def _increment_play_count(self, key: str) -> None:
+        """Increment track_stats.play_count for the track at *key* (KAMP-539).
+
+        In-table increment (seeds play_count=1 when the track_stats row is absent)
+        so it never reads a stale value. No-op when *key* matches no track.
+        """
+        import time
+
+        self._conn.execute(
+            "INSERT INTO track_stats (track_id, play_count, updated_at)"
+            " SELECT id, 1, ? FROM tracks WHERE file_path = ?"
+            " ON CONFLICT(track_id) DO UPDATE SET play_count = play_count + 1,"
+            " updated_at = excluded.updated_at",
             (time.time(), key),
         )
 
@@ -4754,10 +4764,7 @@ class LibraryIndex:
 
         now = time.time()
         key = self._canonical_key_for(file_path)
-        self._conn.execute(
-            "UPDATE tracks SET last_played = ? WHERE file_path = ?",
-            (now, key),
-        )
+        self._write_track_stats(key, last_played=now)
         # Keep album aggregate in sync.
         self._conn.execute(
             """
@@ -4767,7 +4774,6 @@ class LibraryIndex:
             """,
             (now, key, now),
         )
-        self._mirror_track_stats(key, ("last_played",))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.last_played"})
@@ -4780,15 +4786,11 @@ class LibraryIndex:
         Also refreshes the parent album's play_count_avg.
         """
         key = self._canonical_key_for(file_path)
-        self._conn.execute(
-            "UPDATE tracks SET play_count = play_count + 1 WHERE file_path = ?",
-            (key,),
-        )
-        # Mirror the post-increment absolute value (not a +1) into track_stats
-        # BEFORE recomputing the album average — that recompute now reads
-        # play_count through the tracks_with_stats view (i.e. from track_stats),
-        # so the mirror must land first or the average sees the stale value.
-        self._mirror_track_stats(key, ("play_count",))
+        # Increment play_count in track_stats BEFORE recomputing the album average
+        # — that recompute reads play_count through the tracks_with_stats view
+        # (i.e. from track_stats), so the write must land first or the average
+        # sees the stale value.
+        self._increment_play_count(key)
         self._conn.execute(
             """
             UPDATE albums SET play_count_avg = (
@@ -4906,11 +4908,7 @@ class LibraryIndex:
         row so the favorite lands on the canonical track (KAMP-541).
         """
         key = self._canonical_key_for(file_path)
-        self._conn.execute(
-            "UPDATE tracks SET favorite = ? WHERE file_path = ?",
-            (int(favorite), key),
-        )
-        self._mirror_track_stats(key, ("favorite",))
+        self._write_track_stats(key, favorite=int(favorite))
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.favorite"})
@@ -4924,33 +4922,34 @@ class LibraryIndex:
         downloaded.  Matches by (album_id, track_number, disc_number) — the
         album_id FK eliminates the binary-collation string matching that caused
         silent data loss when MusicBrainz normalised album_artist capitalisation.
-        Only updates rows where the local track has favorite=0 to avoid clearing
-        a flag the user explicitly set on the local file.
+        Reads/writes favorite through track_stats — the sole stat store since
+        KAMP-539 dropped tracks.favorite. Only sets track_stats.favorite when it is
+        currently 0, so a flag the user explicitly set on the local file is not
+        re-stamped.
         """
+        import time
+
         for t in new_tracks:
             self._conn.execute(
                 """
-                UPDATE tracks SET favorite = 1
-                WHERE file_path = ?
-                  AND favorite = 0
+                INSERT INTO track_stats (track_id, favorite, updated_at)
+                SELECT loc.id, 1, ?
+                FROM tracks loc
+                WHERE loc.file_path = ?
                   AND EXISTS (
                       SELECT 1 FROM tracks r
-                      WHERE r.album_id = (
-                                SELECT album_id FROM tracks
-                                WHERE file_path = ?
-                            )
+                      JOIN track_stats rs ON rs.track_id = r.id
+                      WHERE r.album_id = loc.album_id
                         AND r.track_number = ?
                         AND r.disc_number = ?
                         AND r.file_path LIKE 'bandcamp://%'
-                        AND r.favorite = 1
+                        AND rs.favorite = 1
                   )
+                ON CONFLICT(track_id) DO UPDATE SET
+                    favorite = 1, updated_at = excluded.updated_at
+                    WHERE track_stats.favorite = 0
                 """,
-                (
-                    str(t.file_path),
-                    str(t.file_path),
-                    t.track_number,
-                    t.disc_number,
-                ),
+                (time.time(), str(t.file_path), t.track_number, t.disc_number),
             )
         if new_tracks:
             self._conn.commit()
@@ -4962,46 +4961,33 @@ class LibraryIndex:
         Called by LibraryScanner after a pre-order album is downloaded so play
         counts accumulated during the streaming period are not lost.  Uses the
         same (album_id, track_number, disc_number) match as inherit_remote_favorites.
-        Only updates when the remote play_count > the local play_count.
+        Reads/writes play_count through track_stats (KAMP-539). Only updates when the
+        remote play_count exceeds the local one.
         """
+        import time
+
+        sibling_max = (
+            "(SELECT MAX(rs.play_count)"
+            " FROM tracks r JOIN track_stats rs ON rs.track_id = r.id"
+            " WHERE r.album_id = loc.album_id"
+            "   AND r.track_number = loc.track_number"
+            "   AND r.disc_number = loc.disc_number"
+            "   AND r.file_path LIKE 'bandcamp://%')"
+        )
         for t in new_tracks:
             self._conn.execute(
-                """
-                UPDATE tracks SET play_count = (
-                    SELECT MAX(r.play_count, tracks.play_count)
-                    FROM tracks r
-                    WHERE r.album_id = (
-                              SELECT album_id FROM tracks
-                              WHERE file_path = ?
-                          )
-                      AND r.track_number = ?
-                      AND r.disc_number = ?
-                      AND r.file_path LIKE 'bandcamp://%'
-                      AND r.play_count > 0
-                    LIMIT 1
-                )
-                WHERE file_path = ?
-                  AND EXISTS (
-                      SELECT 1 FROM tracks r
-                      WHERE r.album_id = (
-                                SELECT album_id FROM tracks
-                                WHERE file_path = ?
-                            )
-                        AND r.track_number = ?
-                        AND r.disc_number = ?
-                        AND r.file_path LIKE 'bandcamp://%'
-                        AND r.play_count > tracks.play_count
-                  )
+                f"""
+                INSERT INTO track_stats (track_id, play_count, updated_at)
+                SELECT loc.id, {sibling_max}, ?
+                FROM tracks loc
+                WHERE loc.file_path = ?
+                  AND {sibling_max} > COALESCE(
+                      (SELECT play_count FROM track_stats WHERE track_id = loc.id), 0)
+                ON CONFLICT(track_id) DO UPDATE SET
+                    play_count = excluded.play_count, updated_at = excluded.updated_at
+                    WHERE excluded.play_count > track_stats.play_count
                 """,
-                (
-                    str(t.file_path),
-                    t.track_number,
-                    t.disc_number,
-                    str(t.file_path),
-                    str(t.file_path),
-                    t.track_number,
-                    t.disc_number,
-                ),
+                (time.time(), str(t.file_path)),
             )
         if new_tracks:
             self._conn.commit()

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -3523,10 +3523,16 @@ class LibraryIndex:
     def update_stream_url(
         self, file_path_uri: str, stream_url: str, expires_at: float
     ) -> None:
-        """Persist a refreshed CDN stream URL and its expiry timestamp for a remote track."""
+        """Persist a refreshed CDN stream URL and its expiry for a remote track.
+
+        Writes the track_sources row addressed by the uri (KAMP-539) — the uri is
+        the stream source's own uri; the legacy tracks.stream_url column this used
+        to write is derived from track_sources by the view now.
+        """
         self._conn.execute(
-            "UPDATE tracks SET stream_url = ?, stream_url_expires_at = ? WHERE file_path = ?",
-            (stream_url, expires_at, file_path_uri),
+            "UPDATE track_sources SET stream_url = ?, stream_url_expires_at = ?"
+            " WHERE uri = ?",
+            (stream_url, expires_at, _canonical_track_uri(file_path_uri)),
         )
         self._conn.commit()
 
@@ -4019,27 +4025,41 @@ class LibraryIndex:
         if touched_album_ids:
             self._refresh_album_aggregates(list(touched_album_ids))
 
-        # Step 5 (KAMP-540): keep the canonical child tables in sync. Every
-        # upserted track gets a refreshed track_sources row (per-source cols read
-        # back from the now-current tracks row) and, if it has none yet, a
-        # track_stats row mirroring its stats (INSERT OR IGNORE so a re-scan never
-        # resets favorite/play_count). Reads still use the old tracks columns —
-        # this only populates the children for KAMP-541/542.
+        # Step 5 (KAMP-540/539): keep the canonical child tables in sync. Every
+        # upserted track gets a refreshed track_sources row whose per-source
+        # columns come from the incoming Track (NOT read back from the tracks row,
+        # so the tracks per-source columns can be dropped in 539) and, if it has
+        # none yet, a default track_stats row (INSERT OR IGNORE so a re-scan never
+        # resets favorite/play_count; a brand-new track starts at 0/0/NULL). The
+        # uri is still taken from the retained tracks.file_path.
         src_params: list[tuple[Any, ...]] = []
         for t in tracks:
             key = _canonical_track_uri(t.file_path)
             _uri, kind, provider, provider_item_id = _derive_source_fields(
                 t.file_path, t.source, t.sale_item_id
             )
-            src_params.append((kind, provider, provider_item_id, key))
+            src_params.append(
+                (
+                    kind,
+                    provider,
+                    provider_item_id,
+                    t.ext,
+                    t.duration,
+                    int(t.embedded_art),
+                    t.file_mtime,
+                    int(t.is_available),
+                    t.stream_url,
+                    t.stream_url_expires_at,
+                    key,
+                )
+            )
         if src_params:
             self._conn.executemany(
                 "INSERT INTO track_sources"
                 " (track_id, kind, provider, provider_item_id, uri, ext, duration,"
                 "  embedded_art, file_mtime, is_available, stream_url,"
                 "  stream_url_expires_at)"
-                " SELECT id, ?, ?, ?, file_path, ext, duration, embedded_art,"
-                "        file_mtime, is_available, stream_url, stream_url_expires_at"
+                " SELECT id, ?, ?, ?, file_path, ?, ?, ?, ?, ?, ?, ?"
                 " FROM tracks WHERE file_path = ?"
                 " ON CONFLICT(uri) DO UPDATE SET"
                 "   track_id = excluded.track_id, kind = excluded.kind,"
@@ -4056,14 +4076,13 @@ class LibraryIndex:
             self._conn.executemany(
                 "INSERT OR IGNORE INTO track_stats"
                 " (track_id, favorite, play_count, last_played)"
-                " SELECT id, favorite, play_count, last_played"
-                " FROM tracks WHERE file_path = ?",
-                [(p[3],) for p in src_params],
+                " SELECT id, 0, 0, NULL FROM tracks WHERE file_path = ?",
+                [(p[-1],) for p in src_params],
             )
             # Step 6 (KAMP-541): attach a newly-scanned file to its existing
             # canonical track (merging the fork) instead of leaving a duplicate
             # streaming+local pair. No-op when there is no stream-only sibling.
-            self._reconcile_scanned_tracks([p[3] for p in src_params])
+            self._reconcile_scanned_tracks([p[-1] for p in src_params])
 
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()
@@ -5070,11 +5089,14 @@ class LibraryIndex:
             return
         str_paths = [str(p) for p in file_paths]
         placeholders = ",".join("?" * len(str_paths))
+        # Write the file source's art fields in track_sources (KAMP-539) — the uri
+        # of a file source is the on-disk path, so the given paths address them
+        # directly; the legacy tracks.embedded_art/file_mtime the view derives.
         self._conn.execute(
-            f"UPDATE tracks SET embedded_art = 1, file_mtime = ?"
-            f" WHERE album_id = ?"
-            f" AND file_path IN ({placeholders})",
-            [now, album_id, *str_paths],
+            f"UPDATE track_sources SET embedded_art = 1, file_mtime = ?"
+            f" WHERE kind = 'file' AND uri IN ({placeholders})"
+            f" AND track_id IN (SELECT id FROM tracks WHERE album_id = ?)",
+            [now, *str_paths, album_id],
         )
         # Update the album row's aggregate art fields.
         self._conn.execute(

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4045,12 +4045,15 @@ class LibraryIndex:
         ]
         touched_from_singles = self._attach_loose_local_singles(single_paths)
 
-        # Step 4: refresh denormalized aggregate columns on the touched album rows.
-        # Run once per batch (not per track) using a correlated subquery. Include
-        # albums reached only through provenance linking (prov_album_ids) and
-        # single re-linking (touched_from_singles) — a nameless single's target
-        # album is not in file_paths (built from named), yet its source/aggregates
-        # must be recomputed now that a local track attached to it.
+        # Step 4: collect the touched album ids (refresh is deferred to after Step 5,
+        # below). Include albums reached only through provenance linking
+        # (prov_album_ids) and single re-linking (touched_from_singles) — a nameless
+        # single's target album is not in file_paths (built from named), yet its
+        # source/aggregates must be recomputed now that a local track attached to it.
+        # The aggregate refresh must run AFTER track_sources is populated (Step 5):
+        # _refresh_album_aggregates derives the album's art/source from the
+        # tracks_with_stats view, which reads track_sources (KAMP-539) — refreshing
+        # first would resolve every new track to source-less type defaults.
         touched_album_ids: set[int] = set(prov_album_ids) | touched_from_singles
         if file_paths:
             all_placeholders = ",".join("?" * len(file_paths))
@@ -4062,8 +4065,6 @@ class LibraryIndex:
                     file_paths,
                 ).fetchall()
             )
-        if touched_album_ids:
-            self._refresh_album_aggregates(list(touched_album_ids))
 
         # Step 5 (KAMP-540/539): keep the canonical child tables in sync. Every
         # upserted track gets a refreshed track_sources row whose per-source
@@ -4109,8 +4110,12 @@ class LibraryIndex:
                 "   embedded_art = excluded.embedded_art,"
                 "   file_mtime = excluded.file_mtime,"
                 "   is_available = excluded.is_available,"
-                "   stream_url = excluded.stream_url,"
-                "   stream_url_expires_at = excluded.stream_url_expires_at",
+                # Preserve a cached CDN URL when the incoming row has none — a
+                # metadata re-index (fetch_album_tracks never populates stream_url)
+                # must not wipe it (mirrors the pre-539 tracks upsert COALESCE).
+                "   stream_url = COALESCE(excluded.stream_url, stream_url),"
+                "   stream_url_expires_at ="
+                "     COALESCE(excluded.stream_url_expires_at, stream_url_expires_at)",
                 src_params,
             )
             self._conn.executemany(
@@ -4123,6 +4128,12 @@ class LibraryIndex:
             # canonical track (merging the fork) instead of leaving a duplicate
             # streaming+local pair. No-op when there is no stream-only sibling.
             self._reconcile_scanned_tracks([p[-1] for p in src_params])
+
+        # Step 4 (deferred from above): now that track_sources is populated,
+        # recompute the touched albums' denormalized aggregates (art/source/counts),
+        # which _refresh_album_aggregates derives from the tracks_with_stats view.
+        if touched_album_ids:
+            self._refresh_album_aggregates(list(touched_album_ids))
 
         # Rebuild the FTS index so new/updated tracks are immediately searchable.
         self._rebuild_fts()

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -1967,34 +1967,70 @@ class LibraryIndex:
             version = 48  # noqa: F841
 
     def _create_tracks_with_stats_view(self) -> None:
-        """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542).
+        """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542/539).
 
-        Projects every ``tracks`` column but shadows ``favorite``/``play_count``/
-        ``last_played`` from ``track_stats`` — the authoritative store since the
-        KAMP-540 dual-write — so read paths resolve stats from the child table and
-        KAMP-539 can drop the legacy columns. While both coexist the shadow
-        COALESCEs back to the legacy column, so a track that somehow lacks a
-        ``track_stats`` row still reads its real value rather than a spurious 0;
-        once 539 drops the legacy columns the fallback becomes the type default.
+        Projects the identity/catalog ``tracks`` columns straight through, and
+        DERIVES the mutable per-track state from the child tables so the legacy
+        ``tracks`` columns can be dropped (KAMP-539):
 
-        Built from ``PRAGMA table_info`` and recreated on every open so it always
-        matches the current ``tracks`` schema (survives 539's column drop with no
-        edit here). Read-only by construction: every writer (UPDATE/INSERT/upsert,
-        the ``tracks_fts`` rowid join, the stat mirrors) stays on the base table,
-        whose ``id`` the view preserves so FTS rowid joins still resolve.
+        - ``favorite``/``play_count``/``last_played`` shadow ``track_stats``.
+        - ``ext``/``duration``/``embedded_art``/``file_mtime``/``is_available``/
+          ``stream_url``/``stream_url_expires_at``/``source`` derive from the
+          track's *preferred* ``track_sources`` row (``ps``), chosen by the same
+          ordering as ``preferred_source``/``_eff_source`` (available first, then
+          local file over stream, then lowest id). ``source`` maps the preferred
+          source's ``kind`` file->'local'/stream->'bandcamp'.
+
+        While a legacy column still exists each derived value COALESCEs back to it,
+        so a track that lacks a child row (a pre-540 row or a bare test fixture)
+        still reads its real value rather than a default; once 539 drops the
+        column the fallback becomes the type default. Column names are identical
+        pre- and post-drop, so ``_row_to_track`` and every ``SELECT *`` consumer
+        are untouched by the drop.
+
+        Read-only by construction: every writer (UPDATE/INSERT/upsert, the
+        ``tracks_fts`` rowid join, the stat/source mirrors) stays on the base
+        tables, whose ``id`` the view preserves so FTS rowid joins still resolve.
         """
+        colset = {r[1] for r in self._conn.execute("PRAGMA table_info(tracks)")}
+        # Derived name -> (SQL expression over ps/ts, SQL default once the legacy
+        # tracks column is dropped in KAMP-539).
+        per_source = {
+            "ext": ("ps.ext", "''"),
+            "duration": ("ps.duration", "0"),
+            "embedded_art": ("ps.embedded_art", "0"),
+            "file_mtime": ("ps.file_mtime", "NULL"),
+            "is_available": ("ps.is_available", "1"),
+            "stream_url": ("ps.stream_url", "NULL"),
+            "stream_url_expires_at": ("ps.stream_url_expires_at", "NULL"),
+            "source": (
+                "CASE WHEN ps.kind = 'file' THEN 'local'"
+                " WHEN ps.kind IS NOT NULL THEN 'bandcamp' END",
+                "'local'",
+            ),
+        }
+        stats = {
+            "favorite": ("ts.favorite", "0"),
+            "play_count": ("ts.play_count", "0"),
+            "last_played": ("ts.last_played", "NULL"),
+        }
+        derived = {**per_source, **stats}
+        # Identity/catalog passthrough columns keep their base-table order.
         cols = [r[1] for r in self._conn.execute("PRAGMA table_info(tracks)")]
-        # column -> SQL default used once the legacy column is dropped (KAMP-539).
-        stats_default = {"favorite": "0", "play_count": "0", "last_played": "NULL"}
-        projected = [f"t.{c}" for c in cols if c not in stats_default]
-        for name, default in stats_default.items():
-            fallback = f"t.{name}" if name in cols else default
-            projected.append(f"COALESCE(ts.{name}, {fallback}) AS {name}")
+        projected = [f"t.{c}" for c in cols if c not in derived]
+        for name, (expr, default) in derived.items():
+            fallback = f"t.{name}" if name in colset else default
+            projected.append(f"COALESCE({expr}, {fallback}) AS {name}")
         self._conn.executescript(
             "DROP VIEW IF EXISTS tracks_with_stats;\n"
             "CREATE VIEW tracks_with_stats AS SELECT "
             + ", ".join(projected)
-            + " FROM tracks t LEFT JOIN track_stats ts ON ts.track_id = t.id;"
+            + " FROM tracks t"
+            " LEFT JOIN track_stats ts ON ts.track_id = t.id"
+            " LEFT JOIN track_sources ps ON ps.id = ("
+            "   SELECT s.id FROM track_sources s WHERE s.track_id = t.id"
+            "   ORDER BY s.is_available DESC, (s.kind = 'file') DESC, s.id LIMIT 1"
+            ");"
         )
         self._conn.commit()
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -354,8 +354,9 @@ class TestLibraryIndex:
         assert version == 48
         assert n_src == 0
 
-    def test_dual_write_mirrors_stats_to_track_stats(self, tmp_path: Path) -> None:
-        """set_favorite/record_played/record_track_started mirror into track_stats (KAMP-540)."""
+    def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
+        """set_favorite/record_played/record_track_started write track_stats, now the
+        sole store — the legacy tracks stat columns are no longer written (KAMP-539)."""
         index = LibraryIndex(tmp_path / "library.db")
         fp = tmp_path / "s.mp3"
         index.upsert_many([_sample_track(fp)])
@@ -370,15 +371,11 @@ class TestLibraryIndex:
             " JOIN tracks t ON t.id = st.track_id WHERE t.file_path = ?",
             (key,),
         ).fetchone()
-        tr = index._conn.execute(
-            "SELECT favorite, play_count, last_played FROM tracks WHERE file_path = ?",
-            (key,),
-        ).fetchone()
         index.close()
 
-        assert st["favorite"] == 1 == tr["favorite"]
-        assert st["play_count"] == 2 == tr["play_count"]
-        assert st["last_played"] == tr["last_played"] and st["last_played"] is not None
+        assert st["favorite"] == 1
+        assert st["play_count"] == 2
+        assert st["last_played"] is not None
 
     def test_upsert_maintains_children_without_resetting_stats(
         self, tmp_path: Path
@@ -774,7 +771,8 @@ class TestLibraryIndex:
         healed = LibraryIndex(db)  # runs the v47 heal
         hc = healed._conn
         t = hc.execute(
-            "SELECT embedded_art, file_mtime, source, file_path FROM tracks WHERE id=?",
+            "SELECT embedded_art, file_mtime, source, file_path"
+            " FROM tracks_with_stats WHERE id=?",
             (tid,),
         ).fetchone()
         a_art = hc.execute(
@@ -1056,9 +1054,7 @@ class TestLibraryIndex:
         healed = LibraryIndex(db)  # runs the v46 collapse
         hc = healed._conn
         n_tracks = hc.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
-        surv = hc.execute(
-            "SELECT id, favorite, play_count, file_path FROM tracks"
-        ).fetchone()
+        surv = hc.execute("SELECT id, file_path FROM tracks").fetchone()
         n_src = hc.execute(
             "SELECT COUNT(*) FROM track_sources WHERE track_id = ?", (surv["id"],)
         ).fetchone()[0]
@@ -1076,8 +1072,7 @@ class TestLibraryIndex:
 
         assert n_tracks == 1
         assert surv["id"] == local_id  # prefer-file: the local row survives
-        assert (surv["favorite"], surv["play_count"]) == (1, 5)  # MAX merge
-        assert (st["favorite"], st["play_count"]) == (1, 5)  # track_stats re-derived
+        assert (st["favorite"], st["play_count"]) == (1, 5)  # MAX merge in track_stats
         assert n_src == 2  # both sources re-parented onto the survivor
         assert surv["file_path"] == "/m/1.mp3"  # realigned to preferred (file) source
         assert pl_tid == local_id  # playlist repointed loser→survivor
@@ -3519,7 +3514,7 @@ class TestRecordTrackStarted:
         after = time.time()
 
         row = index._conn.execute(
-            "SELECT last_played FROM tracks WHERE file_path = ?", (str(p),)
+            "SELECT last_played FROM tracks_with_stats WHERE file_path = ?", (str(p),)
         ).fetchone()
         index.close()
 
@@ -8591,49 +8586,69 @@ class TestInheritRemotePlayCounts:
         t.play_count = play_count
         return t
 
+    def _seed_isolated_pair(
+        self, index: "LibraryIndex", remote_pc: int, local_pc: int, tmp_path: Path
+    ) -> Track:
+        """Insert a streamed track and its local sibling as two SEPARATE rows for the
+        same (album, track, disc), with play_count in track_stats, bypassing the
+        reconcile merge (which supersedes inherit in the normal scan by collapsing
+        the pair). Returns the local Track for the inherit call.
+        """
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album) VALUES ('The Artist','The Album')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        local = self._local_track(tmp_path, 1)
+        for fp, pc in [
+            ("bandcamp://42/1", remote_pc),
+            (str(local.file_path), local_pc),
+        ]:
+            c.execute(
+                "INSERT INTO tracks (file_path, title, album, album_artist, album_id,"
+                " track_number, disc_number) VALUES (?, 'Track 1', 'The Album',"
+                " 'The Artist', ?, 1, 1)",
+                (fp, alb),
+            )
+            tid = c.execute(
+                "SELECT id FROM tracks WHERE file_path = ?", (fp,)
+            ).fetchone()[0]
+            c.execute(
+                "INSERT INTO track_stats (track_id, play_count) VALUES (?, ?)",
+                (tid, pc),
+            )
+        c.commit()
+        return local
+
+    def _local_play_count(self, index: "LibraryIndex", local: Track) -> int:
+        return int(
+            index._conn.execute(
+                "SELECT st.play_count FROM track_stats st JOIN tracks t"
+                " ON t.id = st.track_id WHERE t.file_path = ?",
+                (str(local.file_path),),
+            ).fetchone()[0]
+        )
+
     def test_copies_play_count_from_remote_to_local(self, tmp_path: Path) -> None:
         index = self._setup(tmp_path)
-        remote = self._remote_track("42", 1)
-        index.upsert_many([remote])
-        # play_count is managed by record_played, not upsert_many — set directly
-        index._conn.execute(
-            "UPDATE tracks SET play_count = 7 WHERE file_path LIKE 'bandcamp://%'"
+        local = self._seed_isolated_pair(
+            index, remote_pc=7, local_pc=0, tmp_path=tmp_path
         )
-        index._conn.commit()
-
-        local = self._local_track(tmp_path, 1)
-        index.upsert_many([local])
         index.inherit_remote_play_counts([local])
-
-        result = index.tracks_for_album("The Artist", "The Album")
-        local_result = [t for t in result if "bandcamp" not in str(t.file_path)]
+        pc = self._local_play_count(index, local)
         index.close()
-
-        assert len(local_result) == 1
-        assert local_result[0].play_count == 7
+        assert pc == 7  # inherited from the streamed sibling
 
     def test_keeps_higher_local_play_count(self, tmp_path: Path) -> None:
         """If local play_count > remote, keep the local value."""
         index = self._setup(tmp_path)
-        remote = self._remote_track("42", 1)
-        index.upsert_many([remote])
-        index._conn.execute(
-            "UPDATE tracks SET play_count = 3 WHERE file_path LIKE 'bandcamp://%'"
+        local = self._seed_isolated_pair(
+            index, remote_pc=3, local_pc=10, tmp_path=tmp_path
         )
-        index._conn.commit()
-
-        local = self._local_track(tmp_path, 1)
-        index.upsert_many([local])
-        index._conn.execute("UPDATE tracks SET play_count = 10 WHERE source = 'local'")
-        index._conn.commit()
-        _mirror_stats(index)
         index.inherit_remote_play_counts([local])
-
-        result = index.tracks_for_album("The Artist", "The Album")
-        local_result = [t for t in result if "bandcamp" not in str(t.file_path)]
+        pc = self._local_play_count(index, local)
         index.close()
-
-        assert local_result[0].play_count == 10
+        assert pc == 10  # local's higher count preserved
 
     def test_no_change_when_remote_play_count_is_zero(self, tmp_path: Path) -> None:
         index = self._setup(tmp_path)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -5742,7 +5742,7 @@ class TestMarkAlbumArtEmbedded:
         index.mark_album_art_embedded("Artist", "Record", [t1.file_path, t2.file_path])
 
         rows = index._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE album = 'Record'"
+            "SELECT embedded_art FROM tracks_with_stats WHERE album = 'Record'"
         ).fetchall()
         assert all(r["embedded_art"] == 1 for r in rows)
         index.close()
@@ -5759,7 +5759,7 @@ class TestMarkAlbumArtEmbedded:
         after = time.time()
 
         row = index._conn.execute(
-            "SELECT file_mtime FROM tracks WHERE file_path = ?",
+            "SELECT file_mtime FROM tracks_with_stats WHERE file_path = ?",
             (str(t1.file_path),),
         ).fetchone()
         assert row["file_mtime"] is not None
@@ -6427,7 +6427,8 @@ class TestRemoteTrackSchema:
         )
 
         row = index._conn.execute(
-            "SELECT stream_url, stream_url_expires_at FROM tracks WHERE file_path = ?",
+            "SELECT stream_url, stream_url_expires_at FROM tracks_with_stats"
+            " WHERE file_path = ?",
             (fp_str,),
         ).fetchone()
         index.close()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -151,7 +151,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 48
+        assert version == 49
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -258,7 +258,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -351,7 +351,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 48
+        assert version == 49
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -2613,7 +2613,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2670,7 +2670,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3265,7 +3265,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         assert row[0] == 0
 
@@ -3720,7 +3720,7 @@ class TestFavorite:
         row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -3816,7 +3816,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -3997,7 +3997,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4092,7 +4092,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4100,7 +4100,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -4977,7 +4977,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
 
         index.close()
 
@@ -5668,7 +5668,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -5703,7 +5703,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 48
+        assert version == 49
         index.close()
 
 
@@ -6218,7 +6218,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 48
+        assert version == 49
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6351,7 +6351,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 48
+        assert version == 49
 
 
 class TestRemoteTrackSchema:
@@ -6695,7 +6695,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -6756,7 +6756,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7554,7 +7554,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8113,7 +8113,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -8191,7 +8191,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8397,7 +8397,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -8767,7 +8767,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8864,7 +8864,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -8980,7 +8980,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9485,7 +9485,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9600,7 +9600,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -9698,7 +9698,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -9798,7 +9798,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10305,7 +10305,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 48
+        assert version == 49
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11179,7 +11179,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 48
+        assert version == 49
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12295,7 +12295,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 48
+        assert version == 49
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -12315,7 +12315,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 48
+        assert version == 49
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -12357,7 +12357,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 48
+        assert version == 49
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -93,6 +93,40 @@ def _mirror_stats(index: "LibraryIndex") -> None:
     index._conn.commit()
 
 
+# Columns dropped from tracks in KAMP-539 (v49), with their pre-drop definitions.
+_LEGACY_TRACK_COLUMNS: list[tuple[str, str]] = [
+    ("ext", "TEXT NOT NULL DEFAULT ''"),
+    ("embedded_art", "INTEGER NOT NULL DEFAULT 0"),
+    ("file_mtime", "REAL"),
+    ("source", "TEXT NOT NULL DEFAULT 'local'"),
+    ("stream_url", "TEXT"),
+    ("stream_url_expires_at", "REAL"),
+    ("is_available", "INTEGER NOT NULL DEFAULT 1"),
+    ("duration", "REAL NOT NULL DEFAULT 0"),
+    ("last_played", "REAL"),
+    ("favorite", "INTEGER NOT NULL DEFAULT 0"),
+    ("play_count", "INTEGER NOT NULL DEFAULT 0"),
+]
+
+
+def _readd_legacy_track_columns(index: "LibraryIndex") -> None:
+    """Re-add the per-source/stat columns KAMP-539 dropped and rebuild the view.
+
+    Two uses: a migration test simulates a pre-v49 DB (seed the old row shape, set
+    schema_version back, reopen — the v49 migration drops the columns again), and a
+    feature test seeds favorite/source/etc via a direct ``INSERT INTO tracks``. With
+    the columns present the rebuilt view falls back to them, so pre-539 fixtures keep
+    working; the production drop + derived-view path is validated separately (a real
+    13k-track DB migration and the public-API test suite).
+    """
+    cols = {r[1] for r in index._conn.execute("PRAGMA table_info(tracks)")}
+    for name, decl in _LEGACY_TRACK_COLUMNS:
+        if name not in cols:
+            index._conn.execute(f"ALTER TABLE tracks ADD COLUMN {name} {decl}")
+    index._conn.commit()
+    index._create_tracks_with_stats_view()
+
+
 # ---------------------------------------------------------------------------
 # LibraryIndex
 # ---------------------------------------------------------------------------
@@ -264,7 +298,9 @@ class TestLibraryIndex:
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
         """v45 backfills track_sources/track_stats from tracks per design §3 (KAMP-540)."""
         db_path = tmp_path / "library.db"
-        LibraryIndex(db_path).close()  # full current schema
+        _idx = LibraryIndex(db_path)
+        _readd_legacy_track_columns(_idx)  # seed the pre-v49 row shape
+        _idx.close()
         conn = sqlite3.connect(str(db_path))
         # Rewind to the pre-backfill state: empty children, version 44, raw rows.
         conn.execute("DELETE FROM track_sources")
@@ -317,6 +353,7 @@ class TestLibraryIndex:
     def test_v45_backfill_is_idempotent(self, tmp_path: Path) -> None:
         """Re-running the backfill inserts no duplicate child rows (KAMP-540)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index._conn.execute(
             "INSERT INTO tracks (file_path, source) VALUES ('/m/a.mp3', 'local')"
         )
@@ -410,6 +447,7 @@ class TestLibraryIndex:
     def test_preferred_source_prefers_file_then_available(self, tmp_path: Path) -> None:
         """preferred_source picks a local file, falling through to a stream (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index._conn.execute(
             "INSERT INTO tracks (file_path, source) VALUES ('canon', 'bandcamp')"
         )
@@ -440,6 +478,7 @@ class TestLibraryIndex:
     ) -> None:
         """sources_for_track_ids returns all sources per track, preferred-first (KAMP-537)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO tracks (file_path, source) VALUES ('a', 'local')")
         c.execute("INSERT INTO tracks (file_path, source) VALUES ('b', 'bandcamp')")
@@ -471,6 +510,7 @@ class TestLibraryIndex:
     ) -> None:
         """Removing a local file drops its source but keeps a track that still streams (KAMP-541 C2)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         # Use a real platform path so str(fp) matches the stored uri on Windows too.
         fp = tmp_path / "a.mp3"
         index._conn.execute(
@@ -502,6 +542,7 @@ class TestLibraryIndex:
     def test_remove_track_deletes_sourceless_track(self, tmp_path: Path) -> None:
         """Removing the only (file) source deletes the canonical track (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         fp = tmp_path / "solo.mp3"
         index._conn.execute(
             "INSERT INTO tracks (file_path, source) VALUES (?, 'local')", (str(fp),)
@@ -523,6 +564,7 @@ class TestLibraryIndex:
         """A bucket with >2 rows is left un-merged (KAMP-541 quarantine)."""
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
         alb = c.execute("SELECT id FROM albums").fetchone()[0]
@@ -554,6 +596,7 @@ class TestLibraryIndex:
         """Collapse derives an absent source and keeps the survivor's deferred op (KAMP-541)."""
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
         alb = c.execute("SELECT id FROM albums").fetchone()[0]
@@ -597,6 +640,7 @@ class TestLibraryIndex:
     ) -> None:
         """A downloaded file for an existing stream track attaches as a source (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute(
             "INSERT INTO albums (album_artist, album) VALUES ('The Artist','The Album')"
@@ -715,6 +759,7 @@ class TestLibraryIndex:
         from kamp_core.library import NoStreamableVersionError
 
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidX')")
         c.execute(
@@ -743,6 +788,7 @@ class TestLibraryIndex:
         """v47 restores embedded_art/file_mtime lost by the v46 collapse (KAMP-541)."""
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute(
             "INSERT INTO albums (album_artist, album, embedded_art) VALUES ('A','Alb',0)"
@@ -794,6 +840,7 @@ class TestLibraryIndex:
         """
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid48')")
         c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
@@ -841,6 +888,123 @@ class TestLibraryIndex:
         assert surv == file_id  # survivor is the local download
         assert kinds == ["file", "stream"]  # stream re-parented onto it
 
+    def test_v49_drops_legacy_columns_and_derives_from_children(
+        self, tmp_path: Path
+    ) -> None:
+        """v49 drops the 11 duplicated tracks columns; reads then derive them from
+        track_sources/track_stats via the view, values preserved (KAMP-539)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
+        c = index._conn
+        c.execute(
+            "INSERT INTO tracks (file_path, title, album, album_artist, track_number,"
+            " disc_number, source, ext, duration) VALUES"
+            " ('/m/a.mp3','T','Alb','A',1,1,'local','flac',321.0)"
+        )
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri, ext, duration,"
+            " embedded_art, is_available) VALUES (?, 'file', '/m/a.mp3','flac',321.0,1,1)",
+            (tid,),
+        )
+        c.execute(
+            "INSERT INTO track_stats (track_id, favorite, play_count) VALUES (?, 1, 4)",
+            (tid,),
+        )
+        c.execute("UPDATE schema_version SET version = 48")
+        c.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)  # runs the v49 drop
+        rc = reopened._conn
+        cols = {r[1] for r in rc.execute("PRAGMA table_info(tracks)")}
+        dropped = {
+            "ext",
+            "embedded_art",
+            "file_mtime",
+            "source",
+            "stream_url",
+            "stream_url_expires_at",
+            "is_available",
+            "duration",
+            "favorite",
+            "play_count",
+            "last_played",
+        }
+        t = reopened.get_track_by_id(tid)
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        reopened.close()
+        assert ver == 49
+        assert not (dropped & cols)  # all 11 columns gone from tracks
+        assert {"file_path", "sale_item_id"} <= cols  # retained
+        assert t is not None
+        # Per-source values derive from track_sources; stats from track_stats.
+        assert t.source == "local" and t.ext == "flac" and t.duration == 321.0
+        assert t.favorite is True and t.play_count == 4
+
+    def test_v49_noop_when_columns_already_dropped(self, tmp_path: Path) -> None:
+        """Re-running v49 on a DB that already lacks the columns just bumps the
+        version — idempotent presence check (KAMP-539)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)  # fresh v49 schema — no legacy columns
+        index._conn.execute("UPDATE schema_version SET version = 48")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)  # v49 finds nothing to drop
+        ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
+        reopened.close()
+        assert ver == 49
+        assert "favorite" not in cols
+
+    def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """If a column drop raises (an index on a target column blocks DROP COLUMN),
+        v49 rolls back, leaves the version unbumped so it retries, and rebuilds a
+        usable view (KAMP-539)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
+        # An index on a drop-target column makes ALTER TABLE DROP COLUMN fail.
+        index._conn.execute("CREATE INDEX _t_fav ON tracks(favorite)")
+        index._conn.execute("UPDATE schema_version SET version = 48")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)  # the drop of the indexed column raises
+        rc = reopened._conn
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        cols = {r[1] for r in rc.execute("PRAGMA table_info(tracks)")}
+        n = rc.execute("SELECT COUNT(*) FROM tracks_with_stats").fetchone()[0]
+        reopened.close()
+        assert ver == 48  # not bumped — the next open retries
+        assert "favorite" in cols  # the failed column is not dropped
+        assert n == 0  # the view was rebuilt and is queryable
+
+    def test_v49_skips_drop_when_backup_fails(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """If the pre-drop backup fails, v49 skips the (irreversible) drop and does
+        not bump the version, so it retries on the next open (KAMP-539)."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
+        index._conn.execute("UPDATE schema_version SET version = 48")
+        index._conn.commit()
+        index.close()
+
+        monkeypatch.setattr(LibraryIndex, "_backup_db", lambda self, label: False)
+        reopened = LibraryIndex(db)  # backup fails → drop skipped
+        rc = reopened._conn
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        cols = {r[1] for r in rc.execute("PRAGMA table_info(tracks)")}
+        reopened.close()
+        assert ver == 48  # not bumped
+        assert "favorite" in cols  # columns retained
+
     def test_collapse_heal_works_without_preexisting_view(self, tmp_path: Path) -> None:
         """A collapse heal must build the tracks_with_stats view before running.
 
@@ -855,6 +1019,7 @@ class TestLibraryIndex:
         """
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidv')")
         c.execute("INSERT INTO albums (album_artist, album) VALUES ('A','Alb')")
@@ -907,6 +1072,7 @@ class TestLibraryIndex:
     def test_all_downloads_streamable(self, tmp_path: Path) -> None:
         """all_downloads_streamable is True only when every download has a stream (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sidS')")
         c.execute(
@@ -936,6 +1102,7 @@ class TestLibraryIndex:
     def test_materialize_skips_when_no_matching_track(self, tmp_path: Path) -> None:
         """materialize_stream_tracks attaches nothing when no track matches (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute("INSERT INTO bandcamp_collection (sale_item_id) VALUES ('sid99')")
         c.execute(
@@ -967,6 +1134,7 @@ class TestLibraryIndex:
     def test_sync_to_preferred_noop_without_sources(self, tmp_path: Path) -> None:
         """_sync_tracks_row_to_preferred_source is a no-op for a sourceless track (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index._conn.execute(
             "INSERT INTO tracks (file_path, source) VALUES ('/m/n.mp3', 'local')"
         )
@@ -981,6 +1149,7 @@ class TestLibraryIndex:
     def test_remove_track_legacy_row_without_source(self, tmp_path: Path) -> None:
         """A pre-collapse tracks row with no source is removed by file_path (KAMP-541)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         fp = tmp_path / "legacy.mp3"
         index._conn.execute(
             "INSERT INTO tracks (file_path, source) VALUES (?, 'local')", (str(fp),)
@@ -997,6 +1166,7 @@ class TestLibraryIndex:
 
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute(
             "INSERT INTO albums (album_artist, album, source) VALUES ('A','Alb','bandcamp')"
@@ -1849,6 +2019,7 @@ class TestLibraryScanner:
         _make_mp3(lib / "01.mp3", title="One", album="Fork", album_artist="Artist")
 
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         scanner = LibraryScanner(index)
         scanner.scan(lib)
         conn = index._conn
@@ -2666,7 +2837,7 @@ class TestSearch:
         ]
         # date_added and last_played columns must exist (no exception on select).
         row = index._conn.execute(
-            "SELECT date_added, last_played FROM tracks WHERE id = 1"
+            "SELECT date_added, last_played FROM tracks_with_stats WHERE id = 1"
         ).fetchone()
         index.close()
 
@@ -3024,7 +3195,7 @@ class TestRecordPlayed:
         index.record_played(p)
 
         row = index._conn.execute(
-            "SELECT last_played FROM tracks WHERE file_path = ?", (str(p),)
+            "SELECT last_played FROM tracks_with_stats WHERE file_path = ?", (str(p),)
         ).fetchone()
         index.close()
 
@@ -3261,7 +3432,7 @@ class TestRecordPlayed:
             0
         ]
         row = index._conn.execute(
-            "SELECT play_count FROM tracks WHERE id = 1"
+            "SELECT play_count FROM tracks_with_stats WHERE id = 1"
         ).fetchone()
         index.close()
 
@@ -3410,11 +3581,18 @@ class TestTopArtists:
         _make_indexed_track(
             seed, tmp_path, "t2.mp3", album_artist="Bach", duration=120.0
         )
+        _readd_legacy_track_columns(seed)
         seed.close()
         # Manually set play counts and downgrade version so migration re-runs.
         conn = _sqlite3.connect(str(db_path))
         conn.execute("UPDATE tracks SET play_count = 2 WHERE title = 't1.mp3'")
         conn.execute("UPDATE tracks SET play_count = 3 WHERE title = 't2.mp3'")
+        # duration now lives on track_sources; mirror it back onto the legacy
+        # tracks.duration the v36 backfill (play_count * duration) still reads.
+        conn.execute(
+            "UPDATE tracks SET duration = ("
+            " SELECT s.duration FROM track_sources s WHERE s.track_id = tracks.id LIMIT 1)"
+        )
         conn.execute("UPDATE artists SET play_time = 0")
         conn.execute("UPDATE schema_version SET version = 35")
         conn.commit()
@@ -3717,7 +3895,9 @@ class TestFavorite:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        row = index._conn.execute("SELECT favorite FROM tracks WHERE id = 1").fetchone()
+        row = index._conn.execute(
+            "SELECT favorite FROM tracks_with_stats WHERE id = 1"
+        ).fetchone()
         index.close()
 
         assert version == 49
@@ -3801,6 +3981,23 @@ class TestAlbumFavorite:
         conn = _sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
         conn.execute("INSERT INTO schema_version VALUES (13)")
+        # A v13-era tracks table (columns through file_mtime) so the replayed
+        # v14→v49 migrations find the pre-KAMP-539 columns they reference (e.g.
+        # v17's "UPDATE tracks SET file_mtime = NULL").
+        conn.execute(
+            "CREATE TABLE tracks ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0,"
+            " disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '',"
+            " mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL)"
+        )
         conn.commit()
         conn.close()
 
@@ -3923,12 +4120,15 @@ class TestMtimeReindex:
         _make_mp3(p, title="Original")
 
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         scanner = LibraryScanner(index)
         scanner.scan(lib)
 
         # Simulate the state right after a v5→v6 migration: file_mtime is NULL.
+        # The scanner's re-read decision reads the preferred source's mtime, so
+        # null it on track_sources (the legacy tracks column is dropped in v49).
         index._conn.execute(
-            "UPDATE tracks SET file_mtime = NULL WHERE file_path = ?", (str(p),)
+            "UPDATE track_sources SET file_mtime = NULL WHERE uri = ?", (str(p),)
         )
         index._conn.commit()
 
@@ -3993,7 +4193,7 @@ class TestMtimeReindex:
             0
         ]
         row = index._conn.execute(
-            "SELECT file_mtime FROM tracks WHERE id = 1"
+            "SELECT file_mtime FROM tracks_with_stats WHERE id = 1"
         ).fetchone()
         index.close()
 
@@ -4158,7 +4358,7 @@ class TestSessionManagement:
 
         index = LibraryIndex(db_path)
         rows = index._conn.execute(
-            "SELECT ext, file_mtime FROM tracks ORDER BY file_path"
+            "SELECT ext, file_mtime FROM tracks_with_stats ORDER BY file_path"
         ).fetchall()
         index.close()
 
@@ -4228,7 +4428,7 @@ class TestSessionManagement:
 
         index = LibraryIndex(db_path)
         rows = index._conn.execute(
-            "SELECT file_path, file_mtime FROM tracks ORDER BY file_path"
+            "SELECT file_path, file_mtime FROM tracks_with_stats ORDER BY file_path"
         ).fetchall()
         index.close()
 
@@ -4826,6 +5026,23 @@ class TestMigrationV12ToV13:
                 value TEXT NOT NULL
             )
         """)
+        # A v12-era tracks table (columns through file_mtime). The KAMP-539 drop
+        # removed these from the modern _DDL, so without them the replayed v13→v49
+        # migrations (e.g. v17's "UPDATE tracks SET file_mtime = NULL") fail.
+        conn.execute(
+            "CREATE TABLE tracks ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0,"
+            " disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '',"
+            " mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL)"
+        )
         conn.execute(
             "INSERT INTO sessions (service, session_json, updated_at) VALUES (?, ?, ?)",
             ("bandcamp", _json.dumps({"cookies": [{"name": "x"}]}), 1.0),
@@ -4875,6 +5092,22 @@ class TestMigrationV12ToV13:
                 value TEXT NOT NULL
             )
         """)
+        # A v12-era tracks table (columns through file_mtime) so the replayed
+        # v13→v49 migrations find the pre-KAMP-539 columns they reference.
+        conn.execute(
+            "CREATE TABLE tracks ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0,"
+            " disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '',"
+            " mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL)"
+        )
         already_wrapped = _FakeDPAPI().protect_str(_json.dumps({"cookies": []}))
         conn.execute(
             "INSERT INTO sessions (service, session_json, updated_at) VALUES (?, ?, ?)",
@@ -4928,6 +5161,23 @@ class TestMigrationV11ToV12:
                 value TEXT NOT NULL
             )
         """)
+        # A v11-era tracks table (columns through file_mtime). The KAMP-539 drop
+        # removed these from the modern _DDL, so without them the replayed v12→v49
+        # migrations (e.g. v17's "UPDATE tracks SET file_mtime = NULL") fail.
+        conn.execute(
+            "CREATE TABLE tracks ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " file_path TEXT NOT NULL UNIQUE, title TEXT NOT NULL DEFAULT '',"
+            " artist TEXT NOT NULL DEFAULT '', album_artist TEXT NOT NULL DEFAULT '',"
+            " album TEXT NOT NULL DEFAULT '', year TEXT NOT NULL DEFAULT '',"
+            " track_number INTEGER NOT NULL DEFAULT 0,"
+            " disc_number INTEGER NOT NULL DEFAULT 1,"
+            " ext TEXT NOT NULL DEFAULT '', embedded_art INTEGER NOT NULL DEFAULT 0,"
+            " mb_release_id TEXT NOT NULL DEFAULT '',"
+            " mb_recording_id TEXT NOT NULL DEFAULT '',"
+            " date_added REAL, last_played REAL, favorite INTEGER NOT NULL DEFAULT 0,"
+            " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL)"
+        )
         conn.execute(
             "INSERT INTO sessions (service, session_json, updated_at) VALUES (?, ?, ?)",
             (
@@ -5692,7 +5942,7 @@ class TestMigrationV16ToV17:
         index = LibraryIndex(db_path)
 
         row = index._conn.execute(
-            "SELECT file_mtime FROM tracks WHERE file_path = '/music/01.mp3'"
+            "SELECT file_mtime FROM tracks_with_stats WHERE file_path = '/music/01.mp3'"
         ).fetchone()
         assert row["file_mtime"] is None, "file_mtime should be nulled to force rescan"
         index.close()
@@ -5775,7 +6025,7 @@ class TestMarkAlbumArtEmbedded:
         index.mark_album_art_embedded("Artist", "Record", [t1.file_path])
 
         row = index._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE file_path = ?",
+            "SELECT embedded_art FROM tracks_with_stats WHERE file_path = ?",
             (str(t2.file_path),),
         ).fetchone()
         assert row["embedded_art"] == 0  # t2 not in the list
@@ -5790,7 +6040,7 @@ class TestMarkAlbumArtEmbedded:
         index.mark_album_art_embedded("Artist", "Record", [t1.file_path])
 
         row = index._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE album = 'OtherRecord'"
+            "SELECT embedded_art FROM tracks_with_stats WHERE album = 'OtherRecord'"
         ).fetchone()
         assert row["embedded_art"] == 0
         index.close()
@@ -6393,7 +6643,8 @@ class TestRemoteTrackSchema:
         index.upsert_track(track)
 
         row = index._conn.execute(
-            "SELECT source, stream_url, stream_url_expires_at FROM tracks WHERE file_path = ?",
+            "SELECT source, stream_url, stream_url_expires_at FROM tracks_with_stats"
+            " WHERE file_path = ?",
             (str(track.file_path),),
         ).fetchone()
         index.close()
@@ -6409,7 +6660,7 @@ class TestRemoteTrackSchema:
         index.upsert_track(track)
 
         row = index._conn.execute(
-            "SELECT source FROM tracks WHERE file_path = ?", (str(fp),)
+            "SELECT source FROM tracks_with_stats WHERE file_path = ?", (str(fp),)
         ).fetchone()
         index.close()
 
@@ -6436,6 +6687,98 @@ class TestRemoteTrackSchema:
         assert row["stream_url"] == "https://new-cdn.example.com/track.mp3"
         assert row["stream_url_expires_at"] == 12345.0
 
+    def test_update_stream_url_for_source(self, tmp_path: Path) -> None:
+        """update_stream_url_for_source persists a refreshed CDN url on a specific
+        track_sources row (the _source_id-known refresh path, KAMP-541)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        c = index._conn
+        c.execute("INSERT INTO tracks (file_path) VALUES ('bandcamp://9/1')")
+        tid = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.execute(
+            "INSERT INTO track_sources (track_id, kind, uri, stream_url,"
+            " stream_url_expires_at) VALUES (?, 'stream', 'bandcamp://9/1', 'old', 1.0)",
+            (tid,),
+        )
+        sid = c.execute("SELECT id FROM track_sources").fetchone()[0]
+        c.commit()
+
+        index.update_stream_url_for_source(sid, "https://cdn/new.mp3", 999.0)
+
+        row = c.execute(
+            "SELECT stream_url, stream_url_expires_at FROM track_sources WHERE id = ?",
+            (sid,),
+        ).fetchone()
+        index.close()
+        assert row["stream_url"] == "https://cdn/new.mp3"
+        assert row["stream_url_expires_at"] == 999.0
+
+    def test_update_track_after_album_drain(self, tmp_path: Path) -> None:
+        """Repaths a track, updates album/artist tags, routes the new file_mtime to
+        the file source (KAMP-539), and rebuilds FTS after a deferred album_retag."""
+        index = LibraryIndex(tmp_path / "library.db")
+        old = tmp_path / "old.mp3"
+        new = tmp_path / "new.mp3"
+        index.upsert_track(_sample_track(old))
+        tid = index.get_track_by_path(old).id  # type: ignore[union-attr]
+
+        index.update_track_after_album_drain(
+            tid, new, "New Album", "New Artist", "New Artist", 4242.0
+        )
+
+        t = index.get_track_by_id(tid)
+        src_mtime = index._conn.execute(
+            "SELECT file_mtime FROM track_sources WHERE track_id=? AND kind='file'",
+            (tid,),
+        ).fetchone()[0]
+        index.close()
+        assert t is not None
+        assert str(t.file_path) == str(new)
+        assert t.album == "New Album" and t.album_artist == "New Artist"
+        assert t.artist == "New Artist"
+        assert src_mtime == 4242.0  # file_mtime routed to track_sources
+
+    def test_tracks_for_playlist_returns_tracks_in_position_order(
+        self, tmp_path: Path
+    ) -> None:
+        """tracks_for_playlist reads playlist rows through the tracks_with_stats view
+        (per-source columns derived, KAMP-539) in stored position order."""
+        index = LibraryIndex(tmp_path / "library.db")
+        a = _sample_track(tmp_path / "a.mp3")
+        a.title = "A"
+        b = _sample_track(tmp_path / "b.mp3")
+        b.title = "B"
+        index.upsert_many([a, b])
+        pl = index.create_playlist("P")
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "b.mp3"))  # position 0
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "a.mp3"))  # position 1
+
+        tracks = index.tracks_for_playlist(pl["id"])
+        index.close()
+        assert [t.title for t in tracks] == ["B", "A"]
+
+    def test_settings_round_trip(self, tmp_path: Path) -> None:
+        """get_setting/set_setting/get_all_settings persist and upsert config values."""
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.get_setting("k") is None
+        index.set_setting("k", "v1")
+        assert index.get_setting("k") == "v1"
+        index.set_setting("k", "v2")  # ON CONFLICT DO UPDATE
+        index.set_setting("other", "x")
+        assert index.get_setting("k") == "v2"
+        assert index.get_all_settings() == {"k": "v2", "other": "x"}
+        index.close()
+
+    def test_update_track_mb_recording_id(self, tmp_path: Path) -> None:
+        """Writes mb_recording_id and returns the reloaded Track via the view."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_track(_sample_track(tmp_path / "a.mp3"))
+        tid = index.get_track_by_path(tmp_path / "a.mp3").id  # type: ignore[union-attr]
+        t = index.update_track_mb_recording_id(tid, "mbid-xyz")
+        missing = index.update_track_mb_recording_id(999999, "x")
+        index.close()
+        assert t is not None and t.mb_recording_id == "mbid-xyz"
+        assert missing is None  # unknown id
+
     def test_upsert_many_preserves_stream_url_when_incoming_is_null(
         self, tmp_path: Path
     ) -> None:
@@ -6459,7 +6802,8 @@ class TestRemoteTrackSchema:
         index.upsert_many([re_indexed])
 
         row = index._conn.execute(
-            "SELECT stream_url, stream_url_expires_at FROM tracks WHERE file_path = ?",
+            "SELECT stream_url, stream_url_expires_at FROM tracks_with_stats"
+            " WHERE file_path = ?",
             (str(track.file_path),),
         ).fetchone()
         index.close()
@@ -6515,65 +6859,32 @@ class TestRemoteTrackSchema:
 
         assert found is False
 
-    def test_set_track_source_for_item_updates_matching_tracks(
+    def test_set_track_source_for_item_counts_matching_tracks(
         self, tmp_path: Path
     ) -> None:
-        from pathlib import PurePosixPath
+        """Returns the number of tracks whose file_path belongs to the sale item.
 
+        The track-level source is derived from track_sources now (KAMP-539), so the
+        method no longer writes tracks.source — it only counts matches and refreshes
+        the album badge (see ..._propagates_to_albums).
+        """
         index = LibraryIndex(tmp_path / "library.db")
-        # Insert two remote tracks for the same sale_item_id and one unrelated track.
+        # Two remote tracks for sale_item_id 42 and one unrelated local track.
         index._conn.executemany(
-            "INSERT INTO tracks (file_path, title, artist, album_artist, album, "
-            "track_number, disc_number, release_date, source) VALUES (?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO tracks (file_path, title, artist, album_artist, album,"
+            " track_number, disc_number, release_date) VALUES (?,?,?,?,?,?,?,?)",
             [
-                (
-                    "bandcamp://42/1",
-                    "Track 1",
-                    "Artist",
-                    "Artist",
-                    "Album",
-                    1,
-                    1,
-                    "",
-                    "bandcamp",
-                ),
-                (
-                    "bandcamp://42/2",
-                    "Track 2",
-                    "Artist",
-                    "Artist",
-                    "Album",
-                    2,
-                    1,
-                    "",
-                    "bandcamp",
-                ),
-                (
-                    "/local/file.mp3",
-                    "Local",
-                    "Artist",
-                    "Artist",
-                    "Other",
-                    1,
-                    1,
-                    "",
-                    "local",
-                ),
+                ("bandcamp://42/1", "Track 1", "Artist", "Artist", "Album", 1, 1, ""),
+                ("bandcamp://42/2", "Track 2", "Artist", "Artist", "Album", 2, 1, ""),
+                ("/local/file.mp3", "Local", "Artist", "Artist", "Other", 1, 1, ""),
             ],
         )
         index._conn.commit()
 
         updated = index.set_track_source_for_item("42", "local")
-        rows = index._conn.execute(
-            "SELECT file_path, source FROM tracks ORDER BY file_path"
-        ).fetchall()
         index.close()
 
-        assert updated == 2
-        sources = {r["file_path"]: r["source"] for r in rows}
-        assert sources["bandcamp://42/1"] == "local"
-        assert sources["bandcamp://42/2"] == "local"
-        assert sources["/local/file.mp3"] == "local"  # unchanged
+        assert updated == 2  # the two bandcamp://42/* tracks match
 
     def test_set_track_source_for_item_returns_zero_when_no_match(
         self, tmp_path: Path
@@ -6686,6 +6997,9 @@ class TestRemoteTrackSchema:
         conn.close()
 
         index = LibraryIndex(db_path)
+        # v20 adds source/stream_url; v49 drops them again. Re-add so this test of
+        # the historical v20 migration can assert the columns landed.
+        _readd_legacy_track_columns(index)
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
@@ -6749,7 +7063,7 @@ class TestRemoteTrackSchema:
 
         index = LibraryIndex(db_path)
         rows = index._conn.execute(
-            "SELECT file_path, source FROM tracks ORDER BY file_path"
+            "SELECT file_path, source FROM tracks_with_stats ORDER BY file_path"
         ).fetchall()
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
@@ -6836,6 +7150,7 @@ class TestReleaseDateBackfill:
         effective-source restriction: a naive EXISTS(stream source) would wrongly
         match it and overwrite its file-tag release_date."""
         index = self._make_index(tmp_path)
+        _readd_legacy_track_columns(index)
         c = index._conn
         c.execute(
             "INSERT INTO tracks (file_path, source, album_id, track_number,"
@@ -7388,6 +7703,7 @@ class TestQueuePlayerStateStr:
         self, tmp_path: Path
     ) -> None:
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         # Insert with the canonical URI directly via SQL to bypass Path normalization.
         canonical = "bandcamp://999/3"
         index._conn.execute(
@@ -7624,6 +7940,7 @@ class TestRemoveDownload:
         (play counts are managed exclusively by record_played() in production).
         """
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index.upsert_collection_item("sid42", mode="local", synced_at=1.0)
 
         # Streaming tracks (bandcamp://) inserted first, as they would be pre-download.
@@ -7830,6 +8147,7 @@ class TestRemoveDownload:
         because the user bought+downloaded rather than streamed.
         """
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index.upsert_collection_item(
             "sid99",
             mode="local",
@@ -8389,6 +8707,9 @@ class TestMigrationV25:
         db_path = tmp_path / "library.db"
         self._build_v24_db(db_path)
         index = LibraryIndex(db_path)
+        # v25 adds is_available; v49 drops it again. Re-add so this test of the
+        # historical v25 migration can assert the column landed.
+        _readd_legacy_track_columns(index)
         cols = {
             r[1] for r in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
         }
@@ -8406,7 +8727,9 @@ class TestMigrationV25:
         db_path = tmp_path / "library.db"
         self._build_v24_db(db_path)
         index = LibraryIndex(db_path)
-        row = index._conn.execute("SELECT is_available FROM tracks LIMIT 1").fetchone()
+        row = index._conn.execute(
+            "SELECT is_available FROM tracks_with_stats LIMIT 1"
+        ).fetchone()
         index.close()
 
         assert row is not None
@@ -8856,6 +9179,9 @@ class TestMigrationV27:
         db_path = tmp_path / "library.db"
         self._build_v26_db(db_path)
         index = LibraryIndex(db_path)
+        # v27 adds duration; v49 drops it again. Re-add so this test of the
+        # historical v27 migration can assert the column landed.
+        _readd_legacy_track_columns(index)
         cols = {
             r[1] for r in index._conn.execute("PRAGMA table_info(tracks)").fetchall()
         }
@@ -8872,7 +9198,7 @@ class TestMigrationV27:
         self._build_v26_db(db_path)
         index = LibraryIndex(db_path)
         row = index._conn.execute(
-            "SELECT duration FROM tracks WHERE file_path = 'local/song.mp3'"
+            "SELECT duration FROM tracks_with_stats WHERE file_path = 'local/song.mp3'"
         ).fetchone()
         index.close()
 
@@ -8972,7 +9298,7 @@ class TestMigrationV28:
         rows = {
             r[0]: r[1]
             for r in index._conn.execute(
-                "SELECT file_path, file_mtime FROM tracks"
+                "SELECT file_path, file_mtime FROM tracks_with_stats"
             ).fetchall()
         }
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
@@ -10317,6 +10643,7 @@ class TestMagicPlaylists:
         from kamp_core.library import Track
 
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         track_a = Track(
             file_path=tmp_path / "a.mp3",
             title="Song A",
@@ -10424,6 +10751,7 @@ class TestMagicPlaylists:
     def test_evaluate_filters_by_source_via_track_sources(self, tmp_path: Path) -> None:
         """track.source criteria resolves via track_sources, not tracks.source (KAMP-542)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index.upsert_many([_sample_track(tmp_path / "a.mp3")])
         tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
         # Desync: the track has a file (local) source, but its legacy source column
@@ -11146,7 +11474,13 @@ class TestMigrationV38:
             " play_count INTEGER NOT NULL DEFAULT 0, file_mtime REAL,"
             " genre TEXT NOT NULL DEFAULT '', label TEXT NOT NULL DEFAULT '',"
             " source TEXT NOT NULL DEFAULT 'local', stream_url TEXT,"
-            " stream_url_expires_at REAL)"
+            " stream_url_expires_at REAL,"
+            # album_id (v13), is_available (v25) and duration (v27) all predate v37,
+            # so their migrations do not replay here — a real v37 tracks table has
+            # them, and the v45 backfill guard reads is_available/duration, so they
+            # must be present or track_sources stays empty and the view derives NULL.
+            " album_id INTEGER, is_available INTEGER NOT NULL DEFAULT 1,"
+            " duration REAL NOT NULL DEFAULT 0)"
         )
         conn.execute(
             "CREATE TABLE albums (id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -11217,7 +11551,9 @@ class TestMigrationV38:
         conn = _sqlite3.connect(str(db_path))
         rows = {
             r[0]: r[1]
-            for r in conn.execute("SELECT file_path, file_mtime FROM tracks").fetchall()
+            for r in conn.execute(
+                "SELECT file_path, file_mtime FROM tracks_with_stats"
+            ).fetchall()
         }
         conn.close()
 
@@ -11432,6 +11768,7 @@ class TestStatsReadFromTrackStats:
 
     def _desynced(self, tmp_path: Path) -> tuple["LibraryIndex", int]:
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index.upsert_many([_sample_track(tmp_path / "a.mp3")])
         tid = index._conn.execute("SELECT id FROM tracks").fetchone()[0]
         # Legacy columns say 0/NULL; track_stats (authoritative) says otherwise.
@@ -11471,6 +11808,7 @@ class TestStatsReadFromTrackStats:
     def test_view_falls_back_to_legacy_when_no_stats_row(self, tmp_path: Path) -> None:
         """A track with no track_stats row still reads its legacy value (transition safety)."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         index.upsert_many([_sample_track(tmp_path / "a.mp3")])
         index._conn.execute("UPDATE tracks SET favorite = 1, play_count = 4")
         index._conn.execute("DELETE FROM track_stats")
@@ -11517,6 +11855,7 @@ class TestAlbumSourceClassifier:
 
     def test_badge_matches_legacy_output(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         cases = {
             "downloaded": (
                 [("local", "/m/a1.mp3", ["file"]), ("local", "/m/a2.mp3", ["file"])],
@@ -11910,11 +12249,15 @@ class TestProvenanceLinking:
         # track 1 (as the pipeline now does), inherit_remote_favorites carries the
         # favorite across. Regression for the Ohm Foam "Gush" favorite loss.
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         self._seed_streaming_album(index, "S1", "Ohm Foam", "Gush")
         stream = index.get_track_by_path("bandcamp://S1/1")
         assert stream is not None
         index._conn.execute("UPDATE tracks SET favorite = 1 WHERE id = ?", (stream.id,))
         index._conn.commit()
+        # inherit_remote_favorites reads the authoritative track_stats store, so
+        # mirror the legacy favorite there (as production writers do).
+        _mirror_stats(index)
 
         dl = _download_track(tmp_path / "gush.mp3", "Ohm Foam", "Gush", "S1", n=1)
         dl.title = "Gush"
@@ -11922,7 +12265,7 @@ class TestProvenanceLinking:
         index.inherit_remote_favorites([dl])
 
         fav = index._conn.execute(
-            "SELECT favorite FROM tracks WHERE file_path = ?",
+            "SELECT favorite FROM tracks_with_stats WHERE file_path = ?",
             (str(tmp_path / "gush.mp3"),),
         ).fetchone()[0]
         assert fav == 1
@@ -12219,6 +12562,7 @@ class TestLooseSingleAttach:
         only by trailing whitespace, which the albums UNIQUE index permits): the
         match is ambiguous, so the loose single is left untouched."""
         index = LibraryIndex(tmp_path / "library.db")
+        _readd_legacy_track_columns(index)
         for sid, album_name in (("200", "Celebrity"), ("201", "Celebrity ")):
             index._conn.execute(
                 "INSERT INTO albums (album_artist, album, source) VALUES ('Megahit', ?, 'bandcamp')",
@@ -12267,6 +12611,7 @@ class TestLooseSingleAttach:
         snapshots the DB first."""
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         index.upsert_many([self._stream_single("300", "Megahit", "Celebrity")])
         stream_album = index._conn.execute(
             "SELECT album_id FROM tracks WHERE file_path = 'bandcamp://300/1'"
@@ -12327,6 +12672,7 @@ class TestLooseSingleAttach:
         the tester upgrades without reverting."""
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         index.upsert_many([self._stream_single("400", "Megahit", "Celebrity")])
         album_id = index._conn.execute(
             "SELECT album_id FROM tracks WHERE file_path = 'bandcamp://400/1'"
@@ -12377,6 +12723,7 @@ class TestHealForkedAlbums:
     def test_whitespace_fork_with_sale_item_id_collapses(self, tmp_path: Path) -> None:
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
+        _readd_legacy_track_columns(index)
         # Origin streaming album (spaced name + sale_item_id).
         index.upsert_collection_item(
             "S1", mode="local", band_name="Artist X ", item_title="Album Y"
@@ -12467,14 +12814,18 @@ class TestHealForkedAlbums:
             "INSERT INTO albums (album_artist, album, source) VALUES ('S T ', 'EP', 'local')"
         )
         a2 = cur.lastrowid
+        # source lives on track_sources now (KAMP-539) and isn't asserted here;
+        # only album_id (retained) matters. Omitting the dropped source column keeps
+        # the tracks table at its post-v49 shape so the reopen's v49 migration finds
+        # nothing to drop and takes no backup — what this test checks for.
         index._conn.execute(
-            "INSERT INTO tracks (file_path, title, album, album_artist, source, album_id)"
-            " VALUES ('/m/1.mp3', 'x', 'EP', 'S T', 'local', ?)",
+            "INSERT INTO tracks (file_path, title, album, album_artist, album_id)"
+            " VALUES ('/m/1.mp3', 'x', 'EP', 'S T', ?)",
             (a1,),
         )
         index._conn.execute(
-            "INSERT INTO tracks (file_path, title, album, album_artist, source, album_id)"
-            " VALUES ('/m/2.mp3', 'y', 'EP', 'S T ', 'local', ?)",
+            "INSERT INTO tracks (file_path, title, album, album_artist, album_id)"
+            " VALUES ('/m/2.mp3', 'y', 'EP', 'S T ', ?)",
             (a2,),
         )
         index._conn.commit()

--- a/tests/test_library_write_log.py
+++ b/tests/test_library_write_log.py
@@ -155,7 +155,8 @@ class TestMutationLogging:
         lib.apply_set_artwork("ext-b", "rec-2", "image/jpeg")
 
         row = lib._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", ("rec-2",)
+            "SELECT embedded_art FROM tracks_with_stats WHERE mb_recording_id = ?",
+            ("rec-2",),
         ).fetchone()
         lib.close()
         assert bool(row["embedded_art"]) is True
@@ -274,7 +275,8 @@ class TestRollbackExtension:
         lib.rollback_extension("ext-bad")
 
         row = lib._conn.execute(
-            "SELECT embedded_art FROM tracks WHERE mb_recording_id = ?", ("rec-2",)
+            "SELECT embedded_art FROM tracks_with_stats WHERE mb_recording_id = ?",
+            ("rec-2",),
         ).fetchone()
         lib.close()
         assert bool(row["embedded_art"]) is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5081,9 +5081,7 @@ class TestResolvePlaybackUri:
             "INSERT INTO bandcamp_collection (sale_item_id, album_url)"
             " VALUES ('sid', 'https://a.bandcamp.com/album/x')"
         )
-        c.execute(
-            "INSERT INTO tracks (file_path, source) VALUES ('bandcamp://sid/2', 'bandcamp')"
-        )
+        c.execute("INSERT INTO tracks (file_path) VALUES ('bandcamp://sid/2')")
         tid = c.execute("SELECT id FROM tracks").fetchone()[0]
         c.execute(
             "INSERT INTO track_sources (track_id, kind, provider, provider_item_id, uri,"


### PR DESCRIPTION
## KAMP-539: Contract — drop the duplicated per-source/stat columns from `tracks`

The final **contract** step of the KAMP-533 canonical-track-identity epic. The three-table model (`tracks` identity / `track_sources` per-delivery / `track_stats` stats) was in place with two safety nets: the `tracks_with_stats` view fell back to the legacy `tracks` columns, and writes dual-wrote them. That duplication is the KAMP-532-class divergence source. This PR removes it.

### Scope (user-approved reduction)
Drops the **11 unconstrained** columns — `favorite`, `play_count`, `last_played`, `ext`, `embedded_art`, `file_mtime`, `source`, `stream_url`, `stream_url_expires_at`, `is_available`, `duration` — via per-column `ALTER TABLE DROP COLUMN` (no table rebuild). **Deferred** to follow-up tickets (filed): dropping `file_path` (the UNIQUE identity/join key, ~40 internal sites + FK-referenced rebuild) and `sale_item_id` (indexed + FK); the `inherit_remote_*` deletion decision; and album-granularity `file_path` (`AlbumOut`, missing-album GET paths). Reality Checker confirmed the epic's anti-divergence goal is fully met without them.

### How it works (staged commits)
- **A** — `tracks_with_stats` view **derives** the per-source columns + `source` from the track's preferred `track_sources` row (correlated join, same ordering as `preferred_source`), so `_row_to_track` and every `SELECT *` are untouched by the drop.
- **B.1** — `set_favorite`/`record_played`/`record_track_started`, the collapse **merge**, `inherit_*`, and album aggregates read/write `track_stats` (fixed a reverse-KAMP-532: merging a download onto a favorited stream reset the favorite to 0).
- **B.2** — the upsert's `track_sources`/`track_stats` backfill is sourced from the incoming `Track`, not read back from `tracks`; `update_stream_url`/`mark_album_art_embedded` write `track_sources`.
- **C** — the v48→v49 migration (backup-first, DROP VIEW, `ALTER … DROP COLUMN` ×11, recreate view; idempotent, version-last, view rebuilt in `finally`); remaining writer redirects (upsert INSERT, rename/drain `file_mtime` → `track_sources`, extension set-artwork `embedded_art` → `track_sources`); stripped the `source` COALESCE fallbacks; `_DDL` + `_SCHEMA_VERSION`.
- **D** — migrated ~90 test fixtures off the dropped columns and fixed **3 genuine upsert regressions** the migration surfaced (album-aggregate ordering, `stream_url` preservation, the `set_track_source_for_item` contract).

### Verification
- Full suite green: **2245 passed, 9 skipped**, black + mypy clean, coverage ≥ 93%.
- The v48→v49 migration **validated on a real 13,493-track DB**: all 11 columns dropped, `file_path`/`sale_item_id` retained, every track reads back correctly through the public API (source/favorite/duration/ext derived from the child tables), integrity invariants clean.
- New tests cover the drop, idempotency, atomic rollback on a blocked drop, and skip-on-backup-failure.

Manual (user drives): favorite/play/queue a downloaded track and confirm identical behavior; confirm album art shows after a fresh scan+embed; confirm a streamed track still plays after its URL expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
