### PR TITLE
fix(config): 'embed album art' preference survives restart (KAMP-576)

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -520,6 +520,45 @@ def _cmd_sync(config: Config, download_all: bool = False) -> None:
         syncer.sync_once()
 
 
+def _build_config_values(
+    config: Config,
+    bc_session: dict[str, object] | None,
+    bc_ever_connected: bool,
+) -> dict[str, object]:
+    """Build the config snapshot GET /api/v1/config serves to the UI (KAMP-576).
+
+    Kept as a module-level pure function, not an inline dict, so a test can
+    assert every settable non-``ui.`` key is present: this dict silently
+    drifted from the ``_CONFIG_KEY_TYPES`` allowlist and dropped
+    ``artwork.save_format``, so a disabled "embed art" toggle read as enabled
+    again after restart. ``ui.*`` keys are intentionally absent — they ship via
+    the separate ``/api/v1/ui-state`` endpoint.
+    """
+    bc_username: str | None = bc_session.get("username") if bc_session else None  # type: ignore[assignment]
+    return {
+        "paths.watch_folder": (
+            str(config.paths.watch_folder) if config.paths.watch_folder else None
+        ),
+        "paths.library": str(config.paths.library) if config.paths.library else None,
+        "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
+        "artwork.min_dimension": config.artwork.min_dimension,
+        "artwork.max_bytes": config.artwork.max_bytes,
+        "artwork.save_format": config.artwork.save_format,
+        "library.path_template": config.library.path_template,
+        "bandcamp.connected": bc_session is not None,
+        "bandcamp.username": bc_username,
+        "bandcamp.ever_connected": bc_ever_connected,
+        "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
+        "bandcamp.poll_interval_minutes": (
+            config.bandcamp.poll_interval_minutes if config.bandcamp else None
+        ),
+        "bandcamp.collection_mode": (
+            config.bandcamp.collection_mode if config.bandcamp else None
+        ),
+        "lastfm.username": config.lastfm.username if config.lastfm else None,
+    }
+
+
 def _cmd_daemon(
     config: Config,
     host: str = "127.0.0.1",
@@ -946,29 +985,8 @@ def _cmd_daemon(
 
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")
-    _bc_username: str | None = _bc_session.get("username") if _bc_session else None
     _bc_ever_connected = index.get_setting("bandcamp.ever_connected") == "true"
-    _config_values: dict[str, object] = {
-        "paths.watch_folder": (
-            str(config.paths.watch_folder) if config.paths.watch_folder else None
-        ),
-        "paths.library": str(config.paths.library) if config.paths.library else None,
-        "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
-        "artwork.min_dimension": config.artwork.min_dimension,
-        "artwork.max_bytes": config.artwork.max_bytes,
-        "library.path_template": config.library.path_template,
-        "bandcamp.connected": _bc_session is not None,
-        "bandcamp.username": _bc_username,
-        "bandcamp.ever_connected": _bc_ever_connected,
-        "bandcamp.format": config.bandcamp.format if config.bandcamp else None,
-        "bandcamp.poll_interval_minutes": (
-            config.bandcamp.poll_interval_minutes if config.bandcamp else None
-        ),
-        "bandcamp.collection_mode": (
-            config.bandcamp.collection_mode if config.bandcamp else None
-        ),
-        "lastfm.username": config.lastfm.username if config.lastfm else None,
-    }
+    _config_values = _build_config_values(config, _bc_session, _bc_ever_connected)
 
     # Generate a fresh shared-secret token on every daemon start.  Electron
     # re-reads the file on reconnect so there is no persistent state to sync.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,55 @@
 """Tests for kamp_daemon.__main__ helpers."""
 
 import logging
+from pathlib import Path
 from unittest.mock import patch
+
+from kamp_core.library import LibraryIndex
+from kamp_daemon.__main__ import _build_config_values
+from kamp_daemon.config import _CONFIG_KEY_TYPES, Config
+
+
+class TestBuildConfigValues:
+    """The startup config snapshot GET /api/v1/config serves (KAMP-576).
+
+    Built by a testable function precisely because the previous inline dict
+    silently drifted from the settable-key allowlist and dropped
+    artwork.save_format, so the toggle never survived a restart.
+    """
+
+    def _config(self, tmp_path: Path, **settings: str) -> Config:
+        db = LibraryIndex(tmp_path / "library.db")
+        Config.write_defaults(db)
+        for key, value in settings.items():
+            db.set_setting(key, value)
+        cfg = Config.load(db)
+        db.close()
+        return cfg
+
+    def test_includes_save_format_reflecting_stored_value(self, tmp_path: Path) -> None:
+        cfg = self._config(tmp_path, **{"artwork.save_format": "cover-file"})
+        snapshot = _build_config_values(cfg, bc_session=None, bc_ever_connected=False)
+        assert snapshot["artwork.save_format"] == "cover-file"
+
+    def test_every_settable_non_ui_key_is_present(self, tmp_path: Path) -> None:
+        """Drift guard: every settable key that isn't served by the separate
+        /ui-state endpoint must appear in the snapshot, or its preference
+        cannot survive a restart (this is the whole KAMP-576 bug class)."""
+        cfg = self._config(tmp_path)
+        snapshot = _build_config_values(cfg, bc_session=None, bc_ever_connected=False)
+        for key in _CONFIG_KEY_TYPES:
+            if key.startswith("ui."):
+                continue
+            assert key in snapshot, f"{key} missing from config snapshot"
+
+    def test_reflects_bandcamp_session_presence(self, tmp_path: Path) -> None:
+        cfg = self._config(tmp_path)
+        snapshot = _build_config_values(
+            cfg, bc_session={"username": "alice"}, bc_ever_connected=True
+        )
+        assert snapshot["bandcamp.connected"] is True
+        assert snapshot["bandcamp.username"] == "alice"
+        assert snapshot["bandcamp.ever_connected"] is True
 
 
 class TestLogNoiseSuppression:


### PR DESCRIPTION
Disabling "embed album art in media files", quitting, and reopening showed the toggle enabled again. Fixes KAMP-576.

## Root cause

The daemon's startup config snapshot (`_config_values`, served verbatim by `GET /api/v1/config`) listed `artwork.min_dimension` and `artwork.max_bytes` but **not** `artwork.save_format`. The DB persisted the choice fine — the bug was read-side: the UI computes `initialValue={str('artwork.save_format') !== 'cover-file'}`, and `str()` of a missing key is `''`, so `'' !== 'cover-file'` is always true → toggle renders ON. `patch_config` also writes the in-memory state, so it worked *until* restart, matching the repro exactly.

Same missing key made the manual iTunes art-embed endpoints read `config.get("artwork.save_format", "embedded")` and default to embedded on a fresh start, even when the user chose cover-file. (The download pipeline was unaffected — it reads the real `Config` object, not this snapshot.)

The deeper cause: `_config_values` was a hand-maintained parallel list that drifted from the authoritative allowlist `_CONFIG_KEY_TYPES`, and it was untestable — built inline inside the uvicorn-starting `_cmd_daemon`, so nothing could catch the omission.

## Changes

- `kamp_daemon/__main__.py` — extract the inline snapshot into a module-level `_build_config_values(config, bc_session, bc_ever_connected)`, and add the missing `"artwork.save_format": config.artwork.save_format` entry. `Config.load` already reads the persisted value, so this closes the loop end-to-end.
- No UI change (symptom site only); no coercion-set change (`save_format` is a string enum, and the snapshot and PATCH both store a `str`).

## Testing

- New `tests/test_main.py::TestBuildConfigValues`: `save_format` present and reflecting a stored `"cover-file"`; bandcamp session presence; and a **drift guard** — every settable non-`ui.` key in `_CONFIG_KEY_TYPES` must appear in the snapshot, which fails loudly if this bug class ever recurs.
- Full suite: 2421 passed, coverage 93.56% (up from main's 93.55%). black + mypy clean.
- Note: `test_websocket_sends_initial_state` failed once in a randomized run and passes in isolation and on a deterministic re-run — a pre-existing order-dependent flake in untouched player-websocket code, unrelated to this change.

## Manual Test Plan

- [ ] **The repro:** disable "embed album art in media files" → quit → reopen → toggle still **off**
- [ ] Enable it → quit → reopen → toggle **on** (both directions persist)
- [ ] Fresh start with cover-file selected, then manual "Fetch Album Art" on a local album → writes a `cover.jpg`, does not embed (the second symptom)
- [ ] In-session toggle (no restart) still applies immediately, as before
- [ ] Launch against a **copy** of the production DB and confirm the toggle reflects the stored value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
