### PR TITLE
fix(downloads): align size column across card sections (KAMP-579)

### DIFF
--- a/kamp_ui/src/renderer/src/assets/downloads.css
+++ b/kamp_ui/src/renderer/src/assets/downloads.css
@@ -65,8 +65,13 @@
 .download-card-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 2px;
-  flex: 0 0 auto;
+  /* Reserve space for up to two buttons (2 x 24px + 2px gap) on every card —
+     including the button-less downloading card, which renders an empty actions
+     div — so the size column's right edge stays aligned across the Now
+     Downloading / Queued / Failed sections (KAMP-579). */
+  flex: 0 0 50px;
 }
 .download-card-btn {
   display: flex;

--- a/kamp_ui/src/renderer/src/components/DownloadCard.tsx
+++ b/kamp_ui/src/renderer/src/components/DownloadCard.tsx
@@ -78,39 +78,39 @@ export function DownloadCard({
         )}
       </div>
       {sizeLabel && <div className="download-card-size">{sizeLabel}</div>}
-      {(isQueued || isFailed) && (onRetry || onCancel) && (
-        <div className="download-card-actions">
-          {isFailed && onRetry && (
-            <button
-              className="download-card-btn"
-              {...tooltip('Retry download')}
-              aria-label="Retry download"
-              // stopPropagation on pointerdown so the button doesn't start a card drag
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation()
-                onRetry(id)
-              }}
-            >
-              <RetryIcon size={15} />
-            </button>
-          )}
-          {onCancel && (
-            <button
-              className="download-card-btn"
-              {...tooltip('Remove from queue')}
-              aria-label="Remove from queue"
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation()
-                onCancel(id)
-              }}
-            >
-              <RemoveFromQueueIcon size={16} />
-            </button>
-          )}
-        </div>
-      )}
+      {/* Always rendered (empty on the downloading card) so its reserved width
+          keeps the size column right-aligned across the three sections (KAMP-579). */}
+      <div className="download-card-actions">
+        {isFailed && onRetry && (
+          <button
+            className="download-card-btn"
+            {...tooltip('Retry download')}
+            aria-label="Retry download"
+            // stopPropagation on pointerdown so the button doesn't start a card drag
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onRetry(id)
+            }}
+          >
+            <RetryIcon size={15} />
+          </button>
+        )}
+        {onCancel && (
+          <button
+            className="download-card-btn"
+            {...tooltip('Remove from queue')}
+            aria-label="Remove from queue"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onCancel(id)
+            }}
+          >
+            <RemoveFromQueueIcon size={16} />
+          </button>
+        )}
+      </div>
       {isDownloading && (
         <div
           className={`download-progress${


### PR DESCRIPTION
Fixes the size values not lining up between Download-view sections.

## Cause
The File Size label's horizontal position depended on each card's trailing action buttons — Now Downloading has none (size flush right), Queued has one Cancel, Failed has Retry + Cancel — so the size column shifted per section.

## Fix
Always render the `.download-card-actions` area with a fixed reserved width (two buttons: 2×24px + 2px gap = 50px, right-justified) — empty on the downloading card — so the size column's right edge aligns across Now Downloading / Queued / Failed. Frontend-only; `npm run typecheck` + eslint clean (pre-commit re-ran both).

## Manual test plan
- [ ] With an item downloading and others queued (and ideally one failed), the size values line up vertically (right edges aligned) across all three sections.
- [ ] Queued card still reveals the Cancel button on hover; failed card still shows Retry + Cancel; both hug the right edge.
- [ ] No visual gap regression on the downloading card's right side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)