### PR TITLE
KAMP-608: edit (rename) a genre

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -6578,6 +6578,101 @@ class LibraryIndex:
             self.on_fields_changed({"track.genre"})
         return len(track_ids)
 
+    def validate_genre_rename(self, old: str, new: str) -> None:
+        """Raise ValueError if renaming *old* to *new* is not allowed (KAMP-608).
+
+        *old* isn't inspected here (rename_genre no-ops on an absent genre); this
+        guards *new*.
+        """
+        new = new.strip()
+        if not new:
+            raise ValueError("new genre name is required")
+        if ";" in new:
+            raise ValueError("genre names cannot contain ';'")
+        # Renaming ONTO a merged-away name would land the file tag on `new` but the
+        # DB on that name's merge target (via _set_track_genres) — a silent file/DB
+        # divergence. Reject and point the user at the surviving genre.
+        target = self._merge_map.get(new.casefold())
+        if target is not None:
+            raise ValueError(
+                f"'{new}' is merged into '{target}'; edit '{target}' instead"
+            )
+
+    def rename_genre(self, old: str, new: str) -> int:
+        """Rename genre *old* to *new*, applied to every tagged track (KAMP-608).
+
+        DB only — the caller writes the new tag to the files (like remove_genre).
+        Renaming onto an existing genre folds *old* into it (a one-time union, not
+        a persistent merge rule). Returns the number of retagged tracks (0 if
+        *old* has no genre). Re-validates internally.
+        """
+        self.validate_genre_rename(old, new)
+        new = new.strip()
+        old_row = self._conn.execute(
+            "SELECT id FROM genres WHERE name = ? COLLATE NOCASE", (old,)
+        ).fetchone()
+        if old_row is None:
+            return 0
+        old_id = old_row["id"]
+        # Snapshot the affected tracks + albums before the retag loop mutates
+        # track_genres under us.
+        track_ids = [
+            r["track_id"]
+            for r in self._conn.execute(
+                "SELECT track_id FROM track_genres WHERE genre_id = ?", (old_id,)
+            ).fetchall()
+        ]
+        album_ids: list[int] = []
+        if track_ids:
+            placeholders = ",".join("?" for _ in track_ids)
+            album_ids = [
+                r["album_id"]
+                for r in self._conn.execute(
+                    f"SELECT DISTINCT album_id FROM tracks"
+                    f" WHERE id IN ({placeholders}) AND album_id IS NOT NULL",
+                    track_ids,
+                ).fetchall()
+            ]
+        existing = self._conn.execute(
+            "SELECT id FROM genres WHERE name = ? COLLATE NOCASE", (new,)
+        ).fetchone()
+        if existing is not None and existing["id"] != old_id:
+            # Collision: fold `old` into the existing survivor (one-time union). The
+            # survivor's canonical casing wins — _set_track_genres resolves `new` to
+            # the existing row.
+            for tid in track_ids:
+                replaced = [
+                    new if g.casefold() == old.casefold() else g
+                    for g in self.genres_for_track(tid)
+                ]
+                self._set_track_genres(tid, replaced)
+            # Keep any KAMP-607 merges that targeted `old` valid by re-pointing them
+            # at the survivor, then drop the now-orphaned `old` vocab row.
+            self._conn.execute(
+                "UPDATE genre_merges SET target_id = ? WHERE target_id = ?",
+                (existing["id"], old_id),
+            )
+            self._conn.execute("DELETE FROM genres WHERE id = ?", (old_id,))
+        else:
+            # In-place rename (brand-new name, or a case-only change to the same
+            # row). The id is unchanged, so a genre_merges.target_id pointing at it
+            # follows automatically.
+            self._conn.execute("UPDATE genres SET name = ? WHERE id = ?", (new, old_id))
+            # Resync each track's denormalized "; "-joined string to the new name.
+            for tid in track_ids:
+                self._set_track_genres(tid, self.genres_for_track(tid))
+        for album_id in album_ids:
+            self._refresh_album_genre(album_id)
+        for tid in track_ids:
+            self._refresh_track_fts_row(tid)
+        self._conn.commit()
+        # An in-place rename of a merge target changes its resolved name; a collision
+        # re-pointed target_ids. Either way, refresh the cached map.
+        self._load_merge_map()
+        if self.on_fields_changed:
+            self.on_fields_changed({"track.genre"})
+        return len(track_ids)
+
     def update_album_meta(
         self,
         album_artist: str,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -430,6 +430,11 @@ class GenreMergeRequest(BaseModel):
     target: str
 
 
+class GenreRenameRequest(BaseModel):
+    old: str
+    new: str
+
+
 class ShuffleRequest(BaseModel):
     shuffle: bool
     album_shuffle: bool = False
@@ -1563,6 +1568,56 @@ def create_app(
                 ) from exc
 
         updated = index.create_genre_merge(source, target)
+        _notify_library_changed()
+        return {"ok": True, "tracks_updated": updated}
+
+    @app.post("/api/v1/genres/rename")
+    def rename_genre(req: GenreRenameRequest) -> dict[str, Any]:
+        """Rename a genre, applied to every tagged track (KAMP-608).
+
+        Rewrites each non-remote track's audio-file tag (old -> new) then renames
+        the genre in the DB; renaming onto an existing genre folds the two (one
+        time). Files-first ordering + 409-during-backfill mirror the other genre
+        mutation endpoints.
+        """
+        from kamp_core.library import write_meta_tags_to_file
+
+        old = req.old.strip()
+        new = req.new.strip()
+        if _state["genre_backfill"]["active"]:
+            raise HTTPException(
+                status_code=409,
+                detail="Genre backfill in progress; try again once it finishes",
+            )
+        # Validate BEFORE touching any files so a rejected rename writes nothing.
+        try:
+            index.validate_genre_rename(old, new)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        for track in index.tracks_for_genre(old):
+            if track.is_remote:
+                continue
+            mapped = _dedupe_casefold(
+                [
+                    new if g.casefold() == old.casefold() else g
+                    for g in index.genres_for_track(track.id)
+                ]
+            )
+            try:
+                write_meta_tags_to_file(track.file_path, genres=mapped)
+            except Exception as exc:
+                logger.exception(
+                    "genre tag write failed for track %d (%s)",
+                    track.id,
+                    track.file_path,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to write tags to {track.file_path}: {exc}",
+                ) from exc
+
+        updated = index.rename_genre(old, new)
         _notify_library_changed()
         return {"ok": True, "tracks_updated": updated}
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -783,6 +783,15 @@ export interface GenreMerge {
 
 export const getGenreMerges = (): Promise<GenreMerge[]> => get('/api/v1/genres/merges')
 
+// Rename a genre everywhere (DB + file tags) — KAMP-608. Renaming onto an
+// existing genre folds the two (one-time). Rejects invalid names (400) and
+// backfill races (409).
+export const renameGenre = (
+  old: string,
+  next: string
+): Promise<{ ok: boolean; tracks_updated: number }> =>
+  post('/api/v1/genres/rename', { old, new: next })
+
 // ---------------------------------------------------------------------------
 // MusicBrainz lookup (KAMP-230, shallow candidates + lazy hydration KAMP-584)
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -565,6 +565,20 @@ html[data-platform='win32'] .view-tabs {
   background: var(--surface-hover);
 }
 
+/* Inline genre rename input (KAMP-608) — sized to sit inside the list item. */
+.genre-edit-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1px 4px;
+  margin: -2px 0;
+  font: inherit;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  outline: none;
+}
+
 .collection-list li.active {
   background: var(--accent-dim);
   color: var(--accent);

--- a/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/CollectionPanel.tsx
@@ -4,6 +4,7 @@ import { PanelToggleTab } from './PanelToggleTab'
 import { GenreContextMenu } from './GenreContextMenu'
 import { RemoveGenreModal } from './RemoveGenreModal'
 import { MergeGenreModal } from './MergeGenreModal'
+import { GenreEditInput } from './GenreEditInput'
 
 const COLLECTION_WIDTH_KEY = 'kamp:collection-panel-width'
 const COLLECTION_WIDTH_DEFAULT = 200
@@ -18,11 +19,14 @@ export function CollectionPanel(): React.JSX.Element {
   const selectGenre = useStore((s) => s.selectGenre)
   const removeGenre = useStore((s) => s.removeGenre)
   const mergeGenre = useStore((s) => s.mergeGenre)
+  const renameGenre = useStore((s) => s.renameGenre)
   const toggleCollectionPanel = useStore((s) => s.toggleCollectionPanel)
-  // Genre right-click menu + destructive merge/removal confirmations (KAMP-606/607).
+  // Genre right-click menu + destructive merge/removal confirmations (KAMP-606/607)
+  // + inline rename (KAMP-608).
   const [genreMenu, setGenreMenu] = useState<{ x: number; y: number; genre: string } | null>(null)
   const [pendingRemove, setPendingRemove] = useState<string | null>(null)
   const [pendingMerge, setPendingMerge] = useState<string | null>(null)
+  const [editingGenre, setEditingGenre] = useState<string | null>(null)
   // Which list is shown. An active genre filter forces the Genres tab so
   // re-opening while a genre is selected lands there (KAMP-550); otherwise the
   // last explicitly-chosen tab is restored across restarts (KAMP-612).
@@ -177,21 +181,35 @@ export function CollectionPanel(): React.JSX.Element {
               >
                 All Genres
               </li>
-              {genres.map((genre) => (
-                <li
-                  key={genre}
-                  className={selectedGenre === genre ? 'active' : ''}
-                  tabIndex={0}
-                  onClick={() => selectGenre(genre)}
-                  onKeyDown={(e) => e.key === 'Enter' && selectGenre(genre)}
-                  onContextMenu={(e) => {
-                    e.preventDefault()
-                    setGenreMenu({ x: e.clientX, y: e.clientY, genre })
-                  }}
-                >
-                  {genre}
-                </li>
-              ))}
+              {genres.map((genre) => {
+                const editing = editingGenre === genre
+                return (
+                  <li
+                    key={genre}
+                    className={selectedGenre === genre ? 'active' : ''}
+                    tabIndex={editing ? -1 : 0}
+                    onClick={editing ? undefined : () => selectGenre(genre)}
+                    onKeyDown={editing ? undefined : (e) => e.key === 'Enter' && selectGenre(genre)}
+                    onContextMenu={(e) => {
+                      e.preventDefault()
+                      setGenreMenu({ x: e.clientX, y: e.clientY, genre })
+                    }}
+                  >
+                    {editing ? (
+                      <GenreEditInput
+                        initial={genre}
+                        onCommit={(value) => {
+                          void renameGenre(genre, value)
+                          setEditingGenre(null)
+                        }}
+                        onCancel={() => setEditingGenre(null)}
+                      />
+                    ) : (
+                      genre
+                    )}
+                  </li>
+                )
+              })}
             </>
           )}
         </ul>
@@ -208,6 +226,7 @@ export function CollectionPanel(): React.JSX.Element {
           x={genreMenu.x}
           y={genreMenu.y}
           genre={genreMenu.genre}
+          onEdit={() => setEditingGenre(genreMenu.genre)}
           onMerge={() => setPendingMerge(genreMenu.genre)}
           onRemove={() => setPendingRemove(genreMenu.genre)}
           onClose={() => setGenreMenu(null)}

--- a/kamp_ui/src/renderer/src/components/GenreContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreContextMenu.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { ContextMenu } from './ContextMenu'
-import { RemoveFromQueueIcon, MergeIcon } from './TransportIcons'
+import { RemoveFromQueueIcon, MergeIcon, PencilIcon } from './TransportIcons'
 
 interface Props {
   x: number
   y: number
   genre: string
+  onEdit: () => void
   onMerge: () => void
   onRemove: () => void
   onClose: () => void
@@ -21,9 +22,28 @@ const ICON_SPAN: React.CSSProperties = {
 // Right-click menu for a genre entry in the Collection panel (KAMP-606/607).
 // Both actions are destructive (they retag every track's DB row and file tag),
 // so the caller gates each behind a modal.
-export function GenreContextMenu({ x, y, onMerge, onRemove, onClose }: Props): React.JSX.Element {
+export function GenreContextMenu({
+  x,
+  y,
+  onEdit,
+  onMerge,
+  onRemove,
+  onClose
+}: Props): React.JSX.Element {
   return (
     <ContextMenu x={x} y={y} onClose={onClose}>
+      <button
+        className="track-context-menu-item"
+        onClick={() => {
+          onEdit()
+          onClose()
+        }}
+      >
+        <span style={ICON_SPAN}>
+          <PencilIcon size={12} />
+        </span>
+        Edit Genre
+      </button>
       <button
         className="track-context-menu-item"
         onClick={() => {

--- a/kamp_ui/src/renderer/src/components/GenreEditInput.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreEditInput.tsx
@@ -1,0 +1,54 @@
+import React, { useLayoutEffect, useRef } from 'react'
+
+type Props = {
+  initial: string
+  onCommit: (value: string) => void
+  onCancel: () => void
+}
+
+// Inline single-line genre editor (KAMP-608). Enter or blur commits, Esc cancels.
+// A `done` ref makes it commit-once, so the Enter->blur and Esc->blur sequences
+// can't fire twice. An empty or unchanged value on blur is a cancel.
+export function GenreEditInput({ initial, onCommit, onCancel }: Props): React.JSX.Element {
+  const doneRef = useRef(false)
+  const ref = useRef<HTMLInputElement>(null)
+
+  useLayoutEffect(() => {
+    ref.current?.focus()
+    ref.current?.select()
+  }, [])
+
+  const finish = (value: string): void => {
+    if (doneRef.current) return
+    doneRef.current = true
+    const trimmed = value.trim()
+    if (trimmed && trimmed !== initial) onCommit(trimmed)
+    else onCancel()
+  }
+
+  const cancel = (): void => {
+    if (doneRef.current) return
+    doneRef.current = true
+    onCancel()
+  }
+
+  return (
+    <input
+      ref={ref}
+      className="genre-edit-input"
+      defaultValue={initial}
+      aria-label="Rename genre"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          finish((e.target as HTMLInputElement).value)
+        } else if (e.key === 'Escape') {
+          e.preventDefault()
+          cancel()
+        }
+      }}
+      onBlur={(e) => finish(e.target.value)}
+    />
+  )
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -233,6 +233,7 @@ type PlayerStore = {
   openGenreFilter: (genre: string) => void
   removeGenre: (name: string) => Promise<void>
   mergeGenre: (source: string, target: string) => Promise<void>
+  renameGenre: (oldName: string, newName: string) => Promise<void>
   selectAlbum: (album: Album | null) => Promise<void>
   loadTracks: (albumArtist: string, album: string, trackId?: number | null) => Promise<void>
   setCollectionType: (type: 'albums' | 'playlists') => void
@@ -1097,6 +1098,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
   mergeGenre: async (source, target) => {
     await api.mergeGenres(source, target)
     if (get().library.selectedGenre === source) get().selectGenre(target)
+    await get().loadLibrary()
+    await get().refreshOpenAlbum()
+  },
+
+  // KAMP-608: rename a genre everywhere. The active filter follows the rename.
+  renameGenre: async (oldName, newName) => {
+    await api.renameGenre(oldName, newName)
+    if (get().library.selectedGenre === oldName) get().selectGenre(newName)
     await get().loadLibrary()
     await get().refreshOpenAlbum()
   },

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3686,6 +3686,141 @@ class TestMergeGenre:
 
 
 # ---------------------------------------------------------------------------
+# Rename / edit genre (KAMP-608)
+# ---------------------------------------------------------------------------
+
+
+class TestRenameGenre:
+    """LibraryIndex.rename_genre / validate_genre_rename (KAMP-608)."""
+
+    def _track(
+        self, tmp_path: Path, name: str, album: str, genres: list[str]
+    ) -> "Track":
+        return Track(
+            file_path=tmp_path / f"{name}.mp3",
+            title=name,
+            artist="Artist",
+            album_artist="Artist",
+            album=album,
+            release_date="2020",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            genres=genres,
+        )
+
+    def _index(self, tmp_path: Path) -> LibraryIndex:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._track(tmp_path, "a", "AlbumA", ["shoegaze."]),
+                self._track(tmp_path, "b", "AlbumB", ["shoegaze.", "Ambient"]),
+                self._track(tmp_path, "c", "AlbumC", ["Rock"]),
+            ]
+        )
+        return index
+
+    def _genres_of(self, index: LibraryIndex, title: str) -> list[str]:
+        tid = next(t for t in index.all_tracks() if t.title == title).id
+        return index.genres_for_track(tid)
+
+    def test_in_place_rename_to_new_name(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        count = index.rename_genre("shoegaze.", "Shoegaze")
+        assert count == 2
+        assert "Shoegaze" in index.all_genres()
+        assert "shoegaze." not in index.all_genres()
+        assert self._genres_of(index, "a") == ["Shoegaze"]
+        assert sorted(self._genres_of(index, "b")) == ["Ambient", "Shoegaze"]
+        index.close()
+
+    def test_case_only_rename_no_duplicate_row(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._track(tmp_path, "x", "AlbumX", ["shoegaze"])])
+        index.rename_genre("shoegaze", "Shoegaze")
+        assert index.all_genres() == ["Shoegaze"]
+        rows = index._conn.execute(
+            "SELECT COUNT(*) AS n FROM genres WHERE name = 'Shoegaze' COLLATE NOCASE"
+        ).fetchone()["n"]
+        assert rows == 1
+        assert self._genres_of(index, "x") == ["Shoegaze"]
+        index.close()
+
+    def test_rename_onto_existing_folds_one_time(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._track(tmp_path, "a", "AlbumA", ["shoegaze."]),
+                self._track(tmp_path, "b", "AlbumB", ["Shoegaze"]),
+            ]
+        )
+        index.rename_genre("shoegaze.", "Shoegaze")  # fold typo into the survivor
+        assert index.all_genres() == ["Shoegaze"]
+        assert self._genres_of(index, "a") == ["Shoegaze"]
+        # One-time fold: NO persistent merge rule was created.
+        assert index.list_genre_merges() == []
+        index.close()
+
+    def test_rename_onto_existing_dedupes_when_track_has_both(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [self._track(tmp_path, "x", "AlbumX", ["shoegaze.", "Shoegaze"])]
+        )
+        index.rename_genre("shoegaze.", "Shoegaze")
+        assert self._genres_of(index, "x") == ["Shoegaze"]  # single, not two
+        index.close()
+
+    def test_rename_updates_search(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many([self._track(tmp_path, "s", "AlbumS", ["shoegaze."])])
+        index.rename_genre("shoegaze.", "Dreampop")
+        assert {t.title for t in index.search("dreampop")} == {"s"}
+        assert index.search("shoegaze") == []
+        index.close()
+
+    def test_rename_absent_genre_returns_zero(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        assert index.rename_genre("Nope", "Whatever") == 0
+        index.close()
+
+    def test_rename_merge_target_follows(self, tmp_path: Path) -> None:
+        # Renaming a genre that is a merge target keeps the merge pointing at it.
+        index = self._index(tmp_path)
+        index.create_genre_merge("shoegaze.", "Rock")  # Rock is a merge target
+        index.rename_genre("Rock", "Rock & Roll")
+        assert index.list_genre_merges() == [
+            {"source": "shoegaze.", "target": "Rock & Roll"}
+        ]
+        index.upsert_many([self._track(tmp_path, "n", "AlbumN", ["shoegaze."])])
+        assert self._genres_of(index, "n") == ["Rock & Roll"]
+        index.close()
+
+    def test_rename_onto_merge_source_rejected(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.create_genre_merge("shoegaze.", "Rock")  # "shoegaze." is now a source
+        with pytest.raises(ValueError):
+            index.rename_genre("Ambient", "shoegaze.")
+        index.close()
+
+    def test_rename_rejects_delimiter(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        with pytest.raises(ValueError):
+            index.rename_genre("shoegaze.", "a; b")
+        index.close()
+
+    def test_rename_rejects_empty(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        with pytest.raises(ValueError):
+            index.rename_genre("shoegaze.", "   ")
+        index.close()
+
+
+# ---------------------------------------------------------------------------
 # Sort and record_played
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7364,3 +7364,93 @@ class TestMergeGenres:
         res = client.get("/api/v1/genres/merges")
         assert res.status_code == 200
         assert res.json() == [{"source": "Jazz", "target": "Rock"}]
+
+
+# ---------------------------------------------------------------------------
+# Rename genre endpoint (KAMP-608)
+# ---------------------------------------------------------------------------
+
+
+class TestRenameGenre:
+    """POST /api/v1/genres/rename (KAMP-608)."""
+
+    def test_writes_renamed_tags_and_renames(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.validate_genre_rename.return_value = None
+        mock_index.tracks_for_genre.return_value = [
+            _gtrack(1, "/music/a.mp3"),
+            _gtrack(2, "/music/b.mp3"),
+        ]
+        mock_index.genres_for_track.side_effect = lambda tid: {
+            1: ["shoegaze."],
+            2: ["shoegaze.", "Ambient"],
+        }[tid]
+        mock_index.rename_genre.return_value = 2
+        with patch("kamp_core.library.write_meta_tags_to_file") as wtf:
+            res = client.post(
+                "/api/v1/genres/rename",
+                json={"old": "shoegaze.", "new": "Shoegaze"},
+            )
+        assert res.status_code == 200
+        assert res.json() == {"ok": True, "tracks_updated": 2}
+        calls = {c.args[0]: c.kwargs["genres"] for c in wtf.call_args_list}
+        assert calls[Path("/music/a.mp3")] == ["Shoegaze"]
+        assert calls[Path("/music/b.mp3")] == ["Shoegaze", "Ambient"]
+        mock_index.rename_genre.assert_called_once_with("shoegaze.", "Shoegaze")
+
+    def test_skips_remote_tracks(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.validate_genre_rename.return_value = None
+        mock_index.tracks_for_genre.return_value = [
+            _gtrack(3, "bandcamp://x", is_remote=True)
+        ]
+        mock_index.rename_genre.return_value = 1
+        with patch("kamp_core.library.write_meta_tags_to_file") as wtf:
+            res = client.post(
+                "/api/v1/genres/rename",
+                json={"old": "shoegaze.", "new": "Shoegaze"},
+            )
+        assert res.status_code == 200
+        wtf.assert_not_called()
+        mock_index.rename_genre.assert_called_once_with("shoegaze.", "Shoegaze")
+
+    def test_invalid_rename_is_400_and_writes_nothing(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.validate_genre_rename.side_effect = ValueError("bad name")
+        with patch("kamp_core.library.write_meta_tags_to_file") as wtf:
+            res = client.post(
+                "/api/v1/genres/rename", json={"old": "shoegaze.", "new": "a; b"}
+            )
+        assert res.status_code == 400
+        wtf.assert_not_called()
+        mock_index.rename_genre.assert_not_called()
+
+    def test_conflict_while_backfill_running(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        client.app.state.notify_genre_backfill_progress(0, 10, "running")
+        res = client.post(
+            "/api/v1/genres/rename", json={"old": "shoegaze.", "new": "Shoegaze"}
+        )
+        assert res.status_code == 409
+        mock_index.rename_genre.assert_not_called()
+
+    def test_file_write_failure_leaves_rename_unrecorded(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.validate_genre_rename.return_value = None
+        mock_index.tracks_for_genre.return_value = [_gtrack(1, "/music/a.mp3")]
+        mock_index.genres_for_track.return_value = ["shoegaze."]
+        with patch(
+            "kamp_core.library.write_meta_tags_to_file",
+            side_effect=OSError("locked"),
+        ):
+            res = client.post(
+                "/api/v1/genres/rename",
+                json={"old": "shoegaze.", "new": "Shoegaze"},
+            )
+        assert res.status_code == 500
+        mock_index.rename_genre.assert_not_called()


### PR DESCRIPTION
## KAMP-608: edit (rename) a genre

Fix a genre typo ("shoegaze." → "Shoegaze") in one place instead of album-by-album. Right-click a genre → "Edit Genre" (pencil) turns its row into an inline input; committing renames the genre across every tagged track (DB + audio-file tags). Renaming onto a name that already exists folds the two together (one-time). Last of the genre-management mutating actions before KAMP-610.

### Changes (3 commits)

1. **Core** (`library.py`) — `rename_genre(old, new)`:
   - **In-place** (new/case-only name): `UPDATE genres.name`, resync each track's denormalized string via `_set_track_genres`. The id is unchanged, so a KAMP-607 merge targeting the row follows the rename automatically.
   - **Collision** (name exists): one-time fold — union the tracks into the survivor, re-point any merges that targeted the old row, delete the old row. No persistent merge rule (that's "Merge Genre").
   - `validate_genre_rename` rejects empty, `;`, and renaming onto a merged-away name.
2. **Endpoint** (`server.py`) — `POST /api/v1/genres/rename {old,new}`: validate → files-first write (skip remote) → DB; 409 during backfill; `renameGenre` client wrapper.
3. **UI** — "Edit Genre" (PencilIcon) added to `GenreContextMenu`; a `GenreEditInput` inline editor with **commit-once** semantics (Enter/blur commits, Esc cancels, a `done` ref prevents double-fire); `editingGenre` wiring in CollectionPanel; store `renameGenre` (active filter follows the rename).

### Correctness (Reality-Checker–driven)

- **No file/DB divergence** — renaming *onto* a merged-away name is rejected (it would land the file on `new` but the DB on that name's merge target); the message points at the survivor.
- **Iterate-while-mutating** — the affected track-id list is snapshotted before the retag loop.
- **Delimiter injection** — `;` in a name is rejected.
- **Commit-once inline edit** — Enter→blur / Esc→blur can't fire twice.
- **Accepted / non-applicable:** files-first partial-failure is the same invariant as remove/merge (DB untouched, next scan reconciles, retry idempotent); an album's union derives only from its own tracks (snapshot-album refresh is complete); merge *sources* have no sidebar row, so a rename can't strand one.

### Tests

- `tests/test_library.py::TestRenameGenre` (10) — in-place, case-only (no dup row), one-time fold + no-rule, fold-dedupe, FTS re-index, absent→0, merge-target-follows, reject merge-source / `;` / empty.
- `tests/test_server.py::TestRenameGenre` (5) — renamed-tag writes, remote-skip, 400 invalid, 409 backfill, 500 file-failure.
- Full suite: 2581 passed, coverage 93.69% (above the 93.0 gate). UI typecheck/lint/build clean.

### Manual test plan

- [ ] Right-click a genre → "Edit Genre" (pencil) → row becomes an input prefilled with the name; Esc cancels unchanged.
- [ ] Fix a typo, Enter → sidebar shows the new name; every album/track that had the typo now shows the fix.
- [ ] Verify a file on disk: its tag changed to the new spelling.
- [ ] Case-only rename ("shoegaze" → "Shoegaze") → updates in place, no duplicate row.
- [ ] Rename onto an existing genre → the two fold into one (one-time); the edited genre disappears.
- [ ] Rename a genre that is a merge *target* → the merge follows to the new name.
- [ ] Try renaming onto a merged-away genre name → rejected with a clear message.
- [ ] Rename the active filter → the grid follows.
- [ ] Attempt an edit while a genre backfill runs → 409, no partial change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
