### PR TITLE
feat(downloads): REST endpoints for queue list/reorder/retry/cancel (KAMP-567)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -461,6 +461,12 @@ class AlbumFavoriteRequest(BaseModel):
     favorite: bool
 
 
+class ReorderDownloadsRequest(BaseModel):
+    # KAMP-567: the desired order of the currently-'queued' items (a permutation);
+    # the downloading item is fixed at the top and is not included.
+    provider_item_ids: list[str]
+
+
 class SearchOut(BaseModel):
     albums: list[AlbumOut]
     tracks: list[TrackOut]
@@ -3130,26 +3136,77 @@ def create_app(
         _notify_download_queue()  # structured snapshot for the Downloads view
         return {"ok": True}
 
-    @app.post("/api/v1/bandcamp/collection/{sale_item_id}/retry")
-    def retry_collection_item(sale_item_id: str) -> dict[str, Any]:
-        """Retry a failed download: re-queue it at the END of the queue (KAMP-565).
+    # ------------------------------------------------------------------
+    # Download-queue management (KAMP-567) — provider-neutral REST surface
+    # over the KAMP-564 state machine. Every mutation broadcasts the KAMP-566
+    # download.queue snapshot so connected clients converge.
+    # ------------------------------------------------------------------
+
+    @app.get("/api/v1/downloads")
+    def list_downloads() -> dict[str, Any]:
+        """Return the full download queue in display order (KAMP-567).
+
+        Items are ordered downloading → queued (by position) → failed, each
+        carrying the card fields (status, position, size, error_text, album
+        snapshot). Same shape as the ``download.queue`` WebSocket snapshot.
+        """
+        return {"items": index.download_queue_items()}
+
+    @app.post("/api/v1/downloads/reorder")
+    def reorder_downloads(req: ReorderDownloadsRequest) -> dict[str, Any]:
+        """Reorder the queued items (KAMP-567).
+
+        The body must list exactly the currently-'queued' provider_item_ids in the
+        desired order; the downloading item is fixed at the top and excluded.
+        Returns 400 if the list is not that exact set (e.g. a stale UI reorder).
+        """
+        try:
+            index.reorder_download_queue(req.provider_item_ids)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        _notify_download_queue()
+        return {"ok": True}
+
+    @app.post("/api/v1/downloads/{provider_item_id}/retry")
+    def retry_download_item(provider_item_id: str) -> dict[str, Any]:
+        """Retry a failed download: re-queue it at the END of the queue (KAMP-567).
 
         Returns 503 if the download queue is not configured.
         """
         if dl_queue is None:
             raise HTTPException(status_code=503, detail="Album download not configured")
 
-        index.retry_download(sale_item_id)
-        dl_queue.put(sale_item_id)  # wake the worker
+        index.retry_download(provider_item_id)
+        dl_queue.put(provider_item_id)  # wake the worker
 
+        # Per-item event keeps the library-grid card in sync (queued decoration).
         _broadcast(
             {
                 "type": "bandcamp.album-download",
-                "sale_item_id": sale_item_id,
+                "sale_item_id": provider_item_id,
                 "state": "queued",
             }
         )
-        _notify_download_queue()  # structured snapshot for the Downloads view
+        _notify_download_queue()
+        return {"ok": True}
+
+    @app.delete("/api/v1/downloads/{provider_item_id}")
+    def cancel_download_item(provider_item_id: str) -> dict[str, Any]:
+        """Cancel a queued or failed item — remove it from the queue (KAMP-567).
+
+        Distinct from ``DELETE /api/v1/bandcamp/collection/{id}/download``, which
+        reverts a completed download back to streaming.
+        """
+        index.cancel_download(provider_item_id)
+        # 'removed' clears the library-grid card's queued/failed decoration.
+        _broadcast(
+            {
+                "type": "bandcamp.album-download",
+                "sale_item_id": provider_item_id,
+                "state": "removed",
+            }
+        )
+        _notify_download_queue()
         return {"ok": True}
 
     @app.delete("/api/v1/bandcamp/collection/{sale_item_id}/download")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2970,50 +2970,6 @@ class TestBandcampCollectionDownload:
         assert dl_q.get_nowait() == "11"
         assert dl_q.get_nowait() == "22"
 
-    def test_retry_requeues_and_broadcasts_queued(
-        self,
-        mock_index: MagicMock,
-        mock_engine: MagicMock,
-        mock_queue: MagicMock,
-    ) -> None:
-        """POST .../retry re-queues a failed item and wakes the worker (KAMP-565)."""
-        import queue as _queue
-
-        dl_q: _queue.Queue[str] = _queue.Queue()
-        app = create_app(
-            index=mock_index,
-            engine=mock_engine,
-            queue=mock_queue,
-            dl_queue=dl_q,
-        )
-        with TestClient(app) as c:
-            with c.websocket_connect("/api/v1/ws") as ws:
-                ws.receive_json()  # consume initial state push
-                resp = c.post("/api/v1/bandcamp/collection/42/retry")
-                msg = ws.receive_json()
-                snapshot = ws.receive_json()
-
-        assert resp.status_code == 200
-        mock_index.retry_download.assert_called_once_with("42")
-        assert dl_q.get_nowait() == "42"  # worker woken
-        assert msg == {
-            "type": "bandcamp.album-download",
-            "sale_item_id": "42",
-            "state": "queued",
-        }
-        assert snapshot == {"type": "download.queue", "items": []}  # KAMP-566
-
-    def test_retry_returns_503_when_dl_queue_not_configured(
-        self,
-        mock_index: MagicMock,
-        mock_engine: MagicMock,
-        mock_queue: MagicMock,
-    ) -> None:
-        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
-        resp = TestClient(app).post("/api/v1/bandcamp/collection/42/retry")
-        assert resp.status_code == 503
-        mock_index.retry_download.assert_not_called()
-
     def test_notify_album_download_progress_broadcasts_bytes_and_percent(
         self,
         mock_index: MagicMock,
@@ -3116,6 +3072,144 @@ class TestBandcampCollectionDownload:
     ) -> None:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         assert callable(getattr(app.state, "notify_album_download_status", None))
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/downloads — queue management (KAMP-567)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadQueueEndpoints:
+    """GET/POST/DELETE /api/v1/downloads — list / reorder / retry / cancel."""
+
+    def _app(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        dl_q: Any = None,
+    ) -> Any:
+        return create_app(
+            index=mock_index, engine=mock_engine, queue=mock_queue, dl_queue=dl_q
+        )
+
+    def test_list_returns_queue_items(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        items = [
+            {
+                "provider": "bandcamp",
+                "provider_item_id": "1",
+                "status": "downloading",
+                "position": 1,
+                "size_bytes": 1000,
+                "size_is_estimate": False,
+                "error_text": None,
+                "album_name": "A1",
+                "album_artist": "Artist",
+                "artwork_ref": None,
+                "queued_at": 1.0,
+            }
+        ]
+        mock_index.download_queue_items.return_value = items
+        app = self._app(mock_index, mock_engine, mock_queue)
+        resp = TestClient(app).get("/api/v1/downloads")
+        assert resp.status_code == 200
+        assert resp.json() == {"items": items}
+
+    def test_reorder_reorders_and_broadcasts_snapshot(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        app = self._app(mock_index, mock_engine, mock_queue)
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # initial state push
+                resp = c.post(
+                    "/api/v1/downloads/reorder",
+                    json={"provider_item_ids": ["c", "a", "b"]},
+                )
+                snapshot = ws.receive_json()
+        assert resp.status_code == 200
+        mock_index.reorder_download_queue.assert_called_once_with(["c", "a", "b"])
+        assert snapshot == {"type": "download.queue", "items": []}
+
+    def test_reorder_invalid_permutation_returns_400(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.reorder_download_queue.side_effect = ValueError("stale reorder")
+        app = self._app(mock_index, mock_engine, mock_queue)
+        resp = TestClient(app).post(
+            "/api/v1/downloads/reorder", json={"provider_item_ids": ["a"]}
+        )
+        assert resp.status_code == 400
+
+    def test_retry_requeues_wakes_and_broadcasts(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        import queue as _queue
+
+        dl_q: _queue.Queue[str] = _queue.Queue()
+        app = self._app(mock_index, mock_engine, mock_queue, dl_q)
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # initial state push
+                resp = c.post("/api/v1/downloads/42/retry")
+                msg = ws.receive_json()
+                snapshot = ws.receive_json()
+        assert resp.status_code == 200
+        mock_index.retry_download.assert_called_once_with("42")
+        assert dl_q.get_nowait() == "42"  # worker woken
+        assert msg == {
+            "type": "bandcamp.album-download",
+            "sale_item_id": "42",
+            "state": "queued",
+        }
+        assert snapshot == {"type": "download.queue", "items": []}
+
+    def test_retry_returns_503_when_dl_queue_not_configured(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        app = self._app(mock_index, mock_engine, mock_queue)  # dl_queue=None
+        resp = TestClient(app).post("/api/v1/downloads/42/retry")
+        assert resp.status_code == 503
+        mock_index.retry_download.assert_not_called()
+
+    def test_cancel_removes_and_broadcasts_removed(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        app = self._app(mock_index, mock_engine, mock_queue)
+        with TestClient(app) as c:
+            with c.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # initial state push
+                resp = c.delete("/api/v1/downloads/42")
+                msg = ws.receive_json()
+                snapshot = ws.receive_json()
+        assert resp.status_code == 200
+        mock_index.cancel_download.assert_called_once_with("42")
+        assert msg == {
+            "type": "bandcamp.album-download",
+            "sale_item_id": "42",
+            "state": "removed",
+        }
+        assert snapshot == {"type": "download.queue", "items": []}
 
 
 # DELETE /api/v1/bandcamp/collection/{sale_item_id}/download


### PR DESCRIPTION
## Summary

Step 5 of Epic KAMP-435. Exposes the download queue's management operations to the UI over a provider-neutral `/api/v1/downloads` REST surface, wired over the existing KAMP-564 state-machine methods. Backend-only (the Downloads view is a later epic step).

## Endpoints (all broadcast the KAMP-566 `download.queue` snapshot on mutation)

- **`GET /api/v1/downloads`** → `{"items": [...]}` — the full queue in display order (downloading → queued → failed) with all card fields. Same shape as the `download.queue` WS snapshot.
- **`POST /api/v1/downloads/reorder`** `{"provider_item_ids": [...]}` → `reorder_download_queue`; returns **400** when the list isn't exactly the current queued set (stale UI reorder → the model's `ValueError`).
- **`POST /api/v1/downloads/{id}/retry`** → `retry_download` + wake worker + `bandcamp.album-download` `queued` (library card) + snapshot; **503** when the queue isn't configured. Migrated here from the KAMP-565 `bandcamp/collection/{id}/retry` route (removed) so there is one canonical retry.
- **`DELETE /api/v1/downloads/{id}`** → `cancel_download` + `bandcamp.album-download` `removed` (clears the library-card decoration) + snapshot. Distinct from `DELETE /api/v1/bandcamp/collection/{id}/download`, which reverts a completed download to streaming.

## Test plan
- New `TestDownloadQueueEndpoints`: list returns `download_queue_items`; reorder happy-path (calls model + broadcasts snapshot) and invalid-permutation → 400; retry (calls `retry_download`, wakes worker, broadcasts, 503 without queue); cancel (calls `cancel_download`, broadcasts `removed` + snapshot).
- Migrated the KAMP-565 retry tests to the new path; verified no stale references to the old route remain.
- Full suite: 2322 passed, coverage 93.45%. black + mypy clean.

## Manual test plan
- `GET /api/v1/downloads` returns the sectioned queue with card fields.
- `POST /reorder` with a valid permutation reorders (WS snapshot arrives); a stale list → 400.
- `POST /{id}/retry` re-queues a failed item at the end; 503 without a configured queue.
- `DELETE /{id}` removes a queued/failed item; the library card clears.
- The unrelated revert-to-streaming `DELETE /api/v1/bandcamp/collection/{id}/download` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)