### PR TITLE
KAMP-619: scrobble at 50%-or-4-minutes, whichever comes first

### DIFF
--- a/kamp_core/scrobbler.py
+++ b/kamp_core/scrobbler.py
@@ -1,8 +1,10 @@
 """Last.fm scrobbling integration.
 
 Tracks cumulative listening time per play instance and scrobbles when either
-30 seconds have been listened to, or the track reaches natural end-of-file,
-whichever comes first.
+the Last.fm threshold is crossed (half the track's duration or four minutes,
+whichever comes first; floored at 30s and used as the fallback for
+unknown-duration streams), or the track reaches natural end-of-file, whichever
+comes first.
 
 Threading model
 ---------------
@@ -57,7 +59,19 @@ class _ScrobbleJob:
 LASTFM_API_KEY = "edb4b838db9e37e0433c21761e2f7947"
 LASTFM_API_SECRET = "76d2c23b31352fe60ce8c1e6ba428a46"
 
-_SCROBBLE_THRESHOLD_SECS = 30.0
+# Scrobble timing follows the Last.fm standard (KAMP-619): fire once the listener
+# has heard half the track OR four minutes, whichever comes first, with a 30s
+# minimum. The floor doubles as the fallback for unknown-duration tracks
+# (streams have duration 0), which then keep the historical 30s behavior. We do
+# NOT implement Last.fm's separate "track must be longer than 30s" length
+# exclusion — kamp still scrobbles short tracks at natural EOF (on_track_ended).
+_SCROBBLE_MIN_SECS = 30.0
+_SCROBBLE_CAP_SECS = 240.0
+
+
+def _scrobble_threshold_secs(duration: float) -> float:
+    """Listening seconds required to scrobble a track of *duration* seconds."""
+    return min(max(duration / 2, _SCROBBLE_MIN_SECS), _SCROBBLE_CAP_SECS)
 
 
 def authenticate(username: str, password: str) -> str:
@@ -141,8 +155,9 @@ class Scrobbler:
         """Call at ~1 Hz from the state-saver thread.
 
         Accumulates listening time while *playing* is True and fires the
-        30-second scrobble when the threshold is crossed. Returns immediately;
-        any HTTP call runs on the scrobbler's worker thread.
+        scrobble once *track*'s threshold is crossed (see
+        ``_scrobble_threshold_secs``). Returns immediately; any HTTP call runs
+        on the scrobbler's worker thread.
         """
         now = time.monotonic()
         should_scrobble = False
@@ -157,7 +172,8 @@ class Scrobbler:
             if (
                 track is not None
                 and not self._scrobbled
-                and self._play_listening_secs >= _SCROBBLE_THRESHOLD_SECS
+                and self._play_listening_secs
+                >= _scrobble_threshold_secs(track.duration)
             ):
                 self._scrobbled = True
                 should_scrobble = True

--- a/tests/test_scrobbler.py
+++ b/tests/test_scrobbler.py
@@ -25,6 +25,7 @@ def _track(
     album_artist: str = "Artist",
     track_number: int = 1,
     mb_recording_id: str = "",
+    duration: float = 0.0,
 ) -> Track:
     return Track(
         file_path=Path("/music/01.mp3"),
@@ -39,6 +40,7 @@ def _track(
         embedded_art=False,
         mb_release_id="",
         mb_recording_id=mb_recording_id,
+        duration=duration,
     )
 
 
@@ -190,7 +192,12 @@ class TestOnTrackChanged:
 
 
 # ---------------------------------------------------------------------------
-# Scrobbler.tick — 30-second threshold
+# Scrobbler.tick — half-duration-or-4-minutes threshold (KAMP-619)
+#
+# The threshold is min(max(duration / 2, 30), 240): half the track, capped at
+# 4 minutes, floored at 30s. The cases in this class that use the default
+# _track() (duration=0) exercise the unknown-duration fallback, which floors to
+# 30s — i.e. they also pin the pre-KAMP-619 behavior for streams.
 # ---------------------------------------------------------------------------
 
 
@@ -299,6 +306,82 @@ class TestTick:
         s, net = _make_scrobbler()
         self._advance(s, _track(artist="", title="Metronomic Underground"), 35.0)
         net.scrobble.assert_not_called()
+
+    # -- duration-aware threshold (KAMP-619) --------------------------------
+    # _advance(s, t, N) yields N-1 seconds of accumulated listening (the first
+    # tick after on_track_changed does not accumulate), so boundary values below
+    # are chosen with that off-by-one in mind.
+
+    def test_long_track_scrobbles_at_4min_cap_not_half(self) -> None:
+        """A 10-min track (half=300s) is capped at the 240s ceiling."""
+        s, net = _make_scrobbler()
+        # 234s listened < 240 cap → no scrobble (and proves half=300 is not used).
+        self._advance(s, _track(duration=600), 235.0)
+        net.scrobble.assert_not_called()
+        # 244s listened ≥ 240 cap → scrobble.
+        self._advance(s, _track(duration=600), 245.0)
+        net.scrobble.assert_called_once()
+
+    def test_track_scrobbles_at_half_duration(self) -> None:
+        """A 200s track scrobbles at half (100s), between the 30 floor and 240 cap."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(duration=200), 95.0)  # 94s < 100
+        net.scrobble.assert_not_called()
+        self._advance(s, _track(duration=200), 105.0)  # 104s ≥ 100
+        net.scrobble.assert_called_once()
+
+    def test_cap_boundary_fires_at_exactly_240s(self) -> None:
+        """duration=480 → half==240; the >= check fires at exactly 240s listened."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(duration=480), 240.0)  # 239s < 240
+        net.scrobble.assert_not_called()
+        self._advance(s, _track(duration=480), 241.0)  # exactly 240s ≥ 240
+        net.scrobble.assert_called_once()
+
+    def test_short_track_floored_at_30s_not_half(self) -> None:
+        """A 50s track (half=25s) is floored to the 30s minimum, not scrobbled at 25s."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(duration=50), 26.0)  # 25s < 30 floor
+        net.scrobble.assert_not_called()
+        self._advance(s, _track(duration=50), 32.0)  # 31s ≥ 30 floor
+        net.scrobble.assert_called_once()
+
+    def test_unknown_duration_falls_back_to_30s(self) -> None:
+        """duration=0 (streams) floors to 30s — the pre-KAMP-619 behavior, not the 240 cap."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(duration=0), 29.0)  # 28s < 30
+        net.scrobble.assert_not_called()
+        self._advance(s, _track(duration=0), 31.0)  # 30s ≥ 30
+        net.scrobble.assert_called_once()
+
+    def test_tiny_duration_does_not_scrobble_instantly(self) -> None:
+        """A corrupt 2s duration (half=1s) is floored to 30s, not scrobbled on tick 2."""
+        s, net = _make_scrobbler()
+        self._advance(s, _track(duration=2), 5.0)  # 4s listened
+        net.scrobble.assert_not_called()
+
+    def test_threshold_reads_current_track_duration(self) -> None:
+        """The threshold tracks the current track's duration, not a captured constant."""
+        s, net = _make_scrobbler()
+        # Instance 1: 200s track (threshold 100) crosses at 104s → one scrobble.
+        self._advance(s, _track(duration=200), 105.0)
+        assert net.scrobble.call_count == 1
+        # Instance 2: 600s track (threshold 240). 149s listened is under the new
+        # threshold — if the old 100 were reused this would wrongly fire.
+        self._advance(s, _track(duration=600), 150.0)
+        assert net.scrobble.call_count == 1
+        # Cross the 240 threshold on instance 2.
+        self._advance(s, _track(duration=600), 245.0)
+        assert net.scrobble.call_count == 2
+
+    def test_eof_scrobbles_below_raised_threshold(self) -> None:
+        """A long track played briefly then ended still scrobbles at EOF."""
+        s, net = _make_scrobbler()
+        t = _track(duration=600)  # threshold 240
+        self._advance(s, t, 30.0)  # 29s listened < 240 → tick has not scrobbled
+        net.scrobble.assert_not_called()
+        s.on_track_ended(t)
+        net.scrobble.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## KAMP-619: scrobble at 50%-or-4-minutes, whichever comes first

