### PR TITLE
KAMP-561: Now Playing ambient bokeh from album art

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -660,7 +660,7 @@ export default function App(): React.JSX.Element {
           <LibraryView />
         </div>
         <div className={isNowPlayingPane ? 'view-pane view-pane--active' : 'view-pane'}>
-          <NowPlayingView />
+          <NowPlayingView active={isNowPlayingPane} />
         </div>
         <div className={isDownloadsPane ? 'view-pane view-pane--active' : 'view-pane'}>
           <DownloadsView active={isDownloadsPane} />

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -944,9 +944,27 @@
   gap: 16px;
   height: 100%;
   padding: 16px;
+  /* Containing block for the bokeh canvas (KAMP-561); clip the canvas blur bleed. */
+  position: relative;
+  overflow: hidden;
+}
+
+/* Ambient album-color bokeh behind the art (KAMP-561). The blur unifies the orbs
+   into one dreamy focal plane and hides the reduced-resolution backing store. */
+.now-playing-bokeh {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(28px);
 }
 
 .now-playing-art {
+  /* z-index lifts the art above the positioned bokeh canvas (which paints above
+     static content). */
+  z-index: 1;
   position: relative;
   /* Grow to fill available height, stay square, never exceed container width */
   flex: 1;
@@ -987,6 +1005,9 @@
   gap: 4px;
   width: 100%;
   flex-shrink: 0;
+  /* Lift above the bokeh canvas (KAMP-561). */
+  position: relative;
+  z-index: 1;
 }
 
 .now-playing-title {

--- a/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
+++ b/kamp_ui/src/renderer/src/components/NowPlayingView.tsx
@@ -5,8 +5,9 @@ import { TOOLTIPS } from '../tooltipStrings'
 import { artUrl } from '../api/client'
 import { ContextMenu } from './ContextMenu'
 import { ShareIcon } from './TransportIcons'
+import { BokehBackground } from './nowplaying/BokehBackground'
 
-export function NowPlayingView(): React.JSX.Element {
+export function NowPlayingView({ active = false }: { active?: boolean }): React.JSX.Element {
   const player = useStore((s) => s.player)
   const { current_track } = player
   const [artLoaded, setArtLoaded] = useState(false)
@@ -34,8 +35,15 @@ export function NowPlayingView(): React.JSX.Element {
       )
     : undefined
 
+  const nowPlayingArtUrl = artUrl(
+    currentAlbum?.album_artist ?? current_track.album_artist,
+    currentAlbum?.album ?? current_track.album,
+    { trackId: current_track.album ? null : current_track.id }
+  )
+
   return (
     <div className="now-playing">
+      <BokehBackground active={active} artUrl={nowPlayingArtUrl} />
       <div
         className={`now-playing-art${artLoaded ? ' has-art' : ''}`}
         onContextMenu={(e) => {
@@ -46,13 +54,7 @@ export function NowPlayingView(): React.JSX.Element {
       >
         <span className="now-playing-art-placeholder">♪</span>
         <img
-          src={artUrl(
-            currentAlbum?.album_artist ?? current_track.album_artist,
-            currentAlbum?.album ?? current_track.album,
-            {
-              trackId: current_track.album ? null : current_track.id
-            }
-          )}
+          src={nowPlayingArtUrl}
           onLoad={() => setArtLoaded(true)}
           onError={() => setArtLoaded(false)}
         />

--- a/kamp_ui/src/renderer/src/components/StyleRail.tsx
+++ b/kamp_ui/src/renderer/src/components/StyleRail.tsx
@@ -11,6 +11,8 @@ export function StyleRail(): React.JSX.Element | null {
   const highlightStyle = useStore((s) => s.highlightStyle)
   const setHighlightEnabled = useStore((s) => s.setHighlightEnabled)
   const setHighlightStyle = useStore((s) => s.setHighlightStyle)
+  const nowPlayingGlowEnabled = useStore((s) => s.nowPlayingGlowEnabled)
+  const setNowPlayingGlowEnabled = useStore((s) => s.setNowPlayingGlowEnabled)
 
   if (!styleRailVisible) return null
 
@@ -38,6 +40,14 @@ export function StyleRail(): React.JSX.Element | null {
           </select>
         </label>
       )}
+      <label className="style-rail-control">
+        <input
+          type="checkbox"
+          checked={nowPlayingGlowEnabled}
+          onChange={(e) => setNowPlayingGlowEnabled(e.target.checked)}
+        />
+        Now Playing glow
+      </label>
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
+++ b/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
@@ -1,0 +1,96 @@
+// KAMP-561: React wrapper mounting the bokeh engine behind the Now Playing art.
+// The only React-aware piece; the engine + palette math live in framework-free
+// modules. Gated hard on visibility so the rAF loop never runs while the pane is
+// display:none, the toggle is off, the window is hidden, or reduced-motion is set.
+
+import React, { useEffect, useRef, useState } from 'react'
+import { useStore } from '../../store'
+import { BokehEngine } from './bokehEngine'
+import { accentPalette, loadPalette } from './palette'
+
+interface Props {
+  active: boolean
+  artUrl: string
+}
+
+function accentHex(): string {
+  return getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#7c86e1'
+}
+
+// Inner component: only mounted when the toggle is on, so "off" means zero canvas
+// and zero GPU. All effect hooks live here (always run while mounted).
+function BokehCanvas({ active, artUrl }: Props): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const engineRef = useRef<BokehEngine | null>(null)
+
+  const [hidden, setHidden] = useState(() => document.hidden)
+  // One-shot read (matches useNewArrivalHighlight); a live OS toggle mid-session is
+  // an accepted gap.
+  const [reducedMotion] = useState(
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+
+  // Window hide/show — the rAF must stop when the window is occluded/minimized.
+  useEffect(() => {
+    const onVis = (): void => setHidden(document.hidden)
+    document.addEventListener('visibilitychange', onVis)
+    return () => document.removeEventListener('visibilitychange', onVis)
+  }, [])
+
+  // Create the engine once; tear down only on unmount. ResizeObserver handles
+  // window resizes; the run/pause effect re-sizes explicitly on becoming active.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const engine = new BokehEngine(canvas, accentPalette(accentHex()))
+    engineRef.current = engine
+    engine.resize()
+    const ro = new ResizeObserver(() => engine.resize())
+    ro.observe(canvas)
+    return () => {
+      ro.disconnect()
+      engine.destroy()
+      engineRef.current = null
+    }
+  }, [])
+
+  // Recompute the palette on each track/art change; crossfade in the engine. Guard
+  // against skip races (abort the in-flight fetch, ignore a stale resolution).
+  useEffect(() => {
+    let cancelled = false
+    const controller = new AbortController()
+    void loadPalette(artUrl, accentHex(), controller.signal).then((pal) => {
+      if (!cancelled) engineRef.current?.setPalette(pal)
+    })
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [artUrl])
+
+  // Run the loop only when actually visible and motion is wanted; otherwise paint
+  // the static gradient (reduced-motion) or fully stop (inactive/hidden).
+  const shouldAnimate = active && !reducedMotion && !hidden
+  useEffect(() => {
+    const engine = engineRef.current
+    if (!engine) return
+    if (shouldAnimate) {
+      engine.resize()
+      engine.start()
+      return () => engine.stop()
+    }
+    engine.stop()
+    // Reduced-motion (still active) gets a static repaint; inactive/hidden paints
+    // nothing (it's not visible anyway).
+    if (active && reducedMotion) engine.resize()
+    return undefined
+  }, [shouldAnimate, active, reducedMotion])
+
+  return <canvas ref={canvasRef} className="now-playing-bokeh" aria-hidden="true" />
+}
+
+export function BokehBackground(props: Props): React.JSX.Element | null {
+  const enabled = useStore((s) => s.nowPlayingGlowEnabled)
+  if (!enabled) return null
+  return <BokehCanvas {...props} />
+}

--- a/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
+++ b/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
@@ -1,0 +1,275 @@
+// KAMP-561: framework-free bokeh renderer for the Now Playing background.
+//
+// Soft blurred colored orbs (from the album palette) drifting slowly. Deliberately
+// calm (not beat-reactive) and never louder than the album art. Owns a single rAF
+// handle; start()/stop() are idempotent. The backing store is rendered at reduced
+// resolution and CSS-upscaled — the canvas-wide blur hides the upscale and makes
+// the per-frame fill + blur ~4-16x cheaper (see plan perf notes).
+
+import type { Palette, RGB } from './palette'
+
+// --- tunables (the "5 knobs") ----------------------------------------------
+const RES_SCALE = 0.5 // backing store fraction of (clamped) devicePixelRatio
+const MAX_DPR = 2
+const FRAME_MS = 33 // ~30fps cap — slow drift needs no more
+const CROSSFADE_MS = 1000 // palette recolor duration on track change
+const EDGE_MARGIN = 0.45 // wrap distance beyond [0,1] before respawning an orb
+
+type Tier = 'hero' | 'mid' | 'accent'
+
+interface Orb {
+  bx: number // drifting base position, normalized [0,1] of width/height
+  by: number
+  vx: number // drift velocity, normalized units / second
+  vy: number
+  sizePct: number // diameter as a fraction of S = min(cssW, cssH)
+  ax: number // wobble amplitude, fraction of S
+  ay: number
+  px1: number // incommensurate wobble periods (seconds) — never a closed loop
+  px2: number
+  py1: number
+  py2: number
+  breathP: number // breathing period (seconds)
+  breathPhase: number
+  baseAlpha: number
+  colorIndex: number // stable palette slot (so recolor never flickers)
+}
+
+const rand = (min: number, max: number): number => min + Math.random() * (max - min)
+
+// Tier -> [count, sizePct range, alpha range, cross-screen seconds range].
+const TIERS: Record<
+  Tier,
+  { size: [number, number]; alpha: [number, number]; cross: [number, number] }
+> = {
+  hero: { size: [0.55, 0.75], alpha: [0.32, 0.4], cross: [90, 150] },
+  mid: { size: [0.3, 0.45], alpha: [0.4, 0.5], cross: [60, 110] },
+  accent: { size: [0.12, 0.22], alpha: [0.5, 0.56], cross: [45, 70] }
+}
+
+// 7 orbs, most-dominant palette slots to the big hero orbs.
+const ORB_PLAN: { tier: Tier; colorIndex: number }[] = [
+  { tier: 'hero', colorIndex: 0 },
+  { tier: 'hero', colorIndex: 1 },
+  { tier: 'mid', colorIndex: 2 },
+  { tier: 'mid', colorIndex: 3 },
+  { tier: 'mid', colorIndex: 0 },
+  { tier: 'accent', colorIndex: 4 },
+  { tier: 'accent', colorIndex: 2 }
+]
+
+function makeOrb(plan: { tier: Tier; colorIndex: number }): Orb {
+  const t = TIERS[plan.tier]
+  const cross = rand(t.cross[0], t.cross[1])
+  const angle = rand(0, Math.PI * 2)
+  const speed = 1 / cross // ~1.0 normalized traversal over `cross` seconds
+  return {
+    bx: rand(0, 1),
+    by: rand(0, 1),
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed,
+    sizePct: rand(t.size[0], t.size[1]),
+    ax: rand(0.05, 0.07),
+    ay: rand(0.05, 0.07),
+    px1: rand(15, 19),
+    px2: rand(27, 31),
+    py1: rand(18, 22),
+    py2: rand(29, 33),
+    breathP: rand(12, 20),
+    breathPhase: rand(0, Math.PI * 2),
+    baseAlpha: rand(t.alpha[0], t.alpha[1]),
+    colorIndex: plan.colorIndex
+  }
+}
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t
+const smoothstep = (t: number): number => t * t * (3 - 2 * t)
+const lerpRgb = (a: RGB, b: RGB, t: number): RGB => ({
+  r: Math.round(lerp(a.r, b.r, t)),
+  g: Math.round(lerp(a.g, b.g, t)),
+  b: Math.round(lerp(a.b, b.b, t))
+})
+
+export class BokehEngine {
+  private ctx: CanvasRenderingContext2D | null
+  private orbs: Orb[] = ORB_PLAN.map(makeOrb)
+  private cssW = 0
+  private cssH = 0
+  private scale = 1 // effective backing scale (reduced dpr)
+
+  // Palette crossfade state.
+  private from: RGB[]
+  private to: RGB[]
+  private paletteT = 1 // 0..1
+
+  private elapsed = 0 // animation clock (seconds), advances only while running
+  private rafId: number | null = null
+  private lastTs = 0
+  private lastDraw = 0
+  private bg = '#141414'
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    initial: Palette
+  ) {
+    this.ctx = canvas.getContext('2d')
+    this.from = initial.colors
+    this.to = initial.colors
+    this.refreshBg()
+  }
+
+  // Theme --bg for the vignette (all themes are dark; near-black).
+  private refreshBg(): void {
+    const v = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim()
+    if (v) this.bg = v
+  }
+
+  private currentColors(): RGB[] {
+    if (this.paletteT >= 1) return this.to
+    const t = smoothstep(this.paletteT)
+    return this.to.map((c, i) => lerpRgb(this.from[i] ?? c, c, t))
+  }
+
+  setPalette(next: Palette): void {
+    // Snapshot the currently-interpolated colors so a track change mid-crossfade
+    // continues smoothly rather than snapping.
+    this.from = this.currentColors()
+    this.to = next.colors
+    this.paletteT = 0
+    if (!this.rafId) this.renderStatic() // reduced-motion path repaints on change
+  }
+
+  // HiDPI + reduced-resolution sizing. Bails when the pane is display:none (0x0).
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    if (rect.width === 0 || rect.height === 0) return
+    this.refreshBg()
+    const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR)
+    this.scale = dpr * RES_SCALE
+    this.cssW = rect.width
+    this.cssH = rect.height
+    this.canvas.width = Math.max(1, Math.round(rect.width * this.scale))
+    this.canvas.height = Math.max(1, Math.round(rect.height * this.scale))
+    const ctx = this.ctx
+    if (ctx) {
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.scale(this.scale, this.scale) // draw in CSS-pixel space
+    }
+    if (!this.rafId) this.renderStatic()
+  }
+
+  start(): void {
+    if (this.rafId != null) return
+    this.lastTs = 0
+    this.lastDraw = 0
+    this.rafId = requestAnimationFrame(this.tick)
+  }
+
+  stop(): void {
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+  }
+
+  destroy(): void {
+    this.stop()
+    this.ctx = null
+  }
+
+  private tick = (ts: number): void => {
+    this.rafId = requestAnimationFrame(this.tick)
+    if (this.lastTs === 0) this.lastTs = ts
+    const dt = Math.min(0.1, (ts - this.lastTs) / 1000) // clamp long gaps
+    this.lastTs = ts
+    // 30fps cap: advance the clock every rAF but only repaint every ~FRAME_MS.
+    this.advance(dt)
+    if (ts - this.lastDraw < FRAME_MS) return
+    this.lastDraw = ts
+    this.draw()
+  }
+
+  private advance(dt: number): void {
+    if (document.hidden) return // belt-and-suspenders; the component also gates
+    this.elapsed += dt
+    if (this.paletteT < 1) this.paletteT = Math.min(1, this.paletteT + (dt * 1000) / CROSSFADE_MS)
+    for (const o of this.orbs) {
+      o.bx += o.vx * dt
+      o.by += o.vy * dt
+      if (o.bx < -EDGE_MARGIN) o.bx += 1 + 2 * EDGE_MARGIN
+      else if (o.bx > 1 + EDGE_MARGIN) o.bx -= 1 + 2 * EDGE_MARGIN
+      if (o.by < -EDGE_MARGIN) o.by += 1 + 2 * EDGE_MARGIN
+      else if (o.by > 1 + EDGE_MARGIN) o.by -= 1 + 2 * EDGE_MARGIN
+    }
+  }
+
+  private draw(): void {
+    const ctx = this.ctx
+    if (!ctx || this.cssW === 0) return
+    const { cssW: w, cssH: h } = this
+    const s = Math.min(w, h)
+    const colors = this.currentColors()
+
+    ctx.clearRect(0, 0, w, h)
+    ctx.globalCompositeOperation = 'screen'
+    for (const o of this.orbs) {
+      const ox = o.ax * (Math.sin(this.elapsed / o.px1) + Math.sin(this.elapsed / o.px2))
+      const oy = o.ay * (Math.sin(this.elapsed / o.py1) + Math.sin(this.elapsed / o.py2))
+      const breath = Math.sin(this.elapsed / o.breathP + o.breathPhase)
+      const x = o.bx * w + ox * s
+      const y = o.by * h + oy * s
+      const radius = o.sizePct * s * 0.5 * (1 + 0.08 * breath)
+      if (radius <= 0) continue
+      const alpha = o.baseAlpha * (1 + 0.06 * breath)
+      const c = colors[o.colorIndex] ?? colors[0]
+      const grad = ctx.createRadialGradient(x, y, 0, x, y, radius)
+      grad.addColorStop(0, `rgba(${c.r},${c.g},${c.b},${alpha})`)
+      grad.addColorStop(0.4, `rgba(${c.r},${c.g},${c.b},${alpha * 0.55})`)
+      grad.addColorStop(1, `rgba(${c.r},${c.g},${c.b},0)`)
+      ctx.fillStyle = grad
+      ctx.fillRect(x - radius, y - radius, radius * 2, radius * 2)
+    }
+    ctx.globalCompositeOperation = 'source-over'
+    this.drawVignette(ctx, w, h)
+  }
+
+  // Darken toward the edges with the theme bg so the corners stay calm and the
+  // centered album art reads as the hero.
+  private drawVignette(ctx: CanvasRenderingContext2D, w: number, h: number): void {
+    const cx = w / 2
+    const cy = h / 2
+    const r = Math.hypot(w, h) / 2
+    const grad = ctx.createRadialGradient(cx, cy, r * 0.45, cx, cy, r)
+    grad.addColorStop(0, this.rgbaBg(0))
+    grad.addColorStop(1, this.rgbaBg(0.35))
+    ctx.fillStyle = grad
+    ctx.fillRect(0, 0, w, h)
+  }
+
+  private rgbaBg(a: number): string {
+    // --bg is a hex string on all themes; fall back to near-black.
+    const m = /^#?([0-9a-f]{6})$/i.exec(this.bg)
+    const n = m ? parseInt(m[1], 16) : 0x141414
+    return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`
+  }
+
+  // One-shot static paint for the off/reduced-motion path: a soft gradient of the
+  // two dominant swatches, plus the vignette. No animation.
+  renderStatic(): void {
+    const ctx = this.ctx
+    if (!ctx || this.cssW === 0) return
+    const { cssW: w, cssH: h } = this
+    const colors = this.currentColors()
+    ctx.clearRect(0, 0, w, h)
+    ctx.globalCompositeOperation = 'screen'
+    const grad = ctx.createLinearGradient(0, 0, w, h)
+    const a = colors[0] ?? { r: 40, g: 40, b: 48 }
+    const b = colors[1] ?? a
+    grad.addColorStop(0, `rgba(${a.r},${a.g},${a.b},0.22)`)
+    grad.addColorStop(1, `rgba(${b.r},${b.g},${b.b},0.22)`)
+    ctx.fillStyle = grad
+    ctx.fillRect(0, 0, w, h)
+    ctx.globalCompositeOperation = 'source-over'
+    this.drawVignette(ctx, w, h)
+  }
+}

--- a/kamp_ui/src/renderer/src/components/nowplaying/palette.ts
+++ b/kamp_ui/src/renderer/src/components/nowplaying/palette.ts
@@ -1,0 +1,212 @@
+// KAMP-561: album-art color extraction for the Now Playing ambient bokeh.
+//
+// extractPalette is a PURE function (no DOM/canvas) so the tricky quantize + clamp
+// logic is reason-about-able in isolation. loadPalette does the taint-safe I/O:
+// fetch -> blob -> createImageBitmap -> a tiny offscreen canvas -> getImageData.
+// The blob bytes are local, so the derived canvas is never tainted (unlike drawing
+// the cross-origin <img> element directly, which would throw on getImageData).
+
+export interface RGB {
+  r: number
+  g: number
+  b: number
+}
+
+export interface Palette {
+  // Fixed-length, clamped to a pleasant band so dark/monochrome covers still work.
+  colors: RGB[]
+  source: 'art' | 'accent'
+}
+
+// Tunables (see plan "5 knobs"). Conservative midpoints; adjust by eye.
+export const PALETTE_SIZE = 5
+const SAT_FLOOR = 0.45
+const LIGHT_MIN = 0.45
+const LIGHT_MAX = 0.68
+const HUE_BINS = 16
+// A cover whose dominant colorful hue is below this saturation is "monochrome".
+const MONO_SAT_THRESHOLD = 0.12
+const EXTRACT_SIZE = 32
+
+// --- color-space helpers ----------------------------------------------------
+
+interface HSL {
+  h: number // [0,360)
+  s: number // [0,1]
+  l: number // [0,1]
+}
+
+function rgbToHsl({ r, g, b }: RGB): HSL {
+  const rn = r / 255
+  const gn = g / 255
+  const bn = b / 255
+  const max = Math.max(rn, gn, bn)
+  const min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  const d = max - min
+  if (d === 0) return { h: 0, s: 0, l }
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h: number
+  if (max === rn) h = ((gn - bn) / d + (gn < bn ? 6 : 0)) * 60
+  else if (max === gn) h = ((bn - rn) / d + 2) * 60
+  else h = ((rn - gn) / d + 4) * 60
+  return { h, s, l }
+}
+
+function hslToRgb({ h, s, l }: HSL): RGB {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = (((h % 360) + 360) % 360) / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  let r = 0
+  let g = 0
+  let b = 0
+  if (hp < 1) [r, g, b] = [c, x, 0]
+  else if (hp < 2) [r, g, b] = [x, c, 0]
+  else if (hp < 3) [r, g, b] = [0, c, x]
+  else if (hp < 4) [r, g, b] = [0, x, c]
+  else if (hp < 5) [r, g, b] = [x, 0, c]
+  else [r, g, b] = [c, 0, x]
+  const m = l - c / 2
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255)
+  }
+}
+
+export function hexToRgb(hex: string): RGB | null {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return null
+  const n = parseInt(m[1], 16)
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 }
+}
+
+// Clamp a swatch into the pleasant band (keep the album's hue; fix its tone).
+function clampSwatch(rgb: RGB): RGB {
+  const hsl = rgbToHsl(rgb)
+  return hslToRgb({
+    h: hsl.h,
+    s: Math.max(SAT_FLOOR, hsl.s),
+    l: Math.min(LIGHT_MAX, Math.max(LIGHT_MIN, hsl.l))
+  })
+}
+
+// Pad/truncate to a fixed length by hue-rotating the existing swatches, so the
+// render loop never branches on palette length.
+function padPalette(colors: RGB[]): RGB[] {
+  if (colors.length === 0) return []
+  const out = colors.slice(0, PALETTE_SIZE)
+  const rotations = [30, -30, 60, -60, 90]
+  let i = 0
+  while (out.length < PALETTE_SIZE) {
+    const base = rgbToHsl(colors[i % colors.length])
+    out.push(hslToRgb({ ...base, h: base.h + rotations[i % rotations.length] }))
+    i++
+  }
+  return out
+}
+
+// A palette built from the theme accent — the fallback for monochrome covers,
+// missing art, or a failed decode. Always a valid, on-theme result.
+export function accentPalette(accentHex: string): Palette {
+  const base = hexToRgb(accentHex) ?? { r: 124, g: 134, b: 225 }
+  const hsl = rgbToHsl(base)
+  const rotations = [0, 28, -28, 56, -56]
+  const colors = rotations.map((dh) => clampSwatch(hslToRgb({ h: hsl.h + dh, s: hsl.s, l: hsl.l })))
+  return { colors, source: 'accent' }
+}
+
+/**
+ * Extract a small, clamped palette from decoded image pixels (PURE — KAMP-561).
+ *
+ * Weighted-histogram quantize: each pixel is binned by hue and weighted by
+ * `saturation × mid-lightness`, so a mostly-black cover surfaces its one neon
+ * accent rather than the dominant black. Near-monochrome covers fall back to the
+ * theme accent. Always returns a fixed-length, band-clamped palette.
+ */
+export function extractPalette(data: Uint8ClampedArray, accentHex: string): Palette {
+  const binWeight = new Float64Array(HUE_BINS)
+  const binR = new Float64Array(HUE_BINS)
+  const binG = new Float64Array(HUE_BINS)
+  const binB = new Float64Array(HUE_BINS)
+
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i + 3]
+    if (a < 128) continue
+    const rgb = { r: data[i], g: data[i + 1], b: data[i + 2] }
+    const { h, s, l } = rgbToHsl(rgb)
+    // Prefer colorful, mid-lightness pixels; grey/very dark/blown pixels ~= 0 weight.
+    const w = s * (1 - Math.abs(l - 0.5) * 2)
+    if (w <= 0) continue
+    const bin = Math.min(HUE_BINS - 1, Math.floor((h / 360) * HUE_BINS))
+    binWeight[bin] += w
+    binR[bin] += rgb.r * w
+    binG[bin] += rgb.g * w
+    binB[bin] += rgb.b * w
+  }
+
+  // Rank bins by weight.
+  const ranked = Array.from({ length: HUE_BINS }, (_, i) => i)
+    .filter((i) => binWeight[i] > 0)
+    .sort((a, b) => binWeight[b] - binWeight[a])
+
+  if (ranked.length === 0) return accentPalette(accentHex)
+
+  // Average color of each surviving bin, most-dominant first.
+  const avgs: RGB[] = ranked.map((i) => ({
+    r: Math.round(binR[i] / binWeight[i]),
+    g: Math.round(binG[i] / binWeight[i]),
+    b: Math.round(binB[i] / binWeight[i])
+  }))
+
+  // Monochrome guard: if even the dominant hue is nearly desaturated, the cover is
+  // effectively grey — a band-clamp would invent random colors, so use the accent.
+  if (rgbToHsl(avgs[0]).s < MONO_SAT_THRESHOLD) return accentPalette(accentHex)
+
+  const colors = padPalette(avgs.slice(0, PALETTE_SIZE).map(clampSwatch))
+  return { colors, source: 'art' }
+}
+
+// --- taint-safe loader ------------------------------------------------------
+
+// One reused offscreen canvas across track changes (no per-load allocation).
+let _extractCanvas: HTMLCanvasElement | null = null
+function extractContext(): CanvasRenderingContext2D | null {
+  if (!_extractCanvas) {
+    _extractCanvas = document.createElement('canvas')
+    _extractCanvas.width = EXTRACT_SIZE
+    _extractCanvas.height = EXTRACT_SIZE
+  }
+  return _extractCanvas.getContext('2d', { willReadFrequently: true })
+}
+
+/**
+ * Load an album-art URL and derive its palette (KAMP-561). Taint-safe via
+ * fetch->blob->createImageBitmap. Any failure (missing art, non-image body, abort)
+ * degrades to the accent palette rather than throwing.
+ */
+export async function loadPalette(
+  url: string,
+  accentHex: string,
+  signal?: AbortSignal
+): Promise<Palette> {
+  try {
+    const res = await fetch(url, { signal })
+    if (!res.ok) return accentPalette(accentHex)
+    const blob = await res.blob()
+    const bitmap = await createImageBitmap(blob)
+    const ctx = extractContext()
+    if (!ctx) {
+      bitmap.close()
+      return accentPalette(accentHex)
+    }
+    ctx.clearRect(0, 0, EXTRACT_SIZE, EXTRACT_SIZE)
+    ctx.drawImage(bitmap, 0, 0, EXTRACT_SIZE, EXTRACT_SIZE)
+    bitmap.close()
+    const { data } = ctx.getImageData(0, 0, EXTRACT_SIZE, EXTRACT_SIZE)
+    return extractPalette(data, accentHex)
+  } catch {
+    // AbortError / decode failure / missing art — all degrade to the accent.
+    return accentPalette(accentHex)
+  }
+}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -97,6 +97,8 @@ type PlayerStore = {
   highlightEnabled: boolean
   highlightCutoffSecs: number
   highlightStyle: string
+  // KAMP-561: Now Playing album-color ambient bokeh background.
+  nowPlayingGlowEnabled: boolean
   // KAMP-544: ephemeral, non-persisted "played this session" echo — album key ->
   // epoch-seconds captured when playback started. Masks the latency between
   // hitting play and the server's last_played_at syncing back into the album list
@@ -204,6 +206,7 @@ type PlayerStore = {
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
   setHighlightEnabled: (enabled: boolean) => void
+  setNowPlayingGlowEnabled: (enabled: boolean) => void
   setHighlightStyle: (style: string) => void
   markHighlightPlayed: (album: Album) => void
   setTopAlbumsCount: (n: number) => void
@@ -455,6 +458,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     return saved ? parseInt(saved) : 30
   })(),
   highlightEnabled: localStorage.getItem('kamp:highlight-enabled') !== 'false',
+  nowPlayingGlowEnabled: localStorage.getItem('kamp:nowplaying-glow-enabled') !== 'false',
   highlightCutoffSecs: Date.now() / 1000 - 5 * 86400,
   highlightStyle: localStorage.getItem('kamp:highlight-style') ?? 'shiny',
   playedHighlights: new Map<string, number>(),
@@ -860,6 +864,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setHighlightEnabled: (enabled) => {
     localStorage.setItem('kamp:highlight-enabled', String(enabled))
     set({ highlightEnabled: enabled })
+  },
+
+  setNowPlayingGlowEnabled: (enabled) => {
+    localStorage.setItem('kamp:nowplaying-glow-enabled', String(enabled))
+    set({ nowPlayingGlowEnabled: enabled })
   },
 
   setHighlightStyle: (style) => {


### PR DESCRIPTION
## KAMP-561: Now Playing ambient bokeh from album art

Replaces the static Now Playing background with a slow, playful **ambient bokeh** — soft blurred colored orbs drifting gently, tinted by colors extracted from the current album art. The album art stays the hero; the bokeh is atmosphere, never distraction, and is deliberately **not** beat-reactive. A **Now Playing glow** toggle in Style Settings turns it off entirely.

### What changed

**New — `components/nowplaying/`**
- `palette.ts` — pure `extractPalette` (weighted-histogram hue quantize; each pixel weighted by `saturation × mid-lightness` so a mostly-black cover surfaces its accent, not the black; swatches clamped to a pleasant band — saturation ≥ 0.45, lightness 0.45–0.68 — with the album's hues kept). Near-monochrome covers fall back to the theme accent. `loadPalette` is taint-safe: `fetch → blob → createImageBitmap → 32px offscreen canvas → getImageData`; it never reads the cross-origin `<img>`, and any failure (missing art, decode error, abort) degrades to the accent palette.
- `bokehEngine.ts` — framework-free renderer owning a single rAF handle. Reduced-resolution backing store (~0.5× clamped DPR, CSS-upscaled — the blur hides it) + ~30fps cap, `screen` compositing (all themes are dark, so no light/`multiply` branch), 7 orbs in 3 size tiers with incommensurate sine wobble + breathing, a vignette "clearing" behind the centered art, a ~1s in-place color crossfade on track change, and a static-gradient path for reduced-motion. `start`/`stop`/`resize`/`destroy` are idempotent.
- `BokehBackground.tsx` — the only React-aware piece. Engine created once and torn down on unmount; palette effect keyed on the art URL (AbortController + cancelled-flag guard against skip races); the loop runs only when `active && !reducedMotion && !hidden`, gated by a real `visibilitychange` listener and a one-shot `matchMedia('(prefers-reduced-motion: reduce)')` read. When the toggle is off the canvas isn't mounted at all — zero canvas, zero GPU.

**Wiring**
- `NowPlayingView.tsx` accepts `active?: boolean` and mounts `<BokehBackground>` as the first child of `.now-playing`; `App.tsx` threads `active={isNowPlayingPane}` so the rAF pauses when the pane is `display:none` or covered by search/an extension.
- `store.ts` + `StyleRail.tsx` add the persisted `nowPlayingGlowEnabled` toggle (`localStorage kamp:nowplaying-glow-enabled`), mirroring the existing "Highlight new arrivals" pattern.
- `track-list.css` layers the canvas (`z-index:0`, blurred) behind the art and meta (`z-index:1`).

### Test plan (manual — visual)

- Colorful cover → soft orbs drift slowly in the cover's colors; the art stays clearly separated by the vignette clearing.
- Skip tracks → the bokeh recolors **in place**, smoothly, no blank/flash between tracks.
- Dark / near-monochrome / black-and-white cover → a pleasant accent-fallback palette, not grey sludge.
- Toggle **off** in Style Settings → plain background, no canvas, no CPU/GPU.
- Leave Now Playing (switch views / open search or an extension over it) → loop pauses; return → resumes and resizes correctly.
- Minimize / cover the window → loop pauses (visibilitychange).
- OS "reduce motion" on → a **static** palette gradient, still re-tinting per track, no drifting.
- Resize the window → orbs reflow, no stretching/blur artifacts.
- Missing-art track → no crash; accent-fallback palette.

Tuning knobs (cross-screen time, blur radius, orb alpha, vignette strength, palette clamp band) are at conservative midpoints — expect a tuning cycle or two by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
