### PR TITLE
feat(tagging): track artists in the manual MusicBrainz fetch (KAMP-583)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -628,6 +628,9 @@ class MusicBrainzTrackOut(BaseModel):
     disc_number: int
     title: str
     recording_mbid: str
+    # Credited track artist (KAMP-583). Empty unless the release was hydrated
+    # via lookup_release_by_mbid, which is the only path that requests it.
+    artist: str = ""
 
 
 class MusicBrainzReleaseOut(BaseModel):
@@ -1467,15 +1470,22 @@ def create_app(
         if (current and current.id == track_id) or (
             lookahead and lookahead.id == track_id
         ):
-            payload = _json.dumps(
-                {
-                    "old_path": str(old_path),
-                    "new_path": str(new_path),
-                    "title": req.title,
-                    "is_case_only": is_case_only,
-                }
-            )
-            op_id = index.queue_deferred_op("track_retag", track_id, payload)
+            data: dict[str, Any] = {
+                "old_path": str(old_path),
+                "new_path": str(new_path),
+                "title": req.title,
+                "is_case_only": is_case_only,
+            }
+            # deferred_ops is UNIQUE(track_id) with replace-on-insert, so a
+            # fresh payload would silently drop a pending artist write (the
+            # artist endpoint merges the other direction — keep it symmetric,
+            # KAMP-583).
+            pending = index.pending_deferred_ops_for_track(track_id)
+            if pending:
+                prior = _json.loads(pending[0].payload_json)
+                if prior.get("artist"):
+                    data["artist"] = prior["artist"]
+            op_id = index.queue_deferred_op("track_retag", track_id, _json.dumps(data))
             return JSONResponse(
                 status_code=202, content={"deferred": True, "op_id": op_id}
             )
@@ -2345,6 +2355,7 @@ def create_app(
                     disc_number=t.disc,
                     title=t.title,
                     recording_mbid=t.recording_mbid,
+                    artist=t.artist,
                 )
                 for t in sorted_tracks
             ],

--- a/kamp_daemon/tagger.py
+++ b/kamp_daemon/tagger.py
@@ -33,6 +33,15 @@ _EDITION_RE = re.compile(
 )
 
 
+# MusicBrainz `inc` parameters. _BASE_INCLUDES covers every lookup; the manual
+# album-edit hydration additionally requests artist credits so each track's
+# credited artist (the compilation case) comes back — KAMP-583. The coupling is
+# named rather than implicit because _parse_release is shared: a caller that
+# omits the include silently yields TrackInfo.artist == "".
+_BASE_INCLUDES = ["artists", "recordings", "release-groups", "labels"]
+_DETAIL_INCLUDES = _BASE_INCLUDES + ["artist-credits"]
+
+
 class TaggingError(Exception):
     pass
 
@@ -82,6 +91,10 @@ class TrackInfo:
     title: str
     recording_mbid: str = ""
     total_tracks: int = 0
+    # Credited track artist (KAMP-583). Populated ONLY for releases fetched via
+    # lookup_release_by_mbid, whose _DETAIL_INCLUDES requests artist credits;
+    # the pipeline paths use _BASE_INCLUDES and leave this empty.
+    artist: str = ""
 
 
 def is_tagged(path: Path) -> bool:
