### PR TITLE
feat(downloads): enqueue-then-process download engine with per-item failure capture (KAMP-565)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5300,6 +5300,23 @@ class LibraryIndex:
         """Complete an item: remove it from the queue (done has no row state)."""
         self.dequeue_download(provider_item_id, provider=provider)
 
+    def reset_downloading_to_queued(self, *, provider: str = "bandcamp") -> int:
+        """Re-queue any items left in 'downloading' by an interrupted run.
+
+        Called once on daemon startup: a crash/kill mid-download leaves a row in
+        'downloading', which ``next_queued_download`` never returns, so it would
+        stall forever. Flipping it back to 'queued' (position unchanged, so it
+        keeps its place at the head) lets the processing loop resume it first.
+        Returns the number of rows reset.
+        """
+        cur = self._conn.execute(
+            "UPDATE download_queue SET status = 'queued' "
+            "WHERE provider = ? AND status = 'downloading'",
+            (provider,),
+        )
+        self._conn.commit()
+        return cur.rowcount
+
     def retry_download(
         self, provider_item_id: str, *, provider: str = "bandcamp"
     ) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3078,7 +3078,8 @@ def create_app(
         Returns 404 if the item is not in the collection.
         Returns 503 if the download queue is not configured.
         """
-        if not index.get_collection_item(sale_item_id):
+        item = index.get_collection_item(sale_item_id)
+        if not item:
             raise HTTPException(status_code=404, detail="Collection item not found")
         if dl_queue is None:
             raise HTTPException(status_code=503, detail="Album download not configured")
@@ -3090,9 +3091,35 @@ def create_app(
         index.set_collection_item_mode(sale_item_id, "local")
 
         # Persist first so a restart can replay the queue even if the process
-        # dies before the worker picks up the in-memory item.
-        index.enqueue_download(sale_item_id)
-        dl_queue.put(sale_item_id)
+        # dies before the worker picks up the in-memory item. The album snapshot
+        # lets the Downloads-view card render without a join (KAMP-564).
+        index.enqueue_download(
+            sale_item_id,
+            album_name=item.get("item_title") or None,
+            album_artist=item.get("band_name") or None,
+        )
+        dl_queue.put(sale_item_id)  # wake the worker
+
+        _broadcast(
+            {
+                "type": "bandcamp.album-download",
+                "sale_item_id": sale_item_id,
+                "state": "queued",
+            }
+        )
+        return {"ok": True}
+
+    @app.post("/api/v1/bandcamp/collection/{sale_item_id}/retry")
+    def retry_collection_item(sale_item_id: str) -> dict[str, Any]:
+        """Retry a failed download: re-queue it at the END of the queue (KAMP-565).
+
+        Returns 503 if the download queue is not configured.
+        """
+        if dl_queue is None:
+            raise HTTPException(status_code=503, detail="Album download not configured")
+
+        index.retry_download(sale_item_id)
+        dl_queue.put(sale_item_id)  # wake the worker
 
         _broadcast(
             {

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -528,7 +528,7 @@ def _cmd_daemon(
 ) -> None:
     import queue as _queue_mod
     import threading
-    import time as _time
+
     import uvicorn
 
     from kamp_core.library import LibraryIndex, Track
@@ -1026,65 +1026,51 @@ def _cmd_daemon(
     )
 
     # ---------------------------------------------------------------------------
-    # Single-consumer album download worker (KAMP-408)
+    # Single-consumer album download worker (KAMP-408; queue engine KAMP-565)
     # ---------------------------------------------------------------------------
-    # Serializes all album downloads one at a time (FIFO) so Bandcamp doesn't
-    # 429 us.  Retries rate-limited requests with an exponential back-off
-    # (5 s → 10 s → 20 s) before giving up.
+    # Drains the persistent download_queue one item at a time in `position` order,
+    # driving each through the state machine (downloading → done, or failed +
+    # continue) via process_next_download.  Serializing avoids Bandcamp 429s;
+    # rate-limited requests retry with 5 s → 10 s → 20 s back-off.  `_dl_queue` is
+    # now only a wake signal — endpoints and completed syncs put a sentinel to
+    # nudge the worker; ordering lives in the DB, not the in-memory queue.
 
     def _download_worker() -> None:
-        from .syncer import NeedsLoginError
+        from .syncer import process_next_download
+
+        def _on_state(provider_item_id: str, state: str) -> None:
+            app.state.notify_album_download_status(provider_item_id, state)
+            if state == "done":
+                app.state.notify_library_changed()
+
+        def _wait_for_work() -> None:
+            # Block until an enqueue/sync puts a wake sentinel, with a short
+            # fallback timeout so downloads enqueued by the background poll-sync
+            # (which doesn't signal us directly) are still picked up promptly.
+            try:
+                _dl_queue.get(timeout=5.0)
+            except _queue_mod.Empty:
+                pass
+
+        # A download left 'downloading' by a crash would stall (next_queued_download
+        # only returns 'queued'); re-queue it so this run resumes it first.
+        n_reset = index.reset_downloading_to_queued()
+        if n_reset:
+            _logger.info("Re-queued %d interrupted download(s) after restart", n_reset)
 
         while True:
-            sale_item_id = _dl_queue.get()
-            app.state.notify_album_download_status(sale_item_id, "downloading")
-
-            fn = _album_download_trigger_ref[0]
-            if fn is None:
-                _logger.error(
-                    "Album download trigger not configured for %s", sale_item_id
-                )
-                app.state.notify_album_download_status(sale_item_id, "error")
-                index.dequeue_download(sale_item_id)
+            if _album_download_trigger_ref[0] is None:
+                _wait_for_work()  # trigger not wired yet (startup race)
                 continue
-
-            delays = [5, 10, 20]
-            for delay in delays + [None]:
-                try:
-                    fn(sale_item_id)
-                    app.state.notify_album_download_status(sale_item_id, "done")
-                    app.state.notify_library_changed()
-                    break
-                except NeedsLoginError:
-                    _logger.warning(
-                        "Album download: no valid session for %s", sale_item_id
-                    )
-                    app.state.notify_album_download_status(sale_item_id, "error")
-                    break
-                except Exception as exc:
-                    if "429" in str(exc) and delay is not None:
-                        _logger.warning(
-                            "Album download rate-limited for %s; retrying in %ds",
-                            sale_item_id,
-                            delay,
-                        )
-                        _time.sleep(delay)
-                        continue
-                    _logger.exception("Album download failed for %s", sale_item_id)
-                    app.state.notify_album_download_status(sale_item_id, "error")
-                    break
-
-            index.dequeue_download(sale_item_id)
+            pid = process_next_download(
+                index, _album_download_trigger_ref[0], on_state=_on_state
+            )
+            if pid is None:
+                _wait_for_work()  # queue drained — sleep until woken or timeout
 
     threading.Thread(
         target=_download_worker, daemon=True, name="album-dl-worker"
     ).start()
-
-    # Replay any downloads that survived a daemon restart.  These are put onto
-    # the in-memory queue so the worker picks them up in FIFO order.
-    for _pending_sid in index.pending_downloads():
-        _dl_queue.put(_pending_sid)
-        _logger.info("Replayed queued download: %s", _pending_sid)
 
     # Wrap the existing on_track_end callback to also push track.changed events.
     # Done here (after app creation) so app.state is guaranteed to be available.

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -345,7 +345,8 @@ def sync_new_purchases(
     watch_dir.mkdir(parents=True, exist_ok=True)
 
     downloaded: list[Path] = []
-    download_index = 0  # throttle counter for download-page requests
+    enqueued = 0  # regular purchases handed to the persistent download queue
+    download_index = 0  # throttle counter for inline preorder download-page requests
     for item in new_items:
         sid = str(item.get("sale_item_id", ""))
         band_name = str(item.get("band_name", ""))
@@ -392,49 +393,78 @@ def sync_new_purchases(
             )
             continue
 
-        # Throttle download-page requests to avoid Bandcamp 429 rate limiting.
-        if download_index > 0:
-            time.sleep(1)
-        download_index += 1
         try:
-            if status_callback:
-                status_callback(f"{item_title} by {band_name}")
-            path = _download_item(item, bc_config, watch_dir, session)
-            downloaded.append(path)
-            # Pre-orders stay as 'preorder' until is_preorder flips to False.
-            mode = "preorder" if is_preorder else "local"
-            index.upsert_collection_item(
-                sid,
-                mode=mode,
-                item_type=str(item.get("sale_item_type", "p")),
-                band_name=band_name,
-                item_title=item_title,
-                album_url=album_url,
-                tralbum_id=str(item.get("tralbum_id", "")),
-                synced_at=time.time(),
-                added_at=_parse_purchased(item.get("purchased")),
-                num_streamable_tracks=api_streamable,
-            )
-            # KAMP-523: hand the download's identity to the ingest pipeline so it
-            # writes the metadata we already own and stamps a provenance tag,
-            # instead of re-deriving identity from tags via MusicBrainz.
-            index.add_pending_ingest(
-                str(path), str(sid), str(item.get("tralbum_id", ""))
-            )
-            logger.info(
-                "Downloaded: %s (mode=%s, streamable_tracks=%d)",
-                path.name,
-                mode,
-                api_streamable,
-            )
+            if is_preorder:
+                # Pre-order with newly-released tracks: download inline and keep
+                # 'preorder' mode. Kept off the persistent queue (KAMP-565) so the
+                # KAMP-544 resurface bookkeeping — mode preservation and the
+                # num_streamable_tracks watermark — stays exactly as-is; the generic
+                # queue path (download_single_album) would flip it to 'local'.
+                if download_index > 0:
+                    time.sleep(1)  # throttle download-page requests vs 429s
+                download_index += 1
+                if status_callback:
+                    status_callback(f"{item_title} by {band_name}")
+                path = _download_item(item, bc_config, watch_dir, session)
+                downloaded.append(path)
+                index.upsert_collection_item(
+                    sid,
+                    mode="preorder",
+                    item_type=str(item.get("sale_item_type", "p")),
+                    band_name=band_name,
+                    item_title=item_title,
+                    album_url=album_url,
+                    tralbum_id=str(item.get("tralbum_id", "")),
+                    synced_at=time.time(),
+                    added_at=_parse_purchased(item.get("purchased")),
+                    num_streamable_tracks=api_streamable,
+                )
+                # KAMP-523: hand the download's identity to the ingest pipeline.
+                index.add_pending_ingest(
+                    str(path), str(sid), str(item.get("tralbum_id", ""))
+                )
+                logger.info(
+                    "Downloaded pre-order: %s (streamable_tracks=%d)",
+                    path.name,
+                    api_streamable,
+                )
+            else:
+                # Regular new purchase: enqueue for the persistent download queue
+                # (KAMP-565). Record the collection row as 'remote' (owned, not yet
+                # local) so a re-sync skips it while queued and the worker's
+                # download_single_album can flip it to 'local' after downloading.
+                index.upsert_collection_item(
+                    sid,
+                    mode="remote",
+                    item_type=str(item.get("sale_item_type", "p")),
+                    band_name=band_name,
+                    item_title=item_title,
+                    album_url=album_url,
+                    tralbum_id=str(item.get("tralbum_id", "")),
+                    synced_at=time.time(),
+                    added_at=_parse_purchased(item.get("purchased")),
+                    num_streamable_tracks=api_streamable,
+                )
+                index.enqueue_download(
+                    sid,
+                    album_name=item_title,
+                    album_artist=band_name,
+                    artwork_ref=str(item.get("item_art_url", "") or ""),
+                )
+                enqueued += 1
+                if status_callback:
+                    status_callback(f"Queued {item_title} by {band_name}")
+                logger.info("Queued for download: %r by %r", item_title, band_name)
         except Exception as exc:
             logger.error(
-                "Failed to download %r by %r: %s",
+                "Failed to handle %r by %r: %s",
                 item_title,
                 band_name,
                 exc,
             )
 
+    if enqueued:
+        logger.info("Enqueued %d new purchase(s) for download.", enqueued)
     return downloaded
 
 

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -7,11 +7,15 @@ import logging.handlers
 import multiprocessing
 import queue
 import threading
-from collections.abc import Callable
+import time
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .config import BandcampConfig, Config, _state_dir
+
+if TYPE_CHECKING:
+    from kamp_core.library import LibraryIndex
 
 
 class NeedsLoginError(Exception):
@@ -199,6 +203,69 @@ def _replay_log_queue(log_q: Any) -> None:
             logging.getLogger(record.name).handle(record)
         except queue.Empty:
             break
+
+
+def process_next_download(
+    index: "LibraryIndex",
+    download_fn: Callable[[str], Any],
+    *,
+    provider: str = "bandcamp",
+    on_state: Callable[[str, str], None] | None = None,
+    retry_delays: Sequence[int] = (5, 10, 20),
+    sleep: Callable[[float], None] = time.sleep,
+) -> str | None:
+    """Process the next queued download through the persistent state machine.
+
+    The enqueue-then-process-in-order engine (KAMP-565). Pops the lowest-position
+    'queued' item, marks it 'downloading', runs *download_fn* (the per-item
+    downloader, e.g. ``Syncer.download_album``) with 429 back-off, then either
+    removes it on success ('done' has no row state) or leaves it 'failed' with its
+    error text. **A failed item never aborts the batch** — the failure is captured
+    and the function returns normally so the caller can pull the next item.
+
+    *on_state* (if given) is called ``(provider_item_id, state)`` on each
+    transition ('downloading' | 'done' | 'failed') for WebSocket broadcast.
+
+    Returns the processed provider_item_id, or None when the queue is empty.
+    """
+    pid = index.next_queued_download(provider=provider)
+    if pid is None:
+        return None
+
+    index.mark_downloading(pid, provider=provider)
+    if on_state is not None:
+        on_state(pid, "downloading")
+
+    # 429 back-off: retry the whole item after a delay; the trailing None is the
+    # final attempt with no further retry. Non-429 errors fail immediately.
+    for delay in list(retry_delays) + [None]:
+        try:
+            download_fn(pid)
+        except NeedsLoginError:
+            logger.warning("Download: no valid session for %s", pid)
+            index.mark_download_failed(pid, "Login required", provider=provider)
+            if on_state is not None:
+                on_state(pid, "failed")
+            return pid
+        except Exception as exc:
+            if "429" in str(exc) and delay is not None:
+                logger.warning(
+                    "Download rate-limited for %s; retrying in %ds", pid, delay
+                )
+                sleep(delay)
+                continue
+            logger.exception("Download failed for %s", pid)
+            index.mark_download_failed(pid, str(exc)[:200], provider=provider)
+            if on_state is not None:
+                on_state(pid, "failed")
+            return pid
+        else:
+            index.mark_download_done(pid, provider=provider)
+            if on_state is not None:
+                on_state(pid, "done")
+            return pid
+
+    return pid  # pragma: no cover - loop always returns inside
 
 
 class Syncer:

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -526,7 +526,7 @@ class TestSyncNewPurchases:
         tmp_path: Path,
         items: list[dict[str, Any]],
         known_ids: list[str] | None = None,
-    ) -> list[Path]:
+    ) -> tuple[list[Path], MagicMock]:
         watch_folder = tmp_path / "watch"
         config = _bc_config(tmp_path)
         mock_session = _make_requests_mock(items)
@@ -557,61 +557,45 @@ class TestSyncNewPurchases:
             ),
             patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
-            return sync_new_purchases(config, watch_folder, index)
+            return sync_new_purchases(config, watch_folder, index), index
 
-    def test_downloads_new_items(self, tmp_path: Path) -> None:
+    def test_enqueues_new_items(self, tmp_path: Path) -> None:
+        # Regular purchases are enqueued for the persistent queue (KAMP-565),
+        # not downloaded inline — so nothing is downloaded synchronously.
         items = [_item(1, "Artist A", "Album 1"), _item(2, "Artist B", "Album 2")]
-        paths = self._run(tmp_path, items)
-        assert len(paths) == 2
-        assert all(p.suffix == ".zip" for p in paths)
-        assert all(p.exists() for p in paths)
+        paths, index = self._run(tmp_path, items)
+        assert paths == []
+        assert index.enqueue_download.call_count == 2
+        enqueued_ids = {c.args[0] for c in index.enqueue_download.call_args_list}
+        assert enqueued_ids == {"1", "2"}
 
     def test_skips_known_items(self, tmp_path: Path) -> None:
         items = [_item(1), _item(2)]
-        paths = self._run(tmp_path, items, known_ids=["1", "2"])
+        paths, index = self._run(tmp_path, items, known_ids=["1", "2"])
         assert paths == []
+        index.enqueue_download.assert_not_called()
 
-    def test_downloads_only_new_items(self, tmp_path: Path) -> None:
+    def test_enqueues_only_new_items(self, tmp_path: Path) -> None:
         items = [_item(1), _item(2), _item(3)]
-        paths = self._run(tmp_path, items, known_ids=["1"])
-        assert len(paths) == 2
+        paths, index = self._run(tmp_path, items, known_ids=["1"])
+        assert paths == []
+        assert index.enqueue_download.call_count == 2
 
-    def test_state_updated_after_download(self, tmp_path: Path) -> None:
-        watch_folder = tmp_path / "watch"
-        config = _bc_config(tmp_path)
-        items = [_item(99)]
-        mock_session = _make_requests_mock(items)
-        index = MagicMock()
-        index.get_collection_state.return_value = {}
-
-        def fake_download(
-            item: dict[str, Any],
-            bc_config: BandcampConfig,
-            watch_dir: Path,
-            session: Any,
-        ) -> Path:
-            watch_dir.mkdir(parents=True, exist_ok=True)
-            path = watch_dir / f"{item['sale_item_id']}.zip"
-            path.write_bytes(b"fake")
-            return path
-
-        with (
-            patch(
-                "kamp_daemon.bandcamp._ensure_session",
-                return_value=_make_session_data(),
-            ),
-            patch(
-                "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
-            ),
-            patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
-        ):
-            sync_new_purchases(config, watch_folder, index)
-
-        # Verify the index was asked to record the downloaded item.
+    def test_state_updated_after_enqueue(self, tmp_path: Path) -> None:
+        # A regular new purchase is recorded 'remote' (owned, not yet local) and
+        # enqueued with its album snapshot; the worker flips it to 'local' later.
+        items = [_item(99, "Band X", "Rec Y")]
+        paths, index = self._run(tmp_path, items)
+        assert paths == []
         index.upsert_collection_item.assert_called_once()
-        call_kwargs = index.upsert_collection_item.call_args
-        assert call_kwargs[0][0] == "99"
-        assert call_kwargs[1]["mode"] == "local"
+        call = index.upsert_collection_item.call_args
+        assert call.args[0] == "99"
+        assert call.kwargs["mode"] == "remote"
+        index.enqueue_download.assert_called_once()
+        eq = index.enqueue_download.call_args
+        assert eq.args[0] == "99"
+        assert eq.kwargs["album_name"] == "Rec Y"
+        assert eq.kwargs["album_artist"] == "Band X"
 
     def test_state_persists_across_calls(self, tmp_path: Path) -> None:
         watch_folder = tmp_path / "watch"
@@ -661,7 +645,12 @@ class TestSyncNewPurchases:
 
         assert paths == []
 
-    def test_skips_failed_download_continues_others(self, tmp_path: Path) -> None:
+    def test_one_item_failing_does_not_abort_enqueue_of_others(
+        self, tmp_path: Path
+    ) -> None:
+        # A per-item error during discovery/enqueue must not stop the rest of the
+        # batch (the loop's try/except). Make the first enqueue raise; the second
+        # item must still be enqueued.
         watch_folder = tmp_path / "watch"
         config = _bc_config(tmp_path)
         items = [_item(1), _item(2)]
@@ -670,20 +659,13 @@ class TestSyncNewPurchases:
         index.get_collection_state.return_value = {}
         call_num = 0
 
-        def fake_download(
-            item: dict[str, Any],
-            bc_config: BandcampConfig,
-            watch_dir: Path,
-            session: Any,
-        ) -> Path:
+        def flaky_enqueue(provider_item_id: str, **_kw: Any) -> None:
             nonlocal call_num
             call_num += 1
             if call_num == 1:
-                raise BandcampAPIError("simulated failure")
-            watch_dir.mkdir(parents=True, exist_ok=True)
-            path = watch_dir / f"{item['sale_item_id']}.zip"
-            path.write_bytes(b"fake")
-            return path
+                raise RuntimeError("simulated enqueue failure")
+
+        index.enqueue_download.side_effect = flaky_enqueue
 
         with (
             patch(
@@ -693,11 +675,11 @@ class TestSyncNewPurchases:
             patch(
                 "kamp_daemon.bandcamp._make_requests_session", return_value=mock_session
             ),
-            patch("kamp_daemon.bandcamp._download_item", side_effect=fake_download),
         ):
             paths = sync_new_purchases(config, watch_folder, index)
 
-        assert len(paths) == 1
+        assert paths == []  # regular purchases are enqueued, not downloaded
+        assert index.enqueue_download.call_count == 2  # both attempted despite one fail
 
     def test_warns_when_item_missing_from_redownload_urls(self, tmp_path: Path) -> None:
         """Items absent from the API redownload_urls dict are warned and skipped."""
@@ -755,7 +737,9 @@ class TestSyncNewPurchases:
         ):
             paths = sync_new_purchases(config, watch_folder, index)
 
-        assert len(paths) == 1  # only item 2 downloaded
+        assert paths == []  # item 1 skipped (no url), item 2 enqueued (not downloaded)
+        index.enqueue_download.assert_called_once()
+        assert index.enqueue_download.call_args.args[0] == "2"
 
     def test_refreshes_metadata_for_existing_items(self, tmp_path: Path) -> None:
         """Existing items get band_name/album_url/tralbum_id refreshed even if not downloaded."""
@@ -768,7 +752,7 @@ class TestSyncNewPurchases:
                 tralbum_id=42,
             )
         ]
-        paths = self._run(tmp_path, items, known_ids=["1"])
+        paths, _ = self._run(tmp_path, items, known_ids=["1"])
 
         # No downloads — item was already known.
         assert paths == []
@@ -985,8 +969,12 @@ class TestSyncNewPurchasesPreorder:
 
         assert (tmp_path / "watch" / "1.zip").exists()
 
-    def test_released_preorder_is_downloaded_as_local(self, tmp_path: Path) -> None:
-        """When is_preorder flips to False the ZIP is downloaded and mode='local'."""
+    def test_released_preorder_is_enqueued_not_downloaded_inline(
+        self, tmp_path: Path
+    ) -> None:
+        """When is_preorder flips to False the item is a regular purchase: it is
+        enqueued (recorded 'remote' pre-download) and the worker later flips it to
+        'local' — no inline download in the sync pass (KAMP-565)."""
         item = _item(1, "Band", "Released Album")
         item["is_preorder"] = False
         item["num_streamable_tracks"] = 10
@@ -1006,10 +994,11 @@ class TestSyncNewPurchasesPreorder:
             fake_download=fake_dl,
         )
 
-        assert (tmp_path / "watch" / "1.zip").exists()
+        assert not (tmp_path / "watch" / "1.zip").exists()  # not downloaded inline
+        index.enqueue_download.assert_called_once()
+        assert index.enqueue_download.call_args.args[0] == "1"
         calls = index.upsert_collection_item.call_args_list
-        local_calls = [c for c in calls if c[1].get("mode") == "local"]
-        assert len(local_calls) == 1
+        assert [c for c in calls if c[1].get("mode") == "remote"]  # recorded remote
 
     def test_no_redownload_url_falls_back_to_warning(self, tmp_path: Path) -> None:
         """Items with no redownload_url at all get a warning (genuine edge case)."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8879,6 +8879,33 @@ class TestDownloadQueueStateMachine:
         assert [i["provider"] for i in index.download_queue_items()] == ["other"]
         index.close()
 
+    def test_reset_downloading_to_queued(self, tmp_path: Path) -> None:
+        """An interrupted 'downloading' item is re-queued at its original position
+        (head) so the processing loop resumes it first after a restart (KAMP-565)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        index.mark_downloading("a")  # simulate a crash mid-download
+        assert index.next_queued_download() == "b"  # 'a' is invisible while downloading
+
+        n = index.reset_downloading_to_queued()
+        assert n == 1
+        # 'a' is queued again and, keeping position 1, is picked first.
+        assert self._states(index) == [
+            ("a", "queued"),
+            ("b", "queued"),
+            ("c", "queued"),
+        ]
+        assert index.next_queued_download() == "a"
+        index.close()
+
+    def test_reset_downloading_to_queued_noop_when_none(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")  # 'queued', not 'downloading'
+        assert index.reset_downloading_to_queued() == 0
+        assert self._states(index) == [("a", "queued")]
+        index.close()
+
 
 class TestRemoveDownload:
     """Tests for local_tracks_for_sale_item_id and remove_download."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2891,6 +2891,8 @@ class TestBandcampCollectionDownload:
         mock_index.get_collection_item.return_value = {
             "sale_item_id": "42",
             "mode": "remote",
+            "item_title": "Album 42",
+            "band_name": "Artist 42",
         }
         dl_q: _queue.Queue[str] = _queue.Queue()
         ws_messages: list[dict] = []
@@ -2912,7 +2914,10 @@ class TestBandcampCollectionDownload:
         # DB enqueue and mode update must be called
         mock_index.set_collection_item_mode.assert_called_once_with("42", "local")
         mock_index.set_track_source_for_item.assert_not_called()
-        mock_index.enqueue_download.assert_called_once_with("42")
+        # Enqueued with the album snapshot for the Downloads-view card.
+        mock_index.enqueue_download.assert_called_once_with(
+            "42", album_name="Album 42", album_artist="Artist 42"
+        )
         # Item placed on the in-memory queue
         assert dl_q.get_nowait() == "42"
         # WS broadcast is 'queued', not 'downloading'
@@ -2957,6 +2962,48 @@ class TestBandcampCollectionDownload:
         # Both items are on the queue in FIFO order
         assert dl_q.get_nowait() == "11"
         assert dl_q.get_nowait() == "22"
+
+    def test_retry_requeues_and_broadcasts_queued(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """POST .../retry re-queues a failed item and wakes the worker (KAMP-565)."""
+        import queue as _queue
+
+        dl_q: _queue.Queue[str] = _queue.Queue()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            dl_queue=dl_q,
+        )
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # consume initial state push
+                resp = c.post("/api/v1/bandcamp/collection/42/retry")
+                msg = ws.receive_json()
+
+        assert resp.status_code == 200
+        mock_index.retry_download.assert_called_once_with("42")
+        assert dl_q.get_nowait() == "42"  # worker woken
+        assert msg == {
+            "type": "bandcamp.album-download",
+            "sale_item_id": "42",
+            "state": "queued",
+        }
+
+    def test_retry_returns_503_when_dl_queue_not_configured(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).post("/api/v1/bandcamp/collection/42/retry")
+        assert resp.status_code == 503
+        mock_index.retry_download.assert_not_called()
 
     def test_notify_album_download_progress_broadcasts_percent(
         self,

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -16,7 +16,13 @@ from kamp_daemon.config import (
     MusicBrainzConfig,
     PathsConfig,
 )
-from kamp_daemon.syncer import NeedsLoginError, Syncer, logout
+from kamp_core.library import LibraryIndex
+from kamp_daemon.syncer import (
+    NeedsLoginError,
+    Syncer,
+    logout,
+    process_next_download,
+)
 
 
 def _make_config(tmp_path: Path, poll_interval: int = 0) -> Config:
@@ -972,3 +978,120 @@ class TestDownloadAlbum:
             pytest.raises(RuntimeError, match="Album download failed"),
         ):
             syncer.download_album("42")
+
+
+class TestProcessNextDownload:
+    """process_next_download: the enqueue-then-process-in-order engine (KAMP-565)."""
+
+    @staticmethod
+    def _states(index: LibraryIndex) -> list[tuple[str, str]]:
+        return [
+            (r["provider_item_id"], r["status"]) for r in index.download_queue_items()
+        ]
+
+    def test_returns_none_when_queue_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert process_next_download(index, lambda pid: None) is None
+        index.close()
+
+    def test_success_removes_item_and_reports_states(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        states: list[tuple[str, str]] = []
+        pid = process_next_download(
+            index, lambda pid: None, on_state=lambda p, s: states.append((p, s))
+        )
+        assert pid == "a"
+        assert index.download_queue_items() == []  # done → row deleted
+        assert states == [("a", "downloading"), ("a", "done")]
+        index.close()
+
+    def test_processes_in_position_order(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c"):
+            index.enqueue_download(sid)
+        processed = [process_next_download(index, lambda pid: None) for _ in range(3)]
+        assert processed == ["a", "b", "c"]
+        assert process_next_download(index, lambda pid: None) is None
+        index.close()
+
+    def test_failure_is_captured_and_batch_continues(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b"):
+            index.enqueue_download(sid)
+
+        def _dl(pid: str) -> None:
+            if pid == "a":
+                raise RuntimeError("CDN exploded")
+
+        # 'a' fails but does not raise out; it is left 'failed' with error text.
+        first = process_next_download(index, _dl)
+        assert first == "a"
+        assert index.download_queue_items()[-1]["status"] == "failed"
+        assert "CDN exploded" in index.download_queue_items()[-1]["error_text"]
+        # Processing continues: 'b' is next and succeeds.
+        second = process_next_download(index, _dl)
+        assert second == "b"
+        assert self._states(index) == [("a", "failed")]
+        index.close()
+
+    def test_needs_login_marks_failed(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+
+        def _dl(pid: str) -> None:
+            raise NeedsLoginError("no session")
+
+        pid = process_next_download(index, _dl)
+        assert pid == "a"
+        item = index.download_queue_items()[0]
+        assert item["status"] == "failed"
+        assert item["error_text"] == "Login required"
+        index.close()
+
+    def test_429_retries_then_succeeds(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        attempts = {"n": 0}
+        slept: list[float] = []
+
+        def _dl(pid: str) -> None:
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise RuntimeError("HTTP 429 Too Many Requests")
+
+        pid = process_next_download(
+            index, _dl, retry_delays=(5, 10, 20), sleep=slept.append
+        )
+        assert pid == "a"
+        assert attempts["n"] == 3  # failed twice, succeeded on the third
+        assert slept == [5, 10]  # backed off before each retry
+        assert index.download_queue_items() == []  # ultimately done
+        index.close()
+
+    def test_429_exhausted_marks_failed(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+
+        def _dl(pid: str) -> None:
+            raise RuntimeError("HTTP 429 Too Many Requests")
+
+        pid = process_next_download(
+            index, _dl, retry_delays=(1, 1), sleep=lambda _s: None
+        )
+        assert pid == "a"
+        assert index.download_queue_items()[0]["status"] == "failed"
+        index.close()
+
+    def test_non_429_error_does_not_retry(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        attempts = {"n": 0}
+
+        def _dl(pid: str) -> None:
+            attempts["n"] += 1
+            raise RuntimeError("permanent boom")
+
+        process_next_download(index, _dl, sleep=lambda _s: None)
+        assert attempts["n"] == 1  # no retry for non-429 errors
+        index.close()

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1024,11 +1024,15 @@ class TestProcessNextDownload:
             if pid == "a":
                 raise RuntimeError("CDN exploded")
 
+        states: list[tuple[str, str]] = []
         # 'a' fails but does not raise out; it is left 'failed' with error text.
-        first = process_next_download(index, _dl)
+        first = process_next_download(
+            index, _dl, on_state=lambda p, s: states.append((p, s))
+        )
         assert first == "a"
         assert index.download_queue_items()[-1]["status"] == "failed"
         assert "CDN exploded" in index.download_queue_items()[-1]["error_text"]
+        assert states == [("a", "downloading"), ("a", "failed")]
         # Processing continues: 'b' is next and succeeds.
         second = process_next_download(index, _dl)
         assert second == "b"
@@ -1042,11 +1046,15 @@ class TestProcessNextDownload:
         def _dl(pid: str) -> None:
             raise NeedsLoginError("no session")
 
-        pid = process_next_download(index, _dl)
+        states: list[tuple[str, str]] = []
+        pid = process_next_download(
+            index, _dl, on_state=lambda p, s: states.append((p, s))
+        )
         assert pid == "a"
         item = index.download_queue_items()[0]
         assert item["status"] == "failed"
         assert item["error_text"] == "Login required"
+        assert states == [("a", "downloading"), ("a", "failed")]
         index.close()
 
     def test_429_retries_then_succeeds(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Step 3 of Epic KAMP-435, building on the KAMP-564 persistent `download_queue` state machine. Unifies the two disjoint download paths onto one persistent queue: **enqueue all → process one-at-a-time in `position` order**, driving each item through `downloading` → done (row deleted) or `failed` (row kept with `error_text`) **without aborting the batch**, with restart durability and retry-to-end.

**Scope (565 vs 566):** this owns the processing engine — ordered draining, state-machine transitions, per-item failure capture, retry, restart recovery — and keeps the existing coarse WebSocket events (now emitting a `failed` state). Rich structured WS events + byte-progress + wrapper-callback mirroring are **KAMP-566**.

## Changes

- **`process_next_download`** (`kamp_daemon/syncer.py`, new, fully unit-tested): pops the next `queued` item, marks `downloading`, runs the per-item downloader with 429 back-off, then `done` (delete) or `failed` (keep + error text) — a failure returns normally so the caller continues. This is the engine primitive, extracted so it's testable without the daemon (the old worker had no test).
- **`_download_worker`** (`kamp_daemon/__main__.py`): reworked from an in-memory FIFO that deleted rows on every outcome into a thin loop that drains the DB queue by `position` via `process_next_download` and drives the state machine. `_dl_queue` degrades to a wake signal (with a short fallback timeout so poll-sync enqueues are picked up). On startup, `reset_downloading_to_queued` re-queues any item interrupted mid-download.
- **`reset_downloading_to_queued`** (`kamp_core/library.py`, new): flips `downloading` → `queued` (position preserved) so a crashed download resumes first.
- **`sync_new_purchases`** (`kamp_daemon/bandcamp.py`): regular new purchases are recorded `remote` (owned, not-yet-local) and **enqueued** instead of downloaded inline — so a multi-album sync survives per-item failures and daemon restarts. **Pre-orders stay inline** to preserve the just-merged KAMP-544 resurface bookkeeping (mode preservation + `num_streamable_tracks` watermark), which the generic queue path would break.
- **Endpoints** (`kamp_core/server.py`): the single-album download endpoint now passes the album snapshot to `enqueue_download`; new `POST /api/v1/bandcamp/collection/{id}/retry` re-queues a failed item at the end and wakes the worker.

## Test plan
- `TestProcessNextDownload` (8 tests): empty→None, success→done+states, position-order draining, mid-batch failure isolation (fail one → continue), needs-login→failed, 429 retry-then-succeed (injected `sleep`), 429 exhausted→failed, non-429 no-retry.
- `test_reset_downloading_to_queued` (+ no-op case).
- `sync_new_purchases` tests rewritten for enqueue semantics (regular → enqueue + `remote`; pre-orders still inline; released pre-order now enqueued; per-item enqueue-failure isolation).
- Server: retry endpoint (+503), single-album enqueue passes album metadata.
- Full suite: 2316 passed, coverage 93.43% (above the 93 gate; new engine code fully covered). black + mypy clean.

## Manual test plan
- Multi-album sync: albums download one at a time in queue order.
- Force one item to fail mid-batch: batch continues; failed item stays `failed` with error text (visible via `download_queue_items()` / the `failed` WS event).
- Retry the failed item: re-appears at the end of the queue and downloads.
- Kill the daemon mid-download and restart: interrupted item resumes instead of stalling.
- Single-album download still ingests into the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)