### PR TITLE
KAMP-626: Now Playing bokeh — cursor parallax

### DIFF
--- a/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
+++ b/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
@@ -77,7 +77,28 @@ function BokehCanvas({ active, artUrl }: Props): React.JSX.Element {
     if (shouldAnimate) {
       engine.resize()
       engine.start()
-      return () => engine.stop()
+      // Cursor parallax: drive the eased offset from motion over the pane only
+      // (scoped to .now-playing, not window, so nothing outside it moves the field).
+      // The handlers close over the null-checked local `engine`, so a late event
+      // after teardown is inert. Add + remove are symmetric within this branch.
+      const pane = canvasRef.current?.closest('.now-playing') as HTMLElement | null
+      if (!pane) return () => engine.stop()
+      const onMove = (e: PointerEvent): void => {
+        const rect = pane.getBoundingClientRect()
+        if (rect.width === 0 || rect.height === 0) return
+        engine.setPointer(
+          ((e.clientX - rect.left) / rect.width) * 2 - 1,
+          ((e.clientY - rect.top) / rect.height) * 2 - 1
+        )
+      }
+      const onLeave = (): void => engine.setPointer(0, 0)
+      pane.addEventListener('pointermove', onMove, { passive: true })
+      pane.addEventListener('pointerleave', onLeave, { passive: true })
+      return () => {
+        pane.removeEventListener('pointermove', onMove)
+        pane.removeEventListener('pointerleave', onLeave)
+        engine.stop()
+      }
     }
     engine.stop()
     // Reduced-motion (still active) gets a static repaint; inactive/hidden paints

--- a/kamp_ui/src/renderer/src/components/nowplaying/TUNING.md
+++ b/kamp_ui/src/renderer/src/components/nowplaying/TUNING.md
@@ -5,16 +5,16 @@ the top of two files, plus one CSS line. Nothing here needs a rebuild to try —
 Vite hot-reloads edits, so you can slide values with the app running. All knobs
 are at conservative midpoints; this is the map for adjusting the character by eye.
 
-Grouped by what you actually *see*.
+Grouped by what you actually _see_.
 
 ## Color / mood — `palette.ts`
 
-| Knob | Default | Raise it → |
-|------|---------|-----------|
-| `SAT_FLOOR` | 0.45 | More vivid, punchier colors (lower → muted / pastel) |
-| `LIGHT_MIN` / `LIGHT_MAX` | 0.45 / 0.68 | Brighter glow; widen the gap for more tonal variety |
-| `MONO_SAT_THRESHOLD` | 0.12 | More covers judged "grey" and fall back to the theme accent (lower → trusts faint cover colors) |
-| `HUE_BINS` | 16 | Finer hue separation — more distinct swatches from busy covers |
+| Knob                      | Default     | Raise it →                                                                                      |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `SAT_FLOOR`               | 0.45        | More vivid, punchier colors (lower → muted / pastel)                                            |
+| `LIGHT_MIN` / `LIGHT_MAX` | 0.45 / 0.68 | Brighter glow; widen the gap for more tonal variety                                             |
+| `MONO_SAT_THRESHOLD`      | 0.12        | More covers judged "grey" and fall back to the theme accent (lower → trusts faint cover colors) |
+| `HUE_BINS`                | 16          | Finer hue separation — more distinct swatches from busy covers                                  |
 
 ## Softness / blur — `assets/track-list.css`, `.now-playing-bokeh`
 
@@ -23,21 +23,33 @@ Grouped by what you actually *see*.
 
 ## Motion feel — `bokehEngine.ts`
 
-| Knob | Default | Effect |
-|------|---------|--------|
-| `TIERS[*].cross` | 45–150 s | Seconds to cross the screen. **Raise for slower, calmer drift**; lower for livelier. |
-| `CROSSFADE_MS` | 1000 | Track-change recolor duration. Raise for a lazier color morph. |
-| `ax` / `ay` (in `makeOrb`) | 0.05–0.07 | Wobble amplitude — higher = more meandering, less linear travel. |
-| `breathP` | 12–20 s | Breathing period. Depth is set by the `0.08` (scale) and `0.06` (alpha) factors in `draw()`. |
-| `FRAME_MS` | 33 (~30 fps) | Frame cap. Raise (~50 → ~20 fps) for an even lazier, lighter feel. |
+| Knob                       | Default      | Effect                                                                                       |
+| -------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| `TIERS[*].cross`           | 45–150 s     | Seconds to cross the screen. **Raise for slower, calmer drift**; lower for livelier.         |
+| `CROSSFADE_MS`             | 1000         | Track-change recolor duration. Raise for a lazier color morph.                               |
+| `ax` / `ay` (in `makeOrb`) | 0.05–0.07    | Wobble amplitude — higher = more meandering, less linear travel.                             |
+| `breathP`                  | 12–20 s      | Breathing period. Depth is set by the `0.08` (scale) and `0.06` (alpha) factors in `draw()`. |
+| `FRAME_MS`                 | 33 (~30 fps) | Frame cap. Raise (~50 → ~20 fps) for an even lazier, lighter feel.                           |
+
+## Cursor parallax — `bokehEngine.ts` (KAMP-626)
+
+As the cursor moves over the Now Playing pane the orb field eases a few pixels
+_opposite_ the cursor, then settles. Subtle and heavily damped by design; off under
+`prefers-reduced-motion` and when the pane is inactive/hidden.
+
+| Knob                    | Default                             | Effect                                                                                                                                                                                                                   |
+| ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `TIERS[*].parallax`     | hero 0.010, mid 0.020, accent 0.028 | Per-tier shift amplitude (fraction of the short edge). Raise for a stronger effect. The mapping is intentionally inverted from physical depth — big orbs move least, so the backdrop stays calm while the accents dance. |
+| `PARALLAX_TAU`          | 0.35 s                              | Damping time constant. Higher = slower, heavier follow; lower = snappier.                                                                                                                                                |
+| offset sign in `draw()` | subtract                            | Orbs move opposite the cursor (depth read). Flip to add for a "drag the field" feel.                                                                                                                                     |
 
 ## Density / size / intensity — `bokehEngine.ts`
 
-| Knob | Default | Effect |
-|------|---------|--------|
-| `TIERS[*].size` | hero 0.55–0.75, mid 0.30–0.45, accent 0.12–0.22 | Orb diameter as a fraction of the short screen edge. Bigger hero orbs = more color wash. |
-| `TIERS[*].alpha` | 0.32–0.56 | Per-orb opacity. **Lower the whole set to let the art pop more**; raise for a bolder background. |
-| `ORB_PLAN` | 7 entries | Orb *count* and which palette slot each orb wears. Add/remove rows to change density. |
+| Knob             | Default                                         | Effect                                                                                           |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `TIERS[*].size`  | hero 0.55–0.75, mid 0.30–0.45, accent 0.12–0.22 | Orb diameter as a fraction of the short screen edge. Bigger hero orbs = more color wash.         |
+| `TIERS[*].alpha` | 0.32–0.56                                       | Per-orb opacity. **Lower the whole set to let the art pop more**; raise for a bolder background. |
+| `ORB_PLAN`       | 7 entries                                       | Orb _count_ and which palette slot each orb wears. Add/remove rows to change density.            |
 
 ## Focus on the art (vignette) — `bokehEngine.ts`, `drawVignette()`
 
@@ -63,6 +75,6 @@ Start with three knobs — they change the character the most:
 
 ## Deferred ideas (filed as follow-up tickets)
 
-Cursor parallax, occasional "firefly" motes, a track-change "bloom" pulse, per-theme
-palette tinting, and a dev-only swatch overlay to visualize the extracted palette
-while tuning. See the KAMP tickets linked from KAMP-561.
+Occasional "firefly" motes (KAMP-627), a track-change "bloom" pulse (KAMP-628),
+per-theme palette tinting (KAMP-629), and a dev-only swatch overlay to visualize the
+extracted palette while tuning (KAMP-630). Cursor parallax shipped in KAMP-626 (above).

--- a/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
+++ b/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
@@ -14,6 +14,7 @@ const MAX_DPR = 2
 const FRAME_MS = 33 // ~30fps cap — slow drift needs no more
 const CROSSFADE_MS = 1000 // palette recolor duration on track change
 const EDGE_MARGIN = 0.45 // wrap distance beyond [0,1] before respawning an orb
+const PARALLAX_TAU = 0.35 // seconds — heavy exponential damping of cursor parallax
 
 type Tier = 'hero' | 'mid' | 'accent'
 
@@ -33,18 +34,28 @@ interface Orb {
   breathPhase: number
   baseAlpha: number
   colorIndex: number // stable palette slot (so recolor never flickers)
+  parallax: number // cursor-parallax amplitude, fraction of S
 }
 
 const rand = (min: number, max: number): number => min + Math.random() * (max - min)
 
 // Tier -> [count, sizePct range, alpha range, cross-screen seconds range].
+// `parallax` is the per-tier cursor-parallax amplitude. Note the mapping is
+// intentionally *inverted* from physical depth: hero (big) orbs move least and the
+// small accents move most, so the calm backdrop stays still while the sparkle
+// dances. It reads as atmosphere, not a literal 3D depth cue.
 const TIERS: Record<
   Tier,
-  { size: [number, number]; alpha: [number, number]; cross: [number, number] }
+  {
+    size: [number, number]
+    alpha: [number, number]
+    cross: [number, number]
+    parallax: number
+  }
 > = {
-  hero: { size: [0.55, 0.75], alpha: [0.32, 0.4], cross: [90, 150] },
-  mid: { size: [0.3, 0.45], alpha: [0.4, 0.5], cross: [60, 110] },
-  accent: { size: [0.12, 0.22], alpha: [0.5, 0.56], cross: [45, 70] }
+  hero: { size: [0.55, 0.75], alpha: [0.32, 0.4], cross: [90, 150], parallax: 0.01 },
+  mid: { size: [0.3, 0.45], alpha: [0.4, 0.5], cross: [60, 110], parallax: 0.02 },
+  accent: { size: [0.12, 0.22], alpha: [0.5, 0.56], cross: [45, 70], parallax: 0.028 }
 }
 
 // 7 orbs, most-dominant palette slots to the big hero orbs.
@@ -78,7 +89,8 @@ function makeOrb(plan: { tier: Tier; colorIndex: number }): Orb {
     breathP: rand(12, 20),
     breathPhase: rand(0, Math.PI * 2),
     baseAlpha: rand(t.alpha[0], t.alpha[1]),
-    colorIndex: plan.colorIndex
+    colorIndex: plan.colorIndex,
+    parallax: t.parallax
   }
 }
 