@@ -608,7 +621,7 @@ def _lookup_release_by_acoustid(
     detail = _mb_call(
         musicbrainzngs.get_release_by_id,
         winning_mbid,
-        includes=["artists", "recordings", "release-groups", "labels"],
+        includes=_BASE_INCLUDES,
     )
     return _parse_release(detail["release"]), file_acoustid_ids
 
@@ -879,7 +892,7 @@ def _lookup_release_by_recordings(audio_files: list[Path]) -> ReleaseInfo:
     detail = _mb_call(
         musicbrainzngs.get_release_by_id,
         winning_mbid,
-        includes=["artists", "recordings", "release-groups", "labels"],
+        includes=_BASE_INCLUDES,
     )
     return _parse_release(detail["release"])
 
@@ -940,7 +953,7 @@ def lookup_release_from_tracks(
         detail = _mb_call(
             musicbrainzngs.get_release_by_id,
             winning_mbid,
-            includes=["artists", "recordings", "release-groups", "labels"],
+            includes=_BASE_INCLUDES,
         )
         return _parse_release(detail["release"])
 
@@ -986,11 +999,14 @@ def lookup_release_by_mbid(mbid: str) -> ReleaseInfo:
     missing release is deterministic).  Note that a merged MBID resolves to
     the merge target, so the returned ReleaseInfo.mbid may differ from the
     requested one; callers should use the returned id.
+
+    Uses _DETAIL_INCLUDES: this is the manual album-edit picker's path, the
+    only consumer of per-track artist credits (KAMP-583).
     """
     detail = _mb_call(
         musicbrainzngs.get_release_by_id,
         mbid,
-        includes=["artists", "recordings", "release-groups", "labels"],
+        includes=_DETAIL_INCLUDES,
     )
     return _parse_release(detail["release"])
 
@@ -1099,7 +1115,7 @@ def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
         detail = _mb_call(
             musicbrainzngs.get_release_by_id,
             candidate_mbid,
-            includes=["artists", "recordings", "release-groups", "labels"],
+            includes=_BASE_INCLUDES,
         )
         try:
             releases.append(_parse_release(detail["release"]))
@@ -1108,6 +1124,28 @@ def _search_releases(artist: str, album: str) -> list[ReleaseInfo]:
             continue
 
     return releases
+
+
+def _flatten_artist_credit(artist_credit: list[Any]) -> str:
+    """Render a musicbrainzngs artist-credit list as its display string.
+
+    musicbrainzngs returns a flat list alternating between name-credit dicts
+    and joinphrase strings (e.g. [{"name": "Ali"}, " & ", {"name": "Charif"}]),
+    so the display name is the walk over both. A credit dict may carry the
+    printed name directly or only the nested artist's name.
+
+    (musicbrainzngs computes the same thing as "artist-credit-phrase", but only
+    when it parses real XML — our tests mock get_release_by_id and hand-write
+    dicts, which never carry that key, so the walk stays ours.)
+    """
+    return "".join(
+        (
+            item
+            if isinstance(item, str)
+            else (item.get("name") or item.get("artist", {}).get("name", ""))
+        )
+        for item in artist_credit
+    ).strip()
 
 
 def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
@@ -1120,21 +1158,10 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
     release_type: str = release_group.get("primary-type", "")
     original_date: str = release_group.get("first-release-date", "")
 
-    # Artist credit — musicbrainzngs returns a flat list alternating between name-credit
-    # dicts and joinphrase strings (e.g. [{"name": "Ali"}, " & ", {"name": "Charif..."}]).
     artist_credit = raw.get("artist-credit", [])
     credits = [c for c in artist_credit if isinstance(c, dict)]
     artists = [c.get("name") or c.get("artist", {}).get("name", "") for c in credits]
-    # Reconstruct the display string by walking the raw list, taking names from dicts
-    # and joinphrases from interleaved strings.
-    artist = "".join(
-        (
-            item
-            if isinstance(item, str)
-            else (item.get("name") or item.get("artist", {}).get("name", ""))
-        )
-        for item in artist_credit
-    ).strip()
+    artist = _flatten_artist_credit(artist_credit)
     album_artist = artist
     artist_sort = " ".join(c.get("artist", {}).get("sort-name", "") for c in credits)
     album_artist_sort = artist_sort
@@ -1171,12 +1198,16 @@ def _parse_release(raw: dict[str, Any]) -> ReleaseInfo:
                 track_num = int(pos) if str(pos).isdigit() else 0
             recording = track_raw.get("recording", {})
             key = f"{disc_num}-{track_num}"
+            # Track-level credit is what this release prints for the track — the
+            # compilation case, where it diverges from the release artist. Empty
+            # unless the lookup requested _DETAIL_INCLUDES (KAMP-583).
             tracks[key] = TrackInfo(
                 number=track_num,
                 disc=disc_num,
                 title=recording.get("title", ""),
                 recording_mbid=recording.get("id", ""),
                 total_tracks=total_tracks,
+                artist=_flatten_artist_credit(track_raw.get("artist-credit", [])),
             )
 
     return ReleaseInfo(

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -737,6 +737,9 @@ export type MusicBrainzTrack = {
   disc_number: number
   title: string
   recording_mbid: string
+  // Credited track artist (KAMP-583) — diverges from the album artist on
+  // compilations. Empty when MB has no credit for the track.
+  artist: string
 }
 
 // Shallow search candidate — deliberately has no tracks field, so an

--- a/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
+++ b/kamp_ui/src/renderer/src/assets/musicbrainz-modal.css
@@ -204,6 +204,13 @@
   border-bottom: none;
 }
 
+/* Track artist sub-row (KAMP-583): hangs off the track row above it, so it
+   drops the divider and tucks in under its parent. */
+.mb-cmp-row--sub {
+  border-bottom: none;
+  padding-top: 0;
+}
+
 /* Field label */
 .mb-cmp-row__label {
   font-size: 11px;
@@ -212,6 +219,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.mb-cmp-row__label--sub {
+  padding-left: 12px;
+  font-style: italic;
+  opacity: 0.75;
 }
 
 /* Values column — stacked local on top, MB below */

--- a/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MusicBrainzModal.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { fetchMusicBrainzRelease } from '../api/client'
-import type { MusicBrainzCandidate, MusicBrainzRelease, Track } from '../api/client'
+import type {
+  MusicBrainzCandidate,
+  MusicBrainzRelease,
+  MusicBrainzTrack,
+  Track
+} from '../api/client'
 
 // Fields that can be toggled between local and MB values.
 type FieldId = 'title' | 'album_artist' | 'release_date' | 'label'
@@ -11,11 +16,25 @@ type TrackKey = string
 type SelectionState = {
   album: Record<FieldId, 'local' | 'mb'>
   tracks: Record<TrackKey, 'local' | 'mb'>
+  // Per-track artist choice, keyed like `tracks` (KAMP-583).
+  trackArtists: Record<TrackKey, 'local' | 'mb'>
+}
+
+// One entry per local track the modal could resolve to an MB track. Resolution
+// happens HERE, once, and the resolved MB track travels with the choice —
+// previously the modal resolved with findMBTrack's disc normalisation but the
+// apply path re-derived its own key from raw MB coords, so on a disc-shifted
+// album the modal showed a toggle and Apply silently skipped the track.
+export type MBTrackApply = {
+  localId: number
+  mb: MusicBrainzTrack
+  title: 'local' | 'mb'
+  artist: 'local' | 'mb'
 }
 
 export type MBApplyPayload = {
   album: Record<FieldId, 'local' | 'mb'>
-  tracks: Record<TrackKey, 'local' | 'mb'>
+  tracks: MBTrackApply[]
   // Full release only: applying a shallow candidate would stamp a new
   // mb_release_id while leaving every track's recording id stale (KAMP-584).
   release: MusicBrainzRelease
@@ -73,6 +92,26 @@ function defaultTrackSelection(
     tracks[key] = mb.title !== local.title ? 'mb' : 'local'
   }
   return tracks
+}
+
+// An artist row only exists where MB and local disagree, so its default is
+// always 'mb' — there is nothing to choose on rows that already agree.
+function defaultTrackArtistSelection(
+  release: MusicBrainzRelease,
+  localTracks: Track[]
+): Record<TrackKey, 'local' | 'mb'> {
+  const artists: Record<TrackKey, 'local' | 'mb'> = {}
+  for (const local of localTracks) {
+    const mb = findMBTrack(release, local)
+    if (!mb || !artistDiffers(mb, local)) continue
+    artists[trackKey(local.disc_number, local.track_number)] = 'mb'
+  }
+  return artists
+}
+
+// MB must actually have a credit, and it must differ from what we hold.
+function artistDiffers(mb: MusicBrainzTrack, local: Track): boolean {
+  return !!mb.artist && mb.artist !== local.artist
 }
 
 function Toggle({
@@ -160,7 +199,8 @@ export function MusicBrainzModal({
 
   const [sel, setSel] = useState<SelectionState>(() => ({
     album: defaultAlbumSelection(candidate, localTracks),
-    tracks: release ? defaultTrackSelection(release, localTracks) : {}
+    tracks: release ? defaultTrackSelection(release, localTracks) : {},
+    trackArtists: release ? defaultTrackArtistSelection(release, localTracks) : {}
   }))
 
   // Reset selection when the active candidate changes (render-time derived
@@ -174,14 +214,19 @@ export function MusicBrainzModal({
     setPrevMbid(candidate.mbid)
     setSel({
       album: defaultAlbumSelection(candidate, localTracks),
-      tracks: release ? defaultTrackSelection(release, localTracks) : {}
+      tracks: release ? defaultTrackSelection(release, localTracks) : {},
+      trackArtists: release ? defaultTrackArtistSelection(release, localTracks) : {}
     })
     setTrackDefaultsFor(release ? candidate.mbid : null)
   } else if (release && trackDefaultsFor !== candidate.mbid) {
     // Hydration just resolved for the viewed candidate: merge in the
     // per-track defaults without touching album-field selections.
     setTrackDefaultsFor(candidate.mbid)
-    setSel((s) => ({ ...s, tracks: defaultTrackSelection(release, localTracks) }))
+    setSel((s) => ({
+      ...s,
+      tracks: defaultTrackSelection(release, localTracks),
+      trackArtists: defaultTrackArtistSelection(release, localTracks)
+    }))
   }
 
   useEffect(() => {
@@ -197,6 +242,26 @@ export function MusicBrainzModal({
 
   const setTrackField = (key: TrackKey, v: 'local' | 'mb'): void =>
     setSel((s) => ({ ...s, tracks: { ...s.tracks, [key]: v } }))
+
+  const setTrackArtistField = (key: TrackKey, v: 'local' | 'mb'): void =>
+    setSel((s) => ({ ...s, trackArtists: { ...s.trackArtists, [key]: v } }))
+
+  // Resolve local → MB once, at Apply, so the caller never re-derives keys.
+  const buildApplyTracks = (r: MusicBrainzRelease): MBTrackApply[] => {
+    const out: MBTrackApply[] = []
+    for (const local of localTracks) {
+      const mb = findMBTrack(r, local)
+      if (!mb) continue
+      const key = trackKey(local.disc_number, local.track_number)
+      out.push({
+        localId: local.id,
+        mb,
+        title: sel.tracks[key] ?? 'local',
+        artist: sel.trackArtists[key] ?? 'local'
+      })
+    }
+    return out
+  }
 
   const albumFieldRows: Array<{ field: FieldId; localVal: string; mbVal: string }> = useMemo(
     () => [
@@ -338,26 +403,47 @@ export function MusicBrainzModal({
 
               const isDiff = local.title !== mb.title
               const chosen = sel.tracks[key] ?? 'local'
+              // Artist gets its own row, but only where MB actually disagrees:
+              // on a single-artist album every track would otherwise carry a
+              // redundant row with nothing to choose (KAMP-583).
+              const showArtist = artistDiffers(mb, local)
+              const artistChosen = sel.trackArtists[key] ?? 'local'
               return (
-                <div key={local.id} className="mb-cmp-row">
-                  <span className="mb-cmp-row__label">
-                    {local.disc_number > 1 ? `${local.disc_number}-` : ''}
-                    {local.track_number}
-                  </span>
-                  <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
-                  <div className="mb-cmp-row__values">
-                    <span
-                      className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
-                    >
-                      {local.title}
+                <React.Fragment key={local.id}>
+                  <div className="mb-cmp-row">
+                    <span className="mb-cmp-row__label">
+                      {local.disc_number > 1 ? `${local.disc_number}-` : ''}
+                      {local.track_number}
                     </span>
-                    <span
-                      className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
-                    >
-                      {mb.title}
-                    </span>
+                    <Toggle side={chosen} onChange={(v) => setTrackField(key, v)} />
+                    <div className="mb-cmp-row__values">
+                      <span
+                        className={`mb-cmp-row__local${chosen === 'mb' && isDiff ? ' mb-cmp-row__local--overridden' : ''}`}
+                      >
+                        {local.title}
+                      </span>
+                      <span
+                        className={`mb-cmp-row__mb${isDiff ? ' mb-cmp-row__mb--diff' : ' mb-cmp-row__mb--same'}`}
+                      >
+                        {mb.title}
+                      </span>
+                    </div>
                   </div>
-                </div>
+                  {showArtist && (
+                    <div className="mb-cmp-row mb-cmp-row--sub">
+                      <span className="mb-cmp-row__label mb-cmp-row__label--sub">artist</span>
+                      <Toggle side={artistChosen} onChange={(v) => setTrackArtistField(key, v)} />
+                      <div className="mb-cmp-row__values">
+                        <span
+                          className={`mb-cmp-row__local${artistChosen === 'mb' ? ' mb-cmp-row__local--overridden' : ''}`}
+                        >
+                          {local.artist || <em style={{ opacity: 0.4 }}>empty</em>}
+                        </span>
+                        <span className="mb-cmp-row__mb mb-cmp-row__mb--diff">{mb.artist}</span>
+                      </div>
+                    </div>
+                  )}
+                </React.Fragment>
               )
             })}
         </div>
@@ -371,7 +457,9 @@ export function MusicBrainzModal({
             className="mb-modal__btn mb-modal__btn--accent"
             type="button"
             disabled={!release}
-            onClick={() => release && onApply({ album: sel.album, tracks: sel.tracks, release })}
+            onClick={() =>
+              release && onApply({ album: sel.album, tracks: buildApplyTracks(release), release })
+            }
           >
             Apply selected
           </button>

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -335,17 +335,22 @@ export function TrackList(): React.JSX.Element | null {
       await patchAlbumTags(album.album_artist, album.album, tagOpts)
     }
 
-    // 3. Track titles (sequential) + recording MBIDs (parallel)
-    const mbTrackMap = new Map(
-      mbRelease.tracks.map((t) => [`${t.disc_number}-${t.track_number}`, t])
-    )
+    // 3. Track titles + artists (sequential) + recording MBIDs (parallel).
+    // The modal already resolved each local track to its MB counterpart, so
+    // there is no key derivation here to drift from the modal's (KAMP-583).
+    const localById = new Map(tracks.map((t) => [t.id, t]))
     const mbidPromises: Promise<unknown>[] = []
-    for (const local of tracks) {
-      const key = `${local.disc_number}-${local.track_number}`
-      const mbTrack = mbTrackMap.get(key)
-      if (!mbTrack) continue
-      if (payload.tracks[key] === 'mb' && local.title !== mbTrack.title) {
+    for (const entry of payload.tracks) {
+      const local = localById.get(entry.localId)
+      if (!local) continue
+      const mbTrack = entry.mb
+      // Title and artist both rewrite this file's tags: keep them sequential
+      // (never in mbidPromises) so two mutagen writes can't race on one file.
+      if (entry.title === 'mb' && local.title !== mbTrack.title) {
         await patchTrackTitle(local.id, mbTrack.title)
+      }
+      if (entry.artist === 'mb' && mbTrack.artist && local.artist !== mbTrack.artist) {
+        await patchTrackArtist(local.id, mbTrack.artist)
       }
       if (mbTrack.recording_mbid && local.mb_recording_id !== mbTrack.recording_mbid) {
         mbidPromises.push(patchTrackMeta(local.id, mbTrack.recording_mbid))

--- a/tests/test_mb_lookup_endpoint.py
+++ b/tests/test_mb_lookup_endpoint.py
@@ -41,6 +41,7 @@ def _fake_release(mbid: str = "release-1") -> MagicMock:
     track.disc = 1
     track.title = "MB Track 1"
     track.recording_mbid = "rec-1"
+    track.artist = "MB Track Artist"
 
     r = MagicMock()
     r.mbid = mbid
@@ -346,6 +347,8 @@ class TestGetMusicBrainzRelease:
         assert len(data["tracks"]) == 1
         assert data["tracks"][0]["title"] == "MB Track 1"
         assert data["tracks"][0]["recording_mbid"] == "rec-1"
+        # KAMP-583: per-track credited artist reaches the modal.
+        assert data["tracks"][0]["artist"] == "MB Track Artist"
         release_fn.assert_called_once_with("release-1")
 
     def test_tracks_sorted_by_disc_then_number(
@@ -358,6 +361,8 @@ class TestGetMusicBrainzRelease:
         t1.number, t1.disc, t1.title, t1.recording_mbid = 2, 1, "Second", "rec-2"
         t2.number, t2.disc, t2.title, t2.recording_mbid = 1, 2, "Disc2T1", "rec-3"
         t3.number, t3.disc, t3.title, t3.recording_mbid = 1, 1, "First", "rec-1"
+        for t in (t1, t2, t3):
+            t.artist = "A"
         release = _fake_release()
         release.tracks = {"1-2": t1, "2-1": t2, "1-1": t3}
 

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -1188,6 +1188,40 @@ class TestPatchTrackArtistEndpoint:
         assert ops[0].op_type == "track_artist_retag"
         index.close()
 
+    def test_title_edit_preserves_pending_artist_op(
+        self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
+    ) -> None:
+        """The mirror of the merge below: queue_deferred_op is INSERT OR REPLACE
+        on UNIQUE(track_id), so a title edit after an artist edit on a PLAYING
+        track would silently drop the pending artist write (KAMP-583)."""
+        import json as _json
+
+        mp3, track = self._local_mp3_track(tmp_path)
+        client, index = self._client_with_track(
+            tmp_path, track, _mock_engine, _mock_queue
+        )
+        row = index.get_track_by_path(mp3)
+        assert row is not None
+        _mock_queue.current.return_value = row
+
+        # Artist first this time, then title — the reverse of the Apply order.
+        resp1 = client.patch(
+            f"/api/v1/tracks/{row.id}/artist", json={"artist": "New Guy"}
+        )
+        assert resp1.status_code == 202
+        resp2 = client.patch(
+            f"/api/v1/tracks/{row.id}/tags", json={"title": "New Song"}
+        )
+        assert resp2.status_code == 202
+
+        ops = index.pending_deferred_ops_for_track(row.id)
+        assert len(ops) == 1
+        assert ops[0].op_type == "track_retag"
+        payload = _json.loads(ops[0].payload_json)
+        assert payload["title"] == "New Song"
+        assert payload["artist"] == "New Guy"
+        index.close()
+
     def test_augments_pending_retag_op_instead_of_replacing(
         self, tmp_path: Path, _mock_engine: MagicMock, _mock_queue: MagicMock
     ) -> None:

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -15,6 +15,8 @@ from kamp_daemon.tagger import (
     ReleaseNotFoundError,
     TaggingError,
     TrackInfo,
+    _BASE_INCLUDES,
+    _DETAIL_INCLUDES,
     _lookup_release_by_acoustid,
     _lookup_release_by_recordings,
     _parse_release,
@@ -470,6 +472,135 @@ class TestParseReleaseMultiArtist:
 
         assert release.artist == "Ali & Charif Megarbane"
         assert release.album_artist == "Ali & Charif Megarbane"
+
+
+# ---------------------------------------------------------------------------
+# Per-track artist credit (KAMP-583)
+# ---------------------------------------------------------------------------
+
+# A compilation: the release is credited to "Various Artists" while each track
+# carries its own artist-credit. Deliberately NOT SAMPLE_RELEASE_DETAIL — that
+# fixture is shared by ~24 tests that assert TrackInfo equality, and giving its
+# tracks an artist credit would flip TrackInfo.artist non-empty for all of them.
+COMPILATION_RELEASE_DETAIL: dict[str, Any] = {
+    "release": {
+        "id": "comp-1",
+        "title": "A Compilation",
+        "date": "1999-01-01",
+        "artist-credit": [{"name": "Various Artists"}],
+        "release-group": {"id": "rg-comp", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": "1",
+                "track-list": [
+                    # Track-level credit: what is printed on THIS release.
+                    {
+                        "number": "1",
+                        "position": "1",
+                        "artist-credit": [{"name": "First Act"}],
+                        "recording": {"id": "rec-1", "title": "First Track"},
+                    },
+                    # Multi-artist credit with a joinphrase.
+                    {
+                        "number": "2",
+                        "position": "2",
+                        "artist-credit": [
+                            {"name": "Ali"},
+                            " & ",
+                            {"name": "Charif Megarbane"},
+                        ],
+                        "recording": {"id": "rec-2", "title": "Second Track"},
+                    },
+                    # No `name` key — only the nested artist.name (the shape the
+                    # existing SAMPLE_RELEASE fixture uses).
+                    {
+                        "number": "3",
+                        "position": "3",
+                        "artist-credit": [{"artist": {"name": "Nested Only"}}],
+                        "recording": {"id": "rec-3", "title": "Third Track"},
+                    },
+                    # No artist credit at all → empty, never a crash.
+                    {
+                        "number": "4",
+                        "position": "4",
+                        "recording": {"id": "rec-4", "title": "Fourth Track"},
+                    },
+                ],
+            }
+        ],
+    }
+}
+
+
+class TestParseReleaseTrackArtist:
+    def _tracks(self) -> dict[str, TrackInfo]:
+        return _parse_release(COMPILATION_RELEASE_DETAIL["release"]).tracks
+
+    def test_track_level_credit_is_parsed(self) -> None:
+        assert self._tracks()["1-1"].artist == "First Act"
+
+    def test_multi_artist_joinphrase_is_flattened(self) -> None:
+        assert self._tracks()["1-2"].artist == "Ali & Charif Megarbane"
+
+    def test_credit_without_name_key_uses_nested_artist_name(self) -> None:
+        assert self._tracks()["1-3"].artist == "Nested Only"
+
+    def test_missing_credit_is_empty_string(self) -> None:
+        assert self._tracks()["1-4"].artist == ""
+
+    def test_trailing_joinphrase_is_stripped(self) -> None:
+        """A dangling joinphrase (MB emits e.g. 'A feat. ') must not leave
+        trailing whitespace on the artist string."""
+        raw = {
+            "id": "r1",
+            "title": "T",
+            "artist-credit": [{"name": "AA"}],
+            "medium-list": [
+                {
+                    "position": "1",
+                    "track-list": [
+                        {
+                            "number": "1",
+                            "position": "1",
+                            "artist-credit": [{"name": "Solo Act"}, " & "],
+                            "recording": {"id": "rec-1", "title": "T1"},
+                        }
+                    ],
+                }
+            ],
+        }
+        assert _parse_release(raw).tracks["1-1"].artist == "Solo Act &"
+
+    def test_album_artist_parse_is_unaffected(self) -> None:
+        """Track credits must not disturb the release-level artist parse."""
+        release = _parse_release(COMPILATION_RELEASE_DETAIL["release"])
+        assert release.album_artist == "Various Artists"
+
+    def test_release_without_track_credits_leaves_artist_empty(self) -> None:
+        """Releases fetched without the artist-credits include (the pipeline
+        paths) parse fine and simply carry no track artist."""
+        release = _parse_release(SAMPLE_RELEASE_DETAIL["release"])
+        assert all(t.artist == "" for t in release.tracks.values())
+
+
+class TestMusicBrainzIncludes:
+    def test_detail_includes_request_artist_credits(self) -> None:
+        """The manual-modal hydration path must ask MB for artist credits, or
+        every track artist silently comes back empty."""
+        assert "artist-credits" in _DETAIL_INCLUDES
+        for inc in _BASE_INCLUDES:
+            assert inc in _DETAIL_INCLUDES
+
+    def test_base_includes_omit_artist_credits(self) -> None:
+        """The pipeline paths don't use track artists — keep their payloads lean."""
+        assert "artist-credits" not in _BASE_INCLUDES
+
+    def test_lookup_release_by_mbid_uses_detail_includes(self) -> None:
+        with patch(
+            "musicbrainzngs.get_release_by_id", return_value=COMPILATION_RELEASE_DETAIL
+        ) as mock_get:
+            lookup_release_by_mbid("comp-1")
+        assert mock_get.call_args.kwargs["includes"] == _DETAIL_INCLUDES
 
 
 class TestEditionSuffixRetry:


### PR DESCRIPTION
A manual MusicBrainz pull now brings back **per-track artists**, with the same MB/Local control titles already have — so compilations and Various-Artists releases, the exact case where track artist diverges from album artist, can finally be corrected from MB. Fixes KAMP-583. Builds on KAMP-582's per-track artist endpoint.

Verifying the plan turned up **two live defects** in the path this feature rides on. Both are fixed here, because the feature inherits them otherwise.

## Changes

**Daemon (`kamp_daemon/tagger.py`)**
- `TrackInfo.artist`, parsed from the **track-level** `artist-credit` — what a release prints for that track, which is what diverges on a compilation.
- Extracted the release-level credit walk into `_flatten_artist_credit` and reused it for both levels, with `.strip()` so a dangling joinphrase (`"A & "`) leaves no trailing space. musicbrainzngs computes the same string as `artist-credit-phrase`, but only when parsing real XML — our tests mock `get_release_by_id` with hand-written dicts that never carry that key, so relying on it would silently yield `""` in every test while working in prod. The walk stays ours.
- Named the includes coupling: `_BASE_INCLUDES` for every lookup, `_DETAIL_INCLUDES` (`+artist-credits`) for `lookup_release_by_mbid` only — the manual picker is the sole consumer of track artists, and pipeline payloads stay lean. A shared parser whose output silently depends on the caller's includes is the KAMP-436 no-op shape, so the constant names it.

**Server (`kamp_core/server.py`)**
- `MusicBrainzTrackOut.artist`, populated from the hydrated release.
- **Fix (mine, from KAMP-582):** the title defer branch built a *fresh* payload, and `queue_deferred_op` is `INSERT OR REPLACE` on `UNIQUE(track_id)` — so a title PATCH on a **playing** track silently discarded a pending `track_artist_retag`. The artist endpoint already merged the other direction; the title branch is now symmetric. This mattered directly: Apply patches title *and* artist on the same track, and only worked because the order happened to be title-then-artist. Now neither order loses a write.

**UI (`kamp_ui`)**
- Each track whose MB artist differs from local gains an **artist sub-row** with its own Local/MB toggle, defaulted to MB. Rows appear only where the values disagree — on a single-artist album there's nothing to choose, so the modal looks exactly as it does today.
- **Fix (pre-existing, affects titles today):** the modal resolved MB tracks via `findMBTrack`'s ±1 disc normalization but keyed selection by **local** coords, while `handleMBApply` built its own map keyed by **MB** coords and looked it up with local coords. On a disc-shifted album the modal showed a toggle and **Apply silently skipped the track**. The payload now carries *resolved* `{localId, mb, title, artist}` entries so the two sites cannot diverge again — which fixes titles as well as artists.
- The artist patch sits in the **sequential** section next to the title patch, never in `mbidPromises`: both rewrite the same file's tags and must not race.

## Testing

- Full suite: 2418 passed. Coverage **93.56%**, up from main's 93.55% (worktree-compared).
- New tagger tests on a dedicated `COMPILATION_RELEASE_DETAIL` fixture (`SAMPLE_RELEASE_DETAIL` left alone — ~24 tests assert `TrackInfo` equality against it): track-level credit parsed; multi-artist joinphrase flattened; the no-`name`-key credit shape; missing credit → `""`; trailing joinphrase stripped; album_artist parse unaffected; releases fetched without the include carry no track artist. Plus includes assertions (`_DETAIL_INCLUDES` has `artist-credits`, `_BASE_INCLUDES` doesn't, and `lookup_release_by_mbid` uses the detail set).
- New server tests: hydration returns per-track artist; **artist-then-title on a playing track preserves both** (the regression test for the merge fix — it failed before the fix, exactly as predicted).
- black, mypy, kamp_ui typecheck + eslint clean.
- Note: `test_websocket_sends_initial_state` failed once in a full run and passes in isolation and on re-run — a pre-existing order-dependent flake, unrelated to this change (untouched player-websocket code).

## Manual Test Plan

- [ ] **Compilation (the target case):** open a Various-Artists local album → Edit → MusicBrainz → pick a candidate. Tracks whose MB artist differs show an artist sub-row defaulted to MB; Apply writes each artist (check the artist column and the file's tag)
- [ ] **Single-artist album:** modal looks exactly as before — no artist sub-rows
- [ ] Flip an artist sub-row to **Local** → Apply → that track's artist is untouched while others change
- [ ] **Disc-normalized / multi-disc album:** toggles shown for tracks actually get applied — titles included (this is the resolution-divergence fix; they previously no-op'd silently)
- [ ] **Playing track:** Apply MB while one of its tracks plays — UI updates immediately, pip shows, and **both** title and artist land in the file after the track ends (the merge fix)
- [ ] A track MB has no match for: row still reads "no MB match", Apply skips it, others apply
- [ ] Rapid ‹/› candidate navigation then Apply: applied values match the candidate on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
