### PR TITLE
feat(bandcamp): apply album tags as genres for streamed albums (KAMP-588)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 57
+_SCHEMA_VERSION = 58
 
 
 class NoStreamableVersionError(Exception):
@@ -412,7 +412,10 @@ CREATE TABLE IF NOT EXISTS bandcamp_collection (
     mode                  TEXT NOT NULL DEFAULT 'local',
     synced_at             REAL,
     added_at              REAL NOT NULL DEFAULT 0,
-    num_streamable_tracks INTEGER NOT NULL DEFAULT 0
+    num_streamable_tracks INTEGER NOT NULL DEFAULT 0,
+    -- KAMP-588: JSON array of the album's Bandcamp tags, cached at sync time so a
+    -- later download can stamp them into the files (and KAMP-591 has a fast path).
+    keywords              TEXT
 );
 
 -- Serialized album download queue (KAMP-408; extended into a platform-neutral
@@ -766,6 +769,10 @@ class DownloadOverrides:
     album: str
     titles: dict[int, str]
     artists: dict[int, str] = field(default_factory=dict)
+    # KAMP-588: the album's cached Bandcamp tags, written into the downloaded
+    # files' genre tags at ingest so the local files carry them (the scan then
+    # round-trips them to track_genres). Empty when none were cached.
+    genres: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -2404,7 +2411,25 @@ class LibraryIndex:
             self._rebuild_fts()
             self._conn.execute("UPDATE schema_version SET version = 57")
             self._conn.commit()
-            version = 57  # noqa: F841
+            version = 57
+
+        if version == 57:
+            # v57 -> v58 (KAMP-588): bandcamp_collection gains a keywords column
+            # (JSON array of the album's Bandcamp tags). Unconstrained nullable
+            # column, so a plain ADD COLUMN suffices (not the FK-aware rebuild);
+            # the table is not projected through tracks_with_stats, so no
+            # DROP-VIEW-first trap. Guard on presence for idempotency.
+            _bccols = {
+                r[1]
+                for r in self._conn.execute("PRAGMA table_info(bandcamp_collection)")
+            }
+            if "keywords" not in _bccols:
+                self._conn.execute(
+                    "ALTER TABLE bandcamp_collection ADD COLUMN keywords TEXT"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 58")
+            self._conn.commit()
+            version = 58  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -3899,6 +3924,17 @@ class LibraryIndex:
         )
         self._conn.commit()
         return cur.rowcount > 0
+
+    def set_collection_keywords(self, sale_item_id: str, keywords: list[str]) -> None:
+        """Cache an album's Bandcamp tags (KAMP-588) as a JSON array on its
+        collection row, so a later download can stamp them into the files and the
+        KAMP-591 backfill has a fast path. Dedicated setter (not folded into
+        upsert_collection_item, whose 6 tagless call sites stay untouched)."""
+        self._conn.execute(
+            "UPDATE bandcamp_collection SET keywords = ? WHERE sale_item_id = ?",
+            (json.dumps(keywords), sale_item_id),
+        )
+        self._conn.commit()
 
     def get_remote_collection(self) -> list[dict[str, Any]]:
         """Return all bandcamp_collection rows with mode='remote'."""
@@ -6667,6 +6703,16 @@ class LibraryIndex:
             (sale_item_id,),
         ).fetchone()
 
+        # KAMP-588: the Bandcamp tags cached on the collection row (independent of
+        # any albums row) — stamped into the downloaded files as genres.
+        kw_row = self._conn.execute(
+            "SELECT keywords FROM bandcamp_collection WHERE sale_item_id = ?",
+            (sale_item_id,),
+        ).fetchone()
+        genres: list[str] = (
+            json.loads(kw_row["keywords"]) if kw_row and kw_row["keywords"] else []
+        )
+
         titles: dict[int, str] = {}
         artists: dict[int, str] = {}
         if album is not None:
