### PR TITLE
KAMP-599: disable Alt keyboard shortcut for album mode

### DIFF
--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -35,10 +35,7 @@ const GROUPS: Group[] = [
   },
   {
     label: 'Queue',
-    shortcuts: [
-      { keys: ['Alt'], description: 'Toggle album grouping mode' },
-      { keys: ['Shift', 'click'], description: 'Range select in Next Up' }
-    ]
+    shortcuts: [{ keys: ['Shift', 'click'], description: 'Range select in Next Up' }]
   },
   {
     label: 'View',

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -113,15 +113,6 @@ export function QueuePanel(): React.JSX.Element {
     setAnchorIdx(null)
   }, [tracks.length, position])
 
-  // Alt → toggle album-grouping mode.
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Alt') setAlbumGroupingActive(!albumGroupingActive)
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [albumGroupingActive, setAlbumGroupingActive])
-
   // Clamp width to 33% when the window shrinks.
   useEffect(() => {
     const onWindowResize = (): void => {


### PR DESCRIPTION
## Summary

Removes the global `document` keydown listener that toggled queue album-grouping mode whenever the Alt key was pressed. Alt is a modifier users press incidentally (menu access, alt+click, alt+drag), so it fired the toggle unintentionally. Album grouping remains fully reachable via the existing header toggle button, making the keyboard trigger redundant.

- Deleted the Alt keydown `useEffect` in `QueuePanel.tsx`.
- Removed the `Alt` → "Toggle album grouping mode" entry from `KeyboardShortcutsOverlay.tsx` (the Queue group keeps its Shift+click entry).

`albumGroupingActive` / `setAlbumGroupingActive` remain in use by the header toggle and view-model memos, so no dead references result. Typecheck and lint pass clean for the touched files.

## Manual Test Plan

- Press Alt with the queue visible → album grouping does **not** toggle
- Click the header album-grouping toggle button → grouping still toggles correctly
- Open the keyboard shortcuts overlay (`?`) → no Alt entry under "Queue"; Shift+click entry still present

Resolves KAMP-599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)