### PR TITLE
KAMP-590: give About its own Preferences panel, default to it

### DIFF
--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
+import type { PrefsTab } from '../store'
 import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
@@ -945,9 +946,7 @@ export function PreferencesDialog({
   const cancelGenreBackfill = useStore((s) => s.cancelGenreBackfill)
   const refreshGenreBackfill = useStore((s) => s.refreshGenreBackfill)
   const prefsInitialTab = useStore((s) => s.prefsInitialTab)
-  const [activeTab, setActiveTab] = useState<'general' | 'tagging' | 'services' | 'extensions'>(
-    () => prefsInitialTab
-  )
+  const [activeTab, setActiveTab] = useState<PrefsTab>(() => prefsInitialTab)
 
   // Sync the active tab whenever the dialog opens, so callers can direct to a
   // specific tab (e.g. "Bandcamp options…" → services) on each open.
@@ -1075,6 +1074,14 @@ export function PreferencesDialog({
         <div className="prefs-tabs" role="tablist">
           <button
             role="tab"
+            aria-selected={activeTab === 'about'}
+            className={`prefs-tab${activeTab === 'about' ? ' prefs-tab--active' : ''}`}
+            onClick={() => setActiveTab('about')}
+          >
+            About
+          </button>
+          <button
+            role="tab"
             aria-selected={activeTab === 'general'}
             className={`prefs-tab${activeTab === 'general' ? ' prefs-tab--active' : ''}`}
             onClick={() => setActiveTab('general')}
@@ -1109,6 +1116,33 @@ export function PreferencesDialog({
 
         {/* Scrollable body — content swaps per tab */}
         <div className="prefs-body" role="tabpanel">
+          {activeTab === 'about' && (
+            <>
+              {/* IDENTITY */}
+              <div className="prefs-section">
+                <div className="prefs-section-label">Kamp</div>
+                <p className="prefs-hint">Version {window.api.appVersion}</p>
+              </div>
+
+              {/* COMMUNITY */}
+              <div className="prefs-section">
+                <div className="prefs-section-label">Community</div>
+                <div className="prefs-row">
+                  <button
+                    className="prefs-choose-btn"
+                    onClick={() => window.api.openExternal(DISCORD_INVITE_URL)}
+                  >
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      <DiscordIcon size={16} />
+                      Join Discord
+                    </span>
+                  </button>
+                  <p className="prefs-hint">Give feedback and connect with other Kamp users.</p>
+                </div>
+              </div>
+            </>
+          )}
+
           {activeTab === 'general' && (
             <>
               {configLoading ? null : (
@@ -1170,23 +1204,6 @@ export function PreferencesDialog({
                       hint="{album_artist}  {year}  {album}  {track}  {title}  {ext}"
                       onSave={handleSave}
                     />
-                  </div>
-
-                  {/* ABOUT */}
-                  <div className="prefs-section">
-                    <div className="prefs-section-label">About</div>
-                    <div className="prefs-row">
-                      <button
-                        className="prefs-choose-btn"
-                        onClick={() => window.api.openExternal(DISCORD_INVITE_URL)}
-                      >
-                        <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                          <DiscordIcon size={16} />
-                          Join Discord
-                        </span>
-                      </button>
-                      <p className="prefs-hint">Give feedback and connect with other Kamp users.</p>
-                    </div>
                   </div>
                 </>
               )}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -40,6 +40,9 @@ export type MagicPlaylistModuleConfig = {
 }
 export type PlasmaMode = 'always' | 'sometimes' | 'never'
 export type TraceStyle = 'clean' | 'glowy' | 'trippy'
+// The Preferences dialog tabs. Shared by the store and PreferencesDialog so the
+// two unions can't drift (they previously disagreed on 'tagging').
+export type PrefsTab = 'about' | 'general' | 'tagging' | 'services' | 'extensions'
 
 type LibraryState = {
   albums: Album[]
@@ -332,10 +335,10 @@ type PlayerStore = {
   // Preferences
   configValues: ConfigValues | null
   prefsOpen: boolean
-  prefsInitialTab: 'general' | 'services' | 'extensions'
+  prefsInitialTab: PrefsTab
   loadConfig: () => Promise<void>
   setConfigValue: (key: string, value: string) => Promise<void>
-  openPrefs: (tab?: 'general' | 'services' | 'extensions') => void
+  openPrefs: (tab?: PrefsTab) => void
   closePrefs: () => void
 
   // Update notification
@@ -514,7 +517,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   selectedTheme: (localStorage.getItem('kamp:selected-theme') as ThemeName | null) ?? 'kamp',
   configValues: null,
   prefsOpen: false,
-  prefsInitialTab: 'general',
+  prefsInitialTab: 'about',
   updateAvailable: null,
   deferredOps: {},
 
@@ -1707,7 +1710,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     })
   },
 
-  openPrefs: (tab) => set({ prefsOpen: true, prefsInitialTab: tab ?? 'general' }),
+  openPrefs: (tab) => set({ prefsOpen: true, prefsInitialTab: tab ?? 'about' }),
   closePrefs: () => set({ prefsOpen: false }),
   setUpdateAvailable: (data) => set({ updateAvailable: data }),
 


### PR DESCRIPTION
## Summary

Promotes the About settings from a section inside the General tab to their own Preferences tab, and makes About the **default view** when Preferences opens, per KAMP-590.

- **About tab** added first in the tab strip; opening Preferences with no target tab lands on it.
- **About panel** holds a "Kamp / Version X.Y.Z" identity block plus the existing Discord button + hint. It renders unconditionally (About needs no config, so it is not behind the General tab's config-loading guard).
- The About section is **removed from the General tab** (Paths + Library remain).
- The small version footer stays on every tab (per product decision — version shows in both About and the footer).

## Notes

- Introduced a shared `PrefsTab` type in the store, used by both `prefsInitialTab`/`openPrefs` and the dialog's `activeTab`, so the two tab unions can't drift again. This also fixes a pre-existing bug where the store's union omitted `'tagging'`.
- Existing `openPrefs('services')` (BandcampButton) and the install flow's jump to `'extensions'` are unaffected — only the no-arg default changed to `'about'`.

Typecheck and lint pass clean for the touched files (2 remaining warnings are pre-existing in TransportIcons.tsx). No Python changes; coverage floor unaffected. No README drift.

## Manual Test Plan

- Open Preferences (gear, or Cmd+,) → lands on the **About** tab by default.
- About panel shows "Kamp" + "Version X.Y.Z" and a working "Join Discord" button.
- General tab no longer shows an About section (Paths + Library remain).
- Tabs switch correctly: About / General / Tagging / Services / Extensions.
- "Bandcamp options…" (BandcampButton) still opens Preferences on the **Services** tab.
- Installing an extension still jumps to and highlights the **Extensions** tab.
- The version footer still appears at the bottom on every tab.
- Escape still closes the dialog (KAMP-585 behavior intact).

Resolves KAMP-590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
