### PR TITLE
fix(library): album source badge shows 'mixed' for mixed albums (KAMP-546)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -743,15 +743,15 @@ def _eff_source(alias: str = "t") -> str:
 _EFFECTIVE_SOURCE_EXPR = _eff_source("t")
 
 # Album `source` badge ('local' / 'bandcamp' / 'mixed'), correlated on the outer
-# `albums.id`. Behavior-preserving reconstruction of the legacy formula (which
-# read tracks.source and file_path LIKE 'bandcamp://%'): computes each track's
-# effective source once in a derived table, then applies the identical CASE. The
-# 'mixed' arm is unreachable post-collapse — preserved verbatim so the badge is
-# byte-for-byte unchanged (see KAMP-542; the quirk is tracked separately).
+# `albums.id`. Computes each track's effective source once in a derived table,
+# then classifies the album by whether its tracks agree on preferred delivery
+# kind: 'mixed' when they disagree, else the single kind. This matches
+# _PLAYLIST_SOURCE_EXPR (KAMP-546) — the legacy pre-collapse first branch that
+# short-circuited a mixed album to 'local' was dropped, since post-collapse
+# file_path is the *preferred* uri and that branch fired for exactly the mixed
+# case, leaving the 'mixed' arm dead.
 _ALBUM_SOURCE_SUBQUERY = (
     "(SELECT CASE"
-    "   WHEN COUNT(CASE WHEN es.eff = 'local' THEN 1 END) > 0"
-    "    AND COUNT(CASE WHEN es.eff <> 'local' THEN 1 END) > 0 THEN 'local'"
     "   WHEN COUNT(DISTINCT es.eff) > 1 THEN 'mixed'"
     "   ELSE MIN(es.eff) END"
     "  FROM (SELECT " + _EFFECTIVE_SOURCE_EXPR + " AS eff"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -7683,15 +7683,22 @@ class TestAlbumInfoRemoteFields:
         album: str = "The Album",
         album_artist: str = "The Artist",
         source: str = "local",
+        file_path: "Path | None" = None,
+        track_number: int = 1,
     ) -> None:
