### PR TITLE
feat(downloads): queued reorder (pointer-events drag) + retry + cancel (KAMP-570)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/downloads.css
+++ b/kamp_ui/src/renderer/src/assets/downloads.css
@@ -43,6 +43,58 @@
   opacity: 0.6;
 }
 
+/* Queued cards are pointer-events drag origins (KAMP-570). */
+.download-card--draggable {
+  cursor: grab;
+  user-select: none;
+}
+.download-card--draggable:active {
+  cursor: grabbing;
+}
+
+/* Drag drop-indicators (mirror queue.css). */
+.download-card--drop-above {
+  box-shadow: inset 0 2px 0 0 var(--accent);
+}
+.download-card--drop-below {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+
+/* Retry / Cancel action buttons (KAMP-570). Hover-reveal on queued cards;
+   always visible on failed cards where Retry is a primary recovery action. */
+.download-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+.download-card-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.1s ease,
+    color 0.1s ease,
+    background 0.1s ease;
+}
+.download-card:hover .download-card-btn,
+.download-card--failed .download-card-btn {
+  opacity: 1;
+}
+.download-card-btn:hover {
+  color: var(--accent);
+  background: var(--surface-hover);
+}
+
 .download-card-thumb {
   position: relative;
   flex: 0 0 48px;

--- a/kamp_ui/src/renderer/src/components/DownloadCard.tsx
+++ b/kamp_ui/src/renderer/src/components/DownloadCard.tsx
@@ -2,24 +2,36 @@ import React, { useState } from 'react'
 import type { DownloadItem } from '../api/client'
 import { artUrl } from '../api/client'
 import { formatBytes } from '../utils/formatBytes'
+import { useTooltip } from '../hooks/useTooltip'
+import { RemoveFromQueueIcon, RetryIcon } from './TransportIcons'
 
 /**
- * One row of the Downloads view (KAMP-569), list layout mirroring the library
- * `.module-list-row`: artwork thumbnail + album name + artist + file size.
+ * One row of the Downloads view (KAMP-569/570): artwork thumbnail + album name +
+ * artist + file size, plus interactions (KAMP-570).
  *
- * Read-only display — reorder/retry/cancel controls are KAMP-570.
  * - A `downloading` card shows a byte-progress bar along its bottom edge; the
  *   percent comes from the store's `downloadProgress` map (KAMP-436), passed in
- *   as `progress`. `undefined` → indeterminate pulse, not a 0% bar.
- * - A `failed` card shows its `error_text`.
+ *   as `progress`. `undefined` → indeterminate pulse. No drag/buttons.
+ * - A `queued` card is a pointer-events drag origin (via `onPointerDown`, whose
+ *   handler lives in DownloadsView) and shows a Cancel (X) button.
+ * - A `failed` card shows its `error_text` plus Retry + Cancel buttons.
  */
 export function DownloadCard({
   item,
-  progress
+  progress,
+  dropIdx,
+  onPointerDown,
+  onRetry,
+  onCancel
 }: {
   item: DownloadItem
   progress?: number
+  dropIdx?: number
+  onPointerDown?: (id: string, clientX: number, clientY: number) => void
+  onRetry?: (id: string) => void
+  onCancel?: (id: string) => void
 }): React.JSX.Element {
+  const tooltip = useTooltip()
   const [artFailed, setArtFailed] = useState(false)
   // Resolve art through the daemon's /api/v1/album-art endpoint (same-origin, so
   // the renderer CSP allows it, unlike the raw bcbits.com `artwork_ref` URL). The
@@ -33,10 +45,28 @@ export function DownloadCard({
   const sizeLabel = size ? (item.size_is_estimate ? `~${size}` : size) : ''
 
   const isDownloading = item.status === 'downloading'
+  const isQueued = item.status === 'queued'
   const isFailed = item.status === 'failed'
+  const id = item.provider_item_id
 
   return (
-    <div className={`download-card${isFailed ? ' download-card--failed' : ''}`}>
+    <div
+      className={`download-card${isFailed ? ' download-card--failed' : ''}${
+        isQueued ? ' download-card--draggable' : ''
+      }`}
+      // Pointer-events drag (KAMP-456/458): queued cards only. data-drop-idx lets
+      // DownloadsView resolve the drop target from the cursor position.
+      data-drop-idx={isQueued ? dropIdx : undefined}
+      onPointerDown={
+        isQueued && onPointerDown
+          ? (e) => {
+              if (e.button !== 0) return
+              e.preventDefault()
+              onPointerDown(id, e.clientX, e.clientY)
+            }
+          : undefined
+      }
+    >
       <div className="download-card-thumb">
         {showArt && <img src={artSrc ?? ''} alt="" onError={() => setArtFailed(true)} />}
       </div>
@@ -48,6 +78,39 @@ export function DownloadCard({
         )}
       </div>
       {sizeLabel && <div className="download-card-size">{sizeLabel}</div>}
+      {(isQueued || isFailed) && (onRetry || onCancel) && (
+        <div className="download-card-actions">
+          {isFailed && onRetry && (
+            <button
+              className="download-card-btn"
+              {...tooltip('Retry download')}
+              aria-label="Retry download"
+              // stopPropagation on pointerdown so the button doesn't start a card drag
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation()
+                onRetry(id)
+              }}
+            >
+              <RetryIcon size={15} />
+            </button>
+          )}
+          {onCancel && (
+            <button
+              className="download-card-btn"
+              {...tooltip('Remove from queue')}
+              aria-label="Remove from queue"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation()
+                onCancel(id)
+              }}
+            >
+              <RemoveFromQueueIcon size={16} />
+            </button>
+          )}
+        </div>
+      )}
       {isDownloading && (
         <div
           className={`download-progress${

--- a/kamp_ui/src/renderer/src/components/DownloadsView.tsx
+++ b/kamp_ui/src/renderer/src/components/DownloadsView.tsx
@@ -1,20 +1,33 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useStore } from '../store'
-import type { DownloadItem } from '../api/client'
 import { DownloadCard } from './DownloadCard'
+import { computeNewOrder } from '../utils/computeNewOrder'
 
 /**
- * Downloads view (KAMP-569): the download queue split into Now Downloading /
- * Queued / Failed sections. Read-only display — reorder/retry/cancel are KAMP-570.
+ * Downloads view (KAMP-569/570): the download queue split into Now Downloading /
+ * Queued / Failed sections, with interactions.
  *
  * An empty section is not rendered at all (conditional render — no CSS height
  * animation, per CLAUDE.md). Two whole-view empty states gate ahead of the list:
  * no Downloads-capable service connected, then an empty queue.
+ *
+ * Queued cards drag to reorder via **pointer events** (not HTML5 drag), so Escape
+ * cancels instantly (KAMP-456/458): document pointermove/pointerup/keydown are
+ * wired here on pointerdown and torn down together; the reorder only runs on
+ * pointerup. Retry/Cancel are optimistic store actions reconciled by the WS
+ * `download.queue` snapshot.
  */
 export function DownloadsView(): React.JSX.Element {
   const queue = useStore((s) => s.downloadQueue)
   const configValues = useStore((s) => s.configValues)
   const downloadProgress = useStore((s) => s.downloadProgress)
+  const reorderDownloadQueue = useStore((s) => s.reorderDownloadQueue)
+  const retryDownload = useStore((s) => s.retryDownload)
+  const cancelDownload = useStore((s) => s.cancelDownload)
+
+  // Currently highlighted drop-indicator element (avoids a DOM query on clear).
+  const activeDropRef = useRef<HTMLElement | null>(null)
+  const queuedSectionRef = useRef<HTMLElement | null>(null)
 
   // "Is any Downloads-capable service connected?" — today that is just Bandcamp.
   // configValues is null until loadConfig() resolves, so `?? false` treats the
@@ -46,31 +59,146 @@ export function DownloadsView(): React.JSX.Element {
   const queued = queue.filter((i) => i.status === 'queued')
   const failed = queue.filter((i) => i.status === 'failed')
 
-  const section = (
-    title: string,
-    items: DownloadItem[],
-    withProgress = false
-  ): React.JSX.Element | null =>
-    items.length === 0 ? null : (
-      <section className="downloads-section">
-        <h2 className="downloads-section-title">{title}</h2>
-        {items.map((item) => (
-          <DownloadCard
-            key={`${item.provider}:${item.provider_item_id}`}
-            item={item}
-            // downloadProgress (KAMP-436) is keyed by the bandcamp sale id, which
-            // equals provider_item_id — so the lookup hits for the active download.
-            progress={withProgress ? downloadProgress.get(item.provider_item_id) : undefined}
-          />
-        ))}
-      </section>
-    )
+  // --- Pointer-events drag reorder (queued cards only) ----------------------
+  const clearDropIndicator = (): void => {
+    const el = activeDropRef.current
+    if (el) {
+      el.classList.remove('download-card--drop-above', 'download-card--drop-below')
+      activeDropRef.current = null
+    }
+  }
+
+  const cardUnder = (x: number, y: number): HTMLElement | null => {
+    const el = document.elementFromPoint(x, y)
+    return (el?.closest('.download-card[data-drop-idx]') as HTMLElement | null) ?? null
+  }
+
+  const updateDropIndicator = (x: number, y: number): void => {
+    clearDropIndicator()
+    const card = cardUnder(x, y)
+    if (!card) return
+    const rect = card.getBoundingClientRect()
+    const cls =
+      y < rect.top + rect.height / 2 ? 'download-card--drop-above' : 'download-card--drop-below'
+    card.classList.add(cls)
+    activeDropRef.current = card
+  }
+
+  const resolveDropIdx = (x: number, y: number): number | null => {
+    const card = cardUnder(x, y)
+    if (!card) {
+      // Dropped in the Queued section's empty area → tail.
+      const sec = queuedSectionRef.current
+      if (sec) {
+        const r = sec.getBoundingClientRect()
+        if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return queued.length
+      }
+      return null
+    }
+    const idx = parseInt(card.dataset.dropIdx ?? '')
+    if (isNaN(idx)) return null
+    const rect = card.getBoundingClientRect()
+    return y < rect.top + rect.height / 2 ? idx : idx + 1
+  }
+
+  const handleQueuedPointerDown = (id: string, startX: number, startY: number): void => {
+    const draggedIdx = queued.findIndex((i) => i.provider_item_id === id)
+    if (draggedIdx < 0) return
+    let dragStarted = false
+    let ghost: HTMLDivElement | null = null
+
+    const onMove = (ev: PointerEvent): void => {
+      if (!dragStarted) {
+        if (Math.abs(ev.clientX - startX) < 4 && Math.abs(ev.clientY - startY) < 4) return
+        dragStarted = true
+        ghost = document.createElement('div')
+        ghost.textContent = queued[draggedIdx].album_name || 'Download'
+        ghost.style.cssText =
+          'position:fixed;top:-100px;left:-100px;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;background:var(--accent);color:#fff;padding:4px 10px;border-radius:3px;font-size:12px;font-weight:600;pointer-events:none;z-index:9999'
+        document.body.appendChild(ghost)
+      }
+      if (ghost) {
+        ghost.style.left = `${ev.clientX + 12}px`
+        ghost.style.top = `${ev.clientY - 12}px`
+      }
+      updateDropIndicator(ev.clientX, ev.clientY)
+    }
+
+    const cleanup = (): void => {
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onUp)
+      document.removeEventListener('keydown', onEscape)
+      if (ghost) {
+        document.body.removeChild(ghost)
+        ghost = null
+      }
+      clearDropIndicator()
+    }
+
+    const onUp = (ev: PointerEvent): void => {
+      const wasDrag = dragStarted
+      cleanup()
+      if (!wasDrag) return
+      const dropIdx = resolveDropIdx(ev.clientX, ev.clientY)
+      if (dropIdx === null) return
+      const order = computeNewOrder(queued.length, [draggedIdx], dropIdx)
+      const orderedIds = order.map((i) => queued[i].provider_item_id)
+      void reorderDownloadQueue(orderedIds)
+    }
+
+    // Escape cancels the drag immediately (real DOM listener; no reorder runs).
+    const onEscape = (ev: KeyboardEvent): void => {
+      if (ev.key === 'Escape') cleanup()
+    }
+
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onUp)
+    document.addEventListener('keydown', onEscape)
+  }
 
   return (
     <div className="downloads-view">
-      {section('Now Downloading', downloading, true)}
-      {section('Queued', queued)}
-      {section('Failed', failed)}
+      {downloading.length > 0 && (
+        <section className="downloads-section">
+          <h2 className="downloads-section-title">Now Downloading</h2>
+          {downloading.map((item) => (
+            <DownloadCard
+              key={`${item.provider}:${item.provider_item_id}`}
+              item={item}
+              // downloadProgress (KAMP-436) is keyed by the bandcamp sale id, which
+              // equals provider_item_id — so the lookup hits for the active download.
+              progress={downloadProgress.get(item.provider_item_id)}
+            />
+          ))}
+        </section>
+      )}
+      {queued.length > 0 && (
+        <section className="downloads-section" ref={queuedSectionRef}>
+          <h2 className="downloads-section-title">Queued</h2>
+          {queued.map((item, idx) => (
+            <DownloadCard
+              key={`${item.provider}:${item.provider_item_id}`}
+              item={item}
+              dropIdx={idx}
+              onPointerDown={handleQueuedPointerDown}
+              onCancel={cancelDownload}
+            />
+          ))}
+        </section>
+      )}
+      {failed.length > 0 && (
+        <section className="downloads-section">
+          <h2 className="downloads-section-title">Failed</h2>
+          {failed.map((item) => (
+            <DownloadCard
+              key={`${item.provider}:${item.provider_item_id}`}
+              item={item}
+              onRetry={retryDownload}
+              onCancel={cancelDownload}
+            />
+          ))}
+        </section>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -224,6 +224,16 @@ export function RemoveFromQueueIcon({ size = 16 }: IconProps): React.JSX.Element
   )
 }
 
+// KAMP-570: retry a failed download — a clockwise circular arrow.
+export function RetryIcon({ size = 16 }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} {...STROKE_PROPS}>
+      <path d="M21 5v6h-6" />
+      <path d="M19 13a8 8 0 1 1-2-6.34L21 11" />
+    </svg>
+  )
+}
+
 export function FavoriteIcon({ active, size = 16 }: FavoriteIconProps): React.JSX.Element {
   return (
     <svg

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -170,6 +170,11 @@ type PlayerStore = {
   // KAMP-568: download-queue snapshot (Downloads view)
   loadDownloads: () => Promise<void>
   setDownloadQueue: (items: DownloadItem[]) => void
+  // KAMP-570: Downloads-view interactions (optimistic; the download.queue WS
+  // snapshot reconciles, or loadDownloads() reverts on API failure).
+  reorderDownloadQueue: (orderedQueuedIds: string[]) => Promise<void>
+  retryDownload: (providerItemId: string) => Promise<void>
+  cancelDownload: (providerItemId: string) => Promise<void>
   showFlashToast: (msg: string) => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
@@ -652,6 +657,61 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }
   },
   setDownloadQueue: (items) => set({ downloadQueue: items }),
+  // KAMP-570: reorder the queued items. Optimistically rebuild the queue as
+  // [downloading, ...reordered queued, failed] (the snapshot's section order),
+  // then persist. The download.queue WS snapshot reconciles on success; a failed
+  // call reverts via loadDownloads(). Only 'queued' items are reorderable.
+  reorderDownloadQueue: async (orderedQueuedIds) => {
+    set((s) => {
+      const byId = new Map(s.downloadQueue.map((i) => [i.provider_item_id, i]))
+      const downloading = s.downloadQueue.filter((i) => i.status === 'downloading')
+      const failed = s.downloadQueue.filter((i) => i.status === 'failed')
+      const queued = orderedQueuedIds
+        .map((id) => byId.get(id))
+        .filter((i): i is DownloadItem => i != null)
+      return { downloadQueue: [...downloading, ...queued, ...failed] }
+    })
+    try {
+      await api.reorderDownloads(orderedQueuedIds)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not reorder downloads'
+      get().showFlashToast(msg)
+      void get().loadDownloads() // revert to authoritative state
+    }
+  },
+  // KAMP-570: retry a failed download — re-queue at the end. Optimistically flip
+  // the item to 'queued' in place (it sits after the other queued items in the
+  // array, so it renders at the end of the Queued section).
+  retryDownload: async (providerItemId) => {
+    set((s) => ({
+      downloadQueue: s.downloadQueue.map((i) =>
+        i.provider_item_id === providerItemId
+          ? { ...i, status: 'queued' as const, error_text: null }
+          : i
+      )
+    }))
+    try {
+      await api.retryDownload(providerItemId)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not retry download'
+      get().showFlashToast(msg)
+      void get().loadDownloads()
+    }
+  },
+  // KAMP-570: cancel a queued/failed item — remove it from the queue. Distinct
+  // from removeDownload (which reverts a completed download to streaming).
+  cancelDownload: async (providerItemId) => {
+    set((s) => ({
+      downloadQueue: s.downloadQueue.filter((i) => i.provider_item_id !== providerItemId)
+    }))
+    try {
+      await api.cancelDownload(providerItemId)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not cancel download'
+      get().showFlashToast(msg)
+      void get().loadDownloads()
+    }
+  },
   showFlashToast: (msg) => {
     set({ flashToast: msg })
     setTimeout(() => set({ flashToast: null }), 5000)


### PR DESCRIPTION
## Summary

Step 8 of Epic KAMP-435. Makes the Downloads cards interactive over the REST fns (KAMP-567) and store slice (KAMP-568) that already exist. Frontend-only.

## Changes

- **Queued reorder — pointer-events drag** (NOT HTML5 drag, so Escape cancels instantly, per KAMP-456/458). `DownloadsView` mirrors the play-queue's `handleAlbumCardPointerDown`: on `pointerdown` it wires `document` pointermove/pointerup/keydown, shows a floating ghost past a 4px threshold, tracks the drop target via `elementFromPoint` + `data-drop-idx` (queued cards only), and **reorders only on pointerup** using `computeNewOrder`; Escape runs the same `cleanup()` with no reorder. Only `queued` items move — the downloading item is fixed at top and Failed isn't a drop target.
- **Retry** button on Failed cards (re-queue at end); **Cancel (X)** button on Queued + Failed cards. New `RetryIcon`; `RemoveFromQueueIcon` reused for Cancel. Buttons use `useTooltip` + `aria-label` and `stopPropagation` on `onPointerDown` so a click never starts a card drag.
- **Optimistic store actions** (`reorderDownloadQueue`, `retryDownload`, `cancelDownload`): mutate `downloadQueue` immediately, call the REST endpoint, and let the `download.queue` WS snapshot reconcile; on API error they toast + `loadDownloads()` to revert (no re-fetch on success — avoids the KAMP-532 reconcile race). `cancelDownload` is distinct from the existing `removeDownload` (revert-to-streaming).
- CSS: `--draggable` grab cursor, inset-box-shadow drop indicators (no layout shift under the card's `overflow:hidden`), and `.download-card-btn` (hover-reveal on queued, always-visible on failed).

## Test plan
- Frontend-only (no Python, no unit-test runner): `npm run typecheck` + `eslint` clean (re-run by the pre-commit hook). New CSS selectors verified against the TSX class names.

## Manual test plan (visual — reporter)
- Drag a Queued card to reorder → persists (survives reload); downloading stays fixed at top; can't drop above it or into Failed.
- Escape mid-drag → cancels immediately, no reorder, no ~1s lag.
- Retry a Failed card → moves to end of Queued and downloads; Cancel (X) removes a Queued/Failed item instantly and it stays removed after the WS snapshot.
- A failed REST call reverts the optimistic change (item reappears) with a toast.
- Buttons don't start a drag; hover reveals Cancel on Queued; Retry+Cancel always visible on Failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)