### PR TITLE
KAMP-560: Ctrl+Tab / Ctrl+Shift+Tab cycle through views; deprecate L

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -658,7 +658,28 @@ function createWindow(): void {
   // Zoom-in uses a native menu accelerator whose OS-level capture prevents
   // Chromium's built-in Cmd+= from also firing — so no before-input-event
   // handling needed (and adding it would double-step).
-  mainWindow.webContents.on('before-input-event', (_event, input) => {
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    // View cycling (KAMP-560): Ctrl+Tab / Ctrl+Shift+Tab step through the top-level
+    // tabs. Handled here (not in the renderer) because keydown does not cross the
+    // sandboxed-extension iframe boundary, so a renderer listener would miss the
+    // event whenever an extension tab is focused. preventDefault stops the page from
+    // receiving the keydown (so the default Tab focus-traversal is suppressed too).
+    // Ctrl on all platforms — macOS Cmd+Tab is the OS app switcher and unreachable.
+    // Must come BEFORE the zoom early-return below, which rejects Shift.
+    if (
+      input.type === 'keyDown' &&
+      input.code === 'Tab' &&
+      input.control &&
+      !input.alt &&
+      !input.meta
+    ) {
+      event.preventDefault()
+      mainWindow.webContents.send('cycle-view', input.shift ? 'prev' : 'next')
+      return
+    }
+
+    // Zoom-out: 'CommandOrControl+-' doesn't register reliably (Electron parser
+    // ambiguity on '-'), so intercept via physical key code instead.
     if (input.type !== 'keyDown' || input.shift || input.alt) return
     const cmdOrCtrl = process.platform === 'darwin' ? input.meta : input.control
     if (cmdOrCtrl && input.code === 'Minus') {

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -9,6 +9,7 @@ declare global {
       appVersion: string
       openDirectory: () => Promise<string | null>
       onOpenPreferences: (callback: () => void) => () => void
+      onCycleView: (callback: (direction: 'next' | 'prev') => void) => () => void
       bandcamp: {
         beginLogin: () => Promise<{ ok: boolean; error?: string }>
         onSyncStatus: (callback: (state: 'idle' | 'syncing') => void) => () => void

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -44,6 +44,14 @@ const api = {
     // Return a cleanup function so the caller can unsubscribe.
     return () => ipcRenderer.off('open-preferences', handler)
   },
+  // View cycling (KAMP-560): the main process forwards Ctrl+Tab / Ctrl+Shift+Tab
+  // here as a direction so the renderer can advance through the top-level tabs.
+  onCycleView: (callback: (direction: 'next' | 'prev') => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, direction: 'next' | 'prev'): void =>
+      callback(direction)
+    ipcRenderer.on('cycle-view', handler)
+    return () => ipcRenderer.off('cycle-view', handler)
+  },
   bandcamp: {
     /** Open the Bandcamp login BrowserWindow. Resolves when login succeeds or the window is closed. */
     beginLogin: (): Promise<{ ok: boolean; error?: string }> =>

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -150,6 +150,13 @@ export default function App(): React.JSX.Element {
   const searchBarRef = useRef<HTMLInputElement>(null)
   const mainContentRef = useRef<HTMLElement>(null)
 
+  // Latest-ref to the view-cycle handler (KAMP-560). The IPC subscription below is
+  // registered once, but `cycleView` closes over the current panel list / active
+  // view, so it is reassigned each render (after activateMain is defined). The
+  // no-op default covers renders that early-return before cycleView exists (e.g.
+  // server disconnected); it self-heals once a full render assigns the real one.
+  const cycleViewRef = useRef<(direction: 'next' | 'prev') => void>(() => {})
+
   // Per-view scroll positions — kept current by a scroll listener so we never
   // read a browser-clamped value when the outgoing view's content was taller.
   // Key: active main panel id (built-in view name or extension panel id).
@@ -375,11 +382,6 @@ export default function App(): React.JSX.Element {
           e.preventDefault()
           void prev()
           break
-        case 'l':
-        case 'L':
-          void setActiveView(activeView === 'library' ? 'now-playing' : 'library')
-          setActiveExtPanel(null)
-          break
         case 'q':
         case 'Q':
           // Don't intercept Cmd+Q (macOS quit) or Ctrl+Q.
@@ -413,6 +415,13 @@ export default function App(): React.JSX.Element {
     const cleanup = window.api.onOpenPreferences(openPrefs)
     return cleanup
   }, [openPrefs])
+
+  // Subscribe once to view-cycle events forwarded from the main process; dispatch
+  // through the latest-ref so we always run against the current panel list.
+  useEffect(() => {
+    if (!window.api.onCycleView) return
+    return window.api.onCycleView((direction) => cycleViewRef.current(direction))
+  }, [])
 
   // Discover and load frontend extensions.
   // extState.disabledIds is captured at mount; re-runs if the disabled set changes
@@ -542,32 +551,13 @@ export default function App(): React.JSX.Element {
     el.scrollTop = viewScrollRef.current[activeMainKey] ?? 0
   }, [activeMainKey])
 
-  if (serverStatus === 'disconnected') {
-    return (
-      <>
-        <div className="server-offline">
-          <div className="server-offline-icon">⏻</div>
-          <div className="server-offline-title">kamp server is not running</div>
-          <div className="server-offline-hint">
-            Start it with <code>kamp server</code>
-          </div>
-        </div>
-        {!splashGone && <SplashScreen hiding={splashHiding} slowStart={slowStart} />}
-        <PreferencesDialog
-          extensions={allExtensions}
-          extState={extState}
-          onReviewDenied={handleReviewDenied}
-          onInstalled={refreshExtensions}
-          onUninstalled={reloadAfterUninstall}
-        />
-      </>
-    )
-  }
-
-  const showSetup = onboardingRequired === true && !onboardingComplete
-
   // Panels to show as tabs in the main area nav bar.
   const mainPanels = layout.panelsInSlot('main')
+
+  // The view-cycle ring (KAMP-560) is exactly the rendered top-level tabs: main-slot
+  // panels minus modal views. Downloads (KAMP-585) is an icon, not a tab, so it is
+  // excluded. Single source of truth — used by both the rail render and cycleView.
+  const ringPanels = mainPanels.filter((panel) => panel.id !== 'kamp.downloads')
 
   // Determine whether a given main-slot panel tab is active.
   const isActiveMain = (panel: UnifiedPanel): boolean => {
@@ -597,6 +587,47 @@ export default function App(): React.JSX.Element {
       setActiveExtPanel(panel.id)
     }
   }
+
+  // Advance one step through the ring (KAMP-560). No-op when the current view is not
+  // a ring member (e.g. a modal view like Downloads), matching the tab semantics.
+  const cycleView = (direction: 'next' | 'prev'): void => {
+    const n = ringPanels.length
+    if (n === 0) return
+    const cur = ringPanels.findIndex(isActiveMain)
+    if (cur < 0) return
+    activateMain(ringPanels[(cur + (direction === 'next' ? 1 : -1) + n) % n])
+  }
+  // Keep the latest-ref current so the once-registered cycle-view IPC subscription
+  // always dispatches against the current panel list. Effect form (not a during-
+  // render assignment) so the ref is only written after commit. Defined above the
+  // early return below so this hook keeps a stable order.
+  useEffect(() => {
+    cycleViewRef.current = cycleView
+  })
+
+  if (serverStatus === 'disconnected') {
+    return (
+      <>
+        <div className="server-offline">
+          <div className="server-offline-icon">⏻</div>
+          <div className="server-offline-title">kamp server is not running</div>
+          <div className="server-offline-hint">
+            Start it with <code>kamp server</code>
+          </div>
+        </div>
+        {!splashGone && <SplashScreen hiding={splashHiding} slowStart={slowStart} />}
+        <PreferencesDialog
+          extensions={allExtensions}
+          extState={extState}
+          onReviewDenied={handleReviewDenied}
+          onInstalled={refreshExtensions}
+          onUninstalled={reloadAfterUninstall}
+        />
+      </>
+    )
+  }
+
+  const showSetup = onboardingRequired === true && !onboardingComplete
 
   // Determine what to render in the main content area.
   function renderMainContent(): React.JSX.Element {
@@ -660,17 +691,15 @@ export default function App(): React.JSX.Element {
       <nav className="view-tabs">
         {/* Left group: built-in view tabs (Downloads is now an icon, see right group). */}
         <div className="view-tabs__group view-tabs__group--left">
-          {mainPanels
-            .filter((panel) => panel.id !== 'kamp.downloads')
-            .map((panel) => (
-              <button
-                key={panel.id}
-                className={isActiveMain(panel) && !searchQuery ? 'active' : ''}
-                onClick={() => activateMain(panel)}
-              >
-                {panel.title}
-              </button>
-            ))}
+          {ringPanels.map((panel) => (
+            <button
+              key={panel.id}
+              className={isActiveMain(panel) && !searchQuery ? 'active' : ''}
+              onClick={() => activateMain(panel)}
+            >
+              {panel.title}
+            </button>
+          ))}
         </div>
         <SearchBar ref={searchBarRef} />
         {/* Right group: Downloads icon, status rail, style + preferences buttons. */}

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -27,7 +27,8 @@ const GROUPS: Group[] = [
     label: 'Navigation',
     shortcuts: [
       { keys: [mod, 'K'], description: 'Focus search' },
-      { keys: ['L'], description: 'Library / Now Playing' },
+      // Ctrl (not Cmd) on all platforms — macOS Cmd+Tab is the OS app switcher.
+      { keys: ['Ctrl', 'Tab'], description: 'Cycle views (Shift to reverse)' },
       { keys: ['Q'], description: 'Queue panel' },
       { keys: ['C'], description: 'Collection panel', note: 'Library only' },
       { keys: [mod, ','], description: 'Preferences' }


### PR DESCRIPTION
## Summary

Replaces the `L` shortcut (Library ↔ Now Playing toggle) with **Ctrl+Tab / Ctrl+Shift+Tab** cycling forward/backward through the top-level tab ring, per KAMP-560.

**Ring** = the rendered top-level tabs: Base Kamp, Library, Now Playing, plus any primary-tab extension panels (e.g. Groover). Modal views (Downloads — an icon since KAMP-585) are **not** in the ring; while you're in one, Ctrl+Tab is a no-op. This maps onto a single `ringPanels` helper (`mainPanels` minus Downloads) shared by both the rail render and the cycle logic.

**Binding:** Ctrl on all platforms. The ticket says "ctrl/cmd" but on macOS Cmd+Tab is the OS app switcher and can't be intercepted, so Ctrl is the only viable modifier.

## Why interception is in the main process

Not because Chromium swallows Ctrl+Tab (a bare `BrowserWindow` has no tab strip, so it would reach the renderer). The real reason: **keydown does not cross the sandboxed-extension iframe boundary**, so a renderer-only listener would fail to cycle exactly when a Groover-style extension tab — itself a ring member — is focused. `before-input-event` fires at the host `webContents` and is focus-agnostic (also works from the search box). Electron's `preventDefault()` there stops the page from receiving the keydown, so removing the `L` handler and adding no renderer Ctrl+Tab handler means no double-fire.

## Files

- `src/main/index.ts` — Ctrl+Tab / Ctrl+Shift+Tab branch in the existing `before-input-event` handler, ordered **before** the Shift-rejecting zoom early-return; forwards `cycle-view` ('next'|'prev') IPC.
- `src/preload/index.ts` + `index.d.ts` — `onCycleView` callback bridge, mirroring `onOpenPreferences`.
- `src/renderer/src/App.tsx` — `ringPanels` single source of truth; `cycleView` reuses `isActiveMain`/`activateMain`; a latest-ref (updated via effect) feeds the once-registered IPC subscription. The panel/cycle helpers moved above the disconnected early-return so the ref-update effect keeps a stable hook order. Removed the `L` keydown case.
- `src/renderer/src/components/KeyboardShortcutsOverlay.tsx` — `L` entry replaced with `Ctrl + Tab — Cycle views (Shift to reverse)`.

Typecheck and lint pass clean for the touched files (2 remaining warnings are pre-existing in TransportIcons.tsx). No Python changes; coverage floor unaffected. No README drift.

## Manual Test Plan

- Ctrl+Tab cycles forward Base Kamp → Library → Now Playing → (wrap) Base Kamp; Ctrl+Shift+Tab reverses and wraps the other way.
- With a primary-tab extension (Groover) installed, it appears in the cycle in its tab position; cycling into and out of it works.
- **Focus inside the Groover extension iframe, press Ctrl+Tab → still cycles** (the iframe-focus case renderer-only would miss).
- Type in the search box, press Ctrl+Tab → cycles to the next view and clears search.
- In Downloads (modal view), press Ctrl+Tab / Ctrl+Shift+Tab → nothing happens.
- `L` no longer switches Library / Now Playing.
- Shortcuts overlay (`?`) shows "Ctrl + Tab — Cycle views (Shift to reverse)" and no `L` entry.
- macOS: Cmd+Tab still triggers the OS app switcher (unchanged); Ctrl+Tab cycles. No default Tab focus-traversal side effects.

Resolves KAMP-560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
