### PR TITLE
KAMP-559: toggle mute by clicking the speaker icon

### DIFF
--- a/kamp_core/kamp_fade.lua
+++ b/kamp_core/kamp_fade.lua
@@ -7,6 +7,7 @@
 -- bare label + inner-name target succeeds. This was the bug behind the "timer, not a
 -- fade" behaviour -- the command silently failed so the gain never moved.
 local LABEL = "kampfade"
+local MUTE_LABEL = "kampmute"  -- KAMP-559: independent afade for user mute
 local TARGET = "afade"
 local DUR = 0.15            -- seconds; must match the filter's duration= in _start_mpv
 local PARKED = "1000000000" -- start_time far in the future => filter passes at unity
@@ -110,9 +111,44 @@ mp.register_script_message("kamp-stop", function()
     end)
 end)
 
+-- User mute (KAMP-559) — a SECOND, independent afade (kampmute) so mute and the
+-- pause/resume fade above never fight over one filter. kamp-mute fades the output to
+-- silence and holds it; kamp-unmute fades it back in. mpv resets afade filters to
+-- unity on every seek/load, so the mute is re-applied on playback-restart while held.
+local user_muted = false
+
+local function mutecmd(command, argument)
+    mp.commandv("af-command", MUTE_LABEL, command, argument, TARGET)
+end
+
+-- Arm the mute filter ("out"/"in"), anchored at the filter head like arm() above so
+-- the fade is audible rather than landing inside already-buffered audio.
+local function mute_arm(direction)
+    local pts = mp.get_property_number("audio-pts", 0) or 0
+    if pts < 0 then pts = 0 end
+    mutecmd("type", direction)
+    mutecmd("start_time", tostring(pts + output_lead()))
+end
+
+mp.register_script_message("kamp-mute", function()
+    user_muted = true
+    mute_arm("out")
+end)
+
+mp.register_script_message("kamp-unmute", function()
+    user_muted = false
+    mute_arm("in")
+end)
+
 -- A fresh load resets the filter to its unity definition anyway; re-park to be explicit
 -- and clear the stopped flag so the next resume fades in normally.
 mp.register_event("file-loaded", function()
     park()
     stopped = false
+end)
+
+-- Seeks and loads reset both afade filters to unity; re-apply the user mute so it
+-- survives them (the pause/resume kampfade re-applies via its own kamp-resume path).
+mp.register_event("playback-restart", function()
+    if user_muted then mute_arm("out") end
 end)

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -44,11 +44,12 @@ class PlaybackState:
     position: float = 0.0
     duration: float = 0.0
     volume: int = 100
-    # User mute (KAMP-559). Implemented as a `volume`-property gate, NOT mpv's
-    # `mute` property — kamp_fade.lua owns `mute` as its resume gate (KAMP-508) and
-    # clears it on every transport transition. `volume` stays the logical level
-    # while muted; muting only sends `set_property volume 0` to the output.
+    # User mute (KAMP-559). Muting fades the output via the dedicated `kampmute`
+    # afade (see _start_mpv / kamp_fade.lua) and drops the slider (`volume`) to 0;
+    # `pre_mute_volume` remembers the level to restore on unmute. NOT mpv's `mute`
+    # property (owned by the resume gate, KAMP-508) and NOT a volume-property jump.
     muted: bool = False
+    pre_mute_volume: int = 100
     # Wall-clock time of the last time-pos event from mpv. Used by
     # _state_snapshot() to extrapolate position when events stall (e.g.
     # after seeking near EOF of an HTTP stream: mpv drains its audio
