### PR TITLE
KAMP-605: fetch genres for a single album from Liner Notes

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4024,6 +4024,22 @@ class LibraryIndex:
             ).fetchall()
         ]
 
+    def album_genre_row(self, album_artist: str, album: str) -> dict[str, Any] | None:
+        """The genre-enrichment row for a single album (KAMP-605), regardless of its
+        enriched state — the per-album Fetch button's Bandcamp-keywords source. Same
+        columns as albums_pending_genre_enrichment. Returns None if the album isn't a
+        real (non-virtual) album. LIMIT 1 guards against a duplicate LEFT JOIN row."""
+        r = self._conn.execute(
+            "SELECT a.id, a.album_artist, a.album, a.sale_item_id,"
+            " bc.album_url, bc.keywords"
+            " FROM albums a"
+            " LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id"
+            " WHERE a.album_artist = ? AND a.album = ?"
+            " LIMIT 1",
+            (album_artist, album),
+        ).fetchone()
+        return dict(r) if r else None
+
     def mark_album_genres_enriched(self, album_id: int, ts: float) -> None:
         """Checkpoint an album as processed by the backfill so a restart resumes."""
         self._conn.execute(

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -430,6 +430,10 @@ class MuteRequest(BaseModel):
     muted: bool
 
 
+class GenreFetchOut(BaseModel):
+    genres: list[str]
+
+
 class GenreMergeRequest(BaseModel):
     source: str
     target: str
@@ -1039,6 +1043,7 @@ def create_app(
     auth_token: str | None = None,
     mb_search_fn: Callable[[str, str], list[Any]] | None = None,
     mb_release_fn: Callable[[str], Any] | None = None,
+    genre_fetch_fn: Callable[[str, str], list[str]] | None = None,
 ) -> FastAPI:
     """Return a configured FastAPI application.
 
@@ -2710,6 +2715,23 @@ def create_app(
             )
 
         return MusicBrainzLookupOut(candidates=candidates)
+
+    @app.get("/api/v1/albums/genres/fetch", response_model=GenreFetchOut)
+    async def fetch_album_genres(album_artist: str, album: str) -> GenreFetchOut:
+        """Candidate genres for one album from the configured sources (KAMP-605).
+
+        Read-only: returns candidates for the client to merge + PATCH; it never
+        writes DB or files. Runs the (bounded ~8s) Last.fm fetch off the event
+        loop. 404 if the album has no tracks; 503 if the fetch fn wasn't wired.
+        """
+        if genre_fetch_fn is None:
+            raise HTTPException(status_code=503, detail="Genre fetch not available")
+        if not index.tracks_for_album(album_artist, album):
+            raise HTTPException(status_code=404, detail="Album not found")
+        genres = await asyncio.get_event_loop().run_in_executor(
+            None, genre_fetch_fn, album_artist, album
+        )
+        return GenreFetchOut(genres=genres)
 
     @app.get(
         "/api/v1/albums/musicbrainz/release/{mbid}",

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1074,6 +1074,16 @@ def _cmd_daemon(
 
     _on_allowlist_changed()  # warm the cache with any persisted extras at startup
 
+    def _genre_fetch_fn(album_artist: str, album: str) -> list[str]:
+        # Per-album Fetch button (KAMP-605): read-only candidate fetch. Fresh config
+        # per call so runtime source toggles + allowlist changes are picked up (same
+        # as _on_genre_backfill_start).
+        from .genre_backfill import fetch_album_genre_candidates
+
+        return fetch_album_genre_candidates(
+            index, Config.load(index), album_artist, album
+        )
+
     app = create_app(
         index=index,
         engine=engine,
@@ -1106,6 +1116,7 @@ def _cmd_daemon(
         auth_token=_auth_token,
         mb_search_fn=search_release_candidates,
         mb_release_fn=lookup_release_by_mbid,
+        genre_fetch_fn=_genre_fetch_fn,
     )
 
     # ---------------------------------------------------------------------------

--- a/kamp_daemon/genre_backfill.py
+++ b/kamp_daemon/genre_backfill.py
@@ -20,11 +20,17 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable
 
-from .genre_sources import enrich_album_genres
+from .genre_sources import (
+    GenreQuery,
+    enabled_sources,
+    enrich_album_genres,
+    fetch_all_genres,
+)
 
 if TYPE_CHECKING:
     from kamp_core.library import LibraryIndex
@@ -82,6 +88,32 @@ def _bandcamp_extra_genres(
     if keywords:  # only cache a real result
         index.set_collection_keywords(str(album["sale_item_id"]), keywords)
     return keywords
+
+
+def fetch_album_genre_candidates(
+    index: "LibraryIndex", config: "Config", album_artist: str, album: str
+) -> list[str]:
+    """Candidate genres for one album from the enabled sources — the per-album Fetch
+    button's engine (KAMP-605). READ-ONLY: it queries Last.fm (allowlist-filtered)
+    and, when Bandcamp genres are enabled, the album's CACHED Bandcamp keywords —
+    never a network re-scrape and never a DB/file write (unlike enrich_album_genres,
+    which the caller PATCHes instead). Order-preserving, casefold-deduped."""
+    genres = fetch_all_genres(enabled_sources(config), GenreQuery(album_artist, album))
+    if config.tagging.bandcamp_genres:
+        row = index.album_genre_row(album_artist, album)
+        if row:
+            # session=None keeps _bandcamp_extra_genres cache-only (returns cached
+            # keywords or []; the never-set Event is only defensive — the session=None
+            # short-circuit means it is never read).
+            genres = genres + _bandcamp_extra_genres(
+                index, row, None, threading.Event()
+            )
+    seen: dict[str, str] = {}
+    for name in genres:
+        cf = name.casefold()
+        if cf not in seen:
+            seen[cf] = name
+    return list(seen.values())
 
 
 def run_genre_backfill(

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -758,6 +758,16 @@ export const patchAlbumMeta = (
   return patch(`/api/v1/albums/meta?${params}`, opts)
 }
 
+// Candidate genres for one album from the configured sources (KAMP-605). Read-only:
+// the caller merges these into the album's genres and saves via patchAlbumMeta.
+export const fetchAlbumGenres = (
+  albumArtist: string,
+  album: string
+): Promise<{ genres: string[] }> => {
+  const params = new URLSearchParams({ album_artist: albumArtist, album })
+  return get(`/api/v1/albums/genres/fetch?${params}`)
+}
+
 // Every distinct genre in the library (KAMP-586), for the edit-panel autocomplete.
 export async function getGenres(): Promise<string[]> {
   const res = await fetch(`${BASE_URL}/api/v1/genres`, { headers: _authHeaders() })

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1170,6 +1170,59 @@
   min-width: 0;
 }
 
+/* Genre Fetch (KAMP-605): pulls candidate genres from the configured sources and
+   merges them into the album's genres. Reuses the mb-pill dots-blink animation. */
+.genre-fetch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.genre-fetch-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.genre-fetch-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.genre-fetch-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.genre-fetch-dots {
+  display: inline-flex;
+  gap: 1px;
+  margin-left: 1px;
+}
+
+.genre-fetch-dots span {
+  animation: mb-dot-blink 1.2s ease-in-out infinite;
+  opacity: 0;
+}
+.genre-fetch-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.genre-fetch-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.genre-fetch-msg {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
 /* Read-only and mixed values are dimmed */
 .meta-field--readonly {
   opacity: 0.5;

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -1155,6 +1155,7 @@
   color: rgba(255, 255, 255, 0.4);
   display: flex;
   align-items: center;
+  gap: 8px;
   padding: 5px 0;
   line-height: 1;
 }
@@ -1171,14 +1172,9 @@
 }
 
 /* Genre Fetch (KAMP-605): pulls candidate genres from the configured sources and
-   merges them into the album's genres. Reuses the mb-pill dots-blink animation. */
-.genre-fetch {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
+   merges them into the album's genres. The button sits next to the GENRE label;
+   the transient status message rides in the value cell after the chips. Reuses the
+   mb-pill dots-blink animation. */
 .genre-fetch-btn {
   background: none;
   border: 1px solid var(--border);

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -18,8 +18,25 @@ interface AlbumMetaPanelProps {
     label?: string
     release_date?: string
   }) => Promise<void>
+  // KAMP-605: fetch candidate genres from the configured sources for this album.
+  onFetchGenres?: () => Promise<string[]>
   onHandleMouseDown?: (e: React.MouseEvent) => void
   onHandleDoubleClick?: () => void
+}
+
+// Union new genres into the existing list, case-insensitively (matches
+// GenreChipsInput.sameSet). Only adds — never reorders or drops existing (KAMP-605).
+function mergeGenres(existing: string[], added: string[]): string[] {
+  const have = new Set(existing.map((g) => g.toLowerCase()))
+  const out = [...existing]
+  for (const g of added) {
+    const name = g.trim()
+    if (name && !have.has(name.toLowerCase())) {
+      have.add(name.toLowerCase())
+      out.push(name)
+    }
+  }
+  return out
 }
 
 /**
@@ -115,11 +132,28 @@ export function AlbumMetaPanel({
   expanded,
   onToggle,
   onSave,
+  onFetchGenres,
   onHandleMouseDown,
   onHandleDoubleClick
 }: AlbumMetaPanelProps): React.JSX.Element {
   const panelRef = useRef<HTMLDivElement>(null)
   const openGenreFilter = useStore((s) => s.openGenreFilter)
+  const configValues = useStore((s) => s.configValues)
+  const tooltip = useTooltip()
+
+  // Genre Fetch (KAMP-605): busy flag + a transient status message.
+  const [fetchingGenres, setFetchingGenres] = React.useState(false)
+  const [fetchMsg, setFetchMsg] = React.useState('')
+  useEffect(() => {
+    if (!fetchMsg) return
+    const t = setTimeout(() => setFetchMsg(''), 4000)
+    return () => clearTimeout(t)
+  }, [fetchMsg])
+
+  // Gate the button when no genre source is enabled (fail open if config unloaded).
+  const genreSourcesEnabled =
+    configValues == null ||
+    !!(configValues['tagging.lastfm_genres'] || configValues['tagging.bandcamp_genres'])
 
   const [label, setLabel] = React.useState(() => commonValue(tracks, 'label'))
   const [releaseDate, setReleaseDate] = React.useState(() => commonValue(tracks, 'release_date'))
@@ -166,6 +200,25 @@ export function AlbumMetaPanel({
 
   const handleSaveGenres = (genres: string[]): void => {
     void onSave({ genres })
+  }
+
+  // KAMP-605: fetch candidates, merge (union) into the album's genres, and save via
+  // the normal genre PATCH. The user reviews by removing unwanted chips afterward
+  // (each removal persists, matching the panel's eager-write model).
+  const handleFetchGenres = async (): Promise<void> => {
+    if (!onFetchGenres || fetchingGenres) return
+    setFetchingGenres(true)
+    setFetchMsg('')
+    try {
+      const candidates = await onFetchGenres()
+      const merged = mergeGenres(albumGenres, candidates)
+      if (merged.length === albumGenres.length) setFetchMsg('No new genres')
+      else await onSave({ genres: merged })
+    } catch {
+      setFetchMsg('Fetch failed')
+    } finally {
+      setFetchingGenres(false)
+    }
   }
 
   const handleSaveLabel = (): void => {
@@ -222,6 +275,39 @@ export function AlbumMetaPanel({
                   onCommit={handleSaveGenres}
                   onGenreClick={openGenreFilter}
                 />
+                {editMode && onFetchGenres && (
+                  <div className="genre-fetch">
+                    <button
+                      type="button"
+                      className={`genre-fetch-btn${fetchingGenres ? ' genre-fetch-btn--loading' : ''}`}
+                      disabled={fetchingGenres || !genreSourcesEnabled}
+                      onClick={() => void handleFetchGenres()}
+                      {...tooltip(
+                        genreSourcesEnabled
+                          ? 'Fetch genres from your sources'
+                          : 'Enable Last.fm or Bandcamp genres in Preferences'
+                      )}
+                    >
+                      {fetchingGenres ? (
+                        <>
+                          Fetching
+                          <span className="genre-fetch-dots" aria-hidden="true">
+                            <span>.</span>
+                            <span>.</span>
+                            <span>.</span>
+                          </span>
+                        </>
+                      ) : (
+                        'Fetch'
+                      )}
+                    </button>
+                    {fetchMsg && (
+                      <span className="genre-fetch-msg" aria-live="polite">
+                        {fetchMsg}
+                      </span>
+                    )}
+                  </div>
+                )}
               </dd>
             </div>
           )}

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -266,41 +266,36 @@ export function AlbumMetaPanel({
           )}
           {(albumGenres.length > 0 || editMode) && (
             <div className="album-meta-row">
-              <dt className="album-meta-dt">GENRE</dt>
-              <dd className="album-meta-dd">
+              <dt className="album-meta-dt">
+                GENRE
                 {editMode && onFetchGenres && (
-                  <div className="genre-fetch">
-                    <button
-                      type="button"
-                      className={`genre-fetch-btn${fetchingGenres ? ' genre-fetch-btn--loading' : ''}`}
-                      disabled={fetchingGenres || !genreSourcesEnabled}
-                      onClick={() => void handleFetchGenres()}
-                      {...tooltip(
-                        genreSourcesEnabled
-                          ? 'Fetch genres from your sources'
-                          : 'Enable Last.fm or Bandcamp genres in Preferences'
-                      )}
-                    >
-                      {fetchingGenres ? (
-                        <>
-                          Fetching
-                          <span className="genre-fetch-dots" aria-hidden="true">
-                            <span>.</span>
-                            <span>.</span>
-                            <span>.</span>
-                          </span>
-                        </>
-                      ) : (
-                        'Fetch'
-                      )}
-                    </button>
-                    {fetchMsg && (
-                      <span className="genre-fetch-msg" aria-live="polite">
-                        {fetchMsg}
-                      </span>
+                  <button
+                    type="button"
+                    className={`genre-fetch-btn${fetchingGenres ? ' genre-fetch-btn--loading' : ''}`}
+                    disabled={fetchingGenres || !genreSourcesEnabled}
+                    onClick={() => void handleFetchGenres()}
+                    {...tooltip(
+                      genreSourcesEnabled
+                        ? 'Fetch genres from your sources'
+                        : 'Enable Last.fm or Bandcamp genres in Preferences'
                     )}
-                  </div>
+                  >
+                    {fetchingGenres ? (
+                      <>
+                        Fetching
+                        <span className="genre-fetch-dots" aria-hidden="true">
+                          <span>.</span>
+                          <span>.</span>
+                          <span>.</span>
+                        </span>
+                      </>
+                    ) : (
+                      'Fetch'
+                    )}
+                  </button>
                 )}
+              </dt>
+              <dd className="album-meta-dd">
                 <GenreChipsInput
                   chips={albumGenres}
                   suggestions={genreSuggestions}
@@ -308,6 +303,11 @@ export function AlbumMetaPanel({
                   onCommit={handleSaveGenres}
                   onGenreClick={openGenreFilter}
                 />
+                {fetchMsg && (
+                  <span className="genre-fetch-msg" aria-live="polite">
+                    {fetchMsg}
+                  </span>
+                )}
               </dd>
             </div>
           )}

--- a/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumMetaPanel.tsx
@@ -268,13 +268,6 @@ export function AlbumMetaPanel({
             <div className="album-meta-row">
               <dt className="album-meta-dt">GENRE</dt>
               <dd className="album-meta-dd">
-                <GenreChipsInput
-                  chips={albumGenres}
-                  suggestions={genreSuggestions}
-                  editMode={editMode}
-                  onCommit={handleSaveGenres}
-                  onGenreClick={openGenreFilter}
-                />
                 {editMode && onFetchGenres && (
                   <div className="genre-fetch">
                     <button
@@ -308,6 +301,13 @@ export function AlbumMetaPanel({
                     )}
                   </div>
                 )}
+                <GenreChipsInput
+                  chips={albumGenres}
+                  suggestions={genreSuggestions}
+                  editMode={editMode}
+                  onCommit={handleSaveGenres}
+                  onGenreClick={openGenreFilter}
+                />
               </dd>
             </div>
           )}

--- a/kamp_ui/src/renderer/src/components/TrackList.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
-import { artUrl, fetchMusicBrainzCandidates, patchTrackMeta } from '../api/client'
+import { artUrl, fetchAlbumGenres, fetchMusicBrainzCandidates, patchTrackMeta } from '../api/client'
 import type {
   AlbumTagsCollision,
   MusicBrainzCandidate,
@@ -766,6 +766,9 @@ export function TrackList(): React.JSX.Element | null {
         expanded={albumMetaExpanded}
         onToggle={handleToggle}
         onSave={(opts) => patchAlbumMeta(album.album_artist, album.album, opts)}
+        onFetchGenres={() =>
+          fetchAlbumGenres(album.album_artist, album.album).then((r) => r.genres)
+        }
         onHandleMouseDown={handleResizeMouseDown}
         onHandleDoubleClick={handleResizeReset}
       />

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import replace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -60,6 +61,89 @@ class _Progress:
 
     def __call__(self, done: int, total: int, state: str) -> None:
         self.calls.append((done, total, state))
+
+
+def _cfg(*, lastfm: bool = True, bandcamp: bool = True) -> Config:
+    base = _config()
+    return replace(
+        base,
+        tagging=replace(base.tagging, lastfm_genres=lastfm, bandcamp_genres=bandcamp),
+    )
+
+
+class TestFetchAlbumGenreCandidates:
+    """KAMP-605: the per-album Fetch button's read-only candidate engine."""
+
+    def test_unions_lastfm_and_cached_bandcamp(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: ["Jazz"] if s else [])
+        index = MagicMock()
+        index.album_genre_row.return_value = {
+            "sale_item_id": "S1",
+            "keywords": '["Bebop"]',
+            "album_url": "u",
+        }
+        out = gb.fetch_album_genre_candidates(index, _cfg(), "A", "B")
+        assert out == ["Jazz", "Bebop"]
+        # Read-only: cached keywords are never re-written.
+        index.set_collection_keywords.assert_not_called()
+
+    def test_casefold_dedups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: ["Jazz"] if s else [])
+        index = MagicMock()
+        index.album_genre_row.return_value = {
+            "sale_item_id": "S1",
+            "keywords": '["jazz", "Bebop"]',
+            "album_url": None,
+        }
+        out = gb.fetch_album_genre_candidates(index, _cfg(), "A", "B")
+        assert out == ["Jazz", "Bebop"]
+
+    def test_bandcamp_disabled_skips_extras(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: ["Jazz"] if s else [])
+        index = MagicMock()
+        out = gb.fetch_album_genre_candidates(index, _cfg(bandcamp=False), "A", "B")
+        assert out == ["Jazz"]
+        index.album_genre_row.assert_not_called()
+
+    def test_lastfm_disabled_yields_bandcamp_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # enabled_sources is real: lastfm off -> no sources -> fake fetch returns [].
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: ["Jazz"] if s else [])
+        index = MagicMock()
+        index.album_genre_row.return_value = {
+            "sale_item_id": "S1",
+            "keywords": '["Bebop"]',
+            "album_url": None,
+        }
+        out = gb.fetch_album_genre_candidates(index, _cfg(lastfm=False), "A", "B")
+        assert out == ["Bebop"]
+
+    def test_cold_bandcamp_cache_is_read_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No cached keywords + no session -> [] with no network and no cache write.
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: [])
+        index = MagicMock()
+        index.album_genre_row.return_value = {
+            "sale_item_id": "S1",
+            "keywords": None,
+            "album_url": "https://x/album",
+        }
+        out = gb.fetch_album_genre_candidates(index, _cfg(), "A", "B")
+        assert out == []
+        index.set_collection_keywords.assert_not_called()
+
+    def test_missing_album_row_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gb, "fetch_all_genres", lambda s, q: ["Jazz"] if s else [])
+        index = MagicMock()
+        index.album_genre_row.return_value = None
+        out = gb.fetch_album_genre_candidates(index, _cfg(), "A", "B")
+        assert out == ["Jazz"]
 
 
 class TestRunGenreBackfill:

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -15373,3 +15373,46 @@ class TestKamp552DropColumns:
         index.close()
         assert by_local is not None and by_local.id == tid
         assert by_stream is not None and by_stream.id == tid