@@ -101,6 +113,15 @@ export class BokehEngine {
   private from: RGB[]
   private to: RGB[]
   private paletteT = 1 // 0..1
+
+  // Cursor parallax. Target is set by pointer events (normalized [-1,1], 0 =
+  // pane center); the rendered value eases toward it in advance(). Both start
+  // centered and are reset to center on start() so a resume never inherits a
+  // stale off-center offset.
+  private pointerTargetX = 0
+  private pointerTargetY = 0
+  private pointerX = 0
+  private pointerY = 0
 
   private elapsed = 0 // animation clock (seconds), advances only while running
   private rafId: number | null = null
@@ -139,6 +160,23 @@ export class BokehEngine {
     if (!this.rafId) this.renderStatic() // reduced-motion path repaints on change
   }
 
+  // Set the parallax target from a normalized cursor position (0 = pane center).
+  // Clamped so an out-of-pane coordinate can never push the field past its amplitude.
+  setPointer(nx: number, ny: number): void {
+    this.pointerTargetX = Math.max(-1, Math.min(1, nx))
+    this.pointerTargetY = Math.max(-1, Math.min(1, ny))
+  }
+
+  // Snap both the target and the eased value back to center. Called on start() so a
+  // resume after a stop never inherits a frozen off-center offset (nothing eases it
+  // back while the loop is stopped).
+  private resetPointer(): void {
+    this.pointerTargetX = 0
+    this.pointerTargetY = 0
+    this.pointerX = 0
+    this.pointerY = 0
+  }
+
   // HiDPI + reduced-resolution sizing. Bails when the pane is display:none (0x0).
   resize(): void {
     const rect = this.canvas.getBoundingClientRect()
@@ -162,6 +200,7 @@ export class BokehEngine {
     if (this.rafId != null) return
     this.lastTs = 0
     this.lastDraw = 0
+    this.resetPointer() // resume centered; no stale offset from a prior activation
     this.rafId = requestAnimationFrame(this.tick)
   }
 
@@ -193,6 +232,10 @@ export class BokehEngine {
     if (document.hidden) return // belt-and-suspenders; the component also gates
     this.elapsed += dt
     if (this.paletteT < 1) this.paletteT = Math.min(1, this.paletteT + (dt * 1000) / CROSSFADE_MS)
+    // Framerate-independent exponential lag toward the cursor target.
+    const k = 1 - Math.exp(-dt / PARALLAX_TAU)
+    this.pointerX += (this.pointerTargetX - this.pointerX) * k
+    this.pointerY += (this.pointerTargetY - this.pointerY) * k
     for (const o of this.orbs) {
       o.bx += o.vx * dt
       o.by += o.vy * dt
@@ -216,8 +259,10 @@ export class BokehEngine {
       const ox = o.ax * (Math.sin(this.elapsed / o.px1) + Math.sin(this.elapsed / o.px2))
       const oy = o.ay * (Math.sin(this.elapsed / o.py1) + Math.sin(this.elapsed / o.py2))
       const breath = Math.sin(this.elapsed / o.breathP + o.breathPhase)
-      const x = o.bx * w + ox * s
-      const y = o.by * h + oy * s
+      // Subtract the eased pointer offset so orbs drift *opposite* the cursor —
+      // the "peering through a deeper field" read, not dragging the field along.
+      const x = o.bx * w + ox * s - this.pointerX * o.parallax * s
+      const y = o.by * h + oy * s - this.pointerY * o.parallax * s
       const radius = o.sizePct * s * 0.5 * (1 + 0.08 * breath)
       if (radius <= 0) continue
       const alpha = o.baseAlpha * (1 + 0.06 * breath)

--- a/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
+++ b/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
@@ -14,7 +14,7 @@ const MAX_DPR = 2
 const FRAME_MS = 33 // ~30fps cap — slow drift needs no more
 const CROSSFADE_MS = 1000 // palette recolor duration on track change
 const EDGE_MARGIN = 0.45 // wrap distance beyond [0,1] before respawning an orb
-const PARALLAX_TAU = 0.35 // seconds — heavy exponential damping of cursor parallax
+const PARALLAX_TAU = 0.25 // seconds — heavy exponential damping of cursor parallax
 
 type Tier = 'hero' | 'mid' | 'accent'
 
@@ -53,9 +53,9 @@ const TIERS: Record<
     parallax: number
   }
 > = {
-  hero: { size: [0.55, 0.75], alpha: [0.32, 0.4], cross: [90, 150], parallax: 0.01 },
-  mid: { size: [0.3, 0.45], alpha: [0.4, 0.5], cross: [60, 110], parallax: 0.02 },
-  accent: { size: [0.12, 0.22], alpha: [0.5, 0.56], cross: [45, 70], parallax: 0.028 }
+  hero: { size: [0.55, 0.75], alpha: [0.32, 0.4], cross: [90, 150], parallax: 0.02 },
+  mid: { size: [0.3, 0.45], alpha: [0.4, 0.5], cross: [60, 110], parallax: 0.04 },
+  accent: { size: [0.12, 0.22], alpha: [0.5, 0.56], cross: [45, 70], parallax: 0.056 }
 }
 
 // 7 orbs, most-dominant palette slots to the big hero orbs.


### PR DESCRIPTION
## KAMP-626: Now Playing bokeh — cursor parallax

First of the deferred delight follow-ups to the ambient bokeh (KAMP-561). As the cursor moves over the Now Playing pane, the orb field eases a few pixels **opposite** the cursor and settles back when the cursor leaves — a subtle sense of depth. Heavily damped; atmosphere, never a game.

### What changed

**`bokehEngine.ts`**
- Per-orb `parallax` amplitude by tier — hero 0.010, mid 0.020, accent 0.028 (fraction of the short edge). The big-moves-least mapping is a deliberate aesthetic (calm backdrop, dancing accents), not a literal depth cue — noted in a comment.
- Normalized pointer target + an eased rendered value, with `setPointer()` / `resetPointer()`. The offset eases toward the target in `advance()` via a framerate-independent exponential lag (`k = 1 - exp(-dt/TAU)`, `TAU = 0.35s`) and is subtracted from each orb's position in `draw()`.
- `start()` resets the pointer so a resume after a stop never inherits a stale off-center offset. `renderStatic()` is untouched, so the reduced-motion frame never reads the pointer.

**`BokehBackground.tsx`**
- `pointermove` / `pointerleave` listeners attached inside the existing `shouldAnimate` effect, scoped to the `.now-playing` pane (not `window`), `{ passive: true }`. Handlers close over the null-checked local `engine`; the effect cleanup removes both listeners **and** stops the loop, so add/remove stays symmetric across every active↔inactive / hidden↔visible transition and on unmount. Motion outside the pane never drives the field.

**`TUNING.md`** — documents the parallax knobs (per-tier amplitudes, `PARALLAX_TAU`, offset sign) and moves cursor parallax out of the deferred list.

Rides the existing "Now Playing glow" toggle — off means no canvas and no listener. No CSS or store changes.

### Design notes

Vetted with the Frontend Developer and Reality Checker. Key calls: scope the listener to the pane rather than `window`; ease in `advance()` (framerate-independent) rather than `draw()`; `resetPointer()` on `start()` to kill a stale-frozen-offset bug on re-activation; and no velocity/spring gold-plating — a single exponential ease is the whole "subtle, damped" spec.

### Verification

- `npm run typecheck` and `npm run lint` clean; prettier applied.
- No unit tests (kamp_ui has no runner) — visual verification below.

### Manual test plan

- Play a track, move the cursor across the pane → orbs ease a few px opposite the cursor, accents a touch more than hero orbs; settle when the cursor stops; leave the pane → field recenters.
- Switch away and back → field starts centered and eases in (no frozen off-center offset).
- OS "reduce motion" on → static gradient, no parallax.
- Toggle "Now Playing glow" off → no canvas, no listener, no effect.
- Cover/minimize the window → no parallax (loop stopped); restore → resumes centered.
- Resize the window → normalization tracks the new pane rect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