@@ -6698,6 +6744,7 @@ class LibraryIndex:
                 album=album["display_album"] or album["album"],
                 titles=titles,
                 artists=artists,
+                genres=genres,
             )
 
         # No synced album row (downloaded without syncing streaming rows): fall
@@ -6713,6 +6760,7 @@ class LibraryIndex:
             album_artist=(bc["band_name"] or "").strip(),
             album=(bc["item_title"] or "").strip(),
             titles=titles,
+            genres=genres,
         )
 
     def search(self, query: str) -> list[Track]:

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -584,6 +584,10 @@ def sync_collection_stream(
                 )
                 if tracks:
                     index.upsert_many(tracks)
+                    # KAMP-588: cache the album's Bandcamp tags so a later download
+                    # can stamp them into the files (and KAMP-591 has a fast path).
+                    # All tracks share the album keywords.
+                    index.set_collection_keywords(str(sid), tracks[0].genres)
                     track_count += len(tracks)
                     logger.debug(
                         "Indexed %d track(s) for %r by %r",
@@ -1161,6 +1165,75 @@ def fetch_stream_url(
     )
 
 
+# Bandcamp tags that describe the format/medium rather than a genre — dropped so
+# they don't pollute the genre list (KAMP-588). Location tags (cities/countries)
+# are an unbounded set and are left in; the user prunes them via the KAMP-586
+# chips editor. Compared case-folded.
+_KEYWORD_FORMAT_DENYLIST = frozenset(
+    {
+        "vinyl",
+        "vinyl lp",
+        "cassette",
+        "tape",
+        "cd",
+        "compact disc",
+        "digital",
+        "download",
+        "lp",
+        "ep",
+        "7 inch",
+        "10 inch",
+        "12 inch",
+        "merch",
+    }
+)
+
+
+def parse_album_keywords(html: str) -> list[str]:
+    """Extract artist-supplied Bandcamp tags from an album page as genre names.
+
+    Multi-source, most genre-precise first (KAMP-588): the ``<a class="tag">``
+    links are the artist's own tags with no artist/album-name pollution; the
+    ld+json ``keywords`` field is a robust fallback if the markup changes.
+    HTML-unescaped, stripped, case-insensitively de-duplicated, order-preserving;
+    format/medium words (see denylist) are dropped. Returns ``[]`` when nothing
+    is found — callers WARN if a real page yielded none so a Cloudflare challenge
+    page or a markup change can't ship the feature silently dead.
+    """
+    raw: list[str] = []
+
+    # 1. <a class="tag" href="/tag/...">text</a> — tolerant of attribute order.
+    raw.extend(
+        re.findall(r'<a\b[^>]*\bclass="tag"[^>]*>([^<]+)</a>', html, re.IGNORECASE)
+    )
+
+    # 2. Fallback: the ld+json MusicAlbum "keywords" (list or comma string).
+    if not raw:
+        for m in re.finditer(
+            r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+            html,
+            re.DOTALL | re.IGNORECASE,
+        ):
+            try:
+                data = json.loads(m.group(1))
+            except (ValueError, TypeError):
+                continue
+            kw = data.get("keywords") if isinstance(data, dict) else None
+            if isinstance(kw, str):
+                raw.extend(kw.split(","))
+            elif isinstance(kw, list):
+                raw.extend(str(k) for k in kw)
+            if raw:
+                break
+
+    seen: dict[str, str] = {}
+    for token in raw:
+        name = html_lib.unescape(token).strip()
+        if name and name.casefold() not in _KEYWORD_FORMAT_DENYLIST:
+            seen.setdefault(name.casefold(), name)
+    return list(seen.values())
+
+
 def fetch_album_tracks(
     album_url: str,
     sale_item_id: int,
@@ -1208,6 +1281,14 @@ def fetch_album_tracks(
         year_match = re.search(r"\b(19|20)\d{2}\b", raw_release_date)
         release_date_iso = year_match.group(0) if year_match else ""
 
+    # KAMP-588: artist-supplied Bandcamp tags → genres, from the page HTML already
+    # fetched. WARN when a fetched page yields none so a markup change or a
+    # Cloudflare challenge page can't ship the feature silently dead — most
+    # Bandcamp albums are tagged.
+    keywords = parse_album_keywords(resp.text)
+    if not keywords:
+        logger.warning("fetch_album_tracks: no Bandcamp tags parsed for %s", album_url)
+
     result: list[Track] = []
     for t in trackinfo:
         track_num = t.get("track_num") or (1 if is_single_track else None)
@@ -1235,6 +1316,7 @@ def fetch_album_tracks(
                 date_added=date_added if date_added is not None else time.time(),
                 is_available=is_available,
                 duration=float(t.get("duration") or 0.0),
+                genres=list(keywords),
             )
         )
     return result

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -385,6 +385,14 @@ def _tag_known_bandcamp(
         track.release_group_mbid = rg_mbid
         write_tags_from_track_metadata(audio_file, track, total_tracks=total)
         write_sale_item_id(audio_file, provenance.sale_item_id)
+        # KAMP-588: stamp the album's cached Bandcamp tags as native multi-value
+        # genres so the downloaded files carry them; the watch-folder scan then
+        # round-trips them into track_genres. Replace-semantics, so it doesn't
+        # duplicate any genre frame write_tags_from_track_metadata left.
+        if overrides is not None and overrides.genres:
+            from kamp_core.library import write_meta_tags_to_file  # noqa: PLC0415
+
+            write_meta_tags_to_file(audio_file, genres=overrides.genres)
 
     if overrides is not None and overrides.album:
         title = overrides.album

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -40,6 +40,7 @@ from kamp_daemon.bandcamp import (
     fetch_stream_url,
     get_download_size_bytes,
     mark_collection_synced,
+    parse_album_keywords,
     prefetch_redownload_urls,
     refresh_stream_url,
     sync_collection_stream,
@@ -2708,6 +2709,36 @@ class TestSyncCollectionStream:
         assert album_count == 2  # both albums counted in bandcamp_collection
         assert track_count == 0  # no tracks indexed (fetch failed)
 
+    def test_caches_album_keywords_after_indexing(self, tmp_path: Path) -> None:
+        # KAMP-588: after a streamed album is indexed, its Bandcamp tags (carried
+        # on the tracks' genres) are cached on the collection row for downloads.
+        from pathlib import Path as _Path
+
+        from kamp_core.library import Track
+
+        track = Track(
+            file_path=_Path("bandcamp://1/1"),
+            title="T",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            genres=["shoegaze", "dream pop"],
+        )
+        _result, index = self._run(
+            tmp_path, [_item(1)], already_have_tracks=False, fake_tracks=[track]
+        )
+        index.set_collection_keywords.assert_called_once_with(
+            "1", ["shoegaze", "dream pop"]
+        )
+
     def test_batch_indexed_callback_fires_per_new_batch(self, tmp_path: Path) -> None:
         """batch_indexed_callback fires once per album batch that has new tracks."""
         from kamp_core.library import Track
@@ -3026,6 +3057,31 @@ class TestFetchAlbumTracks:
             "https://x.bandcamp.com/album/y", 1, "B", "A", self._make_session(html)
         )
         assert all(t.source == "bandcamp" for t in result)
+
+    def test_sets_genres_from_bandcamp_tags(self) -> None:
+        # KAMP-588: artist tags in the page HTML become Track.genres (format words
+        # dropped); applied to every track on the album.
+        html = _stream_album_page_html(
+            tracks=[{"title": "T", "track_num": 1, "artist": None, "duration": 100.0}]
+        ).replace(
+            "</body>",
+            '<a class="tag" href="/tag/shoegaze">shoegaze</a>'
+            '<a class="tag" href="/tag/vinyl">vinyl</a></body>',
+        )
+        result = fetch_album_tracks(
+            "https://b.bandcamp.com/album/x", 1, "B", "A", self._make_session(html)
+        )
+        assert result[0].genres == ["shoegaze"]  # vinyl dropped
+
+    def test_no_tags_leaves_genres_empty(self) -> None:
+        result = fetch_album_tracks(
+            "https://b.bandcamp.com/album/x",
+            1,
+            "B",
+            "A",
+            self._make_session(_stream_album_page_html()),
+        )
+        assert all(t.genres == [] for t in result)
 
     def test_no_stream_url(self) -> None:
         html = _stream_album_page_html()
@@ -3776,3 +3832,77 @@ class TestBackfillDownloadSizes:
         assert n == 2
         fetch.assert_not_called()
         fan.assert_not_called()
+
+
+class TestParseAlbumKeywords:
+    """Bandcamp album-page tag extraction → genre names (KAMP-588)."""
+
+    def test_extracts_tag_links(self) -> None:
+        html = (
+            '<div class="tralbum-tags">'
+            '<a class="tag" href="/tag/shoegaze">shoegaze</a>'
+            '<a class="tag" href="/tag/dream-pop">dream pop</a>'
+            "</div>"
+        )
+        assert parse_album_keywords(html) == ["shoegaze", "dream pop"]
+
+    def test_tolerates_attribute_order(self) -> None:
+        # href before class, extra attributes.
+        html = '<a href="/tag/noise" data-x="1" class="tag" rel="tag">noise</a>'
+        assert parse_album_keywords(html) == ["noise"]
+
+    def test_unescapes_entities(self) -> None:
+        html = '<a class="tag" href="/tag/drum-bass">drum &amp; bass</a>'
+        assert parse_album_keywords(html) == ["drum & bass"]
+
+    def test_case_insensitive_dedupe_order_preserving(self) -> None:
+        html = (
+            '<a class="tag" href="/tag/techno">Techno</a>'
+            '<a class="tag" href="/tag/house">house</a>'
+            '<a class="tag" href="/tag/techno">techno</a>'
+        )
+        # first-seen casing wins; order preserved; no duplicate.
+        assert parse_album_keywords(html) == ["Techno", "house"]
+
+    def test_drops_format_words(self) -> None:
+        html = (
+            '<a class="tag" href="/tag/ambient">ambient</a>'
+            '<a class="tag" href="/tag/vinyl">vinyl</a>'
+            '<a class="tag" href="/tag/cassette">Cassette</a>'
+        )
+        assert parse_album_keywords(html) == ["ambient"]
+
+    def test_keeps_location_tags(self) -> None:
+        # Locations are unbounded — left in for the user to prune.
+        html = (
+            '<a class="tag" href="/tag/post-punk">post-punk</a>'
+            '<a class="tag" href="/tag/seattle">seattle</a>'
+        )
+        assert parse_album_keywords(html) == ["post-punk", "seattle"]
+
+    def test_ldjson_fallback_when_no_tag_links(self) -> None:
+        html = (
+            '<script type="application/ld+json">'
+            '{"@type": "MusicAlbum", "keywords": ["jazz", "fusion"]}'
+            "</script>"
+        )
+        assert parse_album_keywords(html) == ["jazz", "fusion"]
+
+    def test_ldjson_comma_string_keywords(self) -> None:
+        html = (
+            '<script type="application/ld+json">'
+            '{"keywords": "jazz, fusion, vinyl"}'
+            "</script>"
+        )
+        # comma-split, format word dropped.
+        assert parse_album_keywords(html) == ["jazz", "fusion"]
+
+    def test_tag_links_preferred_over_ldjson(self) -> None:
+        html = (
+            '<a class="tag" href="/tag/metal">metal</a>'
+            '<script type="application/ld+json">{"keywords": ["pop"]}</script>'
+        )
+        assert parse_album_keywords(html) == ["metal"]
+
+    def test_empty_when_no_tags(self) -> None:
+        assert parse_album_keywords("<html><body>no tags here</body></html>") == []

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 57
+        assert version == 58
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 57
+        assert version == 58
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 57
+        assert ver == 58
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 57
+        assert ver == 58
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 57
+        assert ver == 58
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 57
+        assert ver == 58
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3358,7 +3358,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3415,7 +3415,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3792,7 +3792,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -3835,7 +3835,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -3902,7 +3902,7 @@ class TestPreorderResurface:
         ).fetchone()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "redownload_url" in cols
         # Existing row survived; the new column is NULL for pre-existing data.
         assert row["provider_item_id"] == "keep"
@@ -3928,7 +3928,7 @@ class TestPreorderResurface:
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -4282,7 +4282,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert row is not None
         assert row[0] == 0
 
@@ -4747,7 +4747,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4860,7 +4860,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -5044,7 +5044,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -5139,7 +5139,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 57
+        assert version == 58
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -5147,7 +5147,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 57
+        assert version == 58
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -6074,7 +6074,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 57
+        assert version == 58
 
         index.close()
 
@@ -6805,7 +6805,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 57
+        assert version == 58
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6840,7 +6840,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 57
+        assert version == 58
         index.close()
 
 
@@ -7381,7 +7381,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 57
+        assert version == 58
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7514,7 +7514,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 57
+        assert version == 58
 
 
 class TestRemoteTrackSchema:
@@ -7930,7 +7930,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7991,7 +7991,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8813,7 +8813,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -9746,7 +9746,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9824,7 +9824,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -10033,7 +10033,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -10273,7 +10273,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10373,7 +10373,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10489,7 +10489,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10994,7 +10994,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -11109,7 +11109,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -11207,7 +11207,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -11307,7 +11307,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -11814,7 +11814,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 57
+        assert version == 58
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -12698,7 +12698,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 57
+        assert version == 58
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -13126,6 +13126,28 @@ class TestMultiValueGenre:
         assert [r["name"] for r in rows] == ["J-Pop", "Jazz"]
         # denormalized display string is the canonical "; "-join
         assert track.genre == "J-Pop; Jazz"
+
+    def test_local_rescan_replaces_genres(self, tmp_path: Path) -> None:
+        # KAMP-588 round-trip guard: re-scanning a local file with new genres
+        # REPLACES its track_genres (not merges) — so a downloaded file whose
+        # genres were stamped at ingest lands exactly those, and a later edit on
+        # disk overrides. The stream empty-guard does not apply to local files.
+        index = self._index(tmp_path)
+        path = tmp_path / "1.mp3"
+        index.upsert_many([self._local(path, ["Jazz"])])
+        index.upsert_many([self._local(path, ["Techno", "House"])])
+        track = index.all_tracks()[0]
+        rows = [
+            r["name"]
+            for r in index._conn.execute(
+                "SELECT g.name FROM track_genres tg JOIN genres g ON g.id = tg.genre_id"
+                " WHERE tg.track_id = ? ORDER BY g.name",
+                (track.id,),
+            )
+        ]
+        index.close()
+        assert rows == ["House", "Techno"]  # replaced, no lingering "Jazz"
+        assert track.genre == "House; Techno"
 
     def test_case_insensitive_dedup_first_seen_casing(self, tmp_path: Path) -> None:
         index = self._index(tmp_path)
@@ -13939,6 +13961,59 @@ class TestProvenanceLinking:
         index.close()
 
 
+class TestCollectionKeywords:
+    """bandcamp_collection.keywords cache column + setter (KAMP-588)."""
+
+    def test_fresh_db_has_keywords_column(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        cols = {
+            r[1] for r in index._conn.execute("PRAGMA table_info(bandcamp_collection)")
+        }
+        index.close()
+        assert "keywords" in cols
+
+    def test_set_collection_keywords_roundtrip(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("S1", mode="local", band_name="A", item_title="B")
+        index.set_collection_keywords("S1", ["Shoegaze", "Dream Pop"])
+        raw = index._conn.execute(
+            "SELECT keywords FROM bandcamp_collection WHERE sale_item_id = 'S1'"
+        ).fetchone()[0]
+        index.close()
+        assert json.loads(raw) == ["Shoegaze", "Dream Pop"]
+
+    def test_migration_v57_adds_keywords_column(self, tmp_path: Path) -> None:
+        # A pre-v58 DB has a bandcamp_collection without keywords. Opening it must
+        # add the column and preserve existing rows (KAMP-588). Simulate the old
+        # shape by rebuilding the table without keywords (mirrors a real pre-v58
+        # DB more faithfully than DROP COLUMN).
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index.close()
+        conn = sqlite3.connect(str(db))
+        conn.execute("DROP TABLE bandcamp_collection")
+        conn.execute(
+            "CREATE TABLE bandcamp_collection ("
+            " sale_item_id TEXT PRIMARY KEY, band_name TEXT NOT NULL DEFAULT '')"
+        )
+        conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, band_name)"
+            " VALUES ('S1', 'A')"
+        )
+        conn.execute("UPDATE schema_version SET version = 57")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db)
+        cols = {
+            r[1] for r in index._conn.execute("PRAGMA table_info(bandcamp_collection)")
+        }
+        row = index.get_collection_item("S1")
+        index.close()
+        assert "keywords" in cols
+        assert row is not None and row["band_name"] == "A"
+
+
 class TestDownloadOverrides:
     def test_empty_when_item_unknown(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
@@ -13959,6 +14034,24 @@ class TestDownloadOverrides:
         assert ov.album_artist == "Ohm Foam"
         assert ov.album == "Gush"
         index.close()
+
+    def test_returns_cached_keywords_as_genres(self, tmp_path: Path) -> None:
+        # KAMP-588: cached Bandcamp tags surface as overrides.genres for the
+        # download pipeline to stamp into the files.
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("S1", mode="local", band_name="A", item_title="B")
+        index.upsert_many([_prov_stream_track("S1", "A", "B", n=1)])
+        index.set_collection_keywords("S1", ["shoegaze", "dream pop"])
+        ov = index.download_overrides_for_sale_item("S1")
+        index.close()
+        assert ov.genres == ["shoegaze", "dream pop"]
+
+    def test_genres_empty_when_no_keywords_cached(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_collection_item("S1", mode="local", band_name="A", item_title="B")
+        ov = index.download_overrides_for_sale_item("S1")
+        index.close()
+        assert ov.genres == []
 
     def test_falls_back_to_collection_when_album_row_absent(
         self, tmp_path: Path
@@ -14321,7 +14414,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 57
+        assert version == 58
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -14341,7 +14434,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 57
+        assert version == 58
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -14384,7 +14477,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 57
+        assert version == 58
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -14663,7 +14756,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 57
+        assert ver == 58
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1176,6 +1176,36 @@ class TestKnownBandcampBranch:
         assert idx.pending_ingest_for_path(str(extracted)) is None
         idx.close()
 
+    def test_writes_cached_bandcamp_genres_to_files(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        # KAMP-588: cached Bandcamp tags are stamped as native multi-value genres
+        # onto the downloaded files during ingest.
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+        self._seed_db(db)
+
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(db)
+        idx.set_collection_keywords("S1", ["Shoegaze", "Dream Pop"])
+        extracted = config.paths.watch_folder / "album"
+        extracted.mkdir()
+        f1 = extracted / "01.mp3"
+        _make_bandcamp_mp3(f1, "Artist X", "Album Y", "Track 1", 1)
+        idx.add_pending_ingest(str(extracted), "S1", "T1")
+        idx.close()
+
+        with patch("kamp_daemon.pipeline_impl.KampMusicBrainzTagger") as mock_tagger:
+            mock_tagger.return_value.tag_release.side_effect = Exception("no network")
+            run(extracted, config, index_path=db)
+
+        moved = list(config.paths.library.rglob("*.mp3"))
+        track1 = next(p for p in moved if p.name.startswith("01"))
+        tcon = id3.ID3(str(track1))["TCON"]
+        assert list(tcon.text) == ["Shoegaze", "Dream Pop"]
+
     def test_records_mbid_and_keeps_bandcamp_names_without_overrides(
         self, tmp_path: Path, config: Config
     ) -> None:


### PR DESCRIPTION
Artist-supplied Bandcamp album tags (e.g. "shoegaze", "dream pop") are now applied as multi-value **genres**. Fixes KAMP-588. Builds on the KAMP-586 genre model.

**Scope (per the product owner):** streaming (remote) albums get genres at sync now, and the tags are cached for downloads; **download-only albums (download-mode, never streamed) are deferred to the KAMP-591 bandcamp backfill** — the lower-risk path that reuses already-proven fetches and adds no new bandcamp.com request.

## How it works

- **One shared extractor** `parse_album_keywords(html)` is the whole correctness surface. It prefers the `<a class="tag" href="/tag/…">` links (the artist's own genre tags, no artist/album-name pollution), with the `ld+json` `keywords` field as a robust fallback. Case-insensitive dedupe, order-preserving; a small **format-word denylist** (vinyl/cassette/cd/lp/digital/…) is dropped, **locations are kept** for you to prune via the KAMP-586 chips editor. It **WARNs when a fetched page parses empty** so a markup change or a Cloudflare challenge page can't ship the feature silently dead.
- **Streaming** — `fetch_album_tracks` (already holds the page HTML, already Cloudflare-safe in prod) sets `Track.genres`; `upsert_many`'s genre bridge + stream empty-guard carry them into `track_genres`. No new fetch.
- **Persist** — `bandcamp_collection` gains a `keywords` column (JSON array, schema **v57→v58**, plain ADD COLUMN) via a dedicated `set_collection_keywords` setter; `sync_collection_stream` caches the album's tags. Gives downloads a source and KAMP-591 a fast path.
- **Download handoff** — `DownloadOverrides` gains `genres` (read from the cache column); `_tag_known_bandcamp` writes them into the downloaded files as **native multi-value genres** (replace-semantics), and the existing watch-folder scan round-trips them into `track_genres` — the same mechanism `sale_item_id` already uses. No direct `apply_genres`, no double-write.

## Testing

- Full suite: **2477 passed, 9 skipped**, coverage **93.67%** (matches main). black + mypy clean. (One pre-existing WebSocket timing flake, `test_websocket_sends_initial_state`, passes in isolation and is unrelated to these files.)
- New tests: the extractor across every source form + entities/dedupe/order/denylist/location-kept/empty; the v57→v58 migration + `set_collection_keywords` round-trip; `fetch_album_tracks` sets genres (format words dropped); `sync_collection_stream` caches the tags; `download_overrides_for_sale_item` surfaces them; an end-to-end pending-ingest download that writes native multi-value genres into the file; and an explicit local-rescan **replace** test (a re-scan replaces `track_genres`, doesn't merge).

## Manual Test Plan

- [ ] Sync a streaming Bandcamp album that has artist tags → its genres appear in the library/sidebar/search and match the album's Bandcamp tags (minus format words like "vinyl")
- [ ] A multi-tag album shows all tags as separate genre chips; pruning works
- [ ] Download an album that was streamed → open the file in another tag tool → genres are written into the file; the library still shows them (no duplication)
- [ ] An album with no tags → no genres, no error; the daemon log shows the WARN only if a page fetched but parsed empty
- [ ] Re-sync an album whose genres you edited → your edits survive (stream empty-guard)
- [ ] **Extraction reality check:** confirm genres actually populate for several of your real albums. If they're empty across the board, the tag markup differs from what I assumed — grab one album-page HTML and I'll fix the extractor + add it as a fixture.
- [ ] Launch against a copy of the production DB → clean v57→v58 startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
