### PR TITLE
KAMP-611: clicking a genre pill navigates to its genre filter

### DIFF
--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1238,6 +1238,25 @@
   white-space: nowrap;
 }
 
+/* KAMP-611: read-only chip that navigates to the genre filter. Button reset so
+   it reads as a chip, plus a hover/focus affordance signalling it's actionable. */
+.genre-chip--clickable {
+  font: inherit;
+  font-size: 11px;
+  color: inherit;
+  cursor: pointer;
+}
+
+.genre-chip--clickable:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.genre-chip--clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .genre-chip-remove {
   background: none;
   border: none;

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { useStore } from '../store'
 import { getGenres } from '../api/client'
 import type { Track } from '../api/client'
 import { useTooltip } from '../hooks/useTooltip'
@@ -118,6 +119,7 @@ export function AlbumMetaPanel({
   onHandleDoubleClick
 }: AlbumMetaPanelProps): React.JSX.Element {
   const panelRef = useRef<HTMLDivElement>(null)
+  const openGenreFilter = useStore((s) => s.openGenreFilter)
 
   const [label, setLabel] = React.useState(() => commonValue(tracks, 'label'))
   const [releaseDate, setReleaseDate] = React.useState(() => commonValue(tracks, 'release_date'))
@@ -218,6 +220,7 @@ export function AlbumMetaPanel({
                   suggestions={genreSuggestions}
                   editMode={editMode}
                   onCommit={handleSaveGenres}
+                  onGenreClick={openGenreFilter}
                 />
               </dd>
             </div>

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -27,6 +27,17 @@ export function CollectionPanel(): React.JSX.Element {
     localStorage.setItem(COLLECTION_TAB_KEY, next)
     setTabState(next)
   }
+
+  // KAMP-611: when a genre becomes the active filter (e.g. clicking a genre pill
+  // on an album), surface the Genres tab. Render-phase sync on the selectedGenre
+  // transition (same pattern as GenreChipsInput/AlbumMetaPanel) — state-only, never
+  // persisted, so a user's explicit Artists preference (KAMP-612) survives once the
+  // filter clears. Only fires on an actual change, so manual tab switches stick.
+  const [prevGenre, setPrevGenre] = useState(selectedGenre)
+  if (selectedGenre !== prevGenre) {
+    setPrevGenre(selectedGenre)
+    if (selectedGenre !== null) setTabState('genres')
+  }
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const saved = parseFloat(localStorage.getItem(COLLECTION_WIDTH_KEY) ?? '')
     const max = window.innerWidth * 0.33

--- a/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreChipsInput.tsx
@@ -1,5 +1,6 @@
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTooltip } from '../hooks/useTooltip'
 
 // Multi-value genre editor (KAMP-586): removable chips + type-ahead autocomplete
 // sourced from genres already in the library. Genres may contain spaces
@@ -10,6 +11,9 @@ type Props = {
   suggestions: string[]
   editMode: boolean
   onCommit: (genres: string[]) => void
+  // KAMP-611: when provided, read-only chips become clickable and navigate to
+  // that genre's filter. Ignored in edit mode (chips stay inert there).
+  onGenreClick?: (genre: string) => void
 }
 
 function sameSet(a: string[], b: string[]): boolean {
@@ -22,8 +26,10 @@ export function GenreChipsInput({
   chips: initial,
   suggestions,
   editMode,
-  onCommit
+  onCommit,
+  onGenreClick
 }: Props): React.JSX.Element {
+  const tooltip = useTooltip()
   const [chips, setChips] = useState(initial)
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
@@ -98,11 +104,23 @@ export function GenreChipsInput({
     if (chips.length === 0) return <span className="meta-field--empty">—</span>
     return (
       <span className="genre-chips genre-chips--readonly">
-        {chips.map((c) => (
-          <span key={c} className="genre-chip">
-            {c}
-          </span>
-        ))}
+        {chips.map((c) =>
+          onGenreClick ? (
+            <button
+              key={c}
+              type="button"
+              className="genre-chip genre-chip--clickable"
+              {...tooltip(`Show ${c}`)}
+              onClick={() => onGenreClick(c)}
+            >
+              {c}
+            </button>
+          ) : (
+            <span key={c} className="genre-chip">
+              {c}
+            </span>
+          )
+        )}
       </span>
     )
   }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -230,6 +230,7 @@ type PlayerStore = {
   loadUiState: () => Promise<void>
   selectArtist: (artist: string | null) => void
   selectGenre: (genre: string | null) => void
+  openGenreFilter: (genre: string) => void
   selectAlbum: (album: Album | null) => Promise<void>
   loadTracks: (albumArtist: string, album: string, trackId?: number | null) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
@@ -1069,6 +1070,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set((s) => ({
       library: { ...s.library, selectedGenre: genre, selectedArtist: null, selectedAlbum: null }
     })),
+
+  // KAMP-611: navigate to a genre's filter from a genre pill. Applies the filter
+  // (which clears the open album back to the grid) and opens the Collection panel
+  // if it's collapsed so the active filter is visible. CollectionPanel flips to
+  // the Genres tab off `selectedGenre`.
+  openGenreFilter: (genre) => {
+    get().selectGenre(genre)
+    if (!get().collectionPanelVisible) get().toggleCollectionPanel()
+  },
 
   selectAlbum: async (album) => {
     set((s) => ({


### PR DESCRIPTION
## KAMP-611: clicking a genre tag goes to the genre filter

Read-only genre pills on an album page were inert. Now clicking one filters the library to that genre and surfaces the Collection panel's Genres tab — a one-click path into the genre view. Edit-mode pills stay inert (only their `×` removes), so navigation never fights editing.

### Changes

- **`store.ts`** — new `openGenreFilter(genre)` action: `selectGenre(genre)` (which clears the open album back to the genre-filtered grid) + auto-opens the Collection panel if it's collapsed.
- **`CollectionPanel.tsx`** — a render-phase sync (same pattern as `GenreChipsInput`/`AlbumMetaPanel`, no effect) flips the *visible* sub-tab to Genres when a genre becomes active. It's **state-only, never persisted**, so a user's explicit Artists preference (KAMP-612) survives once the filter clears. Only fires on an actual `selectedGenre` change, so manual tab switches stick.
- **`GenreChipsInput.tsx`** — new optional `onGenreClick`; read-only chips render as `<button type="button" className="genre-chip genre-chip--clickable">` with a "Show {genre}" tooltip (project `useTooltip`). Edit-mode branch untouched.
- **`AlbumMetaPanel.tsx`** — wires `openGenreFilter` → `onGenreClick`.
- **`track-list.css`** — `.genre-chip--clickable`: button reset, pointer, hover highlight, `:focus-visible` ring.

### Notes

- **Filter key correctness:** the chip string is the canonical genre name, and `AlbumGrid` filters case-insensitively on the album's canonical `genres` array — so a clicked chip always matches (no display-vs-key divergence).
- **KAMP-612 preserved:** the tab-switch never writes `localStorage`, so it can't clobber the persisted Artists/Genres preference.
- **Accepted minor edge:** re-clicking the *already-active* genre while you've manually forced the Artists tab won't re-flip it (React bails on the unchanged value). Negligible — the grid is already filtered to that genre. Fixing it would mean lifting the sub-tab into the store (scope creep for a Side).
- No backend changes; kamp_ui has no JS test runner, so verification is manual.

### Manual test plan

- [ ] View-mode album with genres: each pill has pointer cursor, hover highlight, and a "Show {genre}" tooltip.
- [ ] Click a pill → grid filters to that genre; Collection panel opens on the Genres tab with the genre highlighted.
- [ ] Click a pill while the panel is open on the Artists tab → flips to Genres.
- [ ] Manually switch to Artists, restart the app → panel restores to Artists (preference not clobbered).
- [ ] Edit mode: clicking a pill body does nothing; `×` still removes the genre.
- [ ] Click a pill while the panel is collapsed → panel auto-opens showing the genre.
- [ ] Multi-genre / "(mixed)" album → each pill navigates to its own filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
