### PR TITLE
KAMP-618: auto-apply Last.fm genres to newly-added streaming albums

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1462,6 +1462,25 @@ def _cmd_daemon(
 
     core.syncer.progress_callback = _on_download_progress
     core.syncer.on_tracks_indexed = app.state.notify_library_changed
+
+    def _on_stream_albums_added(album_keys: list[tuple[str, str]]) -> None:
+        # KAMP-618: auto-enrich newly-added streaming albums with Last.fm genres on a
+        # background thread (best-effort) so a slow Last.fm never stalls the sync's UI
+        # refresh. Only when a Last.fm source is enabled — Bandcamp keywords were
+        # already applied inline during sync. enrich_albums is scoped to just these
+        # albums (NOT the whole pending set) and does not touch the manual backfill.
+        cfg = Config.load(index)
+        if not _genre_sources.enabled_sources(cfg):
+            return
+
+        def _run() -> None:
+            from .genre_sources import enrich_albums
+
+            enrich_albums(index, album_keys, cfg)
+
+        threading.Thread(target=_run, daemon=True, name="stream-genre-enrich").start()
+
+    core.syncer.on_stream_albums_added = _on_stream_albums_added
     core.watcher.stage_callback = app.state.notify_pipeline_stage
 
     # After each album finishes processing, run a library rescan directly on a

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -480,7 +480,7 @@ def sync_collection_stream(
     art_cache_dir: Path | None = None,
     batch_indexed_callback: Callable[[], None] | None = None,
     apply_bandcamp_genres: bool = True,
-) -> tuple[int, int]:
+) -> tuple[int, int, list[tuple[str, str]]]:
     """Index all Bandcamp purchases as remote rows — no ZIP download.
 
     For each album, upserts a bandcamp_collection row and fetches the album
@@ -494,7 +494,9 @@ def sync_collection_stream(
     key (tralbum_id when available, else sid_<sale_item_id>).  Art fetch
     failures are best-effort — a warning is logged and sync continues.
 
-    Returns (album_count, track_count).
+    Returns (album_count, track_count, new_album_keys), where new_album_keys are the
+    (album_artist, album) tuples of albums indexed for the first time this run
+    (KAMP-618: the set to auto-enrich with Last.fm genres).
     """
     session_data = _ensure_session(bc_config, index)
     session = _make_requests_session(session_data)
