### PR TITLE
feat(genre): multi-value genre model — chips, autocomplete, normalized tables (KAMP-586)

### DIFF
--- a/kamp_core/criteria.py
+++ b/kamp_core/criteria.py
@@ -114,6 +114,25 @@ def _condition_sql(cond: "Condition") -> tuple[str, list[Any], bool]:
             subquery = "NOT " + subquery
         return subquery, [playlist_id], False
 
+    # Genre is multi-value (KAMP-586): resolve via the normalized track_genres
+    # join, not the flat "; "-joined tracks.genre column — a flat `= ?` would
+    # silently stop matching once an album has more than one genre.
+    if field == "track.genre":
+        if op in ("is", "is_not"):
+            match, genre_param = "g.name = ? COLLATE NOCASE", value
+        elif op in ("contains", "not_contains"):
+            match, genre_param = "g.name LIKE ?", f"%{value}%"
+        else:
+            raise ValueError(f"Operator {op!r} not supported for genre")
+        subquery = (
+            "EXISTS (SELECT 1 FROM track_genres tg"
+            " JOIN genres g ON g.id = tg.genre_id"
+            f" WHERE tg.track_id = tracks.id AND {match})"
+        )
+        if op in ("is_not", "not_contains"):
+            subquery = "NOT " + subquery
+        return subquery, [genre_param], False
+
     if field not in _FIELD_MAP:
         raise ValueError(f"Unknown magic playlist field: {field!r}")
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -7958,6 +7958,10 @@ def _read_mp3_tags(path: Path) -> Track:
         return str(frame).replace("\x00", " / ")
 
     artist = _str("TPE1")
