### PR TITLE
feat(downloads): persistent download-queue model + state machine (KAMP-564)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 52
+_SCHEMA_VERSION = 53
 
 
 class NoStreamableVersionError(Exception):
@@ -388,13 +388,30 @@ CREATE TABLE IF NOT EXISTS bandcamp_collection (
     num_streamable_tracks INTEGER NOT NULL DEFAULT 0
 );
 
--- Serialized album download queue (KAMP-408).
--- UNIQUE on sale_item_id prevents double-enqueue; INSERT OR IGNORE is idempotent.
--- queued_at is a Unix timestamp used for FIFO replay order on restart.
+-- Serialized album download queue (KAMP-408; extended into a state machine by
+-- KAMP-564). UNIQUE on sale_item_id prevents double-enqueue; INSERT OR IGNORE is
+-- idempotent. queued_at is a Unix timestamp used for FIFO replay order on restart.
+--
+-- KAMP-564 state machine: status is one of 'queued' | 'downloading' | 'failed'.
+-- A completed download is DELETEd (there is no 'done' row state), matching the
+-- Downloads-view sections (Now Downloading / Queued / Failed). position orders
+-- items within the queued section and is reorderable. size_bytes is nullable per
+-- the KAMP-563 spike (exact Content-Length at download time, or an approximate
+-- pre-download estimate when size_is_estimate=1). album_name/album_artist/
+-- artwork_ref are a denormalized snapshot for the card so it renders without a
+-- join to bandcamp_collection.
 CREATE TABLE IF NOT EXISTS download_queue (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    sale_item_id TEXT    NOT NULL UNIQUE,
-    queued_at    REAL    NOT NULL DEFAULT (unixepoch())
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    sale_item_id     TEXT    NOT NULL UNIQUE,
+    queued_at        REAL    NOT NULL DEFAULT (unixepoch()),
+    status           TEXT    NOT NULL DEFAULT 'queued',
+    position         INTEGER NOT NULL DEFAULT 0,
+    size_bytes       INTEGER,
+    size_is_estimate INTEGER NOT NULL DEFAULT 1,
+    error_text       TEXT,
+    album_name       TEXT,
+    album_artist     TEXT,
+    artwork_ref      TEXT
 );
 
 -- Download → pipeline provenance handoff (KAMP-523). When the Bandcamp
@@ -2204,7 +2221,49 @@ class LibraryIndex:
                     )
             self._conn.execute("UPDATE schema_version SET version = 52")
             self._conn.commit()
-            version = 52  # noqa: F841
+            version = 52
+
+        if version == 52:
+            # v52 -> v53 (KAMP-564): grow the KAMP-408 download_queue into a
+            # persistent state machine for the Downloads view. Purely additive
+            # nullable/defaulted columns — no FK rebuild. Each ADD COLUMN is guarded
+            # by a presence check so a partial/retried migration is idempotent.
+            # Existing queued rows are all 'queued'; backfill position from the old
+            # FIFO order (queued_at, then id) so replay order is preserved.
+            dq_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(download_queue)")
+            }
+            _additions = [
+                ("status", "TEXT NOT NULL DEFAULT 'queued'"),
+                ("position", "INTEGER NOT NULL DEFAULT 0"),
+                ("size_bytes", "INTEGER"),
+                ("size_is_estimate", "INTEGER NOT NULL DEFAULT 1"),
+                ("error_text", "TEXT"),
+                ("album_name", "TEXT"),
+                ("album_artist", "TEXT"),
+                ("artwork_ref", "TEXT"),
+            ]
+            for col, decl in _additions:
+                if col not in dq_cols:
+                    self._conn.execute(
+                        f"ALTER TABLE download_queue ADD COLUMN {col} {decl}"
+                    )
+            if "position" not in dq_cols:
+                # Backfill position to match the pre-v53 FIFO order. Done in Python
+                # (rather than UPDATE ... FROM / ROW_NUMBER, which need newer SQLite)
+                # to stay portable across the SQLite versions users may ship. 1-based;
+                # new/retried items later append at MAX(position)+1.
+                old_rows = self._conn.execute(
+                    "SELECT id FROM download_queue ORDER BY queued_at ASC, id ASC"
+                ).fetchall()
+                for pos, row in enumerate(old_rows, start=1):
+                    self._conn.execute(
+                        "UPDATE download_queue SET position = ? WHERE id = ?",
+                        (pos, row[0]),
+                    )
+            self._conn.execute("UPDATE schema_version SET version = 53")
+            self._conn.commit()
+            version = 53  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -5095,23 +5154,63 @@ class LibraryIndex:
         return len(stale)
 
     # ------------------------------------------------------------------
-    # Download queue (KAMP-408)
+    # Download queue (KAMP-408; state machine KAMP-564)
+    #
+    # A queue row is one of three states: 'queued' | 'downloading' | 'failed'.
+    # A completed download is DELETEd (no 'done' state) — the Downloads view has
+    # only Now Downloading / Queued / Failed sections. `position` orders items
+    # within the queued section and is reorderable; the downloading item is fixed
+    # at the top. See the download_queue DDL for column semantics.
     # ------------------------------------------------------------------
 
-    def enqueue_download(self, sale_item_id: str) -> None:
-        """Add *sale_item_id* to the persistent download queue.
+    _DOWNLOAD_STATES = ("queued", "downloading", "failed")
 
-        INSERT OR IGNORE makes this idempotent — re-enqueuing an already-queued
-        item is a no-op so double-clicks don't produce duplicate work.
+    def _next_download_position(self) -> int:
+        """Return MAX(position)+1 so a new/retried item lands at the end."""
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(position), 0) + 1 AS next FROM download_queue"
+        ).fetchone()
+        return int(row["next"])
+
+    def enqueue_download(
+        self,
+        sale_item_id: str,
+        *,
+        album_name: str | None = None,
+        album_artist: str | None = None,
+        artwork_ref: str | None = None,
+        size_bytes: int | None = None,
+        size_is_estimate: bool = True,
+    ) -> None:
+        """Add *sale_item_id* to the persistent download queue as 'queued'.
+
+        INSERT OR IGNORE makes this idempotent — re-enqueuing an already-present
+        item is a no-op (regardless of its current state) so double-clicks don't
+        produce duplicate work. The optional album snapshot / size are stored on
+        the row so the UI card renders without a join; callers that only have an
+        id (the KAMP-408 single-album path) may omit them.
         """
         self._conn.execute(
-            "INSERT OR IGNORE INTO download_queue (sale_item_id) VALUES (?)",
-            (sale_item_id,),
+            """
+            INSERT OR IGNORE INTO download_queue
+                (sale_item_id, status, position,
+                 album_name, album_artist, artwork_ref, size_bytes, size_is_estimate)
+            VALUES (?, 'queued', ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sale_item_id,
+                self._next_download_position(),
+                album_name,
+                album_artist,
+                artwork_ref,
+                size_bytes,
+                1 if size_is_estimate else 0,
+            ),
         )
         self._conn.commit()
 
     def dequeue_download(self, sale_item_id: str) -> None:
