### PR TITLE
feat(downloads): byte-level progress + structured WebSocket download-state events (KAMP-566)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1015,24 +1015,44 @@ def create_app(
 
     app.state.notify_album_download_status = _notify_album_download_status
 
-    def _notify_album_download_progress(sale_item_id: str, progress: int) -> None:
-        """Broadcast byte-level download progress for a single album (KAMP-436).
+    def _notify_album_download_progress(
+        sale_item_id: str, downloaded_bytes: int, total_bytes: int
+    ) -> None:
+        """Broadcast byte-level download progress for a single album (KAMP-436/566).
 
         Rides the same ``bandcamp.album-download`` event as the coarse state
-        transitions, adding a ``progress`` percentage (0–100) so the album card
-        can reveal its art bottom-up. Called from the syncer's download thread —
-        ``_broadcast`` is thread-safe.
+        transitions. Carries a ``progress`` percentage (0–100) — kept for the
+        KAMP-436 bottom-up album-art reveal — plus the raw ``downloaded_bytes`` /
+        ``total_bytes`` for the Downloads view. Called from the syncer's download
+        thread — ``_broadcast`` is thread-safe.
         """
+        pct = min(100, downloaded_bytes * 100 // total_bytes) if total_bytes else 0
         _broadcast(
             {
                 "type": "bandcamp.album-download",
                 "sale_item_id": sale_item_id,
                 "state": "downloading",
-                "progress": progress,
+                "progress": pct,
+                "downloaded_bytes": downloaded_bytes,
+                "total_bytes": total_bytes,
             }
         )
 
     app.state.notify_album_download_progress = _notify_album_download_progress
+
+    def _notify_download_queue() -> None:
+        """Broadcast a structured snapshot of the whole download queue (KAMP-566).
+
+        Emitted on every queue transition (enqueue / downloading / done / failed /
+        retry) so the Downloads view can render the Now Downloading / Queued /
+        Failed sections. Each item carries status, position, size, error text and
+        the album snapshot (see ``download_queue_items``); failed items carry their
+        ``error_text``, which is how download errors reach the UI. Called from the
+        worker/endpoint threads — ``_broadcast`` is thread-safe.
+        """
+        _broadcast({"type": "download.queue", "items": index.download_queue_items()})
+
+    app.state.notify_download_queue = _notify_download_queue
 
     def _notify_bandcamp_sync_status(status_msg: str) -> None:
         """Broadcast sync state derived from the syncer's status_callback string.
@@ -3107,6 +3127,7 @@ def create_app(
                 "state": "queued",
             }
         )
+        _notify_download_queue()  # structured snapshot for the Downloads view
         return {"ok": True}
 
     @app.post("/api/v1/bandcamp/collection/{sale_item_id}/retry")
@@ -3128,6 +3149,7 @@ def create_app(
                 "state": "queued",
             }
         )