+    # Multi-value genre (KAMP-586): a TCON frame's .text is already the list of
+    # separate values; the legacy `genre` string keeps its " / "-join for display.
+    _tcon = tags.get("TCON")
+    genres = [str(g).strip() for g in (_tcon.text if _tcon else []) if str(g).strip()]
     return Track(
         file_path=path,
         ext="mp3",
@@ -7973,6 +7977,7 @@ def _read_mp3_tags(path: Path) -> Track:
         or _str("TXXX:MusicBrainz Release Id"),
         mb_recording_id=_str("TXXX:MusicBrainz Track Id"),
         genre=_str("TCON"),
+        genres=genres,
         label=_str("TPUB"),
         duration=duration,
         sale_item_id=_str("TXXX:KAMP_SALE_ITEM_ID"),
@@ -8006,6 +8011,9 @@ def _read_m4a_tags(path: Path) -> Track:
     disc_number = disk[0][0] if disk else 1
 
     artist = _s("\xa9ART")
+    # Multi-value genre (KAMP-586): \xa9gen is a list of values.
+    _gen_vals = tags.get("\xa9gen") or []
+    genres = [str(v).strip() for v in _gen_vals if str(v).strip()]
     return Track(
         file_path=path,
         ext="m4a",
@@ -8021,6 +8029,7 @@ def _read_m4a_tags(path: Path) -> Track:
         or _s("----:com.apple.iTunes:MusicBrainz Release Id"),
         mb_recording_id=_s("----:com.apple.iTunes:MusicBrainz Track Id"),
         genre=_s("\xa9gen"),
+        genres=genres,
         label=_s("----:com.apple.iTunes:LABEL"),
         duration=duration,
         sale_item_id=_s("----:com.apple.iTunes:KAMP_SALE_ITEM_ID"),
@@ -8057,6 +8066,9 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
         return vals[0] if vals else ""
 
     artist = _s("ARTIST")
+    # Multi-value genre (KAMP-586): Vorbis allows repeated GENRE comments; the
+    # dict above normalized them to a list.
+    genres = [str(g).strip() for g in tags.get("GENRE", []) if str(g).strip()]
     return Track(
         file_path=path,
         ext="flac" if is_flac else "ogg",
@@ -8072,6 +8084,7 @@ def _read_vorbis_tags(path: Path, *, is_flac: bool) -> Track:
         mb_release_id=_s("MUSICBRAINZ_ALBUMID"),
         mb_recording_id=_s("MUSICBRAINZ_TRACKID"),
         genre=_s("GENRE"),
+        genres=genres,
         label=_s("LABEL") or _s("ORGANIZATION"),
         duration=duration,
         sale_item_id=_s("KAMP_SALE_ITEM_ID"),
@@ -8201,6 +8214,7 @@ def write_meta_tags_to_file(
     path: Path,
     *,
     genre: str | None = None,
+    genres: list[str] | None = None,
     label: str | None = None,
     release_date: str | None = None,
     mb_release_id: str | None = None,
@@ -8209,15 +8223,30 @@ def write_meta_tags_to_file(
 
     Only the fields that are not None are written; the others are left
     unchanged on disk.  This is a tag-only operation — no file rename occurs.
+
+    Genre is multi-value (KAMP-586): pass *genres* (a list) to write native
+    multi-value tags; the legacy scalar *genre* is accepted for back-compat and
+    treated as a single-element list. An empty list clears the genre tag.
     """
+    # Resolve to one effective genre list (None = leave unchanged).
+    genre_list: list[str] | None
+    if genres is not None:
+        genre_list = [g for g in genres if g.strip()]
+    elif genre is not None:
+        genre_list = [genre] if genre.strip() else []
+    else:
+        genre_list = None
+
     suffix = path.suffix.lower()
     if suffix == ".mp3":
         try:
             tags = id3.ID3(str(path))
         except Exception:
             tags = id3.ID3()
-        if genre is not None:
-            tags["TCON"] = id3.TCON(encoding=3, text=genre)
+        if genre_list is not None:
+            tags.delall("TCON")
+            if genre_list:
+                tags["TCON"] = id3.TCON(encoding=3, text=genre_list)
         if label is not None:
             tags["TPUB"] = id3.TPUB(encoding=3, text=label)
         if release_date is not None:
@@ -8231,8 +8260,11 @@ def write_meta_tags_to_file(
         audio = mutagen.mp4.MP4(str(path))
         if audio.tags is None:
             audio.add_tags()
-        if genre is not None:
-            audio.tags["\xa9gen"] = [genre]  # type: ignore[index]
+        if genre_list is not None:
+            if genre_list:
+                audio.tags["\xa9gen"] = genre_list  # type: ignore[index]
+            else:
+                audio.tags.pop("\xa9gen", None)  # type: ignore[union-attr]
         if label is not None:
             audio.tags["----:com.apple.iTunes:LABEL"] = [  # type: ignore[index]
                 mutagen.mp4.MP4FreeForm(label.encode())
@@ -8244,25 +8276,19 @@ def write_meta_tags_to_file(
                 mutagen.mp4.MP4FreeForm(mb_release_id.encode())
             ]
         audio.save()
-    elif suffix == ".flac":
-        audio = mutagen.flac.FLAC(str(path))
+    elif suffix in (".flac", ".ogg"):
+        audio = (
+            mutagen.flac.FLAC(str(path))
+            if suffix == ".flac"
+            else mutagen.oggvorbis.OggVorbis(str(path))
+        )
         if audio.tags is None:
             audio.add_tags()
-        if genre is not None:
-            audio.tags["GENRE"] = [genre]  # type: ignore[index]
-        if label is not None:
-            audio.tags["LABEL"] = [label]  # type: ignore[index]
-        if release_date is not None:
-            audio.tags["DATE"] = [release_date]  # type: ignore[index]
-        if mb_release_id is not None:
-            audio.tags["MUSICBRAINZ_ALBUMID"] = [mb_release_id]  # type: ignore[index]
-        audio.save()
-    elif suffix == ".ogg":
-        audio = mutagen.oggvorbis.OggVorbis(str(path))
-        if audio.tags is None:
-            audio.add_tags()
-        if genre is not None:
-            audio.tags["GENRE"] = [genre]  # type: ignore[index]
+        if genre_list is not None:
+            if genre_list:
+                audio.tags["GENRE"] = genre_list  # type: ignore[index]
+            else:
+                audio.tags.pop("GENRE", None)  # type: ignore[union-attr]
         if label is not None:
             audio.tags["LABEL"] = [label]  # type: ignore[index]
         if release_date is not None:

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 55
+_SCHEMA_VERSION = 56
 
 
 class NoStreamableVersionError(Exception):
@@ -243,6 +243,24 @@ CREATE TABLE IF NOT EXISTS track_stats (
     last_played REAL,
     updated_at  REAL
 );
+
+-- Normalized multi-value genre (KAMP-586). genres holds the distinct genre
+-- vocabulary; track_genres is the many-to-many link. tracks.genre/albums.genre
+-- remain "; "-joined denormalized DISPLAY strings derived from these — never
+-- parsed back for lookup (KAMP-554). Unlike artists (KAMP-545), genres is a
+-- brand-new table with no possible pre-existing case-variant rows, so the
+-- NOCASE-unique constraint is safe inline in the CREATE on every DB.
+CREATE TABLE IF NOT EXISTS genres (
+    id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    UNIQUE (name COLLATE NOCASE)
+);
+CREATE TABLE IF NOT EXISTS track_genres (
+    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    genre_id INTEGER NOT NULL REFERENCES genres(id) ON DELETE CASCADE,
+    PRIMARY KEY (track_id, genre_id)
+);
+CREATE INDEX IF NOT EXISTS idx_track_genres_genre ON track_genres(genre_id);
 
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
 -- derived-aggregate pattern. COLLATE NOCASE on the UNIQUE constraint prevents
@@ -578,6 +596,12 @@ class Track:
     mb_release_id: str
     mb_recording_id: str
     genre: str = field(default="")
+    # Multi-value genres (KAMP-586). Write-path field: the readers populate it
+    # from the file's native multi-value tag, and upsert_many/apply_genres write
+    # it to the normalized track_genres table. `genre` stays the "; "-joined
+    # denormalized display string. compare=False so existing Track-equality
+    # tests are undisturbed.
+    genres: list[str] = field(default_factory=list, compare=False)
     label: str = field(default="")
     id: int = field(default=0, compare=False)
     date_added: float | None = field(default=None, compare=False)
@@ -2319,7 +2343,44 @@ class LibraryIndex:
                 self._conn.execute("ALTER TABLE tracks ADD COLUMN display_artist TEXT")
             self._conn.execute("UPDATE schema_version SET version = 55")
             self._conn.commit()
-            version = 55  # noqa: F841
+            version = 55
+
+        if version == 55:
+            # v55 -> v56 (KAMP-586): backfill the normalized genres/track_genres
+            # tables (created empty by _DDL above) from the existing single-value
+            # tracks.genre column. Old MP3 rows hold a " / "-joined composite from
+            # the pre-586 reader, so split on " / " to recover the real values —
+            # M4A/Vorbis rows were first-only so the split is a no-op there.
+            # Guard on column presence: a synthetic partial-schema test DB may
+            # predate the genre columns and has nothing to backfill (KAMP-552).
+            _tcols = {r[1] for r in self._conn.execute("PRAGMA table_info(tracks)")}
+            if "genre" in _tcols:
+                for row in self._conn.execute(
+                    "SELECT id, genre FROM tracks WHERE genre != ''"
+                ).fetchall():
+                    names = [
+                        part.strip()
+                        for part in str(row["genre"]).split(" / ")
+                        if part.strip()
+                    ]
+                    self._set_track_genres(row["id"], names)
+            # Recompute albums.genre as the DISTINCT union now that track_genres
+            # is populated (SQLite forbids GROUP_CONCAT(DISTINCT x, sep), hence
+            # the nested subquery).
+            _acols = {r[1] for r in self._conn.execute("PRAGMA table_info(albums)")}
+            if "genre" in _acols:
+                self._conn.execute(
+                    "UPDATE albums SET genre = COALESCE("
+                    "  (SELECT GROUP_CONCAT(name, '; ') FROM"
+                    "     (SELECT DISTINCT g.name FROM track_genres tg"
+                    "        JOIN genres g ON g.id = tg.genre_id"
+                    "        JOIN tracks t ON t.id = tg.track_id"
+                    "      WHERE t.album_id = albums.id ORDER BY g.name COLLATE NOCASE)),"
+                    "  '')"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 56")
+            self._conn.commit()
+            version = 56  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -4542,13 +4603,28 @@ class LibraryIndex:
 
         existing_local: list[tuple[int, Track]] = []
         existing_stream: list[tuple[int, Track]] = []
+        # KAMP-586: (track_id, genre_names) to write into the normalized
+        # track_genres table. A directly-constructed Track carries genre but an
+        # empty genres list, so bridge from the scalar; the readers populate
+        # genres from the file's native multi-value tag.
+        genre_writes: list[tuple[int, list[str]]] = []
+
+        def _genre_names(t: Track) -> list[str]:
+            return t.genres if t.genres else ([t.genre] if t.genre.strip() else [])
+
         for uri, t in by_uri.items():
             _u, kind, _prov, _pid = _derive_source_fields(
                 t.file_path, t.source, t.sale_item_id
             )
             if uri in id_map:
-                bucket = existing_stream if kind == "stream" else existing_local
+                is_stream = kind == "stream"
+                bucket = existing_stream if is_stream else existing_local
                 bucket.append((id_map[uri], t))
+                names = _genre_names(t)
+                # Stream re-sync: skip an empty incoming list to preserve a
+                # user's genre edits, mirroring genre=COALESCE(NULLIF(?,'')).
+                if not (is_stream and not names):
+                    genre_writes.append((id_map[uri], names))
             else:
                 cur = self._conn.execute(
                     "INSERT INTO tracks"
@@ -4559,6 +4635,7 @@ class LibraryIndex:
                     _track_to_params(t),
                 )
                 id_map[uri] = cur.lastrowid  # type: ignore[assignment]
+                genre_writes.append((id_map[uri], _genre_names(t)))
         # Identity/catalog fields, positional for both UPDATE batches (id last).
         _upd = lambda tid, t: (
             t.title,
@@ -4594,6 +4671,13 @@ class LibraryIndex:
                 " label=COALESCE(NULLIF(?,''), label) WHERE id=?",
                 [_upd(tid, t) for tid, t in existing_stream],
             )
+
+        # KAMP-586: sync the normalized genres/track_genres tables. Must run
+        # before Step 4 (_refresh_album_aggregates reads track_genres for the
+        # album genre union). _set_track_genres also rewrites the denormalized
+        # tracks.genre to its canonical "; "-joined form.
+        for tid, names in genre_writes:
+            self._set_track_genres(tid, names)
 
         # Step 3: assign album_id on the track rows we just inserted/updated.
         file_paths = [_canonical_track_uri(t.file_path) for t in named]
@@ -4817,7 +4901,11 @@ class LibraryIndex:
                                   FROM tracks_with_stats t WHERE t.album_id = albums.id),
                 source         = {_ALBUM_SOURCE_SUBQUERY},
                 release_date   = (SELECT MAX(t.release_date)   FROM tracks t WHERE t.album_id = albums.id),
-                genre          = (SELECT MAX(t.genre)          FROM tracks t WHERE t.album_id = albums.id),
+                genre          = COALESCE((SELECT GROUP_CONCAT(name, '; ') FROM
+                                    (SELECT DISTINCT g.name FROM track_genres tg
+                                       JOIN genres g ON g.id = tg.genre_id
+                                       JOIN tracks t ON t.id = tg.track_id
+                                     WHERE t.album_id = albums.id ORDER BY g.name COLLATE NOCASE)), ''),
                 label          = (SELECT MAX(t.label)          FROM tracks t WHERE t.album_id = albums.id),
                 mb_release_id  = (SELECT MAX(t.mb_release_id)  FROM tracks t WHERE t.album_id = albums.id)
             WHERE id IN ({id_placeholders})
@@ -5969,6 +6057,123 @@ class LibraryIndex:
         self._conn.commit()
         if self.on_fields_changed:
             self.on_fields_changed({"track.favorite"})
+
+    # -- Multi-value genre (KAMP-586) ---------------------------------------
+
+    def _set_track_genres(self, track_id: int, names: list[str]) -> str:
+        """Replace *track_id*'s genres; return the canonical "; "-joined string.
+
+        The single chokepoint for genre-to-DB writes (KAMP-586). Strips blanks,
+        dedups case-insensitively (first-seen casing becomes canonical via the
+        NOCASE-unique genres table), rewrites the track's track_genres rows, and
+        syncs the denormalized tracks.genre so the normalized and display forms
+        never drift. Caller commits.
+        """
+        seen: dict[str, str] = {}
+        for raw in names:
+            name = raw.strip()
+            if name and name.casefold() not in seen:
+                seen[name.casefold()] = name
+
+        self._conn.execute("DELETE FROM track_genres WHERE track_id = ?", (track_id,))
+        canonical: list[str] = []
+        for name in seen.values():
+            self._conn.execute(
+                "INSERT OR IGNORE INTO genres (name) VALUES (?)", (name,)
+            )
+            row = self._conn.execute(
+                "SELECT id, name FROM genres WHERE name = ? COLLATE NOCASE", (name,)
+            ).fetchone()
+            self._conn.execute(
+                "INSERT OR IGNORE INTO track_genres (track_id, genre_id) VALUES (?, ?)",
+                (track_id, row["id"]),
+            )
+            canonical.append(row["name"])  # canonical casing from the genres table
+        joined = "; ".join(sorted(canonical, key=str.casefold))
+        self._conn.execute(
+            "UPDATE tracks SET genre = ? WHERE id = ?", (joined, track_id)
+        )
+        return joined
+
+    def apply_genres(
+        self,
+        track_ids: list[int],
+        genres: list[str],
+        *,
+        mode: str = "replace",
+    ) -> None:
+        """Apply *genres* to every track in *track_ids* (DB only — no file I/O).
+
+        The shared write path for the genre sprint (KAMP-586). ``replace`` sets
+        each track's genres to exactly *genres*; ``merge`` adds them to whatever
+        the track already has. Refreshes the affected albums' genre union and
+        signals magic-playlist recompute. File writes are the caller's job (the
+        album-meta endpoint writes them in its is_remote-guarded loop).
+
+        NOTE: ``merge`` is a seam for later producers (KAMP-587/588/591); it is
+        mechanism-tested only and its dedup/casing contract firms up when its
+        first consumer lands.
+        """
+        if not track_ids:
+            return
+        for track_id in track_ids:
+            if mode == "merge":
+                existing = [
+                    r["name"]
+                    for r in self._conn.execute(
+                        "SELECT g.name FROM track_genres tg"
+                        " JOIN genres g ON g.id = tg.genre_id"
+                        " WHERE tg.track_id = ?",
+                        (track_id,),
+                    ).fetchall()
+                ]
+                self._set_track_genres(track_id, existing + genres)
+            else:
+                self._set_track_genres(track_id, genres)
+        # Refresh the album-genre union for the affected albums.
+        placeholders = ",".join("?" for _ in track_ids)
+        album_ids = [
+            r["album_id"]
+            for r in self._conn.execute(
+                f"SELECT DISTINCT album_id FROM tracks"
+                f" WHERE id IN ({placeholders}) AND album_id IS NOT NULL",
+                track_ids,
+            ).fetchall()
+        ]
+        for album_id in album_ids:
+            self._refresh_album_genre(album_id)
+        self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.genre"})
+
+    def _refresh_album_genre(self, album_id: int) -> None:
+        """Recompute one album's denormalized genre as the DISTINCT track union.
+
+        SQLite forbids GROUP_CONCAT(DISTINCT x, sep), so the distinct set is
+        collected in a subquery first. Caller commits.
+        """
+        self._conn.execute(
+            "UPDATE albums SET genre = COALESCE("
+            "  (SELECT GROUP_CONCAT(name, '; ') FROM"
+            "     (SELECT DISTINCT g.name FROM track_genres tg"
+            "        JOIN genres g ON g.id = tg.genre_id"
+            "        JOIN tracks t ON t.id = tg.track_id"
+            "      WHERE t.album_id = ? ORDER BY g.name COLLATE NOCASE)), '')"
+            " WHERE id = ?",
+            (album_id, album_id),
+        )
+
+    def all_genres(self) -> list[str]:
+        """Return every distinct genre name in the library, sorted (KAMP-586).
+
+        Backs the album-edit autocomplete and (later) the genre sidebar.
+        """
+        return [
+            r["name"]
+            for r in self._conn.execute(
+                "SELECT name FROM genres ORDER BY name COLLATE NOCASE"
+            ).fetchall()
+        ]
 
     def update_album_meta(
         self,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -614,6 +614,9 @@ class AlbumDisplayRequest(BaseModel):
 
 class AlbumMetaRequest(BaseModel):
     genre: str | None = None
+    # Multi-value genre (KAMP-586): the album's full genre set, applied to every
+    # track (replace). Supersedes the scalar `genre` when present.
+    genres: list[str] | None = None
     label: str | None = None
     release_date: str | None = None
     mb_release_id: str | None = None
@@ -1390,6 +1393,11 @@ def create_app(
     @app.get("/api/v1/artists", response_model=list[str])
     def get_artists() -> list[str]:
         return index.artists()
+
+    @app.get("/api/v1/genres", response_model=list[str])
+    def get_genres() -> list[str]:
+        """Every distinct genre in the library (KAMP-586), for autocomplete."""
+        return index.all_genres()
 
     @app.get("/api/v1/tracks/top", response_model=list[TrackOut])
     def get_top_tracks(limit: int = 10) -> list[TrackOut]:
@@ -2288,11 +2296,24 @@ def create_app(
 
         if (
             req.genre is None
+            and req.genres is None
             and req.label is None
             and req.release_date is None
             and req.mb_release_id is None
         ):
             raise HTTPException(status_code=400, detail="No changes requested")
+
+        # Genre (multi-value, KAMP-586) goes through the shared apply_genres DB
+        # service; the scalar `genre` is bridged for older callers. File writes
+        # stay in this one is_remote-guarded loop so genre and label/date/mbid
+        # are written in a single pass (apply_genres is DB-only).
+        genre_list: list[str] | None
+        if req.genres is not None:
+            genre_list = req.genres
+        elif req.genre is not None:
+            genre_list = [req.genre] if req.genre.strip() else []
+        else:
+            genre_list = None
 
         for track in tracks:
             if track.is_remote:
@@ -2300,7 +2321,7 @@ def create_app(
             try:
                 write_meta_tags_to_file(
                     track.file_path,
-                    genre=req.genre,
+                    genres=genre_list,
                     label=req.label,
                     release_date=req.release_date,
                     mb_release_id=req.mb_release_id,
@@ -2314,15 +2335,20 @@ def create_app(
                     detail=f"Failed to write tags to {track.file_path}: {exc}",
                 ) from exc
 
-        updated = index.update_album_meta(
+        # Genre → normalized tables (all tracks, local + remote); label/date/mbid
+        # → the scalar path. update_album_meta must not also write genre or it
+        # would clobber the normalized rollup with a flat string.
+        if genre_list is not None:
+            index.apply_genres([t.id for t in tracks], genre_list, mode="replace")
+        index.update_album_meta(
             album_artist,
             album,
-            genre=req.genre,
             label=req.label,
             release_date=req.release_date,
             mb_release_id=req.mb_release_id,
         )
         _notify_library_changed()
+        updated = index.tracks_for_album(album_artist, album)
         return AlbumMetaOut(tracks=_tracks_out(index, updated))
 
     _MAX_LOOKUP_CANDIDATES = 10

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -722,10 +722,24 @@ export type AlbumMetaResult = {
 export const patchAlbumMeta = (
   albumArtist: string,
   album: string,
-  opts: { genre?: string; label?: string; release_date?: string; mb_release_id?: string }
+  opts: {
+    genre?: string
+    // Multi-value genre (KAMP-586): the album's full genre set, applied to every track.
+    genres?: string[]
+    label?: string
+    release_date?: string
+    mb_release_id?: string
+  }
 ): Promise<AlbumMetaResult> => {
   const params = new URLSearchParams({ album_artist: albumArtist, album })
   return patch(`/api/v1/albums/meta?${params}`, opts)
+}
+
+// Every distinct genre in the library (KAMP-586), for the edit-panel autocomplete.
+export async function getGenres(): Promise<string[]> {
+  const res = await fetch(`${BASE_URL}/api/v1/genres`, { headers: _authHeaders() })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return (await res.json()) as string[]
 }
 
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1217,6 +1217,97 @@
   padding-bottom: 0;
 }
 
+/* Multi-value genre chips + autocomplete (KAMP-586) */
+.genre-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.genre-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--accent-dim);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.genre-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 1px;
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.genre-chip-remove:hover {
+  opacity: 1;
+}
+
+.genre-chips-input-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 80px;
+}
+
+.genre-chips-input {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  padding: 1px 0;
+  width: 100%;
+  min-width: 0;
+}
+
+.genre-autocomplete {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 2px);
+  left: 0;
+  min-width: 140px;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--surface-raised, #22242b);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.genre-autocomplete-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.genre-autocomplete-item:hover {
+  background: var(--surface-hover, rgba(255, 255, 255, 0.08));
+}
+
 /* Copy-to-clipboard button for read-only fields (e.g. MusicBrainz ID) */
 .meta-field-copy-btn {
   background: none;

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1275,10 +1275,10 @@
 }
 
 .genre-autocomplete {
-  position: absolute;
-  z-index: 20;
-  top: calc(100% + 2px);
-  left: 0;
+  /* Portaled to document.body (see GenreChipsInput) so surrounding track rows
+     cannot clip or paint over it; positioned inline from the input's rect. */
+  position: fixed;
+  z-index: 1100;
   min-width: 140px;
   max-height: 200px;
   overflow-y: auto;
@@ -1304,7 +1304,8 @@
   font-size: 12px;
 }
 
-.genre-autocomplete-item:hover {
+.genre-autocomplete-item:hover,
+.genre-autocomplete-item.active {
   background: var(--surface-hover, rgba(255, 255, 255, 0.08));
 }
 

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect, useRef } from 'react'
+import { getGenres } from '../api/client'
 import type { Track } from '../api/client'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
 import { TagIcon, ChevronIcon } from './TransportIcons'
+import { GenreChipsInput } from './GenreChipsInput'
 
 interface AlbumMetaPanelProps {
   tracks: Track[]
   editMode: boolean
   expanded: boolean
   onToggle: () => void
-  onSave: (opts: { genre?: string; label?: string; release_date?: string }) => Promise<void>
+  onSave: (opts: {
+    genre?: string
+    genres?: string[]
+    label?: string
+    release_date?: string
+  }) => Promise<void>
   onHandleMouseDown?: (e: React.MouseEvent) => void
   onHandleDoubleClick?: () => void
 }
@@ -23,6 +30,22 @@ function commonValue(tracks: Track[], key: keyof Track): string {
   const first = values[0] ?? ''
   if (values.every((v) => v === first)) return first
   return '(mixed)'
+}
+
+/**
+ * The union of every track's genres (KAMP-586). Track.genre is a "; "-joined
+ * display string; a "mixed" album rolls its tracks' genres up into one set that
+ * is applied to every track on save. Case-insensitive dedup, sorted.
+ */
+function unionGenres(tracks: Track[]): string[] {
+  const seen = new Map<string, string>()
+  for (const t of tracks) {
+    for (const g of (t.genre ?? '').split(';')) {
+      const name = g.trim()
+      if (name && !seen.has(name.toLowerCase())) seen.set(name.toLowerCase(), name)
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b))
 }
 
 function hasAnyMeta(tracks: Track[], releaseDate: string): boolean {
@@ -96,7 +119,6 @@ export function AlbumMetaPanel({
 }: AlbumMetaPanelProps): React.JSX.Element {
   const panelRef = useRef<HTMLDivElement>(null)
 
-  const [genre, setGenre] = React.useState(() => commonValue(tracks, 'genre'))
   const [label, setLabel] = React.useState(() => commonValue(tracks, 'label'))
   const [releaseDate, setReleaseDate] = React.useState(() => commonValue(tracks, 'release_date'))
   // Track the last-seen tracks reference so we can sync on external changes
@@ -104,10 +126,30 @@ export function AlbumMetaPanel({
   const [syncedTracks, setSyncedTracks] = React.useState(tracks)
   if (syncedTracks !== tracks) {
     setSyncedTracks(tracks)
-    setGenre(commonValue(tracks, 'genre'))
     setLabel(commonValue(tracks, 'label'))
     setReleaseDate(commonValue(tracks, 'release_date'))
   }
+
+  // Library genre vocabulary for the chips autocomplete — loaded lazily the
+  // first time the panel enters edit mode (KAMP-586).
+  const [genreSuggestions, setGenreSuggestions] = React.useState<string[]>([])
+  useEffect(() => {
+    if (!editMode) return
+    let cancelled = false
+    void getGenres().then(
+      (g) => {
+        if (!cancelled) setGenreSuggestions(g)
+      },
+      () => {
+        /* autocomplete is best-effort */
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [editMode])
+
+  const albumGenres = unionGenres(tracks)
 
   // Instant show/hide — Electron's renderer produces jank with CSS/JS height
   // animations (see CLAUDE.md "CSS height animations in Electron").
@@ -120,9 +162,8 @@ export function AlbumMetaPanel({
   const mbId = tracks[0]?.mb_release_id ?? ''
   const hasContent = hasAnyMeta(tracks, commonValue(tracks, 'release_date'))
 
-  const handleSaveGenre = (): void => {
-    const current = commonValue(tracks, 'genre')
-    if (genre !== current) void onSave({ genre })
+  const handleSaveGenres = (genres: string[]): void => {
+    void onSave({ genres })
   }
 
   const handleSaveLabel = (): void => {
@@ -168,13 +209,19 @@ export function AlbumMetaPanel({
               onBlur={handleSaveReleaseDate}
             />
           )}
-          <MetaField
-            label="GENRE"
-            value={genre}
-            editMode={editMode}
-            onChange={setGenre}
-            onBlur={handleSaveGenre}
-          />
+          {(albumGenres.length > 0 || editMode) && (
+            <div className="album-meta-row">
+              <dt className="album-meta-dt">GENRE</dt>
+              <dd className="album-meta-dd">
+                <GenreChipsInput
+                  chips={albumGenres}
+                  suggestions={genreSuggestions}
+                  editMode={editMode}
+                  onCommit={handleSaveGenres}
+                />
+              </dd>
+            </div>
+          )}
           <MetaField
             label="LABEL"
             value={label}

--- a/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo, useRef, useState } from 'react'
+
+// Multi-value genre editor (KAMP-586): removable chips + type-ahead autocomplete
+// sourced from genres already in the library. Genres may contain spaces
+// ("Free Jazz"). Case-insensitive dedup. Commits the full list on blur (leaving
+// the component), matching the album panel's save-on-blur pattern.
+type Props = {
+  chips: string[]
+  suggestions: string[]
+  editMode: boolean
+  onCommit: (genres: string[]) => void
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = new Set(a.map((x) => x.toLowerCase()))
+  return b.every((x) => sa.has(x.toLowerCase()))
+}
+
+export function GenreChipsInput({
+  chips: initial,
+  suggestions,
+  editMode,
+  onCommit
+}: Props): React.JSX.Element {
+  const [chips, setChips] = useState(initial)
+  const [input, setInput] = useState('')
+  const [open, setOpen] = useState(false)
+  const [initialChips, setInitialChips] = useState(initial)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Re-sync when the external value changes (e.g. after a save round-trips a new
+  // track list). Render-phase update avoids the cascading-render effect pattern.
+  if (!sameSet(initialChips, initial)) {
+    setInitialChips(initial)
+    setChips(initial)
+  }
+
+  const addChip = (raw: string): void => {
+    const name = raw.trim()
+    setInput('')
+    if (!name || chips.some((c) => c.toLowerCase() === name.toLowerCase())) return
+    setChips([...chips, name])
+  }
+
+  const removeChip = (name: string): void => setChips(chips.filter((c) => c !== name))
+
+  const commit = (): void => {
+    if (!sameSet(chips, initialChips)) onCommit(chips)
+  }
+
+  const filtered = useMemo(() => {
+    const q = input.trim().toLowerCase()
+    const have = new Set(chips.map((c) => c.toLowerCase()))
+    return suggestions
+      .filter((s) => !have.has(s.toLowerCase()) && (!q || s.toLowerCase().includes(q)))
+      .slice(0, 8)
+  }, [input, suggestions, chips])
+
+  if (!editMode) {
+    if (chips.length === 0) return <span className="meta-field--empty">—</span>
+    return (
+      <span className="genre-chips genre-chips--readonly">
+        {chips.map((c) => (
+          <span key={c} className="genre-chip">
+            {c}
+          </span>
+        ))}
+      </span>
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="genre-chips genre-chips--editable"
+      onBlur={(e) => {
+        // Only when focus truly leaves the component (not moving between chip
+        // buttons / the input / a suggestion).
+        if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
+          setOpen(false)
+          commit()
+        }
+      }}
+    >
+      {chips.map((c) => (
+        <span key={c} className="genre-chip">
+          {c}
+          <button
+            type="button"
+            className="genre-chip-remove"
+            aria-label={`Remove ${c}`}
+            onClick={() => removeChip(c)}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <div className="genre-chips-input-wrap">
+        <input
+          className="genre-chips-input"
+          value={input}
+          placeholder={chips.length ? '' : 'Add genre…'}
+          aria-label="Add genre"
+          onChange={(e) => {
+            setInput(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault()
+              addChip(input)
+            } else if (e.key === 'Backspace' && !input && chips.length) {
+              removeChip(chips[chips.length - 1])
+            } else if (e.key === 'Escape') {
+              setOpen(false)
+            }
+          }}
+        />
+        {open && filtered.length > 0 && (
+          <ul className="genre-autocomplete" role="listbox">
+            {filtered.map((s) => (
+              <li key={s} role="option" aria-selected={false}>
+                <button
+                  type="button"
+                  className="genre-autocomplete-item"
+                  // onMouseDown fires before the input's blur, so the chip is
+                  // added without the blur committing/closing first.
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    addChip(s)
+                  }}
+                >
+                  {s}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 // Multi-value genre editor (KAMP-586): removable chips + type-ahead autocomplete
 // sourced from genres already in the library. Genres may contain spaces
@@ -26,8 +27,11 @@ export function GenreChipsInput({
   const [chips, setChips] = useState(initial)
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
+  // -1 = nothing highlighted (Enter adds the typed text instead of a suggestion).
+  const [active, setActive] = useState(-1)
   const [initialChips, setInitialChips] = useState(initial)
   const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // Re-sync when the external value changes (e.g. after a save round-trips a new
   // track list). Render-phase update avoids the cascading-render effect pattern.
@@ -39,6 +43,7 @@ export function GenreChipsInput({
   const addChip = (raw: string): void => {
     const name = raw.trim()
     setInput('')
+    setActive(-1)
     if (!name || chips.some((c) => c.toLowerCase() === name.toLowerCase())) return
     setChips([...chips, name])
   }
@@ -56,6 +61,28 @@ export function GenreChipsInput({
       .filter((s) => !have.has(s.toLowerCase()) && (!q || s.toLowerCase().includes(q)))
       .slice(0, 8)
   }, [input, suggestions, chips])
+
+  const showMenu = open && filtered.length > 0
+
+  // The dropdown is portaled to document.body so it can't be clipped or painted
+  // over by the surrounding track rows (they establish their own stacking
+  // context). Fixed-position it under the input, tracking scroll/resize while
+  // open. (Same escape-the-stacking-context approach as ContextMenu.)
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null)
+  useLayoutEffect(() => {
+    if (!showMenu) return
+    const place = (): void => {
+      const r = inputRef.current?.getBoundingClientRect()
+      if (r) setMenuPos({ top: r.bottom + 2, left: r.left, width: r.width })
+    }
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [showMenu, filtered.length])
 
   if (!editMode) {
     if (chips.length === 0) return <span className="meta-field--empty">—</span>
@@ -98,46 +125,69 @@ export function GenreChipsInput({
       ))}
       <div className="genre-chips-input-wrap">
         <input
+          ref={inputRef}
           className="genre-chips-input"
           value={input}
           placeholder={chips.length ? '' : 'Add genre…'}
           aria-label="Add genre"
+          role="combobox"
+          aria-expanded={showMenu}
+          aria-controls="genre-autocomplete-list"
+          aria-activedescendant={active >= 0 ? `genre-opt-${active}` : undefined}
           onChange={(e) => {
             setInput(e.target.value)
             setOpen(true)
+            setActive(-1)
           }}
           onFocus={() => setOpen(true)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ',') {
+            if (e.key === 'ArrowDown') {
               e.preventDefault()
-              addChip(input)
+              setOpen(true)
+              setActive((i) => (filtered.length ? Math.min(i + 1, filtered.length - 1) : -1))
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault()
+              setActive((i) => Math.max(i - 1, -1))
+            } else if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault()
+              addChip(active >= 0 && active < filtered.length ? filtered[active] : input)
             } else if (e.key === 'Backspace' && !input && chips.length) {
               removeChip(chips[chips.length - 1])
             } else if (e.key === 'Escape') {
               setOpen(false)
+              setActive(-1)
             }
           }}
         />
-        {open && filtered.length > 0 && (
-          <ul className="genre-autocomplete" role="listbox">
-            {filtered.map((s) => (
-              <li key={s} role="option" aria-selected={false}>
-                <button
-                  type="button"
-                  className="genre-autocomplete-item"
-                  // onMouseDown fires before the input's blur, so the chip is
-                  // added without the blur committing/closing first.
-                  onMouseDown={(e) => {
-                    e.preventDefault()
-                    addChip(s)
-                  }}
-                >
-                  {s}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
+        {showMenu &&
+          menuPos &&
+          createPortal(
+            <ul
+              id="genre-autocomplete-list"
+              className="genre-autocomplete"
+              role="listbox"
+              style={{ top: menuPos.top, left: menuPos.left, minWidth: menuPos.width }}
+            >
+              {filtered.map((s, i) => (
+                <li key={s} id={`genre-opt-${i}`} role="option" aria-selected={i === active}>
+                  <button
+                    type="button"
+                    className={`genre-autocomplete-item${i === active ? ' active' : ''}`}
+                    // onMouseDown fires before the input's blur, so the chip is
+                    // added without the blur committing/closing first.
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      addChip(s)
+                    }}
+                    onMouseEnter={() => setActive(i)}
+                  >
+                    {s}
+                  </button>
+                </li>
+              ))}
+            </ul>,
+            document.body
+          )}
       </div>
     </div>
   )

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -211,7 +211,13 @@ type PlayerStore = {
   patchAlbumMeta: (
     albumArtist: string,
     album: string,
-    opts: { genre?: string; label?: string; release_date?: string; mb_release_id?: string }
+    opts: {
+      genre?: string
+      genres?: string[]
+      label?: string
+      release_date?: string
+      mb_release_id?: string
+    }
   ) => Promise<void>
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -169,11 +169,33 @@ def test_track_artist_is_not() -> None:
     assert params == ["Nickelback"]
 
 
+def test_track_genre_is_uses_track_genres_exists() -> None:
+    # KAMP-586: genre resolves via the normalized join, not the flat column.
+    frag, params, join = build_query(
+        _criteria(_group(_cond("track.genre", "is", "Jazz")))
+    )
+    assert "EXISTS" in frag
+    assert "track_genres" in frag
+    assert "g.name = ? COLLATE NOCASE" in frag
+    assert not frag.startswith("NOT")
+    assert params == ["Jazz"]
+    assert join is False
+
+
+def test_track_genre_is_not_negates_exists() -> None:
+    frag, params, _ = build_query(
+        _criteria(_group(_cond("track.genre", "is_not", "Jazz")))
+    )
+    assert "NOT EXISTS" in frag
+    assert params == ["Jazz"]
+
+
 def test_track_genre_contains_wraps_value() -> None:
     frag, params, _ = build_query(
         _criteria(_group(_cond("track.genre", "contains", "Rock")))
     )
-    assert "LIKE ?" in frag
+    assert "EXISTS" in frag
+    assert "g.name LIKE ?" in frag
     assert params == ["%Rock%"]
 
 
@@ -181,7 +203,8 @@ def test_track_genre_not_contains() -> None:
     frag, params, _ = build_query(
         _criteria(_group(_cond("track.genre", "not_contains", "Pop")))
     )
-    assert "NOT LIKE ?" in frag
+    assert "NOT EXISTS" in frag
+    assert "g.name LIKE ?" in frag
     assert params == ["%Pop%"]
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2866,6 +2866,40 @@ class TestTagReaders:
         assert track.title == ""
         assert track.ext == "ogg"
 
+    def test_read_mp3_multi_value_genre(self, tmp_path: Path) -> None:
+        # KAMP-586: a TCON with multiple values reads back as a genres list.
+        mp3 = tmp_path / "multi.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        tags = id3.ID3()
+        tags["TCON"] = id3.TCON(encoding=3, text=["Jazz", "J-Pop"])
+        tags.save(str(mp3))
+        track = _read_mp3_tags(mp3)
+        assert track.genres == ["Jazz", "J-Pop"]
+
+    def test_read_m4a_multi_value_genre(self, tmp_path: Path) -> None:
+        m4a = tmp_path / "multi.m4a"
+        m4a.write_bytes(b"\x00" * 32)
+        mock_audio = MagicMock()
+        mock_audio.tags = {"\xa9gen": ["Jazz", "J-Pop"], "\xa9nam": ["T"]}
+        mock_audio.info.length = 1.0
+        with patch("kamp_core.library.mutagen.mp4.MP4", return_value=mock_audio):
+            track = _read_m4a_tags(m4a)
+        assert track.genres == ["Jazz", "J-Pop"]
+
+    def test_read_vorbis_multi_value_genre(self, tmp_path: Path) -> None:
+        ogg = tmp_path / "multi.ogg"
+        ogg.write_bytes(b"\x00" * 8)
+        mock_audio = MagicMock()
+        # Vorbis comments: repeated GENRE keys arrive as a list.
+        mock_audio.tags = {"genre": ["Jazz", "J-Pop"], "title": ["T"]}
+        mock_audio.pictures = []
+        mock_audio.info.length = 1.0
+        with patch(
+            "kamp_core.library.mutagen.oggvorbis.OggVorbis", return_value=mock_audio
+        ):
+            track = _read_vorbis_tags(ogg, is_flac=False)
+        assert track.genres == ["Jazz", "J-Pop"]
+
     def test_read_tags_logs_and_returns_none_on_unexpected_error(
         self, tmp_path: Path
     ) -> None:
@@ -6345,6 +6379,46 @@ class TestWriteMetaTagsToFile:
         assert str(tags["TCON"]) == "Blues"
         assert str(tags["TPUB"]) == "Chess Records"
         assert str(tags["TDRC"]) == "1958"
+
+    def test_writes_multi_value_genre_to_mp3_roundtrip(self, tmp_path: Path) -> None:
+        # KAMP-586: multi-value genres round-trip through the real ID3 TCON frame
+        # and back out via the reader as a list.
+        mp3 = tmp_path / "track.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+
+        write_meta_tags_to_file(mp3, genres=["Jazz", "J-Pop"])
+
+        assert _read_mp3_tags(mp3).genres == ["Jazz", "J-Pop"]
+
+    def test_empty_genres_clears_mp3_tcon(self, tmp_path: Path) -> None:
+        mp3 = tmp_path / "track.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        tags = id3.ID3()
+        tags["TCON"] = id3.TCON(encoding=3, text=["Jazz"])
+        tags.save(str(mp3))
+
+        write_meta_tags_to_file(mp3, genres=[])
+
+        assert id3.ID3(str(mp3)).get("TCON") is None
+
+    def test_writes_multi_value_genre_to_flac(self, tmp_path: Path) -> None:
+        flac = tmp_path / "track.flac"
+        flac.write_bytes(b"\x00" * 8)
+        mock_audio = MagicMock()
+        mock_audio.tags = {}
+        with patch("kamp_core.library.mutagen.flac.FLAC", return_value=mock_audio):
+            write_meta_tags_to_file(flac, genres=["Jazz", "J-Pop"])
+        assert mock_audio.tags["GENRE"] == ["Jazz", "J-Pop"]
+
+    def test_writes_multi_value_genre_to_m4a(self, tmp_path: Path) -> None:
+        m4a = tmp_path / "track.m4a"
+        m4a.write_bytes(b"\x00" * 32)
+        mock_audio = MagicMock()
+        mock_audio.tags = {}
+        with patch("kamp_core.library.mutagen.mp4.MP4", return_value=mock_audio):
+            write_meta_tags_to_file(m4a, genres=["Jazz", "J-Pop"])
+        assert mock_audio.tags["\xa9gen"] == ["Jazz", "J-Pop"]
 
     def test_writes_genre_and_label_to_m4a(self, tmp_path: Path) -> None:
         import mutagen.mp4

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -13120,6 +13120,38 @@ class TestMultiValueGenre:
 
     # -- migration backfill --------------------------------------------------
 
+    def test_magic_playlist_genre_matches_multi_value_album(
+        self, tmp_path: Path
+    ) -> None:
+        """A `track.genre is "Jazz"` rule matches a track tagged ["Jazz","J-Pop"]
+        — the whole reason genre criteria must resolve via track_genres and not
+        the flat "; "-joined column (KAMP-586)."""
+        index = self._index(tmp_path)
+        index.upsert_many(
+            [
+                self._local(tmp_path / "1.mp3", ["Jazz", "J-Pop"]),
+                self._local(tmp_path / "2.mp3", ["Rock"], album="Other"),
+            ]
+        )
+        jazz_track = next(t for t in index.all_tracks() if "Jazz" in t.genre)
+        pid = index.create_magic_playlist(
+            "Jazz",
+            MagicCriteria(
+                groups=[
+                    Group(
+                        conditions=[
+                            Condition(field="track.genre", op="is", value="Jazz")
+                        ],
+                        match="all",
+                    )
+                ],
+                match="all",
+            ),
+        )
+        matched = index.evaluate_magic_playlist(pid)
+        index.close()
+        assert matched == [jazz_track.id]
+
     def test_migration_backfill_splits_mp3_composite(self, tmp_path: Path) -> None:
         """A pre-v56 DB whose tracks.genre holds a " / "-joined MP3 composite
         backfills into separate genre rows (no composite junk in the list)."""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 55
+        assert version == 56
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 55
+        assert version == 56
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 55
+        assert ver == 56
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 55
+        assert ver == 56
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 55
+        assert ver == 56
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 55
+        assert ver == 56
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3218,7 +3218,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3275,7 +3275,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3652,7 +3652,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -3695,7 +3695,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -3762,7 +3762,7 @@ class TestPreorderResurface:
         ).fetchone()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "redownload_url" in cols
         # Existing row survived; the new column is NULL for pre-existing data.
         assert row["provider_item_id"] == "keep"
@@ -3788,7 +3788,7 @@ class TestPreorderResurface:
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -4142,7 +4142,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert row is not None
         assert row[0] == 0
 
@@ -4607,7 +4607,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4720,7 +4720,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -4904,7 +4904,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -4999,7 +4999,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 55
+        assert version == 56
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -5007,7 +5007,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 55
+        assert version == 56
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -5934,7 +5934,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 55
+        assert version == 56
 
         index.close()
 
@@ -6625,7 +6625,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 55
+        assert version == 56
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6660,7 +6660,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 55
+        assert version == 56
         index.close()
 
 
@@ -7201,7 +7201,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 55
+        assert version == 56
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7334,7 +7334,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 55
+        assert version == 56
 
 
 class TestRemoteTrackSchema:
@@ -7750,7 +7750,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7811,7 +7811,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8633,7 +8633,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -9566,7 +9566,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9644,7 +9644,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -9853,7 +9853,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -10093,7 +10093,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10193,7 +10193,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10309,7 +10309,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10814,7 +10814,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -10929,7 +10929,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -11027,7 +11027,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -11127,7 +11127,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -11634,7 +11634,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 55
+        assert version == 56
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -12518,7 +12518,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 55
+        assert version == 56
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -12893,6 +12893,181 @@ class TestDisplayArtistOverride:
         ).fetchone()
         index.close()
         assert row["display_artist"] == "Quux Person"
+
+
+class TestMultiValueGenre:
+    """Normalized genres / track_genres model + apply_genres service (KAMP-586)."""
+
+    def _local(self, path: Path, genres: list[str], album: str = "Alb") -> Track:
+        return Track(
+            file_path=path,
+            title=path.stem,
+            artist="Band",
+            album_artist="Band",
+            album=album,
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genres=genres,
+        )
+
+    def _index(self, tmp_path: Path) -> LibraryIndex:
+        return LibraryIndex(tmp_path / "library.db")
+
+    # -- schema --------------------------------------------------------------
+
+    def test_tables_exist_on_fresh_db(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        tables = {
+            r[0]
+            for r in index._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        index.close()
+        assert {"genres", "track_genres"} <= tables
+
+    # -- _set_track_genres ---------------------------------------------------
+
+    def test_upsert_populates_track_genres_and_denorm(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz", "J-Pop"])])
+        track = index.all_tracks()[0]
+        rows = index._conn.execute(
+            "SELECT g.name FROM track_genres tg JOIN genres g ON g.id = tg.genre_id"
+            " WHERE tg.track_id = ? ORDER BY g.name",
+            (track.id,),
+        ).fetchall()
+        index.close()
+        assert [r["name"] for r in rows] == ["J-Pop", "Jazz"]
+        # denormalized display string is the canonical "; "-join
+        assert track.genre == "J-Pop; Jazz"
+
+    def test_case_insensitive_dedup_first_seen_casing(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        # "Jazz" seen first becomes canonical; a later "jazz" links to the same row.
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz"], album="A1")])
+        index.upsert_many([self._local(tmp_path / "2.mp3", ["jazz"], album="A2")])
+        names = index.all_genres()
+        index.close()
+        assert names == ["Jazz"]  # one canonical row, first-seen casing
+
+    def test_blank_and_duplicate_values_stripped(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz", "  ", "Jazz", ""])])
+        track = index.all_tracks()[0]
+        index.close()
+        assert track.genre == "Jazz"
+
+    def test_genre_with_space_is_one_value(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Free Jazz"])])
+        names = index.all_genres()
+        index.close()
+        assert names == ["Free Jazz"]
+
+    # -- album union rollup --------------------------------------------------
+
+    def test_album_genre_is_distinct_union_across_tracks(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many(
+            [
+                self._local(tmp_path / "1.mp3", ["Jazz"]),
+                self._local(tmp_path / "2.mp3", ["J-Pop", "Jazz"]),
+            ]
+        )
+        album_genre = index._conn.execute("SELECT genre FROM albums").fetchone()[0]
+        index.close()
+        assert album_genre == "J-Pop; Jazz"  # union, sorted, no duplicate Jazz
+
+    # -- apply_genres --------------------------------------------------------
+
+    def test_apply_genres_replace_sets_all_tracks(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many(
+            [
+                self._local(tmp_path / "1.mp3", ["Jazz"]),
+                self._local(tmp_path / "2.mp3", ["Rock"]),
+            ]
+        )
+        ids = [t.id for t in index.all_tracks()]
+
+        index.apply_genres(ids, ["Hip-Hop", "Plunderphonics"], mode="replace")
+
+        genres = {t.genre for t in index.all_tracks()}
+        album_genre = index._conn.execute("SELECT genre FROM albums").fetchone()[0]
+        index.close()
+        assert genres == {"Hip-Hop; Plunderphonics"}
+        assert album_genre == "Hip-Hop; Plunderphonics"
+
+    def test_apply_genres_fires_on_fields_changed(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz"])])
+        calls: list[set[str]] = []
+        index.on_fields_changed = lambda fields: calls.append(fields)
+
+        index.apply_genres([index.all_tracks()[0].id], ["Rock"])
+        index.close()
+        assert {"track.genre"} in calls
+
+    def test_apply_genres_merge_adds(self, tmp_path: Path) -> None:
+        # Mechanism-only test for the seam later producers (587/588/591) consume.
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz"])])
+        tid = index.all_tracks()[0].id
+
+        index.apply_genres([tid], ["Rock"], mode="merge")
+        track = index.all_tracks()[0]
+        index.close()
+        assert track.genre == "Jazz; Rock"
+
+    # -- stream re-sync guard ------------------------------------------------
+
+    def test_stream_resync_empty_preserves_edited_genres(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        stream = _prov_stream_track("S1", "Band", "Alb", n=1)
+        stream.genres = ["Jazz"]
+        index.upsert_many([stream])
+        # A later Bandcamp re-sync sends the same track with NO genre.
+        resync = _prov_stream_track("S1", "Band", "Alb", n=1)
+        index.upsert_many([resync])
+
+        track = index.get_track_by_path("bandcamp://S1/1")
+        rows = index._conn.execute(
+            "SELECT COUNT(*) c FROM track_genres WHERE track_id = ?", (track.id,)
+        ).fetchone()
+        index.close()
+        assert track.genre == "Jazz"  # preserved
+        assert rows["c"] == 1  # normalized rows preserved too
+
+    # -- migration backfill --------------------------------------------------
+
+    def test_migration_backfill_splits_mp3_composite(self, tmp_path: Path) -> None:
+        """A pre-v56 DB whose tracks.genre holds a " / "-joined MP3 composite
+        backfills into separate genre rows (no composite junk in the list)."""
+        db = tmp_path / "library.db"
+        LibraryIndex(db).close()
+        # Simulate a pre-v56 row + empty normalized tables.
+        conn = sqlite3.connect(str(db))
+        conn.execute("DELETE FROM track_genres")
+        conn.execute("DELETE FROM genres")
+        conn.execute(
+            "INSERT INTO tracks (title, artist, album_artist, album, release_date,"
+            " track_number, disc_number, mb_release_id, mb_recording_id, genre, label)"
+            " VALUES ('T','A','A','Al','2020',1,1,'','','Jazz / J-Pop','')"
+        )
+        conn.execute("UPDATE schema_version SET version = 55")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db)
+        names = index.all_genres()
+        index.close()
+        assert names == ["J-Pop", "Jazz"]  # split, not "Jazz / J-Pop"
 
 
 class TestUpsertSyncProtection:
@@ -13885,7 +14060,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 55
+        assert version == 56
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -13905,7 +14080,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 55
+        assert version == 56
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -13948,7 +14123,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 55
+        assert version == 56
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -14227,7 +14402,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 55
+        assert ver == 56
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_mb_lookup_endpoint.py
+++ b/tests/test_mb_lookup_endpoint.py
@@ -449,9 +449,11 @@ class TestPatchAlbumMetaMbReleaseId:
             )
 
         assert resp.status_code == 200
+        # KAMP-586: genre routes through apply_genres, so the file-write and
+        # update_album_meta calls no longer carry a scalar genre.
         mock_write.assert_called_once_with(
             track.file_path,
-            genre=None,
+            genres=None,
             label=None,
             release_date=None,
             mb_release_id="new-mbid",
@@ -459,11 +461,11 @@ class TestPatchAlbumMetaMbReleaseId:
         mock_index.update_album_meta.assert_called_once_with(
             "Band",
             "Record",
-            genre=None,
             label=None,
             release_date=None,
             mb_release_id="new-mbid",
         )
+        mock_index.apply_genres.assert_not_called()
 
     def test_returns_400_when_only_mb_release_id_absent_alongside_other_nones(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -539,6 +539,18 @@ class TestArtistsEndpoint:
         assert c.get("/api/v1/artists").json() == ["Aesop Rock", "Zeppelin"]
 
 
+class TestGenresEndpoint:
+    def test_returns_empty_list_when_no_genres(self, client: TestClient) -> None:
+        assert client.get("/api/v1/genres").json() == []
+
+    def test_returns_genre_list(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.all_genres.return_value = ["Jazz", "Rock"]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        assert TestClient(app).get("/api/v1/genres").json() == ["Jazz", "Rock"]
+
+
 class TestTopArtistsEndpoint:
     def test_returns_empty_list_when_no_artists(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -4134,10 +4146,11 @@ class TestPatchAlbumMetaEndpoint:
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
+        # KAMP-586: genre now routes through the shared apply_genres service,
+        # not update_album_meta.
         track = self._make_track()
         updated = Track(**{**track.__dict__, "genre": "Jazz"})
-        mock_index.tracks_for_album.return_value = [track]
-        mock_index.update_album_meta.return_value = [updated]
+        mock_index.tracks_for_album.return_value = [updated]
 
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         with patch("kamp_core.library.write_meta_tags_to_file"):
@@ -4149,8 +4162,30 @@ class TestPatchAlbumMetaEndpoint:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data["tracks"]) == 1
         assert data["tracks"][0]["genre"] == "Jazz"
+        mock_index.apply_genres.assert_called_once()
+        assert mock_index.apply_genres.call_args.args[1] == ["Jazz"]
+
+    def test_patch_genres_list_routes_to_apply_genres(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        updated = Track(**{**self._make_track().__dict__, "genre": "Jazz; J-Pop"})
+        mock_index.tracks_for_album.return_value = [updated]
+
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        with patch("kamp_core.library.write_meta_tags_to_file"):
+            resp = TestClient(app).patch(
+                "/api/v1/albums/meta",
+                params={"album_artist": "Artist", "album": "Record"},
+                json={"genres": ["Jazz", "J-Pop"]},
+            )
+
+        assert resp.status_code == 200
+        assert mock_index.apply_genres.call_args.args[1] == ["Jazz", "J-Pop"]
+        assert mock_index.apply_genres.call_args.kwargs["mode"] == "replace"
 
     def test_patch_label_and_year_persisted(
         self,
@@ -4160,8 +4195,7 @@ class TestPatchAlbumMetaEndpoint:
     ) -> None:
         track = self._make_track()
         updated = Track(**{**track.__dict__, "label": "ECM", "release_date": "1975"})
-        mock_index.tracks_for_album.return_value = [track]
-        mock_index.update_album_meta.return_value = [updated]
+        mock_index.tracks_for_album.return_value = [updated]
 
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         with patch("kamp_core.library.write_meta_tags_to_file"):
@@ -4172,14 +4206,81 @@ class TestPatchAlbumMetaEndpoint:
             )
 
         assert resp.status_code == 200
+        # genre no longer routed through update_album_meta (KAMP-586).
         mock_index.update_album_meta.assert_called_once_with(
             "Artist",
             "Record",
-            genre=None,
             label="ECM",
             release_date="1975",
             mb_release_id=None,
         )
+        mock_index.apply_genres.assert_not_called()
+
+    def test_multi_value_genre_end_to_end_local_and_remote(
+        self,
+        tmp_path: Path,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Real DB + files (KAMP-586): PATCH genres applies to every track's
+        normalized rows; the local file's tag is written multi-value; the
+        remote track gets DB genres but no (impossible) file write."""
+        import mutagen.id3 as id3
+
+        from kamp_core.library import LibraryIndex
+
+        local_mp3 = tmp_path / "01.mp3"
+        local_mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(local_mp3))
+
+        index = LibraryIndex(tmp_path / "library.db")
+        local = Track(
+            file_path=local_mp3,
+            title="A",
+            artist="Band",
+            album_artist="Band",
+            album="Rec",
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        remote = Track(
+            file_path=Path("bandcamp://S1/2"),
+            title="B",
+            artist="Band",
+            album_artist="Band",
+            album="Rec",
+            release_date="2020",
+            track_number=2,
+            disc_number=1,
+            ext="",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+        )
+        index.upsert_many([local, remote])
+
+        app = create_app(index=index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/albums/meta",
+            params={"album_artist": "Band", "album": "Rec"},
+            json={"genres": ["Jazz", "J-Pop"]},
+        )
+
+        assert resp.status_code == 200
+        # Both tracks carry the genres in the DB (denormalized display string).
+        genres = {t.genre for t in index.all_tracks()}
+        assert genres == {"J-Pop; Jazz"}
+        # The local file's TCON was written multi-value; the remote had no file.
+        tcon = id3.ID3(str(local_mp3))["TCON"]
+        assert set(tcon.text) == {"Jazz", "J-Pop"}
+        assert index.all_genres() == ["J-Pop", "Jazz"]
+        index.close()
 
     def test_returns_404_for_unknown_album(
         self,
@@ -4377,11 +4478,11 @@ class TestPatchAlbumMetaEndpoint:
         mock_engine: MagicMock,
         mock_queue: MagicMock,
     ) -> None:
-        """Bandcamp tracks must not trigger write_meta_tags_to_file."""
+        """Bandcamp tracks must not trigger write_meta_tags_to_file, but their
+        genres still update in the DB via apply_genres (KAMP-586)."""
         remote = self._make_remote_track()
         updated = Track(**{**remote.__dict__, "genre": "Jazz"})
-        mock_index.tracks_for_album.return_value = [remote]
-        mock_index.update_album_meta.return_value = [updated]
+        mock_index.tracks_for_album.return_value = [updated]
 
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         with patch("kamp_core.library.write_meta_tags_to_file") as mock_write:
@@ -4392,15 +4493,9 @@ class TestPatchAlbumMetaEndpoint:
             )
 
         assert resp.status_code == 200
-        mock_write.assert_not_called()
-        mock_index.update_album_meta.assert_called_once_with(
-            "Artist",
-            "Record",
-            genre="Jazz",
-            label=None,
-            release_date=None,
-            mb_release_id=None,
-        )
+        mock_write.assert_not_called()  # no local file to write
+        mock_index.apply_genres.assert_called_once()  # DB still updated
+        assert mock_index.apply_genres.call_args.args[1] == ["Jazz"]
 
     def test_mixed_album_writes_files_only_for_local_tracks(
         self,


### PR DESCRIPTION
Genre becomes multi-value: albums are edited with chips + type-ahead autocomplete, values may contain spaces, and a "mixed" album rolls its tracks' genres into one union applied to every track. Fixes KAMP-586. This is the foundational model the rest of the genre sprint (550/587/588/591/601) builds on, so the write/read seams are the load-bearing part.

## Architecture (the steel thread)

- **Files stay the source of truth.** Genre is written natively multi-value per format (ID3 `TCON` list, MP4 `\xa9gen` list, repeated Vorbis `GENRE`).
- **Normalized `genres` + `track_genres` tables are the query truth** (mirroring `artists`: plain tables, NOCASE-unique — safe inline here since `genres` is brand new). `tracks.genre`/`albums.genre` stay as `"; "`-joined denormalized **display** strings, never parsed back for lookup (KAMP-554).
- **`_set_track_genres` is the single chokepoint** for genre→DB writes (strip, NOCASE first-seen dedup, rewrite `track_genres`, sync the denorm string) — so the normalized and display forms can't drift.
- **`apply_genres(track_ids, genres, *, mode)` is the shared DB-only service.** `replace` is fully implemented and wired; `merge` is a mechanism-tested seam for 587/588/591 (its dedup/casing contract firms up with its first consumer). It fires `on_fields_changed({"track.genre"})` so genre magic-playlists recompute. File writes stay in the album-meta endpoint's one `is_remote`-guarded loop (remote tracks get DB genres, no file).

## What changed

- **Schema/migration (v56):** `genres`/`track_genres` + index; backfill splits old `" / "`-joined MP3 composites so the autocomplete has clean values from day one (column-presence guarded for partial-schema test DBs, KAMP-552).
- **Tag I/O:** readers populate a new `Track.genres` from native multi-value tags; `write_meta_tags_to_file` gains a `genres` list param (empty clears the tag).
- **`albums.genre` = the DISTINCT track union**, centralized at `_refresh_album_aggregates` using the nested-subquery form (SQLite forbids `GROUP_CONCAT(DISTINCT x, sep)`). Only that one live site changes; the frozen v42 migration is untouched.
- **`upsert_many`** populates `track_genres` before the album rollup, bridging from the scalar for directly-constructed Tracks; the stream re-sync path skips an empty incoming list so a Bandcamp re-sync never wipes a user's genre edits.
- **criteria.py:** `track.genre` becomes a self-contained `EXISTS` subquery over `track_genres` (like `in_playlist`), so `is`/`contains` match each value — a flat `"Jazz; J-Pop"` column would silently stop matching `is "Jazz"`.
- **Endpoints:** `PATCH /albums/meta` accepts `genres: list[str]` → `apply_genres(replace)`; new `GET /api/v1/genres` for autocomplete (reused by 550).
- **UI:** new `GenreChipsInput` (chips + autocomplete popover); `AlbumMetaPanel` genre field becomes chips; the read-only "(mixed)" sentinel is replaced by the editable union.

## Deferred to their own tickets (unchanged scope)

FTS genre search → KAMP-601. Genre sidebar (`AlbumInfo.genre` exposure) → KAMP-550. Better-source genre backfill → KAMP-591. This PR builds the tables, service, endpoints, and edit UI they all consume.

## Testing

- Full suite: **2446 passed**, coverage **93.62%** (up from main's 93.56%, worktree-compared). black + mypy clean; kamp_ui typecheck + eslint clean.
- New backend tests: normalized read/write for 4 formats incl. multi-value round-trips; `_set_track_genres` dedup/casing/canonical; `apply_genres` replace + album union + `on_fields_changed` + merge mechanism; stream-resync empty guard; migration `" / "`-split backfill; criteria EXISTS unit tests + a magic-playlist integration test matching a `[Jazz, J-Pop]` track; the album-meta endpoint end-to-end with a real DB + files covering local (file written) and remote (DB only).

## Manual Test Plan

- [ ] Album with one genre → Edit → shows one chip; type "J" → autocomplete lists library genres; pick one → second chip; Save → both persist on reopen and are written to each track's file tag
- [ ] Add a genre with a space ("Free Jazz") → one chip, not two
- [ ] **Mixed album** (tracks disagree): the field rolls up the union as chips; Save applies that union to every track
- [ ] Remove a chip → Save → gone from all tracks (replace semantics)
- [ ] Streaming (bandcamp) album: edit genres → DB updates, no file-write error; a later collection re-sync does **not** wipe the edited genres
- [ ] Magic playlist `track.genre is "Jazz"` matches a track tagged ["Jazz","J-Pop"]; editing an album's genre updates the playlist without restart
- [ ] Autocomplete has no composite junk ("Jazz / J-Pop") after migrating a library with MP3 multi-genre files
- [ ] Migration: launch against a **copy** of the production DB → clean startup, existing genres shown as chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
