### PR TITLE
feat(downloads): background size-backfill for queued downloads (KAMP-574)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5272,6 +5272,24 @@ class LibraryIndex:
         ).fetchone()
         return None if row is None else str(row["provider_item_id"])
 
+    def queued_downloads_missing_size(self, *, provider: str = "bandcamp") -> list[str]:
+        """Return provider_item_ids of 'queued' items that have no size yet.
+
+        Drives the KAMP-574 background size-backfill: only 'queued' rows with a
+        NULL size_bytes are returned (downloading/failed/already-sized rows are
+        excluded), front-of-queue first, so an estimate is never written over the
+        exact Content-Length an in-flight download will set.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT provider_item_id FROM download_queue
+             WHERE provider = ? AND status = 'queued' AND size_bytes IS NULL
+             ORDER BY position ASC, id ASC
+            """,
+            (provider,),
+        ).fetchall()
+        return [str(r["provider_item_id"]) for r in rows]
+
     def mark_downloading(
         self, provider_item_id: str, *, provider: str = "bandcamp"
     ) -> None:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1075,6 +1075,41 @@ def _cmd_daemon(
         target=_download_worker, daemon=True, name="album-dl-worker"
     ).start()
 
+    # ---------------------------------------------------------------------------
+    # Download size backfill (KAMP-574)
+    # ---------------------------------------------------------------------------
+    # Queued items have no File Size until they download (Content-Length). This
+    # background poll fills an *estimate* from each item's download-page size_mb,
+    # throttled, and re-broadcasts the queue snapshot so the Downloads-view cards
+    # update. Best-effort: it only touches the network when queued items lack a
+    # size and a Bandcamp session exists, and never crashes the daemon.
+    _SIZE_BACKFILL_INTERVAL = 8.0  # seconds between poll cycles
+
+    def _size_backfill_worker() -> None:
+        import time as _t
+
+        from .bandcamp import _make_requests_session, backfill_download_sizes
+
+        while True:
+            try:
+                session_data = index.get_session("bandcamp")
+                if session_data and index.queued_downloads_missing_size():
+                    bc = Config.load(index).bandcamp
+                    if bc is not None:
+                        backfill_download_sizes(
+                            index,
+                            bc.format,
+                            _make_requests_session(session_data),
+                            on_updated=lambda _pid: app.state.notify_download_queue(),
+                        )
+            except Exception:
+                _logger.exception("Download size backfill cycle failed")
+            _t.sleep(_SIZE_BACKFILL_INTERVAL)
+
+    threading.Thread(
+        target=_size_backfill_worker, daemon=True, name="download-size-backfill"
+    ).start()
+
     # Wrap the existing on_track_end callback to also push track.changed events.
     # Done here (after app creation) so app.state is guaranteed to be available.
     _original_on_track_end = engine.on_track_end

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1323,6 +1323,112 @@ def _get_cdn_url(redownload_url: str, fmt: str, session: _AnySession) -> str:
     return cdn_url
 
 
