### PR TITLE
feat(library): re-surface pre-order albums on new tracks/release (KAMP-544)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 51
+_SCHEMA_VERSION = 52
 
 
 class NoStreamableVersionError(Exception):
@@ -272,6 +272,13 @@ CREATE TABLE IF NOT EXISTS albums (
     sale_item_id   TEXT    REFERENCES bandcamp_collection(sale_item_id),
     favorite       INTEGER NOT NULL DEFAULT 0,
     date_added     REAL,
+    -- last_track_added_at: detection-time when the album most recently GAINED a
+    -- track (KAMP-544). Unlike date_added (MIN across tracks) this moves forward
+    -- when a pre-order gains a newly-released track, so the album re-surfaces at
+    -- the top of the "date added" sort. Written only by the migration backfill
+    -- and Syncer's bump_album_new_content — never recomputed from tracks, so a
+    -- future aggregate rebuild can't clobber a bump. Reads COALESCE to date_added.
+    last_track_added_at REAL,
     last_played_at REAL,
     play_count_avg REAL    NOT NULL DEFAULT 0,
     art_version    REAL,
@@ -2174,6 +2181,31 @@ class LibraryIndex:
                         self._conn.execute("PRAGMA foreign_keys=ON")
                         self._create_tracks_with_stats_view()
 
+        if version == 51:
+            # v51 -> v52 (KAMP-544): add albums.last_track_added_at — the
+            # detection-time at which the album most recently gained a track, so a
+            # pre-order that picks up a newly-released track re-surfaces at the top
+            # of the "date added" sort (which now keys on
+            # COALESCE(last_track_added_at, date_added)). Purely additive nullable
+            # column — no FK rebuild. Backfill from date_added so existing albums
+            # keep their current ordering until a sync bumps them. Idempotent via a
+            # presence check.
+            album_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(albums)")}
+            if "last_track_added_at" not in album_cols:
+                self._conn.execute(
+                    "ALTER TABLE albums ADD COLUMN last_track_added_at REAL"
+                )
+                # Backfill from date_added when present. Synthetic old-version DBs
+                # in the migration tests may lack it; a NULL last_track_added_at is
+                # fine (reads COALESCE it back to date_added / sort unaffected).
+                if "date_added" in album_cols:
+                    self._conn.execute(
+                        "UPDATE albums SET last_track_added_at = date_added"
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 52")
+            self._conn.commit()
+            version = 52  # noqa: F841
+
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
 
@@ -3533,6 +3565,44 @@ class LibraryIndex:
             " WHERE sale_item_id = ?"
             " AND (date_added IS NULL OR date_added > ?)",
             (date_added, sale_item_id, date_added),
+        )
+        self._conn.commit()
+
+    def count_available_remote_tracks(self, sale_item_id: str) -> int:
+        """Count the streamable (available) remote tracks for *sale_item_id* (KAMP-544).
+
+        Backs the sync-time "did this pre-order gain a track?" signal: when this
+        count increases across a sync, a new track became available (an incremental
+        pre-order release, or the full pre-order → released graduation). ``is_available``
+        lives on ``track_sources``; matches both the canonical bandcamp:// (POSIX)
+        and bandcamp:\\ (Windows) uri forms, mirroring ``update_remote_track_date_added``.
+        """
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM track_sources"
+            " WHERE (uri LIKE ? OR uri LIKE ?) AND is_available = 1",
+            (
+                f"bandcamp://{sale_item_id}/%",
+                f"bandcamp:\\{sale_item_id}\\%",
+            ),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def bump_album_new_content(self, sale_item_id: str, ts: float) -> None:
+        """Move the album's ``last_track_added_at`` forward to *ts* (KAMP-544).
+
+        Called when a sync detects the album gained a newly-available track. The
+        MAX-wins rule keeps the column monotonic (a spurious lower value never
+        pulls the album back down), so the album jumps to — and holds — the top of
+        the "date added" sort until it ages out of the highlight cutoff. This is the
+        only writer of ``last_track_added_at`` besides the v52 migration backfill:
+        it is deliberately NOT recomputed in ``_refresh_album_aggregates`` so a
+        future aggregate rebuild cannot clobber a bump.
+        """
+        self._conn.execute(
+            "UPDATE albums SET last_track_added_at ="
+            " MAX(COALESCE(last_track_added_at, 0), ?)"
+            " WHERE sale_item_id = ?",
+            (ts, sale_item_id),
         )
         self._conn.commit()
 
@@ -5572,7 +5642,10 @@ class LibraryIndex:
                 a.source            AS album_source,
                 a.sale_item_id,
                 a.favorite          AS is_favorite,
-                a.date_added        AS sort_date_added,
+                -- "date added" sorts on the latest content-arrival time so a
+                -- pre-order that gained a track re-surfaces (KAMP-544); falls back
+                -- to date_added for albums never bumped.
+                COALESCE(a.last_track_added_at, a.date_added) AS sort_date_added,
                 a.last_played_at    AS sort_last_played,
                 a.play_count_avg    AS sort_play_count_avg,
                 NULLIF(a.release_date, '')  AS sort_release_date,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -534,6 +534,11 @@ def sync_collection_stream(
             if fetch_index > 0:
                 time.sleep(0.5)
             fetch_index += 1
+            # KAMP-544: snapshot how many streamable tracks this album has BEFORE
+            # the re-sync. If it rises, a pre-order gained a newly-released track
+            # (incremental release or full graduation) and the album should jump
+            # back to the top of "date added" with the new-arrival highlight.
+            available_before = index.count_available_remote_tracks(str(sid))
             try:
                 tracks = fetch_album_tracks(
                     album_url,
@@ -561,6 +566,13 @@ def sync_collection_stream(
                     elif is_preorder_already:
                         # All tracks are now released — graduate to normal remote.
                         index.set_collection_item_mode(str(sid), "remote")
+                    # KAMP-544: re-surface the album when it gained streamable
+                    # tracks. The `available_before > 0` guard skips the first-ever
+                    # index of an album (0 -> N) — that album is already new by its
+                    # date_added; only a *subsequent* increase is a re-arrival.
+                    available_after = index.count_available_remote_tracks(str(sid))
+                    if available_before > 0 and available_after > available_before:
+                        index.bump_album_new_content(str(sid), time.time())
             except Exception as exc:
                 logger.warning(
                     "fetch_album_tracks: skipping tracks for %r by %r (%s): %s",

--- a/kamp_ui/src/renderer/src/components/AlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumCard.tsx
@@ -79,12 +79,12 @@ export function AlbumCard({
     setIsHovered,
     auraActive,
     staticBorderGradient,
-    dismissHighlight
+    markHighlightPlayed
   } = useNewArrivalHighlight(album)
 
-  // Dismiss the highlight the first time this album becomes the active playing track.
+  // Clear the highlight the first time this album becomes the active playing track.
   useEffect(() => {
-    if (isNew && isActive && playing) dismissHighlight(album)
+    if (isNew && isActive && playing) markHighlightPlayed(album)
   }, [isNew, isActive, playing]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // artBlurred persists through the post-download rescan window:

--- a/kamp_ui/src/renderer/src/components/modules/ListView.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/ListView.tsx
@@ -42,12 +42,12 @@ function ListRow({
     setIsHovered,
     auraActive,
     staticBorderGradient,
-    dismissHighlight
+    markHighlightPlayed
   } = useNewArrivalHighlight(album)
 
-  // Dismiss the highlight the first time this album becomes the active playing track.
+  // Clear the highlight the first time this album becomes the active playing track.
   useEffect(() => {
-    if (isNew && isActive && playing) dismissHighlight(album)
+    if (isNew && isActive && playing) markHighlightPlayed(album)
   }, [isNew, isActive, playing]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSelect = (): void => {

--- a/kamp_ui/src/renderer/src/components/useNewArrivalHighlight.ts
+++ b/kamp_ui/src/renderer/src/components/useNewArrivalHighlight.ts
@@ -50,25 +50,45 @@ export interface NewArrivalHighlight {
   auraActive: boolean
   // Defined only when isNew && highlightStyle === 'static'; set as --static-border-gradient
   staticBorderGradient: string | undefined
-  dismissHighlight: (album: Album) => void
+  markHighlightPlayed: (album: Album) => void
+}
+
+/**
+ * Pure predicate for the new-arrival highlight (KAMP-544).
+ *
+ * The highlight is fully derived — no persistent dismissal store. It shows when
+ * the album's most-recent content-arrival time (`added_at`, backed server-side by
+ * `last_track_added_at`) is within the cutoff AND newer than both the last play
+ * and this session's play-echo. So a pre-order that gains a track (added_at jumps
+ * to detection-time) re-surfaces even after an earlier track was played, and the
+ * sparkle still clears the instant the user hits play (the ephemeral echo).
+ */
+export function computeIsNew(
+  album: Album,
+  opts: { highlightEnabled: boolean; cutoffSecs: number; playedEcho: number | undefined }
+): boolean {
+  const addedAt = album.added_at
+  if (!opts.highlightEnabled || addedAt === null || addedAt < opts.cutoffSecs) return false
+  if (album.last_played_at !== null && addedAt <= album.last_played_at) return false
+  if (opts.playedEcho !== undefined && addedAt <= opts.playedEcho) return false
+  return true
 }
 
 export function useNewArrivalHighlight(album: Album): NewArrivalHighlight {
   const highlightEnabled = useStore((s) => s.highlightEnabled)
   const highlightCutoffSecs = useStore((s) => s.highlightCutoffSecs)
   const highlightStyle = useStore((s) => s.highlightStyle)
-  const dismissedHighlightKeys = useStore((s) => s.dismissedHighlightKeys)
-  const dismissHighlight = useStore((s) => s.dismissHighlight)
+  const playedHighlights = useStore((s) => s.playedHighlights)
+  const markHighlightPlayed = useStore((s) => s.markHighlightPlayed)
 
   const albumHighlightKey = album.missing_album
     ? String(album.track_id ?? '')
     : `${album.album_artist}::${album.album}`
-  const isNew =
-    highlightEnabled &&
-    album.added_at !== null &&
-    album.added_at >= highlightCutoffSecs &&
-    album.last_played_at === null &&
-    !dismissedHighlightKeys.has(albumHighlightKey)
+  const isNew = computeIsNew(album, {
+    highlightEnabled,
+    cutoffSecs: highlightCutoffSecs,
+    playedEcho: playedHighlights.get(albumHighlightKey)
+  })
 
   // Start mounting=true so the fast sweep fires immediately; cleared after 1.2s
   const [isMounting, setIsMounting] = useState(isNew)
@@ -198,6 +218,6 @@ export function useNewArrivalHighlight(album: Album): NewArrivalHighlight {
     setIsHovered,
     auraActive,
     staticBorderGradient,
-    dismissHighlight
+    markHighlightPlayed
   }
 }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -80,7 +80,13 @@ type PlayerStore = {
   highlightEnabled: boolean
   highlightCutoffSecs: number
   highlightStyle: string
-  dismissedHighlightKeys: Set<string>
+  // KAMP-544: ephemeral, non-persisted "played this session" echo — album key ->
+  // epoch-seconds captured when playback started. Masks the latency between
+  // hitting play and the server's last_played_at syncing back into the album list
+  // so the new-arrival sparkle vanishes instantly. Not written to localStorage:
+  // on restart last_played_at alone governs, and a later content bump (added_at >
+  // this timestamp) re-shows the highlight for free.
+  playedHighlights: Map<string, number>
   topAlbumsCount: number
   topTracksCount: number
   topArtistsCount: number
@@ -160,7 +166,7 @@ type PlayerStore = {
   setRecentlyAddedDays: (n: number) => void
   setHighlightEnabled: (enabled: boolean) => void
   setHighlightStyle: (style: string) => void
-  dismissHighlight: (album: Album) => void
+  markHighlightPlayed: (album: Album) => void
   setTopAlbumsCount: (n: number) => void
   setTopTracksCount: (n: number) => void
   setTopArtistsCount: (n: number) => void
@@ -365,14 +371,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   highlightEnabled: localStorage.getItem('kamp:highlight-enabled') !== 'false',
   highlightCutoffSecs: Date.now() / 1000 - 5 * 86400,
   highlightStyle: localStorage.getItem('kamp:highlight-style') ?? 'shiny',
-  dismissedHighlightKeys: (() => {
-    try {
-      const saved = localStorage.getItem('kamp:dismissed-highlights')
-      return new Set<string>(saved ? (JSON.parse(saved) as string[]) : [])
-    } catch {
-      return new Set<string>()
-    }
-  })(),
+  playedHighlights: new Map<string, number>(),
   topAlbumsCount: (() => {
     const saved = localStorage.getItem('kamp:top-albums-count')
     return saved ? parseInt(saved) : 10
@@ -657,15 +656,20 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ highlightStyle: style })
   },
 
-  dismissHighlight: (album) => {
+  markHighlightPlayed: (album) => {
+    // KAMP-544: record the moment this album started playing so its new-arrival
+    // sparkle clears immediately (before last_played_at round-trips from the
+    // server). Ephemeral — never persisted. A later sync that adds a track bumps
+    // added_at past this timestamp, which re-shows the highlight.
     const key = album.missing_album
       ? String(album.track_id ?? '')
       : `${album.album_artist}::${album.album}`
-    const next = new Set(get().dismissedHighlightKeys)
-    if (next.has(key)) return
-    next.add(key)
-    localStorage.setItem('kamp:dismissed-highlights', JSON.stringify([...next]))
-    set({ dismissedHighlightKeys: next })
+    const nowSecs = Date.now() / 1000
+    const current = get().playedHighlights
+    if (current.get(key) === nowSecs) return
+    const next = new Map(current)
+    next.set(key, nowSecs)
+    set({ playedHighlights: next })
   },
 
   setTopAlbumsCount: (n) => {

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2839,6 +2839,77 @@ class TestSyncCollectionStream:
 
         index.update_remote_track_date_added.assert_not_called()
 
+    def _run_with_counts(
+        self, tmp_path: Path, item: dict[str, Any], counts: list[int]
+    ) -> MagicMock:
+        """Run a stream sync for one item, stubbing the available-track counts.
+
+        *counts* is [before, after] returned by count_available_remote_tracks
+        (called once before the fetch and once after the upsert).
+        """
+        from kamp_core.library import Track
+        from pathlib import Path as _Path
+
+        fake_track = Track(
+            file_path=_Path("bandcamp://1/1"),
+            title="T",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            release_date="2026",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        mock_session = _make_requests_mock([item])
+        index = MagicMock()
+        index.get_collection_state.return_value = {}
+        index.has_remote_album_tracks.return_value = False  # force the fetch branch
+        index.count_available_remote_tracks.side_effect = counts
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
+            ),
+            patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=[fake_track]),
+        ):
+            sync_collection_stream(config, watch_folder, index)
+        return index
+
+    def test_bumps_new_content_when_available_count_increases(
+        self, tmp_path: Path
+    ) -> None:
+        """An album that gained a streamable track is re-surfaced (KAMP-544)."""
+        index = self._run_with_counts(tmp_path, _item(1), counts=[1, 2])
+        index.bump_album_new_content.assert_called_once()
+        sid, ts = index.bump_album_new_content.call_args[0]
+        assert sid == "1"
+        assert isinstance(ts, float)
+
+    def test_no_bump_when_available_count_unchanged(self, tmp_path: Path) -> None:
+        """A re-sync that adds no new streamable track does not bump (KAMP-544)."""
+        index = self._run_with_counts(tmp_path, _item(1), counts=[2, 2])
+        index.bump_album_new_content.assert_not_called()
+
+    def test_no_bump_on_first_index_when_before_zero(self, tmp_path: Path) -> None:
+        """The first index of an album (0 -> N available) does not bump (KAMP-544).
+
+        A brand-new album is already 'new' by its date_added; only a *subsequent*
+        increase counts as a re-arrival, so the before>0 guard skips this case.
+        """
+        index = self._run_with_counts(tmp_path, _item(1), counts=[0, 3])
+        index.bump_album_new_content.assert_not_called()
+
 
 class TestStreamSyncArtPrefetch:
     """Art prefetch behaviour in sync_collection_stream."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 51
+        assert version == 52
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 51
+        assert version == 52
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 51
+        assert ver == 52
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 51
+        assert ver == 52
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 51
+        assert ver == 52
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 51
+        assert ver == 52
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3218,7 +3218,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3275,7 +3275,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3599,6 +3599,142 @@ class TestAlbumsSort:
         assert [a.album for a in asc_albums] == ["Gamma", "Alpha", "Beta"]
 
 
+class TestPreorderResurface:
+    """last_track_added_at re-surfaces a pre-order that gained a track (KAMP-544)."""
+
+    def _stream_track(
+        self, sid: str, n: int, album: str, *, available: bool = True
+    ) -> Track:
+        return Track(
+            file_path=Path(f"bandcamp://{sid}/{n}"),
+            title=f"T{n}",
+            artist="Preorder Band",
+            album_artist="Preorder Band",
+            album=album,
+            release_date="2026",
+            track_number=n,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            is_available=available,
+        )
+
+    def test_migration_v51_to_v52_adds_and_backfills_column(
+        self, tmp_path: Path
+    ) -> None:
+        """A pre-v52 DB gains last_track_added_at, backfilled from date_added."""
+        db_path = tmp_path / "library.db"
+        # Build a current DB, seed an album with a date_added, then rewind: drop the
+        # new (unconstrained) column and stamp version 51 so open runs the upgrade.
+        idx = LibraryIndex(db_path)
+        idx._conn.execute(
+            "INSERT INTO albums (album_artist, album, date_added)"
+            " VALUES ('A', 'Rec', 1234.0)"
+        )
+        idx._conn.commit()
+        idx.close()
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("ALTER TABLE albums DROP COLUMN last_track_added_at")
+        conn.execute("UPDATE schema_version SET version = 51")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(albums)")}
+        backfilled = index._conn.execute(
+            "SELECT last_track_added_at FROM albums WHERE album = 'Rec'"
+        ).fetchone()[0]
+        index.close()
+
+        assert version == 52
+        assert "last_track_added_at" in cols
+        assert backfilled == 1234.0
+
+    def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._stream_track("777", 1, "PO", available=True),
+                self._stream_track("777", 2, "PO", available=True),
+                self._stream_track("777", 3, "PO", available=False),
+            ]
+        )
+        count = index.count_available_remote_tracks("777")
+        index.close()
+        # Two of three tracks are streamable; the pre-order track is not counted.
+        assert count == 2
+
+    def test_bump_moves_album_to_top_of_date_added(self, tmp_path: Path) -> None:
+        """A bumped album outsorts a newer date_added album on the date_added sort."""
+        index = LibraryIndex(tmp_path / "library.db")
+        # Older album (date_added 1000) that will be bumped; newer album (5000).
+        index.upsert_many([self._stream_track("111", 1, "OldPO")])
+        index.upsert_many(
+            [
+                Track(
+                    file_path=Path("bandcamp://222/1"),
+                    title="N1",
+                    artist="Other",
+                    album_artist="Other",
+                    album="NewAlbum",
+                    release_date="2026",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                    date_added=5000.0,
+                )
+            ]
+        )
+        # Stamp the older album's date_added and link its sale_item_id (the FK to
+        # bandcamp_collection requires the ledger row to exist first).
+        index._conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id) VALUES ('111')"
+        )
+        index._conn.execute(
+            "UPDATE albums SET date_added = 1000.0, sale_item_id = '111'"
+            " WHERE album = 'OldPO'"
+        )
+        index._conn.commit()
+
+        before = index.albums(sort="date_added")
+        assert before[0].album == "NewAlbum"  # 5000 > 1000 before the bump
+
+        index.bump_album_new_content("111", 9000.0)
+        after = index.albums(sort="date_added")
+        index.close()
+        # The bump (9000) beats NewAlbum's date_added (5000).
+        assert after[0].album == "OldPO"
+        assert after[0].added_at == 9000.0
+
+    def test_bump_is_monotonic(self, tmp_path: Path) -> None:
+        """A later bump with an earlier timestamp never lowers last_track_added_at."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._stream_track("333", 1, "PO")])
+        index._conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id) VALUES ('333')"
+        )
+        index._conn.execute("UPDATE albums SET sale_item_id = '333' WHERE album = 'PO'")
+        index._conn.commit()
+
+        index.bump_album_new_content("333", 8000.0)
+        index.bump_album_new_content("333", 2000.0)  # earlier — must be ignored
+        value = index._conn.execute(
+            "SELECT last_track_added_at FROM albums WHERE album = 'PO'"
+        ).fetchone()[0]
+        index.close()
+        assert value == 8000.0
+
+
 class TestRecordPlayed:
     """Tests for LibraryIndex.record_played()."""
 
@@ -3871,7 +4007,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert row is not None
         assert row[0] == 0
 
@@ -4336,7 +4472,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4449,7 +4585,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4633,7 +4769,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4728,7 +4864,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 51
+        assert version == 52
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4736,7 +4872,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 51
+        assert version == 52
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5663,7 +5799,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 51
+        assert version == 52
 
         index.close()
 
@@ -6354,7 +6490,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 51
+        assert version == 52
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6389,7 +6525,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 51
+        assert version == 52
         index.close()
 
 
@@ -6930,7 +7066,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 51
+        assert version == 52
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7063,7 +7199,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 51
+        assert version == 52
 
 
 class TestRemoteTrackSchema:
@@ -7479,7 +7615,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7540,7 +7676,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8362,7 +8498,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8923,7 +9059,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9001,7 +9137,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -9210,7 +9346,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -9450,7 +9586,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9550,7 +9686,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9666,7 +9802,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10171,7 +10307,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -10286,7 +10422,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -10384,7 +10520,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -10484,7 +10620,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -10991,7 +11127,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 51
+        assert version == 52
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -11875,7 +12011,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 51
+        assert version == 52
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -13004,7 +13140,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 51
+        assert version == 52
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -13024,7 +13160,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 51
+        assert version == 52
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -13067,7 +13203,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 51
+        assert version == 52
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -13346,7 +13482,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 51
+        assert ver == 52
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []


### PR DESCRIPTION
## Summary

When a Bandcamp sync picks up a newly-available track for a pre-order album — whether an incremental release or the full pre-order → released graduation — the album now (a) jumps back to the top of the library **date added** sort and (b) re-shows the **new-arrival highlight**, even if one of the previously-released tracks was already played.

Closes KAMP-544.

## Why the shape changed from the estimate (2xLP → LP)

The original plan carried a second schema/localStorage migration and a "re-highlight" redesign to defeat two sticky one-way gates (`last_played_at` and a permanent localStorage dismissal set). Investigation showed the persistent dismissal store's *only* real job is hiding the sparkle the instant you hit play (before `last_played_at` round-trips); across restarts it's fully redundant with `last_played_at`. So it was **eliminated** — the highlight is now fully derived — which dropped the second migration and the dominant unknown.

## Backend

- **Schema v52** — additive nullable `albums.last_track_added_at` (no FK rebuild), backfilled from `date_added`. It records the most recent moment the album gained content and backs the "date added" sort via `COALESCE(last_track_added_at, date_added)`. Written **only** by the migration backfill and `bump_album_new_content` — deliberately *not* recomputed in `_refresh_album_aggregates`, so a future aggregate rebuild can't clobber a bump.
- **`LibraryIndex.count_available_remote_tracks` / `bump_album_new_content`** — the bump is `MAX(existing, ts)`, monotonic.
- **`sync_collection_stream`** — snapshots the album's available-track count before the re-sync and bumps to detection-time when it increases. The `before > 0` guard skips the first-ever index of an album (already "new" by its `date_added`); only a *subsequent* increase is a re-arrival. This single signal (increase in *available* remote tracks) covers new tracks, partial release, and full graduation, and doesn't rely on the flaky `num_streamable_tracks` API counter.

## Frontend

- Highlight logic extracted into a pure `computeIsNew` predicate: shows when `added_at` is within the cutoff **and** newer than both `last_played_at` and the in-session play echo. New content bumps `added_at` past both, re-triggering the highlight for free.
- Removed the persistent `dismissedHighlightKeys` localStorage set; replaced with an **ephemeral, non-persisted** `playedHighlights` map so the sparkle still clears instantly on play. (Orphaned `kamp:dismissed-highlights` localStorage key left untouched — harmless.)
- `date_added` (MIN, purchase/scan) is retained for magic-playlist "recently added" and artist recency — the bump backs only the grid + New Arrivals, as scoped.

## Testing

- **Backend (new):** v51→v52 migration (column added + backfilled, defensive when `date_added` absent), `count_available_remote_tracks`, `bump_album_new_content` monotonicity, date-added sort using the coalesced column, and the sync bump condition (increase → bump; unchanged → no bump; `before==0` → no bump).
- Full suite: **2280 passed, 9 skipped**. black / mypy / UI typecheck / eslint all clean. Coverage 93.41% (above `fail_under`; main is already sub-94% since KAMP-552, and all new code is directly covered).

## Manual Test Plan

_(Visual verification handled by the reviewer.)_
- **New-track re-surface:** a mid-list pre-order that gains a newly-available track jumps to the top of "date added", appears in New Arrivals, and gets the sparkle.
- **Graduation:** a pre-order whose last unavailable track becomes available re-surfaces and re-highlights.
- **Played-then-new:** play an already-released track (highlight clears), then sync in a new track → highlight **reappears** despite the prior play.
- **Instant play echo:** starting playback removes the sparkle immediately and it stays gone after switching albums.
- **No regression:** a normal new album still highlights on arrival, clears on play, and ages out after the cutoff; existing albums unaffected after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)