### PR TITLE
feat(tagging): manual MusicBrainz lookup by artist/album with lazy candidate hydration (KAMP-584)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -629,9 +629,24 @@ class MusicBrainzReleaseOut(BaseModel):
     tracks: list[MusicBrainzTrackOut]
 
 
+class MusicBrainzCandidateOut(BaseModel):
+    # Shallow by design: no tracks field, so "not yet hydrated" can never be
+    # confused with "hydrated, zero matching tracks" (KAMP-584). The UI
+    # hydrates a candidate on demand via /albums/musicbrainz/release/{mbid}.
+    mbid: str
+    release_group_mbid: str
+    title: str
+    album_artist: str
+    release_date: str
+    label: str
+    release_type: str
+    is_current: bool = False
+
+
 class MusicBrainzLookupOut(BaseModel):
-    # Ranked best-first. KAMP-230 always uses candidates[0]; KAMP-231 adds a picker.
-    candidates: list[MusicBrainzReleaseOut]
+    # Ranked best-first; candidates[0] is the album's current release when
+    # its stored mb_release_id still resolves (is_current=True).
+    candidates: list[MusicBrainzCandidateOut]
 
 
 class ItunesCandidateOut(BaseModel):
@@ -932,7 +947,8 @@ def create_app(
     art_cache_dir: Path | None = None,
     dev_mode: bool = False,
     auth_token: str | None = None,
-    mb_lookup_fn: Callable[..., Any] | None = None,
+    mb_search_fn: Callable[[str, str], list[Any]] | None = None,
+    mb_release_fn: Callable[[str], Any] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -2204,21 +2220,58 @@ def create_app(
         _notify_library_changed()
         return AlbumMetaOut(tracks=_tracks_out(index, updated))
 
+    _MAX_LOOKUP_CANDIDATES = 10
+
+    def _to_candidate_out(r: Any, is_current: bool = False) -> MusicBrainzCandidateOut:
+        return MusicBrainzCandidateOut(
+            mbid=r.mbid,
+            release_group_mbid=r.release_group_mbid,
+            title=r.title,
+            album_artist=r.album_artist,
+            release_date=r.release_date,
+            label=r.label,
+            release_type=r.release_type,
+            is_current=is_current,
+        )
+
+    def _to_release_out(r: Any) -> MusicBrainzReleaseOut:
+        sorted_tracks = sorted(r.tracks.values(), key=lambda t: (t.disc, t.number))
+        return MusicBrainzReleaseOut(
+            mbid=r.mbid,
+            release_group_mbid=r.release_group_mbid,
+            title=r.title,
+            album_artist=r.album_artist,
+            release_date=r.release_date,
+            label=r.label,
+            release_type=r.release_type,
+            tracks=[
+                MusicBrainzTrackOut(
+                    track_number=t.number,
+                    disc_number=t.disc,
+                    title=t.title,
+                    recording_mbid=t.recording_mbid,
+                )
+                for t in sorted_tracks
+            ],
+        )
+
     @app.get("/api/v1/albums/musicbrainz", response_model=MusicBrainzLookupOut)
     async def get_album_musicbrainz(
         album_artist: str, album: str
     ) -> MusicBrainzLookupOut:
-        """Fetch ranked MusicBrainz release candidates for an album.
+        """Fetch shallow MusicBrainz release candidates for an album (KAMP-584).
 
-        Uses the same tier-1 (per-track recording votes) + tier-2 (album-level
-        search) strategy as the import pipeline.  Returns up to 5 candidates
-        sorted best-first.  The frontend uses candidates[0] for KAMP-230;
-        KAMP-231 will add a picker that steps through the full list.
+        One album-level search (no per-track calls, no per-candidate
+        hydration) so the lookup stays interactive.  If the album already has
+        a stored mb_release_id that still resolves, that release is pinned
+        first with is_current=True; a dead stored id degrades to search-only.
+        Candidates carry no track lists — the UI hydrates the viewed
+        candidate via GET /api/v1/albums/musicbrainz/release/{mbid}.
 
         Returns 404 if no tracks are found or if MusicBrainz has no match.
-        Returns 503 if mb_lookup_fn was not wired up at server construction.
+        Returns 503 if mb_search_fn was not wired up at server construction.
         """
-        if mb_lookup_fn is None:
+        if mb_search_fn is None:
             raise HTTPException(
                 status_code=503, detail="MusicBrainz lookup not available"
             )
@@ -2227,40 +2280,77 @@ def create_app(
         if not tracks:
             raise HTTPException(status_code=404, detail="Album not found")
 
-        tuples = [(t.artist, t.title, t.album) for t in tracks]
-        try:
-            from kamp_daemon.tagger import TaggingError
+        stored_mbid = next((t.mb_release_id for t in tracks if t.mb_release_id), "")
 
-            releases = await asyncio.get_event_loop().run_in_executor(
-                None, mb_lookup_fn, tuples
+        def _do_lookup() -> tuple[Any | None, list[Any]]:
+            pinned = None
+            if stored_mbid and mb_release_fn is not None:
+                try:
+                    pinned = mb_release_fn(stored_mbid)
+                except Exception:
+                    # Deleted/merged-away id — the search results still stand.
+                    logger.info(
+                        "Stored MB release id %s no longer resolves; "
+                        "falling back to search only",
+                        stored_mbid,
+                    )
+            return pinned, mb_search_fn(album_artist, album)
+
+        try:
+            pinned, results = await asyncio.get_event_loop().run_in_executor(
+                None, _do_lookup
             )
         except Exception as exc:
-            # TaggingError and network failures both surface as 404 with the
-            # human-readable message so the frontend can show "No match found".
+            # Network failures surface as 404 with the human-readable message
+            # so the frontend can show "No match found".
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-        def _to_release_out(r: Any) -> MusicBrainzReleaseOut:
-            sorted_tracks = sorted(r.tracks.values(), key=lambda t: (t.disc, t.number))
-            return MusicBrainzReleaseOut(
-                mbid=r.mbid,
-                release_group_mbid=r.release_group_mbid,
-                title=r.title,
-                album_artist=r.album_artist,
-                release_date=r.release_date,
-                label=r.label,
-                release_type=r.release_type,
-                tracks=[
-                    MusicBrainzTrackOut(
-                        track_number=t.number,
-                        disc_number=t.disc,
-                        title=t.title,
-                        recording_mbid=t.recording_mbid,
-                    )
-                    for t in sorted_tracks
-                ],
+        candidates: list[MusicBrainzCandidateOut] = []
+        if pinned is not None:
+            candidates.append(_to_candidate_out(pinned, is_current=True))
+            # Dedupe on the id MB actually returned — a merged stored id
+            # resolves to the target release, whose id may differ.
+            results = [r for r in results if r.mbid != pinned.mbid]
+        candidates.extend(_to_candidate_out(r) for r in results)
+        candidates = candidates[:_MAX_LOOKUP_CANDIDATES]
+
+        if not candidates:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"No MusicBrainz results for artist={album_artist!r} "
+                    f"album={album!r}"
+                ),
             )
 
-        return MusicBrainzLookupOut(candidates=[_to_release_out(r) for r in releases])
+        return MusicBrainzLookupOut(candidates=candidates)
+
+    @app.get(
+        "/api/v1/albums/musicbrainz/release/{mbid}",
+        response_model=MusicBrainzReleaseOut,
+    )
+    async def get_musicbrainz_release(mbid: str) -> MusicBrainzReleaseOut:
+        """Hydrate one MusicBrainz release (full detail incl. track list).
+
+        Serves the modal's on-demand candidate hydration (KAMP-584).  The
+        returned mbid may differ from the requested one when MB has merged
+        the release — callers should use the returned id.
+
+        Returns 404 for unknown/unparseable releases; 503 if unwired.
+        """
+        if mb_release_fn is None:
+            raise HTTPException(
+                status_code=503, detail="MusicBrainz lookup not available"
+            )
+
+        try:
+            release = await asyncio.get_event_loop().run_in_executor(
+                None, mb_release_fn, mbid
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        return _to_release_out(release)
 
     @app.get("/api/v1/albums/art/search", response_model=ItunesSearchOut)
     async def search_album_art(album_artist: str, album: str) -> ItunesSearchOut:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -536,7 +536,7 @@ def _cmd_daemon(
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
     from kamp_core.server import create_app, resolve_playback_uri
     from kamp_daemon.config import config_set as _config_set
-    from kamp_daemon.tagger import lookup_releases_from_tracks
+    from kamp_daemon.tagger import lookup_release_by_mbid, search_release_candidates
 
     _logger = logging.getLogger(__name__)
     pkg_version = _get_version()
@@ -1022,7 +1022,8 @@ def _cmd_daemon(
         check_stream_url=_check_stream_url,
         dev_mode=bool(os.environ.get("KAMP_DEV")),
         auth_token=_auth_token,
-        mb_lookup_fn=lookup_releases_from_tracks,
+        mb_search_fn=search_release_candidates,
+        mb_release_fn=lookup_release_by_mbid,
     )
 
     # ---------------------------------------------------------------------------

--- a/kamp_daemon/tagger.py
+++ b/kamp_daemon/tagger.py
@@ -37,6 +37,15 @@ class TaggingError(Exception):
     pass
 
 
+class ReleaseNotFoundError(TaggingError):
+    """The requested MusicBrainz release does not exist (HTTP 404).
+
+    Subclasses TaggingError so existing broad handlers keep working, while
+    letting callers (e.g. the manual-lookup endpoints) distinguish a missing
+    release from transient MB failures.
+    """
+
+
 @dataclass
 class ReleaseInfo:
     """Canonical metadata resolved from MusicBrainz."""
@@ -948,88 +957,42 @@ def lookup_release_from_tracks(
 _MAX_MB_CANDIDATES = 5
 
 
-def lookup_releases_from_tracks(
-    tracks: list[tuple[str, str, str]],
+def search_release_candidates(
+    artist: str, album: str, limit: int = 10
 ) -> list[ReleaseInfo]:
-    """Return up to _MAX_MB_CANDIDATES MusicBrainz releases ranked best-first.
+    """Return up to *limit* shallow release candidates from ONE search call.
 
-    Uses the same tier-1 (per-track recording votes) + tier-2 (album-level
-    search) strategy as lookup_release_from_tracks, but returns all parseable
-    candidates instead of stopping at the first.  Designed for the comparison
-    UI where the user selects from multiple possible matches.
-
-    Args:
-        tracks: Sequence of (artist, title, album) strings, one per track.
-
-    Returns:
-        Non-empty list of ReleaseInfo sorted best-first.
-
-    Raises:
-        TaggingError: If no release can be found at all.
+    Designed for the manual album-edit picker (KAMP-584): no per-candidate
+    get_release_by_id hydration, so the whole lookup is a single rate-limited
+    MB request.  Candidates carry only search-result fields (title, artist,
+    date, label, type — all per-release optional in MB search results) and
+    always have an empty ``tracks`` dict; callers hydrate a candidate on
+    demand via lookup_release_by_mbid.
     """
-    if not tracks:
-        raise TaggingError("No tracks provided for MusicBrainz lookup")
-
-    # Tier 1: per-track recording votes — collect top-N voted MBIDs
-    votes: Counter[str] = Counter()
-    for artist, title, album in tracks:
-        if not title:
+    candidates: list[ReleaseInfo] = []
+    for raw in _search_release_candidates_raw(artist, album, limit):
+        try:
+            candidates.append(_parse_release(raw))
+        except (ValueError, KeyError) as exc:
+            logger.debug("Skipping unparseable search result: %s", exc)
             continue
-        result = _mb_call(
-            musicbrainzngs.search_recordings,
-            recording=title,
-            artist=artist,
-            release=album,
-            limit=3,
-        )
-        recordings = result.get("recording-list", [])
-        if not recordings:
-            continue
-        top = recordings[0]
-        for rel in top.get("release-list", []):
-            rel_id = rel.get("id", "")
-            if rel_id:
-                votes[rel_id] += 1
+    return candidates
 
-    seen_mbids: set[str] = set()
-    releases: list[ReleaseInfo] = []
 
-    if votes:
-        logger.debug(
-            "lookup_releases_from_tracks: top votes=%s",
-            dict(votes.most_common(_MAX_MB_CANDIDATES)),
-        )
-        for mbid, _ in votes.most_common(_MAX_MB_CANDIDATES):
-            if len(releases) >= _MAX_MB_CANDIDATES:
-                break
-            try:
-                detail = _mb_call(
-                    musicbrainzngs.get_release_by_id,
-                    mbid,
-                    includes=["artists", "recordings", "release-groups", "labels"],
-                )
-                releases.append(_parse_release(detail["release"]))
-                seen_mbids.add(mbid)
-            except (ValueError, KeyError, TaggingError):
-                continue
+def lookup_release_by_mbid(mbid: str) -> ReleaseInfo:
+    """Fetch and parse one release by MBID (full detail, including tracks).
 
-    # Supplement with tier-2 (album-level) search when tier-1 left us short
-    if len(releases) < _MAX_MB_CANDIDATES:
-        artist, _, album = tracks[0]
-        for r in _search_releases(artist, album):
-            if r.mbid not in seen_mbids:
-                releases.append(r)
-                seen_mbids.add(r.mbid)
-                if len(releases) >= _MAX_MB_CANDIDATES:
-                    break
-
-    if not releases:
-        artist, _, album = tracks[0]
-        raise TaggingError(
-            f"No MusicBrainz results for artist={artist!r} album={album!r}"
-        )
-
-    return releases
+    Raises ReleaseNotFoundError fast on HTTP 404 (no retry backoff — a
+    missing release is deterministic).  Note that a merged MBID resolves to
+    the merge target, so the returned ReleaseInfo.mbid may differ from the
+    requested one; callers should use the returned id.
+    """
+    detail = _mb_call(
+        musicbrainzngs.get_release_by_id,
+        mbid,
+        includes=["artists", "recordings", "release-groups", "labels"],
+    )
+    return _parse_release(detail["release"])
 
 
 def _mb_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
@@ -1040,6 +1003,12 @@ def _mb_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         try:
             return fn(*args, **kwargs)
         except (musicbrainzngs.WebServiceError, musicbrainzngs.NetworkError) as exc:
+            # A 404 is deterministic — retrying only burns the backoff delay.
+            cause = getattr(exc, "cause", None)
+            if getattr(cause, "code", None) == 404:
+                raise ReleaseNotFoundError(
+                    f"MusicBrainz entity not found: {exc}"
+                ) from exc
             if attempt == max_retries:
                 raise TaggingError(
                     f"MusicBrainz request failed after {max_retries} retries: {exc}"
@@ -1065,29 +1034,29 @@ def _search_release(artist: str, album: str) -> ReleaseInfo:
     )
 
 
-def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
-    """Return up to _MAX_MB_CANDIDATES parseable releases for artist + album.
+def _search_release_candidates_raw(
+    artist: str, album: str, limit: int
+) -> list[dict[str, Any]]:
+    """Run one search_releases call and return raw result dicts sorted best-first.
 
-    Performs one search_releases call (retrying with cleaned name when the
-    first attempt returns nothing), then fetches full details for each
-    candidate in preference order (highest score, earliest date).  Returns an
-    empty list rather than raising so callers can decide how to handle zero
-    results.
+    Retries once with any iTunes edition suffix stripped from the album name
+    (e.g. "Abbey Road (Super Deluxe Edition)" → "Abbey Road") when the first
+    attempt returns nothing.  Shared by the pipeline hydrate path
+    (_search_releases) and the manual shallow path (search_release_candidates)
+    so the retry and ordering logic never diverge.
     """
     logger.debug("MusicBrainz search: artist=%r release=%r", artist, album)
     result = _mb_call(
         musicbrainzngs.search_releases,
         artist=artist,
         release=album,
-        limit=_MAX_MB_CANDIDATES,
+        limit=limit,
     )
 
     raw_releases: list[dict[str, Any]] = result.get("release-list", [])
     logger.debug("MusicBrainz returned %d result(s)", len(raw_releases))
 
     if not raw_releases:
-        # Retry once with any iTunes edition suffix stripped from the album name
-        # (e.g. "Abbey Road (Super Deluxe Edition)" → "Abbey Road").
         cleaned = _EDITION_RE.sub("", album).strip()
         if cleaned != album:
             logger.debug(
@@ -1097,12 +1066,9 @@ def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
                 musicbrainzngs.search_releases,
                 artist=artist,
                 release=cleaned,
-                limit=_MAX_MB_CANDIDATES,
+                limit=limit,
             )
             raw_releases = result.get("release-list", [])
-
-    if not raw_releases:
-        return []
 
     # Sort candidates: highest score first; break ties by earliest release date so
     # original/digital releases (e.g. 2020-03-27) beat later vinyl reissues (2021-04-30).
@@ -1111,9 +1077,18 @@ def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
         date = r.get("date", "") or "9999"
         return (-score, date)
 
-    sorted_raw = sorted(raw_releases, key=_sort_key)
+    return sorted(raw_releases, key=_sort_key)
 
-    # Fetch full release details (search_releases returns minimal data).
+
+def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
+    """Return up to _MAX_MB_CANDIDATES parseable, fully-hydrated releases.
+
+    Composes the shared raw search with per-candidate get_release_by_id
+    hydration (search_releases returns minimal data).  Returns an empty list
+    rather than raising so callers can decide how to handle zero results.
+    """
+    sorted_raw = _search_release_candidates_raw(artist, album, _MAX_MB_CANDIDATES)
+
     # Skip releases whose metadata cannot be parsed (e.g. vinyl "A1" track nums).
     releases: list[ReleaseInfo] = []
     for candidate in sorted_raw:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -695,7 +695,7 @@ export const patchAlbumMeta = (
 }
 
 // ---------------------------------------------------------------------------
-// MusicBrainz lookup (KAMP-230)
+// MusicBrainz lookup (KAMP-230, shallow candidates + lazy hydration KAMP-584)
 // ---------------------------------------------------------------------------
 
 export type MusicBrainzTrack = {
@@ -703,6 +703,20 @@ export type MusicBrainzTrack = {
   disc_number: number
   title: string
   recording_mbid: string
+}
+
+// Shallow search candidate — deliberately has no tracks field, so an
+// un-hydrated candidate can never be mistaken for a release with zero
+// matching tracks. Hydrate via fetchMusicBrainzRelease before applying.
+export type MusicBrainzCandidate = {
+  mbid: string
+  release_group_mbid: string
+  title: string
+  album_artist: string
+  release_date: string
+  label: string
+  release_type: string
+  is_current: boolean
 }
 
 export type MusicBrainzRelease = {
@@ -720,7 +734,7 @@ export async function fetchMusicBrainzCandidates(
   albumArtist: string,
   album: string,
   signal: AbortSignal
-): Promise<MusicBrainzRelease[]> {
+): Promise<MusicBrainzCandidate[]> {
   const params = new URLSearchParams({ album_artist: albumArtist, album })
   const res = await fetch(`${BASE_URL}/api/v1/albums/musicbrainz?${params}`, {
     headers: _authHeaders(),
@@ -736,8 +750,29 @@ export async function fetchMusicBrainzCandidates(
     }
     throw new Error(message)
   }
-  const data = (await res.json()) as { candidates: MusicBrainzRelease[] }
+  const data = (await res.json()) as { candidates: MusicBrainzCandidate[] }
   return data.candidates
+}
+
+export async function fetchMusicBrainzRelease(
+  mbid: string,
+  signal: AbortSignal
+): Promise<MusicBrainzRelease> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/albums/musicbrainz/release/${encodeURIComponent(mbid)}`,
+    { headers: _authHeaders(), signal }
+  )
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail && typeof json.detail === 'string') message = json.detail
+    } catch {
+      // ignore
+    }
+    throw new Error(message)
+  }
+  return (await res.json()) as MusicBrainzRelease
 }
 
 export async function patchTrackMeta(trackId: number, mbRecordingId: string): Promise<Track> {

--- a/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import type { MusicBrainzRelease, Track } from '../api/client'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { fetchMusicBrainzRelease } from '../api/client'
+import type { MusicBrainzCandidate, MusicBrainzRelease, Track } from '../api/client'
 
 // Fields that can be toggled between local and MB values.
 type FieldId = 'title' | 'album_artist' | 'release_date' | 'label'
@@ -15,11 +16,13 @@ type SelectionState = {
 export type MBApplyPayload = {
   album: Record<FieldId, 'local' | 'mb'>
   tracks: Record<TrackKey, 'local' | 'mb'>
+  // Full release only: applying a shallow candidate would stamp a new
+  // mb_release_id while leaving every track's recording id stale (KAMP-584).
   release: MusicBrainzRelease
 }
 
 type Props = {
-  candidates: MusicBrainzRelease[]
+  candidates: MusicBrainzCandidate[]
   localTracks: Track[]
   onApply: (payload: MBApplyPayload) => void
   onClose: () => void
@@ -44,14 +47,24 @@ function findMBTrack(
   )
 }
 
-function defaultSelection(release: MusicBrainzRelease, localTracks: Track[]): SelectionState {
-  const album: Record<FieldId, 'local' | 'mb'> = {
-    title: release.title !== localTracks[0]?.album ? 'mb' : 'local',
-    album_artist: release.album_artist !== localTracks[0]?.album_artist ? 'mb' : 'local',
-    release_date: release.release_date !== localTracks[0]?.release_date ? 'mb' : 'local',
-    label: release.label !== localTracks[0]?.label ? 'mb' : 'local'
+// Album-level defaults come from the shallow candidate, so they're available
+// before hydration and survive the shallow → hydrated swap untouched.
+function defaultAlbumSelection(
+  candidate: MusicBrainzCandidate,
+  localTracks: Track[]
+): Record<FieldId, 'local' | 'mb'> {
+  return {
+    title: candidate.title !== localTracks[0]?.album ? 'mb' : 'local',
+    album_artist: candidate.album_artist !== localTracks[0]?.album_artist ? 'mb' : 'local',
+    release_date: candidate.release_date !== localTracks[0]?.release_date ? 'mb' : 'local',
+    label: candidate.label !== localTracks[0]?.label ? 'mb' : 'local'
   }
+}
 
+function defaultTrackSelection(
+  release: MusicBrainzRelease,
+  localTracks: Track[]
+): Record<TrackKey, 'local' | 'mb'> {
   const tracks: Record<TrackKey, 'local' | 'mb'> = {}
   for (const local of localTracks) {
     const mb = findMBTrack(release, local)
@@ -59,8 +72,7 @@ function defaultSelection(release: MusicBrainzRelease, localTracks: Track[]): Se
     const key = trackKey(local.disc_number, local.track_number)
     tracks[key] = mb.title !== local.title ? 'mb' : 'local'
   }
-
-  return { album, tracks }
+  return tracks
 }
 
 function Toggle({
@@ -106,15 +118,70 @@ export function MusicBrainzModal({
   const localAlbum = localTracks[0]
 
   const [candidateIndex, setCandidateIndex] = useState(0)
-  const release = candidates[candidateIndex]
+  const candidate = candidates[candidateIndex]
 
-  const [sel, setSel] = useState<SelectionState>(() => defaultSelection(release, localTracks))
+  // Lazy hydration cache, keyed by the candidate's mbid (not index): rapid
+  // navigation can resolve out of order, and a cached entry must land on the
+  // candidate that requested it. A merged mbid hydrates to a release whose
+  // own id differs — Apply uses the hydrated (canonical) release.
+  const [hydrated, setHydrated] = useState<Record<string, MusicBrainzRelease>>({})
+  const [hydrationError, setHydrationError] = useState<Record<string, string>>({})
+  const hydrateAbortRef = useRef<AbortController | null>(null)
 
-  // Reset selection when the active candidate changes (render-time derived state pattern).
-  const [prevRelease, setPrevRelease] = useState(release)
-  if (release !== prevRelease) {
-    setPrevRelease(release)
-    setSel(defaultSelection(release, localTracks))
+  const release: MusicBrainzRelease | undefined = hydrated[candidate.mbid]
+
+  useEffect(() => {
+    const mbid = candidate.mbid
+    if (hydrated[mbid] || hydrationError[mbid]) return
+    // Supersede any in-flight hydration — one request at a time.
+    hydrateAbortRef.current?.abort()
+    const ctrl = new AbortController()
+    hydrateAbortRef.current = ctrl
+    fetchMusicBrainzRelease(mbid, ctrl.signal).then(
+      (r) => {
+        if (!ctrl.signal.aborted) setHydrated((prev) => ({ ...prev, [mbid]: r }))
+      },
+      (err: unknown) => {
+        if (ctrl.signal.aborted) return
+        const msg = err instanceof Error ? err.message : 'Failed to load release'
+        setHydrationError((prev) => ({ ...prev, [mbid]: msg }))
+      }
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [candidate.mbid])
+
+  // Abort in-flight hydration when the modal unmounts (close).
+  useEffect(() => {
+    return () => {
+      hydrateAbortRef.current?.abort()
+      hydrateAbortRef.current = null
+    }
+  }, [])
+
+  const [sel, setSel] = useState<SelectionState>(() => ({
+    album: defaultAlbumSelection(candidate, localTracks),
+    tracks: release ? defaultTrackSelection(release, localTracks) : {}
+  }))
+
+  // Reset selection when the active candidate changes (render-time derived
+  // state pattern), keyed by mbid so the shallow → hydrated swap of the same
+  // candidate does NOT wipe the user's album-field toggles.
+  const [prevMbid, setPrevMbid] = useState(candidate.mbid)
+  const [trackDefaultsFor, setTrackDefaultsFor] = useState<string | null>(
+    release ? candidate.mbid : null
+  )
+  if (candidate.mbid !== prevMbid) {
+    setPrevMbid(candidate.mbid)
+    setSel({
+      album: defaultAlbumSelection(candidate, localTracks),
+      tracks: release ? defaultTrackSelection(release, localTracks) : {}
+    })
+    setTrackDefaultsFor(release ? candidate.mbid : null)
+  } else if (release && trackDefaultsFor !== candidate.mbid) {
+    // Hydration just resolved for the viewed candidate: merge in the
+    // per-track defaults without touching album-field selections.
+    setTrackDefaultsFor(candidate.mbid)
+    setSel((s) => ({ ...s, tracks: defaultTrackSelection(release, localTracks) }))
   }
 
   useEffect(() => {
@@ -136,25 +203,25 @@ export function MusicBrainzModal({
       {
         field: 'title',
         localVal: localAlbum?.album ?? '',
-        mbVal: release.title
+        mbVal: candidate.title
       },
       {
         field: 'album_artist',
         localVal: localAlbum?.album_artist ?? '',
-        mbVal: release.album_artist
+        mbVal: candidate.album_artist
       },
       {
         field: 'release_date',
         localVal: localAlbum?.release_date ?? '',
-        mbVal: release.release_date
+        mbVal: candidate.release_date
       },
       {
         field: 'label',
         localVal: localAlbum?.label ?? '',
-        mbVal: release.label
+        mbVal: candidate.label
       }
     ],
-    [release, localAlbum]
+    [candidate, localAlbum]
   )
 
   return (
@@ -169,7 +236,7 @@ export function MusicBrainzModal({
         {/* Header */}
         <div className="mb-modal__header">
           <h2 id="mb-modal-title" className="mb-modal__title">
-            MusicBrainz — {release.title}
+            MusicBrainz — {candidate.title}
           </h2>
           <div className="mb-modal__header-right">
             {candidates.length > 1 && (
@@ -197,8 +264,9 @@ export function MusicBrainzModal({
                 </button>
               </div>
             )}
-            {release.release_type && (
-              <span className="mb-modal__release-type">{release.release_type}</span>
+            {candidate.is_current && <span className="mb-modal__release-type">Current</span>}
+            {candidate.release_type && (
+              <span className="mb-modal__release-type">{candidate.release_type}</span>
             )}
           </div>
         </div>
@@ -230,51 +298,68 @@ export function MusicBrainzModal({
             )
           })}
 
-          {/* Track-level titles */}
+          {/* Track-level titles (available once the candidate is hydrated) */}
           <div className="mb-modal__section-label">Tracks</div>
-          {localTracks.map((local) => {
-            const mb = findMBTrack(release, local)
-            const key = trackKey(local.disc_number, local.track_number)
+          {!release && hydrationError[candidate.mbid] && (
+            <div className="mb-cmp-row mb-cmp-row--unmatched">
+              <div className="mb-cmp-row__values" style={{ gridColumn: '1 / -1' }}>
+                <span className="mb-cmp-row__mb--no-match">
+                  Couldn&apos;t load this release: {hydrationError[candidate.mbid]}
+                </span>
+              </div>
+            </div>
+          )}
+          {!release && !hydrationError[candidate.mbid] && (
+            <div className="mb-cmp-row mb-cmp-row--unmatched">
+              <div className="mb-cmp-row__values" style={{ gridColumn: '1 / -1' }}>
+                <span className="mb-cmp-row__local">Loading track list…</span>
+              </div>
+            </div>
+          )}
+          {release &&
+            localTracks.map((local) => {
+              const mb = findMBTrack(release, local)
+              const key = trackKey(local.disc_number, local.track_number)
 
-            if (!mb) {
+              if (!mb) {
+                return (
+                  <div key={local.id} className="mb-cmp-row mb-cmp-row--unmatched">
+                    <span className="mb-cmp-row__label">
+                      {local.disc_number > 1 ? `${local.disc_number}-` : ''}
+                      {local.track_number}
+                    </span>
+                    <div className="mb-cmp-row__values" style={{ gridColumn: '2 / -1' }}>
+                      <span className="mb-cmp-row__local">{local.title}</span>
+                      <span className="mb-cmp-row__mb--no-match">no MB match</span>
+                    </div>
+                  </div>
+                )
+              }
+
+              const isDiff = local.title !== mb.title
+              const chosen = sel.tracks[key] ?? 'local'
               return (
-                <div key={local.id} className="mb-cmp-row mb-cmp-row--unmatched">
+                <div key={local.id} className="mb-cmp-row">
                   <span className="mb-cmp-row__label">
                     {local.disc_number > 1 ? `${local.disc_number}-` : ''}
                     {local.track_number}
                   </span>
-                  <div className="mb-cmp-row__values" style={{ gridColumn: '2 / -1' }}>
-                    <span className="mb-cmp-row__local">{local.title}</span>
-                    <span className="mb-cmp-row__mb--no-match">no MB match</span>
+                  <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
+                  <div className="mb-cmp-row__values">
+                    <span
+                      className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
+                    >
+                      {local.title}
+                    </span>
+                    <span
+                      className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
+                    >
+                      {mb.title}
+                    </span>
                   </div>
                 </div>
               )
-            }
-
-            const isDiff = local.title !== mb.title
-            const chosen = sel.tracks[key] ?? 'local'
-            return (
-              <div key={local.id} className="mb-cmp-row">
-                <span className="mb-cmp-row__label">
-                  {local.disc_number > 1 ? `${local.disc_number}-` : ''}
-                  {local.track_number}
-                </span>
-                <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
-                <div className="mb-cmp-row__values">
-                  <span
-                    className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
-                  >
-                    {local.title}
-                  </span>
-                  <span
-                    className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
-                  >
-                    {mb.title}
-                  </span>
-                </div>
-              </div>
-            )
-          })}
+            })}
         </div>
 
         {/* Footer */}
@@ -285,7 +370,8 @@ export function MusicBrainzModal({
           <button
             className="mb-modal__btn mb-modal__btn--accent"
             type="button"
-            onClick={() => onApply({ album: sel.album, tracks: sel.tracks, release })}
+            disabled={!release}
+            onClick={() => release && onApply({ album: sel.album, tracks: sel.tracks, release })}
           >
             Apply selected
           </button>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -5,7 +5,7 @@ import { TOOLTIPS } from '../tooltipStrings'
 import { artUrl, fetchMusicBrainzCandidates, patchTrackMeta } from '../api/client'
 import type {
   AlbumTagsCollision,
-  MusicBrainzRelease,
+  MusicBrainzCandidate,
   Track,
   TrackTagsCollision
 } from '../api/client'
@@ -58,7 +58,7 @@ type AlbumRenameToast = {
 type MBFetchState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'ready'; candidates: MusicBrainzRelease[] }
+  | { status: 'ready'; candidates: MusicBrainzCandidate[] }
   | { status: 'error'; message: string }
 
 function HeroImage({

--- a/tests/test_mb_lookup_endpoint.py
+++ b/tests/test_mb_lookup_endpoint.py
@@ -78,31 +78,35 @@ def mock_queue() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/v1/albums/musicbrainz
+# GET /api/v1/albums/musicbrainz — shallow candidate list (KAMP-584)
 # ---------------------------------------------------------------------------
 
 
 class TestGetAlbumMusicBrainz:
-    """GET /api/v1/albums/musicbrainz returns ranked MB candidates."""
+    """GET /api/v1/albums/musicbrainz returns shallow ranked MB candidates."""
 
-    def test_happy_path_returns_candidates(
+    def _app(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+        **kwargs: object,
+    ) -> TestClient:
+        return TestClient(
+            create_app(index=mock_index, engine=mock_engine, queue=mock_queue, **kwargs)
+        )
+
+    def test_happy_path_returns_shallow_candidates(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
-        tracks = [_track(1), _track(2)]
-        mock_index.tracks_for_album.return_value = tracks
-        release = _fake_release()
-        lookup_fn = MagicMock(return_value=[release])
+        mock_index.tracks_for_album.return_value = [_track(1), _track(2)]
+        search_fn = MagicMock(return_value=[_fake_release()])
 
-        app = create_app(
-            index=mock_index,
-            engine=mock_engine,
-            queue=mock_queue,
-            mb_lookup_fn=lookup_fn,
-        )
-        resp = TestClient(app).get(
+        client = self._app(mock_index, mock_engine, mock_queue, mb_search_fn=search_fn)
+        resp = client.get(
             "/api/v1/albums/musicbrainz",
             params={"album_artist": "Band", "album": "Record"},
         )
@@ -117,39 +121,134 @@ class TestGetAlbumMusicBrainz:
         assert c["release_date"] == "2021"
         assert c["label"] == "MB Label"
         assert c["release_type"] == "Album"
-        assert len(c["tracks"]) == 1
-        assert c["tracks"][0]["title"] == "MB Track 1"
-        assert c["tracks"][0]["recording_mbid"] == "rec-1"
+        assert c["is_current"] is False
+        # Shallow contract: candidates never carry a track list.
+        assert "tracks" not in c
 
-        # Verify the lookup received the correct (artist, title, album) tuples
-        lookup_fn.assert_called_once_with(
-            [("Band", "Track 1", "Record"), ("Band", "Track 2", "Record")]
-        )
+        # One album-level search — no per-track tuples anymore.
+        search_fn.assert_called_once_with("Band", "Record")
 
-    def test_returns_multiple_candidates(
+    def test_stored_release_id_pinned_first_and_current(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
-        mock_index.tracks_for_album.return_value = [_track(1)]
-        releases = [_fake_release("r1"), _fake_release("r2")]
-        releases[1].title = "MB Record (Deluxe)"
-
-        app = create_app(
-            index=mock_index,
-            engine=mock_engine,
-            queue=mock_queue,
-            mb_lookup_fn=MagicMock(return_value=releases),
+        track = _track(1)
+        track.mb_release_id = "stored-1"
+        mock_index.tracks_for_album.return_value = [track]
+        search_fn = MagicMock(
+            return_value=[
+                _fake_release("s1"),
+                _fake_release("stored-1"),
+                _fake_release("s2"),
+            ]
         )
-        resp = TestClient(app).get(
+        release_fn = MagicMock(return_value=_fake_release("stored-1"))
+
+        client = self._app(
+            mock_index,
+            mock_engine,
+            mock_queue,
+            mb_search_fn=search_fn,
+            mb_release_fn=release_fn,
+        )
+        resp = client.get(
             "/api/v1/albums/musicbrainz",
             params={"album_artist": "Band", "album": "Record"},
         )
 
         assert resp.status_code == 200
-        assert len(resp.json()["candidates"]) == 2
-        assert resp.json()["candidates"][1]["mbid"] == "r2"
+        candidates = resp.json()["candidates"]
+        assert [c["mbid"] for c in candidates] == ["stored-1", "s1", "s2"]
+        assert candidates[0]["is_current"] is True
+        assert candidates[1]["is_current"] is False
+        release_fn.assert_called_once_with("stored-1")
+
+    def test_pin_dedupes_on_canonical_id(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """A merged stored mbid resolves to a new id; dedupe uses the returned id."""
+        track = _track(1)
+        track.mb_release_id = "merged-away"
+        mock_index.tracks_for_album.return_value = [track]
+        search_fn = MagicMock(
+            return_value=[_fake_release("canonical-1"), _fake_release("s2")]
+        )
+        release_fn = MagicMock(return_value=_fake_release("canonical-1"))
+
+        client = self._app(
+            mock_index,
+            mock_engine,
+            mock_queue,
+            mb_search_fn=search_fn,
+            mb_release_fn=release_fn,
+        )
+        resp = client.get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+
+        candidates = resp.json()["candidates"]
+        assert [c["mbid"] for c in candidates] == ["canonical-1", "s2"]
+        assert candidates[0]["is_current"] is True
+
+    def test_pin_degrades_to_search_on_failure(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """A dead stored mbid must not fail the whole lookup."""
+        track = _track(1)
+        track.mb_release_id = "gone-mbid"
+        mock_index.tracks_for_album.return_value = [track]
+        search_fn = MagicMock(return_value=[_fake_release("s1")])
+        release_fn = MagicMock(side_effect=Exception("not found"))
+
+        client = self._app(
+            mock_index,
+            mock_engine,
+            mock_queue,
+            mb_search_fn=search_fn,
+            mb_release_fn=release_fn,
+        )
+        resp = client.get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+
+        assert resp.status_code == 200
+        assert [c["mbid"] for c in resp.json()["candidates"]] == ["s1"]
+
+    def test_candidates_capped_at_ten(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        track = _track(1)
+        track.mb_release_id = "stored-1"
+        mock_index.tracks_for_album.return_value = [track]
+        search_fn = MagicMock(return_value=[_fake_release(f"s{i}") for i in range(12)])
+        release_fn = MagicMock(return_value=_fake_release("stored-1"))
+
+        client = self._app(
+            mock_index,
+            mock_engine,
+            mock_queue,
+            mb_search_fn=search_fn,
+            mb_release_fn=release_fn,
+        )
+        resp = client.get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Band", "album": "Record"},
+        )
+
+        assert len(resp.json()["candidates"]) == 10
 
     def test_returns_404_when_album_not_found(
         self,
@@ -159,41 +258,51 @@ class TestGetAlbumMusicBrainz:
     ) -> None:
         mock_index.tracks_for_album.return_value = []
 
-        app = create_app(
-            index=mock_index,
-            engine=mock_engine,
-            queue=mock_queue,
-            mb_lookup_fn=MagicMock(),
+        client = self._app(
+            mock_index, mock_engine, mock_queue, mb_search_fn=MagicMock()
         )
-        resp = TestClient(app).get(
+        resp = client.get(
             "/api/v1/albums/musicbrainz",
             params={"album_artist": "Ghost", "album": "Void"},
         )
         assert resp.status_code == 404
 
-    def test_returns_404_when_mb_lookup_raises(
+    def test_returns_404_when_search_raises(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
         mock_index.tracks_for_album.return_value = [_track(1)]
-        lookup_fn = MagicMock(side_effect=Exception("No MusicBrainz results"))
+        search_fn = MagicMock(side_effect=Exception("MB is down"))
 
-        app = create_app(
-            index=mock_index,
-            engine=mock_engine,
-            queue=mock_queue,
-            mb_lookup_fn=lookup_fn,
+        client = self._app(mock_index, mock_engine, mock_queue, mb_search_fn=search_fn)
+        resp = client.get(
+            "/api/v1/albums/musicbrainz",
+            params={"album_artist": "Unknown", "album": "Untitled"},
         )
-        resp = TestClient(app).get(
+        assert resp.status_code == 404
+        assert "MB is down" in resp.json()["detail"]
+
+    def test_returns_404_when_no_results(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+
+        client = self._app(
+            mock_index, mock_engine, mock_queue, mb_search_fn=MagicMock(return_value=[])
+        )
+        resp = client.get(
             "/api/v1/albums/musicbrainz",
             params={"album_artist": "Unknown", "album": "Untitled"},
         )
         assert resp.status_code == 404
         assert "No MusicBrainz results" in resp.json()["detail"]
 
-    def test_returns_503_when_lookup_fn_not_wired(
+    def test_returns_503_when_search_fn_not_wired(
         self,
         mock_index: MagicMock,
         mock_engine: MagicMock,
@@ -201,14 +310,43 @@ class TestGetAlbumMusicBrainz:
     ) -> None:
         mock_index.tracks_for_album.return_value = [_track(1)]
 
-        app = create_app(
-            index=mock_index, engine=mock_engine, queue=mock_queue
-        )  # no mb_lookup_fn
-        resp = TestClient(app).get(
+        client = self._app(mock_index, mock_engine, mock_queue)  # no mb fns
+        resp = client.get(
             "/api/v1/albums/musicbrainz",
             params={"album_artist": "Band", "album": "Record"},
         )
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/albums/musicbrainz/release/{mbid} — on-demand hydration (KAMP-584)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMusicBrainzRelease:
+    def test_returns_full_release_with_tracks(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        release_fn = MagicMock(return_value=_fake_release("release-1"))
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_release_fn=release_fn,
+        )
+        resp = TestClient(app).get("/api/v1/albums/musicbrainz/release/release-1")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mbid"] == "release-1"
+        assert len(data["tracks"]) == 1
+        assert data["tracks"][0]["title"] == "MB Track 1"
+        assert data["tracks"][0]["recording_mbid"] == "rec-1"
+        release_fn.assert_called_once_with("release-1")
 
     def test_tracks_sorted_by_disc_then_number(
         self,
@@ -216,7 +354,6 @@ class TestGetAlbumMusicBrainz:
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
-        mock_index.tracks_for_album.return_value = [_track(1)]
         t1, t2, t3 = MagicMock(), MagicMock(), MagicMock()
         t1.number, t1.disc, t1.title, t1.recording_mbid = 2, 1, "Second", "rec-2"
         t2.number, t2.disc, t2.title, t2.recording_mbid = 1, 2, "Disc2T1", "rec-3"
@@ -228,14 +365,41 @@ class TestGetAlbumMusicBrainz:
             index=mock_index,
             engine=mock_engine,
             queue=mock_queue,
-            mb_lookup_fn=MagicMock(return_value=[release]),
+            mb_release_fn=MagicMock(return_value=release),
         )
-        resp = TestClient(app).get(
-            "/api/v1/albums/musicbrainz",
-            params={"album_artist": "Band", "album": "Record"},
-        )
-        titles = [t["title"] for t in resp.json()["candidates"][0]["tracks"]]
+        resp = TestClient(app).get("/api/v1/albums/musicbrainz/release/release-1")
+
+        titles = [t["title"] for t in resp.json()["tracks"]]
         assert titles == ["First", "Second", "Disc2T1"]
+
+    def test_returns_404_when_release_not_found(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        release_fn = MagicMock(side_effect=Exception("entity not found"))
+
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            mb_release_fn=release_fn,
+        )
+        resp = TestClient(app).get("/api/v1/albums/musicbrainz/release/gone-mbid")
+
+        assert resp.status_code == 404
+        assert "entity not found" in resp.json()["detail"]
+
+    def test_returns_503_when_release_fn_not_wired(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).get("/api/v1/albums/musicbrainz/release/any-mbid")
+        assert resp.status_code == 503
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -12,6 +12,7 @@ import pytest
 from kamp_daemon.ext.types import TrackMetadata
 from kamp_daemon.tagger import (
     ReleaseInfo,
+    ReleaseNotFoundError,
     TaggingError,
     TrackInfo,
     _lookup_release_by_acoustid,
@@ -27,9 +28,10 @@ from kamp_daemon.tagger import (
     _write_tags,
     configure_musicbrainz,
     is_tagged,
-    lookup_releases_from_tracks,
+    lookup_release_by_mbid,
     read_release_mbids,
     read_track_metadata_from_file,
+    search_release_candidates,
     tag_directory,
     write_sale_item_id,
     write_tags_from_track_metadata,
@@ -2086,82 +2088,209 @@ class TestWriteTagsFromTrackMetadata:
 
 
 # ---------------------------------------------------------------------------
-# lookup_releases_from_tracks (KAMP-230)
+# search_release_candidates / lookup_release_by_mbid (KAMP-584)
 # ---------------------------------------------------------------------------
 
-RECORDING_HIT: dict[str, Any] = {
-    "recording-list": [
+# Shaped like real ws/2 *search* results: medium-list carries counts, never
+# track listings; label-info/date/release-group are per-release optional.
+SEARCH_RESULT_SHALLOW: dict[str, Any] = {
+    "release-list": [
         {
-            "id": "rec-1",
-            "title": "First Track",
-            "release-list": [{"id": "abc-123"}, {"id": "other-123"}],
-        }
+            "id": "new-100",
+            "title": "Great Album",
+            "date": "2021-05-01",
+            "ext:score": "100",
+            "artist-credit": [
+                {
+                    "name": "Cool Artist",
+                    "artist": {
+                        "id": "am-1",
+                        "name": "Cool Artist",
+                        "sort-name": "Artist, Cool",
+                    },
+                }
+            ],
+            "release-group": {"id": "rg-1", "primary-type": "Album"},
+            "label-info-list": [
+                {"label": {"name": "Reissue Label"}, "catalog-number": "RL-2"}
+            ],
+            "medium-list": [{"format": "CD", "track-count": 10}],
+        },
+        {
+            "id": "old-100",
+            "title": "Great Album",
+            "date": "1999-01-01",
+            "ext:score": "100",
+            "artist-credit": [
+                {"name": "Cool Artist", "artist": {"name": "Cool Artist"}}
+            ],
+            "release-group": {"id": "rg-1", "primary-type": "Album"},
+            "medium-list": [{"format": "CD", "track-count": 10}],
+        },
+        {
+            # Minimal entry: no date, artist-credit, release-group, or label-info.
+            "id": "minimal-90",
+            "title": "Great Album",
+            "ext:score": "90",
+        },
     ]
 }
 
 
-class TestLookupReleasesFromTracks:
-    def test_raises_on_empty_input(self) -> None:
-        with pytest.raises(TaggingError, match="No tracks provided"):
-            lookup_releases_from_tracks([])
-
-    def test_happy_path_tier1_vote(self) -> None:
-        """Tier-1 path: recording votes resolve to a release."""
-        tracks = [("Cool Artist", "First Track", "Great Album")]
-        empty_releases: dict[str, Any] = {"release-list": []}
-        with patch("musicbrainzngs.search_recordings", return_value=RECORDING_HIT):
-            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
-                with patch(
-                    "musicbrainzngs.get_release_by_id",
-                    return_value=SAMPLE_RELEASE_DETAIL,
-                ):
-                    releases = lookup_releases_from_tracks(tracks)
-
-        assert len(releases) >= 1
-        assert releases[0].mbid == "abc-123"
-        assert releases[0].title == "Great Album"
-
-    def test_falls_back_to_tier2_when_no_votes(self) -> None:
-        """When no recording results, falls back to album-level search."""
-        tracks = [("Cool Artist", "First Track", "Great Album")]
-        empty_recordings: dict[str, Any] = {"recording-list": []}
-        with patch("musicbrainzngs.search_recordings", return_value=empty_recordings):
-            with patch("musicbrainzngs.search_releases", return_value=SAMPLE_RELEASE):
-                with patch(
-                    "musicbrainzngs.get_release_by_id",
-                    return_value=SAMPLE_RELEASE_DETAIL,
-                ):
-                    releases = lookup_releases_from_tracks(tracks)
-
-        assert len(releases) >= 1
-        assert releases[0].mbid == "abc-123"
-
-    def test_raises_when_all_paths_fail(self) -> None:
-        """Raises TaggingError when both tier-1 and tier-2 find nothing."""
-        tracks = [("Unknown", "???", "???")]
-        empty_recordings: dict[str, Any] = {"recording-list": []}
-        empty_releases: dict[str, Any] = {"release-list": []}
-        with patch("musicbrainzngs.search_recordings", return_value=empty_recordings):
-            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
-                with pytest.raises(TaggingError, match="No MusicBrainz results"):
-                    lookup_releases_from_tracks(tracks)
-
-    def test_skips_tracks_without_title(self) -> None:
-        """Tracks with empty title strings do not make recording API calls."""
-        tracks = [("Artist", "", "Album"), ("Artist", "Real Title", "Album")]
-        empty_releases: dict[str, Any] = {"release-list": []}
+class TestSearchReleaseCandidates:
+    def test_single_search_call_no_hydration(self) -> None:
+        """One search_releases call; get_release_by_id is never invoked."""
         with patch(
-            "musicbrainzngs.search_recordings", return_value=RECORDING_HIT
-        ) as mock_rec:
-            with patch("musicbrainzngs.search_releases", return_value=empty_releases):
-                with patch(
-                    "musicbrainzngs.get_release_by_id",
-                    return_value=SAMPLE_RELEASE_DETAIL,
-                ):
-                    lookup_releases_from_tracks(tracks)
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ) as mock_search:
+            with patch("musicbrainzngs.get_release_by_id") as mock_get:
+                candidates = search_release_candidates("Cool Artist", "Great Album")
 
-        # Only one call — the empty-title track is skipped.
-        assert mock_rec.call_count == 1
+        assert mock_search.call_count == 1
+        mock_get.assert_not_called()
+        assert len(candidates) == 3
+        assert all(c.tracks == {} for c in candidates)
+
+    def test_score_primary_date_tiebreak_ordering(self) -> None:
+        """Relevance score wins; earliest date breaks ties among equal scores."""
+        with patch(
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ):
+            candidates = search_release_candidates("Cool Artist", "Great Album")
+
+        assert [c.mbid for c in candidates] == ["old-100", "new-100", "minimal-90"]
+
+    def test_default_limit_is_ten(self) -> None:
+        with patch(
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ) as mock_search:
+            search_release_candidates("Cool Artist", "Great Album")
+
+        assert mock_search.call_args.kwargs["limit"] == 10
+
+    def test_custom_limit_forwarded(self) -> None:
+        with patch(
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ) as mock_search:
+            search_release_candidates("Cool Artist", "Great Album", limit=3)
+
+        assert mock_search.call_args.kwargs["limit"] == 3
+
+    def test_optional_fields_default_empty(self) -> None:
+        """Per-release optional MB search fields parse to empty defaults."""
+        with patch(
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ):
+            candidates = search_release_candidates("Cool Artist", "Great Album")
+
+        minimal = candidates[-1]
+        assert minimal.mbid == "minimal-90"
+        assert minimal.release_date == ""
+        assert minimal.label == ""
+        assert minimal.release_type == ""
+        assert minimal.album_artist == ""
+
+    def test_parsed_shallow_fields(self) -> None:
+        """Fields present in search results land on the candidate."""
+        with patch(
+            "musicbrainzngs.search_releases", return_value=SEARCH_RESULT_SHALLOW
+        ):
+            candidates = search_release_candidates("Cool Artist", "Great Album")
+
+        newest = next(c for c in candidates if c.mbid == "new-100")
+        assert newest.title == "Great Album"
+        assert newest.album_artist == "Cool Artist"
+        assert newest.release_date == "2021-05-01"
+        assert newest.label == "Reissue Label"
+        assert newest.release_type == "Album"
+
+    def test_edition_suffix_retry(self) -> None:
+        """Empty first search retries with the edition suffix stripped."""
+        empty: dict[str, Any] = {"release-list": []}
+        with patch(
+            "musicbrainzngs.search_releases",
+            side_effect=[empty, SEARCH_RESULT_SHALLOW],
+        ) as mock_search:
+            candidates = search_release_candidates(
+                "Cool Artist", "Great Album (Super Deluxe Edition)"
+            )
+
+        assert len(candidates) == 3
+        assert mock_search.call_count == 2
+        assert mock_search.call_args.kwargs["release"] == "Great Album"
+
+    def test_returns_empty_list_when_nothing_found(self) -> None:
+        empty: dict[str, Any] = {"release-list": []}
+        with patch("musicbrainzngs.search_releases", return_value=empty):
+            assert search_release_candidates("Unknown", "???") == []
+
+    def test_skips_unparseable_candidate(self) -> None:
+        """A candidate the parser rejects is skipped, not fatal."""
+        broken: dict[str, Any] = {
+            "release-list": [
+                {"title": "No Id Here", "ext:score": "100"},  # missing "id"
+                dict(SEARCH_RESULT_SHALLOW["release-list"][2]),
+            ]
+        }
+        with patch("musicbrainzngs.search_releases", return_value=broken):
+            candidates = search_release_candidates("Cool Artist", "Great Album")
+
+        assert [c.mbid for c in candidates] == ["minimal-90"]
+
+
+class TestLookupReleaseByMbid:
+    def test_returns_parsed_release_with_tracks(self) -> None:
+        with patch(
+            "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+        ):
+            release = lookup_release_by_mbid("abc-123")
+
+        assert release.mbid == "abc-123"
+        assert len(release.tracks) == 2
+
+    def test_merged_mbid_returns_canonical_id(self) -> None:
+        """A merged MBID resolves to the merge target; callers get the new id."""
+        with patch(
+            "musicbrainzngs.get_release_by_id", return_value=SAMPLE_RELEASE_DETAIL
+        ):
+            release = lookup_release_by_mbid("merged-away-mbid")
+
+        assert release.mbid == "abc-123"
+
+    def test_fails_fast_on_404(self) -> None:
+        """HTTP 404 raises ReleaseNotFoundError immediately — no retry backoff."""
+        not_found = musicbrainzngs.ResponseError(cause=MagicMock(code=404))
+        with patch(
+            "musicbrainzngs.get_release_by_id", side_effect=not_found
+        ) as mock_get:
+            with patch("kamp_daemon.tagger.time.sleep") as mock_sleep:
+                with pytest.raises(ReleaseNotFoundError):
+                    lookup_release_by_mbid("gone-mbid")
+
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_release_not_found_is_a_tagging_error(self) -> None:
+        """Existing except TaggingError handlers keep working."""
+        assert issubclass(ReleaseNotFoundError, TaggingError)
+
+    def test_retries_on_transient_error(self) -> None:
+        """Non-404 web service errors still ride the retry backoff."""
+        call_count = 0
+
+        def flaky(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise musicbrainzngs.WebServiceError("503")
+            return SAMPLE_RELEASE_DETAIL
+
+        with patch("musicbrainzngs.get_release_by_id", side_effect=flaky):
+            with patch("kamp_daemon.tagger.time.sleep"):
+                release = lookup_release_by_mbid("abc-123")
+
+        assert call_count == 3
+        assert release.mbid == "abc-123"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Manual MusicBrainz lookup now runs one album-level search instead of one rate-limited `search_recordings` call per track, cutting a ~30 s fetch to ~2 s. Fixes KAMP-584.

## Changes

**Daemon (`kamp_daemon/tagger.py`)**
- New `search_release_candidates(artist, album, limit=10)`: one `search_releases` call returning up to 10 shallow candidates (no per-candidate hydration), ordered score-primary / earliest-date-tiebreak.
- New `lookup_release_by_mbid(mbid)`: full-detail fetch for on-demand hydration. `_mb_call` now fails fast on HTTP 404 (`ReleaseNotFoundError`, a `TaggingError` subclass) instead of riding the 1+2+4 s retry backoff — a missing release is deterministic.
- `_search_releases` split into a shared raw-search stage (`_search_release_candidates_raw`: search + edition-suffix retry + sort) and the hydrate loop, so the pipeline tier-2 fallback and the manual path share one search implementation. The pipeline's per-track voting path (`lookup_release_from_tracks`, singular) is untouched.
- Deleted `lookup_releases_from_tracks` — its only consumer was the manual endpoint.

**Server (`kamp_core/server.py`)**
- `GET /api/v1/albums/musicbrainz` returns up to 10 shallow `MusicBrainzCandidateOut` entries (no `tracks` field, so "not yet hydrated" can never read as "zero matching tracks"). If the album's stored `mb_release_id` still resolves, that release is pinned first with `is_current=true`, deduped against search results on the canonical id MB returns (merged ids resolve to a different id); a dead stored id degrades to search-only.
- New `GET /api/v1/albums/musicbrainz/release/{mbid}` hydrates one release with its track list.
- `create_app` takes `mb_search_fn` + `mb_release_fn` (replaces `mb_lookup_fn`); both wired in `kamp_daemon/__main__.py`.

**UI (`kamp_ui`)**
- The modal hydrates the viewed candidate lazily (on open and on ‹/› navigation), cached by mbid, with supersede-on-nav and abort-on-close; per-candidate loading and error states in the Tracks section.
- Apply is disabled until the viewed candidate is hydrated — applying a shallow candidate would have stamped a new `mb_release_id` while leaving per-track recording ids stale. `MBApplyPayload.release` keeps the full type so that misuse is a compile error.
- Album-field toggles derive from the shallow candidate and survive the shallow→hydrated swap; a "Current" badge marks the album's stored release.

## Testing

- Full suite: 2369 passed, 9 skipped. Coverage 93.55% vs 93.48% on main (no ground lost).
- New tagger tests: shallow search fixture (search-shaped results without track lists / label-info), score/date ordering, limit forwarding, edition-suffix retry, unparseable-candidate skip, 404 fast-fail (no backoff sleeps), merged-mbid canonical-id return, transient-error retry.
- New endpoint tests: shallow candidate shape, stored-id pin (first + `is_current`), canonical-id dedupe, degrade-to-search on dead stored id, 10-candidate cap, 404 (album missing / search failure / zero results), hydration endpoint 200/404, 503 guards on both endpoints.
- kamp_ui typecheck + eslint clean.

## Manual Test Plan

- [ ] Album **without** MB release id: Edit mode → MusicBrainz — candidates appear in ~2 s, up to 10, plausible matches first, earliest-release-first among equal relevance
- [ ] Album **with** MB release id: the current release is candidate 0 with a "Current" badge; alternatives follow; no duplicate of the pinned release
- [ ] Navigate ‹/› rapidly: track section shows "Loading track list…" then fills; no flicker from out-of-order responses; album-field toggles survive hydration
- [ ] Apply button disabled while the track list is loading; enabled after; applying a track title change lands correctly
- [ ] Candidate that fails to load (e.g. network drop mid-navigation): per-candidate error message, other candidates still navigable
- [ ] Close the modal mid-hydration: no console errors, no state updates after close
- [ ] Pipeline regression: watch-folder ingest of a test album still autotags (per-track voting untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
