### PR TITLE
KAMP-551: artist & genre autocomplete for magic playlist criteria

### DIFF
--- a/kamp_ui/src/renderer/src/assets/magic-playlist-modal.css
+++ b/kamp_ui/src/renderer/src/assets/magic-playlist-modal.css
@@ -225,6 +225,53 @@
   width: 64px;
 }
 
+/* Autocomplete (KAMP-551): the wrap takes the text input's flex slot; the dropdown
+   is portaled to document.body (see TextAutocompleteInput) so the modal can't clip
+   it — positioned inline from the input's rect, above the overlay (z-index 900). */
+.magic-autocomplete-wrap {
+  flex: 1;
+  min-width: 140px;
+  display: flex;
+}
+
+.magic-autocomplete-wrap .magic-input--text {
+  flex: 1;
+  min-width: 0;
+}
+
+.magic-autocomplete {
+  position: fixed;
+  z-index: 1100;
+  min-width: 140px;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--surface-raised, #22242b);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.magic-autocomplete-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.magic-autocomplete-item:hover,
+.magic-autocomplete-item.active {
+  background: var(--surface-hover, rgba(255, 255, 255, 0.08));
+}
+
 /* Match pill --------------------------------------------------------------- */
 
 .match-pill {

--- a/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
+++ b/kamp_ui/src/renderer/src/components/MagicPlaylistModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useReducer, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useStore } from '../store'
 import { previewCriteria } from '../api/client'
 import type { CriteriaDoc, CriteriaField, CriteriaOperator, Playlist } from '../api/client'
@@ -333,6 +334,141 @@ function PlaylistInput({
   )
 }
 
+// Single-value text input with a library-sourced autocomplete (KAMP-551), adapted
+// from GenreChipsInput's typeahead (filter + keyboard nav + body-portaled menu that
+// escapes the modal's stacking/scroll context). Suggestions are hints only — the
+// input stays free-text so substring values (for `contains`, etc.) are never blocked.
+function TextAutocompleteInput({
+  value,
+  suggestions,
+  onChange
+}: {
+  value: string
+  suggestions: string[]
+  onChange: (v: string) => void
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  // -1 = nothing highlighted (Enter keeps the typed value rather than a suggestion).
+  const [active, setActive] = useState(-1)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase()
+    return suggestions.filter((s) => !q || s.toLowerCase().includes(q)).slice(0, 8)
+  }, [value, suggestions])
+
+  // Hide the menu once the value already equals the only remaining suggestion.
+  const showMenu =
+    open &&
+    filtered.length > 0 &&
+    !(filtered.length === 1 && filtered[0].toLowerCase() === value.trim().toLowerCase())
+
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null)
+  useLayoutEffect(() => {
+    if (!showMenu) return
+    const place = (): void => {
+      const r = inputRef.current?.getBoundingClientRect()
+      if (r) setMenuPos({ top: r.bottom + 2, left: r.left, width: r.width })
+    }
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [showMenu, filtered.length])
+
+  const pick = (s: string): void => {
+    onChange(s)
+    setOpen(false)
+    setActive(-1)
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className="magic-autocomplete-wrap"
+      onBlur={(e) => {
+        if (!wrapRef.current?.contains(e.relatedTarget as Node | null)) setOpen(false)
+      }}
+    >
+      <input
+        ref={inputRef}
+        className="magic-input magic-input--text"
+        type="text"
+        value={value}
+        placeholder="value"
+        role="combobox"
+        aria-expanded={showMenu}
+        aria-controls="magic-autocomplete-list"
+        aria-activedescendant={active >= 0 ? `magic-autocomplete-opt-${active}` : undefined}
+        onChange={(e) => {
+          onChange(e.target.value)
+          setOpen(true)
+          setActive(-1)
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            setOpen(true)
+            setActive((i) => (filtered.length ? Math.min(i + 1, filtered.length - 1) : -1))
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            setActive((i) => Math.max(i - 1, -1))
+          } else if (e.key === 'Enter') {
+            if (active >= 0 && active < filtered.length) {
+              e.preventDefault()
+              pick(filtered[active])
+            } else {
+              setOpen(false)
+            }
+          } else if (e.key === 'Escape') {
+            setOpen(false)
+            setActive(-1)
+          }
+        }}
+      />
+      {showMenu &&
+        menuPos &&
+        createPortal(
+          <ul
+            id="magic-autocomplete-list"
+            className="magic-autocomplete"
+            role="listbox"
+            style={{ top: menuPos.top, left: menuPos.left, minWidth: menuPos.width }}
+          >
+            {filtered.map((s, i) => (
+              <li
+                key={s}
+                id={`magic-autocomplete-opt-${i}`}
+                role="option"
+                aria-selected={i === active}
+              >
+                <button
+                  type="button"
+                  className={`magic-autocomplete-item${i === active ? ' active' : ''}`}
+                  // onMouseDown fires before the input's blur, so the pick happens
+                  // before the menu closes.
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    pick(s)
+                  }}
+                  onMouseEnter={() => setActive(i)}
+                >
+                  {s}
+                </button>
+              </li>
+            ))}
+          </ul>,
+          document.body
+        )}
+    </div>
+  )
+}
+
 function DateInput({
   dateMeta,
   op,
@@ -432,6 +568,17 @@ function ConditionRow({
   const isBool = fieldType === 'bool'
   const isDate = fieldType === 'date'
 
+  // Autocomplete suggestions for text fields (KAMP-551): artist / album_artist draw
+  // from the library artists, genre from genres. Album has no suggestion source.
+  const artists = useStore((s) => s.library.artists)
+  const genres = useStore((s) => s.library.genres)
+  const suggestions =
+    condition.field === 'track.genre'
+      ? genres
+      : condition.field === 'track.artist' || condition.field === 'track.album_artist'
+        ? artists
+        : null
+
   const handleFieldChange = (newField: CriteriaField): void => {
     const newType = FIELD_META[newField].type
     const newOp = defaultOpForType(newType)
@@ -488,15 +635,22 @@ function ConditionRow({
         />
       )}
 
-      {fieldType === 'text' && (
-        <input
-          className="magic-input magic-input--text"
-          type="text"
-          value={condition.value}
-          placeholder="value"
-          onChange={(e) => onUpdate({ value: e.target.value })}
-        />
-      )}
+      {fieldType === 'text' &&
+        (suggestions ? (
+          <TextAutocompleteInput
+            value={condition.value}
+            suggestions={suggestions}
+            onChange={(v) => onUpdate({ value: v })}
+          />
+        ) : (
+          <input
+            className="magic-input magic-input--text"
+            type="text"
+            value={condition.value}
+            placeholder="value"
+            onChange={(e) => onUpdate({ value: e.target.value })}
+          />
+        ))}
 
       {fieldType === 'int' && (
         <input


### PR DESCRIPTION
## Summary

Adds a library-sourced autocomplete to the magic-playlist criteria value input when the field is **Artist**, **Album Artist**, or **Genre**, per KAMP-551. Previously these were bare text boxes requiring an exact typed value.

- New local `TextAutocompleteInput` in `MagicPlaylistModal.tsx`, adapted from the `GenreChipsInput` typeahead (filter + ↑/↓/Enter/Esc keyboard nav + a `document.body`-portaled dropdown that escapes the modal's stacking/scroll context), but single-value. It stays **free-text** — you can still type a substring for `contains`, etc.; a highlighted suggestion is applied on Enter/click.
- **Suggestions come from the store** (`library.artists` / `library.genres`, already populated by `loadLibrary()`) — no new fetch. `ConditionRow` routes the text branch: `track.artist` / `track.album_artist` → artists, `track.genre` → genres; `track.album` keeps the plain input.
- CSS: `.magic-autocomplete*` + a flex wrapper (mirroring `.genre-autocomplete`); dropdown `z-index: 1100` sits above the modal overlay (900).

Frontend-only — no daemon, DB, or API changes (the `/artists` and `/genres` endpoints already existed and are already consumed by `loadLibrary()`).

## Scope decisions

- **Album Artist included** (same `/artists` data; the ticket names only Artist + Genre, the estimation recommended it).
- **Album excluded** (out of scope, no requested suggestion source; stays a plain input).
- Suggestions show for all operators (still useful for `contains`) and never restrict free-text entry.

Typecheck and lint pass clean. `kamp_ui` has no unit-test runner, so verification is visual. No README drift.

## Manual Test Plan

- New magic playlist → add a rule → field **Artist** → typing filters an artist dropdown; ↑/↓ highlight, Enter/click selects, Esc closes.
- Switch field to **Album Artist** → same artist suggestions; **Genre** → genre suggestions; **Album** → plain input, no dropdown.
- Type a value not in the list (e.g. for `contains`) → kept as typed; the criterion still previews/saves.
- Dropdown paints **above** the modal (not clipped) and tracks scroll/resize; clicking outside closes it and keeps the typed value.
- Edit an existing magic playlist's Artist/Genre rule → autocomplete works there too.
- Large library → the list caps at ~8 filtered suggestions.

Resolves KAMP-551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
