### PR TITLE
feat(ui): global download progress bar above transport + error toast (KAMP-571)

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -280,10 +280,12 @@ export default function App(): React.JSX.Element {
             if (state === 'done' || state === 'removed') {
               void useStore.getState().loadLibrary()
               void useStore.getState().refreshOpenAlbum()
-            } else if (state === 'error') {
-              // KAMP-571: surface a failure toast. The transient error event can
-              // beat the queue snapshot that flips the item to 'failed', so the
-              // name/reason lookup is best-effort with a generic fallback.
+            } else if (state === 'error' || state === 'failed') {
+              // KAMP-571: surface a failure toast. The queue worker emits 'failed'
+              // (e.g. after exhausting 429 back-off retries); the direct download
+              // path emits 'error'. The status event can beat the queue snapshot
+              // that flips the item to 'failed', so the name/reason lookup is
+              // best-effort with a generic fallback.
               const item = useStore
                 .getState()
                 .downloadQueue.find((i) => i.provider_item_id === saleItemId)

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { DownloadsView } from './components/DownloadsView'
 import { PreferencesDialog } from './components/PreferencesDialog'
 import { QueuePanel } from './components/QueuePanel'
 import { BandcampButton } from './components/BandcampButton'
+import { GlobalDownloadBar } from './components/GlobalDownloadBar'
 import { PipelineIndicator } from './components/PipelineIndicator'
 import { SearchBar } from './components/SearchBar'
 import { SearchView } from './components/SearchView'
@@ -105,6 +106,7 @@ export default function App(): React.JSX.Element {
   const bumpMagicPlaylistVersion = useStore((s) => s.bumpMagicPlaylistVersion)
   const serverStatus = useStore((s) => s.serverStatus)
   const flashToast = useStore((s) => s.flashToast)
+  const flashToastTone = useStore((s) => s.flashToastTone)
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const activeView = useStore((s) => s.activeView)
   const setActiveView = useStore((s) => s.setActiveView)
@@ -278,6 +280,16 @@ export default function App(): React.JSX.Element {
             if (state === 'done' || state === 'removed') {
               void useStore.getState().loadLibrary()
               void useStore.getState().refreshOpenAlbum()
+            } else if (state === 'error') {
+              // KAMP-571: surface a failure toast. The transient error event can
+              // beat the queue snapshot that flips the item to 'failed', so the
+              // name/reason lookup is best-effort with a generic fallback.
+              const item = useStore
+                .getState()
+                .downloadQueue.find((i) => i.provider_item_id === saleItemId)
+              const name = item?.album_name || 'an album'
+              const reason = item?.error_text ? `: ${item.error_text}` : ''
+              useStore.getState().showFlashToast(`Download failed — ${name}${reason}`, 'error')
             }
           }
         },
@@ -689,6 +701,9 @@ export default function App(): React.JSX.Element {
         </main>
         {!showSetup && isPanelVisible(rightPanel) && <SlotPanel panel={rightPanel!} />}
       </div>
+      {/* KAMP-571: global download progress bar, directly above the transport in
+          every view (hides itself when the queue is idle). */}
+      <GlobalDownloadBar />
       {bottomPanel && <SlotPanel panel={bottomPanel} />}
       <UpdateBanner />
       {showShortcuts && <KeyboardShortcutsOverlay onClose={() => setShowShortcuts(false)} />}
@@ -711,7 +726,10 @@ export default function App(): React.JSX.Element {
       {/* Phase 2 iframes live here in a hidden holding area until their panel tab is activated */}
       <SandboxedExtensionLoader extensions={phase2Extensions} />
       {flashToast && (
-        <div className="flash-toast" role="status">
+        <div
+          className={`flash-toast${flashToastTone === 'error' ? ' flash-toast--error' : ''}`}
+          role="status"
+        >
           <span className="album-rename-toast-text">{flashToast}</span>
           <div className="album-rename-toast-bar" style={{ animationDuration: '5000ms' }} />
         </div>

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -786,7 +786,9 @@ export type AudioLevelMessage = {
 export type AlbumDownloadMessage = {
   type: 'bandcamp.album-download'
   sale_item_id: string
-  state: 'queued' | 'downloading' | 'done' | 'error' | 'removed'
+  // 'failed' is emitted by the queue worker (process_next_download); 'error' by the
+  // direct single-album download path. Both signal a failure.
+  state: 'queued' | 'downloading' | 'done' | 'error' | 'failed' | 'removed'
   // KAMP-436: byte-progress percent (0–100). Present only on 'downloading'
   // updates when the server knows the total size; absent → keep the pulse.
   progress?: number
@@ -844,7 +846,7 @@ export function connectStateStream(
   onTrackChanged?: () => void,
   onAlbumDownload?: (
     saleItemId: string,
-    state: 'queued' | 'downloading' | 'done' | 'error' | 'removed',
+    state: 'queued' | 'downloading' | 'done' | 'error' | 'failed' | 'removed',
     progress?: number
   ) => void,
   onMagicPlaylistUpdated?: (id: number) => void,

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -517,3 +517,13 @@ html[data-platform='win32'] .view-tabs {
   animation: toast-in 0.22s ease-out;
   pointer-events: none;
 }
+
+/* Error-toned variant (KAMP-571) — download failures and other error toasts. */
+.flash-toast--error {
+  border-color: var(--error);
+  border-left: 3px solid var(--error);
+}
+
+.flash-toast--error .album-rename-toast-bar {
+  background: var(--error);
+}

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -13,6 +13,45 @@
   flex-shrink: 0;
 }
 
+/* Global download progress bar (KAMP-571) — a thin, full-width, clickable bar that
+   sits directly above the transport in every view while downloads are in flight.
+   No chrome (it's a <button>); brightens on hover; no height animation. */
+.global-download-bar {
+  position: relative;
+  z-index: 10;
+  flex-shrink: 0;
+  width: 100%;
+  height: 4px;
+  padding: 0;
+  border: none;
+  background: var(--border);
+  cursor: pointer;
+  overflow: hidden;
+  display: block;
+}
+
+.global-download-bar:hover {
+  background: var(--surface-hover);
+}
+
+.global-download-bar-fill {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.global-download-bar:hover .global-download-bar-fill {
+  filter: brightness(1.15);
+}
+
+/* No live byte-progress yet → sliding pulse (reuses the KAMP-566 keyframe). */
+.global-download-bar-fill--indeterminate {
+  width: 40%;
+  transition: none;
+  animation: download-progress-slide 1.2s ease-in-out infinite;
+}
+
 .transport-track-info {
   --track-info-w: 220px;
   width: var(--track-info-w);

--- a/kamp_ui/src/renderer/src/components/GlobalDownloadBar.tsx
+++ b/kamp_ui/src/renderer/src/components/GlobalDownloadBar.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { useStore } from '../store'
+
+/**
+ * Global download progress bar (KAMP-571): a thin, full-width bar rendered just
+ * above the transport in every view while the download queue has work in flight.
+ * Clicking it opens the Downloads view. It hides when the queue is idle.
+ *
+ * All progress math lives in the store: `downloadBatch.floor` is the batch-anchored
+ * aggregate percent — completed items over the batch total, refined by the in-flight
+ * item's byte-percent, ratcheted monotonically (0–99) and reset when the batch
+ * drains (see store `setDownloadQueue` / `setAlbumProgress`). This component just
+ * renders it, so it never fights the zustand/React re-render rules.
+ */
+export function GlobalDownloadBar(): React.JSX.Element | null {
+  const batch = useStore((s) => s.downloadBatch)
+  const queue = useStore((s) => s.downloadQueue)
+  const setActiveView = useStore((s) => s.setActiveView)
+
+  if (batch == null || batch.total === 0) return null
+
+  const pct = batch.floor
+  const activeCount = queue.filter(
+    (i) => i.status === 'downloading' || i.status === 'queued'
+  ).length
+  // Nothing has reported measurable progress yet → indeterminate pulse instead of
+  // a stuck 0% sliver.
+  const indeterminate = pct <= 0
+
+  return (
+    <button
+      type="button"
+      className="global-download-bar"
+      onClick={() => void setActiveView('downloads')}
+      title={`${activeCount} downloading — click to view`}
+      aria-label={`Downloads in progress (${activeCount}) — open Downloads view`}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(pct)}
+    >
+      <div
+        className={`global-download-bar-fill${
+          indeterminate ? ' global-download-bar-fill--indeterminate' : ''
+        }`}
+        style={indeterminate ? undefined : { width: `${pct}%` }}
+      />
+    </button>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/GlobalDownloadBar.tsx
+++ b/kamp_ui/src/renderer/src/components/GlobalDownloadBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
 
 /**
  * Global download progress bar (KAMP-571): a thin, full-width bar rendered just
@@ -16,6 +17,7 @@ export function GlobalDownloadBar(): React.JSX.Element | null {
   const batch = useStore((s) => s.downloadBatch)
   const queue = useStore((s) => s.downloadQueue)
   const setActiveView = useStore((s) => s.setActiveView)
+  const tooltip = useTooltip()
 
   if (batch == null || batch.total === 0) return null
 
@@ -32,7 +34,7 @@ export function GlobalDownloadBar(): React.JSX.Element | null {
       type="button"
       className="global-download-bar"
       onClick={() => void setActiveView('downloads')}
-      title={`${activeCount} downloading — click to view`}
+      {...tooltip(`${activeCount} downloading — click to view`)}
       aria-label={`Downloads in progress (${activeCount}) — open Downloads view`}
       role="progressbar"
       aria-valuemin={0}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -134,7 +134,16 @@ type PlayerStore = {
   // `download.queue` WS event. Distinct from the per-album KAMP-436 sets above,
   // which decorate the library grid.
   downloadQueue: DownloadItem[]
+  // KAMP-571: batch-anchored aggregate for the global download bar. Tracks the
+  // ids seen active in the current download batch, the running total, how many
+  // have completed (left the queue, not failed), and `floor` — the monotonic
+  // displayed percent (0–99), ratcheted on every snapshot and byte-progress tick.
+  // Null when the queue is idle (bar hidden). Maintained in setDownloadQueue (done/
+  // total) and setAlbumProgress (live floor); the bar just renders `floor`.
+  downloadBatch: { seenIds: string[]; total: number; done: number; floor: number } | null
   flashToast: string | null
+  // KAMP-571: tone for the current flashToast; 'error' renders the red variant.
+  flashToastTone: 'error' | null
   styleRailVisible: boolean
   selectedTheme: ThemeName
 
@@ -175,7 +184,7 @@ type PlayerStore = {
   reorderDownloadQueue: (orderedQueuedIds: string[]) => Promise<void>
   retryDownload: (providerItemId: string) => Promise<void>
   cancelDownload: (providerItemId: string) => Promise<void>
-  showFlashToast: (msg: string) => void
+  showFlashToast: (msg: string, tone?: 'error') => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
   setHighlightEnabled: (enabled: boolean) => void
@@ -325,6 +334,31 @@ const initialPlayer: PlayerState = {
 const _albumTracksKey = (albumArtist: string, album: string, trackId: number | null): string =>
   trackId != null ? `id:${trackId}` : `${albumArtist}\0${album}`
 
+// KAMP-571: raw aggregate percent for the global download bar — completed items
+// plus the currently-downloading item's byte-fraction, over the batch total.
+// downloadProgress is keyed by sale_item_id (== provider_item_id for bandcamp);
+// `?? 0` guards a downloading item with no progress entry yet (avoids NaN).
+const _downloadBarRaw = (
+  items: DownloadItem[],
+  done: number,
+  total: number,
+  progress: Map<string, number>
+): number => {
+  if (total <= 0) return 0
+  let inFlight = 0
+  for (const i of items) {
+    if (i.status === 'downloading') inFlight += (progress.get(i.provider_item_id) ?? 0) / 100
+  }
+  return ((done + inFlight) / total) * 100
+}
+
+// Ratchet the displayed floor up toward `raw`, capped at 99 so the bar never sits
+// at a full-width "stall" during the last item's post-download tag/rescan tail (it
+// hides when the batch drains instead). The floor keeps the fill monotonic — a
+// mid-batch append grows `total` and would otherwise rewind it.
+const _ratchetFloor = (prevFloor: number, raw: number): number =>
+  Math.min(99, Math.max(prevFloor, raw))
+
 export const useStore = create<PlayerStore>((set, get) => ({
   player: initialPlayer,
   library: {
@@ -444,7 +478,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadProgress: new Map<string, number>(),
   taggingAlbumIds: new Set<string>(),
   downloadQueue: [],
+  downloadBatch: null,
   flashToast: null,
+  flashToastTone: null,
   styleRailVisible: false,
   selectedTheme: (localStorage.getItem('kamp:selected-theme') as ThemeName | null) ?? 'kamp',
   configValues: null,
@@ -608,7 +644,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set((s) => {
       const next = new Map(s.downloadProgress)
       next.set(saleItemId, progress)
-      return { downloadProgress: next }
+      // KAMP-571: ratchet the global download bar's floor with the new byte tick.
+      const b = s.downloadBatch
+      if (b == null) return { downloadProgress: next }
+      const floor = _ratchetFloor(b.floor, _downloadBarRaw(s.downloadQueue, b.done, b.total, next))
+      return {
+        downloadProgress: next,
+        downloadBatch: floor === b.floor ? b : { ...b, floor }
+      }
     }),
   clearAlbumProgress: (saleItemId) =>
     set((s) => {
@@ -651,12 +694,56 @@ export const useStore = create<PlayerStore>((set, get) => ({
   loadDownloads: async () => {
     try {
       const { items } = await api.getDownloads()
-      set({ downloadQueue: items })
+      get().setDownloadQueue(items) // route through the batch-tracking setter
     } catch {
       // best-effort; the WS snapshot will populate on the next transition
     }
   },
-  setDownloadQueue: (items) => set({ downloadQueue: items }),
+  setDownloadQueue: (items) =>
+    set((s) => {
+      // KAMP-571: fold the snapshot into the batch-anchored aggregate. A batch is
+      // "everything in flight until the queue drains". When nothing is active the
+      // batch resets (bar hides). Otherwise every newly-seen active id extends the
+      // total; `done` = seen ids that have left the queue without failing.
+      const active = items.filter((i) => i.status === 'downloading' || i.status === 'queued')
+      if (active.length === 0) return { downloadQueue: items, downloadBatch: null }
+
+      const prev = s.downloadBatch
+      const seenIds = prev ? prev.seenIds.slice() : []
+      const seen = new Set(seenIds)
+      for (const i of active) {
+        if (!seen.has(i.provider_item_id)) {
+          seen.add(i.provider_item_id)
+          seenIds.push(i.provider_item_id)
+        }
+      }
+      const activeSet = new Set(active.map((i) => i.provider_item_id))
+      const failedSet = new Set(
+        items.filter((i) => i.status === 'failed').map((i) => i.provider_item_id)
+      )
+      // A completed item has left the queue: seen, but no longer active and not
+      // failed. (Snapshot-only counting can't tell a user-cancelled item from a
+      // completed one, so a mid-batch cancel nudges `done` forward by one — never
+      // backward, and cancelling the last active item empties the batch entirely.)
+      let done = 0
+      for (const id of seenIds) if (!activeSet.has(id) && !failedSet.has(id)) done++
+      const total = seenIds.length
+
+      const raw = _downloadBarRaw(items, done, total, s.downloadProgress)
+      const floor = _ratchetFloor(prev?.floor ?? 0, raw)
+
+      // Reuse the prior object when nothing changed to avoid a re-render per
+      // snapshot (seenIds only grows, so a length match means an id match).
+      const batch =
+        prev &&
+        prev.total === total &&
+        prev.done === done &&
+        prev.floor === floor &&
+        prev.seenIds.length === seenIds.length
+          ? prev
+          : { seenIds, total, done, floor }
+      return { downloadQueue: items, downloadBatch: batch }
+    }),
   // KAMP-570: reorder the queued items. Optimistically rebuild the queue as
   // [downloading, ...reordered queued, failed] (the snapshot's section order),
   // then persist. The download.queue WS snapshot reconciles on success; a failed
@@ -712,9 +799,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
       void get().loadDownloads()
     }
   },
-  showFlashToast: (msg) => {
-    set({ flashToast: msg })
-    setTimeout(() => set({ flashToast: null }), 5000)
+  showFlashToast: (msg, tone) => {
+    // KAMP-571: clear both message and tone on expiry, or the next neutral toast
+    // would inherit a stale 'error' tone until its own re-render.
+    set({ flashToast: msg, flashToastTone: tone ?? null })
+    setTimeout(() => set({ flashToast: null, flashToastTone: null }), 5000)
   },
 
   setRecentlyAddedCount: (n) => {


### PR DESCRIPTION
Step 9 of Epic KAMP-435. Adds the cross-view download affordances: a global aggregate progress bar above the transport, and an error toast on failure.

## What changed
- **Global download bar** (`GlobalDownloadBar.tsx`) — a thin, full-width, clickable bar rendered directly above the transport in **every** view (mounted once in `App.tsx` before the bottom slot). Clicking it opens the Downloads view; it hides when the queue is idle.
- **Batch-anchored aggregate** (store) — fill = completed items over the batch total, refined by the in-flight item's byte-percent. All math lives in the store:
  - `setDownloadQueue` maintains `downloadBatch { seenIds, total, done, floor }` — a batch is everything in flight until the queue drains; `total` grows as new active ids appear, `done` counts ids that left the queue without failing.
  - `setAlbumProgress` ratchets `floor` on every byte tick.
  - `floor` is **monotonic (0–99)**: a mid-batch append never rewinds the bar, and the 99% cap avoids a full-bar "stall" during the last item's post-download tag/rescan tail (the bar hides when the batch drains).
- **Error toast** — the `bandcamp.album-download` `state==='error'` branch raises an error-toned `flashToast`, naming the album when known (best-effort; falls back to "an album"). `showFlashToast(msg, tone?)` gains an optional `'error'` tone; the 5s timer clears both message and tone. New `.flash-toast--error` variant.

## Notes
- The ticket's "PipelineIndicator is a static icon — replace it" premise is **stale** — that's the KAMP-558 top-nav folder/copy/tag indicator, unrelated to downloads. It's left untouched; the bar is a new element.
- Known caveat (documented in code): snapshot-only counting can't distinguish a user-cancelled item from a completed one, so a mid-batch cancel nudges progress **forward** by one — never backward, and cancelling the last active item hides the bar (no false 100%).
- Frontend-only, no Python → coverage gate unaffected. `npm run typecheck` + `eslint` clean (pre-commit hook re-ran both).

## Manual test plan
- [ ] Queue several albums → thin bar appears above the transport in **every** view; climbs as albums complete; hides when the queue drains.
- [ ] Fill never jumps **backward**, including when more albums are queued mid-download (it slows/holds, never rewinds).
- [ ] Click the bar → navigates to the Downloads view.
- [ ] Album downloading with no size known yet → indeterminate pulse, not a stuck 0%.
- [ ] Trigger a failure → error-toned toast names the album (or "an album"), auto-dismisses after 5s; a subsequent neutral toast is **not** red.
- [ ] Cancel a queued item → bar does not jump backward; cancelling the last active item hides the bar.
- [ ] Top-nav PipelineIndicator (folder/copy/tag) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
