### PR TITLE
feat(genres): library-wide genre backfill with progress + cancel (KAMP-591)

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 58
+_SCHEMA_VERSION = 59
 
 
 class NoStreamableVersionError(Exception):
@@ -317,6 +317,10 @@ CREATE TABLE IF NOT EXISTS albums (
     -- NULL means "use the canonical value from Bandcamp".
     display_album        TEXT,
     display_album_artist TEXT,
+    -- KAMP-591: when the library-wide genre backfill last enriched this album.
+    -- NULL means pending; the resumable worker skips already-marked albums so a
+    -- crash/cancel resumes instead of restarting the multi-hour run.
+    genres_enriched_at   REAL,
     UNIQUE (album_artist, album)
 );
 
@@ -2429,7 +2433,21 @@ class LibraryIndex:
                 )
             self._conn.execute("UPDATE schema_version SET version = 58")
             self._conn.commit()
-            version = 58  # noqa: F841
+            version = 58
+
+        if version == 58:
+            # v58 -> v59 (KAMP-591): albums gains genres_enriched_at — the resume
+            # checkpoint for the library-wide genre backfill. Unconstrained nullable
+            # column → plain ADD COLUMN (the albums() query selects explicit columns,
+            # so no view is affected). Presence-guarded for idempotency.
+            _acols2 = {r[1] for r in self._conn.execute("PRAGMA table_info(albums)")}
+            if "genres_enriched_at" not in _acols2:
+                self._conn.execute(
+                    "ALTER TABLE albums ADD COLUMN genres_enriched_at REAL"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 59")
+            self._conn.commit()
+            version = 59  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -3934,6 +3952,39 @@ class LibraryIndex:
             "UPDATE bandcamp_collection SET keywords = ? WHERE sale_item_id = ?",
             (json.dumps(keywords), sale_item_id),
         )