+        _notify_download_queue()  # structured snapshot for the Downloads view
         return {"ok": True}
 
     @app.delete("/api/v1/bandcamp/collection/{sale_item_id}/download")

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1040,6 +1040,9 @@ def _cmd_daemon(
 
         def _on_state(provider_item_id: str, state: str) -> None:
             app.state.notify_album_download_status(provider_item_id, state)
+            # Structured queue snapshot for the Downloads view on every transition
+            # (KAMP-566) — carries failed items' error_text back to the UI.
+            app.state.notify_download_queue()
             if state == "done":
                 app.state.notify_library_changed()
 
@@ -1251,8 +1254,19 @@ def _cmd_daemon(
     _album_download_trigger_ref[0] = core.syncer.download_album
 
     core.syncer.status_callback = app.state.notify_bandcamp_sync_status
-    # KAMP-436: per-album byte-progress, distinct from the global status_callback.
-    core.syncer.progress_callback = app.state.notify_album_download_progress
+    # KAMP-436/566: per-album byte-progress, distinct from the global
+    # status_callback. Persist the exact Content-Length to the queue row once per
+    # item (size_is_estimate=0, overriding any pre-download estimate) and broadcast
+    # the progress, then let the syncer forward each (downloaded, total) tick.
+    _download_sizes_seen: dict[str, int] = {}
+
+    def _on_download_progress(pid: str, downloaded: int, total: int) -> None:
+        if total and _download_sizes_seen.get(pid) != total:
+            index.set_download_size(pid, total, is_estimate=False)
+            _download_sizes_seen[pid] = total
+        app.state.notify_album_download_progress(pid, downloaded, total)
+
+    core.syncer.progress_callback = _on_download_progress
     core.syncer.on_tracks_indexed = app.state.notify_library_changed
     core.watcher.stage_callback = app.state.notify_pipeline_stage
 

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -649,7 +649,7 @@ def download_single_album(
     index: "LibraryIndex",
     sale_item_id: str,
     status_callback: Callable[[str], None] | None = None,
-    on_progress: Callable[[int], None] | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> Path:
     """Download one Bandcamp purchase to *watch_dir* by its *sale_item_id*.
 
@@ -1357,7 +1357,7 @@ def _download_item(
     bc_config: BandcampConfig,
     watch_dir: Path,
     session: _AnySession,
-    on_progress: Callable[[int], None] | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> Path:
     band_name: str = item.get("band_name", "Unknown Artist")
     item_title: str = item.get("item_title", "Unknown Album")
@@ -1457,7 +1457,7 @@ def _download_file(
     dest_base: Path,
     session: _requests.Session,
     fmt: str,
-    on_progress: Callable[[int], None] | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> Path:
     """Stream *cdn_url* to a file under *dest_base*, following redirects.
 
@@ -1485,13 +1485,14 @@ def _download_file(
                 content_type,
                 cdn_url,
             )
-            # KAMP-436: report byte-progress so the album card can reveal its
-            # art bottom-up. Only possible when the server declares a total;
+            # KAMP-436/566: report byte-progress as (downloaded, total) so the
+            # album card can reveal its art bottom-up and the Downloads view can
+            # show exact sizes. Only possible when the server declares a total;
             # throttled by wall-clock time so we emit ~2/s, not per chunk.
             total = _parse_content_length(resp.headers.get("Content-Length"))
             written = 0
             last_emit = time.monotonic()
-            last_pct = -1
+            last_written = -1
             with open(tmp, "wb") as fh:
                 for chunk in resp.iter_content(chunk_size=1024 * 1024):
                     fh.write(chunk)
@@ -1500,15 +1501,13 @@ def _download_file(
                     written += len(chunk)
                     now = time.monotonic()
                     if now - last_emit >= _PROGRESS_MIN_INTERVAL:
-                        pct = min(100, written * 100 // total)
-                        if pct != last_pct:
-                            on_progress(pct)
-                            last_pct = pct
+                        on_progress(written, total)
+                        last_written = written
                         last_emit = now
-            # Always land on a definitive 100 once the bytes are all written,
-            # even if the last in-loop emit was throttled or short of 100.
-            if on_progress is not None and total and last_pct != 100:
-                on_progress(100)
+            # Always land on a definitive (total, total) once the bytes are all
+            # written, even if the last in-loop emit was throttled short of it.
+            if on_progress is not None and total and last_written != total:
+                on_progress(total, total)
 
         with open(tmp, "rb") as fh:
             magic = fh.read(4)

--- a/kamp_daemon/ext/builtin/bandcamp.py
+++ b/kamp_daemon/ext/builtin/bandcamp.py
@@ -180,14 +180,15 @@ class KampBandcampSyncer(BaseSyncer):
         self._inner.on_tracks_indexed = cb
 
     @property
-    def progress_callback(self) -> Callable[[str, int], None] | None:
-        """Per-album byte-progress callback (sale_item_id, percent) (KAMP-436)."""
+    def progress_callback(self) -> Callable[[str, int, int], None] | None:
+        """Per-album byte-progress callback (sale_item_id, downloaded_bytes,
+        total_bytes) (KAMP-436/566)."""
         if self._inner is None:
             return None
         return self._inner.progress_callback
 
     @progress_callback.setter
-    def progress_callback(self, cb: Callable[[str, int], None] | None) -> None:
+    def progress_callback(self, cb: Callable[[str, int, int], None] | None) -> None:
         # Without this setter the assignment lands on the wrapper instead of the
         # inner Syncer that actually runs download_album, so progress is never
         # forwarded — the exact bug behind KAMP-436 showing no reveal.

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -122,9 +122,10 @@ def _download_album_worker(
                 index=index,
                 sale_item_id=sale_item_id,
                 status_callback=lambda msg: status_q.put(msg),
-                # KAMP-436: byte-progress rides the same queue with a "progress:"
-                # prefix so the parent can demux it to progress_callback.
-                on_progress=lambda pct: status_q.put(f"progress:{pct}"),
+                # KAMP-436/566: byte-progress rides the same queue with a
+                # "progress:<downloaded>:<total>" prefix so the parent can demux it
+                # to progress_callback(sale_item_id, downloaded, total).
+                on_progress=lambda dl, tot: status_q.put(f"progress:{dl}:{tot}"),
             )
             result_q.put(("ok", str(dest)))
         finally:
@@ -280,10 +281,10 @@ class Syncer:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self.status_callback: Callable[[str], None] | None = None
-        # KAMP-436: per-album byte-progress, addressed by sale_item_id. Distinct
-        # from status_callback, which drives the global menu-bar sync indicator
-        # and carries no album identity.
-        self.progress_callback: Callable[[str, int], None] | None = None
+        # KAMP-436/566: per-album byte-progress (sale_item_id, downloaded_bytes,
+        # total_bytes), addressed by sale_item_id. Distinct from status_callback,
+        # which drives the global menu-bar sync indicator and carries no identity.
+        self.progress_callback: Callable[[str, int, int], None] | None = None
         self.error_callback: Callable[[str, str, str], None] | None = None
         self.on_tracks_indexed: Callable[[], None] | None = None
 
@@ -517,17 +518,19 @@ class Syncer:
     def _dispatch_download_msg(self, msg: str, sale_item_id: str) -> None:
         """Route a status_q message from the download subprocess.
 
-        Byte-progress arrives as ``"progress:<int>"`` and is demuxed to
-        ``progress_callback(sale_item_id, pct)``; every other message is a
-        human-readable status string for the global sync indicator (KAMP-436).
+        Byte-progress arrives as ``"progress:<downloaded>:<total>"`` and is demuxed
+        to ``progress_callback(sale_item_id, downloaded, total)``; a malformed
+        payload is ignored. Every other message is a human-readable status string
+        for the global sync indicator (KAMP-436/566).
         """
         if msg.startswith("progress:"):
             if self.progress_callback is not None:
+                parts = msg[len("progress:") :].split(":")
                 try:
-                    pct = int(msg[len("progress:") :])
-                except ValueError:
+                    downloaded, total = int(parts[0]), int(parts[1])
+                except (ValueError, IndexError):
                     return
-                self.progress_callback(sale_item_id, pct)
+                self.progress_callback(sale_item_id, downloaded, total)
             return
         if self.status_callback is not None:
             self.status_callback(msg)

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -1761,8 +1761,8 @@ class TestDownloadFile:
         return resp
 
     def test_reports_progress_when_content_length_present(self, tmp_path: Path) -> None:
-        """With a Content-Length header, on_progress fires with a non-decreasing
-        percentage that terminates at 100 (KAMP-436)."""
+        """With a Content-Length header, on_progress fires with non-decreasing
+        (downloaded, total) byte pairs terminating at (total, total) (KAMP-436/566)."""
         from itertools import count
 
         dest_base = tmp_path / "album"
@@ -1771,7 +1771,7 @@ class TestDownloadFile:
         session = MagicMock()
         session.get.return_value = self._make_resp_with_length(chunks, total)
 
-        progress: list[int] = []
+        progress: list[tuple[int, int]] = []
         # Advance monotonic time past the throttle interval on every chunk so
         # each step is emitted, letting us assert the full progression.
         with patch(
@@ -1782,42 +1782,42 @@ class TestDownloadFile:
                 dest_base,
                 session,
                 "mp3-v0",
-                on_progress=progress.append,
+                on_progress=lambda dl, tot: progress.append((dl, tot)),
             )
 
         assert progress, "expected at least one progress callback"
-        assert progress[-1] == 100
-        assert all(0 <= p <= 100 for p in progress)
-        assert progress == sorted(progress)  # non-decreasing
+        assert progress[-1] == (total, total)
+        assert all(0 <= dl <= total and tot == total for dl, tot in progress)
+        assert [dl for dl, _ in progress] == sorted(dl for dl, _ in progress)
 
     def test_no_progress_when_content_length_absent(self, tmp_path: Path) -> None:
-        """Without Content-Length the percentage is unknowable, so on_progress is
+        """Without Content-Length the total is unknowable, so on_progress is
         never called and the UI keeps its indeterminate pulse (KAMP-436)."""
         dest_base = tmp_path / "album"
         session = MagicMock()
         session.get.return_value = self._make_resp([_FAKE_ZIP])  # no Content-Length
 
-        progress: list[int] = []
+        progress: list[tuple[int, int]] = []
         _download_file(
             "https://cdn.example.com/f.zip",
             dest_base,
             session,
             "mp3-v0",
-            on_progress=progress.append,
+            on_progress=lambda dl, tot: progress.append((dl, tot)),
         )
 
         assert progress == []
 
     def test_progress_throttled_but_final_always_emitted(self, tmp_path: Path) -> None:
         """Rapid chunks within the throttle window are coalesced, but a terminal
-        100 is always delivered (KAMP-436)."""
+        (total, total) is always delivered (KAMP-436/566)."""
         dest_base = tmp_path / "album"
         chunks = [_ZIP_MAGIC + b"\x00" * 21] + [b"\x00" * 25] * 3
         total = sum(len(c) for c in chunks)
         session = MagicMock()
         session.get.return_value = self._make_resp_with_length(chunks, total)
 
-        progress: list[int] = []
+        progress: list[tuple[int, int]] = []
         # Time never advances → every intermediate emit is throttled away.
         with patch("kamp_daemon.bandcamp.time.monotonic", side_effect=lambda: 1000.0):
             _download_file(
@@ -1825,10 +1825,10 @@ class TestDownloadFile:
                 dest_base,
                 session,
                 "mp3-v0",
-                on_progress=progress.append,
+                on_progress=lambda dl, tot: progress.append((dl, tot)),
             )
 
-        assert progress == [100]
+        assert progress == [(total, total)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,6 +67,8 @@ def mock_index() -> MagicMock:
     index.get_magic_playlist_criteria.return_value = None
     # Default: no magic playlists for field_index building.
     index.list_all_magic_criteria.return_value = []
+    # Default: empty download queue so download.queue snapshots serialize (KAMP-566).
+    index.download_queue_items.return_value = []
     return index
 
 
@@ -2908,6 +2910,7 @@ class TestBandcampCollectionDownload:
                 ws.receive_json()  # consume initial state push
                 resp = c.post("/api/v1/bandcamp/collection/42/download")
                 ws_messages.append(ws.receive_json())
+                ws_messages.append(ws.receive_json())
 
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
@@ -2926,6 +2929,8 @@ class TestBandcampCollectionDownload:
             "sale_item_id": "42",
             "state": "queued",
         }
+        # Followed by a structured download.queue snapshot (KAMP-566)
+        assert ws_messages[1] == {"type": "download.queue", "items": []}
 
     def test_second_download_also_broadcasts_queued(
         self,
@@ -2951,14 +2956,16 @@ class TestBandcampCollectionDownload:
             with c.websocket_connect("/api/v1/ws") as ws:
                 ws.receive_json()  # consume initial state push
                 c.post("/api/v1/bandcamp/collection/11/download")
-                msg1 = ws.receive_json()
                 c.post("/api/v1/bandcamp/collection/22/download")
-                msg2 = ws.receive_json()
+                # Each POST emits an album-download 'queued' + a download.queue
+                # snapshot; collect the per-item events (ignore snapshots).
+                events = [ws.receive_json() for _ in range(4)]
 
-        assert msg1["state"] == "queued"
-        assert msg1["sale_item_id"] == "11"
-        assert msg2["state"] == "queued"
-        assert msg2["sale_item_id"] == "22"
+        album_events = [e for e in events if e["type"] == "bandcamp.album-download"]
+        assert [(e["sale_item_id"], e["state"]) for e in album_events] == [
+            ("11", "queued"),
+            ("22", "queued"),
+        ]
         # Both items are on the queue in FIFO order
         assert dl_q.get_nowait() == "11"
         assert dl_q.get_nowait() == "22"
@@ -2984,6 +2991,7 @@ class TestBandcampCollectionDownload:
                 ws.receive_json()  # consume initial state push
                 resp = c.post("/api/v1/bandcamp/collection/42/retry")
                 msg = ws.receive_json()
+                snapshot = ws.receive_json()
 
         assert resp.status_code == 200
         mock_index.retry_download.assert_called_once_with("42")
@@ -2993,6 +3001,7 @@ class TestBandcampCollectionDownload:
             "sale_item_id": "42",
             "state": "queued",
         }
+        assert snapshot == {"type": "download.queue", "items": []}  # KAMP-566
 
     def test_retry_returns_503_when_dl_queue_not_configured(
         self,
@@ -3005,26 +3014,89 @@ class TestBandcampCollectionDownload:
         assert resp.status_code == 503
         mock_index.retry_download.assert_not_called()
 
-    def test_notify_album_download_progress_broadcasts_percent(
+    def test_notify_album_download_progress_broadcasts_bytes_and_percent(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
-        """KAMP-436: per-album byte-progress rides bandcamp.album-download with a
-        numeric progress field and state='downloading'."""
+        """KAMP-436/566: per-album progress rides bandcamp.album-download with the
+        derived percent (for the art reveal) plus raw downloaded/total bytes."""
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)
         with c.websocket_connect("/api/v1/ws") as ws:
             ws.receive_json()  # consume initial player.state
-            app.state.notify_album_download_progress("12345", 42)
+            app.state.notify_album_download_progress("12345", 420, 1000)
             msg = ws.receive_json()
         assert msg == {
             "type": "bandcamp.album-download",
             "sale_item_id": "12345",
             "state": "downloading",
             "progress": 42,
+            "downloaded_bytes": 420,
+            "total_bytes": 1000,
         }
+
+    def test_notify_album_download_progress_zero_total_is_safe(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """A zero total (unknowable size) yields progress 0 without dividing by zero."""
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()
+            app.state.notify_album_download_progress("12345", 0, 0)
+            msg = ws.receive_json()
+        assert msg["progress"] == 0
+        assert msg["total_bytes"] == 0
+
+    def test_notify_download_queue_broadcasts_snapshot(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """KAMP-566: notify_download_queue broadcasts a download.queue snapshot of
+        the full queue (status/size/error/album metadata) for the Downloads view."""
+        items = [
+            {
+                "provider": "bandcamp",
+                "provider_item_id": "1",
+                "status": "downloading",
+                "position": 1,
+                "size_bytes": 1000,
+                "size_is_estimate": False,
+                "error_text": None,
+                "album_name": "Album One",
+                "album_artist": "Artist One",
+                "artwork_ref": None,
+                "queued_at": 1.0,
+            },
+            {
+                "provider": "bandcamp",
+                "provider_item_id": "2",
+                "status": "failed",
+                "position": 2,
+                "size_bytes": None,
+                "size_is_estimate": True,
+                "error_text": "HTTP 500",
+                "album_name": "Album Two",
+                "album_artist": "Artist Two",
+                "artwork_ref": None,
+                "queued_at": 2.0,
+            },
+        ]
+        mock_index.download_queue_items.return_value = items
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        with c.websocket_connect("/api/v1/ws") as ws:
+            ws.receive_json()  # consume initial player.state
+            app.state.notify_download_queue()
+            msg = ws.receive_json()
+        assert msg == {"type": "download.queue", "items": items}
 
     def test_notify_album_download_progress_exposed_on_app_state(
         self,
@@ -3034,6 +3106,7 @@ class TestBandcampCollectionDownload:
     ) -> None:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         assert callable(getattr(app.state, "notify_album_download_progress", None))
+        assert callable(getattr(app.state, "notify_download_queue", None))
 
     def test_notify_album_download_status_exposed_on_app_state(
         self,

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -312,21 +312,21 @@ class TestDispatchDownloadMsg:
 
     def test_progress_message_routes_to_progress_callback(self, tmp_path: Path) -> None:
         syncer = Syncer(_make_config(tmp_path))
-        progress: list[tuple[str, int]] = []
+        progress: list[tuple[str, int, int]] = []
         status: list[str] = []
-        syncer.progress_callback = lambda sid, pct: progress.append((sid, pct))
+        syncer.progress_callback = lambda sid, dl, tot: progress.append((sid, dl, tot))
         syncer.status_callback = status.append
 
-        syncer._dispatch_download_msg("progress:42", "12345")
+        syncer._dispatch_download_msg("progress:420:1000", "12345")
 
-        assert progress == [("12345", 42)]
+        assert progress == [("12345", 420, 1000)]
         assert status == []  # must NOT leak to the global sync indicator
 
     def test_status_message_routes_to_status_callback(self, tmp_path: Path) -> None:
         syncer = Syncer(_make_config(tmp_path))
-        progress: list[tuple[str, int]] = []
+        progress: list[tuple[str, int, int]] = []
         status: list[str] = []
-        syncer.progress_callback = lambda sid, pct: progress.append((sid, pct))
+        syncer.progress_callback = lambda sid, dl, tot: progress.append((sid, dl, tot))
         syncer.status_callback = status.append
 
         syncer._dispatch_download_msg("Downloading album 12345…", "12345")
@@ -336,17 +336,18 @@ class TestDispatchDownloadMsg:
 
     def test_malformed_progress_is_ignored(self, tmp_path: Path) -> None:
         syncer = Syncer(_make_config(tmp_path))
-        progress: list[tuple[str, int]] = []
-        syncer.progress_callback = lambda sid, pct: progress.append((sid, pct))
+        progress: list[tuple[str, int, int]] = []
+        syncer.progress_callback = lambda sid, dl, tot: progress.append((sid, dl, tot))
 
-        syncer._dispatch_download_msg("progress:notanint", "12345")
+        syncer._dispatch_download_msg("progress:notanint:1000", "12345")  # bad field
+        syncer._dispatch_download_msg("progress:500", "12345")  # missing total
 
         assert progress == []
 
     def test_progress_without_callback_is_safe(self, tmp_path: Path) -> None:
         syncer = Syncer(_make_config(tmp_path))
         # progress_callback unset (None) — must not raise.
-        syncer._dispatch_download_msg("progress:50", "12345")
+        syncer._dispatch_download_msg("progress:50:100", "12345")
 
 
 class TestLazyImport:


### PR DESCRIPTION
## Summary

Step 4 of Epic KAMP-435. Gives the (future) Downloads view live, structured state instead of the single free-text status string, building on the KAMP-564 model and KAMP-565 processing engine.

**Backend-only** — the Downloads-view UI is a later epic step, so this defines the event contract with Python tests; no frontend code. All changes are additive: existing `bandcamp.album-download` (KAMP-436 art reveal) and `bandcamp.sync-status` (toolbar spinner) consumers keep working (both WS switches ignore unknown event types).

## Changes

- **Byte-level progress**: `_download_file` now emits `(downloaded, total)` instead of a bare percent; the subprocess IPC becomes `progress:<dl>:<tot>`; `Syncer._dispatch_download_msg` demuxes to `progress_callback(sale_item_id, downloaded, total)`. The widened `progress_callback` signature is **mirrored on the `KampBandcampSyncer` wrapper** (the KAMP-436 lesson — miss it and progress silently no-ops in the daemon).
- **Exact file size**: a `__main__` progress handler persists the exact `Content-Length` to the queue row once per item via `set_download_size(pid, total, is_estimate=False)`, overriding any pre-download estimate (KAMP-563/564).
- **`bandcamp.album-download`**: additive `downloaded_bytes`/`total_bytes` fields; `progress` percent is retained (derived) so the art reveal is unbroken.
- **`download.queue` snapshot event** (new): broadcast on every queue transition (from the worker's `_on_state` and the enqueue/retry endpoints), carrying the full `download_queue_items()` list — status, position, size_bytes, size_is_estimate, **error_text**, and album metadata. This is the authoritative Downloads-view feed and is how per-item download **errors** reach the UI.

## Test plan
- `test_bandcamp.py`: `_download_file` emits `(downloaded, total)` byte pairs terminating at `(total, total)`; none when Content-Length absent; throttled-but-final-always.
- `test_syncer.py`: `_dispatch_download_msg` parses `progress:<dl>:<tot>` → `(sid, dl, tot)`; malformed (bad field / missing total) ignored.
- `test_builtin_bandcamp.py`: wrapper `progress_callback` setter forwards to the inner Syncer.
- `test_server.py`: `notify_album_download_progress` broadcasts pct + bytes (and zero-total is safe); `notify_download_queue` broadcasts the `download.queue` snapshot schema; enqueue/retry endpoints emit the snapshot.
- Full suite: 2318 passed, coverage 93.44% (above the 93 gate). black + mypy clean.

## Manual test plan
- Start a download; confirm `bandcamp.album-download` now carries `downloaded_bytes`/`total_bytes` alongside `progress`, and the library-grid art reveal still animates (KAMP-436 unbroken).
- Confirm a `download.queue` snapshot arrives on each transition with the full item list (size, error_text, album metadata).
- After completion, the queue row's `size_bytes` equals the exact Content-Length with `size_is_estimate=0`.
- Force a failure; the snapshot shows that item `status:"failed"` with its `error_text`.
- Confirm the Bandcamp toolbar sync spinner (`bandcamp.sync-status`) still toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)