@@ -1137,10 +1138,10 @@ class MpvPlaybackEngine:
     def _start_mpv(self) -> None:  # pragma: no cover
         """Launch mpv and connect to its IPC channel.
 
-        Note (KAMP-559): a fresh mpv starts at `volume` 100. There is no mid-session
-        restart today, but if crash-recovery is ever added it must re-apply the mute
-        gate (send `set_property volume 0` when `state.muted`) — otherwise a restart
-        would play at full volume while `state.muted` still reads True.
+        Note (KAMP-559): a fresh mpv starts with both afade filters at unity. There is
+        no mid-session restart today, but if crash-recovery is ever added it must
+        re-apply the mute fade (send `kamp-mute` when `state.muted`) — otherwise a
+        restart would play unmuted while `state.muted`/the slider still read muted.
         """
         # Create the Job Object before Popen so we can assign mpv immediately
         # after it spawns. We rely on nested Jobs (Win8+) rather than
@@ -1203,6 +1204,12 @@ class MpvPlaybackEngine:
                 # script re-arms type/start_time via af-command. afade interpolates the
                 # gain per-sample (curve=hsin raised cosine) -- no zipper. See _FADE_LUA.
                 "--af-append=@kampfade:lavfi=[afade=type=out:curve=hsin:"
+                f"start_time=1000000000:duration={_FADE_SECS}]",
+                # Second, independent afade for user mute (KAMP-559). Kept separate
+                # from @kampfade so mute and pause/resume never fight over one filter;
+                # kamp_fade.lua re-arms it via af-command on kamp-mute/kamp-unmute and
+                # re-applies it after seeks/loads (which reset afade to unity).
+                "--af-append=@kampmute:lavfi=[afade=type=out:curve=hsin:"
                 f"start_time=1000000000:duration={_FADE_SECS}]",
             ],
             stdout=subprocess.PIPE,
@@ -1527,15 +1534,17 @@ class MpvPlaybackEngine:
 
     @volume.setter
     def volume(self, value: int) -> None:
-        # INVARIANT (KAMP-559): mpv's `volume` property is written ONLY here. This
-        # setter always clears `state.muted` first, so any explicit volume change
-        # (e.g. dragging the slider) unmutes. If future code ever sends
-        # `set_property volume` elsewhere while muted, it would un-gate the output
-        # while `state.muted` still reads True — mute would silently break. Route
-        # all volume writes through this setter.
+        # INVARIANT (KAMP-559): mpv's `volume` property is the logical level and is
+        # written ONLY here. Mute does NOT touch it — muting fades via the separate
+        # `kampmute` afade (below), leaving `volume` at the logical level so unmute
+        # can fade back in to it. Dragging the slider unmutes: send a fade-in so the
+        # new level is audible if the kampmute gate was closed.
+        was_muted = self.state.muted
         self.state.volume = max(0, min(100, value))
         self.state.muted = False
         self._send_command("set_property", "volume", self.state.volume)
+        if was_muted:
+            self._send_command("script-message", "kamp-unmute")
 
     @property
     def muted(self) -> bool:
@@ -1543,13 +1552,24 @@ class MpvPlaybackEngine:
 
     @muted.setter
     def muted(self, value: bool) -> None:
-        # Gate the output via the `volume` property, never mpv's `mute` property
-        # (owned by kamp_fade.lua's resume gate — KAMP-508). `state.volume` keeps the
-        # logical level so unmute can restore it; muting drives the output to 0.
-        self.state.muted = bool(value)
-        self._send_command(
-            "set_property", "volume", 0 if self.state.muted else self.state.volume
-        )
+        # KAMP-559: mute is a click-free fade via the dedicated `kampmute` afade
+        # filter (script-message → kamp_fade.lua), NOT mpv's `mute` property (owned
+        # by the resume gate, KAMP-508) and NOT a `volume`-property jump (a stepped
+        # volume ramp is zipper noise, KAMP-508). The slider drops to 0 on mute and
+        # restores the remembered level on unmute; the `volume` property is left at
+        # the logical level throughout so the fade math and unmute restore work.
+        want = bool(value)
+        if want == self.state.muted:
+            return
+        if want:
+            self.state.pre_mute_volume = self.state.volume
+            self.state.volume = 0
+            self.state.muted = True
+            self._send_command("script-message", "kamp-mute")
+        else:
+            self.state.muted = False
+            self.state.volume = self.state.pre_mute_volume
+            self._send_command("script-message", "kamp-unmute")
 
     def shutdown(self) -> None:
         if self._proc is not None:

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -44,6 +44,11 @@ class PlaybackState:
     position: float = 0.0
     duration: float = 0.0
     volume: int = 100
