### PR TITLE
KAMP-606: remove a genre from the whole collection

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -6323,6 +6323,87 @@ class LibraryIndex:
             ).fetchall()
         ]
 
+    def genres_for_track(self, track_id: int) -> list[str]:
+        """Canonical genre names linked to *track_id*, sorted NOCASE (KAMP-606).
+
+        Reads the normalized track_genres rows so callers get exact canonical
+        casing without re-parsing the denormalized "; "-joined tracks.genre
+        (a genre name may itself contain "; ").
+        """
+        return [
+            r["name"]
+            for r in self._conn.execute(
+                "SELECT g.name FROM track_genres tg"
+                " JOIN genres g ON g.id = tg.genre_id"
+                " WHERE tg.track_id = ?"
+                " ORDER BY g.name COLLATE NOCASE",
+                (track_id,),
+            ).fetchall()
+        ]
+
+    def remove_genre(self, name: str) -> int:
+        """Remove *name* from every track and delete it from the vocabulary (KAMP-606).
+
+        Strips the genre from all tagged tracks' normalized rows (and the
+        denormalized tracks.genre, via the _set_track_genres chokepoint), deletes
+        the now-orphaned genres row, and refreshes the affected albums' genre
+        union plus the FTS index. DB only — the caller writes the stripped tag to
+        the audio files (the DELETE endpoint's is_remote-guarded loop), exactly
+        as apply_genres leaves file I/O to its caller. Returns the number of
+        tracks that carried the genre (0 if there is no such genre).
+        """
+        row = self._conn.execute(
+            "SELECT id FROM genres WHERE name = ? COLLATE NOCASE", (name,)
+        ).fetchone()
+        if row is None:
+            return 0
+        genre_id = row["id"]
+        track_ids = [
+            r["track_id"]
+            for r in self._conn.execute(
+                "SELECT track_id FROM track_genres WHERE genre_id = ?", (genre_id,)
+            ).fetchall()
+        ]
+        # Affected albums, snapshotted before the mutation.
+        album_ids: list[int] = []
+        if track_ids:
+            placeholders = ",".join("?" for _ in track_ids)
+            album_ids = [
+                r["album_id"]
+                for r in self._conn.execute(
+                    f"SELECT DISTINCT album_id FROM tracks"
+                    f" WHERE id IN ({placeholders}) AND album_id IS NOT NULL",
+                    track_ids,
+                ).fetchall()
+            ]
+        # Rewrite each track's genres to everything BUT the removed one. Deriving
+        # the survivors from track_genres (canonical rows), never from splitting
+        # the "; "-joined tracks.genre, keeps casing exact and is immune to a
+        # genre name that itself contains the delimiter.
+        for tid in track_ids:
+            remaining = [
+                r["name"]
+                for r in self._conn.execute(
+                    "SELECT g.name FROM track_genres tg"
+                    " JOIN genres g ON g.id = tg.genre_id"
+                    " WHERE tg.track_id = ? AND tg.genre_id != ?",
+                    (tid, genre_id),
+                ).fetchall()
+            ]
+            self._set_track_genres(tid, remaining)
+        # Delete the now-orphaned vocabulary row (the issue wants it gone from the
+        # DB, not merely hidden by all_genres' JOIN). Its track_genres rows are
+        # already gone via the rewrites above, so ON DELETE CASCADE is a no-op.
+        self._conn.execute("DELETE FROM genres WHERE id = ?", (genre_id,))
+        for album_id in album_ids:
+            self._refresh_album_genre(album_id)
+        for tid in track_ids:
+            self._refresh_track_fts_row(tid)
+        self._conn.commit()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.genre"})
+        return len(track_ids)
+
     def update_album_meta(
         self,
         album_artist: str,
@@ -6643,6 +6724,23 @@ class LibraryIndex:
             "SELECT * FROM tracks_with_stats WHERE album_id = ?"
             " ORDER BY disc_number, track_number",
             (album_id,),
+        ).fetchall()
+        return [_row_to_track(r) for r in rows]
+
+    def tracks_for_genre(self, name: str) -> list[Track]:
+        """Every track carrying *name* (NOCASE), as Track objects (KAMP-606).
+
+        Backs the remove-genre endpoint's file-write loop, which needs each
+        track's file_path + is_remote. Matches on the normalized track_genres
+        link, not the denormalized string.
+        """
+        rows = self._conn.execute(
+            "SELECT t.* FROM tracks_with_stats t"
+            " JOIN track_genres tg ON tg.track_id = t.id"
+            " JOIN genres g ON g.id = tg.genre_id"
+            " WHERE g.name = ? COLLATE NOCASE"
+            " ORDER BY t.id",
+            (name,),
         ).fetchall()
         return [_row_to_track(r) for r in rows]
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1439,6 +1439,56 @@ def create_app(
         """Every distinct genre in the library (KAMP-586), for autocomplete."""
         return index.all_genres()
 
+    @app.delete("/api/v1/genres")
+    def delete_genre(name: str) -> dict[str, Any]:
+        """Remove a genre from every tagged track and the DB (KAMP-606).
+
+        Strips the genre from each track's audio-file tag (skipping remote-only
+        tracks, which have no local file) and then from the database, deleting
+        the vocabulary entry. File writes happen BEFORE the DB mutation so a
+        mid-way failure leaves the DB intact for the next scan to reconcile —
+        mirroring patch_album_meta. `name` is a query param, not a path segment,
+        because genre names can contain '/'.
+        """
+        from kamp_core.library import write_meta_tags_to_file
+
+        name = name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Genre name required")
+        # A running backfill writes genres off-thread; a concurrent removal could
+        # race it (re-adding the vocab row or a track link). Refuse until it ends.
+        if _state["genre_backfill"]["active"]:
+            raise HTTPException(
+                status_code=409,
+                detail="Genre backfill in progress; try again once it finishes",
+            )
+
+        tracks = index.tracks_for_genre(name)
+        for track in tracks:
+            if track.is_remote:
+                continue
+            remaining = [
+                g
+                for g in index.genres_for_track(track.id)
+                if g.casefold() != name.casefold()
+            ]
+            try:
+                write_meta_tags_to_file(track.file_path, genres=remaining)
+            except Exception as exc:
+                logger.exception(
+                    "genre tag write failed for track %d (%s)",
+                    track.id,
+                    track.file_path,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to write tags to {track.file_path}: {exc}",
+                ) from exc
+
+        updated = index.remove_genre(name)
+        _notify_library_changed()
+        return {"ok": True, "tracks_updated": updated}
+
     @app.get("/api/v1/tracks/top", response_model=list[TrackOut])
     def get_top_tracks(limit: int = 10) -> list[TrackOut]:
         return _tracks_out(index, index.top_tracks(limit))

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -763,6 +763,11 @@ export async function getGenres(): Promise<string[]> {
   return (await res.json()) as string[]
 }
 
+// Remove a genre from every tagged track (DB + file tags) and the DB (KAMP-606).
+// Query param, not path — genre names can contain '/'.
+export const deleteGenre = (name: string): Promise<{ ok: boolean; tracks_updated: number }> =>
+  del(`/api/v1/genres?name=${encodeURIComponent(name)}`)
+
 // ---------------------------------------------------------------------------
 // MusicBrainz lookup (KAMP-230, shallow candidates + lazy hydration KAMP-584)
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { PanelToggleTab } from './PanelToggleTab'
+import { GenreContextMenu } from './GenreContextMenu'
+import { RemoveGenreModal } from './RemoveGenreModal'
 
 const COLLECTION_WIDTH_KEY = 'kamp:collection-panel-width'
 const COLLECTION_WIDTH_DEFAULT = 200
@@ -13,7 +15,11 @@ export function CollectionPanel(): React.JSX.Element {
   const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
   const selectGenre = useStore((s) => s.selectGenre)
+  const removeGenre = useStore((s) => s.removeGenre)
   const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
+  // Genre right-click menu + destructive-removal confirmation (KAMP-606).
+  const [genreMenu, setGenreMenu] = useState<{ x: number; y: number; genre: string } | null>(null)
+  const [pendingRemove, setPendingRemove] = useState<string | null>(null)
   // Which list is shown. An active genre filter forces the Genres tab so
   // re-opening while a genre is selected lands there (KAMP-550); otherwise the
   // last explicitly-chosen tab is restored across restarts (KAMP-612).
@@ -175,6 +181,10 @@ export function CollectionPanel(): React.JSX.Element {
                   tabIndex={0}
                   onClick={() => selectGenre(genre)}
                   onKeyDown={(e) => e.key === 'Enter' && selectGenre(genre)}
+                  onContextMenu={(e) => {
+                    e.preventDefault()
+                    setGenreMenu({ x: e.clientX, y: e.clientY, genre })
+                  }}
                 >
                   {genre}
                 </li>
@@ -190,6 +200,25 @@ export function CollectionPanel(): React.JSX.Element {
       />
       {/* Inner-edge toggle: a child of the panel so it tracks the resize edge. */}
       <PanelToggleTab panel="collection" placement="inner" active onClick={toggleCollectionPanel} />
+      {genreMenu && (
+        <GenreContextMenu
+          x={genreMenu.x}
+          y={genreMenu.y}
+          genre={genreMenu.genre}
+          onRemove={() => setPendingRemove(genreMenu.genre)}
+          onClose={() => setGenreMenu(null)}
+        />
+      )}
+      {pendingRemove && (
+        <RemoveGenreModal
+          genre={pendingRemove}
+          onConfirm={() => {
+            void removeGenre(pendingRemove)
+            setPendingRemove(null)
+          }}
+          onCancel={() => setPendingRemove(null)}
+        />
+      )}
     </aside>
   )
 }

--- a/kamp_ui/src/renderer/src/components/GenreContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreContextMenu.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { ContextMenu } from './ContextMenu'
+import { RemoveFromQueueIcon } from './TransportIcons'
+
+interface Props {
+  x: number
+  y: number
+  genre: string
+  onRemove: () => void
+  onClose: () => void
+}
+
+// Right-click menu for a genre entry in the Collection panel (KAMP-606). The
+// remove action is destructive (strips the genre from every track's DB row and
+// file tag), so the caller gates it behind a confirmation modal.
+export function GenreContextMenu({ x, y, onRemove, onClose }: Props): React.JSX.Element {
+  return (
+    <ContextMenu x={x} y={y} onClose={onClose}>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          onRemove()
+          onClose()
+        }}
+      >
+        <span
+          style={{ marginRight: 6, verticalAlign: 'middle', flexShrink: 0, display: 'inline-flex' }}
+        >
+          <RemoveFromQueueIcon size={12} />
+        </span>
+        Remove Genre from Collection
+      </button>
+    </ContextMenu>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/RemoveGenreModal.tsx
+++ b/kamp_ui/src/renderer/src/components/RemoveGenreModal.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react'
+
+type Props = {
+  genre: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+// Confirmation before a destructive, library-wide genre removal (KAMP-606):
+// it strips the genre from every tagged track's DB row and audio-file tag.
+export function RemoveGenreModal({ genre, onConfirm, onCancel }: Props): React.JSX.Element {
+  // Esc = implicit Cancel.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  return (
+    // Click-away backdrop = implicit Cancel.
+    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="modal collision-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="remove-genre-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="remove-genre-modal-title" className="modal-title">
+          Remove genre
+        </h2>
+        <p className="modal-body">
+          Remove <strong>{genre}</strong> from your collection? This strips it from every tagged
+          track and edits those files&rsquo; tags. This can&rsquo;t be undone.
+        </p>
+        <div className="modal-actions">
+          <button className="modal-btn modal-btn--destructive" onClick={onConfirm}>
+            Remove
+          </button>
+          <button className="modal-btn modal-btn--primary" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -231,6 +231,7 @@ type PlayerStore = {
   selectArtist: (artist: string | null) => void
   selectGenre: (genre: string | null) => void
   openGenreFilter: (genre: string) => void
+  removeGenre: (name: string) => Promise<void>
   selectAlbum: (album: Album | null) => Promise<void>
   loadTracks: (albumArtist: string, album: string, trackId?: number | null) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
@@ -1078,6 +1079,16 @@ export const useStore = create<PlayerStore>((set, get) => ({
   openGenreFilter: (genre) => {
     get().selectGenre(genre)
     if (!get().collectionPanelVisible) get().toggleCollectionPanel()
+  },
+
+  // KAMP-606: remove a genre from every tagged track (DB + file tags) and the
+  // DB. Clears the active filter if it was this genre, then refreshes the
+  // library (genre sidebar + album grid) and any open album's chips.
+  removeGenre: async (name) => {
+    await api.deleteGenre(name)
+    if (get().library.selectedGenre === name) get().selectGenre(null)
+    await get().loadLibrary()
+    await get().refreshOpenAlbum()
   },
 
   selectAlbum: async (album) => {

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3423,6 +3423,118 @@ class TestSearch:
 
 
 # ---------------------------------------------------------------------------
+# Remove genre (KAMP-606)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveGenre:
+    """LibraryIndex.remove_genre / genres_for_track / tracks_for_genre (KAMP-606)."""
+
+    def _track(
+        self, tmp_path: Path, name: str, album: str, genres: list[str]
+    ) -> "Track":
+        return Track(
+            file_path=tmp_path / f"{name}.mp3",
+            title=name,
+            artist="Artist",
+            album_artist="Artist",
+            album=album,
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genres=genres,
+        )
+
+    def _index(self, tmp_path: Path) -> LibraryIndex:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._track(tmp_path, "a", "AlbumA", ["Jazz"]),
+                self._track(tmp_path, "b", "AlbumB", ["Ambient", "Jazz"]),
+                self._track(tmp_path, "c", "AlbumC", ["Rock"]),
+            ]
+        )
+        return index
+
+    def _genre_of(self, index: LibraryIndex, title: str) -> str:
+        return next(t for t in index.all_tracks() if t.title == title).genre
+
+    def test_strips_from_all_tracks_and_drops_from_list(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        count = index.remove_genre("Jazz")
+        assert count == 2  # tracks a and b carried Jazz
+        assert "Jazz" not in index.all_genres()
+        assert self._genre_of(index, "a") == ""  # only genre was Jazz
+        index.close()
+
+    def test_keeps_other_genres_on_multi_genre_track(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.remove_genre("Jazz")
+        assert index.genres_for_track(
+            next(t for t in index.all_tracks() if t.title == "b").id
+        ) == ["Ambient"]
+        assert self._genre_of(index, "b") == "Ambient"
+        index.close()
+
+    def test_leaves_unrelated_genres_untouched(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.remove_genre("Jazz")
+        assert index.all_genres() == ["Ambient", "Rock"]
+        assert self._genre_of(index, "c") == "Rock"
+        index.close()
+
+    def test_deletes_orphan_vocabulary_row(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.remove_genre("Jazz")
+        row = index._conn.execute(
+            "SELECT id FROM genres WHERE name = ? COLLATE NOCASE", ("Jazz",)
+        ).fetchone()
+        assert row is None
+        index.close()
+
+    def test_case_insensitive(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        count = index.remove_genre("jAzZ")  # stored as "Jazz"
+        assert count == 2
+        assert "Jazz" not in index.all_genres()
+        index.close()
+
+    def test_nonexistent_genre_returns_zero(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        assert index.remove_genre("Techno") == 0
+        assert index.all_genres() == ["Ambient", "Jazz", "Rock"]
+        index.close()
+
+    def test_refreshes_album_genre_union(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.remove_genre("Jazz")
+        # AlbumB's denormalized union should now be just "Ambient".
+        genre = index._conn.execute(
+            "SELECT genre FROM albums WHERE album = ?", ("AlbumB",)
+        ).fetchone()["genre"]
+        assert genre == "Ambient"
+        index.close()
+
+    def test_removed_genre_no_longer_searchable(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._track(tmp_path, "s", "AlbumS", ["Shoegaze"])])
+        assert {t.title for t in index.search("shoegaze")} == {"s"}
+        index.remove_genre("Shoegaze")
+        assert index.search("shoegaze") == []
+        index.close()
+
+    def test_tracks_for_genre_matches_nocase(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        titles = {t.title for t in index.tracks_for_genre("jazz")}
+        assert titles == {"a", "b"}
+        index.close()
+
+
+# ---------------------------------------------------------------------------
 # Sort and record_played
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import json
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -7193,3 +7194,77 @@ class TestStatsEndpoint:
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         TestClient(app).get("/api/v1/stats?top_tracks=5")
         mock_index.get_stats.assert_called_once_with(top_tracks_limit=5)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/genres (KAMP-606)
+# ---------------------------------------------------------------------------
+
+
+def _gtrack(track_id: int, path: str, is_remote: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(id=track_id, file_path=Path(path), is_remote=is_remote)
+
+
+class TestDeleteGenre:
+    """Remove a genre from every tagged track and the DB (KAMP-606)."""
+
+    def test_writes_remaining_tags_and_removes(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_genre.return_value = [
+            _gtrack(1, "/music/a.mp3"),
+            _gtrack(2, "/music/b.mp3"),
+        ]
+        mock_index.genres_for_track.side_effect = lambda tid: {
+            1: ["Jazz"],
+            2: ["Ambient", "Jazz"],
+        }[tid]
+        mock_index.remove_genre.return_value = 2
+        with patch("kamp_core.library.write_meta_tags_to_file") as wtf:
+            res = client.delete("/api/v1/genres", params={"name": "Jazz"})
+        assert res.status_code == 200
+        assert res.json() == {"ok": True, "tracks_updated": 2}
+        # Each file's tag is rewritten with the removed genre stripped, others kept.
+        calls = {c.args[0]: c.kwargs["genres"] for c in wtf.call_args_list}
+        assert calls[Path("/music/a.mp3")] == []
+        assert calls[Path("/music/b.mp3")] == ["Ambient"]
+        mock_index.remove_genre.assert_called_once_with("Jazz")
+
+    def test_skips_remote_tracks(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_genre.return_value = [
+            _gtrack(3, "bandcamp://x", is_remote=True)
+        ]
+        mock_index.remove_genre.return_value = 1
+        with patch("kamp_core.library.write_meta_tags_to_file") as wtf:
+            res = client.delete("/api/v1/genres", params={"name": "Jazz"})
+        assert res.status_code == 200
+        wtf.assert_not_called()  # no local file to write
+        mock_index.remove_genre.assert_called_once_with("Jazz")
+
+    def test_blank_name_is_400(self, client: TestClient, mock_index: MagicMock) -> None:
+        res = client.delete("/api/v1/genres", params={"name": "  "})
+        assert res.status_code == 400
+        mock_index.remove_genre.assert_not_called()
+
+    def test_conflict_while_backfill_running(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        client.app.state.notify_genre_backfill_progress(0, 10, "running")
+        res = client.delete("/api/v1/genres", params={"name": "Jazz"})
+        assert res.status_code == 409
+        mock_index.remove_genre.assert_not_called()
+
+    def test_file_write_failure_leaves_db_untouched(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.tracks_for_genre.return_value = [_gtrack(1, "/music/a.mp3")]
+        mock_index.genres_for_track.return_value = ["Jazz"]
+        with patch(
+            "kamp_core.library.write_meta_tags_to_file",
+            side_effect=OSError("locked"),
+        ):
+            res = client.delete("/api/v1/genres", params={"name": "Jazz"})
+        assert res.status_code == 500
+        mock_index.remove_genre.assert_not_called()


### PR DESCRIPTION
## KAMP-606: remove a genre from the whole collection

Steel thread of the genre-management sprint. Right-clicking a genre in the Collection panel now offers "Remove Genre from Collection" (X icon). After a confirmation, the genre is stripped from every tagged track — in the DB **and** the audio-file tags — and deleted from the database. This establishes the bulk-retag core op, the genre-mutation endpoint pattern, and the genre context menu that KAMP-607/608/610 build on.

### Changes (3 commits)

1. **Core** (`kamp_core/library.py`) — `remove_genre(name) -> int` strips the genre from every track via the `_set_track_genres` chokepoint, deletes the orphaned `genres` row, and refreshes album unions + FTS; plus `tracks_for_genre(name)` and `genres_for_track(track_id)` helpers.
2. **Endpoint** (`kamp_core/server.py`) — `DELETE /api/v1/genres?name=<encoded>`: writes the stripped tag to each non-remote track's file *first*, then runs the DB op; `deleteGenre` client wrapper.
3. **UI** — `GenreContextMenu` + right-click wiring on the genre list, a `RemoveGenreModal` confirmation, and a `removeGenre` store action that clears the active filter and refreshes.

### Correctness (Reality-Checker–driven)

- **Files-first ordering** (mirrors `patch_album_meta`): a mid-way file-write failure returns 500 with the DB untouched; the already-written files are reconciled downward by the next library scan — no permanent divergence, and retry is an idempotent no-op.
- **Backfill concurrency**: the endpoint returns **409 while a genre backfill is running** (`_state["genre_backfill"]["active"]`), since the backfill writes genres off-thread.
- **Casing/delimiter**: the post-removal genre list is derived from `track_genres` canonical rows (filtered NOCASE), never by splitting the `"; "`-joined string — immune to tag-casing drift and to a genre name that contains the delimiter.
- **Remote tracks**: DB genre removed, file write skipped (no local file).

### Tests

- `tests/test_library.py::TestRemoveGenre` (9) — strip-from-all, keep-other-genres on multi-genre tracks, leave-unrelated, orphan-row deletion, NOCASE match, non-existent → 0, album-union refresh, FTS de-index, `tracks_for_genre` NOCASE.
- `tests/test_server.py::TestDeleteGenre` (5) — writes remaining tags + removes, skips remote, 400 blank name, 409 during backfill, 500 file-write failure leaves DB untouched.
- Full suite: 2549 passed, coverage 93.65% (above the 93.0 gate). UI typecheck/lint/build clean.

### Scope note

File writes are synchronous (like `patch_album_meta`). A very popular genre = many writes in one request; if that proves slow on large libraries, the KAMP-591 backfill thread+progress pattern is the escape hatch (follow-up). Deferred "ban list" (re-appearance via enrichment) is tracked on KAMP-609.

### Manual test plan

- [ ] Right-click a genre in the Collection panel Genres tab → "Remove Genre from Collection" with the X icon.
- [ ] Click it → confirmation modal; Cancel/Esc/click-away leaves everything unchanged.
- [ ] Confirm → genre leaves the sidebar; albums that only had it drop it; a multi-genre track keeps its others.
- [ ] Verify a file on disk actually lost the genre tag (and kept the others) — reopen the album; the chip is gone.
- [ ] Remove the currently-active genre filter → the grid resets (filter cleared), not an empty/stale filter.
- [ ] A streamed/remote-only track with the genre: DB genre removed, no error.
- [ ] Attempt a remove while a genre backfill is running → blocked with a clear 409 message, no partial mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
