### PR TITLE
KAMP-614: debounce search input to stop per-keystroke request fan-out

### DIFF
--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -198,8 +198,8 @@ async function post<T>(path: string, body?: unknown): Promise<T> {
   return res.json() as Promise<T>
 }
 
-async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, { headers: _authHeaders() })
+async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: _authHeaders(), signal })
   if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`)
   return res.json() as Promise<T>
 }
@@ -339,8 +339,12 @@ export type SearchResult = {
   playlists: PlaylistSearchResult[]
 }
 
-export const search = (q: string, sort = 'album_artist'): Promise<SearchResult> =>
-  get(`/api/v1/search?q=${encodeURIComponent(q)}&sort=${encodeURIComponent(sort)}`)
+export const search = (
+  q: string,
+  sort = 'album_artist',
+  signal?: AbortSignal
+): Promise<SearchResult> =>
+  get(`/api/v1/search?q=${encodeURIComponent(q)}&sort=${encodeURIComponent(sort)}`, signal)
 
 export type RepeatMode = 'off' | 'queue' | 'album' | 'single'
 

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -370,6 +370,16 @@ const initialPlayer: PlayerState = {
 const _albumTracksKey = (albumArtist: string, album: string, trackId: number | null): string =>
   trackId != null ? `id:${trackId}` : `${albumArtist}\0${album}`
 
+// KAMP-614: debounce the search request so a burst of keystrokes fires ONE
+// backend call after the user pauses, not one per letter. Each /api/v1/search
+// runs a whole-library album aggregate that collapses under concurrency (8
+// concurrent calls measured at ~21s), so the fan-out — not any single call —
+// was the ~12s bug. The input text still updates synchronously; only the
+// network call is deferred. _searchAbort cancels a superseded in-flight request.
+const SEARCH_DEBOUNCE_MS = 250
+let _searchTimer: ReturnType<typeof setTimeout> | null = null
+let _searchAbort: AbortController | null = null
+
 // KAMP-571: raw aggregate percent for the global download bar — completed items
 // plus the currently-downloading item's byte-fraction, over the batch total.
 // downloadProgress is keyed by sale_item_id (== provider_item_id for bandcamp);
@@ -570,7 +580,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ sortOrder: sort, sortDir: naturalDir })
     await get().loadLibrary()
     const q = get().searchQuery
-    if (q.trim()) await get().setSearchQuery(q)
+    // Re-run the active search under the new sort (debounced, fire-and-forget).
+    if (q.trim()) get().setSearchQuery(q)
     try {
       await api.setSortOrderApi(sort, naturalDir)
     } catch {
@@ -592,21 +603,38 @@ export const useStore = create<PlayerStore>((set, get) => ({
     set({ libraryFilter: filters })
   },
 
-  setSearchQuery: async (q) => {
+  setSearchQuery: (q) => {
+    // Update the text synchronously so the controlled input stays responsive;
+    // the network call is debounced separately (KAMP-614).
     set({ searchQuery: q })
+    // Any pending call is now stale — cancel the timer and abort the in-flight
+    // request regardless of whether the new query is empty or not.
+    if (_searchTimer !== null) {
+      clearTimeout(_searchTimer)
+      _searchTimer = null
+    }
+    _searchAbort?.abort()
+    _searchAbort = null
     if (!q.trim()) {
+      // Empty query clears immediately — no delayed empty search.
       set({ searchResults: null })
       return
     }
-    try {
-      const results = await api.search(q, get().sortOrder)
-      // Only apply if the query hasn't changed since we fired the request.
-      if (get().searchQuery === q) {
-        set({ searchResults: results })
-      }
-    } catch {
-      // Ignore transient errors — stale results are better than a broken UI.
-    }
+    _searchTimer = setTimeout(() => {
+      _searchTimer = null
+      const controller = new AbortController()
+      _searchAbort = controller
+      api
+        .search(q, get().sortOrder, controller.signal)
+        .then((results) => {
+          // Latest-wins: only apply if the query hasn't changed since we fired.
+          if (get().searchQuery === q) set({ searchResults: results })
+        })
+        .catch(() => {
+          // Ignore AbortError (superseded request) and transient errors —
+          // stale results are better than a broken UI.
+        })
+    }, SEARCH_DEBOUNCE_MS)
   },
 
   setActiveView: async (view) => {


### PR DESCRIPTION
## KAMP-614: search takes ~12 seconds after integrating genre

### Problem
Cmd-K / search-bar search took ~12s to return. The search input fired a backend `/api/v1/search` request on **every keystroke** with no debounce — typing "messa" fired 5 concurrent requests (q=m, me, mes, mess, messa), confirmed in the live daemon log alongside overlapping `/api/v1/albums` load calls.

Each `/api/v1/search` internally runs `index.albums(sort)` — the whole-library album aggregate (materializes the `tracks_with_stats` view, ~13.7k rows) **plus** the KAMP-550 genre pass (full scan of all ~78k `track_genres` rows into a GIL-holding Python loop). In isolation one call is ~380ms, but under the per-keystroke fan-out the concurrent calls collapse: **8 concurrent calls measured at ~21s wall-clock** (vs 3.7s sequential), from GIL + SQLite page-cache/temp-btree contention across simultaneous whole-library materializations. That fan-out is the ~12s bug.

### Fix (frontend-only)
Debounce the search **network call** by 250ms so a burst of keystrokes fires **one** request after the user pauses. The input text still updates synchronously (the controlled input stays responsive) — only `api.search` is deferred.

- `api/client.ts` — thread an optional `AbortSignal` through `get()` and `search()`, matching the pattern already used by other client calls.
- `store.ts` — rework `setSearchQuery`: immediate text set; module-level 250ms debounce timer + `AbortController`; abort the superseded in-flight request; clear results immediately on an empty query (no delayed empty search); preserve the latest-wins guard and swallow `AbortError`.

Backend behavior is unchanged.

### Scope note
The residual per-call `albums()` cost (whole-library view materialization + 78k-row genre pass) is the shared root of the same symptom in **KAMP-615** (initial library load, which genuinely needs the whole-library aggregate). That backend optimization (SQL genre aggregation / memoization) is tracked there — it will fix initial load and make this debounced single search snappier too.

### Testing
- `npm run typecheck` and `npm run lint` pass; pre-commit hooks (black/mypy/typecheck/lint) pass.
- No frontend unit-test runner exists in `kamp_ui`; verified manually in the running dev app.

Manual test plan (verified):
- Type "messa" quickly → daemon log shows a **single** `GET /api/v1/search?q=messa` (not one per letter); results appear well under a second.
- Type fast then keep typing → superseded requests abort; no stale-result flash.
- Clear the search (✕ button and by deleting all text) → results reset immediately; no delayed empty search fires.
- Change sort with a query active → search re-runs correctly under the new sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
