### PR TITLE
feat(genres): make bandcamp label-as-genre application optional

### DIFF
--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3096,7 +3096,7 @@ def create_app(
     )
     # Boolean config keys — stored as Python bool so GET returns true/false, not a
     # string (KAMP-587 re-added this after 589 dropped the last bool key).
-    _BOOL_CONFIG_KEYS = frozenset({"tagging.lastfm_genres"})
+    _BOOL_CONFIG_KEYS = frozenset({"tagging.lastfm_genres", "tagging.bandcamp_genres"})
 
     @app.patch("/api/v1/config")
     def patch_config(req: ConfigPatchRequest) -> dict[str, Any]:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -544,6 +544,7 @@ def _build_config_values(
         "artwork.max_bytes": config.artwork.max_bytes,
         "artwork.save_format": config.artwork.save_format,
         "tagging.lastfm_genres": config.tagging.lastfm_genres,
+        "tagging.bandcamp_genres": config.tagging.bandcamp_genres,
         "library.path_template": config.library.path_template,
         "bandcamp.connected": bc_session is not None,
         "bandcamp.username": bc_username,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -479,6 +479,7 @@ def sync_collection_stream(
     status_callback: Callable[[str], None] | None = None,
     art_cache_dir: Path | None = None,
     batch_indexed_callback: Callable[[], None] | None = None,
+    apply_bandcamp_genres: bool = True,
 ) -> tuple[int, int]:
     """Index all Bandcamp purchases as remote rows — no ZIP download.
 
@@ -583,11 +584,18 @@ def sync_collection_stream(
                     date_added=purchased_ts,
                 )
                 if tracks:
-                    index.upsert_many(tracks)
                     # KAMP-588: cache the album's Bandcamp tags so a later download
                     # can stamp them into the files (and KAMP-591 has a fast path).
-                    # All tracks share the album keywords.
+                    # All tracks share the album keywords. Cache BEFORE any strip
+                    # below so the labels persist even when applying them is off.
                     index.set_collection_keywords(str(sid), tracks[0].genres)
+                    # When applying Bandcamp labels as genres is disabled, drop them
+                    # from the tracks before upsert so they never reach the library
+                    # (the cache above still holds them for a later toggle-on).
+                    if not apply_bandcamp_genres:
+                        for _t in tracks:
+                            _t.genres = []
+                    index.upsert_many(tracks)
                     track_count += len(tracks)
                     logger.debug(
                         "Indexed %d track(s) for %r by %r",

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -52,6 +52,10 @@ class TaggingConfig:
     # point is that ingested files gain genres; it's best-effort and async, so it
     # never slows or fails a download. Users can turn it off in Tagging prefs.
     lastfm_genres: bool = True
+    # KAMP-588: apply the artist-supplied Bandcamp album labels as genre tags.
+    # Default ON. When off, the labels are still cached (so a later toggle-on
+    # applies them without a re-scrape) but never written to the library.
+    bandcamp_genres: bool = True
 
 
 @dataclass
@@ -103,6 +107,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "artwork.max_bytes": "1000000",
     "artwork.save_format": "embedded",
     "tagging.lastfm_genres": "true",
+    "tagging.bandcamp_genres": "true",
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",
@@ -122,6 +127,7 @@ _CONFIG_KEY_TYPES: dict[str, type] = {
     "artwork.max_bytes": int,
     "artwork.save_format": str,
     "tagging.lastfm_genres": bool,
+    "tagging.bandcamp_genres": bool,
     "library.path_template": str,
     "bandcamp.format": str,
     "bandcamp.poll_interval_minutes": int,
@@ -341,6 +347,7 @@ class Config:
             ),
             tagging=TaggingConfig(
                 lastfm_genres=_bool("tagging.lastfm_genres"),
+                bandcamp_genres=_bool("tagging.bandcamp_genres"),
             ),
             bandcamp=BandcampConfig(
                 format=_get("bandcamp.format"),

--- a/kamp_daemon/genre_backfill.py
+++ b/kamp_daemon/genre_backfill.py
@@ -116,7 +116,14 @@ def run_genre_backfill(
             t.id for t in index.tracks_for_album(album["album_artist"], album["album"])
         ]
         if ids and not cancel.is_set():
-            extra = _bandcamp_extra_genres(index, album, session, cancel)
+            # When applying Bandcamp labels is disabled, skip the re-scrape
+            # entirely — no point paying the network (and ban risk) to warm a
+            # cache the user has turned off; the cheap sync-time cache still runs.
+            extra = (
+                _bandcamp_extra_genres(index, album, session, cancel)
+                if config.tagging.bandcamp_genres
+                else []
+            )
             cfg = config if lastfm_ok else cfg_no_lastfm
             started = time.monotonic()
             try:

--- a/kamp_daemon/genre_backfill.py
+++ b/kamp_daemon/genre_backfill.py
@@ -116,14 +116,11 @@ def run_genre_backfill(
             t.id for t in index.tracks_for_album(album["album_artist"], album["album"])
         ]
         if ids and not cancel.is_set():
-            # When applying Bandcamp labels is disabled, skip the re-scrape
-            # entirely — no point paying the network (and ban risk) to warm a
-            # cache the user has turned off; the cheap sync-time cache still runs.
-            extra = (
-                _bandcamp_extra_genres(index, album, session, cancel)
-                if config.tagging.bandcamp_genres
-                else []
-            )
+            # Always re-scrape+cache the Bandcamp labels (warms the keywords cache
+            # for a later toggle-on, and for pre-588 albums a sync never revisits).
+            # When applying them is disabled, only the apply is suppressed.
+            cached = _bandcamp_extra_genres(index, album, session, cancel)
+            extra = cached if config.tagging.bandcamp_genres else []
             cfg = config if lastfm_ok else cfg_no_lastfm
             started = time.monotonic()
             try:

--- a/kamp_daemon/pipeline_impl.py
+++ b/kamp_daemon/pipeline_impl.py
@@ -124,6 +124,11 @@ def run(
                 overrides = index.download_overrides_for_sale_item(
                     provenance.sale_item_id
                 )
+                # When applying Bandcamp labels as genres is disabled, drop the
+                # cached labels so they're not stamped onto the downloaded files
+                # (the collection-row cache still holds them for a toggle-on).
+                if overrides is not None and not config.tagging.bandcamp_genres:
+                    overrides.genres = []
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Provenance lookup failed (non-fatal): %s", exc)
 

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -59,7 +59,12 @@ def _sync_worker(
         try:
             if bc_config.collection_mode == "stream":
                 from .bandcamp import sync_collection_stream
+                from .config import Config
 
+                # Read the "apply Bandcamp labels as genres" toggle from the DB
+                # (subprocess: no inherited config) so a disabled toggle stops the
+                # labels reaching the library while sync still caches them.
+                apply_bc_genres = Config.load(index).tagging.bandcamp_genres
                 album_count, track_count = sync_collection_stream(
                     bc_config=bc_config,
                     watch_dir=watch_dir,
@@ -67,6 +72,7 @@ def _sync_worker(
                     status_callback=lambda msg: status_q.put(msg),
                     art_cache_dir=_state_dir() / "art_cache",
                     batch_indexed_callback=lambda: notify_q.put(True),
+                    apply_bandcamp_genres=apply_bc_genres,
                 )
                 result_q.put(("ok_stream", (album_count, track_count)))
             else:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -426,6 +426,7 @@ export type ConfigValues = {
   'artwork.max_bytes': number | null
   'artwork.save_format': string | null
   'tagging.lastfm_genres': boolean | null
+  'tagging.bandcamp_genres': boolean | null
   'library.path_template': string | null
   'bandcamp.connected': boolean | null
   'bandcamp.username': string | null

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1227,6 +1227,13 @@ export function PreferencesDialog({
                       initialValue={configValues?.['tagging.lastfm_genres'] ?? true}
                       onSave={handleSave}
                     />
+                    <BoolRow
+                      label="Use bandcamp album labels as genres"
+                      configKey="tagging.bandcamp_genres"
+                      hint="Use artist supplied labels on bandcamp items as additional genre tags."
+                      initialValue={configValues?.['tagging.bandcamp_genres'] ?? true}
+                      onSave={handleSave}
+                    />
                     <div className="prefs-row">
                       <div className="prefs-row-header">
                         <span className="prefs-label">Update library genres</span>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -1642,9 +1642,22 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setConfigValue: async (key, value) => {
     await api.patchConfig(key, value)
-    set((s) => ({
-      configValues: s.configValues ? { ...s.configValues, [key]: value } : s.configValues
-    }))
+    // Coerce the optimistic cache to the type the server would return (booleans
+    // and numbers), matching the type loadConfig() populated. Storing the raw
+    // string corrupts a bool key — "false" is truthy, so a disabled toggle
+    // re-renders as ON when the dialog reopens (loadConfig only runs when the
+    // cache is null). Preserve the existing value's type as the source of truth.
+    set((s) => {
+      if (!s.configValues) return s
+      const prev = s.configValues[key as keyof typeof s.configValues]
+      const coerced: string | boolean | number =
+        typeof prev === 'boolean'
+          ? value === 'true'
+          : typeof prev === 'number'
+            ? Number(value)
+            : value
+      return { configValues: { ...s.configValues, [key]: coerced } }
+    })
   },
 
   openPrefs: (tab) => set({ prefsOpen: true, prefsInitialTab: tab ?? 'general' }),

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2578,6 +2578,7 @@ class TestSyncCollectionStream:
         already_have_tracks: bool = True,
         fake_tracks: list[Any] | None = None,
         existing_state: dict[str, str] | None = None,
+        apply_bandcamp_genres: bool = True,
     ) -> tuple[tuple[int, int], MagicMock]:
         watch_folder = tmp_path / "watch"
         config = _bc_config(tmp_path)
@@ -2598,7 +2599,12 @@ class TestSyncCollectionStream:
             ),
             patch("kamp_daemon.bandcamp.fetch_album_tracks", return_value=fake_tracks),
         ):
-            result = sync_collection_stream(config, watch_folder, index)
+            result = sync_collection_stream(
+                config,
+                watch_folder,
+                index,
+                apply_bandcamp_genres=apply_bandcamp_genres,
+            )
 
         return result, index
 
@@ -2738,6 +2744,49 @@ class TestSyncCollectionStream:
         index.set_collection_keywords.assert_called_once_with(
             "1", ["shoegaze", "dream pop"]
         )
+        # apply_bandcamp_genres defaults True — the tracks keep their genres.
+        upserted = index.upsert_many.call_args[0][0]
+        assert upserted[0].genres == ["shoegaze", "dream pop"]
+
+    def test_disabled_bandcamp_genres_caches_but_strips_from_tracks(
+        self, tmp_path: Path
+    ) -> None:
+        # With the toggle off, the labels are still cached on the collection row,
+        # but stripped from the tracks so they never reach the library.
+        from pathlib import Path as _Path
+
+        from kamp_core.library import Track
+
+        track = Track(
+            file_path=_Path("bandcamp://1/1"),
+            title="T",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            genres=["shoegaze", "dream pop"],
+        )
+        _result, index = self._run(
+            tmp_path,
+            [_item(1)],
+            already_have_tracks=False,
+            fake_tracks=[track],
+            apply_bandcamp_genres=False,
+        )
+        # Cache still holds the labels...
+        index.set_collection_keywords.assert_called_once_with(
+            "1", ["shoegaze", "dream pop"]
+        )
+        # ...but the upserted track has no genres.
+        upserted = index.upsert_many.call_args[0][0]
+        assert upserted[0].genres == []
 
     def test_batch_indexed_callback_fires_per_new_batch(self, tmp_path: Path) -> None:
         """batch_indexed_callback fires once per album batch that has new tracks."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,6 +80,18 @@ class TestLoad:
         config = Config.load(db)
         assert config.tagging.lastfm_genres is False
 
+    def test_tagging_bandcamp_genres_default_true(self, db: LibraryIndex) -> None:
+        # Bandcamp album labels are applied as genres by default.
+        Config.write_defaults(db)
+        config = Config.load(db)
+        assert config.tagging.bandcamp_genres is True
+
+    def test_tagging_bandcamp_genres_loads_false(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        db.set_setting("tagging.bandcamp_genres", "false")
+        config = Config.load(db)
+        assert config.tagging.bandcamp_genres is False
+
     def test_load_seeds_defaults_on_fresh_install(self, db: LibraryIndex) -> None:
         config = Config.load(db)
         assert config.bandcamp is not None
@@ -247,6 +259,11 @@ class TestConfigSet:
         Config.write_defaults(db)
         config_set(db, "tagging.lastfm_genres", "true")
         assert db.get_setting("tagging.lastfm_genres") == "true"
+
+    def test_set_bandcamp_genres_bool_key(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        config_set(db, "tagging.bandcamp_genres", "false")
+        assert db.get_setting("tagging.bandcamp_genres") == "false"
 
     def test_bool_wrong_value_raises_value_error(self, db: LibraryIndex) -> None:
         with pytest.raises(ValueError, match="requires true or false"):

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -331,6 +331,30 @@ class TestRunGenreBackfill:
         # Breaker never trips (reset at album 3), so Last.fm stays on throughout.
         assert flags == [True, True, True, True]
 
+    def test_disabled_bandcamp_genres_skips_rescrape_and_apply(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With bandcamp_genres off, a cache-miss album is NOT re-scraped and no
+        # Bandcamp labels are passed to enrich (Last.fm still runs).
+        index = _index(
+            [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/a")]
+        )
+        session = MagicMock()
+        cfg = _config()
+        cfg.tagging.bandcamp_genres = False
+        passed: list[Any] = []
+        monkeypatch.setattr(
+            gb,
+            "enrich_album_genres",
+            lambda idx, ids, cfg, *, extra_genres=(): passed.append(list(extra_genres))
+            or [],
+        )
+        gb.run_genre_backfill(
+            index, cfg, session, _Progress(), threading.Event(), sleep=lambda _s: None
+        )
+        session.get.assert_not_called()  # no re-scrape
+        assert passed == [[]]  # no Bandcamp labels applied
+
     def test_lastfm_circuit_breaker_trips(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -331,15 +331,22 @@ class TestRunGenreBackfill:
         # Breaker never trips (reset at album 3), so Last.fm stays on throughout.
         assert flags == [True, True, True, True]
 
-    def test_disabled_bandcamp_genres_skips_rescrape_and_apply(
+    def test_disabled_bandcamp_genres_caches_but_does_not_apply(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # With bandcamp_genres off, a cache-miss album is NOT re-scraped and no
-        # Bandcamp labels are passed to enrich (Last.fm still runs).
+        # With bandcamp_genres off, a cache-miss album is STILL re-scraped and
+        # cached (warms the cache for a later toggle-on), but the labels are NOT
+        # passed to enrich (Last.fm still runs).
         index = _index(
             [_album(1, sale_item_id="S1", keywords=None, album_url="https://x/a")]
         )
+        resp = MagicMock()
+        resp.text = "<html></html>"
         session = MagicMock()
+        session.get.return_value = resp
+        monkeypatch.setattr(
+            "kamp_daemon.bandcamp.parse_album_keywords", lambda html: ["Noise Rock"]
+        )
         cfg = _config()
         cfg.tagging.bandcamp_genres = False
         passed: list[Any] = []
@@ -352,8 +359,9 @@ class TestRunGenreBackfill:
         gb.run_genre_backfill(
             index, cfg, session, _Progress(), threading.Event(), sleep=lambda _s: None
         )
-        session.get.assert_not_called()  # no re-scrape
-        assert passed == [[]]  # no Bandcamp labels applied
+        session.get.assert_called_once()  # re-scraped to warm the cache
+        index.set_collection_keywords.assert_called_once_with("S1", ["Noise Rock"])
+        assert passed == [[]]  # but labels NOT applied
 
     def test_lastfm_circuit_breaker_trips(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,13 @@ class TestBuildConfigValues:
         snapshot = _build_config_values(cfg, bc_session=None, bc_ever_connected=False)
         assert snapshot["artwork.save_format"] == "cover-file"
 
+    def test_includes_bandcamp_genres_reflecting_stored_value(
+        self, tmp_path: Path
+    ) -> None:
+        cfg = self._config(tmp_path, **{"tagging.bandcamp_genres": "false"})
+        snapshot = _build_config_values(cfg, bc_session=None, bc_ever_connected=False)
+        assert snapshot["tagging.bandcamp_genres"] is False
+
     def test_every_settable_non_ui_key_is_present(self, tmp_path: Path) -> None:
         """Drift guard: every settable key that isn't served by the separate
         /ui-state endpoint must appear in the snapshot, or its preference

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1206,6 +1206,43 @@ class TestKnownBandcampBranch:
         tcon = id3.ID3(str(track1))["TCON"]
         assert list(tcon.text) == ["Shoegaze", "Dream Pop"]
 
+    def test_disabled_bandcamp_genres_not_written_to_files(
+        self, tmp_path: Path, config: Config
+    ) -> None:
+        # With the toggle off, cached Bandcamp labels are NOT stamped onto the
+        # downloaded files (the cache row still holds them for a later toggle-on).
+        config.tagging.bandcamp_genres = False
+        config.paths.watch_folder.mkdir(parents=True)
+        config.paths.library.mkdir(parents=True)
+        db = tmp_path / "lib.db"
+        self._seed_db(db)
+
+        from kamp_core.library import LibraryIndex
+
+        idx = LibraryIndex(db)
+        idx.set_collection_keywords("S1", ["Shoegaze", "Dream Pop"])
+        extracted = config.paths.watch_folder / "album"
+        extracted.mkdir()
+        f1 = extracted / "01.mp3"
+        _make_bandcamp_mp3(f1, "Artist X", "Album Y", "Track 1", 1)
+        idx.add_pending_ingest(str(extracted), "S1", "T1")
+        # Cache is intact and unaffected by the toggle.
+        assert idx.download_overrides_for_sale_item("S1").genres == [
+            "Shoegaze",
+            "Dream Pop",
+        ]
+        idx.close()
+
+        with patch("kamp_daemon.pipeline_impl.KampMusicBrainzTagger") as mock_tagger:
+            mock_tagger.return_value.tag_release.side_effect = Exception("no network")
+            run(extracted, config, index_path=db)
+
+        moved = list(config.paths.library.rglob("*.mp3"))
+        track1 = next(p for p in moved if p.name.startswith("01"))
+        tags = id3.ID3(str(track1))
+        # No Bandcamp genre frame written (TCON absent, or empty if MB set one).
+        assert "TCON" not in tags or list(tags["TCON"].text) in ([], [""])
+
     def test_records_mbid_and_keeps_bandcamp_names_without_overrides(
         self, tmp_path: Path, config: Config
     ) -> None:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -865,6 +865,7 @@ class TestStreamMode:
             status_callback: object = None,
             art_cache_dir: object = None,
             batch_indexed_callback: object = None,
+            apply_bandcamp_genres: bool = True,
         ) -> tuple[int, int]:
             if batch_indexed_callback is not None:
                 batch_indexed_callback()


### PR DESCRIPTION
## Summary

Adds a **"Use bandcamp album labels as genres"** toggle in **Preferences > Tagging > Genres** (default **ON**), mirroring the existing Last.fm toggle. Help text: *"Use artist supplied labels on bandcamp items as additional genre tags."*

When the toggle is **off**, the artist-supplied Bandcamp labels are **still cached** — they're just never applied as genre tags to the library. Turning the toggle back on later applies the cached labels without needing a re-scrape.

## Where it gates (caching always preserved)

Bandcamp labels become library genres at three independent points; each now respects the flag while leaving the cache intact:

- **Sync (streaming albums)** — `sync_collection_stream` gains `apply_bandcamp_genres`. It caches the labels via `set_collection_keywords` first, then strips them from the tracks before `upsert_many` when off. The sync subprocess reads the flag from the DB (`Config.load(index)`).
- **Download (local files)** — the ingest pipeline clears `overrides.genres` when off, so the cached labels aren't stamped onto the downloaded files' genre tags. The collection-row cache is untouched.
- **Backfill (KAMP-591)** — always re-scrapes and caches the Bandcamp labels (warms the keywords cache for a later toggle-on, and for pre-588 albums a sync never revisits); only the *apply* is suppressed when off.

## Config plumbing

`tagging.bandcamp_genres` bool (default `"true"`) wired through `_CONFIG_DEFAULTS`, `_CONFIG_KEY_TYPES`, `Config.load`, the server's `_BOOL_CONFIG_KEYS` coercion set, the startup `_build_config_values` snapshot, and the UI `ConfigValues` type.

## Also fixed: boolean preferences not sticking

`setConfigValue` cached the raw string (`"false"`) in the optimistic update. Since `"false"` is truthy and `BoolRow` reads `initialValue` once via `useState` (and the dialog only re-fetches config when the cache is null), a disabled toggle re-rendered as **ON** after a close/reopen. Now the optimistic cache update is coerced to the type `loadConfig()` populated (boolean/number). This also fixes the same latent bug for the Last.fm toggle.

## Test plan

Automated: full suite green, coverage 93.64% (main baseline 93.62% — net-positive, above the 93% gate). black, mypy, and UI typecheck+lint all clean. New tests cover: config default/load/set; sync caches-but-strips when off (keeps genres when on); download does-not-write-to-files when off; backfill re-scrapes+caches but does-not-apply when off; config snapshot reflects the stored value.

Manual:
- Tagging preferences shows "Use bandcamp album labels as genres", default on; toggling it off **persists** across a close/reopen.
- With it **on**, a synced streaming album and a downloaded album both gain their Bandcamp labels as genres.
- With it **off**, newly synced/downloaded Bandcamp albums do **not** gain the labels as genres, but the labels are still cached (toggle back on → they apply without a re-scrape).
- The library-wide genre backfill with the toggle off applies Last.fm genres, re-scrapes/warms the Bandcamp cache, but does not apply Bandcamp labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)