+# Decimal-unit multipliers for Bandcamp's `size_mb` strings (KAMP-563: Bandcamp
+# reports decimal MB, e.g. "81.2MB"). Matches the UI's formatBytes (also decimal).
+_SIZE_UNIT_BYTES = {
+    "KB": 1_000,
+    "MB": 1_000_000,
+    "GB": 1_000_000_000,
+    "TB": 1_000_000_000_000,
+}
+
+
+def _parse_size_mb(value: str | None) -> int | None:
+    """Parse a Bandcamp download-page size string ("81.2MB", "259MB", "1.2GB")
+    into a byte count, or None when absent/unparseable. A bare number is treated
+    as MB (the field's default unit)."""
+    if not value:
+        return None
+    m = re.match(r"\s*([\d.]+)\s*(KB|MB|GB|TB)?\s*$", str(value), re.IGNORECASE)
+    if not m:
+        return None
+    try:
+        num = float(m.group(1))
+    except ValueError:
+        return None
+    unit = (m.group(2) or "MB").upper()
+    return int(num * _SIZE_UNIT_BYTES[unit])
+
+
+def get_download_size_bytes(
+    redownload_url: str, fmt: str, session: _AnySession
+) -> int | None:
+    """Return the download size in bytes for *fmt* from the item's download page.
+
+    Reads ``download_items[0].downloads[<fmt>].size_mb`` from the same pagedata
+    blob :func:`_get_cdn_url` uses (KAMP-563/574). Best-effort: returns None on
+    any failure (item not ready, format absent, network/parse error) rather than
+    raising, so a background backfill can just skip it and move on.
+    """
+    try:
+        resp = session.get(redownload_url, timeout=30)
+        resp.raise_for_status()
+        blob = _extract_pagedata(resp.text, redownload_url)
+        items: list[dict[str, Any]] = (
+            blob.get("download_items") or blob.get("digital_items") or []
+        )
+        if not items:
+            return None
+        downloads: dict[str, Any] = items[0].get("downloads") or {}
+        fmt_data = downloads.get(fmt)
+        if not isinstance(fmt_data, dict):
+            return None
+        return _parse_size_mb(fmt_data.get("size_mb"))
+    except Exception:
+        return None
+
+
+def backfill_download_sizes(
+    index: "LibraryIndex",
+    fmt: str,
+    session: _AnySession,
+    *,
+    on_updated: Callable[[str], None] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    throttle: float = 1.0,
+) -> int:
+    """Fill an estimated File Size on queued download-queue items (KAMP-574).
+
+    For each 'queued' item lacking a size, fetch the download page's ``size_mb``
+    for *fmt* and store it as an estimate (``is_estimate=True``). The exact
+    Content-Length written when the item starts downloading later overrides it.
+
+    Fetches the collection once to resolve each item's ``redownload_url``, then
+    hits one download page per item, throttled (``throttle`` seconds between
+    items) to avoid Bandcamp 429s. *on_updated* fires with the provider_item_id
+    after each successful size write (used to re-broadcast the queue snapshot).
+    Returns the number of items sized. Items whose size can't be resolved are
+    skipped (they keep a NULL size and retry on the next cycle).
+    """
+    pids = index.queued_downloads_missing_size()
+    if not pids:
+        return 0
+
+    fan_id, _username = _get_fan_info(session)
+    collection = _fetch_collection(fan_id, session, index)
+    url_by_sid: dict[str, str] = {
+        str(item["sale_item_id"]): item["redownload_url"]
+        for item in collection
+        if item.get("sale_item_id") is not None and item.get("redownload_url")
+    }
+
+    sized = 0
+    for i, pid in enumerate(pids):
+        redownload_url = url_by_sid.get(pid)
+        if not redownload_url:
+            continue
+        if i > 0:
+            sleep(throttle)  # rate-limit download-page requests
+        size = get_download_size_bytes(redownload_url, fmt, session)
+        if size is None:
+            continue
+        index.set_download_size(pid, size, is_estimate=True)
+        sized += 1
+        if on_updated is not None:
+            on_updated(pid)
+    return sized
+
+
 def _resolve_cdn_redirect(cdn_url: str, session: _AnySession) -> str:
     """Authenticate the popplers5 CDN URL so that a subsequent cookieless download works.
 

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -20,6 +20,7 @@ from kamp_daemon.bandcamp import (
     _download_file,
     _download_item,
     _parse_content_length,
+    _parse_size_mb,
     _ensure_session,
     _extract_pagedata,
     _fetch_collection,
@@ -32,10 +33,12 @@ from kamp_daemon.bandcamp import (
     _session_from_cookie_file,
     _username_from_logout_cookie,
     _validate_session,
+    backfill_download_sizes,
     download_single_album,
     fetch_album_art_bytes,
     fetch_album_tracks,
     fetch_stream_url,
+    get_download_size_bytes,
     mark_collection_synced,
     refresh_stream_url,
     sync_collection_stream,
@@ -3470,3 +3473,160 @@ class TestDownloadSingleAlbum:
             self._run(
                 tmp_path, collection=[self._collection_item("42", with_url=False)]
             )
+
+
+class TestParseSizeMb:
+    """_parse_size_mb: Bandcamp download-page size string → bytes (KAMP-574)."""
+
+    def test_mb_with_decimal(self) -> None:
+        assert _parse_size_mb("81.2MB") == 81_200_000
+
+    def test_mb_whole(self) -> None:
+        assert _parse_size_mb("259MB") == 259_000_000
+
+    def test_gb(self) -> None:
+        assert _parse_size_mb("1.2GB") == 1_200_000_000
+
+    def test_bare_number_is_mb(self) -> None:
+        assert _parse_size_mb("57") == 57_000_000
+
+    def test_whitespace_and_case(self) -> None:
+        assert _parse_size_mb("  92.5 mb ") == 92_500_000
+
+    def test_none_and_garbage(self) -> None:
+        assert _parse_size_mb(None) is None
+        assert _parse_size_mb("") is None
+        assert _parse_size_mb("unknown") is None
+
+
+class TestGetDownloadSizeBytes:
+    """get_download_size_bytes: read size_mb from the download page (KAMP-574)."""
+
+    def _session(self, blob: dict[str, Any]) -> MagicMock:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.text = _make_pagedata_html(blob)
+        resp.raise_for_status = MagicMock()
+        session.get.return_value = resp
+        return session
+
+    def test_returns_bytes_for_format(self) -> None:
+        blob = {
+            "download_items": [
+                {"downloads": {"flac": {"url": "x", "size_mb": "252.2MB"}}}
+            ]
+        }
+        assert (
+            get_download_size_bytes(
+                "https://bc/download?x", "flac", self._session(blob)
+            )
+            == 252_200_000
+        )
+
+    def test_none_when_format_absent(self) -> None:
+        blob = {"download_items": [{"downloads": {"mp3-v0": {"size_mb": "81MB"}}}]}
+        assert (
+            get_download_size_bytes(
+                "https://bc/download?x", "flac", self._session(blob)
+            )
+            is None
+        )
+
+    def test_none_when_no_downloads(self) -> None:
+        blob = {"download_items": [{"downloads": {}}]}
+        assert (
+            get_download_size_bytes(
+                "https://bc/download?x", "flac", self._session(blob)
+            )
+            is None
+        )
+
+    def test_none_on_network_error(self) -> None:
+        session = MagicMock()
+        session.get.side_effect = RuntimeError("boom")
+        assert get_download_size_bytes("https://bc/download?x", "flac", session) is None
+
+
+class TestBackfillDownloadSizes:
+    """backfill_download_sizes: estimate File Size on queued items (KAMP-574)."""
+
+    def _collection(self, sids: list[str]) -> list[dict[str, Any]]:
+        return [
+            {"sale_item_id": s, "redownload_url": f"https://bc/download?sid={s}"}
+            for s in sids
+        ]
+
+    def test_sizes_queued_items_as_estimates(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = ["a", "b"]
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=self._collection(["a", "b"]),
+        )
+        mocker.patch(
+            "kamp_daemon.bandcamp.get_download_size_bytes",
+            side_effect=[81_000_000, 252_000_000],
+        )
+        updated: list[str] = []
+        slept: list[float] = []
+
+        n = backfill_download_sizes(
+            index,
+            "flac",
+            MagicMock(),
+            on_updated=updated.append,
+            sleep=slept.append,
+        )
+
+        assert n == 2
+        index.set_download_size.assert_any_call("a", 81_000_000, is_estimate=True)
+        index.set_download_size.assert_any_call("b", 252_000_000, is_estimate=True)
+        assert updated == ["a", "b"]
+        assert slept == [1.0]  # throttle between the two items (not before the first)
+
+    def test_skips_items_without_resolvable_size(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = ["a", "b"]
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=self._collection(["a", "b"]),
+        )
+        # 'a' has no size_mb (None); 'b' resolves.
+        mocker.patch(
+            "kamp_daemon.bandcamp.get_download_size_bytes",
+            side_effect=[None, 100_000_000],
+        )
+        n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
+        assert n == 1
+        index.set_download_size.assert_called_once_with(
+            "b", 100_000_000, is_estimate=True
+        )
+
+    def test_noop_when_nothing_queued(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = []
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection")
+        n = backfill_download_sizes(index, "flac", MagicMock())
+        assert n == 0
+        fetch.assert_not_called()  # no collection fetch when nothing needs sizing
+        index.set_download_size.assert_not_called()
+
+    def test_skips_item_missing_from_collection(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = ["a", "gone"]
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        # collection only has 'a' — 'gone' has no redownload_url and is skipped.
+        mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=self._collection(["a"]),
+        )
+        mocker.patch(
+            "kamp_daemon.bandcamp.get_download_size_bytes", return_value=50_000_000
+        )
+        n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
+        assert n == 1
+        index.set_download_size.assert_called_once_with(
+            "a", 50_000_000, is_estimate=True
+        )

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8906,6 +8906,25 @@ class TestDownloadQueueStateMachine:
         assert self._states(index) == [("a", "queued")]
         index.close()
 
+    def test_queued_downloads_missing_size(self, tmp_path: Path) -> None:
+        """Only 'queued' rows with a NULL size, front-of-queue first (KAMP-574)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b", "c", "d"):
+            index.enqueue_download(sid)
+        index.set_download_size("b", 1000, is_estimate=True)  # already sized → excluded
+        index.mark_downloading("a")  # downloading → excluded (only 'queued')
+        # Remaining queued-without-size are c, d in position order.
+        assert index.queued_downloads_missing_size() == ["c", "d"]
+        index.close()
+
+    def test_queued_downloads_missing_size_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.queued_downloads_missing_size() == []
+        index.enqueue_download("a")
+        index.set_download_size("a", 500, is_estimate=False)
+        assert index.queued_downloads_missing_size() == []  # sized
+        index.close()
+
 
 class TestRemoveDownload:
     """Tests for local_tracks_for_sale_item_id and remove_download."""