@@ -511,6 +513,9 @@ def sync_collection_stream(
     existing_state = index.get_collection_state()
     album_count = 0
     track_count = 0
+    # (album_artist, album) of albums newly indexed this run — the streaming-add
+    # Last.fm genre-enrichment set (KAMP-618).
+    new_album_keys: list[tuple[str, str]] = []
     fetch_index = 0  # throttle counter for album-page requests
     for item in collection:
         sid = item.get("sale_item_id")
@@ -560,11 +565,12 @@ def sync_collection_stream(
         # tracks indexed before KAMP-513).  Pre-orders are always re-inspected so
         # newly released tracks and full-release transitions are caught.
         needs_backfill = index.has_remote_tracks_needing_date_backfill(str(sid))
+        # KAMP-618: a truly new album (no prior remote tracks) is a candidate for
+        # auto Last.fm genre enrichment; pre-order/backfill re-inspections of existing
+        # albums are not (they're already in the library).
+        is_new_album = not index.has_remote_album_tracks(str(sid))
         if album_url and (
-            is_preorder_already
-            or api_says_preorder
-            or not index.has_remote_album_tracks(str(sid))
-            or needs_backfill
+            is_preorder_already or api_says_preorder or is_new_album or needs_backfill
         ):
             if fetch_index > 0:
                 time.sleep(0.5)
@@ -597,6 +603,8 @@ def sync_collection_stream(
                             _t.genres = []
                     index.upsert_many(tracks)
                     track_count += len(tracks)
+                    if is_new_album:
+                        new_album_keys.append((band_name, item_title))
                     logger.debug(
                         "Indexed %d track(s) for %r by %r",
                         len(tracks),
@@ -656,7 +664,7 @@ def sync_collection_stream(
         album_count,
         track_count,
     )
-    return album_count, track_count
+    return album_count, track_count, new_album_keys
 
 
 def download_single_album(

--- a/kamp_daemon/ext/builtin/bandcamp.py
+++ b/kamp_daemon/ext/builtin/bandcamp.py
@@ -180,6 +180,24 @@ class KampBandcampSyncer(BaseSyncer):
         self._inner.on_tracks_indexed = cb
 
     @property
+    def on_stream_albums_added(
+        self,
+    ) -> Callable[[list[tuple[str, str]]], None] | None:
+        """Callback fired once per stream sync with newly-indexed album keys (KAMP-618)."""
+        if self._inner is None:
+            return None
+        return self._inner.on_stream_albums_added
+
+    @on_stream_albums_added.setter
+    def on_stream_albums_added(
+        self, cb: Callable[[list[tuple[str, str]]], None] | None
+    ) -> None:
+        assert (
+            self._inner is not None
+        ), "call _configure() before setting on_stream_albums_added"
+        self._inner.on_stream_albums_added = cb
+
+    @property
     def progress_callback(self) -> Callable[[str, int, int], None] | None:
         """Per-album byte-progress callback (sale_item_id, downloaded_bytes,
         total_bytes) (KAMP-436/566)."""

--- a/kamp_daemon/genre_sources.py
+++ b/kamp_daemon/genre_sources.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -375,6 +375,24 @@ def enrich_new_tracks(
         len(album_keys),
         len(tracks),
     )
+    enrich_albums(index, album_keys, config)
+
+
+def enrich_albums(
+    index: "LibraryIndex",
+    album_keys: "Iterable[tuple[str, str]]",
+    config: "Config",
+) -> None:
+    """Enrich each ``(album_artist, album)`` from the enabled sources (KAMP-618).
+
+    The album-keyed core shared by the local-ingest trigger (``enrich_new_tracks``)
+    and the streaming-add trigger: resolves each album's track ids fresh from the DB
+    and calls ``enrich_album_genres``. Cheap no-op when no source is enabled.
+    Synchronous and best-effort per album; callers run it on a background thread so a
+    slow Last.fm can never stall the sync. Does NOT mark albums enriched — the manual
+    backfill's checkpoint is independent (consistent with local ingest)."""
+    if not enabled_sources(config):
+        return
     for album_artist, album in album_keys:
         try:
             ids = [t.id for t in index.tracks_for_album(album_artist, album)]

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -65,7 +65,7 @@ def _sync_worker(
                 # (subprocess: no inherited config) so a disabled toggle stops the
                 # labels reaching the library while sync still caches them.
                 apply_bc_genres = Config.load(index).tagging.bandcamp_genres
-                album_count, track_count = sync_collection_stream(
+                album_count, track_count, new_album_keys = sync_collection_stream(
                     bc_config=bc_config,
                     watch_dir=watch_dir,
                     index=index,
@@ -74,7 +74,7 @@ def _sync_worker(
                     batch_indexed_callback=lambda: notify_q.put(True),
                     apply_bandcamp_genres=apply_bc_genres,
                 )
-                result_q.put(("ok_stream", (album_count, track_count)))
+                result_q.put(("ok_stream", (album_count, track_count, new_album_keys)))
             else:
                 from .bandcamp import sync_new_purchases
 
@@ -293,6 +293,13 @@ class Syncer:
         self.progress_callback: Callable[[str, int, int], None] | None = None
         self.error_callback: Callable[[str, str, str], None] | None = None
         self.on_tracks_indexed: Callable[[], None] | None = None
+        # KAMP-618: fired ONCE at the end of a stream sync with the (album_artist,
+        # album) keys of albums indexed for the first time this run, so the daemon
+        # can auto-enrich them with Last.fm genres. Distinct from on_tracks_indexed
+        # (a per-batch UI ping that can fire mid-sync).
+        self.on_stream_albums_added: Callable[[list[tuple[str, str]]], None] | None = (
+            None
+        )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -469,7 +476,7 @@ class Syncer:
             raise RuntimeError(f"Bandcamp sync failed: {value}")
 
         if status == "ok_stream":
-            album_count, track_count = value
+            album_count, track_count, new_album_keys = value
             if track_count:
                 logger.info(
                     "Sync complete: %d album(s), %d track(s) indexed as remote.",
@@ -482,6 +489,11 @@ class Syncer:
                 logger.info(
                     "Sync complete: %d album(s) already up to date.", album_count
                 )
+            # Fire ONCE, after the subprocess has fully completed, with the newly
+            # indexed albums (KAMP-618). on_tracks_indexed above can fire per-batch
+            # mid-sync, so it is the wrong hook for a one-shot enrichment trigger.
+            if new_album_keys and self.on_stream_albums_added is not None:
+                self.on_stream_albums_added(new_album_keys)
         else:
             paths = value or []
             if paths:

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2610,7 +2610,7 @@ class TestSyncCollectionStream:
 
     def test_upserts_all_items_as_remote(self, tmp_path: Path) -> None:
         items = [_item(1, "Artist A", "Album 1"), _item(2, "Artist B", "Album 2")]
-        (album_count, _track_count), index = self._run(tmp_path, items)
+        (album_count, _track_count, _keys), index = self._run(tmp_path, items)
         assert album_count == 2
         calls = index.upsert_collection_item.call_args_list
         assert len(calls) == 2
@@ -2618,7 +2618,7 @@ class TestSyncCollectionStream:
 
     def test_returns_album_count(self, tmp_path: Path) -> None:
         items = [_item(10), _item(20), _item(30)]
-        (album_count, _), _ = self._run(tmp_path, items)
+        (album_count, _, _), _ = self._run(tmp_path, items)
         assert album_count == 3
 
     def test_fetches_tracks_for_new_albums(self, tmp_path: Path) -> None:
@@ -2642,23 +2642,26 @@ class TestSyncCollectionStream:
             source="bandcamp",
         )
         items = [_item(1)]
-        (album_count, track_count), index = self._run(
+        (album_count, track_count, new_keys), index = self._run(
             tmp_path, items, already_have_tracks=False, fake_tracks=[fake_track]
         )
         assert album_count == 1
         assert track_count == 1
         index.upsert_many.assert_called_once()
+        # KAMP-618: a first-time-indexed album is reported (by its collection
+        # band_name/item_title) for genre enrichment.
+        assert new_keys == [("Band", "Album")]
 
     def test_skips_track_fetch_for_existing_albums(self, tmp_path: Path) -> None:
         """Albums already in tracks table do not trigger fetch_album_tracks."""
         items = [_item(1), _item(2)]
-        (_counts, _), index = self._run(tmp_path, items, already_have_tracks=True)
+        (_counts, _, _), index = self._run(tmp_path, items, already_have_tracks=True)
         index.upsert_many.assert_not_called()
 
     def test_re_upserts_already_remote_item(self, tmp_path: Path) -> None:
         """Idempotent: collection row is always refreshed even if tracks exist."""
         items = [_item(99)]
-        (_counts, _), index = self._run(tmp_path, items, already_have_tracks=True)
+        (_counts, _, _), index = self._run(tmp_path, items, already_have_tracks=True)
         index.upsert_collection_item.assert_called_once()
         assert index.upsert_collection_item.call_args[1]["mode"] == "remote"
 
@@ -2669,7 +2672,7 @@ class TestSyncCollectionStream:
             _item(2, "New Band", "New Album"),
         ]
         # Item 1 was already downloaded; item 2 is new.
-        (album_count, _), index = self._run(
+        (album_count, _, _), index = self._run(
             tmp_path,
             items,
             existing_state={"1": "local"},
@@ -2708,7 +2711,7 @@ class TestSyncCollectionStream:
                 side_effect=BandcampAPIError("rate limited"),
             ),
         ):
-            album_count, track_count = sync_collection_stream(
+            album_count, track_count, _keys = sync_collection_stream(
                 config, watch_folder, index
             )
 

--- a/tests/test_builtin_bandcamp.py
+++ b/tests/test_builtin_bandcamp.py
@@ -241,6 +241,26 @@ class TestKampBandcampSyncer:
         syncer = KampBandcampSyncer(_ctx())
         assert syncer.on_tracks_indexed is None
 
+    def test_on_stream_albums_added_getter_delegates(self) -> None:
+        """on_stream_albums_added getter returns the inner syncer's value (KAMP-618)."""
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer._inner.on_stream_albums_added = cb
+        assert syncer.on_stream_albums_added is cb
+
+    def test_on_stream_albums_added_setter_delegates(self) -> None:
+        """on_stream_albums_added setter writes THROUGH to the inner syncer (KAMP-436
+        wrapper lesson) — otherwise the auto genre-enrich trigger would dead-end."""
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer.on_stream_albums_added = cb
+        assert syncer._inner.on_stream_albums_added is cb
+
+    def test_on_stream_albums_added_none_before_configure(self) -> None:
+        """on_stream_albums_added returns None when _inner has not been configured."""
+        syncer = KampBandcampSyncer(_ctx())
+        assert syncer.on_stream_albums_added is None
+
     def test_methods_assert_before_configure(self) -> None:
         """Calling lifecycle methods before _configure() raises AssertionError."""
         syncer = KampBandcampSyncer(_ctx())

--- a/tests/test_genre_sources.py
+++ b/tests/test_genre_sources.py
@@ -455,3 +455,42 @@ class TestEnrichAlbumGenres:
         index.close()
         assert applied == ["Synth-Pop"]
         assert "Art Pop" in genre and "Synth-Pop" in genre
+
+    # KAMP-618: enrich_albums — the album-keyed core shared by local ingest and the
+    # streaming-add trigger.
+    def test_enrich_albums_enriches_each_key(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+        gs.enrich_albums(index, [("Slowdive", "Souvlaki")], self._config())
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert "Jazz" in genre and "Shoegaze" in genre  # merged, not replaced
+
+    def test_enrich_albums_noop_when_no_source(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        tid = index.all_tracks()[0].id
+        monkeypatch.setattr(gs, "enabled_sources", lambda cfg: [])
+        gs.enrich_albums(index, [("Slowdive", "Souvlaki")], self._config(on=False))
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert genre == "Jazz"  # untouched
+
+    def test_enrich_albums_skips_unknown_album(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        index, _ = self._seed_local(tmp_path, ["Jazz"])
+        monkeypatch.setattr(
+            gs, "enabled_sources", lambda cfg: [_StubSource(["Shoegaze"])]
+        )
+        gs.enrich_albums(index, [("Nobody", "Nothing")], self._config())  # no tracks
+        tid = index.all_tracks()[0].id
+        genre = index.get_track_by_id(tid).genre
+        index.close()
+        assert genre == "Jazz"  # unrelated album untouched, no crash

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -783,7 +783,9 @@ class TestStreamMode:
         """sync_once() in stream mode does not call mark_synced() on first run."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(2, 10)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(2, 10, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
             patch.object(syncer, "mark_synced") as mock_mark,
@@ -797,7 +799,9 @@ class TestStreamMode:
         """sync_all_purchases() in stream mode does not reset the collection state."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(0, 0)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(0, 0, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
         ):
@@ -812,7 +816,7 @@ class TestStreamMode:
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
             patch(
-                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(3, 15)
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(3, 15, [])
             ) as mock_stream,
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
@@ -824,7 +828,9 @@ class TestStreamMode:
         """sync_once() in stream mode logs album and track counts when tracks indexed."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
             patch("kamp_daemon.syncer.logger") as mock_log,
@@ -839,7 +845,9 @@ class TestStreamMode:
         fired: list[bool] = []
         syncer.on_tracks_indexed = lambda: fired.append(True)
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(5, 42, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
         ):
@@ -866,11 +874,11 @@ class TestStreamMode:
             art_cache_dir: object = None,
             batch_indexed_callback: object = None,
             apply_bandcamp_genres: bool = True,
-        ) -> tuple[int, int]:
+        ) -> tuple[int, int, list[tuple[str, str]]]:
             if batch_indexed_callback is not None:
                 batch_indexed_callback()
                 batch_indexed_callback()
-            return (2, 4)
+            return (2, 4, [])
 
         with (
             patch(
@@ -893,12 +901,47 @@ class TestStreamMode:
         fired: list[bool] = []
         syncer.on_tracks_indexed = lambda: fired.append(True)
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
         ):
             syncer.sync_once()
         assert fired == []
+
+    def test_on_stream_albums_added_fires_with_new_keys(self, tmp_path: Path) -> None:
+        """KAMP-618: on_stream_albums_added fires once with the newly-indexed keys."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        got: list[list[tuple[str, str]]] = []
+        syncer.on_stream_albums_added = lambda keys: got.append(keys)
+        with (
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream",
+                return_value=(1, 3, [("Slowdive", "Souvlaki")]),
+            ),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+        assert got == [[("Slowdive", "Souvlaki")]]
+
+    def test_on_stream_albums_added_not_fired_when_no_new_albums(
+        self, tmp_path: Path
+    ) -> None:
+        """No new albums this run -> the enrichment trigger stays silent."""
+        syncer = Syncer(self._make_stream_config(tmp_path))
+        got: list[list[tuple[str, str]]] = []
+        syncer.on_stream_albums_added = lambda keys: got.append(keys)
+        with (
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(2, 5, [])
+            ),
+            patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
+            patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
+        ):
+            syncer.sync_once()
+        assert got == []
 
     def test_sync_once_stream_logs_up_to_date_when_no_new_tracks(
         self, tmp_path: Path
@@ -906,7 +949,9 @@ class TestStreamMode:
         """sync_once() in stream mode logs 'up to date' when track_count == 0."""
         syncer = Syncer(self._make_stream_config(tmp_path))
         with (
-            patch("kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0)),
+            patch(
+                "kamp_daemon.bandcamp.sync_collection_stream", return_value=(636, 0, [])
+            ),
             patch("kamp_daemon.syncer._spawn_worker", side_effect=_inline_worker),
             patch("kamp_daemon.syncer._state_dir", return_value=tmp_path),
             patch("kamp_daemon.syncer.logger") as mock_log,


### PR DESCRIPTION
## Summary

When a Bandcamp **stream** sync adds a new streaming release and *fetch genres from Last.fm* is enabled, the album now gets Last.fm genres automatically (DB merge; no file write for remote tracks), on a background thread — per KAMP-618. Previously streaming albums only got Bandcamp keyword genres during sync, and Last.fm genres only via the manual "Update Library Genres" button.

## Design — why NOT the estimation's "deferred full backfill" (Reality Checker)

- Reusing the manual backfill re-enriches the **whole pending set**. But local ingest (`enrich_new_tracks`) applies genres and **never** calls `mark_album_genres_enriched` — only the backfill does — so for anyone who's never clicked "Update Library Genres," *every local album is "pending."* The full backfill would kick off a whole-library re-enrichment (network + ~8s/album) on the first stream sync.
- `on_tracks_indexed` fires **per-batch, mid-sync** (not once), so it's the wrong hook for a one-shot trigger.
- Reusing `_on_genre_backfill_start` shares the manual running-lock (auto-run would silently no-op the manual button) and its "clear all marks + re-run everything" branch.

**So: scope to just this sync's newly-added albums**, mirroring the local `enrich_new_tracks` path, via a dedicated once-per-sync callback. Existing streaming albums remain the manual backfill's job (clean separation).

## Changes

- `genre_sources.py` — extract `enrich_albums(index, album_keys, config)` from `enrich_new_tracks` (shared album-keyed core; no-op when no source enabled; does **not** mark enriched, consistent with local ingest). `enrich_album_genres` already applies DB genres to remote tracks (skips only the file write).
- `bandcamp.py` — `sync_collection_stream` collects and returns the `(album_artist, album)` keys of first-time-indexed albums → `(album_count, track_count, new_album_keys)`.
- `syncer.py` — thread the 3-tuple through the subprocess; new `on_stream_albums_added` callback fired **once** in the `ok_stream` branch with the keys (`on_tracks_indexed` stays the per-batch UI ping).
- `ext/builtin/bandcamp.py` — mirror the new callback with a `@property`/setter on `KampBandcampSyncer` (KAMP-436 lesson: a missing wrapper setter silently dead-ends).
- `__main__.py` (coverage-omitted glue) — wire the callback to enrich the new albums on a daemon thread, gated on `enabled_sources` (Last.fm on); Bandcamp keywords were already applied inline during sync.

## Tests

- `test_genre_sources.py` — `enrich_albums` enriches each key, no-ops when no source, skips unknown albums.
- `test_bandcamp.py` — a first-time-indexed album is reported in `new_album_keys`; existing stream-sync tests updated for the 3-tuple.
- `test_syncer.py` — `on_stream_albums_added` fires once with the keys, and stays silent when none.
- `test_builtin_bandcamp.py` — wrapper getter/setter/none-before-configure delegation for the new callback.

CI local: black, mypy, full pytest (2622 passed, 93.70%; new testable pieces covered, `__main__` glue is coverage-omitted). No README drift.

## Manual Test Plan

- Last.fm genres ON → add a new Bandcamp streaming release (sync) → the new album shows Last.fm genres (merged with any Bandcamp keywords), applied after sync without a visible full-library backfill.
- Last.fm genres OFF → new streaming album gets only Bandcamp keywords (or none); no auto-enrichment fires.
- Large existing library, first sync with the feature → only the newly-added album(s) get enriched; existing local/streaming albums are untouched (no whole-library backfill).
- Manual "Update Library Genres" still works and is not blocked by the auto path.
- Re-sync an already-present streaming album (no new tracks) → no re-enrichment.

Resolves KAMP-618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
