### PR TITLE
feat(downloads): 'downloads' view scaffolding — nav, store, WS/REST wiring (KAMP-568)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -2872,7 +2872,7 @@ def create_app(
     @app.post("/api/v1/ui/active-view")
     def set_active_view(req: dict[str, Any]) -> dict[str, Any]:
         view = req.get("view", "library")
-        if view not in ("library", "now-playing", "home"):
+        if view not in ("library", "now-playing", "home", "downloads"):
             raise HTTPException(status_code=422, detail="Invalid view")
         _state["ui_active_view"] = view
         if on_ui_state_set is not None:

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -179,7 +179,7 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
         {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
     ),
     "bandcamp.collection_mode": frozenset({"stream", "download"}),
-    "ui.active_view": frozenset({"library", "now-playing", "home"}),
+    "ui.active_view": frozenset({"library", "now-playing", "home", "downloads"}),
     "ui.sort_order": frozenset(
         {"album_artist", "album", "date_added", "last_played", "release_date"}
     ),

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { BaseKampView } from './components/BaseKampView'
 import { ExtensionPanel } from './components/ExtensionPanel'
 import { LibraryView } from './components/LibraryView'
 import { NowPlayingView } from './components/NowPlayingView'
+import { DownloadsView } from './components/DownloadsView'
 import { PreferencesDialog } from './components/PreferencesDialog'
 import { QueuePanel } from './components/QueuePanel'
 import { BandcampButton } from './components/BandcampButton'
@@ -49,6 +50,13 @@ registerBuiltInPanel({
   defaultSlot: 'main',
   compatibleSlots: ['main'],
   component: NowPlayingView
+})
+registerBuiltInPanel({
+  id: 'kamp.downloads',
+  title: 'Downloads',
+  defaultSlot: 'main',
+  compatibleSlots: ['main'],
+  component: DownloadsView
 })
 registerBuiltInPanel({
   id: 'kamp.artist-list',
@@ -230,6 +238,7 @@ export default function App(): React.JSX.Element {
           void loadUiState().then(() => loadLibrary())
           void loadQueue()
           void loadConfig()
+          void useStore.getState().loadDownloads() // KAMP-568: seed Downloads view
           // Reconcile pip state in case deferred_op.completed was missed
           // while the WS was disconnected.
           void getDeferredOps().then((ops) => {
@@ -292,6 +301,10 @@ export default function App(): React.JSX.Element {
             // the rescan flips isRemote, avoiding a flash to the plain badge.
             useStore.getState().clearAlbumTagging(saleItemId)
           }
+        },
+        // KAMP-568: full download-queue snapshot → Downloads-view store slice.
+        (items) => {
+          useStore.getState().setDownloadQueue(items)
         }
       )
     }
@@ -542,6 +555,7 @@ export default function App(): React.JSX.Element {
     if (panel.kind === 'builtin' && panel.id === 'kamp.library') return activeView === 'library'
     if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing')
       return activeView === 'now-playing'
+    if (panel.kind === 'builtin' && panel.id === 'kamp.downloads') return activeView === 'downloads'
     return false
   }
 
@@ -558,6 +572,9 @@ export default function App(): React.JSX.Element {
       if (selectedArtist !== null || selectedAlbum !== null) selectArtist(null)
     } else if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing') {
       void setActiveView('now-playing')
+      setActiveExtPanel(null)
+    } else if (panel.kind === 'builtin' && panel.id === 'kamp.downloads') {
+      void setActiveView('downloads')
       setActiveExtPanel(null)
     } else if (panel.kind === 'extension') {
       setActiveExtPanel(panel.id)
@@ -581,6 +598,7 @@ export default function App(): React.JSX.Element {
     const isHomePane = !searchQuery && !activeExtPanel && activeView === 'home'
     const isLibraryPane = !searchQuery && !activeExtPanel && activeView === 'library'
     const isNowPlayingPane = !searchQuery && !activeExtPanel && activeView === 'now-playing'
+    const isDownloadsPane = !searchQuery && !activeExtPanel && activeView === 'downloads'
     return (
       <>
         {/* key=panel.id forces a fresh component+DOM node on extension panel
@@ -595,6 +613,9 @@ export default function App(): React.JSX.Element {
         </div>
         <div className={isNowPlayingPane ? 'view-pane view-pane--active' : 'view-pane'}>
           <NowPlayingView />
+        </div>
+        <div className={isDownloadsPane ? 'view-pane view-pane--active' : 'view-pane'}>
+          <DownloadsView />
         </div>
       </>
     )

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -355,7 +355,7 @@ export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
   post('/api/v1/config/library-path', { path })
 
 export type UiState = {
-  active_view: 'library' | 'now-playing' | 'home'
+  active_view: 'library' | 'now-playing' | 'home' | 'downloads'
   sort_order:
     | 'album_artist'
     | 'album'
@@ -369,7 +369,7 @@ export type UiState = {
 
 export const getUiState = (): Promise<UiState> => get('/api/v1/ui')
 export const setActiveViewApi = (
-  view: 'library' | 'now-playing' | 'home'
+  view: 'library' | 'now-playing' | 'home' | 'downloads'
 ): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
   sortOrder:
@@ -439,6 +439,37 @@ export const downloadAlbum = (saleItemId: string): Promise<{ ok: boolean }> =>
 
 export const removeDownload = (saleItemId: string): Promise<{ ok: boolean }> =>
   del(`/api/v1/bandcamp/collection/${encodeURIComponent(saleItemId)}/download`)
+
+// ---------------------------------------------------------------------------
+// Download queue (KAMP-568) — provider-neutral /api/v1/downloads surface
+// ---------------------------------------------------------------------------
+
+// One row of the download queue; mirrors the daemon's download_queue_items()
+// (KAMP-564/566). Also the payload shape of the `download.queue` WS snapshot.
+export type DownloadItem = {
+  provider: string
+  provider_item_id: string
+  status: 'queued' | 'downloading' | 'failed'
+  position: number
+  size_bytes: number | null
+  size_is_estimate: boolean
+  error_text: string | null
+  album_name: string | null
+  album_artist: string | null
+  artwork_ref: string | null
+  queued_at: number
+}
+
+export const getDownloads = (): Promise<{ items: DownloadItem[] }> => get('/api/v1/downloads')
+
+export const reorderDownloads = (providerItemIds: string[]): Promise<{ ok: boolean }> =>
+  post('/api/v1/downloads/reorder', { provider_item_ids: providerItemIds })
+
+export const retryDownload = (id: string): Promise<{ ok: boolean }> =>
+  post(`/api/v1/downloads/${encodeURIComponent(id)}/retry`)
+
+export const cancelDownload = (id: string): Promise<{ ok: boolean }> =>
+  del(`/api/v1/downloads/${encodeURIComponent(id)}`)
 
 // ---------------------------------------------------------------------------
 // Player
@@ -776,6 +807,12 @@ export type PipelineStageMessage = {
   // ("" before extraction, and for pre-558 daemons).
   album?: string
 }
+// KAMP-566/568: full download-queue snapshot for the Downloads view, broadcast
+// on every queue transition. `items` is the same shape as GET /api/v1/downloads.
+export type DownloadQueueMessage = {
+  type: 'download.queue'
+  items: DownloadItem[]
+}
 export type ServerMessage =
   | StateMessage
   | TrackChangedMessage
@@ -786,6 +823,7 @@ export type ServerMessage =
   | AlbumDownloadMessage
   | MagicPlaylistUpdatedMessage
   | PipelineStageMessage
+  | DownloadQueueMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -812,7 +850,10 @@ export function connectStateStream(
   onMagicPlaylistUpdated?: (id: number) => void,
   // KAMP-562: per-album pipeline stage. Named distinctly from the preload's
   // global `onPipelineStage` (which drives the nav-bar indicator).
-  onAlbumPipelineStage?: (saleItemId: string | null, stage: string, committed: boolean) => void
+  onAlbumPipelineStage?: (saleItemId: string | null, stage: string, committed: boolean) => void,
+  // KAMP-568: full download-queue snapshot for the Downloads view. Appended last
+  // so the existing positional callbacks keep their indices.
+  onDownloadQueue?: (items: DownloadItem[]) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -834,6 +875,7 @@ export function connectStateStream(
       else if (msg.type === 'magic_playlist.updated') onMagicPlaylistUpdated?.(msg.id)
       else if (msg.type === 'pipeline.stage')
         onAlbumPipelineStage?.(msg.sale_item_id ?? null, msg.stage, msg.committed ?? false)
+      else if (msg.type === 'download.queue') onDownloadQueue?.(msg.items)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/components/DownloadsView.tsx
+++ b/kamp_ui/src/renderer/src/components/DownloadsView.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { useStore } from '../store'
+
+/**
+ * Downloads view (KAMP-568 scaffolding).
+ *
+ * This is the stub that wires the plumbing — the `activeView`/nav slot and the
+ * `downloadQueue` store slice fed by the REST snapshot + `download.queue` WS
+ * event. The real Now Downloading / Queued / Failed cards land in a later epic
+ * step; for now this renders a minimal empty state (or a bare count so the live
+ * wiring is observable).
+ */
+export function DownloadsView(): React.JSX.Element {
+  const queue = useStore((s) => s.downloadQueue)
+
+  if (queue.length === 0) {
+    return (
+      <div className="downloads-empty">
+        <div className="downloads-empty-icon">⬇</div>
+        <div className="downloads-empty-hint">Download queue is empty</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="downloads-empty">
+      <div className="downloads-empty-hint">
+        {queue.length} download{queue.length === 1 ? '' : 's'} in the queue
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -14,6 +14,7 @@ import type {
   AlbumTagsCollision,
   ConfigValues,
   CriteriaDoc,
+  DownloadItem,
   PlayerState,
   Playlist,
   PlaylistTrack,
@@ -68,7 +69,7 @@ type PlayerStore = {
   peakDb: number | null
 
   configuredLibraryPath: string | null
-  activeView: 'library' | 'now-playing' | 'home'
+  activeView: 'library' | 'now-playing' | 'home' | 'downloads'
   moduleOrder: string[]
   hiddenModules: string[]
   moduleDisplayStyles: Record<string, DisplayStyle>
@@ -128,6 +129,11 @@ type PlayerStore = {
   // keyed by sale_item_id. Drives the pulsing tag badge until the rescan flips
   // the album to local.
   taggingAlbumIds: Set<string>
+  // KAMP-568: full download-queue snapshot (Now Downloading / Queued / Failed) for
+  // the Downloads view. Loaded once via GET /api/v1/downloads and kept live by the
+  // `download.queue` WS event. Distinct from the per-album KAMP-436 sets above,
+  // which decorate the library grid.
+  downloadQueue: DownloadItem[]
   flashToast: string | null
   styleRailVisible: boolean
   selectedTheme: ThemeName
@@ -144,7 +150,7 @@ type PlayerStore = {
   ) => Promise<void>
   setSortDir: (dir: 'asc' | 'desc') => Promise<void>
   setLibraryFilter: (filters: string[]) => void
-  setActiveView: (view: 'library' | 'now-playing' | 'home') => Promise<void>
+  setActiveView: (view: 'library' | 'now-playing' | 'home' | 'downloads') => Promise<void>
   setModuleOrder: (ids: string[]) => void
   hideModule: (id: string) => void
   showModule: (id: string) => void
@@ -161,6 +167,9 @@ type PlayerStore = {
   markAlbumTagging: (saleItemId: string) => void
   clearAlbumTagging: (saleItemId: string) => void
   removeDownload: (saleItemId: string) => Promise<void>
+  // KAMP-568: download-queue snapshot (Downloads view)
+  loadDownloads: () => Promise<void>
+  setDownloadQueue: (items: DownloadItem[]) => void
   showFlashToast: (msg: string) => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
@@ -429,6 +438,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   queuedAlbumIds: new Set<string>(),
   downloadProgress: new Map<string, number>(),
   taggingAlbumIds: new Set<string>(),
+  downloadQueue: [],
   flashToast: null,
   styleRailVisible: false,
   selectedTheme: (localStorage.getItem('kamp:selected-theme') as ThemeName | null) ?? 'kamp',
@@ -631,6 +641,17 @@ export const useStore = create<PlayerStore>((set, get) => ({
       get().showFlashToast(msg)
     }
   },
+  // KAMP-568: seed the Downloads view from the REST snapshot; live updates then
+  // arrive via the `download.queue` WS event (setDownloadQueue).
+  loadDownloads: async () => {
+    try {
+      const { items } = await api.getDownloads()
+      set({ downloadQueue: items })
+    } catch {
+      // best-effort; the WS snapshot will populate on the next transition
+    }
+  },
+  setDownloadQueue: (items) => set({ downloadQueue: items }),
   showFlashToast: (msg) => {
     set({ flashToast: msg })
     setTimeout(() => set({ flashToast: null }), 5000)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1903,6 +1903,12 @@ class TestUiStateEndpoints:
         assert resp.status_code == 200
         assert client.get("/api/v1/ui").json()["active_view"] == "home"
 
+    def test_set_active_view_downloads_persists(self, client: TestClient) -> None:
+        """The 'downloads' view (KAMP-568) is accepted and round-trips through GET."""
+        resp = client.post("/api/v1/ui/active-view", json={"view": "downloads"})
+        assert resp.status_code == 200
+        assert client.get("/api/v1/ui").json()["active_view"] == "downloads"
+
     def test_set_active_view_invalid_returns_422(self, client: TestClient) -> None:
         resp = client.post("/api/v1/ui/active-view", json={"view": "bogus"})
         assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Step 6 of Epic KAMP-435 and the first UI slice. Wires the plumbing for the Downloads view — the `activeView` value, a nav entry, a store slice fed by the KAMP-566 `download.queue` snapshot + KAMP-567 `/api/v1/downloads` REST — before the visuals. Ships a **stub** DownloadsView; the Now Downloading / Queued / Failed cards are a later epic step.

## Changes

**Backend (small, testable):**
- Accept `"downloads"` in the `ui.active_view` allowlist (`server.py` validation + `config.py` frozenset) so the view persists instead of 422-ing the round-trip. Python test round-trips it through `GET /api/v1/ui`.

**Renderer (renderer-stream pattern, confirmed — not the preload bridge):**
- Widen the `activeView` union in all 4 canonical spots (store.ts, client.ts).
- `client.ts`: `DownloadItem` type (mirrors `download_queue_items()`), `DownloadQueueMessage` added to `ServerMessage`, REST fns `getDownloads`/`reorderDownloads`/`retryDownload`/`cancelDownload` (reorder body `{provider_item_ids}` per the KAMP-567 model), and an `onDownloadQueue` callback **appended last** to `connectStateStream` (positional-safe) + its branch.
- `store.ts`: `downloadQueue: DownloadItem[]` slice with `setDownloadQueue` + `loadDownloads()`; the existing per-album KAMP-436 sets are untouched.
- `App.tsx`: register the `kamp.downloads` panel (auto nav tab), `isActiveMain`/`activateMain` branches, `isDownloadsPane` pane; wire `onDownloadQueue → setDownloadQueue` and `loadDownloads()` on connect.
- New stub `components/DownloadsView.tsx` (empty-state / bare count).

## Why the renderer stream, not the preload bridge
The ticket named the preload bridge, but the existing `bandcamp.album-download` event and `removeDownload` REST already flow through the renderer's `client.ts` + `connectStateStream` + `App.tsx` → store; the preload bridge is reserved for system-level events (needs-login, OS now-playing). Putting `download.queue` on the renderer stream matches the codebase and avoids redundant duplicate delivery. Confirmed with the reporter.

## Test plan
- Python: `test_set_active_view_downloads_persists` (accepts `'downloads'`, round-trips). Full suite: 2323 passed, coverage 93.45%; black + mypy clean.
- Frontend (no unit-test runner): `npm run typecheck` clean — the union widening makes the compiler prove every `activeView ===` site is exhaustive — and `eslint` clean. Grep-verified no missed `activeView` sites.

## Manual test plan (visual — reporter)
- A "Downloads" tab appears in the view nav; clicking it highlights and shows the stub view; other views still switch.
- The Downloads view selection persists across an app restart (no 422 in the daemon log).
- With a download queued/failed, the store's `downloadQueue` populates from `GET /api/v1/downloads` on connect and updates live on `download.queue` (inspectable via devtools even though the stub renders no cards).
- The KAMP-436 art reveal and the Bandcamp sync spinner still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)