### PR DESCRIPTION
## Summary

Follow-up from KAMP-569 UI feedback. Queued download-queue items showed **no File Size** — the exact size only arrives from `Content-Length` when an item starts downloading. This adds a throttled daemon background task that fills queued cards with an **estimate** (`~81 MB`) from the Bandcamp download page's `size_mb` (the KAMP-563 spike's source, deferred out of the sync/enqueue hot path).

## Changes

- **`bandcamp.py`** (unit-tested):
  - `_parse_size_mb` — Bandcamp size string (`"81.2MB"`, `"259MB"`, `"1.2GB"`, bare-number→MB) → decimal bytes.
  - `get_download_size_bytes(redownload_url, fmt, session)` — reads `download_items[0].downloads[<fmt>].size_mb` from the same pagedata `_get_cdn_url` uses; **best-effort** (returns None on any error).
  - `backfill_download_sizes(index, fmt, session, *, on_updated, sleep, throttle)` — fetches the collection **once** to resolve redownload_urls, sizes each queued item as an estimate (`is_estimate=True`), throttled between items, firing `on_updated` per write.
- **`library.py`** — `queued_downloads_missing_size()` — `status='queued' AND size_bytes IS NULL`, position order (excludes downloading/failed/already-sized so an estimate never clobbers the exact size).
- **`__main__.py`** — `_size_backfill_worker` daemon thread: polls (~8 s), and only when queued items lack a size **and** a Bandcamp session exists does it build the session, read the current configured format fresh, run the backfill, and re-broadcast the `download.queue` snapshot. Best-effort — a failing cycle is logged, never fatal.

The exact `Content-Length` at download start still overrides the estimate (`size_is_estimate=0`, wired in KAMP-566). The UI already renders `~` for estimates (KAMP-569), so **no frontend change**.

## Test plan
- `TestParseSizeMb` (units/bare/whitespace/garbage), `TestGetDownloadSizeBytes` (format present/absent, no downloads, network error), `TestBackfillDownloadSizes` (sizes as estimates + throttle + on_updated; skips unresolvable + collection-missing items; no-op + no collection fetch when nothing queued), and `test_queued_downloads_missing_size` (query filters/order).
- Full suite: 2339 passed, coverage 93.46%. black + mypy clean. (The `__main__` thread is coverage-excluded daemon glue; the core logic it calls is fully tested.)

## Manual test plan
- Queue several albums → queued cards show `~NN MB` estimates filling in progressively (throttled).
- The downloading item shows the exact size (no `~`) once Content-Length arrives, overriding the estimate.
- Bandcamp disconnected → backfill does nothing, no errors in the daemon log.
- A large first-sync doesn't stall the daemon/UI (background + throttled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)