### PR TITLE
feat(genre): Last.fm genre enrichment after ingest (KAMP-587)

### DIFF
--- a/kamp.spec
+++ b/kamp.spec
@@ -96,6 +96,11 @@ datas = [
     # a nonexistent --script path, the script silently never loads, and the
     # script-message-driven transport controls become no-ops (KAMP-519).
     ("kamp_core/kamp_fade.lua", "kamp_core"),
+    # genres.txt is the canonical genre allowlist for KAMP-587 Last.fm enrichment;
+    # genre_sources.py loads it via Path(__file__).parent/"data"/"genres.txt".
+    # collect_submodules gathers only .py, so this non-Python sibling must be
+    # staged explicitly, or the filter silently drops every tag in the frozen app.
+    ("kamp_daemon/data/genres.txt", "kamp_daemon/data"),
 ]
 
 a = Analysis(

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3065,6 +3065,9 @@ def create_app(
     _INT_CONFIG_KEYS = frozenset(
         {"artwork.min_dimension", "artwork.max_bytes", "bandcamp.poll_interval_minutes"}
     )
+    # Boolean config keys — stored as Python bool so GET returns true/false, not a
+    # string (KAMP-587 re-added this after 589 dropped the last bool key).
+    _BOOL_CONFIG_KEYS = frozenset({"tagging.lastfm_genres"})
 
     @app.patch("/api/v1/config")
     def patch_config(req: ConfigPatchRequest) -> dict[str, Any]:
@@ -3076,6 +3079,8 @@ def create_app(
         # Coerce to the correct Python type before caching in memory.
         if req.key in _INT_CONFIG_KEYS:
             coerced: Any = int(req.value)
+        elif req.key in _BOOL_CONFIG_KEYS:
+            coerced = req.value.lower() == "true"
         else:
             coerced = req.value
         _state["config"][req.key] = coerced

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -543,6 +543,7 @@ def _build_config_values(
         "artwork.min_dimension": config.artwork.min_dimension,
         "artwork.max_bytes": config.artwork.max_bytes,
         "artwork.save_format": config.artwork.save_format,
+        "tagging.lastfm_genres": config.tagging.lastfm_genres,
         "library.path_template": config.library.path_template,
         "bandcamp.connected": bc_session is not None,
         "bandcamp.username": bc_username,
@@ -1254,6 +1255,25 @@ def _cmd_daemon(
                     )
             except Exception:
                 _logger.exception("Error invoking extensions after library scan")
+
+            # KAMP-587: enrich the new tracks' genres from external sources
+            # (Last.fm) off the scan thread so a slow/hung fetch can never stall
+            # it. enrich_new_tracks no-ops when the toggle is off (checked inside
+            # the thread via a fresh config load). Best-effort throughout.
+            if result.new_tracks:
+                _new_tracks = result.new_tracks
+
+                def _enrich() -> None:
+                    from .genre_sources import enrich_new_tracks
+
+                    try:
+                        enrich_new_tracks(index, _new_tracks, Config.load(index))
+                    except Exception:
+                        _logger.exception("Error enriching genres after scan")
+
+                threading.Thread(
+                    target=_enrich, daemon=True, name="genre-enrich"
+                ).start()
         finally:
             # Bump the server's library version so connected WebSocket clients
             # receive a "library.changed" push and reload the album list.

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -48,9 +48,10 @@ class MusicBrainzConfig:
 
 @dataclass
 class TaggingConfig:
-    # KAMP-587: opt-in Last.fm genre enrichment after ingest. Default off — it
-    # makes external calls and writes genre tags, so it isn't enabled silently.
-    lastfm_genres: bool = False
+    # KAMP-587: Last.fm genre enrichment after ingest. Default ON — the feature's
+    # point is that ingested files gain genres; it's best-effort and async, so it
+    # never slows or fails a download. Users can turn it off in Tagging prefs.
+    lastfm_genres: bool = True
 
 
 @dataclass
@@ -101,7 +102,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "artwork.min_dimension": "1000",
     "artwork.max_bytes": "1000000",
     "artwork.save_format": "embedded",
-    "tagging.lastfm_genres": "false",
+    "tagging.lastfm_genres": "true",
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -44,6 +44,13 @@ class MusicBrainzConfig:
     # (trust-when-tags-conflict); the pipeline now always keeps existing file
     # tags on conflict. Kept as a namespace to avoid churning its ~8 call sites.
     pass
+
+
+@dataclass
+class TaggingConfig:
+    # KAMP-587: opt-in Last.fm genre enrichment after ingest. Default off — it
+    # makes external calls and writes genre tags, so it isn't enabled silently.
+    lastfm_genres: bool = False
 
 
 @dataclass
@@ -94,6 +101,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "artwork.min_dimension": "1000",
     "artwork.max_bytes": "1000000",
     "artwork.save_format": "embedded",
+    "tagging.lastfm_genres": "false",
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",
@@ -112,6 +120,7 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "artwork.min_dimension": int,
     "artwork.max_bytes": int,
     "artwork.save_format": str,
+    "tagging.lastfm_genres": bool,
     "library.path_template": str,
     "bandcamp.format": str,
     "bandcamp.poll_interval_minutes": int,
@@ -197,6 +206,7 @@ class Config:
     musicbrainz: MusicBrainzConfig
     artwork: ArtworkConfig
     library: LibraryConfig
+    tagging: TaggingConfig = field(default_factory=TaggingConfig)
     bandcamp: BandcampConfig | None = None
     lastfm: LastfmConfig | None = None
     ui: UiConfig = None  # type: ignore[assignment]  # set in __post_init__
@@ -299,6 +309,9 @@ class Config:
             except (ValueError, TypeError):
                 return int(_CONFIG_DEFAULTS[key])
 
+        def _bool(key: str) -> bool:
+            return _get(key).lower() == "true"
+
         lastfm: LastfmConfig | None = None
         _lastfm_session = db.get_session("lastfm")
         if _lastfm_session and _lastfm_session.get("session_key"):
@@ -324,6 +337,9 @@ class Config:
             ),
             library=LibraryConfig(
                 path_template=_get("library.path_template"),
+            ),
+            tagging=TaggingConfig(
+                lastfm_genres=_bool("tagging.lastfm_genres"),
             ),
             bandcamp=BandcampConfig(
                 format=_get("bandcamp.format"),
@@ -386,9 +402,12 @@ def config_set(db: "LibraryIndex", key: str, value: str) -> None:
         raise KeyError(f"Unknown config key {key!r}. Valid keys: {valid}")
 
     target_type = _CONFIG_KEY_TYPES[key]
-    # No bool config keys remain after KAMP-589; re-add a bool branch here (with
-    # a test) when the next bool key lands.
-    if target_type == int:
+    if target_type == bool:
+        # Re-added in KAMP-587 for tagging.lastfm_genres (589 removed the last one).
+        if value.lower() not in ("true", "false"):
+            raise ValueError(f"Key {key!r} requires true or false, got {value!r}")
+        db_value = value.lower()
+    elif target_type == int:
         try:
             db_value = str(int(value))
         except ValueError:

--- a/kamp_daemon/data/genres.txt
+++ b/kamp_daemon/data/genres.txt
@@ -1,0 +1,248 @@
+# Canonical genre allowlist for KAMP-587 Last.fm genre enrichment.
+# Last.fm top-tags are an unbounded, noisy vocabulary ("seen live", "spotify",
+# "00s", "favourites"). Rather than chase junk with a denylist, incoming tags are
+# filtered THROUGH this allowlist (case-insensitive), and emitted in the canonical
+# casing below. One genre per line; blank lines and lines starting with # ignored.
+# Curate freely — adding a line makes that genre eligible; the user can still add
+# anything by hand via the album genre chips editor.
+
+# -- Broad families --
+Rock
+Pop
+Jazz
+Blues
+Folk
+Country
+Classical
+Electronic
+Hip-Hop
+Rap
+R&B
+Soul
+Funk
+Reggae
+Metal
+Punk
+Experimental
+Ambient
+Instrumental
+Soundtrack
+World
+Latin
+Gospel
+Spoken Word
+Comedy
+Easy Listening
+Singer-Songwriter
+
+# -- Rock --
+Alternative Rock
+Indie Rock
+Classic Rock
+Hard Rock
+Psychedelic Rock
+Progressive Rock
+Art Rock
+Garage Rock
+Surf Rock
+Glam Rock
+Southern Rock
+Blues Rock
+Folk Rock
+Country Rock
+Krautrock
+Math Rock
+Post-Rock
+Noise Rock
+Space Rock
+Stoner Rock
+Grunge
+Britpop
+Shoegaze
+Dream Pop
+Slowcore
+Emo
+Post-Hardcore
+Hardcore
+Screamo
+Pop Punk
+Skate Punk
+Post-Punk
+New Wave
+No Wave
+Gothic Rock
+Industrial Rock
+Rockabilly
+
+# -- Pop --
+Indie Pop
+Synth-Pop
+Electropop
+Dance-Pop
+Power Pop
+Art Pop
+Chamber Pop
+Baroque Pop
+Bubblegum Pop
+K-Pop
+J-Pop
+City Pop
+Hyperpop
+Sophisti-Pop
+
+# -- Electronic --
+House
+Deep House
+Tech House
+Progressive House
+Acid House
+Techno
+Detroit Techno
+Minimal Techno
+Trance
+Drum and Bass
+Jungle
+Breakbeat
+Dubstep
+Garage
+UK Garage
+2-Step
+Grime
+Footwork
+Downtempo
+Trip-Hop
+IDM
+Glitch
+Electro
+Synthwave
+Vaporwave
+Chillwave
+Chiptune
+EBM
+Industrial
+Darkwave
+Coldwave
+Witch House
+Big Beat
+Nu-Disco
+Disco
+Italo Disco
+Eurodance
+Hardstyle
+Gabber
+Ambient Techno
+Dub Techno
+Lo-Fi
+Future Bass
+
+# -- Hip-Hop / R&B --
+Boom Bap
+Trap
+Conscious Hip-Hop
+Gangsta Rap
+Alternative Hip-Hop
+Instrumental Hip-Hop
+Cloud Rap
+Drill
+G-Funk
+Neo-Soul
+Contemporary R&B
+Quiet Storm
+New Jack Swing
+Motown
+
+# -- Jazz --
+Bebop
+Hard Bop
+Cool Jazz
+Free Jazz
+Modal Jazz
+Jazz Fusion
+Smooth Jazz
+Swing
+Big Band
+Dixieland
+Bossa Nova
+Latin Jazz
+Nu Jazz
+Spiritual Jazz
+Avant-Garde Jazz
+
+# -- Metal --
+Heavy Metal
+Thrash Metal
+Death Metal
+Black Metal
+Doom Metal
+Sludge Metal
+Power Metal
+Progressive Metal
+Speed Metal
+Groove Metal
+Nu Metal
+Metalcore
+Deathcore
+Folk Metal
+Symphonic Metal
+Gothic Metal
+Industrial Metal
+Djent
+Grindcore
+
+# -- Folk / Country / Roots --
+Contemporary Folk
+Traditional Folk
+Freak Folk
+Indie Folk
+Americana
+Bluegrass
+Alt-Country
+Outlaw Country
+Honky Tonk
+Delta Blues
+Chicago Blues
+Zydeco
+Cajun
+Celtic
+
+# -- World / Regional --
+Afrobeat
+Afrobeats
+Highlife
+Soukous
+Salsa
+Cumbia
+Merengue
+Bachata
+Reggaeton
+Bossa
+Samba
+Flamenco
+Fado
+Bhangra
+Bollywood
+Klezmer
+Dub
+Dancehall
+Ska
+Rocksteady
+Roots Reggae
+
+# -- Ambient / Experimental --
+Drone
+Dark Ambient
+Noise
+Musique Concrète
+Field Recording
+Minimalism
+Neoclassical
+Modern Classical
+New Age
+
+# -- Other --
+Lounge
+Exotica
+Bluegrass Gospel
+Christmas
+Children's Music
+Video Game Music

--- a/kamp_daemon/genre_sources.py
+++ b/kamp_daemon/genre_sources.py
@@ -1,0 +1,271 @@
+"""Genre sources for the post-ingest enrichment step (KAMP-587).
+
+MusicBrainz gives kamp poor genre data, so ingested albums are enriched with
+genres from additional sources — starting with Last.fm via pylast. Fetching is
+best-effort: it runs asynchronously after ingest (never on the pipeline's
+critical path), is wall-clock bounded (pylast hardcodes a 20s read timeout with
+no override), swallows all network errors, and can never fail an ingest.
+
+Last.fm top-tags are an unbounded, noisy vocabulary, so raw tags are filtered
+through a bundled canonical allowlist (``data/genres.txt``) rather than chased
+with a denylist — the ingest merge is additive, so anything written once is
+sticky. The MusicBrainz-as-a-second-source variant is a deferred fast-follow
+through the same ``GenreSource`` interface.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from kamp_core.library import LibraryIndex
+
+    from .config import Config
+
+logger = logging.getLogger(__name__)
+
+# Minimum Last.fm tag weight (0-100) to consider; below this is long-tail noise.
+_MIN_TAG_WEIGHT = 10
+# How many top tags to pull per entity before filtering.
+_TOP_TAGS_LIMIT = 20
+# Per-album wall-clock budget for a source fetch. pylast's read timeout is 20s
+# and cannot be overridden, so bound it ourselves and abandon on expiry.
+_FETCH_TIMEOUT_SECONDS = 8.0
+
+_ALLOWLIST_PATH = Path(__file__).parent / "data" / "genres.txt"
+# casefold -> canonical display name; loaded once.
+_allowlist: dict[str, str] | None = None
+
+
+@dataclass
+class GenreQuery:
+    """The album-level identity a source is queried on. Keyed on album-artist
+    (never a track artist) so compilations/various-artists resolve correctly."""
+
+    album_artist: str
+    album: str
+
+
+class GenreSource(ABC):
+    """A best-effort source of canonical genre names for an album."""
+
+    @abstractmethod
+    def fetch(self, query: GenreQuery) -> list[str]:
+        """Return canonical genres for *query*, or [] on any failure."""
+
+
+def _load_allowlist() -> dict[str, str]:
+    global _allowlist
+    if _allowlist is None:
+        out: dict[str, str] = {}
+        try:
+            for line in _ALLOWLIST_PATH.read_text(encoding="utf-8").splitlines():
+                name = line.strip()
+                if name and not name.startswith("#"):
+                    out.setdefault(name.casefold(), name)
+        except OSError as exc:
+            # A missing data file (e.g. not staged into the frozen bundle) must
+            # not crash — it degrades to "no genres pass the filter", and the
+            # WARN makes that visible rather than silent.
+            logger.warning(
+                "genre allowlist not loaded from %s: %s", _ALLOWLIST_PATH, exc
+            )
+        _allowlist = out
+    return _allowlist
+
+
+def canonicalize(tags: list[str]) -> list[str]:
+    """Filter raw tags to the canonical allowlist (case-insensitive), emit the
+    allowlist's canonical casing, order-preserving and de-duplicated."""
+    allow = _load_allowlist()
+    seen: dict[str, str] = {}
+    for tag in tags:
+        cf = tag.strip().casefold()
+        if cf in allow and cf not in seen:
+            seen[cf] = allow[cf]
+    return list(seen.values())
+
+
+def _run_with_timeout(fn: Callable[[], list[str]], timeout: float) -> list[str]:
+    """Run *fn* on a daemon thread with a wall-clock budget; [] on timeout/error.
+    The abandoned thread may keep running a hung network call, but as a daemon it
+    never blocks shutdown and its result is discarded."""
+    result: list[list[str]] = []
+    error: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            result.append(fn())
+        except BaseException as exc:  # noqa: BLE001 — best-effort, swallow all
+            error.append(exc)
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    t.join(timeout)
+    if t.is_alive():
+        logger.warning("genre fetch exceeded %ss budget; abandoning", timeout)
+        return []
+    if error:
+        logger.warning("genre fetch failed (best-effort): %s", error[0])
+        return []
+    return result[0] if result else []
+
+
+class LastfmGenreSource(GenreSource):
+    """Last.fm genres via pylast, read-only (needs only the app API key). Fetches
+    album then artist top-tags, keeps tags at/above a weight threshold, and
+    filters them to the canonical allowlist."""
+
+    def __init__(self, network: Any = None) -> None:
+        # network is injectable for tests; built lazily from the shared API key.
+        self._network = network
+
+    def _get_network(self) -> Any:
+        if self._network is None:
+            import pylast  # noqa: PLC0415 — heavy import, only when enabled
+
+            from kamp_core.scrobbler import LASTFM_API_KEY  # noqa: PLC0415
+
+            self._network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY)
+        return self._network
+
+    def fetch(self, query: GenreQuery) -> list[str]:
+        raw = _run_with_timeout(lambda: self._fetch_raw(query), _FETCH_TIMEOUT_SECONDS)
+        return canonicalize(raw)
+
+    def _fetch_raw(self, query: GenreQuery) -> list[str]:
+        net = self._get_network()
+        tags: list[str] = []
+        getters: list[Callable[[], list[Any]]] = [
+            lambda: net.get_album(query.album_artist, query.album).get_top_tags(
+                limit=_TOP_TAGS_LIMIT
+            ),
+            lambda: net.get_artist(query.album_artist).get_top_tags(
+                limit=_TOP_TAGS_LIMIT
+            ),
+        ]
+        for getter in getters:
+            try:
+                for top in getter():
+                    try:
+                        weight = int(top.weight or 0)
+                    except (TypeError, ValueError):
+                        weight = 0
+                    if weight >= _MIN_TAG_WEIGHT:
+                        tags.append(str(top.item.get_name()))
+            except Exception as exc:  # noqa: BLE001 — one getter failing is fine
+                logger.debug("Last.fm getter failed (best-effort): %s", exc)
+        return tags
+
+
+def enabled_sources(config: "Config") -> list[GenreSource]:
+    """The genre sources enabled by config. Empty when nothing is on, so the
+    caller can cheaply skip enrichment entirely."""
+    sources: list[GenreSource] = []
+    if config.tagging.lastfm_genres:
+        sources.append(LastfmGenreSource())
+    return sources
+
+
+def fetch_all_genres(sources: list[GenreSource], query: GenreQuery) -> list[str]:
+    """Union the canonical genres from every source, order-preserving, deduped.
+    Each source is already best-effort ([] on failure), so this never raises."""
+    seen: dict[str, str] = {}
+    for source in sources:
+        try:
+            names = source.fetch(query)
+        except Exception as exc:  # noqa: BLE001 — a buggy source can't break enrich
+            logger.warning(
+                "genre source %s failed (best-effort): %s",
+                type(source).__name__,
+                exc,
+            )
+            names = []
+        for name in names:
+            cf = name.casefold()
+            if cf not in seen:
+                seen[cf] = name
+    return list(seen.values())
+
+
+def enrich_album_genres(
+    index: "LibraryIndex", track_ids: list[int], config: "Config"
+) -> list[str]:
+    """Fetch genres for the album containing *track_ids* from the enabled sources
+    and merge them in — DB via ``apply_genres(merge)`` and, for local tracks, the
+    files. The shared enrichment core (KAMP-587; KAMP-591 reuses it library-wide).
+
+    Best-effort and idempotent: returns the genres it applied ([] when nothing is
+    enabled, no tracks resolve, or no source yielded a genre). Files must be
+    written too, not just the DB: a local file's re-scan REPLACES its DB genres
+    from the file, so a DB-only addition would be wiped on the next scan.
+    """
+    sources = enabled_sources(config)
+    if not sources or not track_ids:
+        return []
+    tracks = [t for t in (index.get_track_by_id(tid) for tid in track_ids) if t]
+    if not tracks:
+        return []
+
+    # album_artist is the album-level artist (not the per-track performer), so
+    # this keys correctly for compilations / various-artists.
+    first = tracks[0]
+    query = GenreQuery(album_artist=first.album_artist, album=first.album)
+    genres = fetch_all_genres(sources, query)
+    if not genres:
+        return []
+
+    index.apply_genres([t.id for t in tracks], genres, mode="merge")
+
+    from kamp_core.library import write_meta_tags_to_file  # noqa: PLC0415
+
+    for track in tracks:
+        if track.is_remote:
+            continue
+        # Re-read the post-merge canonical set. The DB read exposes it as the
+        # denormalized "; "-joined `genre` string (the `genres` list is a
+        # write-path field, empty on DB read), so split it for the file write.
+        merged = index.get_track_by_id(track.id)
+        if merged is None:
+            continue
+        names = [g.strip() for g in merged.genre.split(";") if g.strip()]
+        try:
+            write_meta_tags_to_file(Path(merged.file_path), genres=names)
+        except Exception as exc:  # noqa: BLE001 — best-effort file write
+            logger.warning(
+                "genre enrich: file write failed for %s (best-effort): %s",
+                merged.file_path,
+                exc,
+            )
+    return genres
+
+
+def enrich_new_tracks(
+    index: "LibraryIndex", tracks: list[Any], config: "Config"
+) -> None:
+    """Enrich the albums of newly-scanned LOCAL tracks (KAMP-587 trigger core).
+
+    Called with a scan's ``new_tracks`` after each ingest. Groups by album so an
+    album is fetched once, skips remote/streaming tracks (they have no file to
+    stamp), and is a cheap no-op when no source is enabled. Synchronous and
+    best-effort; the daemon runs it on a background thread so a slow Last.fm can
+    never stall the scan.
+    """
+    if not enabled_sources(config):
+        return
+    by_album: dict[tuple[str, str], list[int]] = {}
+    for track in tracks:
+        if not track.is_remote:
+            by_album.setdefault((track.album_artist, track.album), []).append(track.id)
+    for ids in by_album.values():
+        try:
+            enrich_album_genres(index, ids, config)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — one album failing can't break the rest
+            logger.warning("genre enrichment failed (best-effort): %s", exc)

--- a/kamp_daemon/genre_sources.py
+++ b/kamp_daemon/genre_sources.py
@@ -136,7 +136,16 @@ class LastfmGenreSource(GenreSource):
 
     def fetch(self, query: GenreQuery) -> list[str]:
         raw = _run_with_timeout(lambda: self._fetch_raw(query), _FETCH_TIMEOUT_SECONDS)
-        return canonicalize(raw)
+        result = canonicalize(raw)
+        if raw and not result:
+            logger.info(
+                "Last.fm: all %d tag(s) for %r/%r were filtered out by the genre "
+                "allowlist — none matched (extend kamp_daemon/data/genres.txt to keep more)",
+                len(raw),
+                query.album_artist,
+                query.album,
+            )
+        return result
 
     def _fetch_raw(self, query: GenreQuery) -> list[str]:
         net = self._get_network()
@@ -149,7 +158,7 @@ class LastfmGenreSource(GenreSource):
                 limit=_TOP_TAGS_LIMIT
             ),
         ]
-        for getter in getters:
+        for label, getter in zip(("album", "artist"), getters):
             try:
                 for top in getter():
                     try:
@@ -159,7 +168,21 @@ class LastfmGenreSource(GenreSource):
                     if weight >= _MIN_TAG_WEIGHT:
                         tags.append(str(top.item.get_name()))
             except Exception as exc:  # noqa: BLE001 — one getter failing is fine
-                logger.debug("Last.fm getter failed (best-effort): %s", exc)
+                logger.info(
+                    "Last.fm %s tags for %r/%r failed (best-effort): %s",
+                    label,
+                    query.album_artist,
+                    query.album,
+                    exc,
+                )
+        logger.info(
+            "Last.fm: %r by %r → %d raw tag(s) at/above weight %d: %s",
+            query.album,
+            query.album_artist,
+            len(tags),
+            _MIN_TAG_WEIGHT,
+            tags,
+        )
         return tags
 
 
@@ -218,8 +241,21 @@ def enrich_album_genres(
     query = GenreQuery(album_artist=first.album_artist, album=first.album)
     genres = fetch_all_genres(sources, query)
     if not genres:
+        logger.info(
+            "genre enrich: %r by %r — no genres applied (no source returned a "
+            "canonical genre)",
+            query.album,
+            query.album_artist,
+        )
         return []
 
+    logger.info(
+        "genre enrich: %r by %r → applying %s to %d track(s)",
+        query.album,
+        query.album_artist,
+        genres,
+        len(tracks),
+    )
     index.apply_genres([t.id for t in tracks], genres, mode="merge")
 
     from kamp_core.library import write_meta_tags_to_file  # noqa: PLC0415
@@ -250,22 +286,44 @@ def enrich_new_tracks(
 ) -> None:
     """Enrich the albums of newly-scanned LOCAL tracks (KAMP-587 trigger core).
 
-    Called with a scan's ``new_tracks`` after each ingest. Groups by album so an
-    album is fetched once, skips remote/streaming tracks (they have no file to
-    stamp), and is a cheap no-op when no source is enabled. Synchronous and
-    best-effort; the daemon runs it on a background thread so a slow Last.fm can
-    never stall the scan.
+    Called with a scan's ``new_tracks`` after each ingest. Resolves each new
+    album's tracks fresh from the DB (scan-produced Track objects don't carry a
+    DB id), skips remote/streaming albums, and is a cheap no-op when no source is
+    enabled. Synchronous and best-effort; the daemon runs it on a background
+    thread so a slow Last.fm can never stall the scan.
     """
     if not enabled_sources(config):
+        logger.info("genre enrich: skipped — no genre source is enabled")
         return
-    by_album: dict[tuple[str, str], list[int]] = {}
-    for track in tracks:
-        if not track.is_remote:
-            by_album.setdefault((track.album_artist, track.album), []).append(track.id)
-    for ids in by_album.values():
+    # Unique album keys of the new LOCAL tracks. Their track_ids are resolved from
+    # the DB below — the Track objects a scan yields are read from files and have
+    # id=0, so grouping on track.id would resolve nothing.
+    album_keys = {
+        (track.album_artist, track.album)
+        for track in tracks
+        if not track.is_remote and track.album
+    }
+    if not album_keys:
+        logger.info(
+            "genre enrich: %d new track(s) but none are a local album — "
+            "nothing to enrich",
+            len(tracks),
+        )
+        return
+    logger.info(
+        "genre enrich: enriching %d album(s) from %d new track(s)",
+        len(album_keys),
+        len(tracks),
+    )
+    for album_artist, album in album_keys:
         try:
-            enrich_album_genres(index, ids, config)
-        except (
-            Exception
-        ) as exc:  # noqa: BLE001 — one album failing can't break the rest
-            logger.warning("genre enrichment failed (best-effort): %s", exc)
+            ids = [t.id for t in index.tracks_for_album(album_artist, album)]
+            if ids:
+                enrich_album_genres(index, ids, config)
+        except Exception as exc:  # noqa: BLE001 — one album can't break the rest
+            logger.warning(
+                "genre enrichment failed for %r/%r (best-effort): %s",
+                album_artist,
+                album,
+                exc,
+            )

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -408,6 +408,7 @@ export type ConfigValues = {
   'artwork.min_dimension': number | null
   'artwork.max_bytes': number | null
   'artwork.save_format': string | null
+  'tagging.lastfm_genres': boolean | null
   'library.path_template': string | null
   'bandcamp.connected': boolean | null
   'bandcamp.username': string | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1200,6 +1200,18 @@ export function PreferencesDialog({
                       onSave={handleArtworkSave}
                     />
                   </div>
+
+                  {/* GENRES */}
+                  <div className="prefs-section">
+                    <div className="prefs-section-label">Genres</div>
+                    <BoolRow
+                      label="Fetch genres from Last.fm"
+                      configKey="tagging.lastfm_genres"
+                      hint="After a download, kamp adds genres from Last.fm (canonical genres only). Best-effort — it runs in the background and never slows a download."
+                      initialValue={configValues?.['tagging.lastfm_genres'] ?? false}
+                      onSave={handleSave}
+                    />
+                  </div>
                 </>
               )}
             </>

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1208,7 +1208,7 @@ export function PreferencesDialog({
                       label="Fetch genres from Last.fm"
                       configKey="tagging.lastfm_genres"
                       hint="After a download, kamp adds genres from Last.fm (canonical genres only). Best-effort — it runs in the background and never slows a download."
-                      initialValue={configValues?.['tagging.lastfm_genres'] ?? false}
+                      initialValue={configValues?.['tagging.lastfm_genres'] ?? true}
                       onSave={handleSave}
                     />
                   </div>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,17 +68,17 @@ class TestLoad:
         assert config.ui.sort_order == "album_artist"
         assert config.ui.queue_panel_open == 0
 
-    def test_tagging_lastfm_genres_default_false(self, db: LibraryIndex) -> None:
-        # KAMP-587: opt-in, default off.
+    def test_tagging_lastfm_genres_default_true(self, db: LibraryIndex) -> None:
+        # KAMP-587: on by default; ingested files gain genres out of the box.
         Config.write_defaults(db)
-        config = Config.load(db)
-        assert config.tagging.lastfm_genres is False
-
-    def test_tagging_lastfm_genres_loads_true(self, db: LibraryIndex) -> None:
-        Config.write_defaults(db)
-        db.set_setting("tagging.lastfm_genres", "true")
         config = Config.load(db)
         assert config.tagging.lastfm_genres is True
+
+    def test_tagging_lastfm_genres_loads_false(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        db.set_setting("tagging.lastfm_genres", "false")
+        config = Config.load(db)
+        assert config.tagging.lastfm_genres is False
 
     def test_load_seeds_defaults_on_fresh_install(self, db: LibraryIndex) -> None:
         config = Config.load(db)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,18 @@ class TestLoad:
         assert config.ui.sort_order == "album_artist"
         assert config.ui.queue_panel_open == 0
 
+    def test_tagging_lastfm_genres_default_false(self, db: LibraryIndex) -> None:
+        # KAMP-587: opt-in, default off.
+        Config.write_defaults(db)
+        config = Config.load(db)
+        assert config.tagging.lastfm_genres is False
+
+    def test_tagging_lastfm_genres_loads_true(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        db.set_setting("tagging.lastfm_genres", "true")
+        config = Config.load(db)
+        assert config.tagging.lastfm_genres is True
+
     def test_load_seeds_defaults_on_fresh_install(self, db: LibraryIndex) -> None:
         config = Config.load(db)
         assert config.bandcamp is not None
@@ -228,6 +240,17 @@ class TestConfigSet:
         Config.write_defaults(db)
         config_set(db, "artwork.min_dimension", "500")
         assert db.get_setting("artwork.min_dimension") == "500"
+
+    def test_set_bool_key(self, db: LibraryIndex) -> None:
+        # KAMP-587 re-adds bool config handling (removed in 589 when the last bool
+        # key was deprecated); tagging.lastfm_genres is the new bool key.
+        Config.write_defaults(db)
+        config_set(db, "tagging.lastfm_genres", "true")
+        assert db.get_setting("tagging.lastfm_genres") == "true"
+
+    def test_bool_wrong_value_raises_value_error(self, db: LibraryIndex) -> None:
+        with pytest.raises(ValueError, match="requires true or false"):
+            config_set(db, "tagging.lastfm_genres", "yes")
 
     def test_round_trip_load_after_set(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)

--- a/tests/test_genre_sources.py
+++ b/tests/test_genre_sources.py
@@ -1,0 +1,376 @@
+"""Tests for kamp_daemon.genre_sources (KAMP-587 Last.fm genre enrichment)."""
+
+from __future__ import annotations
+
+import time
+import types
+from typing import Any
+
+import pytest
+
+from kamp_daemon import genre_sources as gs
+from kamp_daemon.genre_sources import (
+    GenreQuery,
+    LastfmGenreSource,
+    canonicalize,
+    enabled_sources,
+    fetch_all_genres,
+    _run_with_timeout,
+)
+
+# --- pylast mocks -----------------------------------------------------------
+
+
+class _FakeItem:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+
+class _FakeTop:
+    def __init__(self, name: str, weight: int) -> None:
+        self.item = _FakeItem(name)
+        self.weight = weight
+
+
+class _FakeEntity:
+    def __init__(self, tags: list[_FakeTop], raise_: bool) -> None:
+        self._tags = tags
+        self._raise = raise_
+
+    def get_top_tags(self, limit: int | None = None) -> list[_FakeTop]:
+        if self._raise:
+            raise RuntimeError("boom")
+        return self._tags
+
+
+class _FakeNetwork:
+    def __init__(
+        self,
+        album: list[_FakeTop] | None = None,
+        artist: list[_FakeTop] | None = None,
+        raise_on: str | None = None,
+    ) -> None:
+        self._album = album or []
+        self._artist = artist or []
+        self._raise_on = raise_on
+
+    def get_album(self, artist: str, album: str) -> _FakeEntity:
+        return _FakeEntity(self._album, self._raise_on == "album")
+
+    def get_artist(self, artist: str) -> _FakeEntity:
+        return _FakeEntity(self._artist, self._raise_on == "artist")
+
+
+_Q = GenreQuery(album_artist="Slowdive", album="Souvlaki")
+
+
+# --- canonicalize -----------------------------------------------------------
+
+
+class TestCanonicalize:
+    def test_filters_to_allowlist_with_canonical_casing(self) -> None:
+        # junk dropped; allowlist genres kept in the allowlist's canonical casing.
+        out = canonicalize(["shoegaze", "seen live", "vinyl", "DREAM POP"])
+        assert out == ["Shoegaze", "Dream Pop"]
+
+    def test_dedupes_case_insensitively_order_preserving(self) -> None:
+        out = canonicalize(["Techno", "techno", "House"])
+        assert out == ["Techno", "House"]
+
+    def test_all_junk_returns_empty(self) -> None:
+        assert canonicalize(["seen live", "favourites", "spotify", "00s"]) == []
+
+    def test_missing_allowlist_degrades_to_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        monkeypatch.setattr(gs, "_allowlist", None)
+        monkeypatch.setattr(gs, "_ALLOWLIST_PATH", tmp_path / "nope.txt")
+        try:
+            assert canonicalize(["Shoegaze"]) == []
+        finally:
+            gs._allowlist = None  # reset the module cache for other tests
+
+
+# --- _run_with_timeout ------------------------------------------------------
+
+
+class TestRunWithTimeout:
+    def test_returns_result(self) -> None:
+        assert _run_with_timeout(lambda: ["a", "b"], 1.0) == ["a", "b"]
+
+    def test_abandons_slow_fetch(self) -> None:
+        def slow() -> list[str]:
+            time.sleep(2.0)
+            return ["late"]
+
+        assert _run_with_timeout(slow, 0.1) == []
+
+    def test_swallows_error(self) -> None:
+        def boom() -> list[str]:
+            raise RuntimeError("network down")
+
+        assert _run_with_timeout(boom, 1.0) == []
+
+
+# --- LastfmGenreSource ------------------------------------------------------
+
+
+class TestLastfmGenreSource:
+    def test_fetch_canonicalizes_album_and_artist_tags(self) -> None:
+        net = _FakeNetwork(
+            album=[_FakeTop("Shoegaze", 100), _FakeTop("seen live", 90)],
+            artist=[_FakeTop("Dream Pop", 80)],
+        )
+        out = LastfmGenreSource(network=net).fetch(_Q)
+        assert out == ["Shoegaze", "Dream Pop"]
+
+    def test_weight_threshold_drops_long_tail(self) -> None:
+        net = _FakeNetwork(album=[_FakeTop("Shoegaze", 100), _FakeTop("Noise", 5)])
+        out = LastfmGenreSource(network=net).fetch(_Q)
+        assert out == ["Shoegaze"]  # Noise is allowlisted but under-weighted
+
+    def test_one_getter_failing_still_returns_other(self) -> None:
+        net = _FakeNetwork(artist=[_FakeTop("Dream Pop", 80)], raise_on="album")
+        out = LastfmGenreSource(network=net).fetch(_Q)
+        assert out == ["Dream Pop"]
+
+    def test_total_failure_returns_empty(self) -> None:
+        net = _FakeNetwork(raise_on="album")  # artist empty, album raises
+        assert LastfmGenreSource(network=net).fetch(_Q) == []
+
+    def test_get_network_builds_from_shared_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        captured: dict[str, Any] = {}
+
+        def _fake_net(api_key: str) -> str:
+            captured["key"] = api_key
+            return "NET"
+
+        monkeypatch.setitem(
+            sys.modules, "pylast", types.SimpleNamespace(LastFMNetwork=_fake_net)
+        )
+        monkeypatch.setattr("kamp_core.scrobbler.LASTFM_API_KEY", "K123")
+        net = LastfmGenreSource()._get_network()
+        assert net == "NET"
+        assert captured["key"] == "K123"
+
+
+# --- wiring -----------------------------------------------------------------
+
+
+class TestEnabledSources:
+    def _config(self, on: bool) -> Any:
+        return types.SimpleNamespace(tagging=types.SimpleNamespace(lastfm_genres=on))
+
+    def test_lastfm_enabled(self) -> None:
+        sources = enabled_sources(self._config(True))
+        assert len(sources) == 1 and isinstance(sources[0], LastfmGenreSource)
+
+    def test_disabled_returns_empty(self) -> None:
+        assert enabled_sources(self._config(False)) == []
+
+
+class TestFetchAllGenres:
+    def test_unions_sources_deduped(self) -> None:
+        net1 = _FakeNetwork(album=[_FakeTop("Shoegaze", 100)])
+        net2 = _FakeNetwork(
+            album=[_FakeTop("shoegaze", 100), _FakeTop("Dream Pop", 90)]
+        )
+        out = fetch_all_genres(
+            [LastfmGenreSource(network=net1), LastfmGenreSource(network=net2)], _Q
+        )
+        assert out == ["Shoegaze", "Dream Pop"]
+
+    def test_empty_source_list(self) -> None:
+        assert fetch_all_genres([], _Q) == []
+
+    def test_buggy_source_is_swallowed(self) -> None:
+        class _Boom(gs.GenreSource):
+            def fetch(self, query: GenreQuery) -> list[str]:
+                raise RuntimeError("bug")
+
+        net = _FakeNetwork(album=[_FakeTop("Shoegaze", 100)])
+        out = fetch_all_genres([_Boom(), LastfmGenreSource(network=net)], _Q)
+        assert out == ["Shoegaze"]
+
+
+class _StubSource(gs.GenreSource):
+    def __init__(self, genres: list[str]) -> None:
+        self._genres = genres
+
+    def fetch(self, query: GenreQuery) -> list[str]:
+        return self._genres
+
+
+class TestEnrichAlbumGenres:
+    def _config(self, on: bool = True) -> Any:
+        return types.SimpleNamespace(tagging=types.SimpleNamespace(lastfm_genres=on))
+
+    def _seed_local(self, tmp_path: Any, genres: list[str]) -> Any:
+        import mutagen.id3 as id3
+
+        from kamp_core.library import LibraryIndex, Track
+
+        mp3 = tmp_path / "01.mp3"
+        mp3.write_bytes(b"\xff\xfb" * 64)
+        id3.ID3().save(str(mp3))
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=mp3,
+                    title="T",
+                    artist="Slowdive",
+                    album_artist="Slowdive",
+                    album="Souvlaki",
+                    release_date="1993",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    genres=genres,
+                )
+            ]
+        )
+        return index, mp3
+
+    def test_merges_into_db_and_file(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import mutagen.id3 as id3
+
+        index, mp3 = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+
+        applied = gs.enrich_album_genres(index, [tid], self._config())
+        db_genres = {
+            g.strip() for g in index.get_track_by_id(tid).genre.split(";") if g.strip()
+        }
+        index.close()
+
+        assert applied == ["Shoegaze"]
+        assert db_genres == {"Jazz", "Shoegaze"}  # merge, not replace
+        assert set(id3.ID3(str(mp3))["TCON"].text) == {"Jazz", "Shoegaze"}
+
+    def test_file_write_failure_is_best_effort(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failing file write must not crash enrichment; the DB still updates.
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+
+        def _boom(*a: Any, **k: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("kamp_core.library.write_meta_tags_to_file", _boom)
+        applied = gs.enrich_album_genres(index, [tid], self._config())
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert applied == ["Shoegaze"]
+        assert "Shoegaze" in genre  # DB merge happened despite the file failure
+
+    def test_disabled_config_is_noop(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        # enabled_sources returns [] for a disabled config — no patch needed.
+        applied = gs.enrich_album_genres(index, [tid], self._config(on=False))
+        db_genres = {
+            g.strip() for g in index.get_track_by_id(tid).genre.split(";") if g.strip()
+        }
+        index.close()
+        assert applied == []
+        assert db_genres == {"Jazz"}
+
+    def test_no_source_genres_is_noop(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(gs, "enabled_sources", lambda cfg: [_StubSource([])])
+        applied = gs.enrich_album_genres(index, [tid], self._config())
+        db_genres = {
+            g.strip() for g in index.get_track_by_id(tid).genre.split(";") if g.strip()
+        }
+        index.close()
+        assert applied == []
+        assert db_genres == {"Jazz"}
+
+    def test_enrich_new_tracks_enriches_local_album(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tracks = index.all_tracks()
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+        gs.enrich_new_tracks(index, tracks, self._config())
+        genre = index.get_track_by_id(tracks[0].id).genre
+        index.close()
+        assert "Shoegaze" in genre and "Jazz" in genre
+
+    def test_enrich_new_tracks_disabled_is_noop(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tracks = index.all_tracks()
+        gs.enrich_new_tracks(index, tracks, self._config(on=False))
+        genre = index.get_track_by_id(tracks[0].id).genre
+        index.close()
+        assert genre == "Jazz"
+
+    def test_remote_track_gets_db_genres_no_file_write(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A remote/streaming track has no local file to stamp — apply_genres still
+        # updates the DB, and the file-write branch is skipped (no crash on the
+        # bandcamp:// path).
+        from pathlib import Path as _Path
+
+        from kamp_core.library import LibraryIndex, Track
+
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=_Path("bandcamp://S1/1"),
+                    title="T",
+                    artist="Grimes",
+                    album_artist="Grimes",
+                    album="Visions",
+                    release_date="2012",
+                    track_number=1,
+                    disc_number=1,
+                    ext="",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                    source="bandcamp",
+                    genres=["Art Pop"],
+                )
+            ]
+        )
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Synth-Pop"])]
+        )
+        applied = gs.enrich_album_genres(index, [tid], self._config())
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert applied == ["Synth-Pop"]
+        assert "Art Pop" in genre and "Synth-Pop" in genre

--- a/tests/test_genre_sources.py
+++ b/tests/test_genre_sources.py
@@ -311,16 +311,36 @@ class TestEnrichAlbumGenres:
         assert applied == []
         assert db_genres == {"Jazz"}
 
-    def test_enrich_new_tracks_enriches_local_album(
+    def test_enrich_new_tracks_resolves_ids_from_db(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        index, _ = self._seed_local(tmp_path, ["Jazz"])
-        tracks = index.all_tracks()
+        # A scan's new_tracks are read from files and carry id=0, so the trigger
+        # must resolve real ids from the DB by album — grouping on track.id would
+        # resolve nothing (the bug behind "not working after ingest").
+        from kamp_core.library import Track
+
+        index, mp3 = self._seed_local(tmp_path, ["Jazz"])
+        real_tid = index.all_tracks()[0].id
+        scan_track = Track(
+            file_path=mp3,
+            title="T",
+            artist="Slowdive",
+            album_artist="Slowdive",
+            album="Souvlaki",
+            release_date="1993",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+        )
+        assert scan_track.id == 0  # no DB id, like a real scan result
         monkeypatch.setattr(
             gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
         )
-        gs.enrich_new_tracks(index, tracks, self._config())
-        genre = index.get_track_by_id(tracks[0].id).genre
+        gs.enrich_new_tracks(index, [scan_track], self._config())
+        genre = index.get_track_by_id(real_tid).genre
         index.close()
         assert "Shoegaze" in genre and "Jazz" in genre
 


### PR DESCRIPTION
Adds **Last.fm as a genre source** (via pylast) so ingested albums get good multi-value genres beyond MusicBrainz's poor data. Fixes KAMP-587. Enabled by default (best-effort, async — never slows a download); can be turned off in Tagging preferences. Builds the shared enrichment core KAMP-591 will reuse library-wide.

**Two decisions were resolved before building:** pylast-native (not embedding beets — the product owner's call), and — after a Reality-Checker pass — enrichment runs **asynchronously after ingest**, not inside the blocking pipeline.

## How it works

- **Async, in the main daemon process.** After a scan lands new tracks, a background thread enriches their albums' genres. The pipeline subprocess is untouched, so a slow/hung Last.fm never adds latency to a download. Running in the main process also means pylast/httpx are already collected and proven frozen (the scrobbler uses them there).
- **Shared enrichment core.** `enrich_album_genres` fetches album-level genres from the enabled sources, merges them via the idempotent `apply_genres(mode="merge")` (DB), then writes the merged set into each **local** file — required, because a local re-scan REPLACES DB genres from the file, so a DB-only addition would be wiped. 591 reuses this core.
- **Lightweight `GenreSource` interface** (not a registered extension — the pipeline instantiates sources directly and there's no third-party story). `LastfmGenreSource` reads top-tags via the shared `LASTFM_API_KEY`, read-only.
- **Canonicalize with an ALLOWLIST, not a denylist.** Last.fm tags are unbounded noise ("seen live", "spotify", "00s") and the merge is additive, so anything written once is sticky. Raw tags are filtered through a bundled canonical genre list (`kamp_daemon/data/genres.txt`, staged in `kamp.spec`) plus a weight threshold, and queried on **album-artist** (VA/compilation-safe).
- **Hard wall-clock timeout.** pylast hardcodes a 20s read timeout with no override, so each fetch is bounded by a helper thread; all pylast errors are swallowed to `[]`. Enrichment can never fail an ingest.
- **Config toggle** `tagging.lastfm_genres` (default ON) with a BoolRow in the Tagging preferences tab. This re-adds the bool config-handling KAMP-589 removed (the anticipated "next bool key"), now with a test.

**Deferred (clean fast-follow through the same interface):** MusicBrainz as a second live genre source (`get_release_by_id(mbid, includes=["genres"])`).

## Testing

- Full suite: **2506 passed, 9 skipped**, coverage **93.65%** (at main's level; `genre_sources.py` itself is 94%). black + mypy clean; kamp_ui typecheck + eslint clean.
- New tests: allowlist filtering (junk dropped, canonical casing, dedup) + missing-file degrade; weight threshold; the wall-clock timeout abandons a slow fetch and swallows errors; a hung/failing source yields no genres; `_get_network` builds from the shared key; the enrichment core merges into DB **and** file without clobbering existing genres; remote tracks get DB-only (no file crash); a failed file write is best-effort; and the `enrich_new_tracks` trigger enriches a local album and no-ops when disabled.

## Manual Test Plan

- Enable "Fetch genres from Last.fm" in Tagging preferences; download an album by a well-tagged artist → within a moment it gains sensible genres (library, sidebar, search, chips), written into the files
- Genres are canonical (no "seen live"/"spotify"/decade junk); niche tags not in the allowlist are dropped (add by hand via the 586 chips editor)
- A various-artists album queries by album-artist, not the first track's artist
- Existing genres preserved: an album with Bandcamp tags (588) or user edits keeps them and gains the Last.fm ones (union, no duplicates)
- Toggle OFF → downloads apply no Last.fm genres
- Network down / Last.fm unreachable → the download still completes normally, no genres added, a best-effort warning in the daemon log, nothing quarantined
- A re-scan of an enriched local album keeps the added genres (file+DB consistent)
- **Frozen build:** the allowlist loads (genres actually populate, not all-dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