Aligns kamp's Last.fm scrobble timing with the standard every other scrobbler uses. Today a scrobble fires after a fixed **30 seconds** of listening; now it fires after **half the track's duration OR 4 minutes, whichever comes first**.

### Change

`Scrobbler.tick` computes the threshold per track from `track.duration`:

```python
threshold = min(max(track.duration / 2, 30.0), 240.0)
```

| Track | Scrobbles after |
|-------|-----------------|
| 10 min | 4:00 (the cap) |
| 3 min | 1:30 (half) |
| 50 s | 0:30 (floor) |
| unknown duration (stream) | 0:30 (floor = today's behavior) |

**Why the floor, not the pure `min(duration/2, 240)`:** Bandcamp/streaming tracks have `duration == 0` (the KAMP-399 duration backfill is `source = 'local'` only). The pure form would scrobble those instantly at zero, and raising their threshold to 240 s would mean short streamed tracks never reach the timed scrobble — a skip-before-EOF would drop the scrobble entirely. The 30 s floor closes both the zero- and near-zero-duration traps and preserves today's behavior for streams. The only cost is a known 30–60 s track scrobbling at 30 s instead of pure half (e.g. 50 s → 30 s, not 25 s) — harmless, still one scrobble per play instance.

Unchanged: the cumulative-listening model (accumulate only while playing), the once-per-play-instance guard, and the natural-EOF fallback scrobble. Last.fm's separate ">30 s track-length" exclusion is intentionally **not** implemented (noted in a comment at the threshold); short tracks still scrobble at natural EOF exactly as before.

### Tests

Added a `duration` param to the `_track()` fixture and pinned the new formula: 4-min cap, half rule, exact 240 s boundary, 30 s floor, unknown-duration fallback, near-zero (corrupt-tag) guard, per-instance duration re-read, and EOF firing below a raised threshold. The existing 30 s cases remain valid as the unknown-duration (duration=0) regression net.

Design vetted with the Reality Checker, which rejected the pure-`min` fallback for the streaming regression above.

### Verification

- `poetry run pytest tests/test_scrobbler.py -v --no-cov` → 42 passed
- Full suite: 2633 passed, 9 skipped; coverage 93.76% (gate 93%)
- `black --check` and `mypy` clean
- README has no scrobbling references — no doc drift

### Manual test plan

- ~6 min track → scrobble at ~4:00 (daemon log `Scrobbled: … (N s listened)` + last.fm)
- ~3 min track → ~1:30; ~50 s track → ~30 s
- Bandcamp stream (unknown duration) past 30 s → still scrobbles (no regression)
- Pause partway then resume → cumulative time still reaches threshold; one scrobble
- Long track ended before threshold → EOF scrobble still fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)