+    # User mute (KAMP-559). Implemented as a `volume`-property gate, NOT mpv's
+    # `mute` property — kamp_fade.lua owns `mute` as its resume gate (KAMP-508) and
+    # clears it on every transport transition. `volume` stays the logical level
+    # while muted; muting only sends `set_property volume 0` to the output.
+    muted: bool = False
     # Wall-clock time of the last time-pos event from mpv. Used by
     # _state_snapshot() to extrapolate position when events stall (e.g.
     # after seeking near EOF of an HTTP stream: mpv drains its audio
@@ -1130,7 +1135,13 @@ class MpvPlaybackEngine:
         self._start_mpv()
 
     def _start_mpv(self) -> None:  # pragma: no cover
-        """Launch mpv and connect to its IPC channel."""
+        """Launch mpv and connect to its IPC channel.
+
+        Note (KAMP-559): a fresh mpv starts at `volume` 100. There is no mid-session
+        restart today, but if crash-recovery is ever added it must re-apply the mute
+        gate (send `set_property volume 0` when `state.muted`) — otherwise a restart
+        would play at full volume while `state.muted` still reads True.
+        """
         # Create the Job Object before Popen so we can assign mpv immediately
         # after it spawns. We rely on nested Jobs (Win8+) rather than
         # CREATE_BREAKAWAY_FROM_JOB — breakaway requires the parent's Job to
@@ -1516,8 +1527,29 @@ class MpvPlaybackEngine:
 
     @volume.setter
     def volume(self, value: int) -> None:
+        # INVARIANT (KAMP-559): mpv's `volume` property is written ONLY here. This
+        # setter always clears `state.muted` first, so any explicit volume change
+        # (e.g. dragging the slider) unmutes. If future code ever sends
+        # `set_property volume` elsewhere while muted, it would un-gate the output
+        # while `state.muted` still reads True — mute would silently break. Route
+        # all volume writes through this setter.
         self.state.volume = max(0, min(100, value))
+        self.state.muted = False
         self._send_command("set_property", "volume", self.state.volume)
+
+    @property
+    def muted(self) -> bool:
+        return self.state.muted
+
+    @muted.setter
+    def muted(self, value: bool) -> None:
+        # Gate the output via the `volume` property, never mpv's `mute` property
+        # (owned by kamp_fade.lua's resume gate — KAMP-508). `state.volume` keeps the
+        # logical level so unmute can restore it; muting drives the output to 0.
+        self.state.muted = bool(value)
+        self._send_command(
+            "set_property", "volume", 0 if self.state.muted else self.state.volume
+        )
 
     def shutdown(self) -> None:
         if self._proc is not None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -392,6 +392,7 @@ class PlayerStateOut(BaseModel):
     position: float
     duration: float
     volume: int
+    muted: bool = False
     current_track: TrackOut | None
     next_track: TrackOut | None = None
     buffering: bool = False
@@ -423,6 +424,10 @@ class SeekRequest(BaseModel):
 
 class VolumeRequest(BaseModel):
     volume: int
+
+
+class MuteRequest(BaseModel):
+    muted: bool
 
 
 class GenreMergeRequest(BaseModel):
