### PR TITLE
KAMP-610: review & manage the genre allow list and merge list

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -289,6 +289,15 @@ CREATE TABLE IF NOT EXISTS genre_merges (
     UNIQUE (source COLLATE NOCASE)
 );
 
+-- User additions to the genre allow list (KAMP-610). The shipped allow list is
+-- data/genres.txt (daemon-side); these extras are merged on top at load. Purely
+-- additive and empty on a fresh DB, so it lives in _DDL only (created on every
+-- open via CREATE IF NOT EXISTS) with no data migration or version bump.
+CREATE TABLE IF NOT EXISTS genre_allowlist_extras (
+    name TEXT NOT NULL,
+    UNIQUE (name COLLATE NOCASE)
+);
+
 -- First-class album entity (KAMP-418). Replaces the GROUP BY (album_artist, album)
 -- derived-aggregate pattern. COLLATE NOCASE on the UNIQUE constraint prevents
 -- case-variant duplicates (e.g. "CASTLEBEAT" vs "Castlebeat") from coexisting.
@@ -6484,6 +6493,49 @@ class LibraryIndex:
                 " ORDER BY gm.source COLLATE NOCASE"
             ).fetchall()
         ]
+
+    def remove_genre_merge(self, source: str) -> None:
+        """Delete the merge rule for *source* (KAMP-610).
+
+        Future-only: inbound *source* tags stop mapping to the target, but tracks
+        already retagged under the rule keep the target (no retroactive un-tag).
+        Refreshes the in-memory map. No-op if there is no such rule.
+        """
+        self._conn.execute(
+            "DELETE FROM genre_merges WHERE source = ? COLLATE NOCASE", (source,)
+        )
+        self._conn.commit()
+        self._load_merge_map()
+
+    def add_allowlist_entry(self, name: str) -> None:
+        """Add a user entry to the genre allow list (KAMP-610).
+
+        Persisted overlay merged on top of the shipped data/genres.txt at load
+        time (daemon-side). Case-insensitively unique; a blank name is rejected.
+        """
+        name = name.strip()
+        if not name:
+            raise ValueError("genre name is required")
+        if ";" in name:
+            raise ValueError("genre names cannot contain ';'")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO genre_allowlist_extras (name) VALUES (?)", (name,)
+        )
+        self._conn.commit()
+
+    def list_allowlist_extras(self) -> list[str]:
+        """User-added allow-list entries, sorted NOCASE (KAMP-610)."""
+        return [
+            r["name"]
+            for r in self._conn.execute(
+                "SELECT name FROM genre_allowlist_extras ORDER BY name COLLATE NOCASE"
+            ).fetchall()
+        ]
+
+    def clear_allowlist_extras(self) -> None:
+        """Revert the allow list to the shipped default by dropping all extras (KAMP-610)."""
+        self._conn.execute("DELETE FROM genre_allowlist_extras")
+        self._conn.commit()
 
     def validate_genre_merge(self, source: str, target: str) -> None:
         """Raise ValueError if merging *source* into *target* is not allowed (KAMP-607).

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -435,6 +435,10 @@ class GenreRenameRequest(BaseModel):
     new: str
 
 
+class AllowlistAddRequest(BaseModel):
+    name: str
+
+
 class ShuffleRequest(BaseModel):
     shuffle: bool
     album_shuffle: bool = False
@@ -1020,6 +1024,8 @@ def create_app(
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
     on_genre_backfill_start: Callable[[], None] | None = None,
     on_genre_backfill_cancel: Callable[[], None] | None = None,
+    on_allowlist_changed: Callable[[], None] | None = None,
+    get_default_allowlist: Callable[[], list[str]] | None = None,
     dl_queue: _queue.Queue[str] | None = None,
     refresh_stream_url: Callable[[str, int], tuple[str, float] | None] | None = None,
     check_stream_url: Callable[[str], int] | None = None,
@@ -1520,6 +1526,18 @@ def create_app(
         """All active genre merges as {source, target} (KAMP-607)."""
         return index.list_genre_merges()
 
+    @app.delete("/api/v1/genres/merge")
+    def delete_genre_merge(source: str) -> dict[str, Any]:
+        """Delete a genre merge rule (KAMP-610).
+
+        Future-only: inbound *source* tags stop mapping to the target, but tracks
+        already retagged under the rule keep the target. Query param, not path —
+        genre names can contain '/'.
+        """
+        index.remove_genre_merge(source)
+        _notify_library_changed()
+        return {"ok": True}
+
     @app.post("/api/v1/genres/merge")
     def merge_genres(req: GenreMergeRequest) -> dict[str, Any]:
         """Merge one genre into another (KAMP-607).