+        self._conn.commit()
+
+    # -- genre backfill checkpoint (KAMP-591) --------------------------------
+
+    def albums_pending_genre_enrichment(self) -> list[dict[str, Any]]:
+        """Albums the genre backfill hasn't processed yet (genres_enriched_at IS
+        NULL), oldest first. Each row carries what the worker needs: the album id
+        (to mark done), the names (to resolve tracks + query sources), and the
+        Bandcamp identity/cache (album_url + keywords) for the re-scrape path.
+        Missing-album virtual entries aren't in this table, so they're excluded."""
+        return [
+            dict(r)
+            for r in self._conn.execute(
+                "SELECT a.id, a.album_artist, a.album, a.sale_item_id,"
+                " bc.album_url, bc.keywords"
+                " FROM albums a"
+                " LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id"
+                " WHERE a.genres_enriched_at IS NULL"
+                " ORDER BY a.id"
+            ).fetchall()
+        ]
+
+    def mark_album_genres_enriched(self, album_id: int, ts: float) -> None:
+        """Checkpoint an album as processed by the backfill so a restart resumes."""
+        self._conn.execute(
+            "UPDATE albums SET genres_enriched_at = ? WHERE id = ?", (ts, album_id)
+        )
+        self._conn.commit()
+
+    def clear_genre_enrichment_marks(self) -> None:
+        """Reset every album's checkpoint so a fresh Update Library Genres run
+        re-processes the whole library (KAMP-591)."""
+        self._conn.execute("UPDATE albums SET genres_enriched_at = NULL")
         self._conn.commit()
 
     def get_remote_collection(self) -> list[dict[str, Any]]:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -992,6 +992,8 @@ def create_app(
     on_bandcamp_disconnect: Callable[[], None] | None = None,
     on_bandcamp_sync_trigger: Callable[[], None] | None = None,
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
+    on_genre_backfill_start: Callable[[], None] | None = None,
+    on_genre_backfill_cancel: Callable[[], None] | None = None,
     dl_queue: _queue.Queue[str] | None = None,
     refresh_stream_url: Callable[[str, int], tuple[str, float] | None] | None = None,
     check_stream_url: Callable[[str], int] | None = None,
@@ -1025,6 +1027,11 @@ def create_app(
             "num_albums": 0,
             "num_artists": 0,
         },
+        # genre_backfill (KAMP-591): written by the backfill worker thread, read by
+        # GET /api/v1/genres/backfill/progress (reconnecting clients) + pushed live
+        # over the "genre_backfill.progress" WebSocket event. state ∈ idle/running/
+        # done/cancelled.
+        "genre_backfill": {"active": False, "done": 0, "total": 0, "state": "idle"},
         "ui_active_view": ui_active_view,
         "ui_sort_order": ui_sort_order,
         "ui_sort_dir": ui_sort_dir,
@@ -1191,6 +1198,28 @@ def create_app(
     app.state.notify_play_state_changed = _notify_play_state_changed
     app.state.notify_bandcamp_sync_status = _notify_bandcamp_sync_status
     app.state.notify_pipeline_stage = _notify_pipeline_stage
+
+    def _notify_genre_backfill_progress(done: int, total: int, state: str) -> None:
+        """Update the genre-backfill snapshot (for GET on reconnect) and push it
+        live to WebSocket clients (KAMP-591)."""
+        active = state == "running"
+        _state["genre_backfill"] = {
+            "active": active,
+            "done": done,
+            "total": total,
+            "state": state,
+        }
+        _broadcast(
+            {
+                "type": "genre_backfill.progress",
+                "active": active,
+                "done": done,
+                "total": total,
+                "state": state,
+            }
+        )
+
+    app.state.notify_genre_backfill_progress = _notify_genre_backfill_progress
 
     def _notify_deferred_op_completed(track_id: int, op_id: int) -> None:
         # Refresh the in-memory queue so the renamed track shows the new path/title
@@ -3237,6 +3266,35 @@ def create_app(
             target=on_bandcamp_sync_all_trigger, daemon=True, name="sync-all"
         ).start()
         return {"ok": True}
+
+    @app.post("/api/v1/genres/backfill")
+    def start_genre_backfill() -> dict[str, Any]:
+        """Start the library-wide genre backfill in the background (KAMP-591).
+
+        Returns immediately; progress arrives via ``genre_backfill.progress``
+        WebSocket events (and GET …/progress for reconnecting clients). Rejects a
+        concurrent start — the run can last hours.
+        """
+        import threading
+
+        if on_genre_backfill_start is None:
+            raise HTTPException(status_code=503, detail="Genre backfill not configured")
+        if _state["genre_backfill"]["active"]:
+            return {"ok": True, "started": False}  # already running
+        threading.Thread(
+            target=on_genre_backfill_start, daemon=True, name="genre-backfill"
+        ).start()
+        return {"ok": True, "started": True}
+
+    @app.post("/api/v1/genres/backfill/cancel")
+    def cancel_genre_backfill() -> dict[str, Any]:
+        if on_genre_backfill_cancel is not None:
+            on_genre_backfill_cancel()
+        return {"ok": True}
+
+    @app.get("/api/v1/genres/backfill/progress")
+    def get_genre_backfill_progress() -> dict[str, Any]:
+        return cast(dict[str, Any], _state["genre_backfill"])
 
     @app.post("/api/v1/bandcamp/collection/{sale_item_id}/download")
     def download_collection_item(sale_item_id: str) -> dict[str, Any]:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -983,6 +983,55 @@ def _cmd_daemon(
             _logger.exception("Unhandled error during Bandcamp sync-all")
             app.state.notify_bandcamp_sync_status("")  # back to idle
 
+    # --- KAMP-591: library-wide genre backfill ("Update Library Genres") ---
+    _genre_backfill_cancel = threading.Event()
+    _genre_backfill_lock = threading.Lock()
+    _genre_backfill_running = [False]  # boxed for the closure
+
+    def _on_genre_backfill_start() -> None:
+        with _genre_backfill_lock:
+            if _genre_backfill_running[0]:
+                return  # already running — reject the concurrent start
+            _genre_backfill_running[0] = True
+        _genre_backfill_cancel.clear()
+        try:
+            from .genre_backfill import run_genre_backfill
+
+            cfg = Config.load(index)
+            # Best-effort proxy-aware Bandcamp session (None when not logged in →
+            # the per-album re-scrape is skipped and Last.fm still runs).
+            session = None
+            session_data = index.get_session("bandcamp")
+            if session_data:
+                try:
+                    from .bandcamp import _make_requests_session
+
+                    session = _make_requests_session(session_data)
+                except Exception:
+                    _logger.exception(
+                        "genre backfill: could not build a Bandcamp session"
+                    )
+            # A completed library (nothing pending) means the user wants a fresh
+            # re-run; a partial state (crash/cancel) resumes the remainder instead.
+            if not index.albums_pending_genre_enrichment():
+                index.clear_genre_enrichment_marks()
+            run_genre_backfill(
+                index,
+                cfg,
+                session,
+                app.state.notify_genre_backfill_progress,
+                _genre_backfill_cancel,
+            )
+        except Exception:
+            _logger.exception("Unhandled error in genre backfill")
+            app.state.notify_genre_backfill_progress(0, 0, "error")
+        finally:
+            with _genre_backfill_lock:
+                _genre_backfill_running[0] = False
+
+    def _on_genre_backfill_cancel() -> None:
+        _genre_backfill_cancel.set()
+
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")
     _bc_ever_connected = index.get_setting("bandcamp.ever_connected") == "true"
@@ -1034,6 +1083,8 @@ def _cmd_daemon(
         on_bandcamp_disconnect=_on_bandcamp_disconnect,
         on_bandcamp_sync_trigger=_on_bandcamp_sync_trigger,
         on_bandcamp_sync_all_trigger=_on_bandcamp_sync_all_trigger,
+        on_genre_backfill_start=_on_genre_backfill_start,
+        on_genre_backfill_cancel=_on_genre_backfill_cancel,
         dl_queue=_dl_queue,
         art_cache_dir=_state_dir() / "art_cache",
         refresh_stream_url=_refresh_stream_url,

--- a/kamp_daemon/genre_backfill.py
+++ b/kamp_daemon/genre_backfill.py
@@ -1,0 +1,152 @@
+"""Library-wide genre backfill worker (KAMP-591).
+
+The "Update Library Genres" button runs this over every album: it re-fetches
+genres from the new sources and merges them in via the shared per-album unit
+(``enrich_album_genres``, KAMP-587) — Last.fm for all albums, plus each Bandcamp
+album's original artist tags (cached from KAMP-588, or a one-time page re-scrape
+for pre-588 albums whose cache is empty; a re-sync never backfills those).
+
+The run can take hours on a large library, so it is:
+- **Resumable** — driven by the ``albums.genres_enriched_at`` checkpoint, so a
+  crash or cancel resumes from the un-enriched albums instead of restarting.
+- **Cancellable** — a ``threading.Event`` checked before each album and before
+  each network op.
+- **Best-effort** — any source/album failing is logged and skipped; a
+  circuit-breaker disables Last.fm for the rest of the run if it goes dark, so
+  thousands of stacked timeouts don't turn a down service into a multi-hour stall.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Callable
+
+from .genre_sources import enrich_album_genres
+
+if TYPE_CHECKING:
+    from kamp_core.library import LibraryIndex
+
+    from .config import Config
+
+logger = logging.getLogger(__name__)
+
+# Pacing between albums (Bandcamp page GETs are HTML scraping — a ban risk — so a
+# floor sleep spaces them; only cache-miss albums re-scrape).
+_THROTTLE_S = 1.0
+# An album whose enrich took ~this long AND yielded nothing almost certainly hit
+# the Last.fm wall-clock timeout — count it toward the circuit breaker.
+_LASTFM_SLOW_S = 6.0
+_LASTFM_BREAKER_N = 5
+
+# State strings for the progress payload.
+RUNNING, DONE, CANCELLED = "running", "done", "cancelled"
+
+ProgressCb = Callable[[int, int, str], None]
+
+
+def _bandcamp_extra_genres(
+    index: "LibraryIndex", album: dict[str, Any], session: Any, cancel: Any
+) -> list[str]:
+    """The album's Bandcamp tags, applied verbatim (588-consistent): cached
+    keywords if present, else a one-time proxy re-scrape that is cached. [] for
+    non-Bandcamp albums, no session, or a failed/empty scrape (an empty result is
+    NEVER cached — it may be a silent Cloudflare challenge page)."""
+    if not album.get("sale_item_id"):
+        return []
+    raw = album.get("keywords")
+    if raw:  # cache hit — no network
+        try:
+            return list(json.loads(raw))
+        except (ValueError, TypeError):
+            return []
+    album_url = album.get("album_url")
+    if not session or not album_url or cancel.is_set():
+        return []
+    try:
+        # session is a proxy-aware session (Cloudflare-safe when frozen); never a
+        # raw requests.Session. .text works for both, like fetch_album_tracks.
+        from .bandcamp import parse_album_keywords  # noqa: PLC0415
+
+        resp = session.get(album_url, timeout=30)
+        keywords = parse_album_keywords(resp.text)
+    except Exception as exc:  # noqa: BLE001 — best-effort re-scrape
+        logger.info(
+            "genre backfill: Bandcamp re-scrape failed for %s (best-effort): %s",
+            album_url,
+            exc,
+        )
+        return []
+    if keywords:  # only cache a real result
+        index.set_collection_keywords(str(album["sale_item_id"]), keywords)
+    return keywords
+
+
+def run_genre_backfill(
+    index: "LibraryIndex",
+    config: "Config",
+    session: Any,
+    notify: ProgressCb,
+    cancel: Any,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Enrich genres for every pending album. *session* may be None (no Bandcamp
+    login) — Last.fm still runs. *notify(done, total, state)* reports progress."""
+    pending = index.albums_pending_genre_enrichment()
+    total = len(pending)
+    notify(0, total, RUNNING)
+    if total == 0:
+        notify(0, 0, DONE)
+        return
+
+    lastfm_ok = True
+    consecutive_slow = 0
+    cfg_no_lastfm = replace(
+        config, tagging=replace(config.tagging, lastfm_genres=False)
+    )
+
+    for done, album in enumerate(pending, start=1):
+        if cancel.is_set():
+            notify(done - 1, total, CANCELLED)
+            return
+        ids = [
+            t.id for t in index.tracks_for_album(album["album_artist"], album["album"])
+        ]
+        if ids and not cancel.is_set():
+            extra = _bandcamp_extra_genres(index, album, session, cancel)
+            cfg = config if lastfm_ok else cfg_no_lastfm
+            started = time.monotonic()
+            try:
+                applied = enrich_album_genres(index, ids, cfg, extra_genres=extra)
+            except Exception as exc:  # noqa: BLE001 — one album can't break the run
+                logger.warning(
+                    "genre backfill: enrich failed for %r (best-effort): %s",
+                    album["album"],
+                    exc,
+                )
+                applied = []
+            elapsed = time.monotonic() - started
+            if lastfm_ok:
+                if not applied and elapsed >= _LASTFM_SLOW_S:
+                    consecutive_slow += 1
+                    if consecutive_slow >= _LASTFM_BREAKER_N:
+                        lastfm_ok = False
+                        logger.warning(
+                            "genre backfill: Last.fm looks unreachable "
+                            "(%d slow empty albums) — disabling it for the rest "
+                            "of this run; Bandcamp continues",
+                            consecutive_slow,
+                        )
+                elif applied:
+                    consecutive_slow = 0
+
+        # Checkpoint after each album (even empty ones) so a resume skips it.
+        index.mark_album_genres_enriched(album["id"], time.time())
+        notify(done, total, RUNNING)
+        if done < total:
+            sleep(_THROTTLE_S)
+
+    notify(total, total, DONE)

--- a/kamp_daemon/genre_sources.py
+++ b/kamp_daemon/genre_sources.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kamp_core.library import LibraryIndex
@@ -216,20 +217,36 @@ def fetch_all_genres(sources: list[GenreSource], query: GenreQuery) -> list[str]
     return list(seen.values())
 
 
-def enrich_album_genres(
-    index: "LibraryIndex", track_ids: list[int], config: "Config"
-) -> list[str]:
-    """Fetch genres for the album containing *track_ids* from the enabled sources
-    and merge them in — DB via ``apply_genres(merge)`` and, for local tracks, the
-    files. The shared enrichment core (KAMP-587; KAMP-591 reuses it library-wide).
+# Serializes genre writes so the 587 ingest-enrichment and the 591 library
+# backfill can never write the same file's tags concurrently (SQLite serializes
+# the DB, but two mutagen save()s on one file can produce a torn tag).
+_ENRICH_LOCK = threading.Lock()
 
-    Best-effort and idempotent: returns the genres it applied ([] when nothing is
-    enabled, no tracks resolve, or no source yielded a genre). Files must be
-    written too, not just the DB: a local file's re-scan REPLACES its DB genres
-    from the file, so a DB-only addition would be wiped on the next scan.
+
+def enrich_album_genres(
+    index: "LibraryIndex",
+    track_ids: list[int],
+    config: "Config",
+    *,
+    extra_genres: "Sequence[str]" = (),
+) -> list[str]:
+    """Merge genres into the album containing *track_ids* — DB via
+    ``apply_genres(merge)`` and, for local tracks, the files. The shared
+    enrichment core (KAMP-587; KAMP-591 reuses it library-wide).
+
+    Genres come from the enabled sources (Last.fm, allowlist-filtered) unioned
+    with *extra_genres*. ``extra_genres`` is applied VERBATIM — it is the caller's
+    already-filtered source (KAMP-591 passes Bandcamp keywords, pre-filtered by
+    ``parse_album_keywords``); re-running the Last.fm allowlist would diverge from
+    588 and drop the artist's niche tags. Crucially, extra_genres alone can drive
+    an apply even when Last.fm is off/empty.
+
+    Best-effort and idempotent: returns the genres applied ([] when no track
+    resolves or the union is empty). Files must be written, not just the DB: a
+    local file's re-scan REPLACES its DB genres from the file, so a DB-only
+    addition would be wiped on the next scan.
     """
-    sources = enabled_sources(config)
-    if not sources or not track_ids:
+    if not track_ids:
         return []
     tracks = [t for t in (index.get_track_by_id(tid) for tid in track_ids) if t]
     if not tracks:
@@ -239,11 +256,19 @@ def enrich_album_genres(
     # this keys correctly for compilations / various-artists.
     first = tracks[0]
     query = GenreQuery(album_artist=first.album_artist, album=first.album)
-    genres = fetch_all_genres(sources, query)
-    if not genres:
+    fetched = fetch_all_genres(enabled_sources(config), query)  # allowlist-filtered
+
+    # Union the fetched (Last.fm) + extra (verbatim) genres, order-preserving,
+    # case-insensitively deduped. Gate on the UNION so Bandcamp-only genres apply.
+    seen: dict[str, str] = {}
+    for name in (*fetched, *extra_genres):
+        cf = name.casefold()
+        if name and cf not in seen:
+            seen[cf] = name
+    to_apply = list(seen.values())
+    if not to_apply:
         logger.info(
-            "genre enrich: %r by %r — no genres applied (no source returned a "
-            "canonical genre)",
+            "genre enrich: %r by %r — no genres applied",
             query.album,
             query.album_artist,
         )
@@ -253,32 +278,32 @@ def enrich_album_genres(
         "genre enrich: %r by %r → applying %s to %d track(s)",
         query.album,
         query.album_artist,
-        genres,
+        to_apply,
         len(tracks),
     )
-    index.apply_genres([t.id for t in tracks], genres, mode="merge")
-
     from kamp_core.library import write_meta_tags_to_file  # noqa: PLC0415
 
-    for track in tracks:
-        if track.is_remote:
-            continue
-        # Re-read the post-merge canonical set. The DB read exposes it as the
-        # denormalized "; "-joined `genre` string (the `genres` list is a
-        # write-path field, empty on DB read), so split it for the file write.
-        merged = index.get_track_by_id(track.id)
-        if merged is None:
-            continue
-        names = [g.strip() for g in merged.genre.split(";") if g.strip()]
-        try:
-            write_meta_tags_to_file(Path(merged.file_path), genres=names)
-        except Exception as exc:  # noqa: BLE001 — best-effort file write
-            logger.warning(
-                "genre enrich: file write failed for %s (best-effort): %s",
-                merged.file_path,
-                exc,
-            )
-    return genres
+    with _ENRICH_LOCK:
+        index.apply_genres([t.id for t in tracks], to_apply, mode="merge")
+        for track in tracks:
+            if track.is_remote:
+                continue
+            # Re-read the post-merge canonical set. The DB read exposes it as the
+            # denormalized "; "-joined `genre` string (the `genres` list is a
+            # write-path field, empty on DB read), so split it for the file write.
+            merged = index.get_track_by_id(track.id)
+            if merged is None:
+                continue
+            names = [g.strip() for g in merged.genre.split(";") if g.strip()]
+            try:
+                write_meta_tags_to_file(Path(merged.file_path), genres=names)
+            except Exception as exc:  # noqa: BLE001 — best-effort file write
+                logger.warning(
+                    "genre enrich: file write failed for %s (best-effort): %s",
+                    merged.file_path,
+                    exc,
+                )
+    return to_apply
 
 
 def enrich_new_tracks(

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -401,6 +401,23 @@ export type ScanProgress = {
 
 export const getScanProgress = (): Promise<ScanProgress> => get('/api/v1/library/scan/progress')
 
+// KAMP-591: library-wide genre backfill (re-fetch genres for every album).
+export type GenreBackfillProgress = {
+  active: boolean
+  done: number
+  total: number
+  state: 'idle' | 'running' | 'done' | 'cancelled' | 'error'
+}
+
+export const startGenreBackfill = (): Promise<{ ok: boolean; started: boolean }> =>
+  post('/api/v1/genres/backfill')
+
+export const cancelGenreBackfill = (): Promise<{ ok: boolean }> =>
+  post('/api/v1/genres/backfill/cancel')
+
+export const getGenreBackfillProgress = (): Promise<GenreBackfillProgress> =>
+  get('/api/v1/genres/backfill/progress')
+
 export type ConfigValues = {
   'paths.watch_folder': string | null
   'paths.library': string | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -939,6 +939,10 @@ export function PreferencesDialog({
   const scanLibrary = useStore((s) => s.scanLibrary)
   const scanStatus = useStore((s) => s.scanStatus)
   const scanProgress = useStore((s) => s.scanProgress)
+  const genreBackfill = useStore((s) => s.genreBackfill)
+  const startGenreBackfill = useStore((s) => s.startGenreBackfill)
+  const cancelGenreBackfill = useStore((s) => s.cancelGenreBackfill)
+  const refreshGenreBackfill = useStore((s) => s.refreshGenreBackfill)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
   const [activeTab, setActiveTab] = useState<'general' | 'tagging' | 'services' | 'extensions'>(
     () => prefsInitialTab
@@ -985,6 +989,18 @@ export function PreferencesDialog({
       void loadConfig()
     }
   }, [prefsOpen, configValues, loadConfig])
+
+  // KAMP-591: while the Tagging tab is open, resync genre-backfill progress and
+  // poll (~1 Hz) as long as a run is active. The interval is bounded by the tab
+  // being visible, so a multi-hour run never polls after prefs is closed.
+  const backfillActive = genreBackfill?.active ?? false
+  useEffect(() => {
+    if (!prefsOpen || activeTab !== 'tagging') return
+    void refreshGenreBackfill()
+    if (!backfillActive) return
+    const poll = setInterval(() => void refreshGenreBackfill(), 1000)
+    return () => clearInterval(poll)
+  }, [prefsOpen, activeTab, backfillActive, refreshGenreBackfill])
 
   // Close on Escape.
   useEffect(() => {
@@ -1211,6 +1227,64 @@ export function PreferencesDialog({
                       initialValue={configValues?.['tagging.lastfm_genres'] ?? true}
                       onSave={handleSave}
                     />
+                    <div className="prefs-row">
+                      <div className="prefs-row-header">
+                        <span className="prefs-label">Update library genres</span>
+                      </div>
+                      {backfillActive ? (
+                        <div className="prefs-scan-status">
+                          <span className="prefs-scan-scanning">
+                            {genreBackfill && genreBackfill.total > 0
+                              ? `Updating genres… ${genreBackfill.done} / ${genreBackfill.total} albums`
+                              : 'Starting…'}
+                          </span>
+                          {genreBackfill && genreBackfill.total > 0 && (
+                            <div className="prefs-scan-progress">
+                              <div
+                                className="prefs-scan-progress-fill"
+                                style={{
+                                  width: `${(genreBackfill.done / genreBackfill.total) * 100}%`
+                                }}
+                              />
+                            </div>
+                          )}
+                          <button
+                            className="prefs-choose-btn"
+                            onClick={() => void cancelGenreBackfill()}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          className="prefs-choose-btn"
+                          onClick={() => void startGenreBackfill()}
+                        >
+                          Update Library Genres
+                        </button>
+                      )}
+                      {!backfillActive && genreBackfill?.state === 'done' && (
+                        <p className="prefs-hint">
+                          Genre update complete{' '}
+                          {genreBackfill.total > 0 ? `(${genreBackfill.total} albums)` : ''}.
+                        </p>
+                      )}
+                      {!backfillActive && genreBackfill?.state === 'cancelled' && (
+                        <p className="prefs-hint">Genre update cancelled.</p>
+                      )}
+                      {!backfillActive && genreBackfill?.state === 'error' && (
+                        <p className="prefs-hint" style={{ color: 'var(--error)' }}>
+                          Genre update failed — check the server logs.
+                        </p>
+                      )}
+                      {!backfillActive && !genreBackfill && (
+                        <p className="prefs-hint">
+                          Re-fetch genres for every album from Last.fm (and re-scrape original tags
+                          for older Bandcamp albums). Runs in the background; existing genres are
+                          kept and only added to.
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </>
               )}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -18,6 +18,7 @@ import type {
   PlayerState,
   Playlist,
   PlaylistTrack,
+  GenreBackfillProgress,
   QueueState,
   ScanProgress,
   ScanResult,
@@ -66,6 +67,8 @@ type PlayerStore = {
   lastScanResult: ScanResult | null
   scanError: string | null
   scanProgress: ScanProgress | null
+  // KAMP-591: library-wide genre backfill progress (null when never started this session).
+  genreBackfill: GenreBackfillProgress | null
 
   leftDb: number | null
   rightDb: number | null
@@ -312,6 +315,9 @@ type PlayerStore = {
   refreshOpenAlbum: () => Promise<void>
   patchOpenAlbum: (album: Album) => void
   scanLibrary: () => Promise<void>
+  startGenreBackfill: () => Promise<void>
+  cancelGenreBackfill: () => Promise<void>
+  refreshGenreBackfill: () => Promise<void>
   setLibraryPath: (path: string) => Promise<void>
   setWatchFolderPath: (path: string) => Promise<void>
   applyServerState: (state: PlayerState) => void
@@ -393,6 +399,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   lastScanResult: null,
   scanError: null,
   scanProgress: null,
+  genreBackfill: null,
   leftDb: null,
   rightDb: null,
   crestDb: null,
@@ -1669,6 +1676,42 @@ export const useStore = create<PlayerStore>((set, get) => ({
       set({ scanStatus: 'error', scanError: msg, scanProgress: null })
     } finally {
       clearInterval(pollInterval)
+    }
+  },
+
+  // KAMP-591: library-wide genre backfill. The daemon owns the long-running task;
+  // the UI kicks it off and polls the GET progress endpoint (~1 Hz) while it runs.
+  // Polling — not the websocket — mirrors scanLibrary and keeps the progress
+  // read self-contained: it only matters while the preferences dialog is open.
+  startGenreBackfill: async () => {
+    set({
+      genreBackfill: { active: true, done: 0, total: 0, state: 'running' }
+    })
+    try {
+      await api.startGenreBackfill()
+    } catch {
+      set({ genreBackfill: { active: false, done: 0, total: 0, state: 'error' } })
+      return
+    }
+    void get().refreshGenreBackfill()
+  },
+
+  cancelGenreBackfill: async () => {
+    try {
+      await api.cancelGenreBackfill()
+    } catch {
+      // best-effort — the poll will reflect the true state
+    }
+  },
+
+  // One-shot fetch of the current backfill progress. Cadence is owned by the
+  // caller (PreferencesDialog polls while open + active) so no interval outlives
+  // the dialog — a multi-hour run shouldn't poll forever after prefs is closed.
+  refreshGenreBackfill: async () => {
+    try {
+      set({ genreBackfill: await api.getGenreBackfillProgress() })
+    } catch {
+      // transient — leave the last known state in place
     }
   }
 }))

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -1,0 +1,357 @@
+"""Tests for kamp_daemon.genre_backfill (KAMP-591 library-wide genre backfill)."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from kamp_daemon import genre_backfill as gb
+from kamp_daemon.config import (
+    ArtworkConfig,
+    Config,
+    LibraryConfig,
+    MusicBrainzConfig,
+    PathsConfig,
+    TaggingConfig,
+)
+
+
+def _config() -> Config:
+    return Config(
+        paths=PathsConfig(watch_folder=None, library=None),
+        musicbrainz=MusicBrainzConfig(),
+        artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
+        library=LibraryConfig(path_template=""),
+        tagging=TaggingConfig(lastfm_genres=True),
+    )
+
+
+class _Track:
+    def __init__(self, tid: int) -> None:
+        self.id = tid
+
+
+def _album(aid: int, **extra: Any) -> dict[str, Any]:
+    row = {
+        "id": aid,
+        "album_artist": f"Artist{aid}",
+        "album": f"Album{aid}",
+        "sale_item_id": None,
+        "album_url": None,
+        "keywords": None,
+    }
+    row.update(extra)
+    return row
+
+
+def _index(albums: list[dict[str, Any]]) -> MagicMock:
+    index = MagicMock()
+    index.albums_pending_genre_enrichment.return_value = albums
+    index.tracks_for_album.return_value = [_Track(1)]
+    return index
+
+
+class _Progress:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int, str]] = []
+
+    def __call__(self, done: int, total: int, state: str) -> None:
+        self.calls.append((done, total, state))
+
+
+class TestRunGenreBackfill:
+    def test_enriches_each_album_and_marks_done(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = _index([_album(1), _album(2)])
+        calls: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, **kw: calls.append(ids) or [],
+        )
+        prog = _Progress()
+        gb.run_genre_backfill(
+            index, _config(), None, prog, threading.Event(), sleep=lambda _s: None
+        )
+        assert len(calls) == 2  # both albums enriched
+        assert index.mark_album_genres_enriched.call_count == 2
+        assert prog.calls[-1] == (2, 2, gb.DONE)
+
+    def test_empty_library_reports_done(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        prog = _Progress()
+        gb.run_genre_backfill(
+            _index([]), _config(), None, prog, threading.Event(), sleep=lambda _s: None
+        )
+        assert prog.calls[-1] == (0, 0, gb.DONE)
+
+    def test_cancel_stops_mid_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        index = _index([_album(1), _album(2), _album(3)])
+        cancel = threading.Event()
+        seen: list[int] = []
+
+        def _enrich(idx: Any, ids: Any, cfg: Any, **kw: Any) -> list[str]:
+            seen.append(1)
+            cancel.set()  # cancel after the first album
+            return []
+
+        monkeypatch.setattr(gb, "enrich_album_genres", _enrich)
+        prog = _Progress()
+        gb.run_genre_backfill(
+            index, _config(), None, prog, cancel, sleep=lambda _s: None
+        )
+        assert len(seen) == 1  # stopped before the 2nd album
+        assert prog.calls[-1][2] == gb.CANCELLED
+
+    def test_bandcamp_cache_hit_skips_rescrape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords='["Shoegaze"]', album_url="u")]
+        )
+        session = MagicMock()  # must NOT be used on a cache hit
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            session,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        session.get.assert_not_called()
+        assert passed == [["Shoegaze"]]
+
+    def test_bandcamp_cache_miss_rescrapes_and_caches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/album")]
+        )
+        resp = MagicMock()
+        resp.text = "<html></html>"
+        session = MagicMock()
+        session.get.return_value = resp
+        monkeypatch.setattr(
+            "kamp_daemon.bandcamp.parse_album_keywords", lambda html: ["Noise Rock"]
+        )
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            session,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        session.get.assert_called_once()
+        index.set_collection_keywords.assert_called_once_with("S1", ["Noise Rock"])
+        assert passed == [["Noise Rock"]]
+
+    def test_empty_rescrape_is_not_cached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A challenge page parses to [] — must NOT be cached (would permanently
+        # skip the album on future runs).
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/a")]
+        )
+        resp = MagicMock()
+        resp.text = "<html>challenge</html>"
+        session = MagicMock()
+        session.get.return_value = resp
+        monkeypatch.setattr(
+            "kamp_daemon.bandcamp.parse_album_keywords", lambda html: []
+        )
+        monkeypatch.setattr(gb, "enrich_album_genres", lambda idx, ids, cfg, **kw: [])
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            session,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        index.set_collection_keywords.assert_not_called()
+
+    def test_malformed_keywords_cache_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A corrupt keywords blob must degrade to [] (no genres), never crash or
+        # trigger a re-scrape.
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords="not-json", album_url="u")]
+        )
+        session = MagicMock()
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            session,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        session.get.assert_not_called()
+        assert passed == [[]]
+
+    def test_no_session_skips_bandcamp_rescrape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A cache-miss Bandcamp album with no session (not logged in) yields no
+        # extra genres — Last.fm still runs.
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/a")]
+        )
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            None,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        assert passed == [[]]
+
+    def test_rescrape_exception_is_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/a")]
+        )
+        session = MagicMock()
+        session.get.side_effect = RuntimeError("boom")
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            session,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        index.set_collection_keywords.assert_not_called()
+        assert passed == [[]]
+
+    def test_album_with_no_tracks_is_marked_and_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An album whose tracks resolve to nothing is checkpointed but never
+        # enriched (no ids to apply to).
+        index = _index([_album(1)])
+        index.tracks_for_album.return_value = []
+        called: list[Any] = []
+        monkeypatch.setattr(
+            gb, "enrich_album_genres", lambda *a, **k: called.append(1) or []
+        )
+        prog = _Progress()
+        gb.run_genre_backfill(
+            index, _config(), None, prog, threading.Event(), sleep=lambda _s: None
+        )
+        assert called == []  # never enriched
+        index.mark_album_genres_enriched.assert_called_once()  # still checkpointed
+        assert prog.calls[-1] == (1, 1, gb.DONE)
+
+    def test_enrich_exception_does_not_break_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index = _index([_album(1), _album(2)])
+
+        def _enrich(idx: Any, ids: Any, cfg: Any, **kw: Any) -> list[str]:
+            raise RuntimeError("network exploded")
+
+        monkeypatch.setattr(gb, "enrich_album_genres", _enrich)
+        prog = _Progress()
+        gb.run_genre_backfill(
+            index, _config(), None, prog, threading.Event(), sleep=lambda _s: None
+        )
+        # Both albums attempted and checkpointed despite the raise.
+        assert index.mark_album_genres_enriched.call_count == 2
+        assert prog.calls[-1] == (2, 2, gb.DONE)
+
+    def test_breaker_resets_on_productive_album(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A slow+empty album increments the breaker; a productive album resets it,
+        # so an intermittent Last.fm never trips the breaker.
+        monkeypatch.setattr(gb, "_LASTFM_SLOW_S", -1.0)  # every album counts as slow
+        monkeypatch.setattr(gb, "_LASTFM_BREAKER_N", 3)
+        index = _index([_album(i) for i in range(1, 5)])
+        # album 1,2 empty (slow) → count=2; album 3 productive → reset; album 4 empty.
+        results = iter([[], [], ["Rock"], []])
+        flags: list[bool] = []
+
+        def _enrich(idx: Any, ids: Any, cfg: Any, **kw: Any) -> list[str]:
+            flags.append(cfg.tagging.lastfm_genres)
+            return next(results)
+
+        monkeypatch.setattr(gb, "enrich_album_genres", _enrich)
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            None,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        # Breaker never trips (reset at album 3), so Last.fm stays on throughout.
+        assert flags == [True, True, True, True]
+
+    def test_lastfm_circuit_breaker_trips(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # After N slow+empty albums, Last.fm is disabled for the rest of the run:
+        # subsequent enrich calls receive a config with lastfm_genres=False.
+        monkeypatch.setattr(gb, "_LASTFM_SLOW_S", -1.0)  # every empty album counts
+        monkeypatch.setattr(gb, "_LASTFM_BREAKER_N", 2)
+        index = _index([_album(i) for i in range(1, 6)])
+        flags: list[bool] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, **kw: flags.append(cfg.tagging.lastfm_genres) or [],
+        )
+        gb.run_genre_backfill(
+            index,
+            _config(),
+            None,
+            _Progress(),
+            threading.Event(),
+            sleep=lambda _s: None,
+        )
+        # First 2 albums with Last.fm on (both empty → trips), then off for 3-5.
+        assert flags == [True, True, False, False, False]

--- a/tests/test_genre_sources.py
+++ b/tests/test_genre_sources.py
@@ -263,6 +263,37 @@ class TestEnrichAlbumGenres:
         assert db_genres == {"Jazz", "Shoegaze"}  # merge, not replace
         assert set(id3.ID3(str(mp3))["TCON"].text) == {"Jazz", "Shoegaze"}
 
+    def test_extra_genres_apply_verbatim_without_lastfm(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # KAMP-591: extra_genres (Bandcamp keywords) apply even when Last.fm is
+        # off/empty, and VERBATIM — "Portland" is not in the allowlist but a
+        # Bandcamp album's location tag is kept (588 consistency), unlike Last.fm.
+        index, _ = self._seed_local(tmp_path, [])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(gs, "enabled_sources", lambda cfg: [])  # Last.fm off
+        applied = gs.enrich_album_genres(
+            index, [tid], self._config(), extra_genres=["Portland", "Shoegaze"]
+        )
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert set(applied) == {"Portland", "Shoegaze"}
+        assert "Portland" in genre and "Shoegaze" in genre
+
+    def test_union_lastfm_and_extra_deduped(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, [])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+        applied = gs.enrich_album_genres(
+            index, [tid], self._config(), extra_genres=["shoegaze", "Dream Pop"]
+        )
+        index.close()
+        assert applied == ["Shoegaze", "Dream Pop"]  # dedup, order-preserving
+
     def test_file_write_failure_is_best_effort(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 58
+        assert version == 59
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 58
+        assert version == 59
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -990,7 +990,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 58
+        assert ver == 59
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1012,7 +1012,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 58
+        assert ver == 59
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1109,7 +1109,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 58
+        assert ver == 59
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1233,7 +1233,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 58
+        assert ver == 59
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3358,7 +3358,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3415,7 +3415,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -3792,7 +3792,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -3835,7 +3835,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -3902,7 +3902,7 @@ class TestPreorderResurface:
         ).fetchone()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "redownload_url" in cols
         # Existing row survived; the new column is NULL for pre-existing data.
         assert row["provider_item_id"] == "keep"
@@ -3928,7 +3928,7 @@ class TestPreorderResurface:
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -4282,7 +4282,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert row is not None
         assert row[0] == 0
 
@@ -4747,7 +4747,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -4860,7 +4860,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -5044,7 +5044,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -5139,7 +5139,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 58
+        assert version == 59
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -5147,7 +5147,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 58
+        assert version == 59
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -6074,7 +6074,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 58
+        assert version == 59
 
         index.close()
 
@@ -6805,7 +6805,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 58
+        assert version == 59
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -6840,7 +6840,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 58
+        assert version == 59
         index.close()
 
 
@@ -7381,7 +7381,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 58
+        assert version == 59
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -7514,7 +7514,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 58
+        assert version == 59
 
 
 class TestRemoteTrackSchema:
@@ -7930,7 +7930,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -7991,7 +7991,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -8813,7 +8813,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -9746,7 +9746,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -9824,7 +9824,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -10033,7 +10033,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -10273,7 +10273,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10373,7 +10373,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -10489,7 +10489,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -10994,7 +10994,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -11109,7 +11109,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -11207,7 +11207,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -11307,7 +11307,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -11814,7 +11814,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 58
+        assert version == 59
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -12698,7 +12698,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 58
+        assert version == 59
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -13961,6 +13961,73 @@ class TestProvenanceLinking:
         index.close()
 
 
+class TestGenreEnrichmentCheckpoint:
+    """albums.genres_enriched_at resume checkpoint + helpers (KAMP-591)."""
+
+    def _index_with_album(self, tmp_path: Path) -> LibraryIndex:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                Track(
+                    file_path=tmp_path / "1.mp3",
+                    title="T",
+                    artist="A",
+                    album_artist="A",
+                    album="Alb",
+                    release_date="2020",
+                    track_number=1,
+                    disc_number=1,
+                    ext="mp3",
+                    embedded_art=False,
+                    mb_release_id="",
+                    mb_recording_id="",
+                )
+            ]
+        )
+        return index
+
+    def test_fresh_db_has_column(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(albums)")}
+        index.close()
+        assert "genres_enriched_at" in cols
+
+    def test_pending_mark_clear_cycle(self, tmp_path: Path) -> None:
+        index = self._index_with_album(tmp_path)
+        pending = index.albums_pending_genre_enrichment()
+        assert len(pending) == 1
+        assert pending[0]["album"] == "Alb"
+        aid = pending[0]["id"]
+
+        index.mark_album_genres_enriched(aid, 123.0)
+        assert index.albums_pending_genre_enrichment() == []  # marked → excluded
+
+        index.clear_genre_enrichment_marks()
+        assert len(index.albums_pending_genre_enrichment()) == 1  # reset re-pends
+        index.close()
+
+    def test_migration_v58_adds_column(self, tmp_path: Path) -> None:
+        # A pre-v59 albums table lacks genres_enriched_at. Drop the view before the
+        # column (KAMP-582 CI lesson), simulate v58, reopen → migration re-adds it
+        # and the existing album is preserved (now pending).
+        db = tmp_path / "library.db"
+        index = self._index_with_album(tmp_path)
+        index.close()
+        conn = sqlite3.connect(str(db))
+        conn.execute("DROP VIEW IF EXISTS tracks_with_stats")
+        conn.execute("ALTER TABLE albums DROP COLUMN genres_enriched_at")
+        conn.execute("UPDATE schema_version SET version = 58")
+        conn.commit()
+        conn.close()
+
+        index = LibraryIndex(db)
+        cols = {r[1] for r in index._conn.execute("PRAGMA table_info(albums)")}
+        pending = index.albums_pending_genre_enrichment()
+        index.close()
+        assert "genres_enriched_at" in cols
+        assert len(pending) == 1
+
+
 class TestCollectionKeywords:
     """bandcamp_collection.keywords cache column + setter (KAMP-588)."""
 
@@ -14414,7 +14481,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 58
+        assert version == 59
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -14434,7 +14501,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 58
+        assert version == 59
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -14477,7 +14544,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 58
+        assert version == 59
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -14756,7 +14823,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 58
+        assert ver == 59
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -565,6 +565,60 @@ class TestGenresEndpoint:
         assert TestClient(app).get("/api/v1/genres").json() == ["Jazz", "Rock"]
 
 
+class TestGenreBackfillEndpoints:
+    """POST/GET /api/v1/genres/backfill (KAMP-591)."""
+
+    def test_start_spawns_worker(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        called = threading.Event()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_genre_backfill_start=called.set,
+        )
+        resp = TestClient(app).post("/api/v1/genres/backfill")
+        assert resp.json() == {"ok": True, "started": True}
+        assert called.wait(timeout=2.0)  # the daemon thread ran the callback
+
+    def test_start_rejected_when_active(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        start = MagicMock()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_genre_backfill_start=start,
+        )
+        app.state.notify_genre_backfill_progress(1, 10, "running")  # mark active
+        resp = TestClient(app).post("/api/v1/genres/backfill")
+        assert resp.json() == {"ok": True, "started": False}
+        start.assert_not_called()
+
+    def test_cancel_calls_callback(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        cancel = MagicMock()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_genre_backfill_cancel=cancel,
+        )
+        TestClient(app).post("/api/v1/genres/backfill/cancel")
+        cancel.assert_called_once()
+
+    def test_progress_snapshot(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        app.state.notify_genre_backfill_progress(3, 10, "running")
+        data = TestClient(app).get("/api/v1/genres/backfill/progress").json()
+        assert data == {"active": True, "done": 3, "total": 10, "state": "running"}
+
+
 class TestTopArtistsEndpoint:
     def test_returns_empty_list_when_no_artists(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

Adds an **"Update Library Genres"** button in the Tagging preferences tab that re-fetches genres for *every* album in the library and merges them in — the one mechanism for backfilling the existing library after the genre sprint (586/587/588), since a re-sync never revisits already-indexed albums.

Each album gets:
- **Last.fm genres** (canonical, allowlist-filtered) — DB-only for streaming albums, DB + file tags for local ones.
- **Bandcamp original artist tags** — from the KAMP-588 keyword cache, or a one-time proxy page re-scrape for pre-588 albums whose cache is empty (applied verbatim, 588-consistent; never re-run through the Last.fm allowlist).

The run is **best-effort, cancellable, and resumable**: a per-album `genres_enriched_at` checkpoint means a crash or cancel resumes from the un-enriched albums instead of restarting, and a Last.fm circuit breaker keeps a dark service from turning thousands of stacked timeouts into a multi-hour stall.

## Changes

- **`genre_sources.py`** — `enrich_album_genres` gains `extra_genres` (verbatim, allowlist-bypassed); its early return now gates on the fetched+extra **union** so Bandcamp-only genres apply even when Last.fm is off/empty. A module-level `_ENRICH_LOCK` serializes file writes so the 587 ingest-enrichment and this backfill can't tear a mutagen tag on the same file.
- **`genre_backfill.py`** (new) — `run_genre_backfill`: iterate pending albums, per-album Bandcamp cache-or-rescrape (proxy session, never cache an empty/challenge-page result), enrich + checkpoint, cancel checks before each album/network op, inter-album throttle, and a consecutive-slow-empty Last.fm circuit breaker.
- **`library.py`** — schema **v58 → v59**: `albums.genres_enriched_at REAL` checkpoint + `albums_pending_genre_enrichment` / `mark_album_genres_enriched` / `clear_genre_enrichment_marks` helpers.
- **`server.py`** — `POST /api/v1/genres/backfill` (+`/cancel`, +`/progress`) with a `_state` snapshot and a `genre_backfill.progress` websocket broadcast; a concurrent start is rejected (`started: false`).
- **`__main__.py`** — cancel `threading.Event` + `Lock`-guarded running flag, best-effort proxy session acquisition, and clears the checkpoint marks only when nothing is pending (so an interrupted run resumes rather than restarts).
- **UI** — button + progress/cancel row in the Genres section of the Tagging tab; `client.ts` start/cancel/progress; the store and dialog poll the progress endpoint (~1 Hz) while the tab is open, bounded so a multi-hour run never polls after prefs is closed.

## Test plan

Automated: 2528 passing, coverage 93.63% (main baseline 93.62% — net-positive, above the 93% gate). `genre_backfill.py` at 97%. black, mypy, and UI typecheck+lint all clean.

Manual:
- Tagging preferences shows "Update Library Genres"; clicking it starts a run with live `N / total` progress.
- A streaming album gains Last.fm genres in the library; a downloaded one gains them in its files too.
- A pre-588 Bandcamp album gains its original artist tags (re-scraped); re-running does **not** re-scrape it (cache populated).
- Existing/user-edited genres are preserved and only added to (merge, no duplicates).
- Cancel mid-run stops within an album or two and leaves already-done albums enriched.
- Kill/restart the daemon mid-run, re-run → it resumes from the un-enriched albums.
- With Last.fm down, the run still completes (breaker trips, Bandcamp continues); nothing corrupted.
- No torn/duplicate genre tags on files touched while a normal download+ingest happens during the run.
- Frozen build: the Bandcamp re-scrape returns tags via the proxy path, not empty.
- Launch against a copy of the production DB → clean v58 → v59 startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)