### PR TITLE
feat(ui): functional pipeline indicator with folder/copy/tag states (KAMP-558)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1044,7 +1044,10 @@ def create_app(
         _broadcast({"type": "bandcamp.sync-status", "state": state})
 
     def _notify_pipeline_stage(
-        stage: str, sale_item_id: str | None = None, committed: bool = False
+        stage: str,
+        sale_item_id: str | None = None,
+        committed: bool = False,
+        album: str = "",
     ) -> None:
         """Broadcast the current pipeline stage to all connected WebSocket clients.
 
@@ -1056,6 +1059,8 @@ def create_app(
         global pipeline indicator ignores it and reads only ``stage``.
         *committed* is True on the terminal "" reset only when the item reached
         the library, letting the UI tell success (rescan coming) from quarantine.
+        KAMP-558: *album* is a human-readable album label ("" before extraction)
+        so the pipeline indicator can show "Copying {album}…" / "Tagging {album}…".
         Called from the watcher thread — _broadcast is thread-safe.
         """
         _broadcast(
@@ -1064,6 +1069,7 @@ def create_app(
                 "stage": stage,
                 "sale_item_id": sale_item_id,
                 "committed": committed,
+                "album": album,
             }
         )
 

--- a/kamp_daemon/pipeline.py
+++ b/kamp_daemon/pipeline.py
@@ -33,9 +33,10 @@ _DIR_SENTINEL = "__dir__:"
 _NOTIFY_SENTINEL = "__notify__:"
 
 # Prefix written to stage_q for a pipeline stage update (KAMP-562). Payload is a
-# compact JSON object with "stage", "sale_item_id" (str | null), and "committed"
-# (bool) so the parent can route the stage to the right album card. The old bare
-# stage string is still accepted by _handle_stage_msg for defensiveness.
+# compact JSON object with "stage", "sale_item_id" (str | null), "committed"
+# (bool), and "album" (str; KAMP-558, the album label for the indicator tooltip)
+# so the parent can route the stage to the right album card. The old bare stage
+# string is still accepted by _handle_stage_msg for defensiveness.
 _STAGE_SENTINEL = "__stage__:"
 
 
@@ -81,9 +82,9 @@ def _pipeline_worker(
             path,
             config,
             _on_directory=lambda d: stage_q.put(f"{_DIR_SENTINEL}{d}"),
-            stage_callback=lambda s, sid, c: stage_q.put(
+            stage_callback=lambda s, sid, c, alb: stage_q.put(
                 f"{_STAGE_SENTINEL}"
-                f"{json.dumps({'stage': s, 'sale_item_id': sid, 'committed': c})}"
+                f"{json.dumps({'stage': s, 'sale_item_id': sid, 'committed': c, 'album': alb})}"
             ),
             notify_callback=lambda s: stage_q.put(s),
             # KAMP-523: the live DB path so the pipeline can consume the
@@ -121,7 +122,7 @@ def _spawn_worker(  # pragma: no cover
 
 def _handle_stage_msg(
     msg: str,
-    stage_callback: Callable[[str, str | None, bool], None] | None,
+    stage_callback: Callable[[str, str | None, bool, str], None] | None,
     on_directory: Callable[[Path], None] | None,
     notification_callback: Callable[[str, str, str], None] | None = None,
 ) -> None:
@@ -146,12 +147,13 @@ def _handle_stage_msg(
                     payload["stage"],
                     payload.get("sale_item_id"),
                     bool(payload.get("committed", False)),
+                    payload.get("album", ""),
                 )
             except Exception:
                 logger.warning("Malformed stage sentinel: %r", msg)
     elif stage_callback is not None:
         # Defensive: a bare (legacy) stage string carries no album identity.
-        stage_callback(msg, None, False)
+        stage_callback(msg, None, False, "")
 
 
 def _replay_log_queue(log_q: Any) -> None:
@@ -168,7 +170,7 @@ def run_in_subprocess(
     path: Path,
     config: Config,
     _on_directory: Callable[[Path], None] | None = None,
-    stage_callback: Callable[[str, str | None, bool], None] | None = None,
+    stage_callback: Callable[[str, str | None, bool, str], None] | None = None,
     notification_callback: Callable[[str, str, str], None] | None = None,
 ) -> None:
     """Process a single staging item in an isolated subprocess.

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -75,7 +75,7 @@ def run(
     path: Path,
     config: Config,
     _on_directory: Callable[[Path], None] | None = None,
-    stage_callback: Callable[[str, str | None, bool], None] | None = None,
+    stage_callback: Callable[[str, str | None, bool, str], None] | None = None,
     notify_callback: Callable[[str], None] | None = None,
     index_path: Path | None = None,
 ) -> None:
@@ -83,13 +83,15 @@ def run(
 
     On per-step failure the item is moved to <watch-folder>/errors/ so the watcher
     does not trigger on it again.  *stage_callback* (if provided) is called with
-    ``(stage, sale_item_id, committed)`` — the current stage name ("Extracting",
-    "Tagging", etc.), the Bandcamp ``sale_item_id`` for this artifact (KAMP-562;
-    ``None`` for non-download drops), and whether the item has been committed to
-    the library. It is also called with an empty stage string in a finally block
-    so the caller can reset its display; that terminal call carries the final
-    *committed* value so a per-album UI can tell success (rescan coming → hold)
-    from quarantine (no rescan → clear now).
+    ``(stage, sale_item_id, committed, album)`` — the current stage name
+    ("Extracting", "Tagging", etc.), the Bandcamp ``sale_item_id`` for this
+    artifact (KAMP-562; ``None`` for non-download drops), whether the item has
+    been committed to the library, and a human-readable album label (KAMP-558;
+    the extracted directory name, ``""`` before extraction). It is also called
+    with an empty stage string in a finally block so the caller can reset its
+    display; that terminal call carries the final *committed* value so a
+    per-album UI can tell success (rescan coming → hold) from quarantine (no
+    rescan → clear now).
     *notify_callback* (if provided) receives __notify__: sentinel strings that
     the parent process routes to rumps.notification().
     """
@@ -133,10 +135,16 @@ def run(
         provenance.sale_item_id if provenance is not None else None
     )
     committed = False
+    # KAMP-558: a human-readable album label for the pipeline indicator's
+    # tooltip ("Copying {album}…" / "Tagging {album}…"). Empty until extraction
+    # gives us the on-disk album folder name; cosmetic only — never a key. `emit`
+    # reads it at call time (Python closure) so later stages carry the resolved
+    # name while the pre-extraction "Extracting" tooltip stays generic.
+    album = ""
 
     def emit(stage: str) -> None:
         if stage_callback:
-            stage_callback(stage, sale_item_id, committed)
+            stage_callback(stage, sale_item_id, committed, album)
 
     try:
         # --- 1. Extract -------------------------------------------------------
@@ -150,6 +158,11 @@ def run(
             _notify(notify_callback, "Extraction failed", path.name)
             _quarantine(path, watch_folder)
             return
+
+        # KAMP-558: now that extraction succeeded, the on-disk album folder name
+        # is the best display label for the indicator tooltip. Subsequent emits
+        # (Tagging/Updating artwork/Moving) carry it via the `album` closure var.
+        album = directory.name
 
         # Notify the watcher of the watch folder directory as early as possible so it
         # can cancel any pending debounce timer for this directory.  Without this,

--- a/kamp_daemon/watcher.py
+++ b/kamp_daemon/watcher.py
@@ -62,7 +62,7 @@ class _WatchHandler(FileSystemEventHandler):
             thread_name_prefix="pipeline",
         )
         # Set by Watcher to surface current pipeline stage in the menu bar.
-        self.stage_callback: Callable[[str, str | None, bool], None] | None = None
+        self.stage_callback: Callable[[str, str | None, bool, str], None] | None = None
         # Set by Watcher to deliver error notifications to the menu bar.
         self.notification_callback: Callable[[str, str, str], None] | None = None
         # Called after each successful pipeline run so the library watcher can
@@ -229,17 +229,17 @@ class Watcher:
         self._handler = _WatchHandler(config)
         self._paused = False
         self._started = False  # False until start() succeeds with a real path
-        self._stage_callback: Callable[[str, str | None, bool], None] | None = None
+        self._stage_callback: Callable[[str, str | None, bool, str], None] | None = None
         self._notification_callback: Callable[[str, str, str], None] | None = None
         self._on_pipeline_complete: Callable[[], None] | None = None
 
     @property
-    def stage_callback(self) -> Callable[[str, str | None, bool], None] | None:
+    def stage_callback(self) -> Callable[[str, str | None, bool, str], None] | None:
         return self._stage_callback
 
     @stage_callback.setter
     def stage_callback(
-        self, cb: Callable[[str, str | None, bool], None] | None
+        self, cb: Callable[[str, str | None, bool, str], None] | None
     ) -> None:
         self._stage_callback = cb
         self._handler.stage_callback = cb

--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -947,6 +947,16 @@ app.whenReady().then(async () => {
     shell.showItemInFolder(filePath)
   })
 
+  // KAMP-558: open a folder (the Music Library) in Finder/Explorer. shell.openPath
+  // reports failure via a resolved non-empty string (never throws), so surface it
+  // in the log rather than failing silently when the folder is missing/renamed.
+  ipcMain.on('shell:open-path', (_event, path: string) => {
+    if (!path) return
+    void shell.openPath(path).then((err) => {
+      if (err) console.error(`[kamp] shell.openPath(${path}) failed: ${err}`)
+    })
+  })
+
   ipcMain.on('shell:open-external', (_event, url: string) => {
     void shell.openExternal(url)
   })

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -16,7 +16,7 @@ declare global {
         triggerSyncAll: () => Promise<{ ok: boolean }>
       }
       pipeline: {
-        onStage: (callback: (stage: string) => void) => () => void
+        onStage: (callback: (stage: string, album: string) => void) => () => void
       }
       onUpdateAvailable: (
         callback: (data: { version: string; notes: string }) => void
@@ -24,6 +24,7 @@ declare global {
       dismissUpdate: (version: string) => Promise<void>
       getApiToken: () => string | null
       showItemInFolder: (filePath: string) => void
+      openPath: (path: string) => void
       openExternal: (url: string) => void
       setBgColor: (color: string) => void
     }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -91,6 +91,8 @@ const api = {
   getApiToken: (): string | null => _readKampToken(),
   showItemInFolder: (filePath: string): void =>
     ipcRenderer.send('shell:show-item-in-folder', filePath),
+  // KAMP-558: open a folder (e.g. the Music Library) in Finder/Explorer.
+  openPath: (path: string): void => ipcRenderer.send('shell:open-path', path),
   openExternal: (url: string): void => ipcRenderer.send('shell:open-external', url),
   setBgColor: (color: string): void => ipcRenderer.send('kamp:set-bg-color', color)
 }

--- a/kamp_ui/src/preload/kampAPI.ts
+++ b/kamp_ui/src/preload/kampAPI.ts
@@ -43,7 +43,7 @@ const registerCallbacks = new Set<(manifest: PanelManifest) => void>()
 const trackChangeCallbacks = new Set<(state: PlayerState) => void>()
 const playStateChangeCallbacks = new Set<(state: PlayerState) => void>()
 const syncStatusCallbacks = new Set<(state: 'idle' | 'syncing') => void>()
-const pipelineStageCallbacks = new Set<(stage: string) => void>()
+const pipelineStageCallbacks = new Set<(stage: string, album: string) => void>()
 let _pushWs: WebSocket | null = null
 
 function ensurePushWs(): void {
@@ -77,8 +77,10 @@ function ensurePushWs(): void {
         const state = (msg as unknown as { state: 'idle' | 'syncing' }).state
         syncStatusCallbacks.forEach((cb) => cb(state))
       } else if (msg.type === 'pipeline.stage') {
-        const stage = (msg as unknown as { stage: string }).stage
-        pipelineStageCallbacks.forEach((cb) => cb(stage))
+        // KAMP-558: album is "" before extraction (and for pre-558 daemons); the
+        // indicator renders a generic tooltip in that case.
+        const { stage, album } = msg as unknown as { stage: string; album?: string }
+        pipelineStageCallbacks.forEach((cb) => cb(stage, album ?? ''))
       } else if (msg.type === 'bandcamp.proxy-fetch') {
         // Relay a bandcamp.com HTTP request through Electron's net module so
         // Chromium's TLS stack (real browser fingerprint) is used instead of
@@ -110,7 +112,7 @@ export function onBandcampSyncStatus(callback: (state: 'idle' | 'syncing') => vo
   return () => syncStatusCallbacks.delete(callback)
 }
 
-export function onPipelineStage(callback: (stage: string) => void): () => void {
+export function onPipelineStage(callback: (stage: string, album: string) => void): () => void {
   pipelineStageCallbacks.add(callback)
   return () => pipelineStageCallbacks.delete(callback)
 }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -772,6 +772,9 @@ export type PipelineStageMessage = {
   // library, so the UI can tell success (rescan coming) from quarantine.
   sale_item_id?: string | null
   committed?: boolean
+  // KAMP-558: human-readable album label for the pipeline indicator tooltip
+  // ("" before extraction, and for pre-558 daemons).
+  album?: string
 }
 export type ServerMessage =
   | StateMessage

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -242,9 +242,43 @@ html[data-platform='win32'] .view-tabs {
   cursor: default;
 }
 
+/* Idle state is a real <button>: reset the native chrome, keep the rail look. */
+.pipeline-indicator--idle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.pipeline-indicator--idle:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.pipeline-indicator--idle:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
 .pipeline-indicator--active {
   color: var(--accent);
+}
+
+/* Copying: spinning two-arrows (transform only — safe in the Electron renderer). */
+.pipeline-indicator--copying svg {
+  animation: spin 1s linear infinite;
+}
+
+/* Tagging: pulsing tag (opacity only). */
+.pipeline-indicator--tagging {
   animation: bandcamp-pulse 1.4s ease-in-out infinite;
+}
+
+/* Respect reduced-motion: hold the highlighted icon steady, no spin/pulse. */
+@media (prefers-reduced-motion: reduce) {
+  .pipeline-indicator--copying svg,
+  .pipeline-indicator--tagging {
+    animation: none;
+  }
 }
 
 .bandcamp-context-menu {

--- a/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
+++ b/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
@@ -1,53 +1,123 @@
 import React, { useEffect, useState } from 'react'
 import { useTooltip } from '../hooks/useTooltip'
+import { useStore } from '../store'
 
-export function PipelineIndicator(): React.JSX.Element | null {
+// The stage label the daemon emits for the metadata-tagging step. Every other
+// non-empty stage (Extracting / Updating artwork / Moving) is treated as the
+// "copying to library" phase. Kept as a named constant so a backend rewording
+// is a one-line change here (KAMP-558).
+const TAGGING_STAGE = 'Tagging'
+
+type IndicatorMode = 'idle' | 'copying' | 'tagging'
+
+/**
+ * Pure mapping from the raw pipeline stage + album label to the indicator's
+ * visual mode and tooltip. Extracted so the state machine is reviewable without
+ * a renderer (kamp_ui has no unit-test runner).
+ *
+ * - ''            → idle folder (tooltip is the folder action, set by the caller)
+ * - 'Tagging'     → pulsing tag, "Tagging {album}…"
+ * - anything else → spinning arrows, "Copying {album} to Library…"
+ *
+ * album is "" before extraction (and for pre-558 daemons); the tooltip drops the
+ * trailing " {album}" in that case rather than showing a double space.
+ */
+function deriveState(stage: string, album: string): { mode: IndicatorMode; tooltip: string } {
+  if (stage === '') {
+    return { mode: 'idle', tooltip: 'Open Music Library in Finder/Explorer' }
+  }
+  const name = album.trim()
+  if (stage === TAGGING_STAGE) {
+    return { mode: 'tagging', tooltip: name ? `Tagging ${name}…` : 'Tagging…' }
+  }
+  return {
+    mode: 'copying',
+    tooltip: name ? `Copying ${name} to Library…` : 'Copying to Library…'
+  }
+}
+
+export function PipelineIndicator(): React.JSX.Element {
   const [stage, setStage] = useState('')
+  const [album, setAlbum] = useState('')
+  const libraryPath = useStore((s) => s.configuredLibraryPath)
   const tooltip = useTooltip()
 
   useEffect(() => {
-    return window.api.pipeline.onStage(setStage)
+    return window.api.pipeline.onStage((s, a) => {
+      setStage(s)
+      // Reset the album on the terminal empty stage so a stale label can't leak
+      // into the next run's early "Extracting" tooltip.
+      setAlbum(s === '' ? '' : a)
+    })
   }, [])
 
+  const { mode, tooltip: tip } = deriveState(stage, album)
+
+  if (mode === 'idle') {
+    // Idle is an actionable button: click opens the Music Library folder. Disabled
+    // (non-interactive) until a library path is configured (fresh onboarding).
+    return (
+      <button
+        type="button"
+        className="pipeline-indicator pipeline-indicator--idle"
+        disabled={!libraryPath}
+        onClick={() => {
+          if (libraryPath) window.api.openPath(libraryPath)
+        }}
+        aria-label={tip}
+        {...tooltip(tip)}
+      >
+        {/* Folder */}
+        <svg viewBox="0 0 20 20" width="20" height="20" fill="currentColor" aria-hidden="true">
+          <path d="M2 5.5A1.5 1.5 0 0 1 3.5 4h3.3a1.5 1.5 0 0 1 1.06.44l1 1a1.5 1.5 0 0 0 1.06.44H16.5A1.5 1.5 0 0 1 18 7.5v7A1.5 1.5 0 0 1 16.5 16h-13A1.5 1.5 0 0 1 2 14.5v-9Z" />
+        </svg>
+      </button>
+    )
+  }
+
+  const className =
+    mode === 'tagging'
+      ? 'pipeline-indicator pipeline-indicator--active pipeline-indicator--tagging'
+      : 'pipeline-indicator pipeline-indicator--active pipeline-indicator--copying'
+
   return (
-    <div
-      className={`pipeline-indicator${stage ? ' pipeline-indicator--active' : ''}`}
-      {...tooltip(stage || 'Idle')}
-    >
-      {/* Approximates SF Symbol "music.note.list": a note head + stem + three horizontal lines */}
-      <svg viewBox="0 0 20 20" width="20" height="20" fill="currentColor" aria-hidden="true">
-        <ellipse cx="5.5" cy="14" rx="2.5" ry="2" />
-        <rect x="7.5" y="5" width="1.5" height="9" />
-        <rect x="7.5" y="5" width="5" height="1.5" />
-        {/* <rect x="11" y="5" width="1.5" height="5" /> */}
-        <line
-          x1="13"
-          y1="5"
-          x2="18"
-          y2="5"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-        />
-        <line
-          x1="13"
-          y1="9"
-          x2="18"
-          y2="9"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-        />
-        <line
-          x1="13"
-          y1="13"
-          x2="18"
-          y2="13"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-        />
-      </svg>
+    <div className={className} aria-label={tip} {...tooltip(tip)}>
+      {mode === 'tagging' ? (
+        // Tag
+        <svg viewBox="0 0 20 20" width="20" height="20" fill="currentColor" aria-hidden="true">
+          <path d="M3 3.8A.8.8 0 0 1 3.8 3h5.13a1.5 1.5 0 0 1 1.06.44l6.07 6.07a1.5 1.5 0 0 1 0 2.12l-4.5 4.5a1.5 1.5 0 0 1-2.12 0L3.44 10.06A1.5 1.5 0 0 1 3 9V3.8Zm3.25 3.45a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z" />
+        </svg>
+      ) : (
+        // Two arrows chasing each other (copy / in-progress)
+        <svg viewBox="0 0 20 20" width="20" height="20" fill="none" aria-hidden="true">
+          <path
+            d="M16 10a6 6 0 0 1-10.6 3.8"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <path
+            d="M4 10a6 6 0 0 1 10.6-3.8"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <path
+            d="M14.8 3.4l.2 3-3-.4"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M5.2 16.6l-.2-3 3 .4"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
+++ b/kamp_ui/src/renderer/src/components/PipelineIndicator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useTooltip } from '../hooks/useTooltip'
+import { fileManagerName } from '../hooks/platformLabel'
 import { useStore } from '../store'
 
 // The stage label the daemon emits for the metadata-tagging step. Every other
@@ -15,16 +16,21 @@ type IndicatorMode = 'idle' | 'copying' | 'tagging'
  * visual mode and tooltip. Extracted so the state machine is reviewable without
  * a renderer (kamp_ui has no unit-test runner).
  *
- * - ''            → idle folder (tooltip is the folder action, set by the caller)
+ * - ''            → idle folder, "Open Music Library in {fileManager}"
  * - 'Tagging'     → pulsing tag, "Tagging {album}…"
  * - anything else → spinning arrows, "Copying {album} to Library…"
  *
  * album is "" before extraction (and for pre-558 daemons); the tooltip drops the
  * trailing " {album}" in that case rather than showing a double space.
+ * fileManager is the platform's file-manager name (Finder / Explorer / Files).
  */
-function deriveState(stage: string, album: string): { mode: IndicatorMode; tooltip: string } {
+function deriveState(
+  stage: string,
+  album: string,
+  fileManager: string
+): { mode: IndicatorMode; tooltip: string } {
   if (stage === '') {
-    return { mode: 'idle', tooltip: 'Open Music Library in Finder/Explorer' }
+    return { mode: 'idle', tooltip: `Open Music Library in ${fileManager}` }
   }
   const name = album.trim()
   if (stage === TAGGING_STAGE) {
@@ -51,7 +57,7 @@ export function PipelineIndicator(): React.JSX.Element {
     })
   }, [])
 
-  const { mode, tooltip: tip } = deriveState(stage, album)
+  const { mode, tooltip: tip } = deriveState(stage, album, fileManagerName())
 
   if (mode === 'idle') {
     // Idle is an actionable button: click opens the Music Library folder. Disabled

--- a/kamp_ui/src/renderer/src/hooks/platformLabel.ts
+++ b/kamp_ui/src/renderer/src/hooks/platformLabel.ts
@@ -4,3 +4,11 @@ export function revealInFinderLabel(): string {
   if (p === 'win32') return '↗ Show in Explorer'
   return '↗ Show in Files'
 }
+
+/** The platform's file-manager name: Finder (macOS), Explorer (Windows), Files. */
+export function fileManagerName(): string {
+  const p = window.electron.process.platform
+  if (p === 'darwin') return 'Finder'
+  if (p === 'win32') return 'Explorer'
+  return 'Files'
+}

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -124,7 +124,7 @@ class TestNotifySentinel:
         stage_received: list[str] = []
         _handle_stage_msg(
             self._make_notify_msg(),
-            stage_callback=lambda s, _sid, _c: stage_received.append(s),
+            stage_callback=lambda s, _sid, _c, _a: stage_received.append(s),
             on_directory=None,
             notification_callback=lambda *a: None,
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -491,7 +491,11 @@ class TestStageCallback:
             patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
             patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[]),
         ):
-            run(album_dir, config, stage_callback=lambda s, _sid, _c: calls.append(s))
+            run(
+                album_dir,
+                config,
+                stage_callback=lambda s, _sid, _c, _alb: calls.append(s),
+            )
 
         assert calls == ["Extracting", "Tagging", "Updating artwork", "Moving", ""]
 
@@ -504,7 +508,7 @@ class TestStageCallback:
         bad_zip.write_bytes(b"not a zip")
         calls: list[str] = []
 
-        run(bad_zip, config, stage_callback=lambda s, _sid, _c: calls.append(s))
+        run(bad_zip, config, stage_callback=lambda s, _sid, _c, _alb: calls.append(s))
 
         assert calls[-1] == ""
 
@@ -516,7 +520,11 @@ class TestStageCallback:
         calls: list[str] = []
 
         with patch("musicbrainzngs.search_releases", return_value={"release-list": []}):
-            run(album_dir, config, stage_callback=lambda s, _sid, _c: calls.append(s))
+            run(
+                album_dir,
+                config,
+                stage_callback=lambda s, _sid, _c, _alb: calls.append(s),
+            )
 
         assert calls[-1] == ""
 
@@ -555,7 +563,7 @@ class TestStageCallback:
             run(
                 album_dir,
                 config,
-                stage_callback=lambda s, sid, c: stages.append((s, sid, c)),
+                stage_callback=lambda s, sid, c, _alb: stages.append((s, sid, c)),
                 index_path=db,
             )
 
@@ -591,7 +599,7 @@ class TestStageCallback:
             run(
                 album_dir,
                 config,
-                stage_callback=lambda s, sid, c: stages.append((s, sid, c)),
+                stage_callback=lambda s, sid, c, _alb: stages.append((s, sid, c)),
                 index_path=db,
             )
 
@@ -615,10 +623,43 @@ class TestStageCallback:
             run(
                 album_dir,
                 config,
-                stage_callback=lambda s, sid, c: stages.append((s, sid, c)),
+                stage_callback=lambda s, sid, c, _alb: stages.append((s, sid, c)),
             )  # no index_path → no provenance
 
         assert {sid for _s, sid, _c in stages} == {None}
+
+    # -- KAMP-558: stage payload carries the album display label --------------
+
+    def test_stage_payload_carries_album_after_extraction(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        """The album label is empty before extraction (so the Extracting tooltip
+        stays generic) and becomes the on-disk album folder name for every stage
+        after extraction succeeds (KAMP-558)."""
+        album_dir = self._setup_dir(config)  # created as watch_folder/"test-album"
+        stages: list[tuple[str, str]] = []
+
+        with (
+            patch.object(
+                KampMusicBrainzTagger, "tag_release", return_value=MOCK_TRACKS
+            ),
+            patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
+            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[]),
+        ):
+            run(
+                album_dir,
+                config,
+                stage_callback=lambda s, _sid, _c, alb: stages.append((s, alb)),
+            )
+
+        by_stage = dict(stages)
+        # Extracting fires before we know the album folder → generic (empty).
+        assert by_stage["Extracting"] == ""
+        # Post-extraction stages carry the album folder name.
+        assert by_stage["Tagging"] == "test-album"
+        assert by_stage["Moving"] == "test-album"
+        # The terminal reset also carries it (the closure keeps the resolved name).
+        assert by_stage[""] == "test-album"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_subprocess.py
+++ b/tests/test_pipeline_subprocess.py
@@ -190,7 +190,7 @@ class TestRunInSubprocess:
             run_in_subprocess(
                 tmp_path / "album",
                 _make_config(tmp_path),
-                stage_callback=lambda s, _sid, _c: received.append(s),
+                stage_callback=lambda s, _sid, _c, _a: received.append(s),
             )
 
         assert received == ["Extracting", "Tagging"]
@@ -294,7 +294,7 @@ class TestOnDirectorySentinel:
             run_in_subprocess(
                 tmp_path / "album.zip",
                 _make_config(tmp_path),
-                stage_callback=lambda s, _sid, _c: stage_received.append(s),
+                stage_callback=lambda s, _sid, _c, _a: stage_received.append(s),
             )
 
         assert stage_received == ["Tagging"]
@@ -340,35 +340,50 @@ class TestOnDirectorySentinel:
 
 class TestHandleStageMsg:
     def test_stage_sentinel_decodes_to_stage_callback(self) -> None:
-        """A __stage__: sentinel decodes to (stage, sale_item_id, committed) — the
-        KAMP-562 per-album payload."""
-        received: list[tuple[str, str | None, bool]] = []
-        msg = f'{_STAGE_SENTINEL}{json.dumps({"stage": "Tagging", "sale_item_id": "S1", "committed": False})}'
-        _handle_stage_msg(msg, lambda s, sid, c: received.append((s, sid, c)), None)
-        assert received == [("Tagging", "S1", False)]
+        """A __stage__: sentinel decodes to (stage, sale_item_id, committed, album)
+        — the KAMP-562 per-album payload plus the KAMP-558 album label."""
+        received: list[tuple[str, str | None, bool, str]] = []
+        msg = f'{_STAGE_SENTINEL}{json.dumps({"stage": "Tagging", "sale_item_id": "S1", "committed": False, "album": "My Album"})}'
+        _handle_stage_msg(
+            msg, lambda s, sid, c, a: received.append((s, sid, c, a)), None
+        )
+        assert received == [("Tagging", "S1", False, "My Album")]
 
     def test_stage_sentinel_terminal_committed_true(self) -> None:
-        received: list[tuple[str, str | None, bool]] = []
-        msg = f'{_STAGE_SENTINEL}{json.dumps({"stage": "", "sale_item_id": "S1", "committed": True})}'
-        _handle_stage_msg(msg, lambda s, sid, c: received.append((s, sid, c)), None)
-        assert received == [("", "S1", True)]
+        received: list[tuple[str, str | None, bool, str]] = []
+        msg = f'{_STAGE_SENTINEL}{json.dumps({"stage": "", "sale_item_id": "S1", "committed": True, "album": "My Album"})}'
+        _handle_stage_msg(
+            msg, lambda s, sid, c, a: received.append((s, sid, c, a)), None
+        )
+        assert received == [("", "S1", True, "My Album")]
+
+    def test_stage_sentinel_missing_album_defaults_empty(self) -> None:
+        """A pre-KAMP-558 payload with no "album" key decodes with album="" — the
+        .get default keeps mixed-version / replayed messages safe."""
+        received: list[tuple[str, str | None, bool, str]] = []
+        msg = f'{_STAGE_SENTINEL}{json.dumps({"stage": "Moving", "sale_item_id": "S1", "committed": False})}'
+        _handle_stage_msg(
+            msg, lambda s, sid, c, a: received.append((s, sid, c, a)), None
+        )
+        assert received == [("Moving", "S1", False, "")]
 
     def test_malformed_stage_sentinel_is_ignored(self) -> None:
-        received: list[tuple[str, str | None, bool]] = []
+        received: list[tuple[str, str | None, bool, str]] = []
         _handle_stage_msg(
             f"{_STAGE_SENTINEL}not-json",
-            lambda s, sid, c: received.append((s, sid, c)),
+            lambda s, sid, c, a: received.append((s, sid, c, a)),
             None,
         )
         assert received == []
 
     def test_bare_stage_label_falls_through_with_null_id(self) -> None:
-        """A legacy bare stage string is accepted defensively as (stage, None, False)."""
-        received: list[tuple[str, str | None, bool]] = []
+        """A legacy bare stage string is accepted defensively as
+        (stage, None, False, "")."""
+        received: list[tuple[str, str | None, bool, str]] = []
         _handle_stage_msg(
-            "Tagging", lambda s, sid, c: received.append((s, sid, c)), None
+            "Tagging", lambda s, sid, c, a: received.append((s, sid, c, a)), None
         )
-        assert received == [("Tagging", None, False)]
+        assert received == [("Tagging", None, False, "")]
 
     def test_dir_sentinel_calls_on_directory(self, tmp_path: Path) -> None:
         called: list[Path] = []
@@ -378,7 +393,9 @@ class TestHandleStageMsg:
     def test_dir_sentinel_not_forwarded_to_stage_callback(self, tmp_path: Path) -> None:
         received: list[str] = []
         _handle_stage_msg(
-            f"{_DIR_SENTINEL}{tmp_path}", lambda s, _sid, _c: received.append(s), None
+            f"{_DIR_SENTINEL}{tmp_path}",
+            lambda s, _sid, _c, _a: received.append(s),
+            None,
         )
         assert received == []
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2751,26 +2751,29 @@ class TestBandcampSync:
         mock_queue: MagicMock,
     ) -> None:
         """KAMP-562: the pipeline.stage event carries sale_item_id + committed so a
-        per-album card can show a tagging badge; the global indicator ignores them."""
+        per-album card can show a tagging badge; the global indicator ignores them.
+        KAMP-558: it also carries the album label for the indicator tooltip."""
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         with c.websocket_connect("/api/v1/ws") as ws:
             ws.receive_json()  # consume initial player.state
-            app.state.notify_pipeline_stage("Tagging", "392692056", False)
+            app.state.notify_pipeline_stage("Tagging", "392692056", False, "My Album")
             during = ws.receive_json()
-            app.state.notify_pipeline_stage("", "392692056", True)
+            app.state.notify_pipeline_stage("", "392692056", True, "My Album")
             terminal = ws.receive_json()
         assert during == {
             "type": "pipeline.stage",
             "stage": "Tagging",
             "sale_item_id": "392692056",
             "committed": False,
+            "album": "My Album",
         }
         assert terminal == {
             "type": "pipeline.stage",
             "stage": "",
             "sale_item_id": "392692056",
             "committed": True,
+            "album": "My Album",
         }
 
     def test_notify_pipeline_stage_defaults_are_backward_compatible(
@@ -2780,7 +2783,8 @@ class TestBandcampSync:
         mock_queue: MagicMock,
     ) -> None:
         """Called with just a stage (the global indicator's usage), sale_item_id is
-        None and committed False — the payload the preload consumer already tolerates.
+        None, committed False, and album "" — the payload the preload consumer
+        already tolerates.
         """
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
@@ -2793,6 +2797,7 @@ class TestBandcampSync:
             "stage": "Extracting",
             "sale_item_id": None,
             "committed": False,
+            "album": "",
         }
 
 


### PR DESCRIPTION
## Summary

Turns the status-rail pipeline indicator from a passive music-note radiator into a functional, legible control with three states — riding on the KAMP-562 stage protocol and adding one display field (`album`) for the tooltips.

- **idle** (`stage == ""`): a **folder** button that opens the Music Library folder in Finder/Explorer; tooltip *"Open Music Library in Finder/Explorer"*. Disabled (non-interactive) until a library path is configured.
- **Tagging**: a **pulsing tag** icon; tooltip *"Tagging {album}…"*.
- **any other active stage** (Extracting / Updating artwork / Moving): **spinning two-arrows**; tooltip *"Copying {album} to Library…"*.

The old music-note icon and "Idle" tooltip are retired.

## How it works

**Backend** — thread a human-readable `album` label through the existing `_STAGE_SENTINEL` JSON protocol that KAMP-562 established: `pipeline_impl.run` → `pipeline.py` → `watcher.py` → `server._notify_pipeline_stage` broadcast. `album` is `""` before extraction (so the pre-album "Extracting" tooltip stays generic) and becomes the on-disk album folder name (`directory.name`) afterward — cosmetic only, never used as a key. The new 4th arg is a keyword with default `""` at every hop and read via `.get("album", "")`, so mixed-version / legacy bare-string messages can't break the chain or freeze the indicator.

**UI** — new `shell.openPath` IPC (mirrors the existing `showItemInFolder` channel); a pure `deriveState(stage, album)` helper for the state machine (reviewable without a unit runner); transform/opacity-only animations (`spin` + `bandcamp-pulse`, both pre-existing keyframes) with a `prefers-reduced-motion` guard.

## Files

- Backend: `kamp_daemon/pipeline_impl.py`, `kamp_daemon/pipeline.py`, `kamp_daemon/watcher.py`, `kamp_core/server.py`
- Preload/main: `kamp_ui/src/preload/{kampAPI.ts,index.ts,index.d.ts}`, `kamp_ui/src/main/index.ts`, `kamp_ui/src/renderer/src/api/client.ts`
- Renderer/CSS: `kamp_ui/src/renderer/src/components/PipelineIndicator.tsx`, `kamp_ui/src/renderer/src/assets/layout.css`
- Tests: `tests/test_pipeline.py`, `tests/test_pipeline_subprocess.py`, `tests/test_server.py`, `tests/test_notifications.py`

## CI

- `pytest`: 2273 passed, 9 skipped; coverage 93.40% (above the 93 gate; new album-threading paths are covered, including the pre-558 `album=""` default branch)
- `black --check`, `mypy`: clean
- UI `typecheck` + `lint`: clean
- README: no drift (indicator not documented there)

## Manual Test Plan

- **Idle**: folder icon; tooltip "Open Music Library in Finder/Explorer"; click opens the library folder.
- **Fresh onboarding** (no library path): folder button disabled, no dead click.
- **Drop an album** into the watch folder: spinning "Copying … to Library…" → pulsing "Tagging {album}…" → back to folder on completion.
- `{album}` in the tooltip is the extracted folder name (not the raw ZIP stem); early Extracting shows the generic "Copying to Library…".
- **Quarantine** (bad/empty archive): indicator returns to idle, doesn't stick.
- **Break/rename** the library path then click idle: `shell.openPath` failure is logged in main, not a silent hang.
- `prefers-reduced-motion` on: active icons don't animate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)