@@ -1435,6 +1440,7 @@ def create_app(
             position=pos,
             duration=engine.state.duration,
             volume=engine.state.volume,
+            muted=engine.state.muted,
             current_track=_track_out(index, current) if current else None,
             next_track=_track_out(index, nxt) if nxt else None,
             buffering=_state["buffering"],
@@ -3900,6 +3906,11 @@ def create_app(
     @app.post("/api/v1/player/volume")
     def set_volume(req: VolumeRequest) -> dict[str, Any]:
         engine.volume = req.volume
+        return {"ok": True}
+
+    @app.post("/api/v1/player/mute")
+    def set_mute(req: MuteRequest) -> dict[str, Any]:
+        engine.muted = req.muted
         return {"ok": True}
 
     @app.post("/api/v1/player/next")

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -105,6 +105,7 @@ export type PlayerState = {
   position: number
   duration: number
   volume: number
+  muted: boolean
   current_track: Track | null
   next_track: Track | null
   buffering: boolean
@@ -518,6 +519,7 @@ export const seek = (position: number): Promise<unknown> =>
   post('/api/v1/player/seek', { position })
 export const setVolume = (volume: number): Promise<unknown> =>
   post('/api/v1/player/volume', { volume })
+export const setMuted = (muted: boolean): Promise<unknown> => post('/api/v1/player/mute', { muted })
 export const nextTrack = (): Promise<unknown> => post('/api/v1/player/next')
 export const prevTrack = (): Promise<unknown> => post('/api/v1/player/prev')
 export const setShuffle = (shuffle: boolean, albumShuffle = false): Promise<unknown> =>

--- a/kamp_ui/src/renderer/src/assets/transport.css
+++ b/kamp_ui/src/renderer/src/assets/transport.css
@@ -195,12 +195,29 @@
   gap: 6px;
 }
 
-/* Wrap the VolumeIcon SVG in an inline-flex span so its box centers on the
+/* Wrap the VolumeIcon SVG in an inline-flex element so its box centers on the
    flex row's centerline, matching .transport-btn's centering. */
 .volume-icon {
   display: inline-flex;
   align-items: center;
   color: var(--text-dim);
+}
+
+/* The speaker icon is a mute toggle button (KAMP-559) — strip the native button
+   chrome so it reads as the plain icon it replaced. */
+.volume-icon--btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.volume-icon--btn:hover {
+  color: var(--text);
+}
+
+.volume-icon--muted {
+  color: var(--accent);
 }
 
 .volume-slider {

--- a/kamp_ui/src/renderer/src/components/TransportBar.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportBar.tsx
@@ -11,7 +11,8 @@ import {
   RepeatIcon,
   ShuffleIcon,
   StopIcon,
-  VolumeIcon
+  VolumeIcon,
+  VolumeMutedIcon
 } from './TransportIcons'
 import { formatTime } from '../utils/formatTime'
 
@@ -23,6 +24,7 @@ export function TransportBar(): React.JSX.Element {
   const prev = useStore((s) => s.prev)
   const seek = useStore((s) => s.seek)
   const setVolume = useStore((s) => s.setVolume)
+  const setMuted = useStore((s) => s.setMuted)
   const setFavorite = useStore((s) => s.setFavorite)
   const queue = useStore((s) => s.queue)
   const setShuffle = useStore((s) => s.setShuffle)
@@ -35,7 +37,10 @@ export function TransportBar(): React.JSX.Element {
   const selectArtist = useStore((s) => s.selectArtist)
   const setActiveView = useStore((s) => s.setActiveView)
 
-  const { playing, position, duration, volume, current_track, buffering } = player
+  const { playing, position, duration, volume, muted, current_track, buffering } = player
+  // Show the muted glyph while explicitly muted OR at volume 0, so the icon never
+  // implies sound at zero output (KAMP-559).
+  const showMuted = muted || volume === 0
 
   const currentAlbum = current_track
     ? albums.find(
@@ -284,9 +289,16 @@ export function TransportBar(): React.JSX.Element {
       </div>
 
       <div className="transport-volume">
-        <span className="volume-icon" aria-hidden="true">
-          <VolumeIcon />
-        </span>
+        <button
+          type="button"
+          className={`volume-icon volume-icon--btn${showMuted ? ' volume-icon--muted' : ''}`}
+          onClick={() => void setMuted(!muted)}
+          aria-pressed={muted}
+          aria-label={muted ? 'Unmute' : 'Mute'}
+          {...tooltip(muted ? TOOLTIPS.TRANSPORT_UNMUTE : TOOLTIPS.TRANSPORT_MUTE)}
+        >
+          {showMuted ? <VolumeMutedIcon /> : <VolumeIcon />}
+        </button>
         <input
           type="range"
           className="volume-slider"

--- a/kamp_ui/src/renderer/src/components/TransportIcons.tsx
+++ b/kamp_ui/src/renderer/src/components/TransportIcons.tsx
@@ -85,6 +85,18 @@ export function VolumeIcon({ size = 20 }: IconProps): React.JSX.Element {
   )
 }
 
+export function VolumeMutedIcon({ size = 20 }: IconProps): React.JSX.Element {
+  // Muted variant (KAMP-559): the same speaker cone with an X where the waves
+  // are. Matches Lucide's VolumeX geometry so it aligns with VolumeIcon.
+  return (
+    <svg width={size} height={size} {...STROKE_PROPS}>
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+      <line x1="22" y1="9" x2="16" y2="15" />
+      <line x1="16" y1="9" x2="22" y2="15" />
+    </svg>
+  )
+}
+
 export function QueueIcon({ size = 20 }: IconProps): React.JSX.Element {
   return (
     <svg width={size} height={size} {...STROKE_PROPS}>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -64,6 +64,9 @@ type LibraryState = {
 
 type PlayerStore = {
   player: PlayerState
+  // Volume to restore when unmuting (KAMP-559). Mirrors the daemon's pre_mute_volume
+  // so the optimistic unmute can restore the slider before the next state broadcast.
+  preMuteVolume: number
   library: LibraryState
   serverStatus: 'connected' | 'reconnecting' | 'disconnected'
   scanStatus: 'idle' | 'scanning' | 'done' | 'error'
@@ -391,6 +394,7 @@ const _ratchetFloor = (prevFloor: number, raw: number): number =>
 
 export const useStore = create<PlayerStore>((set, get) => ({
   player: initialPlayer,
+  preMuteVolume: 100,
   library: {
     albums: [],
     artists: [],
@@ -1351,7 +1355,15 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setMuted: async (muted) => {
     await api.setMuted(muted)
-    set((s) => ({ player: { ...s.player, muted } }))
+    // Optimistically mirror the daemon (KAMP-559): mute drops the slider to 0 and
+    // remembers the level; unmute restores it. Keeps the icon + slider instant
+    // rather than waiting for the next state broadcast.
+    set((s) => {
+      if (muted) {
+        return { preMuteVolume: s.player.volume, player: { ...s.player, muted: true, volume: 0 } }
+      }
+      return { player: { ...s.player, muted: false, volume: s.preMuteVolume } }
+    })
   },
 
   setAlbumGroupingActive: (active) => {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -278,6 +278,7 @@ type PlayerStore = {
   prev: () => Promise<void>
   seek: (position: number) => Promise<void>
   setVolume: (volume: number) => Promise<void>
+  setMuted: (muted: boolean) => Promise<void>
   setAlbumGroupingActive: (active: boolean) => void
   setShuffle: (shuffle: boolean) => Promise<void>
   setRepeat: () => Promise<void>
@@ -351,6 +352,7 @@ const initialPlayer: PlayerState = {
   position: 0,
   duration: 0,
   volume: 100,
+  muted: false,
   current_track: null,
   next_track: null,
   buffering: false
@@ -1342,7 +1344,14 @@ export const useStore = create<PlayerStore>((set, get) => ({
 
   setVolume: async (volume) => {
     await api.setVolume(volume)
-    set((s) => ({ player: { ...s.player, volume } }))
+    // The daemon clears mute on any explicit volume change (drag-to-unmute,
+    // KAMP-559); mirror that optimistically so the icon updates immediately.
+    set((s) => ({ player: { ...s.player, volume, muted: false } }))
+  },
+
+  setMuted: async (muted) => {
+    await api.setMuted(muted)
+    set((s) => ({ player: { ...s.player, muted } }))
   },
 
   setAlbumGroupingActive: (active) => {

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -11,6 +11,8 @@ export const TOOLTIPS = {
   COLLECTION_TOGGLE: 'Collection (C)',
   TRANSPORT_FAVORITE_ADD: 'Add to favorites',
   TRANSPORT_FAVORITE_REMOVE: 'Remove from favorites',
+  TRANSPORT_MUTE: 'Mute',
+  TRANSPORT_UNMUTE: 'Unmute',
 
   // Library / track list actions
   LIBRARY_FETCH_MB: 'Fetch tags from MusicBrainz',

--- a/kamp_ui/src/shared/kampAPI.ts
+++ b/kamp_ui/src/shared/kampAPI.ts
@@ -118,6 +118,7 @@ export type PlayerState = {
   position: number
   duration: number
   volume: number
+  muted?: boolean
   current_track: Track | null
   buffering?: boolean
 }

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1523,42 +1523,68 @@ class TestMpvPlaybackEngine:
         engine.volume = 75
         send.assert_called_once_with("set_property", "volume", 75)
 
-    def test_mute_gates_output_without_changing_logical_volume(self) -> None:
-        # KAMP-559: muting drives the mpv output to 0 but keeps state.volume as the
-        # logical level so unmute can restore it.
+    def test_mute_fades_out_and_drops_slider_to_zero(self) -> None:
+        # KAMP-559: muting fades via the kampmute afade (script-message) and drops the
+        # slider to 0, remembering the level to restore. The `volume` property (logical
+        # level) is left untouched so unmute can fade back in to it.
         engine, send = _make_engine()
         engine.volume = 70
         send.reset_mock()
         engine.muted = True
         assert engine.muted is True
-        assert engine.state.volume == 70
-        send.assert_called_once_with("set_property", "volume", 0)
+        assert engine.state.volume == 0
+        assert engine.state.pre_mute_volume == 70
+        send.assert_called_once_with("script-message", "kamp-mute")
 
-    def test_unmute_restores_logical_volume(self) -> None:
+    def test_unmute_fades_in_and_restores_slider(self) -> None:
         engine, send = _make_engine()
         engine.volume = 70
         engine.muted = True
         send.reset_mock()
         engine.muted = False
         assert engine.muted is False
-        send.assert_called_once_with("set_property", "volume", 70)
+        assert engine.state.volume == 70
+        send.assert_called_once_with("script-message", "kamp-unmute")
 
-    def test_setting_volume_clears_mute(self) -> None:
-        # KAMP-559: dragging the slider while muted unmutes.
+    def test_mute_toggle_is_idempotent(self) -> None:
+        # Re-asserting the same mute state does nothing (endpoint sends absolute state).
         engine, send = _make_engine()
+        engine.volume = 70
         engine.muted = True
+        send.reset_mock()
+        engine.muted = True
+        send.assert_not_called()
+        assert engine.state.volume == 0
+
+    def test_mute_when_volume_zero_keeps_slider_zero(self) -> None:
+        # KAMP-559: muting/unmuting at volume 0 leaves the slider at 0.
+        engine, _ = _make_engine()
+        engine.volume = 0
+        engine.muted = True
+        assert engine.state.volume == 0
+        engine.muted = False
+        assert engine.state.volume == 0
+
+    def test_dragging_volume_while_muted_unmutes_and_fades_in(self) -> None:
+        engine, send = _make_engine()
+        engine.muted = True  # default volume 100 -> muted, slider 0, pre_mute 100
         send.reset_mock()
         engine.volume = 50
         assert engine.muted is False
-        send.assert_called_once_with("set_property", "volume", 50)
+        assert engine.state.volume == 50
+        send.assert_any_call("set_property", "volume", 50)
+        send.assert_any_call("script-message", "kamp-unmute")
 
-    def test_mute_never_touches_mpv_mute_property(self) -> None:
-        # Regression guard for KAMP-559/508: mute must gate via `volume`, never the
-        # `mute` property that kamp_fade.lua clears on every transport transition.
+    def test_mute_never_writes_volume_property(self) -> None:
+        # KAMP-559: mute must fade via the afade, never a volume-property jump
+        # (zipper noise, KAMP-508) — and never mpv's `mute` property (resume gate).
         engine, send = _make_engine()
+        engine.volume = 70
+        send.reset_mock()
         engine.muted = True
         engine.muted = False
         for call in send.call_args_list:
+            assert call.args[:2] != ("set_property", "volume")
             assert call.args[:2] != ("set_property", "mute")
 
     def test_stop_sends_script_message(self) -> None:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1523,6 +1523,44 @@ class TestMpvPlaybackEngine:
         engine.volume = 75
         send.assert_called_once_with("set_property", "volume", 75)
 
+    def test_mute_gates_output_without_changing_logical_volume(self) -> None:
+        # KAMP-559: muting drives the mpv output to 0 but keeps state.volume as the
+        # logical level so unmute can restore it.
+        engine, send = _make_engine()
+        engine.volume = 70
+        send.reset_mock()
+        engine.muted = True
+        assert engine.muted is True
+        assert engine.state.volume == 70
+        send.assert_called_once_with("set_property", "volume", 0)
+
+    def test_unmute_restores_logical_volume(self) -> None:
+        engine, send = _make_engine()
+        engine.volume = 70
+        engine.muted = True
+        send.reset_mock()
+        engine.muted = False
+        assert engine.muted is False
+        send.assert_called_once_with("set_property", "volume", 70)
+
+    def test_setting_volume_clears_mute(self) -> None:
+        # KAMP-559: dragging the slider while muted unmutes.
+        engine, send = _make_engine()
+        engine.muted = True
+        send.reset_mock()
+        engine.volume = 50
+        assert engine.muted is False
+        send.assert_called_once_with("set_property", "volume", 50)
+
+    def test_mute_never_touches_mpv_mute_property(self) -> None:
+        # Regression guard for KAMP-559/508: mute must gate via `volume`, never the
+        # `mute` property that kamp_fade.lua clears on every transport transition.
+        engine, send = _make_engine()
+        engine.muted = True
+        engine.muted = False
+        for call in send.call_args_list:
+            assert call.args[:2] != ("set_property", "mute")
+
     def test_stop_sends_script_message(self) -> None:
         engine, send = _make_engine()
         engine.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -884,7 +884,18 @@ class TestPlayerStateEndpoint:
         assert data["position"] == pytest.approx(0.0)
         assert data["duration"] == pytest.approx(0.0)
         assert data["volume"] == 100
+        assert data["muted"] is False
         assert data["current_track"] is None
+
+    def test_state_reflects_muted(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        # The snapshot reads engine.state.muted directly (KAMP-559). Assigning
+        # engine.muted on a MagicMock does not run the real setter, so seed state.
+        mock_engine.state = PlaybackState(muted=True)
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        data = TestClient(app).get("/api/v1/player/state").json()
+        assert data["muted"] is True
 
     def test_includes_current_track_when_playing(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
@@ -990,6 +1001,11 @@ class TestPlayerControlEndpoints:
         response = client.post("/api/v1/player/volume", json={"volume": 80})
         assert response.status_code == 200
         assert mock_engine.volume == 80
+
+    def test_set_mute(self, client: TestClient, mock_engine: MagicMock) -> None:
+        response = client.post("/api/v1/player/mute", json={"muted": True})
+        assert response.status_code == 200
+        assert mock_engine.muted is True
 
     def test_next_track(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock


### PR DESCRIPTION
## Summary

The speaker icon next to the volume slider is now a one-click mute toggle, per KAMP-559. Muting:
- **fades** the output smoothly (no click/discontinuity), like the pause/resume fade;
- **drops the volume slider to 0** and restores the previous level on unmute (muting while the slider is already 0 leaves it at 0);
- reflects state in the glyph (VolumeX when muted or at volume 0) and tooltip (Mute/Unmute).

## Design

**Mute fade uses a dedicated second `afade` filter, not mpv `volume` or `mute`.**
- `kamp_core/kamp_fade.lua` already owns mpv's `mute` property as its resume gate (KAMP-508) and clears it on every transport transition — so mute can't use `mute`. A stepped `volume`-property ramp is zipper noise (also KAMP-508) — so mute can't ramp `volume` either.
- A second `@kampmute` afade is appended in `_start_mpv`, kept **independent** of the pause/resume `@kampfade` so the two never fight over one filter (pause/resume code is untouched). `kamp-mute` / `kamp-unmute` script-messages arm it via `af-command`; it's re-applied on `playback-restart` so mute survives seeks/loads (which reset afade filters to unity).
- The engine leaves the `volume` property at the logical level throughout (only dragging the slider writes it). The slider value (`state.volume`) drops to 0 on mute; `pre_mute_volume` holds the restore level. Dragging the slider unmutes (writes the new level + fades the gate back in). The store mirrors this optimistically (`preMuteVolume`) so the icon and slider update instantly.

## Files

- `playback.py` — `PlaybackState.pre_mute_volume`; `muted` setter fades via `kamp-mute`/`kamp-unmute` and moves the slider; volume setter fades the gate open on drag-unmute; second `@kampmute` afade in `_start_mpv`.
- `kamp_fade.lua` — `kamp-mute`/`kamp-unmute` handlers on the `kampmute` filter + `playback-restart` re-mute.
- `server.py` — `MuteRequest`; `muted` in `PlayerStateOut` + the single state snapshot; `POST /api/v1/player/mute`.
- `client.ts` + `shared/kampAPI.ts` — `muted` on both `PlayerState` mirrors; `setMuted`.
- `store.ts` — `preMuteVolume`; optimistic `setMuted` (slider to 0 / restore); `setVolume` clears `muted`.
- `TransportIcons.tsx` — `VolumeMutedIcon`. `TransportBar.tsx` — speaker span → accessible toggle button (`aria-pressed` + Mute/Unmute label); muted glyph on `muted || volume === 0`.
- Tests — engine: mute fades out + slider→0 + remembers level; unmute fades in + restores; mute-at-0 stays 0; idempotent; drag-while-muted unmutes; a guard that mute writes neither the `volume` nor `mute` property. server: `/mute` endpoint + `muted` in the snapshot.

## ⚠️ Needs real-device audio verification

The audio-fade path can't be verified here (`--ao=null` hides output-buffer timing per KAMP-508, and two-afade `af-command` addressing is unverified). Please listen for:
- Mute → smooth fade to silence (no click); unmute → smooth fade back to the prior level.
- Mute persisting silent across pause → resume, track change, and a seek (the `playback-restart` re-mute). Watch for a brief blip at track-start / post-seek while muted, and tell me if it needs tuning.
- Drag-to-unmute plays smoothly at the new level.

## Manual Test Plan

- Click the speaker → fades to silence, slider animates/drops to 0, glyph muted, tooltip "Unmute".
- Click again → fades back to the prior level, slider restores, glyph normal.
- Mute, then pause/resume/next-track/seek → stays muted.
- Mute, then drag the slider up → unmutes and plays at the new level.
- Slider at 0, click mute/unmute → stays 0.
- The speaker control is a focusable button with `aria-pressed` and a Mute/Unmute label.

CI local: black, mypy, full pytest (2605 passed, 93.72% — the repo's post-552 baseline; new engine branches covered), frontend typecheck + lint. No README drift.

Resolves KAMP-559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
