### PR TITLE
feat(library): genre filter with Artists|Genres sidebar mini-tabs (KAMP-550)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -685,6 +685,11 @@ class AlbumInfo:
     # no override; the canonical album/album_artist is the authoritative value.
     display_album: str | None = None
     display_album_artist: str | None = None
+    # DISTINCT union of the album's track genres (KAMP-550), built from the
+    # normalized track_genres tables — canonical names, sorted NOCASE. Backs the
+    # library genre filter; the client matches on membership without re-parsing
+    # the denormalized "; " display string.
+    genres: list[str] = field(default_factory=list, compare=False)
 
     # Allow dict-style access so callers can use a["album_artist"] etc.
     def __getitem__(self, key: str) -> Any:
@@ -6402,6 +6407,27 @@ class LibraryIndex:
             WHERE t.album = ''
             ORDER BY {order_by}
             """).fetchall()  # noqa: S608 — order_by is from a whitelist, not user input
+        # Per-album genre union (KAMP-550), read from the normalized track_genres
+        # in one grouped pass. Keyed both by album_id (named albums) and track_id
+        # (missing-album virtual entries have no albums row), so each entry can
+        # resolve its own. Ordered by NOCASE name so each union comes out sorted;
+        # genres.name is already the single canonical casing, so plain membership
+        # dedup suffices.
+        genres_by_album: dict[int, list[str]] = {}
+        genres_by_track: dict[int, list[str]] = {}
+        for gr in self._conn.execute(
+            "SELECT t.album_id AS aid, t.id AS tid, g.name AS name"
+            " FROM track_genres tg"
+            " JOIN genres g ON g.id = tg.genre_id"
+            " JOIN tracks t ON t.id = tg.track_id"
+            " ORDER BY g.name COLLATE NOCASE"
+        ).fetchall():
+            if gr["aid"] is not None:
+                album_list = genres_by_album.setdefault(gr["aid"], [])
+                if gr["name"] not in album_list:
+                    album_list.append(gr["name"])
+            genres_by_track.setdefault(gr["tid"], []).append(gr["name"])
+
         return [
             AlbumInfo(
                 album_id=r["album_id"],
@@ -6428,6 +6454,11 @@ class LibraryIndex:
                 sale_item_id=r["sale_item_id"],
                 display_album=r["display_album"],
                 display_album_artist=r["display_album_artist"],
+                genres=(
+                    genres_by_track.get(r["missing_track_id"], [])
+                    if r["missing_album"]
+                    else genres_by_album.get(r["album_id"], [])
+                ),
             )
             for r in rows
         ]

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -6169,14 +6169,22 @@ class LibraryIndex:
         )
 
     def all_genres(self) -> list[str]:
-        """Return every distinct genre name in the library, sorted (KAMP-586).
+        """Return every genre applied to at least one track, sorted (KAMP-586).
 
-        Backs the album-edit autocomplete and (later) the genre sidebar.
+        Backs the album-edit autocomplete and the genre sidebar (KAMP-550).
+        A genre whose last track link was removed is an orphan: its
+        ``genres``-table row lingers (``_set_track_genres`` only INSERTs OR
+        IGNOREs, never deletes) but it must not appear in the list, or a genre
+        no album carries would haunt the sidebar. Joining ``track_genres``
+        drops orphans and keeps this list consistent with the per-album genre
+        sets, which are already derived from ``track_genres``.
         """
         return [
             r["name"]
             for r in self._conn.execute(
-                "SELECT name FROM genres ORDER BY name COLLATE NOCASE"
+                "SELECT DISTINCT g.name FROM genres g"
+                " JOIN track_genres tg ON tg.genre_id = g.id"
+                " ORDER BY g.name COLLATE NOCASE"
             ).fetchall()
         ]
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 from kamp_core.library import (
+    AlbumInfo,
     ArtistInfo,
     LibraryIndex,
     LibraryScanner,
@@ -352,6 +353,38 @@ class AlbumOut(BaseModel):
     # User-set display overrides for streaming albums (KAMP-467). None means no override.
     display_album: str | None = None
     display_album_artist: str | None = None
+    # DISTINCT union of the album's track genres (KAMP-550); backs the library
+    # genre filter. Canonical names, sorted NOCASE.
+    genres: list[str] = []
+
+    @classmethod
+    def from_album_info(cls, a: "AlbumInfo") -> "AlbumOut":
+        """Build from an AlbumInfo. The single mapping so a new field can't be
+        dropped at a subset of the (many) construction sites (KAMP-550/554)."""
+        return cls(
+            album_artist=a.album_artist,
+            album=a.album,
+            release_date=a.release_date,
+            track_count=a.track_count,
+            has_art=a.has_art,
+            missing_album=a.missing_album,
+            track_id=a.missing_track_id,
+            art_version=a.art_version,
+            added_at=a.added_at,
+            last_played_at=a.last_played_at,
+            play_count_avg=a.play_count_avg,
+            favorite=a.favorite,
+            has_favorite_track=a.has_favorite_track,
+            source=a.source,
+            has_remote_tracks=a.has_remote_tracks,
+            sale_item_id=a.sale_item_id,
+            is_preorder=a.is_preorder,
+            num_streamable_tracks=a.num_streamable_tracks,
+            album_url=a.album_url,
+            display_album=a.display_album,
+            display_album_artist=a.display_album_artist,
+            genres=a.genres,
+        )
 
 
 class PlayerStateOut(BaseModel):
@@ -1355,29 +1388,7 @@ def create_app(
         # direction="" means use the natural per-key default (historical behaviour).
         sort_dir = direction if direction in ("asc", "desc") else None
         return [
-            AlbumOut(
-                album_artist=a.album_artist,
-                album=a.album,
-                release_date=a.release_date,
-                track_count=a.track_count,
-                has_art=a.has_art,
-                missing_album=a.missing_album,
-                track_id=a.missing_track_id,
-                art_version=a.art_version,
-                added_at=a.added_at,
-                last_played_at=a.last_played_at,
-                play_count_avg=a.play_count_avg,
-                favorite=a.favorite,
-                has_favorite_track=a.has_favorite_track,
-                source=a.source,
-                has_remote_tracks=a.has_remote_tracks,
-                sale_item_id=a.sale_item_id,
-                is_preorder=a.is_preorder,
-                num_streamable_tracks=a.num_streamable_tracks,
-                album_url=a.album_url,
-                display_album=a.display_album,
-                display_album_artist=a.display_album_artist,
-            )
+            AlbumOut.from_album_info(a)
             for a in index.albums(sort=sort, sort_dir=sort_dir)
         ]
 
@@ -2255,29 +2266,7 @@ def create_app(
         if result is None:
             raise HTTPException(status_code=404, detail="Album not found")
         _notify_library_changed()
-        return AlbumOut(
-            album_artist=result.album_artist,
-            album=result.album,
-            release_date=result.release_date,
-            track_count=result.track_count,
-            has_art=result.has_art,
-            missing_album=result.missing_album,
-            track_id=result.missing_track_id,
-            art_version=result.art_version,
-            added_at=result.added_at,
-            last_played_at=result.last_played_at,
-            play_count_avg=result.play_count_avg,
-            favorite=result.favorite,
-            has_favorite_track=result.has_favorite_track,
-            source=result.source,
-            has_remote_tracks=result.has_remote_tracks,
-            sale_item_id=result.sale_item_id,
-            is_preorder=result.is_preorder,
-            num_streamable_tracks=result.num_streamable_tracks,
-            album_url=result.album_url,
-            display_album=result.display_album,
-            display_album_artist=result.display_album_artist,
-        )
+        return AlbumOut.from_album_info(result)
 
     @app.patch("/api/v1/albums/meta")
     def patch_album_meta(
@@ -2636,29 +2625,7 @@ def create_app(
         albums = index.albums()
         for a in albums:
             if a.album_artist == body.album_artist and a.album == body.album:
-                return AlbumOut(
-                    album_artist=a.album_artist,
-                    album=a.album,
-                    release_date=a.release_date,
-                    track_count=a.track_count,
-                    has_art=a.has_art,
-                    missing_album=a.missing_album,
-                    track_id=a.missing_track_id,
-                    art_version=a.art_version,
-                    added_at=a.added_at,
-                    last_played_at=a.last_played_at,
-                    play_count_avg=a.play_count_avg,
-                    favorite=a.favorite,
-                    has_favorite_track=a.has_favorite_track,
-                    source=a.source,
-                    has_remote_tracks=a.has_remote_tracks,
-                    sale_item_id=a.sale_item_id,
-                    is_preorder=a.is_preorder,
-                    num_streamable_tracks=a.num_streamable_tracks,
-                    album_url=a.album_url,
-                    display_album=a.display_album,
-                    display_album_artist=a.display_album_artist,
-                )
+                return AlbumOut.from_album_info(a)
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
     @app.post("/api/v1/albums/art/apply-local", response_model=AlbumOut)
@@ -2766,29 +2733,7 @@ def create_app(
         albums = index.albums()
         for a in albums:
             if a.album_artist == album_artist and a.album == album:
-                return AlbumOut(
-                    album_artist=a.album_artist,
-                    album=a.album,
-                    release_date=a.release_date,
-                    track_count=a.track_count,
-                    has_art=a.has_art,
-                    missing_album=a.missing_album,
-                    track_id=a.missing_track_id,
-                    art_version=a.art_version,
-                    added_at=a.added_at,
-                    last_played_at=a.last_played_at,
-                    play_count_avg=a.play_count_avg,
-                    favorite=a.favorite,
-                    has_favorite_track=a.has_favorite_track,
-                    source=a.source,
-                    has_remote_tracks=a.has_remote_tracks,
-                    sale_item_id=a.sale_item_id,
-                    is_preorder=a.is_preorder,
-                    num_streamable_tracks=a.num_streamable_tracks,
-                    album_url=a.album_url,
-                    display_album=a.display_album,
-                    display_album_artist=a.display_album_artist,
-                )
+                return AlbumOut.from_album_info(a)
         raise HTTPException(status_code=404, detail="Album not found after apply")
 
     @app.get("/api/v1/album-art")
@@ -2926,29 +2871,7 @@ def create_app(
         fts_keys = {(t.album_artist.lower(), t.album.lower()) for t in fts_tracks}
         fts_ids = {t.id for t in fts_tracks if not t.album}
         albums = [
-            AlbumOut(
-                album_artist=a.album_artist,
-                album=a.album,
-                release_date=a.release_date,
-                track_count=a.track_count,
-                has_art=a.has_art,
-                missing_album=a.missing_album,
-                track_id=a.missing_track_id,
-                art_version=a.art_version,
-                added_at=a.added_at,
-                last_played_at=a.last_played_at,
-                play_count_avg=a.play_count_avg,
-                favorite=a.favorite,
-                has_favorite_track=a.has_favorite_track,
-                source=a.source,
-                has_remote_tracks=a.has_remote_tracks,
-                sale_item_id=a.sale_item_id,
-                is_preorder=a.is_preorder,
-                num_streamable_tracks=a.num_streamable_tracks,
-                album_url=a.album_url,
-                display_album=a.display_album,
-                display_album_artist=a.display_album_artist,
-            )
+            AlbumOut.from_album_info(a)
             for a in index.albums(sort=sort)
             if (a.album_artist.lower(), a.album.lower()) in fts_keys
             or (a.missing_album and a.missing_track_id in fts_ids)

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -95,6 +95,9 @@ export type Album = {
   // User-set display overrides for streaming albums (KAMP-467). Undefined means no override.
   display_album?: string
   display_album_artist?: string
+  // DISTINCT union of the album's track genres (KAMP-550); backs the library
+  // genre filter. Canonical names, sorted NOCASE.
+  genres: string[]
 }
 
 export type PlayerState = {

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -434,6 +434,48 @@ html[data-platform='win32'] .view-tabs {
   border-bottom: 1px solid var(--border);
 }
 
+/* Library sidebar mini-tabs (Artists | Genres) — KAMP-550 */
+.library-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.library-tab {
+  flex: 1;
+  padding: 10px 8px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.library-tab:hover {
+  color: var(--text);
+}
+
+.library-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.library-list-empty {
+  padding: 12px 14px;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-style: italic;
+  cursor: default;
+}
+
+.library-list-empty:hover {
+  background: none;
+}
+
 .artist-list {
   list-style: none;
   overflow-y: auto;

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -21,7 +21,9 @@ const ALBUM_SORT_OPTIONS = [
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
+  const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
+  const selectGenre = useStore((s) => s.selectGenre)
   const libraryFilter = useStore((s) => s.libraryFilter)
   const sortOrder = useStore((s) => s.sortOrder)
   const sortDir = useStore((s) => s.sortDir)
@@ -41,7 +43,17 @@ export function AlbumGrid(): React.JSX.Element {
     }
   }, [])
 
-  let visible = selectedArtist ? albums.filter((a) => a.album_artist === selectedArtist) : albums
+  // Genre takes precedence over artist (KAMP-550). The two are mutually
+  // exclusive via the store actions, but precedence keeps the grid deterministic
+  // even if both were somehow set. Genre matches on canonical-name membership —
+  // no re-parsing of a joined string, so it can't diverge from the sidebar list.
+  let visible = albums
+  if (selectedGenre) {
+    const g = selectedGenre.toLowerCase()
+    visible = albums.filter((a) => a.genres.some((name) => name.toLowerCase() === g))
+  } else if (selectedArtist) {
+    visible = albums.filter((a) => a.album_artist === selectedArtist)
+  }
 
   if (libraryFilter.length > 0) {
     const QUALITATIVE_FILTERS = ['favorite_album', 'has_favorite_track', 'unplayed', 'top_albums']
@@ -76,6 +88,7 @@ export function AlbumGrid(): React.JSX.Element {
   const emptyMessage = (): string => {
     if (albums.length === 0) return 'No albums in library.'
     if (libraryFilter.length > 0) return 'No albums match the active filter.'
+    if (selectedGenre) return 'No albums for this genre.'
     return 'No albums for this artist.'
   }
 
@@ -92,13 +105,15 @@ export function AlbumGrid(): React.JSX.Element {
         <SourceControl />
         <FilterControl />
       </div>
-      {selectedArtist && (
+      {(selectedGenre || selectedArtist) && (
         <nav className="breadcrumb album-grid-breadcrumb" aria-label="Navigation">
-          <button onClick={() => selectArtist(null)}>Library</button>
+          <button onClick={() => (selectedGenre ? selectGenre(null) : selectArtist(null))}>
+            Library
+          </button>
           <span className="breadcrumb-sep" aria-hidden="true">
             ›
           </span>
-          <span>{selectedArtist}</span>
+          <span>{selectedGenre ?? selectedArtist}</span>
         </nav>
       )}
       {visible.length === 0 ? (

--- a/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/ArtistPanel.tsx
@@ -6,8 +6,17 @@ const ARTIST_WIDTH_DEFAULT = 200
 
 export function ArtistPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
-  const selected = useStore((s) => s.library.selectedArtist)
+  const genres = useStore((s) => s.library.genres)
+  const selectedArtist = useStore((s) => s.library.selectedArtist)
+  const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
+  const selectGenre = useStore((s) => s.selectGenre)
+  // Which list is shown. Seeded from the active filter so re-opening while a
+  // genre is selected lands on the Genres tab (KAMP-550). Switching tabs is a
+  // pure view change — it never alters the active filter.
+  const [tab, setTab] = useState<'artists' | 'genres'>(
+    selectedGenre !== null ? 'genres' : 'artists'
+  )
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const saved = parseFloat(localStorage.getItem(ARTIST_WIDTH_KEY) ?? '')
     const max = window.innerWidth * 0.33
@@ -80,28 +89,79 @@ export function ArtistPanel(): React.JSX.Element {
       className={`artist-panel${isResizing ? ' artist-panel--resizing' : ''}`}
       style={{ width: panelWidth }}
     >
-      <div className="panel-header">Artists</div>
-      <ul className="artist-list">
-        <li
-          className={selected === null ? 'active' : ''}
-          tabIndex={0}
-          onClick={() => selectArtist(null)}
-          onKeyDown={(e) => e.key === 'Enter' && selectArtist(null)}
+      <div className="library-tabs" role="tablist" aria-label="Library filter">
+        <button
+          id="lib-tab-artists"
+          role="tab"
+          aria-selected={tab === 'artists'}
+          className={`library-tab${tab === 'artists' ? ' active' : ''}`}
+          onClick={() => setTab('artists')}
         >
-          All Artists
-        </li>
-        {artists.map((artist) => (
+          Artists
+        </button>
+        <button
+          id="lib-tab-genres"
+          role="tab"
+          aria-selected={tab === 'genres'}
+          className={`library-tab${tab === 'genres' ? ' active' : ''}`}
+          onClick={() => setTab('genres')}
+        >
+          Genres
+        </button>
+      </div>
+      {tab === 'artists' ? (
+        <ul className="artist-list" role="tabpanel" aria-labelledby="lib-tab-artists">
           <li
-            key={artist}
-            className={selected === artist ? 'active' : ''}
+            className={selectedArtist === null ? 'active' : ''}
             tabIndex={0}
-            onClick={() => selectArtist(artist)}
-            onKeyDown={(e) => e.key === 'Enter' && selectArtist(artist)}
+            onClick={() => selectArtist(null)}
+            onKeyDown={(e) => e.key === 'Enter' && selectArtist(null)}
           >
-            {artist}
+            All Artists
           </li>
-        ))}
-      </ul>
+          {artists.map((artist) => (
+            <li
+              key={artist}
+              className={selectedArtist === artist ? 'active' : ''}
+              tabIndex={0}
+              onClick={() => selectArtist(artist)}
+              onKeyDown={(e) => e.key === 'Enter' && selectArtist(artist)}
+            >
+              {artist}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul className="artist-list" role="tabpanel" aria-labelledby="lib-tab-genres">
+          {genres.length === 0 ? (
+            <li className="library-list-empty" aria-disabled="true">
+              No genres tagged yet
+            </li>
+          ) : (
+            <>
+              <li
+                className={selectedGenre === null ? 'active' : ''}
+                tabIndex={0}
+                onClick={() => selectGenre(null)}
+                onKeyDown={(e) => e.key === 'Enter' && selectGenre(null)}
+              >
+                All Genres
+              </li>
+              {genres.map((genre) => (
+                <li
+                  key={genre}
+                  className={selectedGenre === genre ? 'active' : ''}
+                  tabIndex={0}
+                  onClick={() => selectGenre(genre)}
+                  onKeyDown={(e) => e.key === 'Enter' && selectGenre(genre)}
+                >
+                  {genre}
+                </li>
+              ))}
+            </>
+          )}
+        </ul>
+      )}
       <div
         className="artist-resize-handle"
         onMouseDown={handleResizeMouseDown}

--- a/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
@@ -48,7 +48,17 @@ export function GenreChipsInput({
     setChips([...chips, name])
   }
 
-  const removeChip = (name: string): void => setChips(chips.filter((c) => c !== name))
+  const removeChip = (name: string): void => {
+    const next = chips.filter((c) => c !== name)
+    setChips(next)
+    // Persist removals immediately instead of waiting for the container's blur.
+    // Clicking a chip's × can leave focus outside the input (on macOS a button
+    // click doesn't focus it), so the focusout that normally commits never
+    // fires when the user then navigates away — the removal was silently
+    // dropped and the genre "healed" on reopen (KAMP-550). Adds keep focus in
+    // the input, so their blur-commit already works.
+    if (!sameSet(next, initialChips)) onCommit(next)
+  }
 
   const commit = (): void => {
     if (!sameSet(chips, initialChips)) onCommit(chips)

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -305,7 +305,9 @@ export function PlaylistView(): React.JSX.Element | null {
           favorite: albumFavMap.get(key) ?? false,
           has_favorite_track: t.favorite,
           source: t.source === 'bandcamp' ? 'bandcamp' : 'local',
-          has_remote_tracks: t.source !== 'local'
+          has_remote_tracks: t.source !== 'local',
+          // Synthesised from a playlist track; the genre filter never runs here.
+          genres: []
         })
       } else {
         const alb = seen.get(key)!

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -158,7 +158,8 @@ export function QueueContextMenu({
                     favorite: false,
                     has_favorite_track: false,
                     source: 'local',
-                    has_remote_tracks: false
+                    has_remote_tracks: false,
+                    genres: []
                   }
                   void setActiveView('library')
                   void selectAlbum(found)

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -210,7 +210,8 @@ export function TrackContextMenu({
                     favorite: false,
                     has_favorite_track: false,
                     source: 'local',
-                    has_remote_tracks: false
+                    has_remote_tracks: false,
+                    genres: []
                   }
                   void setActiveView('library')
                   void selectAlbum(found)

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -43,7 +43,11 @@ export type TraceStyle = 'clean' | 'glowy' | 'trippy'
 type LibraryState = {
   albums: Album[]
   artists: string[]
+  genres: string[]
   selectedArtist: string | null
+  // Active genre filter (KAMP-550). Mutually exclusive with selectedArtist:
+  // picking one clears the other.
+  selectedGenre: string | null
   selectedAlbum: Album | null
   tracks: Track[]
   tracksAlbumKey: string | null // "artist\0album" key for the loaded track list
@@ -222,6 +226,7 @@ type PlayerStore = {
   loadLibrary: () => Promise<void>
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
+  selectGenre: (genre: string | null) => void
   selectAlbum: (album: Album | null) => Promise<void>
   loadTracks: (albumArtist: string, album: string, trackId?: number | null) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
@@ -371,7 +376,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
   library: {
     albums: [],
     artists: [],
+    genres: [],
     selectedArtist: null,
+    selectedGenre: null,
     selectedAlbum: null,
     tracks: [],
     tracksAlbumKey: null,
@@ -979,9 +986,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
     try {
       const sort = get().sortOrder
       const dir = get().sortDir
-      const [albums, artists, playlists] = await Promise.all([
+      const [albums, artists, genres, playlists] = await Promise.all([
         api.getAlbums(sort, dir),
         api.getArtists(),
+        api.getGenres(),
         api.getPlaylists()
       ])
       set((s) => {
@@ -1001,6 +1009,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
             ...s.library,
             albums,
             artists,
+            genres,
             playlists,
             selectedAlbum: refreshedSelectedAlbum
           },
@@ -1042,8 +1051,17 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   patchOpenAlbum: (album) => set((s) => ({ library: { ...s.library, selectedAlbum: album } })),
 
+  // Artist and genre filters are mutually exclusive (KAMP-550): selecting one
+  // clears the other so only one filter is ever active.
   selectArtist: (artist) =>
-    set((s) => ({ library: { ...s.library, selectedArtist: artist, selectedAlbum: null } })),
+    set((s) => ({
+      library: { ...s.library, selectedArtist: artist, selectedGenre: null, selectedAlbum: null }
+    })),
+
+  selectGenre: (genre) =>
+    set((s) => ({
+      library: { ...s.library, selectedGenre: genre, selectedArtist: null, selectedAlbum: null }
+    })),
 
   selectAlbum: async (album) => {
     set((s) => ({

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -13113,6 +13113,20 @@ class TestMultiValueGenre:
         assert genres == {"Hip-Hop; Plunderphonics"}
         assert album_genre == "Hip-Hop; Plunderphonics"
 
+    def test_all_genres_excludes_orphans_after_removal(self, tmp_path: Path) -> None:
+        # KAMP-550 bug: removing a genre's last track link left it lingering in
+        # the sidebar/autocomplete list. all_genres() must drop a genre once no
+        # track carries it, even though its genres-table row persists.
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Unknown"])])
+        tid = index.all_tracks()[0].id
+
+        index.apply_genres([tid], ["Punk"], mode="replace")
+
+        names = index.all_genres()
+        index.close()
+        assert names == ["Punk"]  # "Unknown" is orphaned and no longer listed
+
     def test_apply_genres_fires_on_fields_changed(self, tmp_path: Path) -> None:
         index = self._index(tmp_path)
         index.upsert_many([self._local(tmp_path / "1.mp3", ["Jazz"])])

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -13058,6 +13058,41 @@ class TestMultiValueGenre:
         index.close()
         assert album_genre == "J-Pop; Jazz"  # union, sorted, no duplicate Jazz
 
+    # -- albums() genre exposure (KAMP-550) ----------------------------------
+
+    def test_albums_exposes_genre_union_as_list(self, tmp_path: Path) -> None:
+        # The per-album genres list drives the sidebar genre filter; it is built
+        # from the normalized track_genres (canonical names), not by re-splitting
+        # the denormalized "; " string, so the sidebar and filter can't diverge.
+        index = self._index(tmp_path)
+        index.upsert_many(
+            [
+                self._local(tmp_path / "1.mp3", ["Jazz"]),
+                self._local(tmp_path / "2.mp3", ["J-Pop", "Jazz"]),
+            ]
+        )
+        album = index.albums()[0]
+        index.close()
+        assert album.genres == ["J-Pop", "Jazz"]  # union, deduped, sorted NOCASE
+
+    def test_albums_genres_empty_when_untagged(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", [])])
+        album = index.albums()[0]
+        index.close()
+        assert album.genres == []
+
+    def test_albums_missing_album_track_carries_its_genres(
+        self, tmp_path: Path
+    ) -> None:
+        # A track with an empty album tag surfaces as its own virtual album with
+        # no album row, so its genres resolve by track id, not album id.
+        index = self._index(tmp_path)
+        index.upsert_many([self._local(tmp_path / "1.mp3", ["Ambient"], album="")])
+        album = next(a for a in index.albums() if a.missing_album)
+        index.close()
+        assert album.genres == ["Ambient"]
+
     # -- apply_genres --------------------------------------------------------
 
     def test_apply_genres_replace_sets_all_tracks(self, tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ def _album(
     release_date: str = "2024",
     count: int = 10,
     has_art: bool = False,
+    genres: list[str] | None = None,
 ) -> AlbumInfo:
     return AlbumInfo(
         album_artist=artist,
@@ -51,6 +52,7 @@ def _album(
         release_date=release_date,
         track_count=count,
         has_art=has_art,
+        genres=genres or [],
     )
 
 
@@ -268,6 +270,18 @@ class TestAlbumsEndpoint:
         c = TestClient(app)
         album = c.get("/api/v1/albums").json()[0]
         assert album["has_art"] is True
+
+    def test_album_exposes_genres(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        # The genre list drives the library genre filter (KAMP-550).
+        mock_index.albums.return_value = [
+            _album("Artist", "Record", genres=["J-Pop", "Jazz"])
+        ]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        album = c.get("/api/v1/albums").json()[0]
+        assert album["genres"] == ["J-Pop", "Jazz"]
 
     def test_album_includes_art_version(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -6951,7 +6965,30 @@ class TestPatchAlbumDisplayEndpoint:
             source="bandcamp",
             display_album="Short",
             display_album_artist="B",
+            genres=["Shoegaze"],
         )
+
+    def test_response_carries_genres(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        # Regression: this response flows back into the UI's open-album state, so
+        # a display edit must NOT blank the album's genres. Guards the shared
+        # AlbumOut.from_album_info() covering all five construction sites (KAMP-550).
+        mock_index.update_album_display.return_value = self._album_info()
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        resp = TestClient(app).patch(
+            "/api/v1/albums/display",
+            json={
+                "album_artist": "Band",
+                "album": "Long Name",
+                "display_album": "Short",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["genres"] == ["Shoegaze"]
 
     def test_returns_updated_album(
         self,


### PR DESCRIPTION
Turns the Artists sidebar into a Library sidebar with **Artists | Genres** mini-tabs. The Genres tab lists every genre in the library; clicking one filters the album grid to albums carrying that genre, composing in-memory with the existing artist/source/qualitative filters exactly like the artist filter. Fixes KAMP-550. Builds directly on KAMP-586's normalized genre model.

## Architecture

- **Filter client-side, over the full in-memory album list** — the album grid composes every filter in render (artist, source, qualitative, now genre). A server `?genre=` param would mutate the shared `albums` array and corrupt sibling filters (e.g. the Top-Albums top-100 computation reads the full array), so genre mirrors the artist path exactly.
- **Structured `genres: list[str]` per album, not a re-split display string.** The sidebar list comes from canonical `all_genres()`; the grid matches on membership against a per-album genre array built in `albums()` **straight from the normalized `track_genres` tables** (canonical names, no string parsing anywhere). One tokenizer — the sidebar list and the grid filter can't diverge on a genre name that happens to contain the `"; "` delimiter.
- **One `AlbumOut.from_album_info()` classmethod.** There were five identical `AlbumInfo → AlbumOut` construction sites; adding `genres` to only some would have silently returned blank genres at three of them (including the album-display-edit response that flows back into the open-album UI state). Collapsed all five to the shared classmethod — the KAMP-554 "enumerate by grep, not memory" lesson, enforced structurally.
- **Mutual exclusivity** — `selectArtist`/`selectGenre` each set their own value and null the sibling; AlbumGrid also applies a deterministic genre-wins precedence so it never depends on only-one-being-set.
- **Mini-tabs are a pure view switch** (never change the active filter), with semantic `role="tab"`/`tablist`/`tabpanel` + `aria-selected`. Instant `display` swap between lists (no height animation — Electron renderer jank, per CLAUDE.md).

## What changed

- **library.py:** `AlbumInfo.genres`; `albums()` populates it via one extra grouped query over `track_genres` keyed by both album_id (named albums) and track_id (missing-album virtual entries, which have no album row).
- **server.py:** `AlbumOut.genres` + `AlbumOut.from_album_info()`; all five construction sites migrated (net −110 lines). `/api/v1/genres` was already added in KAMP-586.
- **UI:** client `Album.genres`; store `genres` + `selectedGenre` + `selectGenre` + `loadLibrary` wiring; `ArtistPanel` mini-tabs + genre list + empty state; `AlbumGrid` genre filter + generalized breadcrumb + empty message; mini-tab CSS. Three synthesized-`Album` call sites (playlist album view, two context menus) get `genres: []`.

## Testing

- Full suite: **2451 passed, 9 skipped**, coverage **93.63%** (flat vs main's post-586 93.63%). black + mypy clean; kamp_ui typecheck + eslint clean.
- New backend tests: `albums()` returns the correct per-album genre union (multi-value, single-genre, missing-album track, untagged); `/api/v1/albums` AlbumOut carries `genres`; the album-display-edit response carries `genres` (regression guard for the five-site silent-blank bug).

## Manual Test Plan

- [ ] Sidebar shows [Artists | Genres] tabs; Artists tab behaves exactly as before
- [ ] Genres tab lists all library genres; clicking one filters the grid; breadcrumb reads "Library › <Genre>"; clicking "Library" clears it
- [ ] A multi-genre album (e.g. Jazz + J-Pop) appears under **both** genres
- [ ] Picking a genre clears any active artist filter and vice versa; "All Genres"/"All Artists" reset rows work
- [ ] Switching tabs alone does NOT change the active filter (filtered by artist, tap Genres → grid unchanged until a genre is picked)
- [ ] A genre with a space ("Free Jazz") filters correctly
- [ ] Zero-genre library: Genres tab shows "No genres tagged yet", tab still present
- [ ] Editing an album's display name or embedding art does not blank its genre in the reopened panel/grid
- [ ] Genre selection survives navigating into an album and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
