### PR TITLE
KAMP-612: rename Artist panel to Collection panel + floating toggle tabs

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -63,14 +63,16 @@ registerBuiltInPanel({
   id: 'kamp.collection',
   title: 'Collection',
   defaultSlot: 'left',
-  compatibleSlots: ['left', 'right'],
+  // KAMP-612: Collection is fixed to the left slot; slots no longer swap.
+  compatibleSlots: ['left'],
   component: CollectionPanel
 })
 registerBuiltInPanel({
   id: 'kamp.queue',
   title: 'Queue',
   defaultSlot: 'right',
-  compatibleSlots: ['left', 'right'],
+  // KAMP-612: Queue is fixed to the right slot; slots no longer swap.
+  compatibleSlots: ['right'],
   component: QueuePanel
 })
 registerBuiltInPanel({
@@ -379,9 +381,9 @@ export default function App(): React.JSX.Element {
           if (e.metaKey || e.ctrlKey) break
           toggleQueuePanel()
           break
-        case 'a':
-        case 'A':
-          // Artist panel is only relevant in Library.
+        case 'c':
+        case 'C':
+          // Collection panel is only relevant in Library.
           if (activeView === 'library') toggleCollectionPanel()
           break
       }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStore } from './store'
 import { connectStateStream, getDeferredOps } from './api/client'
-import { ArtistPanel } from './components/ArtistPanel'
+import { CollectionPanel } from './components/CollectionPanel'
 import { BaseKampView } from './components/BaseKampView'
 import { ExtensionPanel } from './components/ExtensionPanel'
 import { LibraryView } from './components/LibraryView'
@@ -60,11 +60,11 @@ registerBuiltInPanel({
   component: DownloadsView
 })
 registerBuiltInPanel({
-  id: 'kamp.artist-list',
-  title: 'Artists',
+  id: 'kamp.collection',
+  title: 'Collection',
   defaultSlot: 'left',
   compatibleSlots: ['left', 'right'],
-  component: ArtistPanel
+  component: CollectionPanel
 })
 registerBuiltInPanel({
   id: 'kamp.queue',
@@ -118,8 +118,8 @@ export default function App(): React.JSX.Element {
   const loadQueue = useStore((s) => s.loadQueue)
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
-  const artistPanelVisible = useStore((s) => s.artistPanelVisible)
-  const toggleArtistPanel = useStore((s) => s.toggleArtistPanel)
+  const collectionPanelVisible = useStore((s) => s.collectionPanelVisible)
+  const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
   const openPrefs = useStore((s) => s.openPrefs)
   const toggleStyleRail = useStore((s) => s.toggleStyleRail)
   const selectArtist = useStore((s) => s.selectArtist)
@@ -382,7 +382,7 @@ export default function App(): React.JSX.Element {
         case 'a':
         case 'A':
           // Artist panel is only relevant in Library.
-          if (activeView === 'library') toggleArtistPanel()
+          if (activeView === 'library') toggleCollectionPanel()
           break
       }
     }
@@ -397,7 +397,7 @@ export default function App(): React.JSX.Element {
     searchQuery,
     setSearchQuery,
     toggleQueuePanel,
-    toggleArtistPanel,
+    toggleCollectionPanel,
     openPrefs
   ])
 
@@ -640,7 +640,7 @@ export default function App(): React.JSX.Element {
   const isPanelVisible = (p: UnifiedPanel | undefined): boolean => {
     if (!p) return false
     if (p.id === 'kamp.queue') return queueVisible
-    if (p.id === 'kamp.artist-list') return activeView === 'library' && artistPanelVisible
+    if (p.id === 'kamp.collection') return activeView === 'library' && collectionPanelVisible
     return true
   }
 

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { useStore } from './store'
 import { connectStateStream, getDeferredOps } from './api/client'
 import { CollectionPanel } from './components/CollectionPanel'
+import { PanelToggleTabs } from './components/PanelToggleTabs'
 import { BaseKampView } from './components/BaseKampView'
 import { ExtensionPanel } from './components/ExtensionPanel'
 import { LibraryView } from './components/LibraryView'
@@ -704,6 +705,7 @@ export default function App(): React.JSX.Element {
           {renderMainContent()}
         </main>
         {!showSetup && isPanelVisible(rightPanel) && <SlotPanel panel={rightPanel!} />}
+        {!showSetup && <PanelToggleTabs />}
       </div>
       {/* KAMP-571: global download progress bar, directly above the transport in
           every view (hides itself when the queue is idle). */}

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -374,16 +374,14 @@ html[data-platform='win32'] .view-tabs {
   border-color: var(--accent);
 }
 
+/* left / right offsets are set inline so the tab tracks the panel's inner edge
+   (open) or rests against the app edge (closed). KAMP-612. */
 .panel-tab--collection {
-  left: 0;
-  border-left: none;
   border-top-right-radius: 17px;
   border-bottom-right-radius: 17px;
 }
 
 .panel-tab--queue {
-  right: 0;
-  border-right: none;
   border-top-left-radius: 17px;
   border-bottom-left-radius: 17px;
 }

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -374,8 +374,6 @@ html[data-platform='win32'] .view-tabs {
   border-color: var(--accent);
 }
 
-/* left / right offsets are set inline so the tab tracks the panel's inner edge
-   (open) or rests against the app edge (closed). KAMP-612. */
 .panel-tab--collection {
   border-top-right-radius: 17px;
   border-bottom-right-radius: 17px;
@@ -384,6 +382,28 @@ html[data-platform='win32'] .view-tabs {
 .panel-tab--queue {
   border-top-left-radius: 17px;
   border-bottom-left-radius: 17px;
+}
+
+/* Edge placement: the reopen handle, resting against the app-body edge while the
+   panel is collapsed. */
+.panel-tab--edge.panel-tab--collection {
+  left: 0;
+}
+
+.panel-tab--edge.panel-tab--queue {
+  right: 0;
+}
+
+/* Inner placement: a child of the (relatively-positioned) panel, translated fully
+   past the panel's inner edge so it overlaps the library and moves with a resize. */
+.panel-tab--inner.panel-tab--collection {
+  right: 0;
+  transform: translateX(100%);
+}
+
+.panel-tab--inner.panel-tab--queue {
+  left: 0;
+  transform: translateX(-100%);
 }
 
 .main-content {
@@ -446,7 +466,10 @@ html[data-platform='win32'] .view-tabs {
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* visible (not hidden) so the inner-edge toggle tab can poke over the library
+     while staying a child of the panel — that coupling makes it track resize
+     exactly. The list scrolls via its own overflow. KAMP-612. */
+  overflow: visible;
 }
 
 .collection-resize-handle {

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -393,9 +393,9 @@ html[data-platform='win32'] .view-tabs {
   margin: 0 -16px;
 }
 
-/* Artist panel ------------------------------------------------------------- */
+/* Collection panel --------------------------------------------------------- */
 
-.artist-panel {
+.collection-panel {
   min-width: 200px;
   flex-shrink: 0;
   position: relative;
@@ -405,7 +405,7 @@ html[data-platform='win32'] .view-tabs {
   overflow: hidden;
 }
 
-.artist-resize-handle {
+.collection-resize-handle {
   position: absolute;
   right: 0;
   top: 0;
@@ -415,12 +415,12 @@ html[data-platform='win32'] .view-tabs {
   z-index: 10;
 }
 
-.artist-panel--resizing {
+.collection-panel--resizing {
   cursor: ew-resize;
   user-select: none;
 }
 
-.artist-panel--resizing .artist-list li:hover {
+.collection-panel--resizing .collection-list li:hover {
   background: none;
 }
 
@@ -476,7 +476,7 @@ html[data-platform='win32'] .view-tabs {
   background: none;
 }
 
-.artist-list {
+.collection-list {
   list-style: none;
   overflow-y: auto;
   flex: 1;
@@ -484,7 +484,7 @@ html[data-platform='win32'] .view-tabs {
   scrollbar-color: var(--border) transparent;
 }
 
-.artist-list li {
+.collection-list li {
   padding: 8px 14px;
   cursor: pointer;
   border-radius: 4px;
@@ -494,18 +494,18 @@ html[data-platform='win32'] .view-tabs {
   text-overflow: ellipsis;
 }
 
-.artist-list li:hover {
+.collection-list li:hover {
   background: var(--surface-hover);
 }
 
-.artist-list li.active {
+.collection-list li.active {
   background: var(--accent-dim);
   color: var(--accent);
 }
 
 /* Focus-visible rings ----------------------------------------------------- */
 
-.artist-list li:focus-visible,
+.collection-list li:focus-visible,
 .album-card:focus-visible,
 .transport-btn:focus-visible,
 .back-btn:focus-visible,
@@ -534,7 +534,7 @@ html[data-platform='win32'] .view-tabs {
 }
 
 .track-row:active,
-.artist-list li:active {
+.collection-list li:active {
   opacity: 0.7;
 }
 

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -340,6 +340,52 @@ html[data-platform='win32'] .view-tabs {
   display: flex;
   flex: 1;
   overflow: hidden;
+  /* Anchor for the floating panel-toggle tabs (KAMP-612). */
+  position: relative;
+}
+
+/* Floating rounded panel-toggle tabs, anchored to the app-body bottom edges.
+   Rendered outside the panels so they persist when a panel is collapsed
+   (collapsed panels are unmounted). KAMP-612. */
+.panel-tab {
+  position: absolute;
+  bottom: 12px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.panel-tab:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.panel-tab.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.panel-tab--collection {
+  left: 0;
+  border-left: none;
+  border-top-right-radius: 17px;
+  border-bottom-right-radius: 17px;
+}
+
+.panel-tab--queue {
+  right: 0;
+  border-right: none;
+  border-top-left-radius: 17px;
+  border-bottom-left-radius: 17px;
 }
 
 .main-content {

--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -219,15 +219,6 @@
   font-size: 12px;
 }
 
-/* Queue toggle button in transport bar */
-.queue-toggle-btn {
-  font-size: 15px;
-}
-
-.queue-toggle-btn.active {
-  color: var(--accent);
-}
-
 .favorite-btn {
   color: var(--text-dim);
 }

--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -8,7 +8,9 @@
   background: var(--surface);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* visible so the inner-edge toggle tab can poke over the library as a child of
+     the panel, tracking resize exactly. Inner content scrolls on its own. KAMP-612. */
+  overflow: visible;
 }
 
 .queue-resize-handle {

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import { PanelToggleTab } from './PanelToggleTab'
 
 const COLLECTION_WIDTH_KEY = 'kamp:collection-panel-width'
 const COLLECTION_WIDTH_DEFAULT = 200
@@ -12,7 +13,7 @@ export function CollectionPanel(): React.JSX.Element {
   const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
   const selectGenre = useStore((s) => s.selectGenre)
-  const setCollectionPanelWidth = useStore((s) => s.setCollectionPanelWidth)
+  const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
   // Which list is shown. An active genre filter forces the Genres tab so
   // re-opening while a genre is selected lands there (KAMP-550); otherwise the
   // last explicitly-chosen tab is restored across restarts (KAMP-612).
@@ -37,12 +38,6 @@ export function CollectionPanel(): React.JSX.Element {
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(COLLECTION_WIDTH_DEFAULT)
   const didDragRef = useRef(false)
-
-  // Mirror the live width into the store so the floating Collection toggle tab
-  // tracks the panel's inner edge, including during a resize drag (KAMP-612).
-  useEffect(() => {
-    setCollectionPanelWidth(panelWidth)
-  }, [panelWidth, setCollectionPanelWidth])
 
   // Clamp width to 33% when the window shrinks.
   useEffect(() => {
@@ -182,6 +177,8 @@ export function CollectionPanel(): React.JSX.Element {
         onMouseDown={handleResizeMouseDown}
         onDoubleClick={handleResizeDoubleClick}
       />
+      {/* Inner-edge toggle: a child of the panel so it tracks the resize edge. */}
+      <PanelToggleTab panel="collection" placement="inner" active onClick={toggleCollectionPanel} />
     </aside>
   )
 }

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -12,6 +12,7 @@ export function CollectionPanel(): React.JSX.Element {
   const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
   const selectGenre = useStore((s) => s.selectGenre)
+  const setCollectionPanelWidth = useStore((s) => s.setCollectionPanelWidth)
   // Which list is shown. An active genre filter forces the Genres tab so
   // re-opening while a genre is selected lands there (KAMP-550); otherwise the
   // last explicitly-chosen tab is restored across restarts (KAMP-612).
@@ -36,6 +37,12 @@ export function CollectionPanel(): React.JSX.Element {
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(COLLECTION_WIDTH_DEFAULT)
   const didDragRef = useRef(false)
+
+  // Mirror the live width into the store so the floating Collection toggle tab
+  // tracks the panel's inner edge, including during a resize drag (KAMP-612).
+  useEffect(() => {
+    setCollectionPanelWidth(panelWidth)
+  }, [panelWidth, setCollectionPanelWidth])
 
   // Clamp width to 33% when the window shrinks.
   useEffect(() => {

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 
-const ARTIST_WIDTH_KEY = 'kamp:artist-panel-width'
-const ARTIST_WIDTH_DEFAULT = 200
+const COLLECTION_WIDTH_KEY = 'kamp:collection-panel-width'
+const COLLECTION_WIDTH_DEFAULT = 200
 
-export function ArtistPanel(): React.JSX.Element {
+export function CollectionPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
   const genres = useStore((s) => s.library.genres)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
@@ -18,15 +18,15 @@ export function ArtistPanel(): React.JSX.Element {
     selectedGenre !== null ? 'genres' : 'artists'
   )
   const [panelWidth, setPanelWidth] = useState<number>(() => {
-    const saved = parseFloat(localStorage.getItem(ARTIST_WIDTH_KEY) ?? '')
+    const saved = parseFloat(localStorage.getItem(COLLECTION_WIDTH_KEY) ?? '')
     const max = window.innerWidth * 0.33
     return isNaN(saved)
-      ? ARTIST_WIDTH_DEFAULT
-      : Math.min(max, Math.max(ARTIST_WIDTH_DEFAULT, saved))
+      ? COLLECTION_WIDTH_DEFAULT
+      : Math.min(max, Math.max(COLLECTION_WIDTH_DEFAULT, saved))
   })
   const [isResizing, setIsResizing] = useState(false)
   const dragStartXRef = useRef(0)
-  const widthAtDragStartRef = useRef(ARTIST_WIDTH_DEFAULT)
+  const widthAtDragStartRef = useRef(COLLECTION_WIDTH_DEFAULT)
   const didDragRef = useRef(false)
 
   // Clamp width to 33% when the window shrinks.
@@ -35,7 +35,7 @@ export function ArtistPanel(): React.JSX.Element {
       const max = window.innerWidth * 0.33
       setPanelWidth((w) => {
         if (w > max) {
-          localStorage.setItem(ARTIST_WIDTH_KEY, String(Math.round(max)))
+          localStorage.setItem(COLLECTION_WIDTH_KEY, String(Math.round(max)))
           return max
         }
         return w
@@ -59,7 +59,7 @@ export function ArtistPanel(): React.JSX.Element {
       if (!didDragRef.current) return
       const max = window.innerWidth * 0.33
       setPanelWidth(
-        Math.min(max, Math.max(ARTIST_WIDTH_DEFAULT, widthAtDragStartRef.current + delta))
+        Math.min(max, Math.max(COLLECTION_WIDTH_DEFAULT, widthAtDragStartRef.current + delta))
       )
     }
 
@@ -69,7 +69,7 @@ export function ArtistPanel(): React.JSX.Element {
       setIsResizing(false)
       if (didDragRef.current) {
         setPanelWidth((w) => {
-          localStorage.setItem(ARTIST_WIDTH_KEY, String(Math.round(w)))
+          localStorage.setItem(COLLECTION_WIDTH_KEY, String(Math.round(w)))
           return w
         })
       }
@@ -80,13 +80,13 @@ export function ArtistPanel(): React.JSX.Element {
   }
 
   function handleResizeDoubleClick(): void {
-    setPanelWidth(ARTIST_WIDTH_DEFAULT)
-    localStorage.setItem(ARTIST_WIDTH_KEY, String(ARTIST_WIDTH_DEFAULT))
+    setPanelWidth(COLLECTION_WIDTH_DEFAULT)
+    localStorage.setItem(COLLECTION_WIDTH_KEY, String(COLLECTION_WIDTH_DEFAULT))
   }
 
   return (
     <aside
-      className={`artist-panel${isResizing ? ' artist-panel--resizing' : ''}`}
+      className={`collection-panel${isResizing ? ' collection-panel--resizing' : ''}`}
       style={{ width: panelWidth }}
     >
       <div className="library-tabs" role="tablist" aria-label="Library filter">
@@ -110,7 +110,7 @@ export function ArtistPanel(): React.JSX.Element {
         </button>
       </div>
       {tab === 'artists' ? (
-        <ul className="artist-list" role="tabpanel" aria-labelledby="lib-tab-artists">
+        <ul className="collection-list" role="tabpanel" aria-labelledby="lib-tab-artists">
           <li
             className={selectedArtist === null ? 'active' : ''}
             tabIndex={0}
@@ -132,7 +132,7 @@ export function ArtistPanel(): React.JSX.Element {
           ))}
         </ul>
       ) : (
-        <ul className="artist-list" role="tabpanel" aria-labelledby="lib-tab-genres">
+        <ul className="collection-list" role="tabpanel" aria-labelledby="lib-tab-genres">
           {genres.length === 0 ? (
             <li className="library-list-empty" aria-disabled="true">
               No genres tagged yet
@@ -163,7 +163,7 @@ export function ArtistPanel(): React.JSX.Element {
         </ul>
       )}
       <div
-        className="artist-resize-handle"
+        className="collection-resize-handle"
         onMouseDown={handleResizeMouseDown}
         onDoubleClick={handleResizeDoubleClick}
       />

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../store'
 
 const COLLECTION_WIDTH_KEY = 'kamp:collection-panel-width'
 const COLLECTION_WIDTH_DEFAULT = 200
+const COLLECTION_TAB_KEY = 'kamp:collection-tab'
 
 export function CollectionPanel(): React.JSX.Element {
   const artists = useStore((s) => s.library.artists)
@@ -11,12 +12,19 @@ export function CollectionPanel(): React.JSX.Element {
   const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
   const selectGenre = useStore((s) => s.selectGenre)
-  // Which list is shown. Seeded from the active filter so re-opening while a
-  // genre is selected lands on the Genres tab (KAMP-550). Switching tabs is a
-  // pure view change — it never alters the active filter.
-  const [tab, setTab] = useState<'artists' | 'genres'>(
-    selectedGenre !== null ? 'genres' : 'artists'
-  )
+  // Which list is shown. An active genre filter forces the Genres tab so
+  // re-opening while a genre is selected lands there (KAMP-550); otherwise the
+  // last explicitly-chosen tab is restored across restarts (KAMP-612).
+  // Switching tabs is a pure view change — it never alters the active filter.
+  const [tab, setTabState] = useState<'artists' | 'genres'>(() => {
+    if (selectedGenre !== null) return 'genres'
+    return localStorage.getItem(COLLECTION_TAB_KEY) === 'genres' ? 'genres' : 'artists'
+  })
+
+  function setTab(next: 'artists' | 'genres'): void {
+    localStorage.setItem(COLLECTION_TAB_KEY, next)
+    setTabState(next)
+  }
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const saved = parseFloat(localStorage.getItem(COLLECTION_WIDTH_KEY) ?? '')
     const max = window.innerWidth * 0.33

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -29,7 +29,7 @@ const GROUPS: Group[] = [
       { keys: [mod, 'K'], description: 'Focus search' },
       { keys: ['L'], description: 'Library / Now Playing' },
       { keys: ['Q'], description: 'Queue panel' },
-      { keys: ['A'], description: 'Artist panel', note: 'Library only' },
+      { keys: ['C'], description: 'Collection panel', note: 'Library only' },
       { keys: [mod, ','], description: 'Preferences' }
     ]
   },

--- a/kamp_ui/src/renderer/src/components/PanelToggleTab.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelToggleTab.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
+import { CollectionIcon, QueueIcon } from './TransportIcons'
+
+// Shared rounded toggle tab for the Collection and Queue panels (KAMP-612).
+// Rendered in two places with different positioning:
+//  - "inner": a child of the panel, poking over the library at its inner edge —
+//    it shares the panel's layout box, so it tracks a resize drag exactly.
+//  - "edge": a child of the app body, resting against the window edge — the
+//    reopen handle shown while the panel is collapsed (and thus unmounted).
+interface PanelToggleTabProps {
+  panel: 'collection' | 'queue'
+  placement: 'inner' | 'edge'
+  active: boolean
+  onClick: () => void
+}
+
+export function PanelToggleTab({
+  panel,
+  placement,
+  active,
+  onClick
+}: PanelToggleTabProps): React.JSX.Element {
+  const tooltip = useTooltip()
+  const isCollection = panel === 'collection'
+  return (
+    <button
+      className={`panel-tab panel-tab--${panel} panel-tab--${placement}${active ? ' active' : ''}`}
+      onClick={onClick}
+      {...tooltip(isCollection ? TOOLTIPS.COLLECTION_TOGGLE : TOOLTIPS.TRANSPORT_QUEUE)}
+      aria-label={isCollection ? 'Collection' : 'Queue'}
+      aria-pressed={active}
+    >
+      {isCollection ? <CollectionIcon size={18} /> : <QueueIcon size={18} />}
+    </button>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useStore } from '../store'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
-import { CollectionIcon } from './TransportIcons'
+import { CollectionIcon, QueueIcon } from './TransportIcons'
 
 // Floating rounded toggle tabs anchored to the bottom edges of the app body.
 // They render independently of the panels themselves so they stay clickable
@@ -13,6 +13,8 @@ export function PanelToggleTabs(): React.JSX.Element {
   const activeView = useStore((s) => s.activeView)
   const collectionPanelVisible = useStore((s) => s.collectionPanelVisible)
   const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
+  const queueVisible = useStore((s) => s.queueVisible)
+  const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
 
   return (
     <>
@@ -28,6 +30,16 @@ export function PanelToggleTabs(): React.JSX.Element {
           <CollectionIcon size={18} />
         </button>
       )}
+      {/* Queue is available in every view. */}
+      <button
+        className={`panel-tab panel-tab--queue${queueVisible ? ' active' : ''}`}
+        onClick={toggleQueuePanel}
+        {...tooltip(TOOLTIPS.TRANSPORT_QUEUE)}
+        aria-label="Queue"
+        aria-pressed={queueVisible}
+      >
+        <QueueIcon size={18} />
+      </button>
     </>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
@@ -1,51 +1,33 @@
 import React from 'react'
 import { useStore } from '../store'
-import { useTooltip } from '../hooks/useTooltip'
-import { TOOLTIPS } from '../tooltipStrings'
-import { CollectionIcon, QueueIcon } from './TransportIcons'
+import { PanelToggleTab } from './PanelToggleTab'
 
-// Floating rounded toggle tabs anchored to the bottom edges of the app body.
-// They render independently of the panels themselves so they stay clickable
-// when a panel is collapsed — collapsed panels are unmounted entirely, so the
-// panel's own chrome can't host the toggle. When a panel is open the tab sits at
-// that panel's inner edge (overlapping the library) and tracks a resize drag;
-// when closed it rests against the app edge as the reopen handle. KAMP-612.
+// Reopen handles for the Collection and Queue panels, anchored to the app-body
+// edges. Shown ONLY while a panel is collapsed — an open panel renders its own
+// inner-edge toggle (which tracks a resize drag). Rendered outside the panel
+// visibility gate so a collapsed panel can still be reopened. KAMP-612.
 export function PanelToggleTabs(): React.JSX.Element {
-  const tooltip = useTooltip()
   const activeView = useStore((s) => s.activeView)
   const collectionPanelVisible = useStore((s) => s.collectionPanelVisible)
   const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
-  const collectionPanelWidth = useStore((s) => s.collectionPanelWidth)
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
-  const queuePanelWidth = useStore((s) => s.queuePanelWidth)
 
   return (
     <>
       {/* Collection panel only exists in the library view. */}
-      {activeView === 'library' && (
-        <button
-          className={`panel-tab panel-tab--collection${collectionPanelVisible ? ' active' : ''}`}
-          style={{ left: collectionPanelVisible ? collectionPanelWidth : 0 }}
+      {activeView === 'library' && !collectionPanelVisible && (
+        <PanelToggleTab
+          panel="collection"
+          placement="edge"
+          active={false}
           onClick={toggleCollectionPanel}
-          {...tooltip(TOOLTIPS.COLLECTION_TOGGLE)}
-          aria-label="Collection"
-          aria-pressed={collectionPanelVisible}
-        >
-          <CollectionIcon size={18} />
-        </button>
+        />
       )}
       {/* Queue is available in every view. */}
-      <button
-        className={`panel-tab panel-tab--queue${queueVisible ? ' active' : ''}`}
-        style={{ right: queueVisible ? queuePanelWidth : 0 }}
-        onClick={toggleQueuePanel}
-        {...tooltip(TOOLTIPS.TRANSPORT_QUEUE)}
-        aria-label="Queue"
-        aria-pressed={queueVisible}
-      >
-        <QueueIcon size={18} />
-      </button>
+      {!queueVisible && (
+        <PanelToggleTab panel="queue" placement="edge" active={false} onClick={toggleQueuePanel} />
+      )}
     </>
   )
 }

--- a/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
@@ -7,14 +7,18 @@ import { CollectionIcon, QueueIcon } from './TransportIcons'
 // Floating rounded toggle tabs anchored to the bottom edges of the app body.
 // They render independently of the panels themselves so they stay clickable
 // when a panel is collapsed — collapsed panels are unmounted entirely, so the
-// panel's own chrome can't host the toggle. KAMP-612.
+// panel's own chrome can't host the toggle. When a panel is open the tab sits at
+// that panel's inner edge (overlapping the library) and tracks a resize drag;
+// when closed it rests against the app edge as the reopen handle. KAMP-612.
 export function PanelToggleTabs(): React.JSX.Element {
   const tooltip = useTooltip()
   const activeView = useStore((s) => s.activeView)
   const collectionPanelVisible = useStore((s) => s.collectionPanelVisible)
   const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
+  const collectionPanelWidth = useStore((s) => s.collectionPanelWidth)
   const queueVisible = useStore((s) => s.queueVisible)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const queuePanelWidth = useStore((s) => s.queuePanelWidth)
 
   return (
     <>
@@ -22,6 +26,7 @@ export function PanelToggleTabs(): React.JSX.Element {
       {activeView === 'library' && (
         <button
           className={`panel-tab panel-tab--collection${collectionPanelVisible ? ' active' : ''}`}
+          style={{ left: collectionPanelVisible ? collectionPanelWidth : 0 }}
           onClick={toggleCollectionPanel}
           {...tooltip(TOOLTIPS.COLLECTION_TOGGLE)}
           aria-label="Collection"
@@ -33,6 +38,7 @@ export function PanelToggleTabs(): React.JSX.Element {
       {/* Queue is available in every view. */}
       <button
         className={`panel-tab panel-tab--queue${queueVisible ? ' active' : ''}`}
+        style={{ right: queueVisible ? queuePanelWidth : 0 }}
         onClick={toggleQueuePanel}
         {...tooltip(TOOLTIPS.TRANSPORT_QUEUE)}
         aria-label="Queue"

--- a/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
+++ b/kamp_ui/src/renderer/src/components/PanelToggleTabs.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useStore } from '../store'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
+import { CollectionIcon } from './TransportIcons'
+
+// Floating rounded toggle tabs anchored to the bottom edges of the app body.
+// They render independently of the panels themselves so they stay clickable
+// when a panel is collapsed — collapsed panels are unmounted entirely, so the
+// panel's own chrome can't host the toggle. KAMP-612.
+export function PanelToggleTabs(): React.JSX.Element {
+  const tooltip = useTooltip()
+  const activeView = useStore((s) => s.activeView)
+  const collectionPanelVisible = useStore((s) => s.collectionPanelVisible)
+  const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
+
+  return (
+    <>
+      {/* Collection panel only exists in the library view. */}
+      {activeView === 'library' && (
+        <button
+          className={`panel-tab panel-tab--collection${collectionPanelVisible ? ' active' : ''}`}
+          onClick={toggleCollectionPanel}
+          {...tooltip(TOOLTIPS.COLLECTION_TOGGLE)}
+          aria-label="Collection"
+          aria-pressed={collectionPanelVisible}
+        >
+          <CollectionIcon size={18} />
+        </button>
+      )}
+    </>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -5,6 +5,7 @@ import { TOOLTIPS } from '../tooltipStrings'
 import { QueueContextMenu } from './QueueContextMenu'
 import { QueueAlbumCard } from './QueueAlbumCard'
 import { FavoriteIcon, WarnIcon, GoToAlbumIcon } from './TransportIcons'
+import { PanelToggleTab } from './PanelToggleTab'
 import type { Track } from '../api/client'
 import { computeNewOrder } from '../utils/computeNewOrder'
 
@@ -39,7 +40,6 @@ type ContextMenu = {
 export function QueuePanel(): React.JSX.Element {
   const queue = useStore((s) => s.queue)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
-  const setQueuePanelWidth = useStore((s) => s.setQueuePanelWidth)
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
   const reorderQueue = useStore((s) => s.reorderQueue)
   const skipToQueueTrack = useStore((s) => s.skipToQueueTrack)
@@ -73,12 +73,6 @@ export function QueuePanel(): React.JSX.Element {
   const [isResizing, setIsResizing] = useState(false)
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(QUEUE_WIDTH_DEFAULT)
-
-  // Mirror the live width into the store so the floating Queue toggle tab tracks
-  // the panel's inner edge, including during a resize drag (KAMP-612).
-  useEffect(() => {
-    setQueuePanelWidth(queueWidth)
-  }, [queueWidth, setQueuePanelWidth])
   const didDragRef = useRef(false)
   const albumGroupingActive = useStore((s) => s.albumGroupingActive)
   const setAlbumGroupingActive = useStore((s) => s.setAlbumGroupingActive)
@@ -756,6 +750,8 @@ export function QueuePanel(): React.JSX.Element {
         onMouseDown={handleResizeMouseDown}
         onDoubleClick={handleResizeDoubleClick}
       />
+      {/* Inner-edge toggle: a child of the panel so it tracks the resize edge. */}
+      <PanelToggleTab panel="queue" placement="inner" active onClick={toggleQueuePanel} />
       <div className="queue-panel-header">
         <div className="queue-panel-header-left">
           <span className="queue-panel-label">QUEUE</span>

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -39,6 +39,7 @@ type ContextMenu = {
 export function QueuePanel(): React.JSX.Element {
   const queue = useStore((s) => s.queue)
   const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
+  const setQueuePanelWidth = useStore((s) => s.setQueuePanelWidth)
   const moveQueueTrack = useStore((s) => s.moveQueueTrack)
   const reorderQueue = useStore((s) => s.reorderQueue)
   const skipToQueueTrack = useStore((s) => s.skipToQueueTrack)
@@ -72,6 +73,12 @@ export function QueuePanel(): React.JSX.Element {
   const [isResizing, setIsResizing] = useState(false)
   const dragStartXRef = useRef(0)
   const widthAtDragStartRef = useRef(QUEUE_WIDTH_DEFAULT)
+
+  // Mirror the live width into the store so the floating Queue toggle tab tracks
+  // the panel's inner edge, including during a resize drag (KAMP-612).
+  useEffect(() => {
+    setQueuePanelWidth(queueWidth)
+  }, [queueWidth, setQueuePanelWidth])
   const didDragRef = useRef(false)
   const albumGroupingActive = useStore((s) => s.albumGroupingActive)
   const setAlbumGroupingActive = useStore((s) => s.setAlbumGroupingActive)

--- a/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
+++ b/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
@@ -24,6 +24,36 @@ interface TooltipDisplay {
   phase: Phase
 }
 
+// The bubble is memoized on `display` so it only re-renders when the tooltip
+// itself changes — NOT on every parent (whole-app) re-render. Without this, a
+// frequent app re-render (audio metering, playback ticks) would re-apply the
+// inline `left: display.x` and wipe the horizontal clamp applied imperatively in
+// the layout effect below, letting the tooltip escape the viewport edge on tabs
+// pinned to the app border (KAMP-612).
+interface TooltipBubbleProps {
+  display: TooltipDisplay
+  bubbleRef: React.RefObject<HTMLDivElement | null>
+}
+
+function TooltipBubbleImpl({ display, bubbleRef }: TooltipBubbleProps): React.ReactElement {
+  return createPortal(
+    <div
+      ref={bubbleRef}
+      role="tooltip"
+      id="kamp-tooltip"
+      className="kamp-tooltip"
+      data-phase={display.phase}
+      data-direction={display.above ? 'above' : 'below'}
+      style={{ left: display.x, top: display.y }}
+    >
+      {display.text}
+    </div>,
+    document.body
+  )
+}
+
+const TooltipBubble = React.memo(TooltipBubbleImpl)
+
 export function TooltipProvider({ children }: { children: React.ReactNode }): React.ReactElement {
   const [display, setDisplay] = useState<TooltipDisplay | null>(null)
   const portalRef = useRef<HTMLDivElement>(null)
@@ -106,21 +136,7 @@ export function TooltipProvider({ children }: { children: React.ReactNode }): Re
   return (
     <TooltipContext.Provider value={{ arm, disarm }}>
       {children}
-      {display &&
-        createPortal(
-          <div
-            ref={portalRef}
-            role="tooltip"
-            id="kamp-tooltip"
-            className="kamp-tooltip"
-            data-phase={display.phase}
-            data-direction={display.above ? 'above' : 'below'}
-            style={{ left: display.x, top: display.y }}
-          >
-            {display.text}
-          </div>,
-          document.body
-        )}
+      {display && <TooltipBubble display={display} bubbleRef={portalRef} />}
     </TooltipContext.Provider>
   )
 }

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -8,7 +8,6 @@ import {
   PauseIcon,
   PlayIcon,
   PrevIcon,
-  QueueIcon,
   RepeatIcon,
   ShuffleIcon,
   StopIcon,
@@ -24,8 +23,6 @@ export function TransportBar(): React.JSX.Element {
   const prev = useStore((s) => s.prev)
   const seek = useStore((s) => s.seek)
   const setVolume = useStore((s) => s.setVolume)
-  const queueVisible = useStore((s) => s.queueVisible)
-  const toggleQueuePanel = useStore((s) => s.toggleQueuePanel)
   const setFavorite = useStore((s) => s.setFavorite)
   const queue = useStore((s) => s.queue)
   const setShuffle = useStore((s) => s.setShuffle)
@@ -301,16 +298,6 @@ export function TransportBar(): React.JSX.Element {
         />
         <span className="volume-label">{volume}</span>
       </div>
-
-      <button
-        className={`transport-btn queue-toggle-btn${queueVisible ? ' active' : ''}`}
-        onClick={toggleQueuePanel}
-        {...tooltip(TOOLTIPS.TRANSPORT_QUEUE)}
-        aria-label="Queue"
-        aria-pressed={queueVisible}
-      >
-        <QueueIcon />
-      </button>
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -95,6 +95,22 @@ export function QueueIcon({ size = 20 }: IconProps): React.JSX.Element {
   )
 }
 
+export function CollectionIcon({ size = 20 }: IconProps): React.JSX.Element {
+  // Stacked-crate "collection" glyph (KAMP-612 asset). Native viewBox is 1200.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 1200 1200"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="m938.63 911.52h-677.27c-26.664 0-48.359-21.695-48.359-48.359v-349.62c0-26.664 21.695-48.359 48.359-48.359h677.26c26.676 0 48.371 21.695 48.371 48.359v349.62c0.011719 26.664-21.695 48.359-48.359 48.359zm-677.27-404.33c-3.457 0-6.3594 2.9141-6.3594 6.3594v349.61c0 3.4453 2.9141 6.3594 6.3594 6.3594h677.26c3.457 0 6.3711-2.9141 6.3711-6.3594v-349.62c0-3.4453-2.9141-6.3594-6.3711-6.3594h-677.26zm639.86-109.36c0-11.594-9.3945-21-21-21h-560.45c-11.594 0-21 9.4062-21 21s9.4062 21 21 21h560.44c11.602 0 21.008-9.4062 21.008-21zm-68.496-88.344c0-11.594-9.3945-21-21-21h-423.45c-11.594 0-21 9.4062-21 21s9.4062 21 21 21h423.46c11.59 0 20.996-9.4062 20.996-21z" />
+    </svg>
+  )
+}
+
 export function QueueAddIcon({ size = 20 }: IconProps): React.JSX.Element {
   return (
     <svg width={size} height={size} {...STROKE_PROPS}>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -125,12 +125,6 @@ type PlayerStore = {
   queueVisible: boolean
   collectionPanelVisible: boolean
   collectionPanelSnapshot: boolean | null // saved visibility before entering Now Playing
-  // KAMP-612: live mirrors of the panels' own resizable widths, so the floating
-  // toggle tabs can sit at each panel's inner edge and track a resize drag. The
-  // panels remain the source of truth (they own persistence); these are updated
-  // via setCollectionPanelWidth / setQueuePanelWidth on every width change.
-  collectionPanelWidth: number
-  queuePanelWidth: number
   queue: QueueState | null
   albumGroupingActive: boolean
   downloadingAlbumIds: Set<string>
@@ -165,8 +159,6 @@ type PlayerStore = {
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   toggleQueuePanel: () => void
   toggleCollectionPanel: () => void
-  setCollectionPanelWidth: (width: number) => void
-  setQueuePanelWidth: (width: number) => void
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (
@@ -500,11 +492,6 @@ export const useStore = create<PlayerStore>((set, get) => ({
   // Client-only persistence — no backend endpoint needed for this toggle.
   collectionPanelVisible: localStorage.getItem('kamp:collection-panel-visible') !== 'false',
   collectionPanelSnapshot: null,
-  // Seed from the panels' persisted widths so the toggle tabs are positioned
-  // correctly on first paint, before the panels mount and sync (KAMP-612).
-  collectionPanelWidth:
-    parseFloat(localStorage.getItem('kamp:collection-panel-width') ?? '') || 200,
-  queuePanelWidth: parseFloat(localStorage.getItem('kamp:queue-width') ?? '') || 280,
   queue: null,
   albumGroupingActive: localStorage.getItem('kamp:album-view') === 'true',
   downloadingAlbumIds: new Set<string>(),
@@ -538,11 +525,6 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ collectionPanelVisible: next })
     localStorage.setItem('kamp:collection-panel-visible', String(next))
   },
-
-  // Live width mirrors for the floating toggle tabs (KAMP-612). Pure state — the
-  // panels own localStorage persistence.
-  setCollectionPanelWidth: (width) => set({ collectionPanelWidth: width }),
-  setQueuePanelWidth: (width) => set({ queuePanelWidth: width }),
 
   loadQueue: async () => {
     try {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -125,6 +125,12 @@ type PlayerStore = {
   queueVisible: boolean
   collectionPanelVisible: boolean
   collectionPanelSnapshot: boolean | null // saved visibility before entering Now Playing
+  // KAMP-612: live mirrors of the panels' own resizable widths, so the floating
+  // toggle tabs can sit at each panel's inner edge and track a resize drag. The
+  // panels remain the source of truth (they own persistence); these are updated
+  // via setCollectionPanelWidth / setQueuePanelWidth on every width change.
+  collectionPanelWidth: number
+  queuePanelWidth: number
   queue: QueueState | null
   albumGroupingActive: boolean
   downloadingAlbumIds: Set<string>
@@ -159,6 +165,8 @@ type PlayerStore = {
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   toggleQueuePanel: () => void
   toggleCollectionPanel: () => void
+  setCollectionPanelWidth: (width: number) => void
+  setQueuePanelWidth: (width: number) => void
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (
@@ -492,6 +500,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
   // Client-only persistence — no backend endpoint needed for this toggle.
   collectionPanelVisible: localStorage.getItem('kamp:collection-panel-visible') !== 'false',
   collectionPanelSnapshot: null,
+  // Seed from the panels' persisted widths so the toggle tabs are positioned
+  // correctly on first paint, before the panels mount and sync (KAMP-612).
+  collectionPanelWidth:
+    parseFloat(localStorage.getItem('kamp:collection-panel-width') ?? '') || 200,
+  queuePanelWidth: parseFloat(localStorage.getItem('kamp:queue-width') ?? '') || 280,
   queue: null,
   albumGroupingActive: localStorage.getItem('kamp:album-view') === 'true',
   downloadingAlbumIds: new Set<string>(),
@@ -525,6 +538,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ collectionPanelVisible: next })
     localStorage.setItem('kamp:collection-panel-visible', String(next))
   },
+
+  // Live width mirrors for the floating toggle tabs (KAMP-612). Pure state — the
+  // panels own localStorage persistence.
+  setCollectionPanelWidth: (width) => set({ collectionPanelWidth: width }),
+  setQueuePanelWidth: (width) => set({ queuePanelWidth: width }),
 
   loadQueue: async () => {
     try {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -123,8 +123,8 @@ type PlayerStore = {
   searchQuery: string
   searchResults: SearchResult | null
   queueVisible: boolean
-  artistPanelVisible: boolean
-  artistPanelSnapshot: boolean | null // saved visibility before entering Now Playing
+  collectionPanelVisible: boolean
+  collectionPanelSnapshot: boolean | null // saved visibility before entering Now Playing
   queue: QueueState | null
   albumGroupingActive: boolean
   downloadingAlbumIds: Set<string>
@@ -158,7 +158,7 @@ type PlayerStore = {
   setAudioLevel: (leftDb: number, rightDb: number, crestDb: number, peakDb: number) => void
   setServerStatus: (status: 'connected' | 'reconnecting' | 'disconnected') => void
   toggleQueuePanel: () => void
-  toggleArtistPanel: () => void
+  toggleCollectionPanel: () => void
   loadQueue: () => Promise<void>
   setSearchQuery: (q: string) => void
   setSortOrder: (
@@ -490,8 +490,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   searchResults: null,
   queueVisible: false,
   // Client-only persistence — no backend endpoint needed for this toggle.
-  artistPanelVisible: localStorage.getItem('kamp:artist-panel-visible') !== 'false',
-  artistPanelSnapshot: null,
+  collectionPanelVisible: localStorage.getItem('kamp:collection-panel-visible') !== 'false',
+  collectionPanelSnapshot: null,
   queue: null,
   albumGroupingActive: localStorage.getItem('kamp:album-view') === 'true',
   downloadingAlbumIds: new Set<string>(),
@@ -520,10 +520,10 @@ export const useStore = create<PlayerStore>((set, get) => ({
     void api.setQueuePanelApi(next)
   },
 
-  toggleArtistPanel: () => {
-    const next = !get().artistPanelVisible
-    set({ artistPanelVisible: next })
-    localStorage.setItem('kamp:artist-panel-visible', String(next))
+  toggleCollectionPanel: () => {
+    const next = !get().collectionPanelVisible
+    set({ collectionPanelVisible: next })
+    localStorage.setItem('kamp:collection-panel-visible', String(next))
   },
 
   loadQueue: async () => {
@@ -589,20 +589,20 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   setActiveView: async (view) => {
-    const { artistPanelVisible, artistPanelSnapshot } = get()
+    const { collectionPanelVisible, collectionPanelSnapshot } = get()
     if (view === 'library') {
-      // Restore the artist panel to its pre-non-library state.
-      const restored = artistPanelSnapshot ?? artistPanelVisible
-      set({ activeView: view, artistPanelSnapshot: null, artistPanelVisible: restored })
-      localStorage.setItem('kamp:artist-panel-visible', String(restored))
+      // Restore the collection panel to its pre-non-library state.
+      const restored = collectionPanelSnapshot ?? collectionPanelVisible
+      set({ activeView: view, collectionPanelSnapshot: null, collectionPanelVisible: restored })
+      localStorage.setItem('kamp:collection-panel-visible', String(restored))
     } else {
-      // Hide the artist panel (only relevant in Library) on any non-library view.
+      // Hide the collection panel (only relevant in Library) on any non-library view.
       // Preserve any existing snapshot so round-trips through multiple non-library views
       // (e.g. now-playing → home → library) still restore the original user preference.
       // Persist false so a restart outside the library doesn't reopen the panel.
-      const snapshot = artistPanelSnapshot ?? artistPanelVisible
-      set({ activeView: view, artistPanelSnapshot: snapshot, artistPanelVisible: false })
-      localStorage.setItem('kamp:artist-panel-visible', 'false')
+      const snapshot = collectionPanelSnapshot ?? collectionPanelVisible
+      set({ activeView: view, collectionPanelSnapshot: snapshot, collectionPanelVisible: false })
+      localStorage.setItem('kamp:collection-panel-visible', 'false')
     }
     try {
       await api.setActiveViewApi(view)

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -8,6 +8,7 @@ export const TOOLTIPS = {
   TRANSPORT_SHUFFLE: 'Shuffle',
   TRANSPORT_REPEAT: 'Repeat',
   TRANSPORT_QUEUE: 'Queue (Q)',
+  COLLECTION_TOGGLE: 'Collection (C)',
   TRANSPORT_FAVORITE_ADD: 'Add to favorites',
   TRANSPORT_FAVORITE_REMOVE: 'Remove from favorites',
 


### PR DESCRIPTION
## KAMP-612: 'artist' panel is 'collection' panel

The left "Artist" panel now hosts both Artists and Genres, so it's really the user's **Collection**. This renames it, gives both the Collection and Queue panels a discoverable floating toggle tab, moves the Queue toggle out of the crowded transport bar, and persists the sub-tab plus both panels' open/close state across restarts.

### Changes (5 commits)

1. **Rename** — `ArtistPanel.tsx` → `CollectionPanel.tsx`, store symbols (`collectionPanelVisible`, `toggleCollectionPanel`, `collectionPanelSnapshot`), `localStorage` keys, panel id `kamp.collection` + title "Collection", and CSS classes. No behavior change.
2. **Shortcut A → C** (bare — inherits the existing input-focus guard so typing `c` in a field doesn't toggle) + shortcuts overlay updated. `compatibleSlots` tightened to `['left']` (collection) / `['right']` (queue) to encode that slots no longer swap.
3. **Collection tab** — a rounded floating toggle using the provided `collection.svg` (new `CollectionIcon`), library-only, tooltip "Collection (C)". Rendered outside the `isPanelVisible` gate so it stays clickable when the panel is collapsed.
4. **Queue tab** — matching rounded toggle, wired to the existing `toggleQueuePanel` (server-persisted via `ui.queue_panel_open`); the transport-bar queue button and its now-orphaned CSS are removed, freeing transport space.
5. **Sub-tab persistence** — new `kamp:collection-tab` key. Precedence: an active genre filter forces the Genres tab (KAMP-550); otherwise the last explicitly-chosen tab is restored.

### Follow-up polish (review feedback)

6. **Tab anchoring / resize coupling** — each tab sits at its panel's **inner edge** (overlapping the library) when open, and rests against the app edge when closed. To keep the tab glued to the edge *during a resize drag*, the open-state tab is rendered as a **child of the panel** (shared `PanelToggleTab` component, `overflow: visible` on the panels) so it moves in the same layout pass as the width change — exact coupling, no JS. When a panel is collapsed (unmounted), `PanelToggleTabs` renders a reopen handle at the app edge. (An earlier store-width-mirror approach lagged a frame because the tab and edge were separate React renders; this replaces it.)
7. **Tooltip clamp fix** — the viewport clamp lived in a `[display]` effect, but `TooltipProvider` wraps the whole app, so a frequent parent re-render (audio metering, playback ticks) re-applied the inline `left` and wiped the clamp without re-running the effect — letting the Collection tooltip escape the left edge. The tooltip bubble is now a memoized portal that only re-renders when the tooltip itself changes, so the clamp holds.

### Notes

- Open/close persistence already existed (collection via client `localStorage`, queue via server `ui.queue_panel_open`); this verifies and reuses it rather than rebuilding.
- Slot-swap was already dead code (no UI called `movePanel`); the slot system stays for extension panels.
- The `localStorage` key rename resets panel width/visibility to defaults **once** on first launch — accepted one-time reset.
- No height/max-height animation (Electron lesson) — instant show/hide.

### Manual test plan (visual)

- [ ] `C` in Library toggles the Collection panel; `A` does nothing; typing `c` in search does not toggle.
- [ ] `C` / Collection tab hidden outside Library; Queue tab works in all views.
- [ ] Collection tab visible when panel is open **and** collapsed; correct glyph; tooltip "Collection (C)".
- [ ] Queue tab toggles the queue; transport bar reflows cleanly without the old button; tooltip "Queue (Q)".
- [ ] When a panel is open, its tab sits at the panel's inner edge overlapping the library; **drag the panel resize handle → the tab moves with the edge live**. When closed, the tab rests at the app edge.
- [ ] Collection tooltip does not clip off the left window edge (hover repeatedly while audio/playback is active).
- [ ] Switch to Genres, restart → still Genres. Switch to Artists, restart → still Artists.
- [ ] With a genre filter active, restart → lands on Genres regardless of persisted tab.
- [ ] Collection panel open/closed state survives restart (client); Queue open/closed survives restart (server round-trip).
- [ ] Panel resize/clamp still works after the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