+
+
+class TestAlbumGenreRow:
+    """KAMP-605: single-album genre-enrichment row for the per-album Fetch button."""
+
+    def test_returns_row_with_cached_bandcamp_keywords(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        aid = _add_artist(index, "Artist")
+        # The albums.sale_item_id FK points at bandcamp_collection — insert it first.
+        index._conn.execute(
+            "INSERT INTO bandcamp_collection (sale_item_id, keywords)"
+            " VALUES ('S1', '[\"Shoegaze\"]')"
+        )
+        _add_album_with_track(
+            index, "Artist", "Album", aid, "bandcamp://S1/1", sale_item_id="S1"
+        )
+        index._conn.commit()
+        row = index.album_genre_row("Artist", "Album")
+        index.close()
+        assert row is not None
+        assert row["album_artist"] == "Artist"
+        assert row["sale_item_id"] == "S1"
+        assert row["keywords"] == '["Shoegaze"]'
+
+    def test_returns_row_for_enriched_album_no_bandcamp(self, tmp_path: Path) -> None:
+        # No genres_enriched_at filter and no bandcamp row -> keywords None.
+        index = LibraryIndex(tmp_path / "library.db")
+        aid = _add_artist(index, "Artist")
+        album_id = _add_album_with_track(index, "Artist", "Album", aid, "/x/01.mp3")
+        index._conn.execute(
+            "UPDATE albums SET genres_enriched_at = 123 WHERE id = ?", (album_id,)
+        )
+        index._conn.commit()
+        row = index.album_genre_row("Artist", "Album")
+        index.close()
+        assert row is not None
+        assert row["keywords"] is None
+
+    def test_none_for_unknown_album(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        result = index.album_genre_row("Nobody", "Nothing")
+        index.close()
+        assert result is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7540,3 +7540,47 @@ class TestGenreManagement:
         assert res.status_code == 200
         mock_index.clear_allowlist_extras.assert_called_once()
         hook.assert_called_once()
+
+
+class TestFetchAlbumGenresEndpoint:
+    """KAMP-605: GET /api/v1/albums/genres/fetch — read-only candidate fetch."""
+
+    def test_returns_candidates(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = [_track(1)]
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            genre_fetch_fn=lambda aa, al: ["Jazz", "Bebop"],
+        )
+        res = TestClient(app).get(
+            "/api/v1/albums/genres/fetch",
+            params={"album_artist": "A", "album": "B"},
+        )
+        assert res.status_code == 200
+        assert res.json() == {"genres": ["Jazz", "Bebop"]}
+
+    def test_404_when_album_has_no_tracks(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.tracks_for_album.return_value = []
+        app = create_app(
+            index=mock_index,
+            engine=mock_engine,
+            queue=mock_queue,
+            genre_fetch_fn=lambda aa, al: ["Jazz"],
+        )
+        res = TestClient(app).get(
+            "/api/v1/albums/genres/fetch",
+            params={"album_artist": "A", "album": "B"},
+        )
+        assert res.status_code == 404
+
+    def test_503_when_fetch_fn_not_wired(self, client: TestClient) -> None:
+        res = client.get(
+            "/api/v1/albums/genres/fetch",
+            params={"album_artist": "A", "album": "B"},
+        )
+        assert res.status_code == 503


### PR DESCRIPTION
## Summary

Adds a per-album genre Fetch to Liner Notes, per KAMP-605. In album Edit mode, a **Fetch** button next to Genre pulls candidate genres from the configured sources (Last.fm, allowlist-filtered, plus the album's cached Bandcamp keywords) and merges them into the album's genres.

## Design (Reality-Checker validated; user-confirmed "immediate merge")

- **Read-only fetch endpoint.** `GET /api/v1/albums/genres/fetch` returns candidates and never writes DB or files. The write happens only through the existing genre PATCH.
- **Immediate merge-commit.** On fetch, the client unions candidates with the album's current genres and saves via `patchAlbumMeta` (replace-mode → net merge). This matches the panel's existing eager-write model (removing a chip already saves immediately, KAMP-550), needs **no `GenreChipsInput` changes**, and keeps all nontrivial logic in the testable daemon layer. The user reviews by removing unwanted chips afterward (each removal persists, as today). A blur-based "preview" was rejected — the chip editor's eager-write contract makes it silently buggy and it has no UI test coverage.
- **Bandcamp = cache-only** (`session=None`): unions the album's cached `keywords`, never a click-time re-scrape (no Cloudflare/ban risk). A Bandcamp album with a cold keywords cache yields Last.fm-only.
- **Gated button:** disabled with a hint when neither Last.fm nor Bandcamp genres are enabled; busy dots while fetching (~8s worst case); "No new genres" / "Fetch failed" feedback.

## Changes

**Daemon**
- `library.py` — `album_genre_row(album_artist, album)`: single-album genre-enrichment row (keywords/sale_item_id/album_url), no enriched filter, `LIMIT 1`.
- `genre_backfill.py` — `fetch_album_genre_candidates(index, config, aa, al)`: `fetch_all_genres(enabled_sources(config), …)` unioned with cache-only Bandcamp keywords (via `_bandcamp_extra_genres(session=None)`), casefold-deduped. Read-only.
- `server.py` — `GenreFetchOut`; injected `genre_fetch_fn`; `GET /api/v1/albums/genres/fetch` (async + `run_in_executor` for the bounded Last.fm call); 404 if the album has no tracks, 503 if unwired.
- `__main__.py` — wires `genre_fetch_fn` with fresh `Config.load(index)` per call (picks up runtime source toggles + allowlist).

**Renderer**
- `client.ts` — `fetchAlbumGenres`.
- `AlbumMetaPanel.tsx` — `onFetchGenres` prop; Fetch button in the GENRE row (edit mode) with busy/feedback/gating; union-merge → `onSave`.
- `TrackList.tsx` — wires `onFetchGenres` with the album key.
- `track-list.css` — `.genre-fetch*` styles (reusing the mb-pill dots animation).

**Tests**
- `test_genre_backfill.py::TestFetchAlbumGenreCandidates` — Last.fm + cached Bandcamp union; casefold dedup; `bandcamp_genres=False` suppresses; `lastfm_genres=False` → Bandcamp-only; **read-only guard** (no network / no DB write with `session=None`).
- `test_library.py::TestAlbumGenreRow` — row with keywords, enriched album no-bandcamp, unknown album → None.
- `test_server.py::TestFetchAlbumGenresEndpoint` — 200 shape / 404 no tracks / 503 unwired.

CI local: black, mypy, full pytest (2617 passed, 93.74% — new daemon lines covered), frontend typecheck + lint. No README drift.

## Manual Test Plan

- Local album → Edit tags → **Fetch** appears next to Genre. Click → busy dots → genres merge in and persist; chips update.
- Fetch again → "No new genres".
- Remove a fetched chip → persists (existing eager behavior).
- Album with no Last.fm match + cold Bandcamp cache → "No new genres" (no error).
- Disable both Last.fm + Bandcamp genres in Preferences → Fetch is disabled with a hint.
- Bandcamp album with cached keywords → those appear on Fetch.
- Not in edit mode → no Fetch button; genre editing still saves normally.

Resolves KAMP-605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
