### PR TITLE
fix(downloads): persist redownload_url to end per-item collection re-fetch (KAMP-575)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 53
+_SCHEMA_VERSION = 54
 
 
 class NoStreamableVersionError(Exception):
@@ -417,6 +417,12 @@ CREATE TABLE IF NOT EXISTS download_queue (
     album_name       TEXT,
     album_artist     TEXT,
     artwork_ref      TEXT,
+    -- redownload_url (KAMP-575): the Bandcamp download *page* link, captured from
+    -- the collection item at enqueue time. Reused on download and size-estimation
+    -- so those paths need not re-fetch the whole collection per item (the source of
+    -- the 429 storm). Long-lived; the ephemeral CDN URL is resolved fresh per call.
+    -- NULL when the enqueuer didn't have it (e.g. the REST single-download path).
+    redownload_url   TEXT,
     UNIQUE (provider, provider_item_id)
 );
 
@@ -2282,7 +2288,24 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 53")
             self._conn.commit()
-            version = 53  # noqa: F841
+            version = 53
+
+        if version == 53:
+            # v53 -> v54 (KAMP-575): persist the Bandcamp download-page link on each
+            # queue row so the download worker and size-backfill reuse it instead of
+            # re-paginating the whole collection per item (which triggered 429s).
+            # Unconstrained column → a plain ALTER is safe (no rebuild, unlike v53).
+            # Presence-guarded so a re-run after a crash is idempotent.
+            dq_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(download_queue)")
+            }
+            if "redownload_url" not in dq_cols:
+                self._conn.execute(
+                    "ALTER TABLE download_queue ADD COLUMN redownload_url TEXT"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 54")
+            self._conn.commit()
+            version = 54  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -5201,6 +5224,7 @@ class LibraryIndex:
         artwork_ref: str | None = None,
         size_bytes: int | None = None,
         size_is_estimate: bool = True,
+        redownload_url: str | None = None,
     ) -> None:
         """Add (*provider*, *provider_item_id*) to the download queue as 'queued'.
 
@@ -5210,13 +5234,19 @@ class LibraryIndex:
         its current state) so double-clicks don't produce duplicate work. The
         optional album snapshot / size are stored on the row so the UI card renders
         without a join; callers that only have an id may omit them.
+
+        *redownload_url* (KAMP-575) is the Bandcamp download-page link for the item,
+        stored so the download worker and size-backfill reuse it instead of
+        re-fetching the whole collection per item. Omit it when unavailable (the
+        download path then falls back to a one-off collection re-fetch).
         """
         self._conn.execute(
             """
             INSERT OR IGNORE INTO download_queue
                 (provider, provider_item_id, status, position,
-                 album_name, album_artist, artwork_ref, size_bytes, size_is_estimate)
-            VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, ?)
+                 album_name, album_artist, artwork_ref, size_bytes, size_is_estimate,
+                 redownload_url)
+            VALUES (?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 provider,
@@ -5227,6 +5257,7 @@ class LibraryIndex:
                 artwork_ref,
                 size_bytes,
                 1 if size_is_estimate else 0,
+                redownload_url,
             ),
         )
         self._conn.commit()
@@ -5304,9 +5335,15 @@ class LibraryIndex:
     def mark_download_failed(
         self, provider_item_id: str, error_text: str, *, provider: str = "bandcamp"
     ) -> None:
-        """Transition an item to 'failed', recording *error_text* for the card."""
+        """Transition an item to 'failed', recording *error_text* for the card.
+
+        Also clears redownload_url (KAMP-575): if the stored link was the cause
+        (stale/dead), a subsequent retry finds no URL and re-fetches a fresh one,
+        healing the item without any inline stale-vs-ratelimit guesswork.
+        """
         self._conn.execute(
-            "UPDATE download_queue SET status = 'failed', error_text = ? "
+            "UPDATE download_queue "
+            "SET status = 'failed', error_text = ?, redownload_url = NULL "
             "WHERE provider = ? AND provider_item_id = ?",
             (error_text, provider, provider_item_id),
         )
@@ -5450,6 +5487,56 @@ class LibraryIndex:
             }
             for r in rows
         ]
+
+    def get_download_item(
+        self, provider_item_id: str, *, provider: str = "bandcamp"
+    ) -> dict[str, Any] | None:
+        """Return one queue row as a dict, or None if absent (KAMP-575).
+
+        The download worker uses this to recover the stored ``redownload_url`` plus
+        the album snapshot (``album_name``/``album_artist`` = band/title) so it can
+        download without re-fetching the collection.
+        """
+        r = self._conn.execute(
+            """
+            SELECT provider, provider_item_id, status, position,
+                   size_bytes, size_is_estimate, error_text,
+                   album_name, album_artist, artwork_ref, redownload_url
+              FROM download_queue
+             WHERE provider = ? AND provider_item_id = ?
+            """,
+            (provider, provider_item_id),
+        ).fetchone()
+        if r is None:
+            return None
+        return {
+            "provider": r["provider"],
+            "provider_item_id": r["provider_item_id"],
+            "status": r["status"],
+            "position": r["position"],
+            "size_bytes": r["size_bytes"],
+            "size_is_estimate": bool(r["size_is_estimate"]),
+            "error_text": r["error_text"],
+            "album_name": r["album_name"],
+            "album_artist": r["album_artist"],
+            "artwork_ref": r["artwork_ref"],
+            "redownload_url": r["redownload_url"],
+        }
+
+    def download_redownload_urls(
+        self, *, provider: str = "bandcamp"
+    ) -> dict[str, str | None]:
+        """Map provider_item_id → stored redownload_url for all queued rows (KAMP-575).
+
+        Lets the size-backfill reuse stored links instead of re-fetching the whole
+        collection. A value is None when the row has no stored URL.
+        """
+        rows = self._conn.execute(
+            "SELECT provider_item_id, redownload_url FROM download_queue "
+            "WHERE provider = ? AND status = 'queued'",
+            (provider,),
+        ).fetchall()
+        return {str(r["provider_item_id"]): r["redownload_url"] for r in rows}
 
     def update_track_after_album_drain(
         self,

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5419,6 +5419,22 @@ class LibraryIndex:
         )
         self._conn.commit()
 
+    def set_download_redownload_url(
+        self, provider_item_id: str, redownload_url: str, *, provider: str = "bandcamp"
+    ) -> None:
+        """Store the download-page link on a queue row (KAMP-575).
+
+        Lets the download worker fill URLs with a single collection fetch per drain
+        (see prefetch_redownload_urls) so it can then download every item via the
+        fast path instead of re-fetching the collection once per item.
+        """
+        self._conn.execute(
+            "UPDATE download_queue SET redownload_url = ? "
+            "WHERE provider = ? AND provider_item_id = ?",
+            (redownload_url, provider, provider_item_id),
+        )
+        self._conn.commit()
+
     def reorder_download_queue(
         self, ordered_provider_item_ids: list[str], *, provider: str = "bandcamp"
     ) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3123,6 +3123,10 @@ def create_app(
             sale_item_id,
             album_name=item.get("item_title") or None,
             album_artist=item.get("band_name") or None,
+            # KAMP-575: the ledger row rarely carries a live redownload_url, so this
+            # is usually None → the download worker falls back to a one-off
+            # collection re-fetch for this single item (no batch storm).
+            redownload_url=item.get("redownload_url") or None,
         )
         dl_queue.put(sale_item_id)  # wake the worker
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1035,7 +1035,13 @@ def _cmd_daemon(
     # now only a wake signal — endpoints and completed syncs put a sentinel to
     # nudge the worker; ordering lives in the DB, not the in-memory queue.
 
+    # Set while the download worker is draining the queue. The size-backfill
+    # (KAMP-574) yields to it: downloads own the Bandcamp rate budget while active,
+    # so an every-8s collection walk can't starve them into 429s (KAMP-575).
+    _downloads_active = threading.Event()
+
     def _download_worker() -> None:
+        from .bandcamp import _make_requests_session, prefetch_redownload_urls
         from .syncer import process_next_download
 
         def _on_state(provider_item_id: str, state: str) -> None:
@@ -1055,6 +1061,25 @@ def _cmd_daemon(
             except _queue_mod.Empty:
                 pass
 
+        def _prefetch_urls() -> None:
+            # One collection fetch per drain to fill any missing redownload_urls, so
+            # every item downloads via the fast path (no per-item collection re-fetch
+            # — the 429 storm). Best-effort: a failure just leaves the per-item
+            # fallback to resolve URLs (the size-backfill is paused, so it has room).
+            try:
+                session_data = index.get_session("bandcamp")
+                if session_data:
+                    n = prefetch_redownload_urls(
+                        index, _make_requests_session(session_data)
+                    )
+                    if n:
+                        _logger.info("Prefetched %d download URL(s) for the queue", n)
+            except Exception:
+                _logger.warning(
+                    "Download URL prefetch failed; falling back to per-item resolution",
+                    exc_info=True,
+                )
+
         # A download left 'downloading' by a crash would stall (next_queued_download
         # only returns 'queued'); re-queue it so this run resumes it first.
         n_reset = index.reset_downloading_to_queued()
@@ -1065,11 +1090,20 @@ def _cmd_daemon(
             if _album_download_trigger_ref[0] is None:
                 _wait_for_work()  # trigger not wired yet (startup race)
                 continue
-            pid = process_next_download(
-                index, _album_download_trigger_ref[0], on_state=_on_state
-            )
-            if pid is None:
-                _wait_for_work()  # queue drained — sleep until woken or timeout
+            if index.next_queued_download() is None:
+                _downloads_active.clear()  # nothing to do → let the backfill run
+                _wait_for_work()
+                continue
+            # Draining: claim the rate budget and fill URLs once for the whole batch.
+            _downloads_active.set()
+            _prefetch_urls()
+            while (
+                process_next_download(
+                    index, _album_download_trigger_ref[0], on_state=_on_state
+                )
+                is not None
+            ):
+                pass  # drain fully before yielding the budget back
 
     threading.Thread(
         target=_download_worker, daemon=True, name="album-dl-worker"
@@ -1084,13 +1118,20 @@ def _cmd_daemon(
     # update. Best-effort: it only touches the network when queued items lack a
     # size and a Bandcamp session exists, and never crashes the daemon.
     _SIZE_BACKFILL_INTERVAL = 8.0  # seconds between poll cycles
+    _SIZE_BACKFILL_MAX_BACKOFF = 300.0  # cap the 429 back-off at 5 minutes
 
     def _size_backfill_worker() -> None:
         import time as _t
 
         from .bandcamp import _make_requests_session, backfill_download_sizes
 
+        backoff = _SIZE_BACKFILL_INTERVAL
         while True:
+            # Yield to active downloads — they own the rate budget while draining, so
+            # this optional size poll never competes them into 429s (KAMP-575).
+            if _downloads_active.is_set():
+                _t.sleep(_SIZE_BACKFILL_INTERVAL)
+                continue
             try:
                 session_data = index.get_session("bandcamp")
                 if session_data and index.queued_downloads_missing_size():
@@ -1102,9 +1143,20 @@ def _cmd_daemon(
                             _make_requests_session(session_data),
                             on_updated=lambda _pid: app.state.notify_download_queue(),
                         )
-            except Exception:
-                _logger.exception("Download size backfill cycle failed")
-            _t.sleep(_SIZE_BACKFILL_INTERVAL)
+                backoff = _SIZE_BACKFILL_INTERVAL  # success → reset the back-off
+                _t.sleep(_SIZE_BACKFILL_INTERVAL)
+            except Exception as exc:
+                # A 429 means we're rate-limited; exponentially back off instead of
+                # hammering every 8s (which poisoned the budget and spammed the log).
+                if "429" in str(exc):
+                    backoff = min(backoff * 2, _SIZE_BACKFILL_MAX_BACKOFF)
+                    _logger.warning(
+                        "Download size backfill rate-limited; backing off %.0fs",
+                        backoff,
+                    )
+                else:
+                    _logger.exception("Download size backfill cycle failed")
+                _t.sleep(backoff)
 
     threading.Thread(
         target=_size_backfill_worker, daemon=True, name="download-size-backfill"

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1035,11 +1035,6 @@ def _cmd_daemon(
     # now only a wake signal — endpoints and completed syncs put a sentinel to
     # nudge the worker; ordering lives in the DB, not the in-memory queue.
 
-    # Set while the download worker is draining the queue. The size-backfill
-    # (KAMP-574) yields to it: downloads own the Bandcamp rate budget while active,
-    # so an every-8s collection walk can't starve them into 429s (KAMP-575).
-    _downloads_active = threading.Event()
-
     def _download_worker() -> None:
         from .bandcamp import _make_requests_session, prefetch_redownload_urls
         from .syncer import process_next_download
@@ -1064,8 +1059,9 @@ def _cmd_daemon(
         def _prefetch_urls() -> None:
             # One collection fetch per drain to fill any missing redownload_urls, so
             # every item downloads via the fast path (no per-item collection re-fetch
-            # — the 429 storm). Best-effort: a failure just leaves the per-item
-            # fallback to resolve URLs (the size-backfill is paused, so it has room).
+            # — the 429 storm). This also populates URLs the size-backfill needs, so
+            # it too avoids the collection endpoint. Best-effort: a failure just
+            # leaves the per-item fallback to resolve URLs.
             try:
                 session_data = index.get_session("bandcamp")
                 if session_data:
@@ -1091,11 +1087,10 @@ def _cmd_daemon(
                 _wait_for_work()  # trigger not wired yet (startup race)
                 continue
             if index.next_queued_download() is None:
-                _downloads_active.clear()  # nothing to do → let the backfill run
                 _wait_for_work()
                 continue
-            # Draining: claim the rate budget and fill URLs once for the whole batch.
-            _downloads_active.set()
+            # Draining: fill any missing URLs once for the whole batch, then drain
+            # via the fast path (no per-item collection re-fetch).
             _prefetch_urls()
             while (
                 process_next_download(
@@ -1103,7 +1098,7 @@ def _cmd_daemon(
                 )
                 is not None
             ):
-                pass  # drain fully before yielding the budget back
+                pass  # drain the whole queue before sleeping again
 
     threading.Thread(
         target=_download_worker, daemon=True, name="album-dl-worker"
@@ -1127,11 +1122,6 @@ def _cmd_daemon(
 
         backoff = _SIZE_BACKFILL_INTERVAL
         while True:
-            # Yield to active downloads — they own the rate budget while draining, so
-            # this optional size poll never competes them into 429s (KAMP-575).
-            if _downloads_active.is_set():
-                _t.sleep(_SIZE_BACKFILL_INTERVAL)
-                continue
             try:
                 session_data = index.get_session("bandcamp")
                 if session_data and index.queued_downloads_missing_size():

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -450,6 +450,10 @@ def sync_new_purchases(
                     album_name=item_title,
                     album_artist=band_name,
                     artwork_ref=str(item.get("item_art_url", "") or ""),
+                    # KAMP-575: persist the download-page link (already embedded in
+                    # this collection item) so the worker needn't re-fetch the whole
+                    # collection per item at download time.
+                    redownload_url=item.get("redownload_url"),
                 )
                 enqueued += 1
                 if status_callback:
@@ -666,24 +670,49 @@ def download_single_album(
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
 
-    fan_id, _ = _get_fan_info(session)
+    # KAMP-575 fast path: if the queue row carries the download-page link captured
+    # at enqueue time, reuse it and skip the collection fetch entirely (the per-item
+    # re-fetch was the 429 storm). No _get_fan_info either — that call hits
+    # collection_summary, which we no longer need. The item dict is reconstructed
+    # from local DB: band_name/item_title from the row's album snapshot (stored
+    # verbatim at enqueue), tralbum_id from the collection ledger. On any failure
+    # the item is marked failed (which NULLs the stored URL), so a retry re-fetches.
+    queue_row = index.get_download_item(sale_item_id)
+    stored_url = queue_row.get("redownload_url") if queue_row else None
+    item: dict[str, Any] | None = None
 
-    # Use the same collection API path that sync_new_purchases uses.
-    # _fetch_collection paginates the full collection and embeds redownload_url
-    # (from each page's redownload_urls dict) directly into every item dict.
-    # _get_download_links (HTML scrape) only shows recent purchases on the
-    # profile page and misses items that are not in the visible scroll window.
-    if status_callback:
-        status_callback(f"Fetching collection for {sale_item_id}…")
-    collection = _fetch_collection(fan_id, session, index)
+    if stored_url:
+        ledger = index.get_collection_item(sale_item_id) or {}
+        item = {
+            "sale_item_id": int(sale_item_id),
+            "redownload_url": stored_url,
+            "band_name": (queue_row or {}).get("album_artist")
+            or ledger.get("band_name")
+            or "Unknown Artist",
+            "item_title": (queue_row or {}).get("album_name")
+            or ledger.get("item_title")
+            or "Unknown Album",
+            "tralbum_id": ledger.get("tralbum_id", ""),
+        }
+    else:
+        # Fallback (no stored URL — e.g. a REST-enqueued item, or a healed retry).
+        # Use the same collection API path that sync_new_purchases uses.
+        # _fetch_collection paginates the full collection and embeds redownload_url
+        # (from each page's redownload_urls dict) directly into every item dict.
+        # _get_download_links (HTML scrape) only shows recent purchases on the
+        # profile page and misses items outside the visible scroll window.
+        fan_id, _ = _get_fan_info(session)
+        if status_callback:
+            status_callback(f"Fetching collection for {sale_item_id}…")
+        collection = _fetch_collection(fan_id, session, index)
 
-    target_id = int(sale_item_id)
-    item = next((i for i in collection if i.get("sale_item_id") == target_id), None)
-    if item is None or not item.get("redownload_url"):
-        raise BandcampAPIError(
-            f"No download link found for sale_item_id={sale_item_id} "
-            f"(item not in collection or redownload_url missing)"
-        )
+        target_id = int(sale_item_id)
+        item = next((i for i in collection if i.get("sale_item_id") == target_id), None)
+        if item is None or not item.get("redownload_url"):
+            raise BandcampAPIError(
+                f"No download link found for sale_item_id={sale_item_id} "
+                f"(item not in collection or redownload_url missing)"
+            )
 
     if status_callback:
         status_callback(f"Downloading album {sale_item_id}…")
@@ -1393,24 +1422,33 @@ def backfill_download_sizes(
     for *fmt* and store it as an estimate (``is_estimate=True``). The exact
     Content-Length written when the item starts downloading later overrides it.
 
-    Fetches the collection once to resolve each item's ``redownload_url``, then
-    hits one download page per item, throttled (``throttle`` seconds between
-    items) to avoid Bandcamp 429s. *on_updated* fires with the provider_item_id
-    after each successful size write (used to re-broadcast the queue snapshot).
-    Returns the number of items sized. Items whose size can't be resolved are
-    skipped (they keep a NULL size and retry on the next cycle).
+    Reuses each item's ``redownload_url`` persisted on the queue row at enqueue
+    (KAMP-575), so no collection fetch is needed in the common case; it hits one
+    download page per item, throttled (``throttle`` seconds between items) to avoid
+    Bandcamp 429s. The collection is fetched once only as a fallback when some item
+    to size lacks a stored URL (e.g. a REST-enqueued item). *on_updated* fires with
+    the provider_item_id after each successful size write (used to re-broadcast the
+    queue snapshot). Returns the number of items sized. Items whose size can't be
+    resolved are skipped (they keep a NULL size and retry on the next cycle).
     """
     pids = index.queued_downloads_missing_size()
     if not pids:
         return 0
 
-    fan_id, _username = _get_fan_info(session)
-    collection = _fetch_collection(fan_id, session, index)
+    # Prefer stored redownload_urls — the whole point of KAMP-575 is to avoid the
+    # per-cycle full-collection walk that contended for the rate limit.
     url_by_sid: dict[str, str] = {
-        str(item["sale_item_id"]): item["redownload_url"]
-        for item in collection
-        if item.get("sale_item_id") is not None and item.get("redownload_url")
+        pid: url for pid, url in index.download_redownload_urls().items() if url
     }
+    # Pay for a single collection fetch only if some item still lacks a URL.
+    if any(pid not in url_by_sid for pid in pids):
+        fan_id, _username = _get_fan_info(session)
+        collection = _fetch_collection(fan_id, session, index)
+        for item in collection:
+            sid = item.get("sale_item_id")
+            url = item.get("redownload_url")
+            if sid is not None and url:
+                url_by_sid.setdefault(str(sid), url)
 
     sized = 0
     for i, pid in enumerate(pids):

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1407,6 +1407,34 @@ def get_download_size_bytes(
         return None
 
 
+def prefetch_redownload_urls(index: "LibraryIndex", session: _AnySession) -> int:
+    """Fill missing redownload_urls on queued rows with a SINGLE collection fetch.
+
+    The download worker calls this once per drain (KAMP-575) so it can then download
+    every item via the fast path — no per-item collection re-fetch, which was the
+    429 storm. Rows that already have a URL (freshly enqueued with it) are left
+    alone, so this is a no-op (and does no network I/O) once URLs are populated.
+
+    Returns the number of rows populated. Best-effort: the caller catches failures;
+    a 429 here just leaves rows unfilled so the per-item fallback runs (with the
+    size-backfill paused, it has room). Never raises for a "nothing to do" case.
+    """
+    missing = {pid for pid, url in index.download_redownload_urls().items() if not url}
+    if not missing:
+        return 0
+
+    fan_id, _username = _get_fan_info(session)
+    collection = _fetch_collection(fan_id, session, index)
+    n = 0
+    for item in collection:
+        sid = item.get("sale_item_id")
+        url = item.get("redownload_url")
+        if sid is not None and url and str(sid) in missing:
+            index.set_download_redownload_url(str(sid), url)
+            n += 1
+    return n
+
+
 def backfill_download_sizes(
     index: "LibraryIndex",
     fmt: str,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1450,41 +1450,33 @@ def backfill_download_sizes(
     for *fmt* and store it as an estimate (``is_estimate=True``). The exact
     Content-Length written when the item starts downloading later overrides it.
 
-    Reuses each item's ``redownload_url`` persisted on the queue row at enqueue
-    (KAMP-575), so no collection fetch is needed in the common case; it hits one
-    download page per item, throttled (``throttle`` seconds between items) to avoid
-    Bandcamp 429s. The collection is fetched once only as a fallback when some item
-    to size lacks a stored URL (e.g. a REST-enqueued item). *on_updated* fires with
-    the provider_item_id after each successful size write (used to re-broadcast the
-    queue snapshot). Returns the number of items sized. Items whose size can't be
-    resolved are skipped (they keep a NULL size and retry on the next cycle).
+    Uses only each item's stored ``redownload_url`` (KAMP-575) — it NEVER fetches
+    the collection here. The collection endpoint is the rate-limited one; the
+    per-item download PAGE this hits is not, so this can run alongside downloads
+    without competing them into 429s. Items still lacking a stored URL are skipped
+    and picked up on a later cycle once the download worker's per-drain prefetch
+    fills them in. Requests are throttled (``throttle`` seconds between page
+    fetches). *on_updated* fires with the provider_item_id after each successful
+    size write (used to re-broadcast the queue snapshot). Returns the number of
+    items sized; unresolved items keep a NULL size and retry next cycle.
     """
     pids = index.queued_downloads_missing_size()
     if not pids:
         return 0
 
-    # Prefer stored redownload_urls — the whole point of KAMP-575 is to avoid the
-    # per-cycle full-collection walk that contended for the rate limit.
     url_by_sid: dict[str, str] = {
         pid: url for pid, url in index.download_redownload_urls().items() if url
     }
-    # Pay for a single collection fetch only if some item still lacks a URL.
-    if any(pid not in url_by_sid for pid in pids):
-        fan_id, _username = _get_fan_info(session)
-        collection = _fetch_collection(fan_id, session, index)
-        for item in collection:
-            sid = item.get("sale_item_id")
-            url = item.get("redownload_url")
-            if sid is not None and url:
-                url_by_sid.setdefault(str(sid), url)
 
     sized = 0
-    for i, pid in enumerate(pids):
+    fetched = 0
+    for pid in pids:
         redownload_url = url_by_sid.get(pid)
         if not redownload_url:
-            continue
-        if i > 0:
+            continue  # no stored URL yet → skip (the prefetch will fill it in)
+        if fetched > 0:
             sleep(throttle)  # rate-limit download-page requests
+        fetched += 1
         size = get_download_size_bytes(redownload_url, fmt, session)
         if size is None:
             continue

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -3396,6 +3396,9 @@ class TestDownloadSingleAlbum:
         config = _bc_config(tmp_path)
         watch_folder = tmp_path / "watch"
         index = MagicMock()
+        # No stored redownload_url → exercise the fallback (collection re-fetch)
+        # path. The fast path is covered separately (KAMP-575).
+        index.get_download_item.return_value = None
 
         def fake_download_item(
             item: dict,
@@ -3441,6 +3444,7 @@ class TestDownloadSingleAlbum:
     def test_updates_collection_mode_and_track_source(self, tmp_path: Path) -> None:
         config = _bc_config(tmp_path)
         index = MagicMock()
+        index.get_download_item.return_value = None  # fallback path
         fake_collection = [self._collection_item("42")]
 
         with (
@@ -3473,6 +3477,87 @@ class TestDownloadSingleAlbum:
             self._run(
                 tmp_path, collection=[self._collection_item("42", with_url=False)]
             )
+
+    def test_fast_path_uses_stored_url_without_collection_fetch(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-575: a queue row with a stored redownload_url downloads WITHOUT any
+        collection fetch or fan-info call — reconstructing the item from local DB.
+        This is the regression fix: no per-item collection re-fetch → no 429 storm.
+        """
+        config = _bc_config(tmp_path)
+        index = MagicMock()
+        index.get_download_item.return_value = {
+            "redownload_url": "https://bandcamp.com/download?id=42&sig=xyz",
+            "album_artist": "Test Band",
+            "album_name": "Test Album",
+        }
+        index.get_collection_item.return_value = {"tralbum_id": "tr-99"}
+
+        captured: dict[str, Any] = {}
+
+        def fake_download_item(item: dict, *_a: object, **_k: object) -> Path:
+            captured.update(item)
+            dest = tmp_path / "42.zip"
+            dest.write_bytes(b"zip")
+            return dest
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=MagicMock()
+            ),
+            patch("kamp_daemon.bandcamp._get_fan_info") as fan,
+            patch("kamp_daemon.bandcamp._fetch_collection") as fetch,
+            patch(
+                "kamp_daemon.bandcamp._download_item", side_effect=fake_download_item
+            ),
+        ):
+            dest = download_single_album(config, tmp_path / "watch", index, "42")
+
+        assert dest.exists()
+        fetch.assert_not_called()  # the whole point: no collection walk
+        fan.assert_not_called()  # nor a collection_summary hit
+        # Item reconstructed from local DB: URL + band/title from the row, tralbum
+        # from the ledger.
+        assert (
+            captured["redownload_url"] == "https://bandcamp.com/download?id=42&sig=xyz"
+        )
+        assert captured["band_name"] == "Test Band"
+        assert captured["item_title"] == "Test Album"
+        index.set_collection_item_mode.assert_called_once_with("42", "local")
+        index.add_pending_ingest.assert_called_once_with(str(dest), "42", "tr-99")
+
+    def test_no_stored_url_falls_back_to_collection_fetch(self, tmp_path: Path) -> None:
+        """No stored redownload_url → the collection is fetched to resolve it."""
+        config = _bc_config(tmp_path)
+        index = MagicMock()
+        index.get_download_item.return_value = {"redownload_url": None}
+
+        with (
+            patch(
+                "kamp_daemon.bandcamp._ensure_session",
+                return_value=_make_session_data(),
+            ),
+            patch(
+                "kamp_daemon.bandcamp._make_requests_session", return_value=MagicMock()
+            ),
+            patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u")) as fan,
+            patch(
+                "kamp_daemon.bandcamp._fetch_collection",
+                return_value=[self._collection_item("42")],
+            ) as fetch,
+            patch(
+                "kamp_daemon.bandcamp._download_item", return_value=tmp_path / "a.zip"
+            ),
+        ):
+            download_single_album(config, tmp_path / "watch", index, "42")
+
+        fetch.assert_called_once()  # fell back to the collection re-fetch
+        fan.assert_called_once()
 
 
 class TestParseSizeMb:
@@ -3559,6 +3644,7 @@ class TestBackfillDownloadSizes:
     def test_sizes_queued_items_as_estimates(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "b"]
+        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
         mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
         mocker.patch(
             "kamp_daemon.bandcamp._fetch_collection",
@@ -3588,6 +3674,7 @@ class TestBackfillDownloadSizes:
     def test_skips_items_without_resolvable_size(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "b"]
+        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
         mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
         mocker.patch(
             "kamp_daemon.bandcamp._fetch_collection",
@@ -3616,6 +3703,7 @@ class TestBackfillDownloadSizes:
     def test_skips_item_missing_from_collection(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "gone"]
+        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
         mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
         # collection only has 'a' — 'gone' has no redownload_url and is skipped.
         mocker.patch(
@@ -3630,3 +3718,46 @@ class TestBackfillDownloadSizes:
         index.set_download_size.assert_called_once_with(
             "a", 50_000_000, is_estimate=True
         )
+
+    def test_uses_stored_urls_without_collection_fetch(
+        self, mocker: MockerFixture
+    ) -> None:
+        """KAMP-575: when every queued item has a stored redownload_url, the backfill
+        sizes them WITHOUT fetching the collection (removes the every-8s walk)."""
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = ["a", "b"]
+        index.download_redownload_urls.return_value = {
+            "a": "https://bc/download?sid=a",
+            "b": "https://bc/download?sid=b",
+        }
+        fan = mocker.patch("kamp_daemon.bandcamp._get_fan_info")
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection")
+        mocker.patch(
+            "kamp_daemon.bandcamp.get_download_size_bytes",
+            side_effect=[81_000_000, 252_000_000],
+        )
+        n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
+        assert n == 2
+        fetch.assert_not_called()  # the point: no collection walk
+        fan.assert_not_called()
+
+    def test_partial_stored_urls_falls_back_to_collection(
+        self, mocker: MockerFixture
+    ) -> None:
+        """If some queued item lacks a stored URL, a single collection fetch fills
+        the gap (the stored URL for the other item is still reused)."""
+        index = MagicMock()
+        index.queued_downloads_missing_size.return_value = ["a", "b"]
+        index.download_redownload_urls.return_value = {"a": "https://bc/download?sid=a"}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=self._collection(["b"]),
+        )
+        mocker.patch(
+            "kamp_daemon.bandcamp.get_download_size_bytes",
+            side_effect=[81_000_000, 252_000_000],
+        )
+        n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
+        assert n == 2
+        fetch.assert_called_once()  # one fetch to resolve the missing 'b'

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -40,6 +40,7 @@ from kamp_daemon.bandcamp import (
     fetch_stream_url,
     get_download_size_bytes,
     mark_collection_synced,
+    prefetch_redownload_urls,
     refresh_stream_url,
     sync_collection_stream,
     sync_new_purchases,
@@ -3630,6 +3631,53 @@ class TestGetDownloadSizeBytes:
         session = MagicMock()
         session.get.side_effect = RuntimeError("boom")
         assert get_download_size_bytes("https://bc/download?x", "flac", session) is None
+
+
+class TestPrefetchRedownloadUrls:
+    """prefetch_redownload_urls: fill missing queue URLs with one fetch (KAMP-575)."""
+
+    def test_populates_missing_urls_with_one_fetch(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"111": None, "222": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=[
+                {"sale_item_id": 111, "redownload_url": "https://dl/111"},
+                {"sale_item_id": 222, "redownload_url": "https://dl/222"},
+            ],
+        )
+        n = prefetch_redownload_urls(index, MagicMock())
+        assert n == 2
+        fetch.assert_called_once()  # ONE collection fetch for the whole batch
+        index.set_download_redownload_url.assert_any_call("111", "https://dl/111")
+        index.set_download_redownload_url.assert_any_call("222", "https://dl/222")
+
+    def test_noop_when_no_missing_urls(self, mocker: MockerFixture) -> None:
+        """All queued rows already have URLs → no network I/O, nothing written."""
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"111": "https://dl/111"}
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection")
+        n = prefetch_redownload_urls(index, MagicMock())
+        assert n == 0
+        fetch.assert_not_called()
+        index.set_download_redownload_url.assert_not_called()
+
+    def test_skips_items_not_in_collection(self, mocker: MockerFixture) -> None:
+        """A queued id absent from the collection is left unfilled (per-item
+        fallback will resolve it)."""
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"111": None, "999": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=[{"sale_item_id": 111, "redownload_url": "https://dl/111"}],
+        )
+        n = prefetch_redownload_urls(index, MagicMock())
+        assert n == 1
+        index.set_download_redownload_url.assert_called_once_with(
+            "111", "https://dl/111"
+        )
 
 
 class TestBackfillDownloadSizes:

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -3683,21 +3683,13 @@ class TestPrefetchRedownloadUrls:
 class TestBackfillDownloadSizes:
     """backfill_download_sizes: estimate File Size on queued items (KAMP-574)."""
 
-    def _collection(self, sids: list[str]) -> list[dict[str, Any]]:
-        return [
-            {"sale_item_id": s, "redownload_url": f"https://bc/download?sid={s}"}
-            for s in sids
-        ]
-
     def test_sizes_queued_items_as_estimates(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "b"]
-        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
-        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
-        mocker.patch(
-            "kamp_daemon.bandcamp._fetch_collection",
-            return_value=self._collection(["a", "b"]),
-        )
+        index.download_redownload_urls.return_value = {
+            "a": "https://bc/download?sid=a",
+            "b": "https://bc/download?sid=b",
+        }
         mocker.patch(
             "kamp_daemon.bandcamp.get_download_size_bytes",
             side_effect=[81_000_000, 252_000_000],
@@ -3717,17 +3709,15 @@ class TestBackfillDownloadSizes:
         index.set_download_size.assert_any_call("a", 81_000_000, is_estimate=True)
         index.set_download_size.assert_any_call("b", 252_000_000, is_estimate=True)
         assert updated == ["a", "b"]
-        assert slept == [1.0]  # throttle between the two items (not before the first)
+        assert slept == [1.0]  # throttle between the two fetches (not before the first)
 
     def test_skips_items_without_resolvable_size(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "b"]
-        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
-        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
-        mocker.patch(
-            "kamp_daemon.bandcamp._fetch_collection",
-            return_value=self._collection(["a", "b"]),
-        )
+        index.download_redownload_urls.return_value = {
+            "a": "https://bc/download?sid=a",
+            "b": "https://bc/download?sid=b",
+        }
         # 'a' has no size_mb (None); 'b' resolves.
         mocker.patch(
             "kamp_daemon.bandcamp.get_download_size_bytes",
@@ -3742,22 +3732,20 @@ class TestBackfillDownloadSizes:
     def test_noop_when_nothing_queued(self, mocker: MockerFixture) -> None:
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = []
-        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection")
+        size = mocker.patch("kamp_daemon.bandcamp.get_download_size_bytes")
         n = backfill_download_sizes(index, "flac", MagicMock())
         assert n == 0
-        fetch.assert_not_called()  # no collection fetch when nothing needs sizing
+        size.assert_not_called()  # nothing to size
         index.set_download_size.assert_not_called()
 
-    def test_skips_item_missing_from_collection(self, mocker: MockerFixture) -> None:
+    def test_skips_item_without_stored_url(self, mocker: MockerFixture) -> None:
+        """An item without a stored URL is skipped — the backfill NEVER fetches the
+        collection to resolve it (the prefetch fills it in on a later cycle)."""
         index = MagicMock()
-        index.queued_downloads_missing_size.return_value = ["a", "gone"]
-        index.download_redownload_urls.return_value = {}  # no stored URLs → fallback
-        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
-        # collection only has 'a' — 'gone' has no redownload_url and is skipped.
-        mocker.patch(
-            "kamp_daemon.bandcamp._fetch_collection",
-            return_value=self._collection(["a"]),
-        )
+        index.queued_downloads_missing_size.return_value = ["a", "nourl"]
+        index.download_redownload_urls.return_value = {"a": "https://bc/download?sid=a"}
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection")
+        fan = mocker.patch("kamp_daemon.bandcamp._get_fan_info")
         mocker.patch(
             "kamp_daemon.bandcamp.get_download_size_bytes", return_value=50_000_000
         )
@@ -3766,12 +3754,12 @@ class TestBackfillDownloadSizes:
         index.set_download_size.assert_called_once_with(
             "a", 50_000_000, is_estimate=True
         )
+        fetch.assert_not_called()  # never touches the rate-limited collection endpoint
+        fan.assert_not_called()
 
-    def test_uses_stored_urls_without_collection_fetch(
-        self, mocker: MockerFixture
-    ) -> None:
-        """KAMP-575: when every queued item has a stored redownload_url, the backfill
-        sizes them WITHOUT fetching the collection (removes the every-8s walk)."""
+    def test_never_fetches_collection(self, mocker: MockerFixture) -> None:
+        """KAMP-575: the backfill sizes items via stored URLs only and never hits
+        the collection endpoint (which is what tripped the 429s)."""
         index = MagicMock()
         index.queued_downloads_missing_size.return_value = ["a", "b"]
         index.download_redownload_urls.return_value = {
@@ -3786,26 +3774,5 @@ class TestBackfillDownloadSizes:
         )
         n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
         assert n == 2
-        fetch.assert_not_called()  # the point: no collection walk
+        fetch.assert_not_called()
         fan.assert_not_called()
-
-    def test_partial_stored_urls_falls_back_to_collection(
-        self, mocker: MockerFixture
-    ) -> None:
-        """If some queued item lacks a stored URL, a single collection fetch fills
-        the gap (the stored URL for the other item is still reused)."""
-        index = MagicMock()
-        index.queued_downloads_missing_size.return_value = ["a", "b"]
-        index.download_redownload_urls.return_value = {"a": "https://bc/download?sid=a"}
-        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
-        fetch = mocker.patch(
-            "kamp_daemon.bandcamp._fetch_collection",
-            return_value=self._collection(["b"]),
-        )
-        mocker.patch(
-            "kamp_daemon.bandcamp.get_download_size_bytes",
-            side_effect=[81_000_000, 252_000_000],
-        )
-        n = backfill_download_sizes(index, "flac", MagicMock(), sleep=lambda _s: None)
-        assert n == 2
-        fetch.assert_called_once()  # one fetch to resolve the missing 'b'

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 53
+        assert version == 54
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 53
+        assert version == 54
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 53
+        assert ver == 54
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 53
+        assert ver == 54
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 53
+        assert ver == 54
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 53
+        assert ver == 54
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3218,7 +3218,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3275,7 +3275,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3652,7 +3652,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -3695,7 +3695,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -3718,6 +3718,78 @@ class TestPreorderResurface:
             ("bandcamp", "first", "queued", 1),
             ("bandcamp", "second", "queued", 2),
         ]
+
+    def test_migration_v53_to_v54_adds_redownload_url(self, tmp_path: Path) -> None:
+        """A pre-v54 download_queue gains a nullable redownload_url column via an
+        additive ALTER (no rebuild); existing rows survive with NULL (KAMP-575)."""
+        db_path = tmp_path / "library.db"
+        # Build a current DB, then rewind download_queue to the v53 shape (same
+        # columns minus redownload_url) and stamp version 53 so open runs v54.
+        LibraryIndex(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP TABLE download_queue")
+        conn.execute(
+            "CREATE TABLE download_queue ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " provider TEXT NOT NULL DEFAULT 'bandcamp',"
+            " provider_item_id TEXT NOT NULL,"
+            " queued_at REAL NOT NULL DEFAULT (unixepoch()),"
+            " status TEXT NOT NULL DEFAULT 'queued',"
+            " position INTEGER NOT NULL DEFAULT 0,"
+            " size_bytes INTEGER,"
+            " size_is_estimate INTEGER NOT NULL DEFAULT 1,"
+            " error_text TEXT,"
+            " album_name TEXT,"
+            " album_artist TEXT,"
+            " artwork_ref TEXT,"
+            " UNIQUE (provider, provider_item_id))"
+        )
+        conn.execute(
+            "INSERT INTO download_queue (provider, provider_item_id, position)"
+            " VALUES ('bandcamp', 'keep', 1)"
+        )
+        conn.execute("UPDATE schema_version SET version = 53")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
+        row = index._conn.execute(
+            "SELECT provider_item_id, redownload_url FROM download_queue"
+        ).fetchone()
+        index.close()
+
+        assert version == 54
+        assert "redownload_url" in cols
+        # Existing row survived; the new column is NULL for pre-existing data.
+        assert row["provider_item_id"] == "keep"
+        assert row["redownload_url"] is None
+
+    def test_migration_v53_to_v54_presence_guard_idempotent(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-running the v54 step when redownload_url already exists is a no-op
+        (the PRAGMA presence guard skips the ALTER) — models a crash-retry."""
+        db_path = tmp_path / "library.db"
+        LibraryIndex(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        # Column already present (current schema), but version rewound to 53.
+        conn.execute("UPDATE schema_version SET version = 53")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db_path)  # must not raise "duplicate column name"
+        version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
+            0
+        ]
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
+        index.close()
+
+        assert version == 54
+        assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -4070,7 +4142,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert row is not None
         assert row[0] == 0
 
@@ -4535,7 +4607,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4648,7 +4720,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4832,7 +4904,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4927,7 +4999,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 53
+        assert version == 54
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -4935,7 +5007,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 53
+        assert version == 54
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5862,7 +5934,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 53
+        assert version == 54
 
         index.close()
 
@@ -6553,7 +6625,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 53
+        assert version == 54
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6588,7 +6660,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 53
+        assert version == 54
         index.close()
 
 
@@ -7129,7 +7201,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 53
+        assert version == 54
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7262,7 +7334,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 53
+        assert version == 54
 
 
 class TestRemoteTrackSchema:
@@ -7678,7 +7750,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7739,7 +7811,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8561,7 +8633,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -8663,6 +8735,62 @@ class TestDownloadQueueStateMachine:
             index.enqueue_download(sid)
         positions = [i["position"] for i in index.download_queue_items()]
         assert positions == [1, 2, 3]
+        index.close()
+
+    def test_enqueue_persists_and_gets_redownload_url(self, tmp_path: Path) -> None:
+        """KAMP-575: the download-page link is stored and retrievable via
+        get_download_item so the worker needn't re-fetch the collection."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download(
+            "111",
+            album_name="Miss Colombia",
+            album_artist="Lido Pimienta",
+            redownload_url="https://bandcamp.com/download?id=111&sig=abc",
+        )
+        row = index.get_download_item("111")
+        assert row is not None
+        assert row["redownload_url"] == "https://bandcamp.com/download?id=111&sig=abc"
+        assert row["album_name"] == "Miss Colombia"
+        assert row["album_artist"] == "Lido Pimienta"
+        index.close()
+
+    def test_enqueue_redownload_url_defaults_null(self, tmp_path: Path) -> None:
+        """Omitting redownload_url stores NULL (the REST single-download path)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("222")
+        row = index.get_download_item("222")
+        assert row is not None
+        assert row["redownload_url"] is None
+        index.close()
+
+    def test_get_download_item_absent_returns_none(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.get_download_item("nope") is None
+        index.close()
+
+    def test_download_redownload_urls_maps_queued_only(self, tmp_path: Path) -> None:
+        """The bulk map (used by the size-backfill) covers queued rows and reflects
+        NULLs for items enqueued without a URL."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a", redownload_url="https://dl/a")
+        index.enqueue_download("b")  # no URL
+        index.enqueue_download("c", redownload_url="https://dl/c")
+        index.mark_downloading("c")  # not 'queued' anymore → excluded
+        urls = index.download_redownload_urls()
+        assert urls == {"a": "https://dl/a", "b": None}
+        index.close()
+
+    def test_mark_download_failed_clears_redownload_url(self, tmp_path: Path) -> None:
+        """KAMP-575: failing an item NULLs its stored URL so a retry re-fetches a
+        fresh one (heals a stale/dead link without inline classification)."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a", redownload_url="https://dl/stale")
+        index.mark_download_failed("a", "HTTP 429")
+        row = index.get_download_item("a")
+        assert row is not None
+        assert row["status"] == "failed"
+        assert row["error_text"] == "HTTP 429"
+        assert row["redownload_url"] is None
         index.close()
 
     def test_next_queued_download_is_lowest_position(self, tmp_path: Path) -> None:
@@ -9428,7 +9556,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9506,7 +9634,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -9715,7 +9843,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -9955,7 +10083,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10055,7 +10183,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10171,7 +10299,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10676,7 +10804,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -10791,7 +10919,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -10889,7 +11017,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -10989,7 +11117,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -11496,7 +11624,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 53
+        assert version == 54
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -12380,7 +12508,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 53
+        assert version == 54
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -13509,7 +13637,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 53
+        assert version == 54
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -13529,7 +13657,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 53
+        assert version == 54
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -13572,7 +13700,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 53
+        assert version == 54
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -13851,7 +13979,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 53
+        assert ver == 54
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -8793,6 +8793,16 @@ class TestDownloadQueueStateMachine:
         assert row["redownload_url"] is None
         index.close()
 
+    def test_set_download_redownload_url(self, tmp_path: Path) -> None:
+        """KAMP-575: the download worker fills a missing URL (via one collection
+        fetch per drain) so subsequent items download via the fast path."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")  # enqueued without a URL
+        assert index.get_download_item("a")["redownload_url"] is None  # type: ignore[index]
+        index.set_download_redownload_url("a", "https://dl/fresh")
+        assert index.get_download_item("a")["redownload_url"] == "https://dl/fresh"  # type: ignore[index]
+        index.close()
+
     def test_next_queued_download_is_lowest_position(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         for sid in ("a", "b", "c"):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2925,7 +2925,10 @@ class TestBandcampCollectionDownload:
         mock_index.set_track_source_for_item.assert_not_called()
         # Enqueued with the album snapshot for the Downloads-view card.
         mock_index.enqueue_download.assert_called_once_with(
-            "42", album_name="Album 42", album_artist="Artist 42"
+            "42",
+            album_name="Album 42",
+            album_artist="Artist 42",
+            redownload_url=None,  # KAMP-575: ledger lacks a live URL → fallback
         )
         # Item placed on the in-memory queue
         assert dl_q.get_nowait() == "42"


### PR DESCRIPTION
## The bug

Queueing 5 Bandcamp albums downloads only 2; the rest fail with HTTP 429.

## Root cause (a regression from KAMP-565, not a new subsystem bug)

The old "download all" path fetched the collection **once** and downloaded every new item reusing each item's embedded `redownload_url`. The download-queue path enqueues items but **discarded** `redownload_url`, so each `download_single_album` re-paginated the **entire** collection (`collection_items` + `hidden_items`) just to re-derive one item's URL — one full collection walk per queued item. The KAMP-574 size-backfill did the same every 8s. That collection-API hammering, concurrent with the poll-sync's `collection_summary`, tripped Bandcamp's rate limit.

## The fix — reconcile onto a persisted identity

Persist the download-**page** link (long-lived; `_get_cdn_url` resolves the ephemeral CDN URL fresh per call) on each queue row at enqueue, and reuse it on download and size-estimation. Those paths then make **zero** collection-API calls in the common (sync-originated) case — restoring the old batch behavior.

- **Schema v53→v54**: additive `redownload_url TEXT` column (plain `ALTER`, no rebuild; presence-guarded for crash-retry idempotency).
- **enqueue**: `enqueue_download(..., redownload_url=...)`; `sync_new_purchases` passes the in-hand URL; the REST single-download endpoint passes it too (usually NULL from the ledger → that one item falls back).
- **download fast path**: with a stored URL, reconstruct the item from **local DB only** (URL from the row, band/title from the album snapshot, tralbum from the collection ledger) and skip both `_fetch_collection` and `_get_fan_info`. No stored URL → the existing collection re-fetch, unchanged.
- **No inline 429-vs-stale classification** (a Cloudflare ratelimit can arrive as an HTML challenge, not a clean 429 — classifying inline could misread a ratelimit as "stale" and add collection load mid-storm). Instead, `mark_download_failed` **NULLs the URL**, so a retry re-fetches a fresh one — healing staleness without guesswork.
- **size-backfill** reuses stored URLs; fetches the collection only if some queued item still lacks one.

What's intentionally untouched: the poll-sync (post-fix it's the only collection caller during downloads, exactly as in the old working world) and the `(5,10,20)` backoff.

## Tests
- Migration v53→v54 (adds column, survives rows) + presence-guard idempotency.
- enqueue persists/omits URL; `get_download_item`; `download_redownload_urls` map; `mark_download_failed` clears URL.
- download **fast path** asserts `_fetch_collection`/`_get_fan_info` are NOT called; **fallback** asserts they are.
- backfill: stored-URL path skips the collection fetch; partial → one fetch; none → fallback.
- All migration tests bumped 53→54. Full suite: 2350 passed, coverage 93.47% (≥93 gate; consistent with the post-KAMP-552 baseline). black + mypy clean.

## Manual test plan
- [ ] Queue 5 albums (sync-originated) → all 5 download, no 429s; daemon log shows no `collection_items`/`collection_summary` from the download worker or size-backfill during the batch.
- [ ] Restart the daemon mid-queue → interrupted items resume from their stored URL (no re-fetch).
- [ ] A failed item → Retry → re-fetches a fresh URL and downloads (verifies the clear-on-failure heal).
- [ ] Single-album download via the UI button → still works (one-off collection re-fetch).
- [ ] Size estimates still appear on queued cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (2nd commit) — the backfill was the real aggressor

Field-testing showed downloads still 429'd after the first success, with the log flooded by `Download size backfill cycle failed` tracebacks. Root cause the first commit missed: the **size-backfill worker re-fetched the whole collection every 8s, 429'd, and retried forever**, poisoning the rate budget so the download worker's *fallback* fetches also 429'd. And the stored-URL fast path never engaged because the already-queued rows had NULL URLs (enqueued before the column existed; `sync` skips already-`remote` items so it never re-populates them).

- **Size-backfill yields to active downloads** (a shared `_downloads_active` event — downloads own the rate budget while draining) and **backs off exponentially on 429** (cap 5 min) instead of hammering every 8s. No more competition, no more log spam.
- **Download worker prefetches missing URLs with ONE collection fetch per drain** (`prefetch_redownload_urls` + `set_download_redownload_url`), then drains the whole batch via the fast path — so an existing NULL-URL backlog stops doing per-item re-fetches (matching the old "fetch once" profile). Best-effort: a 429 there falls back to per-item resolution, which now has room.

New tests: `set_download_redownload_url`; `prefetch_redownload_urls` (populates with one fetch / no-op when all present / skips items absent from the collection). The daemon-glue worker loops live in the coverage-excluded `__main__.py`. Full suite: 2353 passed, coverage 93.48%.

---

## Follow-up (3rd commit) — sizes stopped showing on queued cards

The 2nd commit paused the size-backfill for the entire drain, which meant queued cards never got a size estimate (the queue was empty by the time the backfill unpaused). Fixed the balance:

- The rate-limited endpoint is the **collection API**, not the per-item download **page**. So the size-backfill now uses **only stored `redownload_url`s** (populated by the download worker's per-drain prefetch) and **never fetches the collection** — it can run freely alongside downloads without competing on the rate-limited endpoint. Items still lacking a URL are skipped and sized on a later cycle once the prefetch fills them in.
- The `_downloads_active` pause is removed entirely (no longer needed). The backfill's 429 back-off is kept as defense.

Backfill tests rewritten for the stored-URLs-only behavior (sizes via stored URLs; skips items without a URL; asserts the collection endpoint is never hit). Full suite: 2352 passed, coverage 93.48%.