+        # file_path defaults to tmp_path/name (a local file); pass a raw
+        # bandcamp:// path to seed a genuine stream track (its track_sources row
+        # is a 'stream', so its effective source is 'bandcamp'). track_number
+        # distinguishes tracks so a file + stream pair at the same number is not
+        # merged into one downloaded-and-streamable canonical (KAMP-532).
         track = Track(
-            file_path=tmp_path / name,
+            file_path=file_path if file_path is not None else tmp_path / name,
             title=name,
             artist=album_artist,
             album_artist=album_artist,
             album=album,
             release_date="2024",
-            track_number=1,
+            track_number=track_number,
             disc_number=1,
             ext="mp3",
             embedded_art=False,
@@ -7725,25 +7732,30 @@ class TestAlbumInfoRemoteFields:
 
     def test_mixed_album_has_mixed_source(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
-        self._insert_track(index, tmp_path, "t1.mp3", source="local")
-        self._insert_track(index, tmp_path, "bandcamp://999/2", source="bandcamp")
+        self._insert_track(index, tmp_path, "t1.mp3", source="local", track_number=1)
+        # Track 2 is a genuine stream-only track (raw bandcamp:// path -> a
+        # 'stream' source row); a different track_number keeps it distinct from
+        # track 1 rather than merging into one downloaded+streamable canonical.
+        self._insert_track(
+            index,
+            tmp_path,
+            "T2",
+            source="bandcamp",
+            file_path=Path("bandcamp://999/2"),
+            track_number=2,
+        )
         albums = index.albums()
         index.close()
 
         assert len(albums) == 1
-        # Post-collapse the badge is reconstructed from track_sources (KAMP-542).
         # A genuinely mixed album (one local-preferred + one stream-preferred
-        # track) reads 'local', not 'mixed' — the pre-existing quirk tracked in
-        # KAMP-546. The old formula returned 'mixed' here only because this
-        # fixture's "bandcamp" track has a mangled, non-bandcamp:// file_path
-        # (tmp_path / "bandcamp://999/2"), a state that cannot occur in production
-        # where a stream track's file_path IS its bandcamp:// uri.
-        assert albums[0].source == "local"
-        # has_remote_tracks is derived from the badge (album_source != 'local'), so
-        # it follows the same KAMP-546 quirk: a realistic mixed album reads
-        # 'local' -> has_remote_tracks False. This already matches production on
-        # main (where a realistic mixed album's badge is 'local').
-        assert albums[0].has_remote_tracks is False
+        # track) reads 'mixed' (KAMP-546): the album classifier now matches the
+        # playlist one — 'mixed' whenever the tracks disagree on preferred
+        # delivery kind. Reconstructed from track_sources (KAMP-542).
+        assert albums[0].source == "mixed"
+        # has_remote_tracks is derived from the badge (album_source != 'local'):
+        # a mixed album does have streamable tracks, so it is True.
+        assert albums[0].has_remote_tracks is True
 
     def test_in_bandcamp_collection_true(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -7941,8 +7953,10 @@ class TestAlbumInfoRemoteFields:
 
         assert len(albums) == 1
         assert albums[0].track_count == 2  # only local tracks, not 4
-        assert albums[0].source == "local"
-        assert albums[0].has_remote_tracks is False
+        # The album holds file-only and stream-only tracks, so it reads 'mixed'
+        # (KAMP-546); track_count still counts only the downloaded files.
+        assert albums[0].source == "mixed"
+        assert albums[0].has_remote_tracks is True
 
     # (KAMP-541) The old "tracks_for_album excludes bandcamp rows when a local
     # sibling exists" test is removed: the local-wins filter is gone because the
@@ -12172,10 +12186,10 @@ class TestStatsReadFromTrackStats:
 
 
 class TestAlbumSourceClassifier:
-    """The album `source` badge reads track_sources (not tracks.source) but is
-    byte-for-byte behavior-preserving vs the legacy formula, including the
-    post-collapse quirk where a mixed album reads 'local' and 'mixed' is
-    unreachable (tracked separately; preserved here per KAMP-542)."""
+    """The album `source` badge reads track_sources (not tracks.source) and
+    classifies a mixed album (tracks disagreeing on preferred delivery kind) as
+    'mixed', matching the playlist classifier (KAMP-546). All-downloaded reads
+    'local', all-stream reads 'bandcamp'."""
 
     def _album(self, index: "LibraryIndex", name: str, tracks: list) -> int:
         c = index._conn
@@ -12216,13 +12230,14 @@ class TestAlbumSourceClassifier:
                 ],
                 "bandcamp",
             ),
-            # Post-collapse quirk: a mixed album reads 'local' (preserved, not 'mixed').
+            # A mixed album (one file-only, one stream-only track) reads 'mixed'
+            # (KAMP-546): the tracks disagree on preferred delivery kind.
             "mixed": (
                 [
                     ("local", "/m/c1.mp3", ["file"]),
                     ("bandcamp", "bandcamp://C/2", ["stream"]),
                 ],
-                "local",
+                "mixed",
             ),
             "downloaded_and_streamable": (
                 [


### PR DESCRIPTION
## Summary

The album grid `source` badge never rendered `'mixed'`: an album with some downloaded and some stream-only tracks read `'local'`, and only a zero-download album read `'bandcamp'`. Playlists were unaffected — their classifier already emits `'mixed'`.

**Root cause:** `_ALBUM_SOURCE_SUBQUERY` kept a legacy pre-collapse first `CASE` branch that short-circuited to `'local'` whenever an album had both a local-effective and a stream-effective track. Post-collapse (KAMP-541), `file_path` is the *preferred* delivery uri, so that branch fired for exactly the mixed case — leaving the `'mixed'` arm dead. Two derived fields inherited the mislabel: `has_remote_tracks` (wrongly `False`) and `track_count` (reached its local-only branch for the wrong reason).

**Fix:** Drop the dead branch so `COUNT(DISTINCT eff) > 1 THEN 'mixed'` decides, aligning the album classifier with `_PLAYLIST_SOURCE_EXPR`. One SQL branch removed; downstream fields (`has_remote_tracks`, `track_count`) read the recomputed `a.source` and correct automatically. The UI already renders a `'mixed'` album badge (generic cloud icon, same as playlists), so no frontend change.

## Behavior

| Album | Before | After |
| --- | --- | --- |
| All downloaded | `local` | `local` |
| All stream-only | `bandcamp` | `bandcamp` |
| Mixed (some downloaded, some stream-only) | `local` | **`mixed`** |
| One track downloaded AND streamable | `local` | `local` |

`has_remote_tracks` is now `True` for a mixed album. `track_count` for a mixed album still counts only local tracks.

## Tests

- Updated the three assertions KAMP-542 pinned to the quirk (`TestAlbumSourceClassifier::test_badge_matches_legacy_output`, `TestAlbumInfoRemoteFields::test_mixed_album_has_mixed_source` + its `has_remote_tracks`).
- Updated a 4th, not enumerated in the ticket: `test_albums_deduplicates_when_local_and_bc_tracks_coexist` is a genuinely mixed album (2 file-only + 2 stream-only tracks) and now reads `'mixed'`; `track_count == 2` unchanged.
- `test_mixed_album_has_mixed_source` now seeds a real stream-only track (raw `bandcamp://` path + distinct `track_number`) so the KAMP-532 merge doesn't collapse the pair into one downloaded+streamable canonical.
- Full suite: 2246 passed, coverage 93.29%. black + mypy clean.

## Manual test plan

- Album grid: an album with some downloaded and some stream-only tracks shows the remote/cloud source badge (mixed), not bare local.
- All-downloaded shows no remote badge; all-stream shows the Bandcamp badge.
- A mixed album's track count still reflects only its downloaded tracks.
- `remote_only` / `local_only` library filters behave sensibly for a mixed album (it now passes `remote_only`).
- Playlist badges unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)