@@ -1620,6 +1638,36 @@ def create_app(
         updated = index.rename_genre(old, new)
         _notify_library_changed()
         return {"ok": True, "tracks_updated": updated}
+
+    @app.get("/api/v1/genres/allowlist")
+    def get_genre_allowlist() -> dict[str, list[str]]:
+        """The user's allow-list additions + the shipped defaults (KAMP-610).
+
+        `defaults` is the read-only shipped list (for the optional full-list view);
+        it comes from a daemon-supplied callable so kamp_core never imports the
+        daemon-side genre_sources module.
+        """
+        defaults = get_default_allowlist() if get_default_allowlist is not None else []
+        return {"extras": index.list_allowlist_extras(), "defaults": defaults}
+
+    @app.post("/api/v1/genres/allowlist")
+    def add_genre_allowlist(req: AllowlistAddRequest) -> dict[str, Any]:
+        """Add a user entry to the genre allow list (KAMP-610)."""
+        try:
+            index.add_allowlist_entry(req.name)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if on_allowlist_changed is not None:
+            on_allowlist_changed()
+        return {"ok": True, "extras": index.list_allowlist_extras()}
+
+    @app.post("/api/v1/genres/allowlist/revert")
+    def revert_genre_allowlist() -> dict[str, Any]:
+        """Revert the allow list to the shipped default (drop all extras). KAMP-610."""
+        index.clear_allowlist_extras()
+        if on_allowlist_changed is not None:
+            on_allowlist_changed()
+        return {"ok": True}
 
     @app.get("/api/v1/tracks/top", response_model=list[TrackOut])
     def get_top_tracks(limit: int = 10) -> list[TrackOut]:

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1064,6 +1064,16 @@ def _cmd_daemon(
 
     from kamp_daemon.bandcamp import check_stream_url as _check_stream_url
 
+    # KAMP-610: bridge the DB allow-list overlay into the genre_sources module
+    # cache. On any change (and once at startup) push the current extras and
+    # invalidate the cache so future enrichment sees them.
+    from kamp_daemon import genre_sources as _genre_sources
+
+    def _on_allowlist_changed() -> None:
+        _genre_sources.set_allowlist_extras(index.list_allowlist_extras())
+
+    _on_allowlist_changed()  # warm the cache with any persisted extras at startup
+
     app = create_app(
         index=index,
         engine=engine,
@@ -1086,6 +1096,8 @@ def _cmd_daemon(
         on_bandcamp_sync_all_trigger=_on_bandcamp_sync_all_trigger,
         on_genre_backfill_start=_on_genre_backfill_start,
         on_genre_backfill_cancel=_on_genre_backfill_cancel,
+        on_allowlist_changed=_on_allowlist_changed,
+        get_default_allowlist=_genre_sources.default_allowlist_names,
         dl_queue=_dl_queue,
         art_cache_dir=_state_dir() / "art_cache",
         refresh_stream_url=_refresh_stream_url,

--- a/kamp_daemon/genre_sources.py
+++ b/kamp_daemon/genre_sources.py
@@ -39,8 +39,14 @@ _TOP_TAGS_LIMIT = 20
 _FETCH_TIMEOUT_SECONDS = 8.0
 
 _ALLOWLIST_PATH = Path(__file__).parent / "data" / "genres.txt"
-# casefold -> canonical display name; loaded once.
+# casefold -> canonical display name; built lazily, rebuilt when extras change.
 _allowlist: dict[str, str] | None = None
+# User additions to the allow list (KAMP-610), pushed in from the DB overlay by
+# the daemon. Merged on top of the shipped list at load. Guarded, together with
+# the cache, by _allowlist_lock — the HTTP endpoint thread writes while the
+# genre-enrich / backfill threads read.
+_extras: list[str] = []
+_allowlist_lock = threading.Lock()
 
 
 @dataclass
@@ -60,24 +66,53 @@ class GenreSource(ABC):
         """Return canonical genres for *query*, or [] on any failure."""
 
 
+def _read_default_allowlist() -> dict[str, str]:
+    """Parse the shipped data/genres.txt into casefold -> canonical (KAMP-587)."""
+    out: dict[str, str] = {}
+    try:
+        for line in _ALLOWLIST_PATH.read_text(encoding="utf-8").splitlines():
+            name = line.strip()
+            if name and not name.startswith("#"):
+                out.setdefault(name.casefold(), name)
+    except OSError as exc:
+        # A missing data file (e.g. not staged into the frozen bundle) must not
+        # crash — it degrades to "no genres pass the filter", and the WARN makes
+        # that visible rather than silent.
+        logger.warning("genre allowlist not loaded from %s: %s", _ALLOWLIST_PATH, exc)
+    return out
+
+
+def default_allowlist_names() -> list[str]:
+    """The shipped canonical allow-list names, sorted, extras excluded (KAMP-610)."""
+    return sorted(_read_default_allowlist().values(), key=str.casefold)
+
+
+def set_allowlist_extras(names: list[str]) -> None:
+    """Replace the user allow-list additions and invalidate the cache (KAMP-610).
+
+    Called by the daemon whenever the DB overlay changes (and once at startup).
+    The cache rebuilds lazily on the next canonicalize; the lock makes the swap
+    safe against the enrichment/backfill threads reading concurrently.
+    """
+    global _extras, _allowlist
+    with _allowlist_lock:
+        _extras = list(names)
+        _allowlist = None
+
+
 def _load_allowlist() -> dict[str, str]:
     global _allowlist
-    if _allowlist is None:
-        out: dict[str, str] = {}
-        try:
-            for line in _ALLOWLIST_PATH.read_text(encoding="utf-8").splitlines():
-                name = line.strip()
-                if name and not name.startswith("#"):
-                    out.setdefault(name.casefold(), name)
-        except OSError as exc:
-            # A missing data file (e.g. not staged into the frozen bundle) must
-            # not crash — it degrades to "no genres pass the filter", and the
-            # WARN makes that visible rather than silent.
-            logger.warning(
-                "genre allowlist not loaded from %s: %s", _ALLOWLIST_PATH, exc
-            )
-        _allowlist = out
-    return _allowlist
+    with _allowlist_lock:
+        if _allowlist is None:
+            out = _read_default_allowlist()
+            # User extras layer on top; a shipped default's canonical casing wins
+            # on overlap (setdefault keeps the already-present key).
+            for name in _extras:
+                cleaned = name.strip()
+                if cleaned:
+                    out.setdefault(cleaned.casefold(), cleaned)
+            _allowlist = out
+        return _allowlist
 
 
 def canonicalize(tags: list[str]) -> list[str]:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -792,6 +792,25 @@ export const renameGenre = (
 ): Promise<{ ok: boolean; tracks_updated: number }> =>
   post('/api/v1/genres/rename', { old, new: next })
 
+// Delete a genre merge rule (KAMP-610) — future-only; already-merged tracks keep
+// the target. Query param — names can contain '/'.
+export const deleteGenreMerge = (source: string): Promise<{ ok: boolean }> =>
+  del(`/api/v1/genres/merge?source=${encodeURIComponent(source)}`)
+
+// Genre allow-list management (KAMP-610).
+export interface GenreAllowlist {
+  extras: string[]
+  defaults: string[]
+}
+
+export const getGenreAllowlist = (): Promise<GenreAllowlist> => get('/api/v1/genres/allowlist')
+
+export const addAllowlistEntry = (name: string): Promise<{ ok: boolean; extras: string[] }> =>
+  post('/api/v1/genres/allowlist', { name })
+
+export const revertAllowlist = (): Promise<{ ok: boolean }> =>
+  post('/api/v1/genres/allowlist/revert')
+
 // ---------------------------------------------------------------------------
 // MusicBrainz lookup (KAMP-230, shallow candidates + lazy hydration KAMP-584)
 // ---------------------------------------------------------------------------

--- a/kamp_ui/src/renderer/src/assets/preferences.css
+++ b/kamp_ui/src/renderer/src/assets/preferences.css
@@ -249,6 +249,126 @@
   outline-offset: 1px;
 }
 
+/* Genre management (KAMP-610) */
+.genre-admin-add {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.genre-admin-input {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.genre-admin-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 6px 0;
+}
+
+.genre-admin-empty {
+  margin: 6px 0;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-dim);
+}
+
+.genre-admin-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.prefs-link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.prefs-link-btn:hover {
+  text-decoration: underline;
+}
+
+.genre-admin-full {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 8px;
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-dim);
+  columns: 2;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.genre-merge-rows {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+}
+
+.genre-merge-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 2px;
+  border-bottom: 1px solid var(--border);
+}
+
+.genre-merge-text {
+  font-size: 12px;
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.genre-merge-arrow {
+  color: var(--text-dim);
+  margin: 0 2px;
+}
+
+.genre-merge-controls {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.genre-merge-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.genre-merge-btn:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
 .prefs-saved-check {
   font-size: 12px;
   color: var(--accent);

--- a/kamp_ui/src/renderer/src/components/GenreManagementSection.tsx
+++ b/kamp_ui/src/renderer/src/components/GenreManagementSection.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react'
+import {
+  getGenreAllowlist,
+  addAllowlistEntry,
+  revertAllowlist,
+  getGenreMerges,
+  deleteGenreMerge,
+  mergeGenres,
+  type GenreMerge
+} from '../api/client'
+import { RemoveFromQueueIcon, PencilIcon } from './TransportIcons'
+import { MergeGenreModal } from './MergeGenreModal'
+
+// Preferences → genre management (KAMP-610): add/revert allow-list entries and
+// review / edit / delete the merges created in KAMP-607.
+export function GenreManagementSection(): React.JSX.Element {
+  const [extras, setExtras] = useState<string[]>([])
+  const [defaults, setDefaults] = useState<string[]>([])
+  const [merges, setMerges] = useState<GenreMerge[]>([])
+  const [input, setInput] = useState('')
+  const [showFull, setShowFull] = useState(false)
+  const [editing, setEditing] = useState<GenreMerge | null>(null)
+
+  const loadAllowlist = (): void => {
+    void getGenreAllowlist().then((a) => {
+      setExtras(a.extras)
+      setDefaults(a.defaults)
+    })
+  }
+  const loadMerges = (): void => {
+    void getGenreMerges().then(setMerges)
+  }
+  useEffect(() => {
+    loadAllowlist()
+    loadMerges()
+  }, [])
+
+  // Only surface additions that aren't already shipped defaults (casefold).
+  const defaultSet = new Set(defaults.map((d) => d.toLowerCase()))
+  const additions = extras.filter((e) => !defaultSet.has(e.toLowerCase()))
+
+  const addEntry = (): void => {
+    const name = input.trim()
+    if (!name) return
+    setInput('')
+    void addAllowlistEntry(name)
+      .then(loadAllowlist)
+      .catch(() => loadAllowlist())
+  }
+
+  return (
+    <div className="prefs-section">
+      <div className="prefs-section-label">Genre allow list</div>
+      <p className="prefs-hint">
+        Genres from Last.fm are filtered to a built-in list. Add your own entries here; they apply
+        to future enrichment.
+      </p>
+
+      <div className="genre-admin-add">
+        <input
+          className="genre-admin-input"
+          value={input}
+          placeholder="Add a genre…"
+          aria-label="Add allow-list genre"
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              addEntry()
+            }
+          }}
+        />
+        <button className="prefs-choose-btn" onClick={addEntry} disabled={!input.trim()}>
+          Add
+        </button>
+      </div>
+
+      {additions.length > 0 ? (
+        <div className="genre-admin-chips">
+          {additions.map((g) => (
+            <span key={g} className="genre-chip">
+              {g}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="genre-admin-empty">No additions — using the built-in list.</p>
+      )}
+
+      <div className="genre-admin-actions">
+        <button
+          className="prefs-choose-btn"
+          onClick={() => {
+            void revertAllowlist().then(loadAllowlist)
+          }}
+          disabled={additions.length === 0}
+        >
+          Revert to default
+        </button>
+        <button className="prefs-link-btn" onClick={() => setShowFull((v) => !v)}>
+          {showFull ? 'Hide built-in list' : 'View built-in list'}
+        </button>
+      </div>
+      {showFull && (
+        <ul className="genre-admin-full">
+          {defaults.map((g) => (
+            <li key={g}>{g}</li>
+          ))}
+        </ul>
+      )}
+
+      <div className="prefs-section-label" style={{ marginTop: 20 }}>
+        Genre merges
+      </div>
+      <p className="prefs-hint">
+        Deleting or editing a merge only affects future tags — tracks already merged keep the target
+        genre.
+      </p>
+      {merges.length === 0 ? (
+        <p className="genre-admin-empty">No merges yet.</p>
+      ) : (
+        <ul className="genre-merge-rows">
+          {merges.map((m) => (
+            <li key={m.source} className="genre-merge-row">
+              <span className="genre-merge-text">
+                {m.source} <span className="genre-merge-arrow">→</span> {m.target}
+              </span>
+              <span className="genre-merge-controls">
+                <button
+                  className="genre-merge-btn"
+                  aria-label={`Edit merge of ${m.source}`}
+                  onClick={() => setEditing(m)}
+                >
+                  <PencilIcon size={13} />
+                </button>
+                <button
+                  className="genre-merge-btn"
+                  aria-label={`Delete merge of ${m.source}`}
+                  onClick={() => {
+                    void deleteGenreMerge(m.source).then(loadMerges)
+                  }}
+                >
+                  <RemoveFromQueueIcon size={13} />
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {editing && (
+        <MergeGenreModal
+          source={editing.source}
+          currentTarget={editing.target}
+          onConfirm={(target) => {
+            void mergeGenres(editing.source, target).then(loadMerges)
+            setEditing(null)
+          }}
+          onCancel={() => setEditing(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/MergeGenreModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MergeGenreModal.tsx
@@ -4,6 +4,8 @@ import { getGenreMerges } from '../api/client'
 
 type Props = {
   source: string
+  // Pre-selected target when editing an existing merge (KAMP-610).
+  currentTarget?: string
   onConfirm: (target: string) => void
   onCancel: () => void
 }
@@ -11,10 +13,15 @@ type Props = {
 // Pick a target genre to merge the source into (KAMP-607). The target list
 // excludes the source itself and any genre that is already a merge source
 // (a merge target can't be a source — no chains).
-export function MergeGenreModal({ source, onConfirm, onCancel }: Props): React.JSX.Element {
+export function MergeGenreModal({
+  source,
+  currentTarget,
+  onConfirm,
+  onCancel
+}: Props): React.JSX.Element {
   const genres = useStore((s) => s.library.genres)
   const [filter, setFilter] = useState('')
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useState<string | null>(currentTarget ?? null)
   const [excluded, setExcluded] = useState<Set<string>>(new Set())
 
   // Esc = implicit Cancel.

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -5,6 +5,7 @@ import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
 import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
 import { DiscordIcon } from './TransportIcons'
+import { GenreManagementSection } from './GenreManagementSection'
 
 // Keys whose values must be integers — sent as strings over the wire but
 // stored as numbers in the config.
@@ -1293,6 +1294,7 @@ export function PreferencesDialog({
                       )}
                     </div>
                   </div>
+                  <GenreManagementSection />
                 </>
               )}
             </>

--- a/tests/test_genre_sources.py
+++ b/tests/test_genre_sources.py
@@ -94,6 +94,36 @@ class TestCanonicalize:
             gs._allowlist = None  # reset the module cache for other tests
 
 
+# --- allow-list extras (KAMP-610) -------------------------------------------
+
+
+class TestAllowlistExtras:
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> Any:
+        yield
+        gs._extras = []
+        gs._allowlist = None  # restore pristine module state for other tests
+
+    def test_extras_pass_through_canonicalize(self) -> None:
+        gs.set_allowlist_extras(["Zzz Fake Genre"])
+        assert canonicalize(["zzz fake genre"]) == ["Zzz Fake Genre"]
+
+    def test_set_extras_invalidates_cache(self) -> None:
+        assert canonicalize(["zzz fake genre"]) == []  # loads cache without extras
+        gs.set_allowlist_extras(["Zzz Fake Genre"])
+        assert canonicalize(["zzz fake genre"]) == ["Zzz Fake Genre"]  # rebuilt
+
+    def test_default_casing_wins_over_extra(self) -> None:
+        gs.set_allowlist_extras(["shoegaze"])  # a shipped default is "Shoegaze"
+        assert canonicalize(["SHOEGAZE"]) == ["Shoegaze"]
+
+    def test_default_allowlist_names_excludes_extras(self) -> None:
+        gs.set_allowlist_extras(["Zzz Fake Genre"])
+        names = gs.default_allowlist_names()
+        assert "Zzz Fake Genre" not in names
+        assert "Shoegaze" in names  # a real shipped default
+
+
 # --- _run_with_timeout ------------------------------------------------------
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3684,6 +3684,70 @@ class TestMergeGenre:
         assert self._genres_of(index, "j") == ["Jazz"]
         index.close()
 
+    def test_remove_genre_merge_is_future_only(self, tmp_path: Path) -> None:
+        # KAMP-610: deleting a merge rule stops future mapping but does NOT undo
+        # tracks already retagged to the target.
+        index = self._index(tmp_path)
+        index.create_genre_merge("Jazz", "Rock")  # a + b retagged Jazz -> Rock
+        index.remove_genre_merge("jazz")  # NOCASE
+        assert index.list_genre_merges() == []
+        # Already-merged tracks keep Rock.
+        assert self._genres_of(index, "a") == ["Rock"]
+        # A fresh inbound Jazz now stays Jazz.
+        index.upsert_many([self._track(tmp_path, "j", "AlbumJ", ["Jazz"])])
+        assert self._genres_of(index, "j") == ["Jazz"]
+        index.close()
+
+    def test_remove_genre_merge_absent_is_noop(self, tmp_path: Path) -> None:
+        index = self._index(tmp_path)
+        index.remove_genre_merge("Nope")  # no such rule — no error
+        index.close()
+
+
+# ---------------------------------------------------------------------------
+# Genre allow-list extras (KAMP-610)
+# ---------------------------------------------------------------------------
+
+
+class TestGenreAllowlistExtras:
+    """LibraryIndex allow-list overlay: add / list / clear (KAMP-610)."""
+
+    def test_add_and_list(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.add_allowlist_entry("Vaporwave")
+        index.add_allowlist_entry("Chillwave")
+        assert index.list_allowlist_extras() == [
+            "Chillwave",
+            "Vaporwave",
+        ]  # NOCASE sort
+        index.close()
+
+    def test_add_is_case_insensitively_unique(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.add_allowlist_entry("Vaporwave")
+        index.add_allowlist_entry("vaporwave")  # dup (NOCASE) — ignored
+        assert index.list_allowlist_extras() == ["Vaporwave"]
+        index.close()
+
+    def test_clear_reverts(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.add_allowlist_entry("Vaporwave")
+        index.clear_allowlist_extras()
+        assert index.list_allowlist_extras() == []
+        index.close()
+
+    def test_add_rejects_empty(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        with pytest.raises(ValueError):
+            index.add_allowlist_entry("   ")
+        index.close()
+
+    def test_add_rejects_delimiter(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        with pytest.raises(ValueError):
+            index.add_allowlist_entry("a; b")
+        index.close()
+
 
 # ---------------------------------------------------------------------------
 # Rename / edit genre (KAMP-608)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7454,3 +7454,73 @@ class TestRenameGenre:
             )
         assert res.status_code == 500
         mock_index.rename_genre.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Genre management: allow-list + merge delete (KAMP-610)
+# ---------------------------------------------------------------------------
+
+
+class TestGenreManagement:
+    """Allow-list add/revert/get + delete-merge endpoints (KAMP-610)."""
+
+    def test_delete_genre_merge(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        res = client.delete("/api/v1/genres/merge", params={"source": "Jazz"})
+        assert res.status_code == 200
+        mock_index.remove_genre_merge.assert_called_once_with("Jazz")
+
+    def test_get_allowlist_returns_extras_and_defaults(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.list_allowlist_extras.return_value = ["Vaporwave"]
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            get_default_allowlist=lambda: ["Ambient", "Rock"],
+        )
+        res = TestClient(app).get("/api/v1/genres/allowlist")
+        assert res.status_code == 200
+        assert res.json() == {"extras": ["Vaporwave"], "defaults": ["Ambient", "Rock"]}
+
+    def test_add_allowlist_entry_fires_hook(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.list_allowlist_extras.return_value = ["Vaporwave"]
+        hook = MagicMock()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_allowlist_changed=hook,
+        )
+        res = TestClient(app).post(
+            "/api/v1/genres/allowlist", json={"name": "Vaporwave"}
+        )
+        assert res.status_code == 200
+        mock_index.add_allowlist_entry.assert_called_once_with("Vaporwave")
+        hook.assert_called_once()
+
+    def test_add_allowlist_entry_invalid_is_400(
+        self, client: TestClient, mock_index: MagicMock
+    ) -> None:
+        mock_index.add_allowlist_entry.side_effect = ValueError("bad name")
+        res = client.post("/api/v1/genres/allowlist", json={"name": "  "})
+        assert res.status_code == 400
+
+    def test_revert_allowlist_fires_hook(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        hook = MagicMock()
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            on_allowlist_changed=hook,
+        )
+        res = TestClient(app).post("/api/v1/genres/allowlist/revert")
+        assert res.status_code == 200
+        mock_index.clear_allowlist_extras.assert_called_once()
+        hook.assert_called_once()


### PR DESCRIPTION
## KAMP-610: review & manage the genre allow list and merge list

Closes the genre-management sprint. Adds a Preferences → Genres management area: add your own entries to the allow list and revert to the shipped default, and review / edit / delete the genre merges created in KAMP-607.

### Changes (3 commits)

1. **Core + cache** — `genre_allowlist_extras` table (in `_DDL`, additive, no version bump) with `add_allowlist_entry` / `list_allowlist_extras` / `clear_allowlist_extras`; `remove_genre_merge(source)` (future-only). In `genre_sources.py`: `set_allowlist_extras` + a `threading.Lock` guarding invalidate/rebuild in `_load_allowlist` (which now merges the extras on top of `genres.txt`), plus `default_allowlist_names()`.
2. **Endpoints + wiring** — `GET/POST /genres/allowlist`, `POST /genres/allowlist/revert`, `DELETE /genres/merge?source=`; a new `on_allowlist_changed` hook + `get_default_allowlist` callable on `create_app` (so `kamp_core` never imports `kamp_daemon`); `__main__` bridges the DB overlay into the module cache and warms it at startup. Client wrappers.
3. **UI** — `GenreManagementSection` in PreferencesDialog: allow-list additions (add input + "Revert to default" + optional read-only built-in list) and a merge list (`source → target` rows with edit → `MergeGenreModal` (now takes a `currentTarget` pre-select) and delete ×), with a "future-only" note.

### Design decisions (confirmed with user)

- **Allow list is add + revert only** — no per-item removal and no changes to the ~248 shipped defaults; additions are an overlay merged on top, revert clears only additions.
- **Merge delete/edit are future-only** — already-merged tracks keep the target; only future inbound tags are affected.

### Correctness (Reality-Checker–driven)

- **Cache thread-safety** — the endpoint thread mutates the allowlist while enrichment/backfill threads read it; a `threading.Lock` serializes invalidate + rebuild, and `canonicalize` iterates a stable dict snapshot (rebuilds always assign a fresh dict).
- **Layering** — `library.py` stays pure-DB; the daemon closure bridges DB → `genre_sources`; the GET endpoint gets the shipped defaults via an injected callable.
- **No version bump** — the additive empty table lives in `_DDL` `CREATE IF NOT EXISTS` (created on every open), avoiding another churn of the ~40 schema-version assertions.
- **Casing** — extras layer *under* defaults (`setdefault`), so a shipped default's canonical casing wins on overlap; the UI hides additions already covered by defaults.
- **Edit-merge** — reuses the upsert `POST /genres/merge`; `validate_genre_merge` permits re-merging an existing source, and the modal pre-selects the current target.

### Tests

- `tests/test_library.py`: allow-list extras add/list/clear + NOCASE + reject empty/`;`; `remove_genre_merge` future-only + absent no-op.
- `tests/test_genre_sources.py`: extras reach `canonicalize`, cache invalidation, default-casing-wins, `default_allowlist_names` excludes extras.
- `tests/test_server.py`: allowlist get/add(+hook)/revert(+hook)/400, delete-merge.
- Full suite: 2597 passed, coverage 93.70%. UI typecheck/lint/build clean.

### Manual test plan

- [ ] Preferences → Genres: add an allow-list entry → it appears under your additions.
- [ ] With Last.fm enrichment on, an album whose tags include the new entry now keeps it (via a fresh enrich/backfill).
- [ ] "Revert to default" clears your additions; shipped defaults unaffected. "View built-in list" shows the defaults read-only.
- [ ] Merge list shows `source → target`. Delete one → gone; already-merged tracks stay on the target; a fresh inbound source tag now stays itself.
- [ ] Edit a merge → new target → the row updates; future inbound source maps to the new target.
- [ ] Restart → additions and remaining merges persist; added entries survive a daemon restart (startup cache warm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
