### PR TITLE
fix(library): heal case-variant artist splits + prevent recurrence (KAMP-545)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -259,6 +259,15 @@ CREATE TABLE IF NOT EXISTS artists (
     play_time REAL NOT NULL DEFAULT 0
 );
 
+-- Case-insensitive uniqueness on artist name (KAMP-545). albums.album_artist is
+-- COLLATE NOCASE, so without this a case-variant ("SUNN O)))" vs "Sunn O)))")
+-- spawns a second artists row and splits an artist's albums across two ids. The
+-- plain BINARY UNIQUE above is left in place (redundant but harmless). Enforced as
+-- an index rather than a table rebuild because artists.id is FK-referenced by
+-- albums.artist_id and PRAGMA foreign_keys is a no-op inside the migration txn.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artists_name_nocase
+    ON artists(name COLLATE NOCASE);
+
 CREATE TABLE IF NOT EXISTS albums (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     album_artist   TEXT    NOT NULL DEFAULT '' COLLATE NOCASE,
@@ -3896,10 +3905,14 @@ class LibraryIndex:
                 """,
                 album_params,
             )
-            # Wire artist_id on any albums rows that are missing it.
+            # Wire artist_id on any albums rows that are missing it. The name match
+            # is COLLATE NOCASE (KAMP-545): with the case-insensitive artists index,
+            # a differently-cased album_artist resolves to the single canonical
+            # artist row instead of failing the BINARY compare and leaving
+            # artist_id NULL (which would orphan the album from every artist filter).
             self._conn.execute("""
                 UPDATE albums SET artist_id = (
-                    SELECT id FROM artists WHERE name = album_artist
+                    SELECT id FROM artists WHERE name = album_artist COLLATE NOCASE
                 )
                 WHERE artist_id IS NULL
                 """)
@@ -4904,8 +4917,12 @@ class LibraryIndex:
         self._conn.execute(
             "INSERT OR IGNORE INTO artists (name) VALUES (?)", (artist_name,)
         )
+        # COLLATE NOCASE (KAMP-545): the INSERT OR IGNORE above is a no-op when a
+        # case-variant row already exists, so a BINARY match here would update zero
+        # rows and silently drop the play_time. Match the canonical row regardless
+        # of casing.
         self._conn.execute(
-            "UPDATE artists SET play_time = play_time + ? WHERE name = ?",
+            "UPDATE artists SET play_time = play_time + ? WHERE name = ? COLLATE NOCASE",
             (elapsed_seconds, artist_name),
         )
         self._conn.commit()

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 49
+_SCHEMA_VERSION = 50
 
 
 class NoStreamableVersionError(Exception):
@@ -258,15 +258,12 @@ CREATE TABLE IF NOT EXISTS artists (
     name      TEXT NOT NULL UNIQUE,
     play_time REAL NOT NULL DEFAULT 0
 );
-
--- Case-insensitive uniqueness on artist name (KAMP-545). albums.album_artist is
--- COLLATE NOCASE, so without this a case-variant ("SUNN O)))" vs "Sunn O)))")
--- spawns a second artists row and splits an artist's albums across two ids. The
--- plain BINARY UNIQUE above is left in place (redundant but harmless). Enforced as
--- an index rather than a table rebuild because artists.id is FK-referenced by
--- albums.artist_id and PRAGMA foreign_keys is a no-op inside the migration txn.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_artists_name_nocase
-    ON artists(name COLLATE NOCASE);
+-- NOTE (KAMP-545): the case-insensitive uniqueness index on artists.name is NOT
+-- created here. _DDL runs at the top of every _migrate() — including on an
+-- existing forked DB before the v50 heal — where a UNIQUE(name COLLATE NOCASE)
+-- would fail on the duplicate rows and abort startup. It is created instead by
+-- _create_artist_name_nocase_index(): immediately for brand-new DBs and after the
+-- heal for upgrades (mirrors _create_sale_item_id_unique_index / KAMP-523).
 
 CREATE TABLE IF NOT EXISTS albums (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -848,6 +845,7 @@ class LibraryIndex:
             # heal, do not run for a brand-new DB).
             self._create_sale_item_id_unique_index()
             self._create_tracks_sale_item_id_index()
+            self._create_artist_name_nocase_index()
             self._conn.execute(
                 "INSERT INTO schema_version (version) VALUES (?)", (_SCHEMA_VERSION,)
             )
@@ -2017,6 +2015,213 @@ class LibraryIndex:
                     )
                 finally:
                     self._create_tracks_with_stats_view()
+
+        if version == 49:
+            # v49 -> v50 (KAMP-545): collapse artists rows that differ only in
+            # case, then enforce case-insensitive uniqueness on artists.name.
+            # Gated on == 49 (not < 50) so a v49 that rolled back — which leaves
+            # the version at 48 to retry — is not skipped past by v50.
+            # album_artist is COLLATE NOCASE but artists.name was BINARY-unique, so
+            # a case-variant name (bandcamp uppercases many) spawned a second
+            # artists row and split an artist's albums across two ids — the
+            # orphaned album vanished from the artist filter (which keys on
+            # artists.id). _heal_case_variant_artists backs up first and returns
+            # False only when work was needed but the backup failed, so we leave
+            # the version at 49 and retry on the next open. The NOCASE unique index
+            # is created only after a clean heal (it would throw on any surviving
+            # dupe); creating it is idempotent, so a clean library just adds it.
+            if self._heal_case_variant_artists():
+                self._create_artist_name_nocase_index()
+                self._conn.execute("UPDATE schema_version SET version = 50")
+                self._conn.commit()
+                version = 50  # noqa: F841
+
+    def _create_artist_name_nocase_index(self) -> None:
+        """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
+
+        Created here rather than in _DDL because _DDL runs before the v50 heal on
+        an existing forked DB, where the index would fail on the duplicate rows.
+        Defensive on IntegrityError (mirrors _create_sale_item_id_unique_index):
+        an aborted migration would make the DB unopenable, which is far worse than
+        a missing guard index — the NOCASE joins added in KAMP-545 still resolve
+        linking deterministically without it.
+        """
+        if not self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='artists'"
+        ).fetchone():  # pragma: no cover - artists always exists post-_DDL
+            return
+        try:
+            self._conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_artists_name_nocase"
+                " ON artists(name COLLATE NOCASE)"
+            )
+        except sqlite3.IntegrityError:  # pragma: no cover - defensive
+            logger.warning(
+                "Could not create UNIQUE index on artists.name — case-variant"
+                " artist rows remain; linking falls back to the NOCASE joins."
+            )
+
+    def _heal_case_variant_artists(self) -> bool:
+        """Collapse artists rows differing only in case into one canonical row.
+
+        For each ``LOWER(name)`` group with more than one row (KAMP-545):
+
+        * pick a survivor — the casing of a linked ``bandcamp_collection.band_name``
+          when any album in the group is Bandcamp-sourced (authoritative, and the
+          casing a future sync would otherwise re-fork on), else the row owning the
+          most albums (tie-break lowest id);
+        * repoint every loser album onto the survivor, fold ``play_time``, delete
+          the loser row;
+        * best-effort, collision-guarded, normalize the survivor's album /
+          track / ``band_name`` strings to the canonical casing.
+
+        Backs up first. Returns True when it is safe to proceed to the version
+        bump (nothing to do, or healed cleanly); False only when work was needed
+        but the backup failed, so the migration retries on the next open.
+
+        artists/albums/albums.artist_id are guaranteed present here — _migrate runs
+        _DDL and the v36 migration before this block — so only band_name is checked
+        (bandcamp_collection predates it until v19, and choosing the survivor casing
+        from it requires the column).
+        """
+        bcc_cols = {
+            r[1]
+            for r in self._conn.execute(
+                "PRAGMA table_info(bandcamp_collection)"
+            ).fetchall()
+        }
+        has_band_name = "band_name" in bcc_cols
+
+        groups = [
+            [int(x) for x in r[0].split(",")]
+            for r in self._conn.execute(
+                "SELECT GROUP_CONCAT(id) FROM artists"
+                " GROUP BY name COLLATE NOCASE HAVING COUNT(*) > 1"
+            ).fetchall()
+        ]
+        if not groups:
+            return True
+        if not self._backup_db("KAMP-545 v50 case-variant artist heal"):
+            return False
+        try:
+            for ids in groups:
+                self._heal_artist_group(ids, has_band_name)
+            self._rebuild_fts()  # album_artist changed on the normalized rows
+            self._conn.commit()
+            logger.info(
+                "KAMP-545 heal: collapsed %d case-variant artist group(s)",
+                len(groups),
+            )
+            return True
+        except Exception:
+            self._conn.rollback()
+            logger.exception(
+                "KAMP-545 heal failed — rolled back; retrying on next open."
+                " Restore from the backup if needed."
+            )
+            return False
+
+    def _heal_artist_group(self, ids: list[int], has_band_name: bool) -> None:
+        """Merge one case-variant ``artists`` group (see _heal_case_variant_artists)."""
+        placeholders = ",".join("?" * len(ids))
+        counts = {aid: 0 for aid in ids}
+        for r in self._conn.execute(
+            f"SELECT artist_id, COUNT(*) AS n FROM albums"
+            f" WHERE artist_id IN ({placeholders}) GROUP BY artist_id",
+            ids,
+        ).fetchall():
+            counts[r["artist_id"]] = r["n"]
+
+        # Canonical casing: prefer a linked Bandcamp band_name (the casing a future
+        # sync would re-insert, so matching it prevents a re-fork); else the
+        # survivor row's own name.
+        canon: str | None = None
+        if has_band_name:
+            row = self._conn.execute(
+                f"SELECT bc.band_name FROM albums a"
+                f" JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id"
+                f" WHERE a.artist_id IN ({placeholders})"
+                f"   AND a.sale_item_id IS NOT NULL AND TRIM(bc.band_name) != ''"
+                f" ORDER BY a.id LIMIT 1",
+                ids,
+            ).fetchone()
+            if row is not None:
+                canon = row["band_name"].strip()
+
+        # Survivor: the group row matching the canonical casing when we have one,
+        # else the row owning the most albums (tie-break lowest id).
+        survivor = min(ids, key=lambda aid: (-counts[aid], aid))
+        if canon is not None:
+            match = self._conn.execute(
+                f"SELECT id FROM artists WHERE id IN ({placeholders})"
+                f"   AND name = ? COLLATE NOCASE ORDER BY id LIMIT 1",
+                ids + [canon],
+            ).fetchone()
+            if match is not None:
+                survivor = match["id"]
+        else:
+            canon = self._conn.execute(
+                "SELECT name FROM artists WHERE id = ?", (survivor,)
+            ).fetchone()["name"]
+
+        # 1. Fold each loser into the survivor: carry play_time, repoint albums,
+        #    delete the loser row.
+        for loser in (aid for aid in ids if aid != survivor):
+            self._conn.execute(
+                "UPDATE artists SET play_time = play_time"
+                " + (SELECT IFNULL(play_time, 0) FROM artists WHERE id=?)"
+                " WHERE id=?",
+                (loser, survivor),
+            )
+            self._conn.execute(
+                "UPDATE albums SET artist_id=? WHERE artist_id=?", (survivor, loser)
+            )
+            self._conn.execute("DELETE FROM artists WHERE id=?", (loser,))
+
+        # 2. Rename the survivor row to the canonical casing. No collision is
+        #    possible: every other row sharing this NOCASE name was just deleted.
+        self._conn.execute("UPDATE artists SET name=? WHERE id=?", (canon, survivor))
+
+        # 3. Normalize the survivor's album strings to the canonical casing.
+        #    tracks.artist is deliberately left untouched so per-track artists on
+        #    Various Artists albums survive. The collision check is defensive:
+        #    UNIQUE(album_artist, album) is itself NOCASE, so a case-only rename
+        #    never changes the key and cannot collide (unlike the whitespace-trim
+        #    in KAMP-523's _merge_album_pair) — but we guard rather than risk
+        #    aborting the whole migration on a malformed row.
+        for a in self._conn.execute(
+            "SELECT id, album, album_artist FROM albums WHERE artist_id=?",
+            (survivor,),
+        ).fetchall():
+            if a["album_artist"] == canon:
+                continue
+            collision = self._conn.execute(
+                "SELECT 1 FROM albums WHERE album_artist=? COLLATE NOCASE"
+                "   AND album=? COLLATE NOCASE AND id!=?",
+                (canon, a["album"], a["id"]),
+            ).fetchone()
+            if collision is not None:  # pragma: no cover - defensive (see above)
+                logger.warning(
+                    "KAMP-545 heal: album %d kept casing %r (canonical %r collides"
+                    " with a distinct release)",
+                    a["id"],
+                    a["album_artist"],
+                    canon,
+                )
+                continue
+            self._conn.execute(
+                "UPDATE albums SET album_artist=? WHERE id=?", (canon, a["id"])
+            )
+            self._conn.execute(
+                "UPDATE tracks SET album_artist=? WHERE album_id=?", (canon, a["id"])
+            )
+            if has_band_name:
+                self._conn.execute(
+                    "UPDATE bandcamp_collection SET band_name=?"
+                    " WHERE sale_item_id = (SELECT sale_item_id FROM albums WHERE id=?)"
+                    "   AND sale_item_id IS NOT NULL",
+                    (canon, a["id"]),
+                )
 
     def _create_tracks_with_stats_view(self) -> None:
         """(Re)create the read-only ``tracks_with_stats`` view (KAMP-542/539).

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2700,7 +2700,11 @@ def create_app(
         # then filter the pre-sorted album list so the response respects sort order.
         # Missing-album tracks have album="" in the DB, so also match them by
         # file_path since their AlbumInfo.album is the display title, not "".
-        fts_keys = {(t.album_artist, t.album) for t in fts_tracks}
+        # Keys are lower-cased so the match honours the NOCASE collation on
+        # albums.album_artist/album (KAMP-545): an album row whose casing diverges
+        # from its tracks' casing (e.g. row "SUNN O)))" vs tracks "Sunn O)))") would
+        # otherwise be dropped from the album cards even though its tracks matched.
+        fts_keys = {(t.album_artist.lower(), t.album.lower()) for t in fts_tracks}
         fts_paths = {str(t.file_path) for t in fts_tracks if not t.album}
         albums = [
             AlbumOut(
@@ -2728,7 +2732,7 @@ def create_app(
                 display_album_artist=a.display_album_artist,
             )
             for a in index.albums(sort=sort)
-            if (a.album_artist, a.album) in fts_keys
+            if (a.album_artist.lower(), a.album.lower()) in fts_keys
             or (a.missing_album and a.file_path in fts_paths)
         ]
         albums.sort(key=lambda a: not a.favorite)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1331,6 +1331,60 @@ class TestLibraryIndex:
 
         assert artists == ["Aesop Rock", "Zeppelin"]
 
+    def test_case_variant_album_artist_does_not_split_artist_row(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-545: two albums by one artist with divergent casing must share a
+        single artists row and artist_id, not fork onto two."""
+        index = LibraryIndex(tmp_path / "library.db")
+        local = _sample_track(tmp_path / "0.mp3")
+        local.album_artist = "Sunn O)))"
+        local.album = "Monoliths & Dimensions"
+        bandcamp = _sample_track(tmp_path / "1.mp3")
+        bandcamp.album_artist = "SUNN O)))"  # bandcamp uppercased the name
+        bandcamp.album = "Life Metal"
+        index.upsert_many([local, bandcamp])
+
+        artist_rows = index._conn.execute(
+            "SELECT COUNT(*) FROM artists WHERE name = 'sunn o)))' COLLATE NOCASE"
+        ).fetchone()[0]
+        artist_ids = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT artist_id FROM albums"
+                " WHERE album_artist = 'sunn o)))' COLLATE NOCASE"
+            )
+        }
+        index.close()
+
+        assert artist_rows == 1
+        assert len(artist_ids) == 1 and None not in artist_ids
+
+    def test_record_play_time_credits_single_case_variant_artist(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-545: play_time for a case-variant artist accrues to the one
+        canonical row rather than being lost to a BINARY name mismatch."""
+        index = LibraryIndex(tmp_path / "library.db")
+        first = _sample_track(tmp_path / "0.mp3")
+        first.album_artist = "Kylesa"
+        second = _sample_track(tmp_path / "1.mp3")
+        second.album_artist = "KYLESA"
+        second.album = "Spiral Shadow"
+        index.upsert_many([first, second])
+
+        index.record_play_time(tmp_path / "0.mp3", 30.0)
+        index.record_play_time(tmp_path / "1.mp3", 12.0)
+
+        rows = index._conn.execute(
+            "SELECT COUNT(*), COALESCE(SUM(play_time), 0) FROM artists"
+            " WHERE name = 'kylesa' COLLATE NOCASE"
+        ).fetchone()
+        index.close()
+
+        assert rows[0] == 1
+        assert rows[1] == 42.0
+
     def test_tracks_for_album_sorted_by_disc_then_track(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         for disc, track_num, title in [(1, 2, "B"), (2, 1, "C"), (1, 1, "A")]:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -127,6 +127,46 @@ def _readd_legacy_track_columns(index: "LibraryIndex") -> None:
     index._create_tracks_with_stats_view()
 
 
+def _open_forkable_v49(db: Path) -> "LibraryIndex":
+    """Open a fresh index, drop the NOCASE artist index, and stamp version 49 so
+    a reopen exercises the KAMP-545 v50 heal. The dropped index lets the caller
+    seed case-variant artist rows that the BINARY UNIQUE alone still permits."""
+    index = LibraryIndex(db)
+    index._conn.execute("DROP INDEX IF EXISTS idx_artists_name_nocase")
+    index._conn.execute("UPDATE schema_version SET version = 49")
+    index._conn.commit()
+    return index
+
+
+def _add_artist(index: "LibraryIndex", name: str, play_time: float = 0.0) -> int:
+    cur = index._conn.execute(
+        "INSERT INTO artists (name, play_time) VALUES (?, ?)", (name, play_time)
+    )
+    return int(cur.lastrowid)  # type: ignore[arg-type]
+
+
+def _add_album_with_track(
+    index: "LibraryIndex",
+    album_artist: str,
+    album: str,
+    artist_id: int,
+    file_path: str,
+    sale_item_id: str | None = None,
+) -> int:
+    cur = index._conn.execute(
+        "INSERT INTO albums (album_artist, album, artist_id, sale_item_id)"
+        " VALUES (?, ?, ?, ?)",
+        (album_artist, album, artist_id, sale_item_id),
+    )
+    album_id = int(cur.lastrowid)  # type: ignore[arg-type]
+    index._conn.execute(
+        "INSERT INTO tracks (file_path, title, artist, album_artist, album, album_id,"
+        " track_number, disc_number) VALUES (?, 'T', ?, ?, ?, ?, 1, 1)",
+        (file_path, album_artist, album_artist, album, album_id),
+    )
+    return album_id
+
+
 # ---------------------------------------------------------------------------
 # LibraryIndex
 # ---------------------------------------------------------------------------
@@ -185,7 +225,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 49
+        assert version == 50
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -292,7 +332,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -388,7 +428,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 49
+        assert version == 50
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -935,7 +975,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 49
+        assert ver == 50
         assert not (dropped & cols)  # all 11 columns gone from tracks
         assert {"file_path", "sale_item_id"} <= cols  # retained
         assert t is not None
@@ -956,7 +996,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 49
+        assert ver == 50
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1004,6 +1044,237 @@ class TestLibraryIndex:
         reopened.close()
         assert ver == 48  # not bumped
         assert "favorite" in cols  # columns retained
+
+    def test_v50_reunites_case_variant_artist_split(self, tmp_path: Path) -> None:
+        """v50 folds two case-variant artists rows into one, repoints both albums
+        onto the survivor, and normalizes album/track casing (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        a_lower = _add_artist(index, "Sunn O)))")  # inserted first -> lower id
+        a_upper = _add_artist(index, "SUNN O)))")
+        _add_album_with_track(
+            index, "Sunn O)))", "Monoliths & Dimensions", a_lower, "/m/a.mp3"
+        )
+        _add_album_with_track(index, "SUNN O)))", "Life Metal", a_upper, "/m/b.mp3")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)  # runs the v50 heal
+        rc = reopened._conn
+        names = [
+            r[0]
+            for r in rc.execute(
+                "SELECT name FROM artists WHERE name = 'sunn o)))' COLLATE NOCASE"
+            )
+        ]
+        album_artist_ids = {
+            r[0]
+            for r in rc.execute(
+                "SELECT artist_id FROM albums"
+                " WHERE album IN ('Monoliths & Dimensions', 'Life Metal')"
+            )
+        }
+        album_casings = {
+            r[0]
+            for r in rc.execute(
+                "SELECT album_artist FROM albums"
+                " WHERE album IN ('Monoliths & Dimensions', 'Life Metal')"
+            )
+        }
+        track_casings = {r[0] for r in rc.execute("SELECT album_artist FROM tracks")}
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        has_index = rc.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index'"
+            " AND name='idx_artists_name_nocase'"
+        ).fetchone()
+        reopened.close()
+
+        assert names == ["Sunn O)))"]  # one row, canonical = lowest-id casing
+        assert len(album_artist_ids) == 1 and None not in album_artist_ids
+        assert album_casings == {"Sunn O)))"}  # both albums normalized
+        assert track_casings == {"Sunn O)))"}  # tracks normalized too
+        assert ver == 50
+        assert has_index is not None  # NOCASE uniqueness now enforced
+
+    def test_v50_folds_play_time_and_removes_orphan_variant(
+        self, tmp_path: Path
+    ) -> None:
+        """A case-variant row owning zero albums is deleted and its play_time
+        folded into the survivor (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        keep = _add_artist(index, "The Mountain Goats", play_time=100.0)
+        orphan = _add_artist(index, "the Mountain Goats", play_time=25.0)
+        _add_album_with_track(
+            index, "The Mountain Goats", "Tallahassee", keep, "/m/tmg.mp3"
+        )
+        # orphan owns no albums
+        assert orphan  # referenced for clarity
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        rows = rc.execute(
+            "SELECT name, play_time FROM artists"
+            " WHERE name = 'the mountain goats' COLLATE NOCASE"
+        ).fetchall()
+        reopened.close()
+
+        assert len(rows) == 1
+        assert rows[0]["name"] == "The Mountain Goats"
+        assert rows[0]["play_time"] == 125.0  # folded
+
+    def test_v50_survivor_casing_follows_bandcamp_band_name(
+        self, tmp_path: Path
+    ) -> None:
+        """When an album in the group is Bandcamp-linked, the canonical casing is
+        taken from band_name — even against the most-albums heuristic (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        index._conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, band_name)"
+            " VALUES ('k1', 'Kylesa')"
+        )
+        # "KYLESA" owns two albums (incl. the bandcamp one) and was inserted first,
+        # so most-albums AND lowest-id would both pick it — band_name must override.
+        upper = _add_artist(index, "KYLESA")
+        lower = _add_artist(index, "Kylesa")
+        _add_album_with_track(
+            index, "KYLESA", "Spiral Shadow", upper, "/m/k1.mp3", sale_item_id="k1"
+        )
+        _add_album_with_track(index, "KYLESA", "Ultraviolet", upper, "/m/k2.mp3")
+        _add_album_with_track(index, "Kylesa", "Static Tensions", lower, "/m/k3.mp3")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        names = [
+            r[0]
+            for r in rc.execute(
+                "SELECT name FROM artists WHERE name = 'kylesa' COLLATE NOCASE"
+            )
+        ]
+        casings = {r[0] for r in rc.execute("SELECT album_artist FROM albums")}
+        band_name = rc.execute(
+            "SELECT band_name FROM bandcamp_collection WHERE sale_item_id = 'k1'"
+        ).fetchone()[0]
+        reopened.close()
+
+        assert names == ["Kylesa"]  # band_name casing won over most-albums
+        assert casings == {"Kylesa"}
+        assert band_name == "Kylesa"
+
+    def test_v50_uses_most_albums_when_no_band_name_column(
+        self, tmp_path: Path
+    ) -> None:
+        """On an old schema whose bandcamp_collection predates band_name, the heal
+        falls back to the most-albums / lowest-id survivor (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        # Simulate a pre-band_name bandcamp_collection so has_band_name is False.
+        index._conn.execute("DROP TABLE bandcamp_collection")
+        index._conn.execute(
+            "CREATE TABLE bandcamp_collection (sale_item_id TEXT PRIMARY KEY)"
+        )
+        few = _add_artist(index, "Kylesa")  # lower id, but fewer albums
+        many = _add_artist(index, "KYLESA")
+        _add_album_with_track(index, "Kylesa", "Static Tensions", few, "/m/k1.mp3")
+        _add_album_with_track(index, "KYLESA", "Spiral Shadow", many, "/m/k2.mp3")
+        _add_album_with_track(index, "KYLESA", "Ultraviolet", many, "/m/k3.mp3")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        names = [
+            r[0]
+            for r in rc.execute(
+                "SELECT name FROM artists WHERE name = 'kylesa' COLLATE NOCASE"
+            )
+        ]
+        reopened.close()
+
+        assert names == ["KYLESA"]  # most albums wins with no band_name to consult
+
+    def test_v50_noop_on_clean_library(self, tmp_path: Path) -> None:
+        """A v49 DB with no case-variant artists bumps to 50 and adds the index
+        without taking a backup (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        _add_artist(index, "Boris")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        has_index = rc.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index'"
+            " AND name='idx_artists_name_nocase'"
+        ).fetchone()
+        reopened.close()
+        backups = list(tmp_path.glob("library.db.bak-*"))
+
+        assert ver == 50
+        assert has_index is not None
+        assert backups == []  # no work -> no backup
+
+    def test_v50_retries_when_backup_fails(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """If the pre-heal backup fails while case variants exist, v50 leaves the
+        version at 49 and the duplicate rows intact so it retries (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        a1 = _add_artist(index, "Kylesa")
+        a2 = _add_artist(index, "KYLESA")
+        _add_album_with_track(index, "Kylesa", "Static Tensions", a1, "/m/k1.mp3")
+        _add_album_with_track(index, "KYLESA", "Spiral Shadow", a2, "/m/k2.mp3")
+        index._conn.commit()
+        index.close()
+
+        monkeypatch.setattr(LibraryIndex, "_backup_db", lambda self, label: False)
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        n_artists = rc.execute(
+            "SELECT COUNT(*) FROM artists WHERE name = 'kylesa' COLLATE NOCASE"
+        ).fetchone()[0]
+        reopened.close()
+
+        assert ver == 49  # not bumped — retries on next open
+        assert n_artists == 2  # duplicate rows untouched
+
+    def test_v50_rolls_back_and_retries_when_heal_raises(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """If a group merge raises mid-heal, the whole migration rolls back, the
+        version stays 49, and the duplicate rows survive intact (KAMP-545)."""
+        db = tmp_path / "library.db"
+        index = _open_forkable_v49(db)
+        a1 = _add_artist(index, "Kylesa")
+        a2 = _add_artist(index, "KYLESA")
+        _add_album_with_track(index, "Kylesa", "Static Tensions", a1, "/m/k1.mp3")
+        _add_album_with_track(index, "KYLESA", "Spiral Shadow", a2, "/m/k2.mp3")
+        index._conn.commit()
+        index.close()
+
+        def _boom(self: "LibraryIndex", ids: list[int], has_band_name: bool) -> None:
+            raise RuntimeError("simulated heal failure")
+
+        monkeypatch.setattr(LibraryIndex, "_heal_artist_group", _boom)
+        reopened = LibraryIndex(db)
+        rc = reopened._conn
+        ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
+        n_artists = rc.execute(
+            "SELECT COUNT(*) FROM artists WHERE name = 'kylesa' COLLATE NOCASE"
+        ).fetchone()[0]
+        reopened.close()
+
+        assert ver == 49  # rolled back, not bumped
+        assert n_artists == 2  # both rows intact after rollback
 
     def test_collapse_heal_works_without_preexisting_view(self, tmp_path: Path) -> None:
         """A collapse heal must build the tracks_with_stats view before running.
@@ -2838,7 +3109,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -2895,7 +3166,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3490,7 +3761,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         assert row[0] == 0
 
@@ -3954,7 +4225,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4067,7 +4338,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4251,7 +4522,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4346,7 +4617,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4354,7 +4625,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5281,7 +5552,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
 
         index.close()
 
@@ -5972,7 +6243,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6007,7 +6278,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 49
+        assert version == 50
         index.close()
 
 
@@ -6522,7 +6793,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 49
+        assert version == 50
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -6655,7 +6926,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 49
+        assert version == 50
 
 
 class TestRemoteTrackSchema:
@@ -7063,7 +7334,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7124,7 +7395,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -7924,7 +8195,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8485,7 +8756,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -8563,7 +8834,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -8772,7 +9043,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -9144,7 +9415,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9244,7 +9515,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9360,7 +9631,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -9865,7 +10136,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -9980,7 +10251,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -10078,7 +10349,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -10178,7 +10449,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10685,7 +10956,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 49
+        assert version == 50
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11567,7 +11838,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 49
+        assert version == 50
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12694,7 +12965,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 49
+        assert version == 50
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -12714,7 +12985,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 49
+        assert version == 50
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -12757,7 +13028,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 49
+        assert version == 50
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1744,6 +1744,21 @@ class TestSearchEndpoint:
         assert len(data["albums"]) == 1
         assert data["albums"][0]["album"] == "Kid A"
 
+    def test_album_card_matches_track_case_insensitively(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """KAMP-545: an album row whose album_artist casing diverges from its
+        tracks' casing ("SUNN O)))" vs "Sunn O)))") still surfaces as an album
+        card — the album↔track match honours the NOCASE collation."""
+        t = _track(1, album="sunn O)))", artist="Sunn O)))")
+        mock_index.search.return_value = [t]
+        mock_index.albums.return_value = [_album("SUNN O)))", "sunn O)))")]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=sunn")
+        data = res.json()
+        assert len(data["albums"]) == 1
+        assert data["albums"][0]["album_artist"] == "SUNN O)))"
+
     def test_albums_deduplicated_when_multiple_tracks_match(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## KAMP-545: Case-variant artist names split an album onto a duplicate `artists` row

`artists.name` was `TEXT UNIQUE` (BINARY / case-sensitive) while `albums.album_artist` is `COLLATE NOCASE`. When two albums by one artist disagreed on casing — a local rip `Sunn O)))` vs a bandcamp sync `SUNN O)))` (bandcamp uppercases many names) — the upsert's `INSERT OR IGNORE INTO artists (name)` spawned a **second** artists row, and the two albums linked to different `artist_id`s. The artist filter keys on `artists.id`, so the orphaned album vanished from search and the filter. Surfaced during KAMP-541 DB validation; pre-existing, not a 541 regression.

### Fix — prevent + heal (parent epic KAMP-533)

**Prevent (commit 1).** A `UNIQUE INDEX ... (name COLLATE NOCASE)` enforces case-insensitive uniqueness so a case-variant can never spawn a second row. Enforced as an index rather than a table rebuild because `artists.id` is FK-referenced by `albums.artist_id` and `PRAGMA foreign_keys` is a no-op inside the migration transaction — a `DROP TABLE` rebuild risks bricking the upgrade. The two live artist-name joins (`albums.artist_id` wiring and `record_play_time`) become `COLLATE NOCASE` so a differently-cased `album_artist` resolves to the single canonical row instead of orphaning the album (`artist_id` NULL) or dropping play_time on a silent BINARY miss.

**Heal (commit 2, v49 → v50).** For each `LOWER(name)` group with more than one row: pick a survivor (the linked `bandcamp_collection.band_name` casing when the group has a Bandcamp album — authoritative, and the casing a future sync would otherwise re-fork on; else most-albums / lowest-id), repoint every loser album onto it, fold `play_time`, delete the loser, then normalize the survivor's album / track / `band_name` strings to the canonical casing (rebuilding FTS). `tracks.artist` is left untouched so Various Artists per-track credits survive. Backup-first, one transaction, version-last, rolls back and retries on failure; gated on `== 49` so a rolled-back v49 is not skipped past. The NOCASE index is created after a clean heal (and immediately for fresh DBs), never in `_DDL` — which runs before the heal and would throw on the duplicate rows.

**Search album cards (commit 3).** `/api/v1/search` built its album cards by matching each album's `(album_artist, album)` against the search tracks' keys as exact, case-sensitive tuples. An album row whose casing diverges from its tracks' casing — e.g. row `SUNN O)))` (from the Bandcamp band_name) vs tracks `Sunn O)))` (from the file tags) — was dropped from the cards even though its tracks matched, so it was invisible in search while present in the grid and the artist filter. This is the "doesn't appear in search" half of the acceptance and predates the ticket (the row/track divergence is pre-existing; the heal skips such an album because its row already equals the canonical casing). Fixed by lower-casing both sides so the album↔track match honours the NOCASE collation — a query-time fix that repairs already-migrated libraries with no re-migration. Verified against the real production DB: the self-titled `sunn O)))` album now returns as a card.

### Verification

- Full suite green: **2257 passed, 9 skipped**, black + mypy clean, coverage 93.08%.
- 14 new tests: two prevention (no split on divergent casing; play_time credits one row), seven heal (reunite split, fold play_time + drop orphan, band_name-driven survivor, most-albums fallback with no band_name column, no-op on clean library, backup-fail retry, atomic rollback on heal error), one search (album card matches its tracks case-insensitively), plus the version-bump assertions.
- **Validated on a copy of the real production DB:** 978 → 970 artists (the 8 case-variant rows removed), 8 → 0 case-variant groups, 0 album_artists split across ids, NOCASE index created, schema v50. The survivor rule reproduces the intended canonicals (Kylesa, Run the Jewels, Sunn O))), The Mountain Goats, ...).

Manual (user drives): confirm SUNN O))) / KYLESA / Run the Jewels / The Mountain Goats each reunite under one artist in search + the artist filter; confirm a subsequent bandcamp sync with different casing does not re-create a duplicate; spot-check a Various Artists album keeps its per-track artists.

Reduced-scope note carried from the epic: dropping `tracks.file_path`/`sale_item_id` remains deferred (KAMP-552); this ticket touches only the artist-identity split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
