### PR TITLE
feat(prefs): dedicated Tagging preferences tab; deprecate trust-MB (KAMP-589)

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3065,8 +3065,6 @@ def create_app(
     _INT_CONFIG_KEYS = frozenset(
         {"artwork.min_dimension", "artwork.max_bytes", "bandcamp.poll_interval_minutes"}
     )
-    # Boolean config keys — stored as Python bool so JSON serialises as true/false.
-    _BOOL_CONFIG_KEYS = frozenset({"musicbrainz.trust-musicbrainz-when-tags-conflict"})
 
     @app.patch("/api/v1/config")
     def patch_config(req: ConfigPatchRequest) -> dict[str, Any]:
@@ -3078,8 +3076,6 @@ def create_app(
         # Coerce to the correct Python type before caching in memory.
         if req.key in _INT_CONFIG_KEYS:
             coerced: Any = int(req.value)
-        elif req.key in _BOOL_CONFIG_KEYS:
-            coerced = req.value.lower() == "true"
         else:
             coerced = req.value
         _state["config"][req.key] = coerced

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -540,7 +540,6 @@ def _build_config_values(
             str(config.paths.watch_folder) if config.paths.watch_folder else None
         ),
         "paths.library": str(config.paths.library) if config.paths.library else None,
-        "musicbrainz.trust-musicbrainz-when-tags-conflict": config.musicbrainz.trust_musicbrainz_when_tags_conflict,
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
         "artwork.save_format": config.artwork.save_format,

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -40,8 +40,10 @@ class PathsConfig:
 
 @dataclass
 class MusicBrainzConfig:
-    # When False: skip ID3 writes when MB artist/album differs from existing tags.
-    trust_musicbrainz_when_tags_conflict: bool = False
+    # Reserved for future MusicBrainz config. KAMP-589 removed the sole field
+    # (trust-when-tags-conflict); the pipeline now always keeps existing file
+    # tags on conflict. Kept as a namespace to avoid churning its ~8 call sites.
+    pass
 
 
 @dataclass
@@ -89,7 +91,6 @@ def _prompt(label: str, default: str) -> str:
 # Default values for all non-path config keys (stored as text in the DB).
 # Last.fm credentials are stored in the OS keychain via the sessions table, not here.
 _CONFIG_DEFAULTS: dict[str, str] = {
-    "musicbrainz.trust-musicbrainz-when-tags-conflict": "false",
     "artwork.min_dimension": "1000",
     "artwork.max_bytes": "1000000",
     "artwork.save_format": "embedded",
@@ -108,7 +109,6 @@ _CONFIG_DEFAULTS: dict[str, str] = {
 _CONFIG_KEY_TYPES: dict[str, type] = {
     "paths.watch_folder": str,
     "paths.library": str,
-    "musicbrainz.trust-musicbrainz-when-tags-conflict": bool,
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,
     "artwork.save_format": str,
@@ -169,6 +169,10 @@ _DEPRECATED_KEY_MESSAGES: dict[str, str] = {
     # Deprecated in TASK-151: Last.fm credentials moved to OS keychain.
     "lastfm.session_key": "Last.fm credentials are managed via the Last.fm connect flow.",
     "lastfm.username": "Last.fm credentials are managed via the Last.fm connect flow.",
+    # Deprecated in KAMP-589: MusicBrainz never overwrites conflicting file tags.
+    "musicbrainz.trust-musicbrainz-when-tags-conflict": (
+        "MusicBrainz no longer overwrites conflicting file tags; this option was removed."
+    ),
 }
 _DEPRECATED_KEYS: frozenset[str] = frozenset(_DEPRECATED_KEY_MESSAGES)
 
@@ -289,9 +293,6 @@ class Config:
         def _get(key: str) -> str:
             return settings.get(key, _CONFIG_DEFAULTS.get(key, ""))
 
-        def _bool(key: str) -> bool:
-            return _get(key).lower() == "true"
-
         def _int(key: str) -> int:
             try:
                 return int(_get(key))
@@ -315,11 +316,7 @@ class Config:
                 watch_folder=_get_path("paths.watch_folder"),
                 library=_get_path("paths.library"),
             ),
-            musicbrainz=MusicBrainzConfig(
-                trust_musicbrainz_when_tags_conflict=_bool(
-                    "musicbrainz.trust-musicbrainz-when-tags-conflict"
-                ),
-            ),
+            musicbrainz=MusicBrainzConfig(),
             artwork=ArtworkConfig(
                 min_dimension=_int("artwork.min_dimension"),
                 max_bytes=_int("artwork.max_bytes"),
@@ -389,11 +386,9 @@ def config_set(db: "LibraryIndex", key: str, value: str) -> None:
         raise KeyError(f"Unknown config key {key!r}. Valid keys: {valid}")
 
     target_type = _CONFIG_KEY_TYPES[key]
-    if target_type == bool:
-        if value.lower() not in ("true", "false"):
-            raise ValueError(f"Key {key!r} requires true or false, got {value!r}")
-        db_value = value.lower()
-    elif target_type == int:
+    # No bool config keys remain after KAMP-589; re-add a bool branch here (with
+    # a test) when the next bool key lands.
+    if target_type == int:
         try:
             db_value = str(int(value))
         except ValueError:

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -212,14 +212,13 @@ def run(
                 tracks = [read_track_metadata_from_file(f) for f in audio_files]
                 tagger = KampMusicBrainzTagger(ctx)
                 enriched = tagger.tag_release(tracks)
-                if (
-                    not config.musicbrainz.trust_musicbrainz_when_tags_conflict
-                    and _mb_tags_conflict(tracks, enriched)
-                ):
+                if _mb_tags_conflict(tracks, enriched):
                     # MB returned different artist/album than the existing file
                     # tags — likely a mis-match for a release not yet in the DB.
                     # Keep the existing ID3 tags but still use the MB MBID for
                     # artwork: the MBID is valid even if the name strings differ.
+                    # KAMP-589 removed the trust-MB override, so this is always
+                    # the conflict path.
                     first = tracks[0] if tracks else None
                     logger.warning(
                         "MusicBrainz tags conflict with existing file tags "

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -405,7 +405,6 @@ export type ConfigValues = {
   'paths.watch_folder': string | null
   'paths.library': string | null
   'musicbrainz.contact': string | null
-  'musicbrainz.trust-musicbrainz-when-tags-conflict': boolean | null
   'artwork.min_dimension': number | null
   'artwork.max_bytes': number | null
   'artwork.save_format': string | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -940,7 +940,7 @@ export function PreferencesDialog({
   const scanStatus = useStore((s) => s.scanStatus)
   const scanProgress = useStore((s) => s.scanProgress)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
-  const [activeTab, setActiveTab] = useState<'general' | 'services' | 'extensions'>(
+  const [activeTab, setActiveTab] = useState<'general' | 'tagging' | 'services' | 'extensions'>(
     () => prefsInitialTab
   )
 
@@ -998,9 +998,10 @@ export function PreferencesDialog({
 
   if (!prefsOpen) return null
 
-  // Show a loading placeholder while config is being fetched (General/Services tabs).
+  // Show a loading placeholder while config is being fetched (config-backed tabs).
   const configLoading =
-    configValues === null && (activeTab === 'general' || activeTab === 'services')
+    configValues === null &&
+    (activeTab === 'general' || activeTab === 'tagging' || activeTab === 'services')
 
   const hasBandcamp = configValues !== null
 
@@ -1055,6 +1056,14 @@ export function PreferencesDialog({
             onClick={() => setActiveTab('general')}
           >
             General
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'tagging'}
+            className={`prefs-tab${activeTab === 'tagging' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('tagging')}
+          >
+            Tagging
           </button>
           <button
             role="tab"
@@ -1139,6 +1148,31 @@ export function PreferencesDialog({
                     />
                   </div>
 
+                  {/* ABOUT */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">About</div>
+                    <div className="prefs-row">
+                      <button
+                        className="prefs-choose-btn"
+                        onClick={() => window.api.openExternal(DISCORD_INVITE_URL)}
+                      >
+                        <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                          <DiscordIcon size={16} />
+                          Join Discord
+                        </span>
+                      </button>
+                      <p className="prefs-hint">Give feedback and connect with other Kamp users.</p>
+                    </div>
+                  </div>
+                </>
+              )}
+            </>
+          )}
+
+          {activeTab === 'tagging' && (
+            <>
+              {configLoading ? null : (
+                <>
                   {/* ARTWORK */}
                   <div className="prefs-section">
                     <div className="prefs-section-label">Artwork</div>
@@ -1165,23 +1199,6 @@ export function PreferencesDialog({
                       initialValue={str('artwork.save_format') !== 'cover-file'}
                       onSave={handleArtworkSave}
                     />
-                  </div>
-
-                  {/* ABOUT */}
-                  <div className="prefs-section">
-                    <div className="prefs-section-label">About</div>
-                    <div className="prefs-row">
-                      <button
-                        className="prefs-choose-btn"
-                        onClick={() => window.api.openExternal(DISCORD_INVITE_URL)}
-                      >
-                        <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                          <DiscordIcon size={16} />
-                          Join Discord
-                        </span>
-                      </button>
-                      <p className="prefs-hint">Give feedback and connect with other Kamp users.</p>
-                    </div>
                   </div>
                 </>
               )}
@@ -1238,20 +1255,6 @@ export function PreferencesDialog({
                     onConnected={() => void loadConfig()}
                     onDisconnected={() => void loadConfig()}
                   />
-
-                  {/* MUSICBRAINZ */}
-                  <div className="prefs-section">
-                    <div className="prefs-section-label">MusicBrainz</div>
-                    <BoolRow
-                      label="Trust MusicBrainz when tags conflict"
-                      configKey="musicbrainz.trust-musicbrainz-when-tags-conflict"
-                      hint="When off, if MusicBrainz returns a different artist or album than the file's existing tags, the ID3 tags are left unchanged and only artwork is updated."
-                      initialValue={
-                        configValues?.['musicbrainz.trust-musicbrainz-when-tags-conflict'] ?? true
-                      }
-                      onSave={handleSave}
-                    />
-                  </div>
                 </>
               )}
             </>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture
 from kamp_core.library import LibraryIndex
 from kamp_daemon.config import (
     _CONFIG_DEFAULTS,
+    _CONFIG_KEY_TYPES,
     Config,
     LastfmConfig,
     BandcampConfig,
@@ -37,7 +38,7 @@ def db(tmp_path: Path, mocker: MockerFixture) -> LibraryIndex:
 
 
 class TestWriteDefaults:
-    def test_writes_all_11_keys(self, db: LibraryIndex) -> None:
+    def test_writes_all_default_keys(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
         settings = db.get_all_settings()
         assert len(settings) == len(_CONFIG_DEFAULTS)
@@ -57,7 +58,6 @@ class TestLoad:
         # Paths have no default — they are None until the user sets them via onboarding.
         assert config.paths.watch_folder is None
         assert config.paths.library is None
-        assert config.musicbrainz.trust_musicbrainz_when_tags_conflict is False
         assert config.artwork.min_dimension == 1000
         assert config.artwork.max_bytes == 1_000_000
         assert config.bandcamp is not None
@@ -189,13 +189,14 @@ class TestConfigShow:
         Config.write_defaults(db)
         output = config_show(db)
         assert "[paths]" in output
-        assert "[musicbrainz]" in output
         assert "[artwork]" in output
         assert "[library]" in output
         assert "[bandcamp]" in output
         assert "[ui]" in output
         # Last.fm credentials are in the session store, not config — no [lastfm] section.
         assert "[lastfm]" not in output
+        # KAMP-589 removed the only musicbrainz key, so its section is gone too.
+        assert "[musicbrainz]" not in output
 
     def test_includes_key_value_pairs(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
@@ -228,14 +229,6 @@ class TestConfigSet:
         config_set(db, "artwork.min_dimension", "500")
         assert db.get_setting("artwork.min_dimension") == "500"
 
-    def test_set_bool_key(self, db: LibraryIndex) -> None:
-        Config.write_defaults(db)
-        config_set(db, "musicbrainz.trust-musicbrainz-when-tags-conflict", "false")
-        assert (
-            db.get_setting("musicbrainz.trust-musicbrainz-when-tags-conflict")
-            == "false"
-        )
-
     def test_round_trip_load_after_set(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
         config_set(db, "paths.watch_folder", "~/round/trip")
@@ -250,10 +243,6 @@ class TestConfigSet:
     def test_wrong_type_raises_value_error(self, db: LibraryIndex) -> None:
         with pytest.raises(ValueError, match="requires an integer"):
             config_set(db, "artwork.min_dimension", "not-an-int")
-
-    def test_bool_wrong_value_raises_value_error(self, db: LibraryIndex) -> None:
-        with pytest.raises(ValueError, match="requires true or false"):
-            config_set(db, "musicbrainz.trust-musicbrainz-when-tags-conflict", "yes")
 
     def test_bandcamp_format_valid_value_succeeds(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
@@ -307,6 +296,16 @@ class TestConfigSet:
     def test_set_lastfm_session_key_raises_deprecated(self, db: LibraryIndex) -> None:
         with pytest.raises(KeyError, match="deprecated"):
             config_set(db, "lastfm.session_key", "newkey")
+
+    def test_deprecated_trust_musicbrainz_raises(self, db: LibraryIndex) -> None:
+        # KAMP-589: the trust-MusicBrainz option was removed; setting it hints.
+        with pytest.raises(KeyError, match="deprecated"):
+            config_set(db, "musicbrainz.trust-musicbrainz-when-tags-conflict", "true")
+
+    def test_trust_musicbrainz_absent_from_key_types(self) -> None:
+        assert (
+            "musicbrainz.trust-musicbrainz-when-tags-conflict" not in _CONFIG_KEY_TYPES
+        )
 
     def test_path_key_relative_raises(self, db: LibraryIndex) -> None:
         with pytest.raises(ValueError, match="requires an absolute path"):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -721,15 +721,13 @@ class TestMbTagsConflict:
 # ---------------------------------------------------------------------------
 
 
-def _make_conflict_config(tmp_path: Path, trust: bool) -> Config:
+def _make_conflict_config(tmp_path: Path) -> Config:
     return Config(
         paths=PathsConfig(
             watch_folder=tmp_path / "watch",
             library=tmp_path / "library",
         ),
-        musicbrainz=MusicBrainzConfig(
-            trust_musicbrainz_when_tags_conflict=trust,
-        ),
+        musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=5_000_000),
         library=LibraryConfig(
             path_template="{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}"
@@ -762,7 +760,8 @@ MB_CONFLICTING_TRACKS = [
 
 
 class TestMbConflictFallback:
-    """When trust=False and MB returns mismatched tags, ID3 writes are skipped."""
+    """When MB returns mismatched tags, ID3 writes are skipped (KAMP-589: always;
+    the trust-MB override was removed) but artwork still uses the MB MBID."""
 
     def _setup_album(self, config: Config) -> tuple[Path, Path]:
         config.paths.watch_folder.mkdir(parents=True)
@@ -773,9 +772,9 @@ class TestMbConflictFallback:
         _make_mp3_with_tags(mp3, artist="File Artist", album="File Album")
         return album_dir, mp3
 
-    def test_skips_id3_write_on_conflict_when_not_trusted(self, tmp_path: Path) -> None:
-        """When trust=False and tags conflict, write_tags_from_track_metadata is not called."""
-        config = _make_conflict_config(tmp_path, trust=False)
+    def test_skips_id3_write_on_conflict(self, tmp_path: Path) -> None:
+        """When tags conflict, write_tags_from_track_metadata is not called (KAMP-589)."""
+        config = _make_conflict_config(tmp_path)
         album_dir, mp3 = self._setup_album(config)
 
         with (
@@ -792,11 +791,9 @@ class TestMbConflictFallback:
 
         mock_write.assert_not_called()
 
-    def test_artwork_still_runs_on_conflict_when_not_trusted(
-        self, tmp_path: Path
-    ) -> None:
+    def test_artwork_still_runs_on_conflict(self, tmp_path: Path) -> None:
         """Artwork step always runs even when ID3 tags are skipped due to conflict."""
-        config = _make_conflict_config(tmp_path, trust=False)
+        config = _make_conflict_config(tmp_path)
         album_dir, mp3 = self._setup_album(config)
 
         with (
@@ -818,28 +815,9 @@ class TestMbConflictFallback:
         assert call_kwargs.kwargs["release_mbid"] == "rel-123"
         assert call_kwargs.kwargs["release_group_mbid"] == "rg-123"
 
-    def test_writes_id3_when_trusted_despite_conflict(self, tmp_path: Path) -> None:
-        """When trust=True (default), MB tags are written even if they differ."""
-        config = _make_conflict_config(tmp_path, trust=True)
-        album_dir, mp3 = self._setup_album(config)
-
-        with (
-            patch.object(
-                KampMusicBrainzTagger, "tag_release", return_value=MB_CONFLICTING_TRACKS
-            ),
-            patch(
-                "kamp_daemon.pipeline_impl.write_tags_from_track_metadata"
-            ) as mock_write,
-            patch("kamp_daemon.pipeline_impl._fetch_and_embed_via_extension"),
-            patch("kamp_daemon.pipeline_impl.move_to_library", return_value=[mp3]),
-        ):
-            run(album_dir, config)
-
-        mock_write.assert_called_once()
-
     def test_writes_id3_when_no_conflict(self, tmp_path: Path) -> None:
-        """When tags agree with MB, ID3 is written normally even with trust=False."""
-        config = _make_conflict_config(tmp_path, trust=False)
+        """When tags agree with MB, ID3 is written normally (no conflict)."""
+        config = _make_conflict_config(tmp_path)
         config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
         album_dir = config.paths.watch_folder / "mb-album"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -179,9 +179,8 @@ class TestReload:
         """reload() replaces the stored config."""
         syncer = Syncer(_make_config(tmp_path, poll_interval=0))
         new_config = _make_config(tmp_path, poll_interval=0)
-        new_config.musicbrainz.trust_musicbrainz_when_tags_conflict = False
         syncer.reload(new_config)
-        assert syncer._config.musicbrainz.trust_musicbrainz_when_tags_conflict is False
+        assert syncer._config is new_config
 
     def test_reload_changed_interval_no_existing_thread(self, tmp_path: Path) -> None:
         """reload() with interval change when no thread was running starts one."""


### PR DESCRIPTION
Adds a dedicated **Tagging** tab to Preferences and **deprecates the trust-MusicBrainz option**. Fixes KAMP-589. This is also the home KAMP-591 (Update Library Genres button) and KAMP-587 (genre-source toggles) will build on.

## What changed

**UI:** Preferences now shows **General | Tagging | Services | Extensions**. The artwork prefs — Minimum dimension, Maximum file size, and "Embed album art in media files?" — moved from General into the new Tagging tab. The Services tab's MusicBrainz section (the trust toggle) is removed. The `ConfigValues` client type drops the trust key alongside it.

**Deprecation:** `musicbrainz.trust-musicbrainz-when-tags-conflict` was the only path that let MusicBrainz overwrite conflicting file tags. It's removed; the surviving behavior is the former default (`trust=False`): on an artist/album conflict between MusicBrainz and the file's existing tags, **keep the file's ID3 tags** and still **adopt the MB MBID for artwork**. The pipeline condition is now unconditional (`if _mb_tags_conflict(...)`). Setting the key via `kamp config set` now returns a deprecation hint; a lingering value in an existing DB is silently ignored (no migration needed).

**Dead-code cascade:** trust was the *only* bool config key, so its removal takes the now-unreachable bool-handling with it — the config `_bool` helper, `config_set`'s bool branch, and the server's `_BOOL_CONFIG_KEYS` + its coercion branch — each with a comment so the next bool key re-adds a *tested* branch rather than shipping an uncovered one. `MusicBrainzConfig` is kept as an empty (reserved) dataclass to avoid churning its ~8 construction sites across the daemon + 6 test fixtures.

## Testing

- Full suite: **2458 passed, 9 skipped**, coverage **93.67%** (up from main's 93.64% — the dead-code removal). black + mypy clean; kamp_ui typecheck + eslint clean.
- Backend tests: new deprecation test (`config_set` on the key raises the hint; key absent from the type registry); `config_show` no longer emits a `[musicbrainz]` section; the pipeline conflict-fallback tests now assert the permanent behavior (conflict → no ID3 write, artwork still uses the MB MBID; no-conflict → ID3 written); the deleted trust=True test and the obsolete bool-key tests are removed.

## Manual Test Plan

- [ ] Preferences shows four tabs: General, Tagging, Services, Extensions
- [ ] Tagging tab has Minimum dimension, Maximum file size, "Embed album art in media files?" — each persists and round-trips on reopen
- [ ] General no longer shows Artwork; Services no longer shows a MusicBrainz section
- [ ] Opening straight onto the Tagging tab shows the fields populated (no blank flash)
- [ ] `kamp config set musicbrainz.trust-musicbrainz-when-tags-conflict true` returns the deprecation hint, not a silent success
- [ ] Tag/sync an album whose file tags differ from MusicBrainz → file ID3 tags preserved, artwork still fetched
- [ ] Launch against a copy of the production DB (which may still hold the old key) → clean startup, key ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