-        """Remove *sale_item_id* from the persistent download queue after completion."""
+        """Remove *sale_item_id* from the queue (e.g. after a completed download)."""
         self._conn.execute(
             "DELETE FROM download_queue WHERE sale_item_id = ?", (sale_item_id,)
         )
@@ -5121,11 +5220,149 @@ class LibraryIndex:
         """Return all queued sale_item_ids in FIFO order (oldest first).
 
         Used on daemon restart to replay any downloads that survived a shutdown.
+        Preserved verbatim for the KAMP-408 single-album worker; returns every
+        row regardless of state, ordered by the original queued_at/id FIFO.
         """
         rows = self._conn.execute(
             "SELECT sale_item_id FROM download_queue ORDER BY queued_at ASC, id ASC"
         ).fetchall()
         return [r["sale_item_id"] for r in rows]
+
+    def next_queued_download(self) -> str | None:
+        """Return the next item to download: the lowest-position 'queued' row.
+
+        The dequeue-next-in-order pick for the processing loop. Returns None when
+        no item is currently queued (an in-flight 'downloading' item is skipped).
+        """
+        row = self._conn.execute("""
+            SELECT sale_item_id FROM download_queue
+             WHERE status = 'queued'
+             ORDER BY position ASC, id ASC
+             LIMIT 1
+            """).fetchone()
+        return None if row is None else str(row["sale_item_id"])
+
+    def mark_downloading(self, sale_item_id: str) -> None:
+        """Transition *sale_item_id* to 'downloading' and clear any prior error."""
+        self._conn.execute(
+            "UPDATE download_queue SET status = 'downloading', error_text = NULL "
+            "WHERE sale_item_id = ?",
+            (sale_item_id,),
+        )
+        self._conn.commit()
+
+    def mark_download_failed(self, sale_item_id: str, error_text: str) -> None:
+        """Transition *sale_item_id* to 'failed', recording *error_text* for the card."""
+        self._conn.execute(
+            "UPDATE download_queue SET status = 'failed', error_text = ? "
+            "WHERE sale_item_id = ?",
+            (error_text, sale_item_id),
+        )
+        self._conn.commit()
+
+    def mark_download_done(self, sale_item_id: str) -> None:
+        """Complete *sale_item_id*: remove it from the queue (done has no row state)."""
+        self.dequeue_download(sale_item_id)
+
+    def retry_download(self, sale_item_id: str) -> None:
+        """Re-queue a failed item at the END of the queue, clearing its error.
+
+        No-op if the id is not present. Retry-to-end matches the epic: a retried
+        item goes behind everything currently queued.
+        """
+        self._conn.execute(
+            "UPDATE download_queue "
+            "SET status = 'queued', error_text = NULL, position = ? "
+            "WHERE sale_item_id = ?",
+            (self._next_download_position(), sale_item_id),
+        )
+        self._conn.commit()
+
+    def cancel_download(self, sale_item_id: str) -> None:
+        """Cancel/remove *sale_item_id* from the queue (Queued or Failed card X).
+
+        Named to avoid colliding with :meth:`remove_download`, which reverts an
+        already-downloaded album back to streaming — a different operation.
+        """
+        self.dequeue_download(sale_item_id)
+
+    def set_download_size(
+        self, sale_item_id: str, size_bytes: int | None, *, is_estimate: bool = True
+    ) -> None:
+        """Set the file size for *sale_item_id*.
+
+        Per the KAMP-563 spike: an approximate pre-download value (is_estimate=True,
+        from the download page's size_mb) is overwritten by the exact Content-Length
+        (is_estimate=False) once the download starts.
+        """
+        self._conn.execute(
+            "UPDATE download_queue SET size_bytes = ?, size_is_estimate = ? "
+            "WHERE sale_item_id = ?",
+            (size_bytes, 1 if is_estimate else 0, sale_item_id),
+        )
+        self._conn.commit()
+
+    def reorder_download_queue(self, ordered_sale_item_ids: list[str]) -> None:
+        """Reassign queued-item positions to the given order.
+
+        *ordered_sale_item_ids* must be exactly the current set of 'queued' items
+        (a permutation) — the currently-'downloading' item is fixed at the top and
+        is never part of the ordering. Raises ValueError on any mismatch so a stale
+        UI reorder is rejected rather than silently corrupting order.
+        """
+        current = [
+            str(r["sale_item_id"])
+            for r in self._conn.execute(
+                "SELECT sale_item_id FROM download_queue WHERE status = 'queued'"
+            ).fetchall()
+        ]
+        if sorted(ordered_sale_item_ids) != sorted(current):
+            raise ValueError(
+                "reorder_download_queue requires exactly the current queued items; "
+                f"got {ordered_sale_item_ids!r}, queued={current!r}"
+            )
+        for pos, sid in enumerate(ordered_sale_item_ids, start=1):
+            self._conn.execute(
+                "UPDATE download_queue SET position = ? WHERE sale_item_id = ?",
+                (pos, sid),
+            )
+        self._conn.commit()
+
+    def download_queue_items(self) -> list[dict[str, Any]]:
+        """Return every queue row as a dict, in display order for the Downloads view.
+
+        Ordered downloading → queued (by position) → failed, so the caller can slice
+        into the three UI sections. Each dict carries all columns (status, position,
+        size_bytes, size_is_estimate, error_text, album snapshot, …).
+        """
+        rows = self._conn.execute("""
+            SELECT sale_item_id, queued_at, status, position,
+                   size_bytes, size_is_estimate, error_text,
+                   album_name, album_artist, artwork_ref
+              FROM download_queue
+             ORDER BY CASE status
+                        WHEN 'downloading' THEN 0
+                        WHEN 'queued'      THEN 1
+                        WHEN 'failed'      THEN 2
+                        ELSE 3
+                      END,
+                      position ASC, queued_at ASC, id ASC
+            """).fetchall()
+        return [
+            {
+                "sale_item_id": r["sale_item_id"],
+                "queued_at": r["queued_at"],
+                "status": r["status"],
+                "position": r["position"],
+                "size_bytes": r["size_bytes"],
+                "size_is_estimate": bool(r["size_is_estimate"]),
+                "error_text": r["error_text"],
+                "album_name": r["album_name"],
+                "album_artist": r["album_artist"],
+                "artwork_ref": r["artwork_ref"],
+            }
+            for r in rows
+        ]
 
     def update_track_after_album_drain(
         self,

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -388,9 +388,13 @@ CREATE TABLE IF NOT EXISTS bandcamp_collection (
     num_streamable_tracks INTEGER NOT NULL DEFAULT 0
 );
 
--- Serialized album download queue (KAMP-408; extended into a state machine by
--- KAMP-564). UNIQUE on sale_item_id prevents double-enqueue; INSERT OR IGNORE is
--- idempotent. queued_at is a Unix timestamp used for FIFO replay order on restart.
+-- Serialized album download queue (KAMP-408; extended into a platform-neutral
+-- state machine by KAMP-564). Identity is (provider, provider_item_id) — the same
+-- generalization track_sources uses — so downloads are not tied to Bandcamp even
+-- though it is the only provider today (provider defaults to 'bandcamp';
+-- provider_item_id is the old sale_item_id). UNIQUE(provider, provider_item_id)
+-- prevents double-enqueue; INSERT OR IGNORE is idempotent. queued_at is a Unix
+-- timestamp used for FIFO replay order on restart.
 --
 -- KAMP-564 state machine: status is one of 'queued' | 'downloading' | 'failed'.
 -- A completed download is DELETEd (there is no 'done' row state), matching the
@@ -399,10 +403,11 @@ CREATE TABLE IF NOT EXISTS bandcamp_collection (
 -- the KAMP-563 spike (exact Content-Length at download time, or an approximate
 -- pre-download estimate when size_is_estimate=1). album_name/album_artist/
 -- artwork_ref are a denormalized snapshot for the card so it renders without a
--- join to bandcamp_collection.
+-- join to the provider's collection table.
 CREATE TABLE IF NOT EXISTS download_queue (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
-    sale_item_id     TEXT    NOT NULL UNIQUE,
+    provider         TEXT    NOT NULL DEFAULT 'bandcamp',
+    provider_item_id TEXT    NOT NULL,
     queued_at        REAL    NOT NULL DEFAULT (unixepoch()),
     status           TEXT    NOT NULL DEFAULT 'queued',
     position         INTEGER NOT NULL DEFAULT 0,
@@ -411,7 +416,8 @@ CREATE TABLE IF NOT EXISTS download_queue (
     error_text       TEXT,
     album_name       TEXT,
     album_artist     TEXT,
-    artwork_ref      TEXT
+    artwork_ref      TEXT,
+    UNIQUE (provider, provider_item_id)
 );
 
 -- Download → pipeline provenance handoff (KAMP-523). When the Bandcamp
@@ -2225,42 +2231,55 @@ class LibraryIndex:
 
         if version == 52:
             # v52 -> v53 (KAMP-564): grow the KAMP-408 download_queue into a
-            # persistent state machine for the Downloads view. Purely additive
-            # nullable/defaulted columns — no FK rebuild. Each ADD COLUMN is guarded
-            # by a presence check so a partial/retried migration is idempotent.
-            # Existing queued rows are all 'queued'; backfill position from the old
-            # FIFO order (queued_at, then id) so replay order is preserved.
-            dq_cols = {
+            # persistent, platform-neutral state machine for the Downloads view.
+            # Rebuild rather than ALTER: the old table keyed on the Bandcamp-specific
+            # `sale_item_id`, but downloads are a general capability (other services
+            # may follow), so identity becomes (provider, provider_item_id) — the
+            # same generalization track_sources already uses. download_queue has no
+            # foreign keys and nothing references it, so a plain create/copy/drop/
+            # rename inside the migration transaction is safe (no FK-off dance).
+            old_cols = {
                 r[1] for r in self._conn.execute("PRAGMA table_info(download_queue)")
             }
-            _additions = [
-                ("status", "TEXT NOT NULL DEFAULT 'queued'"),
-                ("position", "INTEGER NOT NULL DEFAULT 0"),
-                ("size_bytes", "INTEGER"),
-                ("size_is_estimate", "INTEGER NOT NULL DEFAULT 1"),
-                ("error_text", "TEXT"),
-                ("album_name", "TEXT"),
-                ("album_artist", "TEXT"),
-                ("artwork_ref", "TEXT"),
-            ]
-            for col, decl in _additions:
-                if col not in dq_cols:
-                    self._conn.execute(
-                        f"ALTER TABLE download_queue ADD COLUMN {col} {decl}"
+            if "provider_item_id" not in old_cols:
+                self._conn.execute("DROP TABLE IF EXISTS download_queue_v53")
+                self._conn.execute("""
+                    CREATE TABLE download_queue_v53 (
+                        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                        provider         TEXT    NOT NULL DEFAULT 'bandcamp',
+                        provider_item_id TEXT    NOT NULL,
+                        queued_at        REAL    NOT NULL DEFAULT (unixepoch()),
+                        status           TEXT    NOT NULL DEFAULT 'queued',
+                        position         INTEGER NOT NULL DEFAULT 0,
+                        size_bytes       INTEGER,
+                        size_is_estimate INTEGER NOT NULL DEFAULT 1,
+                        error_text       TEXT,
+                        album_name       TEXT,
+                        album_artist     TEXT,
+                        artwork_ref      TEXT,
+                        UNIQUE (provider, provider_item_id)
                     )
-            if "position" not in dq_cols:
-                # Backfill position to match the pre-v53 FIFO order. Done in Python
-                # (rather than UPDATE ... FROM / ROW_NUMBER, which need newer SQLite)
-                # to stay portable across the SQLite versions users may ship. 1-based;
-                # new/retried items later append at MAX(position)+1.
+                    """)
+                # Copy existing rows: every pre-v53 item is a Bandcamp sale_item_id,
+                # so provider='bandcamp' and provider_item_id=sale_item_id. Backfill
+                # position from the old FIFO order (queued_at, then id) so replay
+                # order is preserved; status defaults to 'queued'. Done in Python
+                # (not ROW_NUMBER) to stay portable across shipped SQLite versions.
                 old_rows = self._conn.execute(
-                    "SELECT id FROM download_queue ORDER BY queued_at ASC, id ASC"
+                    "SELECT id, sale_item_id, queued_at FROM download_queue "
+                    "ORDER BY queued_at ASC, id ASC"
                 ).fetchall()
                 for pos, row in enumerate(old_rows, start=1):
                     self._conn.execute(
-                        "UPDATE download_queue SET position = ? WHERE id = ?",
-                        (pos, row[0]),
+                        "INSERT INTO download_queue_v53 "
+                        "(id, provider, provider_item_id, queued_at, position) "
+                        "VALUES (?, 'bandcamp', ?, ?, ?)",
+                        (row[0], row[1], row[2], pos),
                     )
+                self._conn.execute("DROP TABLE download_queue")
+                self._conn.execute(
+                    "ALTER TABLE download_queue_v53 RENAME TO download_queue"
+                )
             self._conn.execute("UPDATE schema_version SET version = 53")
             self._conn.commit()
             version = 53  # noqa: F841
@@ -5174,31 +5193,34 @@ class LibraryIndex:
 
     def enqueue_download(
         self,
-        sale_item_id: str,
+        provider_item_id: str,
         *,
+        provider: str = "bandcamp",
         album_name: str | None = None,
         album_artist: str | None = None,
         artwork_ref: str | None = None,
         size_bytes: int | None = None,
         size_is_estimate: bool = True,
     ) -> None:
-        """Add *sale_item_id* to the persistent download queue as 'queued'.
+        """Add (*provider*, *provider_item_id*) to the download queue as 'queued'.
 
-        INSERT OR IGNORE makes this idempotent — re-enqueuing an already-present
-        item is a no-op (regardless of its current state) so double-clicks don't
-        produce duplicate work. The optional album snapshot / size are stored on
-        the row so the UI card renders without a join; callers that only have an
-        id (the KAMP-408 single-album path) may omit them.
+        *provider_item_id* is the service's opaque item id (a Bandcamp sale_item_id
+        today); *provider* defaults to 'bandcamp'. INSERT OR IGNORE makes this
+        idempotent — re-enqueuing an already-present item is a no-op (regardless of
+        its current state) so double-clicks don't produce duplicate work. The
+        optional album snapshot / size are stored on the row so the UI card renders
+        without a join; callers that only have an id may omit them.
         """
         self._conn.execute(
             """
             INSERT OR IGNORE INTO download_queue
-                (sale_item_id, status, position,
+                (provider, provider_item_id, status, position,
                  album_name, album_artist, artwork_ref, size_bytes, size_is_estimate)
-            VALUES (?, 'queued', ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, ?)
             """,
             (
-                sale_item_id,
+                provider,
+                provider_item_id,
                 self._next_download_position(),
                 album_name,
                 album_artist,
@@ -5209,62 +5231,78 @@ class LibraryIndex:
         )
         self._conn.commit()
 
-    def dequeue_download(self, sale_item_id: str) -> None:
-        """Remove *sale_item_id* from the queue (e.g. after a completed download)."""
+    def dequeue_download(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Remove an item from the queue (e.g. after a completed download)."""
         self._conn.execute(
-            "DELETE FROM download_queue WHERE sale_item_id = ?", (sale_item_id,)
+            "DELETE FROM download_queue " "WHERE provider = ? AND provider_item_id = ?",
+            (provider, provider_item_id),
         )
         self._conn.commit()
 
-    def pending_downloads(self) -> list[str]:
-        """Return all queued sale_item_ids in FIFO order (oldest first).
+    def pending_downloads(self, *, provider: str = "bandcamp") -> list[str]:
+        """Return all queued provider_item_ids in FIFO order (oldest first).
 
         Used on daemon restart to replay any downloads that survived a shutdown.
-        Preserved verbatim for the KAMP-408 single-album worker; returns every
-        row regardless of state, ordered by the original queued_at/id FIFO.
+        Preserved for the KAMP-408 single-album worker; returns every row for
+        *provider* regardless of state, ordered by the original queued_at/id FIFO.
         """
         rows = self._conn.execute(
-            "SELECT sale_item_id FROM download_queue ORDER BY queued_at ASC, id ASC"
+            "SELECT provider_item_id FROM download_queue "
+            "WHERE provider = ? ORDER BY queued_at ASC, id ASC",
+            (provider,),
         ).fetchall()
-        return [r["sale_item_id"] for r in rows]
+        return [r["provider_item_id"] for r in rows]
 
-    def next_queued_download(self) -> str | None:
+    def next_queued_download(self, *, provider: str = "bandcamp") -> str | None:
         """Return the next item to download: the lowest-position 'queued' row.
 
         The dequeue-next-in-order pick for the processing loop. Returns None when
         no item is currently queued (an in-flight 'downloading' item is skipped).
         """
-        row = self._conn.execute("""
-            SELECT sale_item_id FROM download_queue
-             WHERE status = 'queued'
+        row = self._conn.execute(
+            """
+            SELECT provider_item_id FROM download_queue
+             WHERE provider = ? AND status = 'queued'
              ORDER BY position ASC, id ASC
              LIMIT 1
-            """).fetchone()
-        return None if row is None else str(row["sale_item_id"])
+            """,
+            (provider,),
+        ).fetchone()
+        return None if row is None else str(row["provider_item_id"])
 
-    def mark_downloading(self, sale_item_id: str) -> None:
-        """Transition *sale_item_id* to 'downloading' and clear any prior error."""
+    def mark_downloading(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Transition an item to 'downloading' and clear any prior error."""
         self._conn.execute(
             "UPDATE download_queue SET status = 'downloading', error_text = NULL "
-            "WHERE sale_item_id = ?",
-            (sale_item_id,),
+            "WHERE provider = ? AND provider_item_id = ?",
+            (provider, provider_item_id),
         )
         self._conn.commit()
 
-    def mark_download_failed(self, sale_item_id: str, error_text: str) -> None:
-        """Transition *sale_item_id* to 'failed', recording *error_text* for the card."""
+    def mark_download_failed(
+        self, provider_item_id: str, error_text: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Transition an item to 'failed', recording *error_text* for the card."""
         self._conn.execute(
             "UPDATE download_queue SET status = 'failed', error_text = ? "
-            "WHERE sale_item_id = ?",
-            (error_text, sale_item_id),
+            "WHERE provider = ? AND provider_item_id = ?",
+            (error_text, provider, provider_item_id),
         )
         self._conn.commit()
 
-    def mark_download_done(self, sale_item_id: str) -> None:
-        """Complete *sale_item_id*: remove it from the queue (done has no row state)."""
-        self.dequeue_download(sale_item_id)
+    def mark_download_done(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Complete an item: remove it from the queue (done has no row state)."""
+        self.dequeue_download(provider_item_id, provider=provider)
 
-    def retry_download(self, sale_item_id: str) -> None:
+    def retry_download(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> None:
         """Re-queue a failed item at the END of the queue, clearing its error.
 
         No-op if the id is not present. Retry-to-end matches the epic: a retried
@@ -5273,23 +5311,30 @@ class LibraryIndex:
         self._conn.execute(
             "UPDATE download_queue "
             "SET status = 'queued', error_text = NULL, position = ? "
-            "WHERE sale_item_id = ?",
-            (self._next_download_position(), sale_item_id),
+            "WHERE provider = ? AND provider_item_id = ?",
+            (self._next_download_position(), provider, provider_item_id),
         )
         self._conn.commit()
 
-    def cancel_download(self, sale_item_id: str) -> None:
-        """Cancel/remove *sale_item_id* from the queue (Queued or Failed card X).
+    def cancel_download(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Cancel/remove an item from the queue (Queued or Failed card X).
 
         Named to avoid colliding with :meth:`remove_download`, which reverts an
         already-downloaded album back to streaming — a different operation.
         """
-        self.dequeue_download(sale_item_id)
+        self.dequeue_download(provider_item_id, provider=provider)
 
     def set_download_size(
-        self, sale_item_id: str, size_bytes: int | None, *, is_estimate: bool = True
+        self,
+        provider_item_id: str,
+        size_bytes: int | None,
+        *,
+        provider: str = "bandcamp",
+        is_estimate: bool = True,
     ) -> None:
-        """Set the file size for *sale_item_id*.
+        """Set the file size for an item.
 
         Per the KAMP-563 spike: an approximate pre-download value (is_estimate=True,
         from the download page's size_mb) is overwritten by the exact Content-Length
@@ -5297,34 +5342,40 @@ class LibraryIndex:
         """
         self._conn.execute(
             "UPDATE download_queue SET size_bytes = ?, size_is_estimate = ? "
-            "WHERE sale_item_id = ?",
-            (size_bytes, 1 if is_estimate else 0, sale_item_id),
+            "WHERE provider = ? AND provider_item_id = ?",
+            (size_bytes, 1 if is_estimate else 0, provider, provider_item_id),
         )
         self._conn.commit()
 
-    def reorder_download_queue(self, ordered_sale_item_ids: list[str]) -> None:
-        """Reassign queued-item positions to the given order.
+    def reorder_download_queue(
+        self, ordered_provider_item_ids: list[str], *, provider: str = "bandcamp"
+    ) -> None:
+        """Reassign queued-item positions for *provider* to the given order.
 
-        *ordered_sale_item_ids* must be exactly the current set of 'queued' items
-        (a permutation) — the currently-'downloading' item is fixed at the top and
-        is never part of the ordering. Raises ValueError on any mismatch so a stale
-        UI reorder is rejected rather than silently corrupting order.
+        *ordered_provider_item_ids* must be exactly the current set of 'queued'
+        items for *provider* (a permutation) — the currently-'downloading' item is
+        fixed at the top and is never part of the ordering. Raises ValueError on any
+        mismatch so a stale UI reorder is rejected rather than silently corrupting
+        order.
         """
         current = [
-            str(r["sale_item_id"])
+            str(r["provider_item_id"])
             for r in self._conn.execute(
-                "SELECT sale_item_id FROM download_queue WHERE status = 'queued'"
+                "SELECT provider_item_id FROM download_queue "
+                "WHERE provider = ? AND status = 'queued'",
+                (provider,),
             ).fetchall()
         ]
-        if sorted(ordered_sale_item_ids) != sorted(current):
+        if sorted(ordered_provider_item_ids) != sorted(current):
             raise ValueError(
                 "reorder_download_queue requires exactly the current queued items; "
-                f"got {ordered_sale_item_ids!r}, queued={current!r}"
+                f"got {ordered_provider_item_ids!r}, queued={current!r}"
             )
-        for pos, sid in enumerate(ordered_sale_item_ids, start=1):
+        for pos, pid in enumerate(ordered_provider_item_ids, start=1):
             self._conn.execute(
-                "UPDATE download_queue SET position = ? WHERE sale_item_id = ?",
-                (pos, sid),
+                "UPDATE download_queue SET position = ? "
+                "WHERE provider = ? AND provider_item_id = ?",
+                (pos, provider, pid),
             )
         self._conn.commit()
 
@@ -5332,11 +5383,11 @@ class LibraryIndex:
         """Return every queue row as a dict, in display order for the Downloads view.
 
         Ordered downloading → queued (by position) → failed, so the caller can slice
-        into the three UI sections. Each dict carries all columns (status, position,
-        size_bytes, size_is_estimate, error_text, album snapshot, …).
+        into the three UI sections. Each dict carries all columns (provider,
+        provider_item_id, status, position, size, error, album snapshot, …).
         """
         rows = self._conn.execute("""
-            SELECT sale_item_id, queued_at, status, position,
+            SELECT provider, provider_item_id, queued_at, status, position,
                    size_bytes, size_is_estimate, error_text,
                    album_name, album_artist, artwork_ref
               FROM download_queue
@@ -5350,7 +5401,8 @@ class LibraryIndex:
             """).fetchall()
         return [
             {
-                "sale_item_id": r["sale_item_id"],
+                "provider": r["provider"],
+                "provider_item_id": r["provider_item_id"],
                 "queued_at": r["queued_at"],
                 "status": r["status"],
                 "position": r["position"],

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 52
+        assert version == 53
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 52
+        assert version == 53
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 52
+        assert ver == 53
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 52
+        assert ver == 53
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 52
+        assert ver == 53
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 52
+        assert ver == 53
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3218,7 +3218,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3275,7 +3275,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3652,9 +3652,68 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
+
+    def test_migration_v52_to_v53_extends_download_queue(self, tmp_path: Path) -> None:
+        """A pre-v53 DB gains the queue state-machine columns; position backfills
+        from the old FIFO order and existing rows survive (KAMP-564)."""
+        db_path = tmp_path / "library.db"
+        # Build a current DB, seed two queued rows with distinct queued_at, then
+        # rewind: drop the v53 columns and stamp version 52 so open runs the upgrade.
+        idx = LibraryIndex(db_path)
+        idx.enqueue_download("first")
+        import time
+
+        time.sleep(0.01)  # distinct queued_at so the FIFO backfill order is defined
+        idx.enqueue_download("second")
+        idx._conn.commit()
+        idx.close()
+        conn = sqlite3.connect(str(db_path))
+        for col in (
+            "status",
+            "position",
+            "size_bytes",
+            "size_is_estimate",
+            "error_text",
+            "album_name",
+            "album_artist",
+            "artwork_ref",
+        ):
+            conn.execute(f"ALTER TABLE download_queue DROP COLUMN {col}")
+        conn.execute("UPDATE schema_version SET version = 52")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
+        rows = index._conn.execute(
+            "SELECT sale_item_id, status, position FROM download_queue"
+            " ORDER BY position ASC"
+        ).fetchall()
+        index.close()
+
+        assert version == 53
+        assert {
+            "status",
+            "position",
+            "size_bytes",
+            "size_is_estimate",
+            "error_text",
+            "album_name",
+            "album_artist",
+            "artwork_ref",
+        } <= cols
+        # Existing rows survived, defaulted to 'queued', with position backfilled
+        # 1,2 to match the pre-v53 FIFO (queued_at) order.
+        assert [(r["sale_item_id"], r["status"], r["position"]) for r in rows] == [
+            ("first", "queued", 1),
+            ("second", "queued", 2),
+        ]
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -4007,7 +4066,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert row is not None
         assert row[0] == 0
 
@@ -4472,7 +4531,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4585,7 +4644,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4769,7 +4828,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4864,7 +4923,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 52
+        assert version == 53
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4872,7 +4931,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 52
+        assert version == 53
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5799,7 +5858,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 52
+        assert version == 53
 
         index.close()
 
@@ -6490,7 +6549,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 52
+        assert version == 53
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6525,7 +6584,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 52
+        assert version == 53
         index.close()
 
 
@@ -7066,7 +7125,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 52
+        assert version == 53
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7199,7 +7258,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 52
+        assert version == 53
 
 
 class TestRemoteTrackSchema:
@@ -7615,7 +7674,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7676,7 +7735,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8498,7 +8557,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8555,6 +8614,240 @@ class TestDownloadQueue:
         index.dequeue_download("nonexistent")  # must not raise
         assert index.pending_downloads() == []
         index.close()
+
+
+class TestDownloadQueueStateMachine:
+    """Persistent download-queue state machine: status transitions, ordering,
+    reorder, retry-to-end, cancel, size, and restart persistence (KAMP-564)."""
+
+    def _states(self, index: "LibraryIndex") -> "list[tuple[str, str]]":
+        """Return (sale_item_id, status) for every queue row in display order."""
+        return [(r["sale_item_id"], r["status"]) for r in index.download_queue_items()]
+
+    def test_enqueue_defaults_to_queued(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("111")
+        items = index.download_queue_items()
+        assert len(items) == 1
+        assert items[0]["status"] == "queued"
+        assert items[0]["position"] == 1
+        index.close()
+
+    def test_enqueue_stores_album_snapshot_and_size(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download(
+            "111",
+            album_name="Miss Colombia",
+            album_artist="Lido Pimienta",
+            artwork_ref="a0471946789",
+            size_bytes=81_200_000,
+            size_is_estimate=True,
+        )
+        item = index.download_queue_items()[0]
+        assert item["album_name"] == "Miss Colombia"
+        assert item["album_artist"] == "Lido Pimienta"
+        assert item["artwork_ref"] == "a0471946789"
+        assert item["size_bytes"] == 81_200_000
+        assert item["size_is_estimate"] is True
+        index.close()
+
+    def test_enqueue_appends_at_end(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        positions = [i["position"] for i in index.download_queue_items()]
+        assert positions == [1, 2, 3]
+        index.close()
+
+    def test_next_queued_download_is_lowest_position(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        assert index.next_queued_download() == "a"
+        index.close()
+
+    def test_next_queued_download_skips_downloading(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.enqueue_download("b")
+        index.mark_downloading("a")  # a is in-flight, not "queued"
+        assert index.next_queued_download() == "b"
+        index.close()
+
+    def test_next_queued_download_none_when_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.next_queued_download() is None
+        index.enqueue_download("a")
+        index.mark_downloading("a")
+        assert index.next_queued_download() is None  # only in-flight item remains
+        index.close()
+
+    def test_mark_downloading_sorts_to_top(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_downloading("b")
+        # downloading first, then queued by position (a before c)
+        assert self._states(index) == [
+            ("b", "downloading"),
+            ("a", "queued"),
+            ("c", "queued"),
+        ]
+        index.close()
+
+    def test_mark_download_failed_records_error(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.mark_download_failed("a", "HTTP 429 too many requests")
+        item = index.download_queue_items()[0]
+        assert item["status"] == "failed"
+        assert item["error_text"] == "HTTP 429 too many requests"
+        index.close()
+
+    def test_mark_downloading_clears_prior_error(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.mark_download_failed("a", "boom")
+        index.mark_downloading("a")
+        item = index.download_queue_items()[0]
+        assert item["status"] == "downloading"
+        assert item["error_text"] is None
+        index.close()
+
+    def test_mark_download_done_removes_row(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.enqueue_download("b")
+        index.mark_download_done("a")
+        assert self._states(index) == [("b", "queued")]
+        index.close()
+
+    def test_failed_items_sort_last(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_downloading("a")
+        index.mark_download_failed("b", "boom")
+        assert self._states(index) == [
+            ("a", "downloading"),
+            ("c", "queued"),
+            ("b", "failed"),
+        ]
+        index.close()
+
+    def test_retry_requeues_at_end(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_download_failed("a", "boom")
+        index.retry_download("a")
+        # a returns to 'queued' but behind b and c (retry-to-end), error cleared
+        assert self._states(index) == [
+            ("b", "queued"),
+            ("c", "queued"),
+            ("a", "queued"),
+        ]
+        assert index.download_queue_items()[-1]["error_text"] is None
+        assert index.next_queued_download() == "b"
+        index.close()
+
+    def test_retry_nonexistent_is_noop(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.retry_download("nope")  # must not raise
+        assert index.download_queue_items() == []
+        index.close()
+
+    def test_cancel_removes_item(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.enqueue_download("b")
+        index.mark_download_failed("b", "boom")
+        index.cancel_download("a")  # cancel a queued item
+        index.cancel_download("b")  # cancel a failed item
+        assert index.download_queue_items() == []
+        index.close()
+
+    def test_reorder_queued_items(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.reorder_download_queue(["c", "a", "b"])
+        assert [i["sale_item_id"] for i in index.download_queue_items()] == [
+            "c",
+            "a",
+            "b",
+        ]
+        assert index.next_queued_download() == "c"
+        index.close()
+
+    def test_reorder_excludes_downloading_item(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_downloading("a")  # fixed at top, not part of the reorder
+        index.reorder_download_queue(["c", "b"])
+        assert self._states(index) == [
+            ("a", "downloading"),
+            ("c", "queued"),
+            ("b", "queued"),
+        ]
+        index.close()
+
+    def test_reorder_rejects_mismatched_set(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.enqueue_download("b")
+        with pytest.raises(ValueError):
+            index.reorder_download_queue(["a"])  # missing 'b'
+        with pytest.raises(ValueError):
+            index.reorder_download_queue(["a", "b", "c"])  # unknown 'c'
+        index.close()
+
+    def test_reorder_rejects_downloading_item_in_list(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.enqueue_download("b")
+        index.mark_downloading("a")
+        with pytest.raises(ValueError):
+            index.reorder_download_queue(["a", "b"])  # 'a' is downloading, not queued
+        index.close()
+
+    def test_set_download_size_overwrites_estimate(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a", size_bytes=81_000_000, size_is_estimate=True)
+        # exact Content-Length arrives at download start
+        index.set_download_size("a", 82_531_204, is_estimate=False)
+        item = index.download_queue_items()[0]
+        assert item["size_bytes"] == 82_531_204
+        assert item["size_is_estimate"] is False
+        index.close()
+
+    def test_enqueue_is_idempotent_preserves_state(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        index.mark_downloading("a")
+        index.enqueue_download("a")  # re-enqueue is a no-op, does not reset status
+        assert self._states(index) == [("a", "downloading")]
+        index.close()
+
+    def test_persistence_survives_reopen(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "library.db"
+        index = LibraryIndex(db_path)
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_downloading("a")
+        index.mark_download_failed("b", "boom")
+        index.reorder_download_queue(["c"])  # only c is queued
+        index.close()
+
+        reopened = LibraryIndex(db_path)
+        assert self._states(reopened) == [
+            ("a", "downloading"),
+            ("c", "queued"),
+            ("b", "failed"),
+        ]
+        assert reopened.download_queue_items()[2]["error_text"] == "boom"
+        reopened.close()
 
 
 class TestRemoveDownload:
@@ -9059,7 +9352,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9137,7 +9430,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -9346,7 +9639,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -9586,7 +9879,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9686,7 +9979,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -9802,7 +10095,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10307,7 +10600,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -10422,7 +10715,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -10520,7 +10813,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -10620,7 +10913,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -11127,7 +11420,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 52
+        assert version == 53
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -12011,7 +12304,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 52
+        assert version == 53
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -13140,7 +13433,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 52
+        assert version == 53
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -13160,7 +13453,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 52
+        assert version == 53
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -13203,7 +13496,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 52
+        assert version == 53
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -13482,7 +13775,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 52
+        assert ver == 53
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3656,32 +3656,30 @@ class TestPreorderResurface:
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
-    def test_migration_v52_to_v53_extends_download_queue(self, tmp_path: Path) -> None:
-        """A pre-v53 DB gains the queue state-machine columns; position backfills
-        from the old FIFO order and existing rows survive (KAMP-564)."""
+    def test_migration_v52_to_v53_rebuilds_download_queue(self, tmp_path: Path) -> None:
+        """A pre-v53 DB's Bandcamp-specific download_queue (sale_item_id) is rebuilt
+        into the platform-neutral (provider, provider_item_id) state-machine shape;
+        existing rows survive as provider='bandcamp' with position backfilled from
+        the old FIFO order (KAMP-564)."""
         db_path = tmp_path / "library.db"
-        # Build a current DB, seed two queued rows with distinct queued_at, then
-        # rewind: drop the v53 columns and stamp version 52 so open runs the upgrade.
-        idx = LibraryIndex(db_path)
-        idx.enqueue_download("first")
-        import time
-
-        time.sleep(0.01)  # distinct queued_at so the FIFO backfill order is defined
-        idx.enqueue_download("second")
-        idx._conn.commit()
-        idx.close()
+        # Build a current DB, then rewind download_queue to the genuine KAMP-408
+        # (v23) shape — a table keyed on sale_item_id — and stamp version 52 so open
+        # runs the v53 rebuild. Two rows with distinct queued_at fix the FIFO order.
+        LibraryIndex(db_path).close()
         conn = sqlite3.connect(str(db_path))
-        for col in (
-            "status",
-            "position",
-            "size_bytes",
-            "size_is_estimate",
-            "error_text",
-            "album_name",
-            "album_artist",
-            "artwork_ref",
-        ):
-            conn.execute(f"ALTER TABLE download_queue DROP COLUMN {col}")
+        conn.execute("DROP TABLE download_queue")
+        conn.execute(
+            "CREATE TABLE download_queue ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " sale_item_id TEXT NOT NULL UNIQUE,"
+            " queued_at REAL NOT NULL DEFAULT (unixepoch()))"
+        )
+        conn.execute(
+            "INSERT INTO download_queue (sale_item_id, queued_at) VALUES ('first', 1.0)"
+        )
+        conn.execute(
+            "INSERT INTO download_queue (sale_item_id, queued_at) VALUES ('second', 2.0)"
+        )
         conn.execute("UPDATE schema_version SET version = 52")
         conn.commit()
         conn.close()
@@ -3692,13 +3690,16 @@ class TestPreorderResurface:
         ]
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         rows = index._conn.execute(
-            "SELECT sale_item_id, status, position FROM download_queue"
+            "SELECT provider, provider_item_id, status, position FROM download_queue"
             " ORDER BY position ASC"
         ).fetchall()
         index.close()
 
         assert version == 53
+        assert "sale_item_id" not in cols
         assert {
+            "provider",
+            "provider_item_id",
             "status",
             "position",
             "size_bytes",
@@ -3708,11 +3709,14 @@ class TestPreorderResurface:
             "album_artist",
             "artwork_ref",
         } <= cols
-        # Existing rows survived, defaulted to 'queued', with position backfilled
-        # 1,2 to match the pre-v53 FIFO (queued_at) order.
-        assert [(r["sale_item_id"], r["status"], r["position"]) for r in rows] == [
-            ("first", "queued", 1),
-            ("second", "queued", 2),
+        # Existing rows survived as bandcamp items, defaulted to 'queued', with
+        # position backfilled 1,2 to match the pre-v53 FIFO (queued_at) order.
+        assert [
+            (r["provider"], r["provider_item_id"], r["status"], r["position"])
+            for r in rows
+        ] == [
+            ("bandcamp", "first", "queued", 1),
+            ("bandcamp", "second", "queued", 2),
         ]
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -8621,8 +8625,10 @@ class TestDownloadQueueStateMachine:
     reorder, retry-to-end, cancel, size, and restart persistence (KAMP-564)."""
 
     def _states(self, index: "LibraryIndex") -> "list[tuple[str, str]]":
-        """Return (sale_item_id, status) for every queue row in display order."""
-        return [(r["sale_item_id"], r["status"]) for r in index.download_queue_items()]
+        """Return (provider_item_id, status) for every queue row in display order."""
+        return [
+            (r["provider_item_id"], r["status"]) for r in index.download_queue_items()
+        ]
 
     def test_enqueue_defaults_to_queued(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -8772,7 +8778,7 @@ class TestDownloadQueueStateMachine:
         for sid in ("a", "b", "c"):
             index.enqueue_download(sid)
         index.reorder_download_queue(["c", "a", "b"])
-        assert [i["sale_item_id"] for i in index.download_queue_items()] == [
+        assert [i["provider_item_id"] for i in index.download_queue_items()] == [
             "c",
             "a",
             "b",
@@ -8848,6 +8854,30 @@ class TestDownloadQueueStateMachine:
         ]
         assert reopened.download_queue_items()[2]["error_text"] == "boom"
         reopened.close()
+
+    def test_provider_defaults_to_bandcamp(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        assert index.download_queue_items()[0]["provider"] == "bandcamp"
+        index.close()
+
+    def test_same_item_id_distinct_across_providers(self, tmp_path: Path) -> None:
+        """Identity is (provider, provider_item_id): the same id under two providers
+        is two independent rows, and per-provider ops don't cross-talk."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("x", provider="bandcamp")
+        index.enqueue_download("x", provider="other")
+        assert len(index.download_queue_items()) == 2
+        # A transition on one provider's item leaves the other untouched.
+        index.mark_downloading("x", provider="other")
+        by_provider = {i["provider"]: i["status"] for i in index.download_queue_items()}
+        assert by_provider == {"bandcamp": "queued", "other": "downloading"}
+        # Per-provider reads/removes are scoped.
+        assert index.next_queued_download(provider="bandcamp") == "x"
+        assert index.next_queued_download(provider="other") is None
+        index.cancel_download("x", provider="bandcamp")
+        assert [i["provider"] for i in index.download_queue_items()] == ["other"]
+        index.close()
 
 
 class TestRemoveDownload:


### PR DESCRIPTION
## Summary

Step 2 of Epic KAMP-435 (download queue). Grows the minimal KAMP-408 `download_queue` table into a **persistent, platform-neutral state machine** the Downloads view will render as Now Downloading / Queued / Failed cards, building on the KAMP-563 file-size spike.

**Scope: model + methods + tests only.** No rewiring of the live worker/syncer/server/UI — those are **KAMP-565** (enqueue-then-process engine) and **KAMP-566** (byte progress + structured WS events). The existing single-album download path keeps working unchanged (verified).

### Schema (migration v52 → v53, table rebuild)
`download_queue` is rebuilt from the Bandcamp-specific `sale_item_id` key onto **`(provider, provider_item_id)`** — the same platform-neutral generalization `track_sources` already uses — so downloads aren't tied to Bandcamp even though it's the only provider today (`provider` defaults to `'bandcamp'`). New columns: `status` (`queued`|`downloading`|`failed`; done = row deleted), `position` (reorderable), `size_bytes` + `size_is_estimate` (per KAMP-563), `error_text`, and a denormalized `album_name`/`album_artist`/`artwork_ref` snapshot. `UNIQUE(provider, provider_item_id)` preserves `INSERT OR IGNORE` idempotency and lets the same id coexist across services. The rebuild is safe (no FKs/children); existing rows copy over as `provider='bandcamp'` with `position` backfilled from the old FIFO order. Both `_DDL` and the migration are updated; `_SCHEMA_VERSION` → 53.

### State-machine API on `LibraryIndex`
Every method takes `provider_item_id` plus an optional `provider='bandcamp'` kwarg (existing positional callers unaffected):
- `enqueue_download(provider_item_id, *, provider='bandcamp', album_name=…, album_artist=…, artwork_ref=…, size_bytes=…, size_is_estimate=…)`
- `next_queued_download` · `mark_downloading` · `mark_download_failed` · `mark_download_done`
- `retry_download` (re-queue at end, clears error) · `reorder_download_queue` (queued items only; downloading fixed at top; rejects a non-permutation) · `cancel_download`
- `set_download_size` (estimate → exact) · `download_queue_items` (sectioned display order; exposes `provider` + `provider_item_id`)
- `enqueue_download`/`dequeue_download`/`pending_downloads` kept for the live KAMP-408 worker.

> Note: `cancel_download` is named to avoid colliding with the pre-existing `remove_download` (revert-a-download-to-streaming), a different operation.

## Test plan
- `TestDownloadQueueStateMachine` (23 tests): transitions, section ordering, next-in-order, reorder happy-path + mismatch + downloading-excluded, retry-to-end, cancel (queued & failed), size estimate→exact, idempotent re-enqueue preserves state, restart-persistence round-trip, provider default, and cross-provider identity isolation.
- `test_migration_v52_to_v53_rebuilds_download_queue`: genuine pre-v53 (KAMP-408 `sale_item_id`) table → rebuilt to `(provider, provider_item_id)`, rows survive as `bandcamp` with `position` backfilled, `sale_item_id` gone, version 53.
- Existing `TestDownloadQueue` (KAMP-408) still green — back-compat.
- Migration sanity-checked against a copy of the production DB.
- Full suite: 2304 passed, coverage 93.45% (above the 93 gate; main is already sub-94% pre-existing — new code is fully covered). black + mypy clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)