### PR TITLE
KAMP-615: fast library load — optimize albums() genre pass + loading-state gate

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -6864,6 +6864,54 @@ class LibraryIndex:
         if self.on_fields_changed:
             self.on_fields_changed({"album.favorite"})
 
+    def _album_genre_maps(
+        self,
+    ) -> tuple[dict[int, list[str]], dict[int, list[str]]]:
+        """Return (genres_by_album, genres_by_track) for ``albums()`` (KAMP-550).
+
+        Both map to a NOCASE-sorted list of genre names. ``genres.name`` is
+        already the single canonical casing, so each list is duplicate-free.
+
+        Split into two SQL-aggregated passes (KAMP-615) instead of one 78k-row
+        (track x genre) scan + Python dedup, which held the GIL and collapsed
+        under the concurrent startup fan-out (8 concurrent albums() = ~18s):
+
+        - ``genres_by_album`` uses ``SELECT DISTINCT album_id, name`` so SQLite
+          collapses each album's genres to one row per (album, genre); the
+          Python side just appends.
+        - ``genres_by_track`` is fetched ONLY for missing-album tracks
+          (``album = ''``). INVARIANT: it is only ever indexed by an
+          ``albums()`` missing-album ``missing_track_id``, and the main UNION
+          defines those entries as exactly ``WHERE t.album = ''`` — the same
+          predicate — so this restriction is behaviour-preserving. Do not index
+          this map by an arbitrary track id.
+
+        The ``, g.name`` tie-break after ``COLLATE NOCASE`` makes ordering
+        deterministic across SQLite versions (dev 3.51 vs the bundled/CI older
+        build) for any hypothetical case-variant genres.
+        """
+        genres_by_album: dict[int, list[str]] = {}
+        for gr in self._conn.execute(
+            "SELECT DISTINCT t.album_id AS aid, g.name AS name"
+            " FROM track_genres tg"
+            " JOIN genres g ON g.id = tg.genre_id"
+            " JOIN tracks t ON t.id = tg.track_id"
+            " WHERE t.album_id IS NOT NULL"
+            " ORDER BY g.name COLLATE NOCASE, g.name"
+        ).fetchall():
+            genres_by_album.setdefault(gr["aid"], []).append(gr["name"])
+        genres_by_track: dict[int, list[str]] = {}
+        for gr in self._conn.execute(
+            "SELECT t.id AS tid, g.name AS name"
+            " FROM track_genres tg"
+            " JOIN genres g ON g.id = tg.genre_id"
+            " JOIN tracks t ON t.id = tg.track_id"
+            " WHERE t.album = ''"
+            " ORDER BY g.name COLLATE NOCASE, g.name"
+        ).fetchall():
+            genres_by_track.setdefault(gr["tid"], []).append(gr["name"])
+        return genres_by_album, genres_by_track
+
     def albums(
         self, sort: str = "album_artist", sort_dir: str | None = None
     ) -> list[AlbumInfo]:
@@ -6968,26 +7016,8 @@ class LibraryIndex:
             WHERE t.album = ''
             ORDER BY {order_by}
             """).fetchall()  # noqa: S608 — order_by is from a whitelist, not user input
-        # Per-album genre union (KAMP-550), read from the normalized track_genres
-        # in one grouped pass. Keyed both by album_id (named albums) and track_id
-        # (missing-album virtual entries have no albums row), so each entry can
-        # resolve its own. Ordered by NOCASE name so each union comes out sorted;
-        # genres.name is already the single canonical casing, so plain membership
-        # dedup suffices.
-        genres_by_album: dict[int, list[str]] = {}
-        genres_by_track: dict[int, list[str]] = {}
-        for gr in self._conn.execute(
-            "SELECT t.album_id AS aid, t.id AS tid, g.name AS name"
-            " FROM track_genres tg"
-            " JOIN genres g ON g.id = tg.genre_id"
-            " JOIN tracks t ON t.id = tg.track_id"
-            " ORDER BY g.name COLLATE NOCASE"
-        ).fetchall():
-            if gr["aid"] is not None:
-                album_list = genres_by_album.setdefault(gr["aid"], [])
-                if gr["name"] not in album_list:
-                    album_list.append(gr["name"])
-            genres_by_track.setdefault(gr["tid"], []).append(gr["name"])
+        # Per-album genre union (KAMP-550), resolved once for the whole result.
+        genres_by_album, genres_by_track = self._album_genre_maps()
 
         return [
             AlbumInfo(

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -606,6 +606,16 @@ _DEFAULT_SORT_DIR: dict[str, str] = {
     "release_date": "DESC",
 }
 
+# top_albums() metric -> (albums-table column, presence filter) whitelist
+# (KAMP-615). The home "Top Albums" / "Last Played" modules need only the top-N
+# named albums by a metric that's already denormalized on the albums table, so
+# they rank off it directly instead of aggregating the whole library. Values are
+# a fixed whitelist — never interpolate caller input into the SQL.
+_TOP_ALBUM_METRICS: dict[str, tuple[str, str]] = {
+    "most_played": ("play_count_avg", "play_count_avg > 0"),
+    "last_played": ("last_played_at", "last_played_at IS NOT NULL"),
+}
+
 
 def _make_fts_query(q: str) -> str:
     """Convert a plain user query into an FTS5 MATCH expression.
@@ -869,6 +879,58 @@ _ALBUM_SOURCE_SUBQUERY = (
     "  FROM (SELECT " + _EFFECTIVE_SOURCE_EXPR + " AS eff"
     "        FROM tracks t WHERE t.album_id = albums.id) es)"
 )
+
+# The named-album SELECT projection shared by albums() (its first UNION branch)
+# and top_albums() (KAMP-615). Both aggregate the same columns per album over
+# `albums a LEFT JOIN tracks_with_stats t ... LEFT JOIN bandcamp_collection bc`
+# (GROUP BY a.id); keeping the list in one place means a new AlbumInfo field is
+# added once, not at two divergent query sites.
+_NAMED_ALBUM_COLUMNS = f"""
+                a.id                AS album_id,
+                NULL                AS missing_track_id,
+                a.album_artist,
+                a.album,
+                a.release_date,
+                a.source            AS album_source,
+                a.sale_item_id,
+                a.favorite          AS is_favorite,
+                -- "date added" sorts on the latest content-arrival time so a
+                -- pre-order that gained a track re-surfaces (KAMP-544); falls back
+                -- to date_added for albums never bumped.
+                COALESCE(a.last_track_added_at, a.date_added) AS sort_date_added,
+                a.last_played_at    AS sort_last_played,
+                a.play_count_avg    AS sort_play_count_avg,
+                NULLIF(a.release_date, '')  AS sort_release_date,
+                a.art_version,
+                -- has_art: remote-only albums always have CDN art; others use embedded_art.
+                CASE WHEN a.source = 'bandcamp' THEN 1 ELSE a.embedded_art END AS has_art,
+                0                   AS missing_album,
+                ''                  AS file_path,
+                -- track_count: for mixed or local albums count only local tracks
+                -- so the dedup state (local+remote rows coexisting) shows real files.
+                CASE WHEN a.source IN ('mixed', 'local')
+                     THEN COUNT(CASE WHEN {_eff_source("t")} = 'local' THEN 1 END)
+                     ELSE COUNT(t.id)
+                END                 AS track_count,
+                MAX(t.favorite)     AS has_favorite_track,
+                -- in_bandcamp_collection: True only when mode='local' (user downloaded it).
+                CASE WHEN bc.mode = 'local' THEN 1 ELSE 0 END AS in_bc,
+                -- is_preorder: True when the album is a Bandcamp pre-order (KAMP-423).
+                CASE WHEN bc.mode = 'preorder' THEN 1 ELSE 0 END AS is_preorder,
+                -- num_streamable_tracks: 0 => no streamable version (KAMP-527).
+                COALESCE(bc.num_streamable_tracks, 0) AS num_streamable_tracks,
+                -- album_url: Bandcamp page URL for sharing (KAMP-367).
+                COALESCE(bc.album_url, '') AS album_url,
+                -- display overrides for streaming albums (KAMP-467).
+                a.display_album,
+                a.display_album_artist,
+                -- effective album title used for sort-by-album ordering.
+                COALESCE(a.display_album, a.album) AS sort_album"""
+
+_NAMED_ALBUM_FROM = """
+            FROM albums a
+            LEFT JOIN tracks_with_stats t ON t.album_id = a.id
+            LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id"""
 
 
 class LibraryIndex:
@@ -6865,9 +6927,14 @@ class LibraryIndex:
             self.on_fields_changed({"album.favorite"})
 
     def _album_genre_maps(
-        self,
+        self, album_ids: list[int] | None = None
     ) -> tuple[dict[int, list[str]], dict[int, list[str]]]:
         """Return (genres_by_album, genres_by_track) for ``albums()`` (KAMP-550).
+
+        *album_ids* (KAMP-615): when given, ``genres_by_album`` is scoped to just
+        those albums (for ``top_albums()``, which returns only named albums), and
+        ``genres_by_track`` comes back empty — the scoped callers have no
+        missing-album entries. ``None`` computes both maps for the whole library.
 
         Both map to a NOCASE-sorted list of genre names. ``genres.name`` is
         already the single canonical casing, so each list is duplicate-free.
@@ -6890,26 +6957,35 @@ class LibraryIndex:
         deterministic across SQLite versions (dev 3.51 vs the bundled/CI older
         build) for any hypothetical case-variant genres.
         """
+        if album_ids is not None:
+            scope = f" AND t.album_id IN ({','.join('?' * len(album_ids))})"
+            params: tuple[int, ...] = tuple(album_ids)
+        else:
+            scope, params = "", ()
         genres_by_album: dict[int, list[str]] = {}
-        for gr in self._conn.execute(
-            "SELECT DISTINCT t.album_id AS aid, g.name AS name"
-            " FROM track_genres tg"
-            " JOIN genres g ON g.id = tg.genre_id"
-            " JOIN tracks t ON t.id = tg.track_id"
-            " WHERE t.album_id IS NOT NULL"
-            " ORDER BY g.name COLLATE NOCASE, g.name"
-        ).fetchall():
-            genres_by_album.setdefault(gr["aid"], []).append(gr["name"])
+        if album_ids is None or album_ids:
+            for gr in self._conn.execute(
+                "SELECT DISTINCT t.album_id AS aid, g.name AS name"
+                " FROM track_genres tg"
+                " JOIN genres g ON g.id = tg.genre_id"
+                " JOIN tracks t ON t.id = tg.track_id"
+                " WHERE t.album_id IS NOT NULL"
+                + scope
+                + " ORDER BY g.name COLLATE NOCASE, g.name",
+                params,
+            ).fetchall():
+                genres_by_album.setdefault(gr["aid"], []).append(gr["name"])
         genres_by_track: dict[int, list[str]] = {}
-        for gr in self._conn.execute(
-            "SELECT t.id AS tid, g.name AS name"
-            " FROM track_genres tg"
-            " JOIN genres g ON g.id = tg.genre_id"
-            " JOIN tracks t ON t.id = tg.track_id"
-            " WHERE t.album = ''"
-            " ORDER BY g.name COLLATE NOCASE, g.name"
-        ).fetchall():
-            genres_by_track.setdefault(gr["tid"], []).append(gr["name"])
+        if album_ids is None:
+            for gr in self._conn.execute(
+                "SELECT t.id AS tid, g.name AS name"
+                " FROM track_genres tg"
+                " JOIN genres g ON g.id = tg.genre_id"
+                " JOIN tracks t ON t.id = tg.track_id"
+                " WHERE t.album = ''"
+                " ORDER BY g.name COLLATE NOCASE, g.name"
+            ).fetchall():
+                genres_by_track.setdefault(gr["tid"], []).append(gr["name"])
         return genres_by_album, genres_by_track
 
     def albums(
@@ -6939,49 +7015,8 @@ class LibraryIndex:
         order_by = clause.format(dir=dir_sql)
         rows = self._conn.execute(f"""
             SELECT
-                a.id                AS album_id,
-                NULL                AS missing_track_id,
-                a.album_artist,
-                a.album,
-                a.release_date,
-                a.source            AS album_source,
-                a.sale_item_id,
-                a.favorite          AS is_favorite,
-                -- "date added" sorts on the latest content-arrival time so a
-                -- pre-order that gained a track re-surfaces (KAMP-544); falls back
-                -- to date_added for albums never bumped.
-                COALESCE(a.last_track_added_at, a.date_added) AS sort_date_added,
-                a.last_played_at    AS sort_last_played,
-                a.play_count_avg    AS sort_play_count_avg,
-                NULLIF(a.release_date, '')  AS sort_release_date,
-                a.art_version,
-                -- has_art: remote-only albums always have CDN art; others use embedded_art.
-                CASE WHEN a.source = 'bandcamp' THEN 1 ELSE a.embedded_art END AS has_art,
-                0                   AS missing_album,
-                ''                  AS file_path,
-                -- track_count: for mixed or local albums count only local tracks
-                -- so the dedup state (local+remote rows coexisting) shows real files.
-                CASE WHEN a.source IN ('mixed', 'local')
-                     THEN COUNT(CASE WHEN {_eff_source("t")} = 'local' THEN 1 END)
-                     ELSE COUNT(t.id)
-                END                 AS track_count,
-                MAX(t.favorite)     AS has_favorite_track,
-                -- in_bandcamp_collection: True only when mode='local' (user downloaded it).
-                CASE WHEN bc.mode = 'local' THEN 1 ELSE 0 END AS in_bc,
-                -- is_preorder: True when the album is a Bandcamp pre-order (KAMP-423).
-                CASE WHEN bc.mode = 'preorder' THEN 1 ELSE 0 END AS is_preorder,
-                -- num_streamable_tracks: 0 => no streamable version (KAMP-527).
-                COALESCE(bc.num_streamable_tracks, 0) AS num_streamable_tracks,
-                -- album_url: Bandcamp page URL for sharing (KAMP-367).
-                COALESCE(bc.album_url, '') AS album_url,
-                -- display overrides for streaming albums (KAMP-467).
-                a.display_album,
-                a.display_album_artist,
-                -- effective album title used for sort-by-album ordering.
-                COALESCE(a.display_album, a.album) AS sort_album
-            FROM albums a
-            LEFT JOIN tracks_with_stats t ON t.album_id = a.id
-            LEFT JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id
+                {_NAMED_ALBUM_COLUMNS}
+            {_NAMED_ALBUM_FROM}
             GROUP BY a.id
             UNION ALL
             -- Missing-album tracks: each track with album='' appears as its own
@@ -7018,40 +7053,109 @@ class LibraryIndex:
             """).fetchall()  # noqa: S608 — order_by is from a whitelist, not user input
         # Per-album genre union (KAMP-550), resolved once for the whole result.
         genres_by_album, genres_by_track = self._album_genre_maps()
-
         return [
-            AlbumInfo(
-                album_id=r["album_id"],
-                missing_track_id=r["missing_track_id"],
-                album_artist=r["album_artist"],
-                album=r["album"],
-                release_date=r["release_date"],
-                track_count=r["track_count"],
-                has_art=bool(r["has_art"]),
-                missing_album=bool(r["missing_album"]),
-                file_path=r["file_path"],
-                art_version=r["art_version"],
-                added_at=r["sort_date_added"],
-                last_played_at=r["sort_last_played"],
-                play_count_avg=r["sort_play_count_avg"] or 0.0,
-                favorite=bool(r["is_favorite"]),
-                has_favorite_track=bool(r["has_favorite_track"]),
-                source=r["album_source"],
-                has_remote_tracks=r["album_source"] != "local",
-                in_bandcamp_collection=bool(r["in_bc"]),
-                is_preorder=bool(r["is_preorder"]),
-                num_streamable_tracks=r["num_streamable_tracks"],
-                album_url=r["album_url"] or "",
-                sale_item_id=r["sale_item_id"],
-                display_album=r["display_album"],
-                display_album_artist=r["display_album_artist"],
-                genres=(
-                    genres_by_track.get(r["missing_track_id"], [])
-                    if r["missing_album"]
-                    else genres_by_album.get(r["album_id"], [])
-                ),
-            )
-            for r in rows
+            self._album_info_from_row(r, genres_by_album, genres_by_track) for r in rows
+        ]
+
+    @staticmethod
+    def _album_info_from_row(
+        r: sqlite3.Row,
+        genres_by_album: dict[int, list[str]],
+        genres_by_track: dict[int, list[str]],
+    ) -> AlbumInfo:
+        """Map one albums()/top_albums() result row to an AlbumInfo.
+
+        The single AlbumInfo construction site (KAMP-550) shared by both queries
+        so a new field can't be added to one and forgotten on the other. Rows
+        from the named branch (missing_album=0) resolve genres by album_id; the
+        missing-album branch resolves by missing_track_id.
+        """
+        return AlbumInfo(
+            album_id=r["album_id"],
+            missing_track_id=r["missing_track_id"],
+            album_artist=r["album_artist"],
+            album=r["album"],
+            release_date=r["release_date"],
+            track_count=r["track_count"],
+            has_art=bool(r["has_art"]),
+            missing_album=bool(r["missing_album"]),
+            file_path=r["file_path"],
+            art_version=r["art_version"],
+            added_at=r["sort_date_added"],
+            last_played_at=r["sort_last_played"],
+            play_count_avg=r["sort_play_count_avg"] or 0.0,
+            favorite=bool(r["is_favorite"]),
+            has_favorite_track=bool(r["has_favorite_track"]),
+            source=r["album_source"],
+            has_remote_tracks=r["album_source"] != "local",
+            in_bandcamp_collection=bool(r["in_bc"]),
+            is_preorder=bool(r["is_preorder"]),
+            num_streamable_tracks=r["num_streamable_tracks"],
+            album_url=r["album_url"] or "",
+            sale_item_id=r["sale_item_id"],
+            display_album=r["display_album"],
+            display_album_artist=r["display_album_artist"],
+            genres=(
+                genres_by_track.get(r["missing_track_id"], [])
+                if r["missing_album"]
+                else genres_by_album.get(r["album_id"], [])
+            ),
+        )
+
+    def top_albums(
+        self, metric: str, limit: int | None = None, since: float | None = None
+    ) -> list[AlbumInfo]:
+        """Return the top named albums by *metric* (KAMP-615).
+
+        *metric* is a key of ``_TOP_ALBUM_METRICS`` (``most_played`` /
+        ``last_played``); anything else raises ``ValueError``. *limit* caps the
+        count (``None`` = all matching). *since* (unix seconds), for
+        ``last_played`` only, restricts to plays at or after that time (the Last
+        Played module's day-window).
+
+        This is the fast path behind the home modules that previously fetched the
+        entire ``albums()`` result and sliced it client-side — repeatedly, on
+        every track change — which forced a whole-library aggregate + genre pass
+        each time. Here the ranking reads the denormalized ``albums`` table
+        directly (no per-track view materialization), then the AlbumInfo columns
+        and genres are computed for ONLY the top-N albums. Unlike ``albums()``
+        this returns named albums only: missing-album (untagged) tracks never
+        appear in these modules.
+        """
+        try:
+            col, presence = _TOP_ALBUM_METRICS[metric]
+        except KeyError:
+            raise ValueError(f"unknown top-albums metric: {metric!r}") from None
+        where = presence
+        params: list[Any] = []
+        if metric == "last_played" and since is not None:
+            where += " AND last_played_at >= ?"
+            params.append(since)
+        # Rank cheaply off the denormalized albums columns. Tie-break matches the
+        # _SORT_CLAUSES secondary key so ordering is identical to albums().
+        sql = (
+            f"SELECT id FROM albums WHERE {where}"  # noqa: S608 - col/where are whitelisted
+            f" ORDER BY {col} DESC, album_artist COLLATE NOCASE"
+        )
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        ids = [r["id"] for r in self._conn.execute(sql, params).fetchall()]
+        if not ids:
+            return []
+        placeholders = ",".join("?" * len(ids))
+        rows = self._conn.execute(
+            f"SELECT {_NAMED_ALBUM_COLUMNS} {_NAMED_ALBUM_FROM}"  # noqa: S608 - constant projection
+            f" WHERE a.id IN ({placeholders}) GROUP BY a.id",
+            ids,
+        ).fetchall()
+        by_id = {r["album_id"]: r for r in rows}
+        genres_by_album, genres_by_track = self._album_genre_maps(ids)
+        # IN() does not preserve order — re-emit in the ranked id order.
+        return [
+            self._album_info_from_row(by_id[i], genres_by_album, genres_by_track)
+            for i in ids
+            if i in by_id
         ]
 
     def artists(self) -> list[str]:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1464,6 +1464,25 @@ def create_app(
             for a in index.albums(sort=sort, sort_dir=sort_dir)
         ]
 
+    @app.get("/api/v1/albums/top", response_model=list[AlbumOut])
+    def get_top_albums(metric: str, limit: int = 0, since: float = 0) -> list[AlbumOut]:
+        """Top named albums by a denormalized metric (KAMP-615).
+
+        Powers the Top Albums / Last Played home modules cheaply, without the
+        whole-library aggregate that GET /api/v1/albums runs. ``limit=0`` means
+        no cap; ``since`` (unix seconds, ``last_played`` only) applies the Last
+        Played day-window. An unknown metric is a 422.
+        """
+        try:
+            albums = index.top_albums(
+                metric,
+                limit=limit if limit > 0 else None,
+                since=since if since > 0 else None,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return [AlbumOut.from_album_info(a) for a in albums]
+
     @app.get("/api/v1/stats", response_model=StatsOut)
     def get_stats(top_tracks: int = 3) -> StatsOut:
         s = index.get_stats(top_tracks_limit=top_tracks)

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -259,6 +259,15 @@ export const getAlbums = (sort = 'album_artist', dir = ''): Promise<Album[]> =>
     `/api/v1/albums?sort=${encodeURIComponent(sort)}${dir ? `&direction=${encodeURIComponent(dir)}` : ''}`
   )
 
+// Top named albums by a denormalized metric (KAMP-615) — powers the Top Albums
+// and Last Played home modules without the whole-library albums() scan.
+// limit=0 means no cap; since (unix seconds, last_played only) applies a day window.
+export const getTopAlbums = (
+  metric: 'most_played' | 'last_played',
+  limit = 0,
+  since = 0
+): Promise<Album[]> => get(`/api/v1/albums/top?metric=${metric}&limit=${limit}&since=${since}`)
+
 // Returns the URL for an album's cover art; load it in an <img> src.
 // The server returns 404 when no art is embedded — handle with onError.
 // Pass trackId for a missing-album card (album tag empty) to resolve the single

--- a/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumGrid.tsx
@@ -20,6 +20,7 @@ const ALBUM_SORT_OPTIONS = [
 
 export function AlbumGrid(): React.JSX.Element {
   const albums = useStore((s) => s.library.albums)
+  const loaded = useStore((s) => s.library.loaded)
   const selectedArtist = useStore((s) => s.library.selectedArtist)
   const selectedGenre = useStore((s) => s.library.selectedGenre)
   const selectArtist = useStore((s) => s.selectArtist)
@@ -86,7 +87,9 @@ export function AlbumGrid(): React.JSX.Element {
   }
 
   const emptyMessage = (): string => {
-    if (albums.length === 0) return 'No albums in library.'
+    // While the first library fetch is pending, albums is [] — show a neutral
+    // loading message instead of the false "empty library" one (KAMP-615).
+    if (albums.length === 0) return loaded ? 'No albums in library.' : 'Loading…'
     if (libraryFilter.length > 0) return 'No albums match the active filter.'
     if (selectedGenre) return 'No albums for this genre.'
     return 'No albums for this artist.'

--- a/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/LastPlayedModule.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { getAlbums } from '../../api/client'
+import { getTopAlbums } from '../../api/client'
 import type { Album } from '../../api/client'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
@@ -82,16 +82,11 @@ export function LastPlayedModule({ displayStyle }: ModuleProps): React.JSX.Eleme
     // Skip until the server is reachable; this effect re-fires when serverStatus
     // transitions to 'connected', so modules populate without a manual reload.
     if (serverStatus !== 'connected') return
-    getAlbums('last_played')
-      .then((all) => {
-        const cutoff = days > 0 ? Date.now() / 1000 - days * 86400 : null
-        const played = all
-          .filter(
-            (a) => a.last_played_at !== null && (cutoff === null || a.last_played_at >= cutoff)
-          )
-          .slice(0, count > 0 ? count : undefined)
-        setAlbums(played)
-      })
+    // KAMP-615: the server ranks, day-windows, and limits (only top-N albums
+    // enriched) instead of us fetching the whole library on every track change.
+    const since = days > 0 ? Date.now() / 1000 - days * 86400 : 0
+    getTopAlbums('last_played', count > 0 ? count : 0, since)
+      .then(setAlbums)
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [count, days, lastPlayedVersion, serverStatus])

--- a/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/TopAlbumsModule.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { getAlbums } from '../../api/client'
+import { getTopAlbums } from '../../api/client'
 import type { Album } from '../../api/client'
 import { useStore } from '../../store'
 import { ShelfView } from './ShelfView'
@@ -58,13 +58,10 @@ export function TopAlbumsModule({ displayStyle }: ModuleProps): React.JSX.Elemen
 
   useEffect(() => {
     if (serverStatus !== 'connected') return
-    getAlbums('most_played')
-      .then((all) => {
-        const played = all
-          .filter((a) => a.play_count_avg > 0)
-          .slice(0, count > 0 ? count : undefined)
-        setAlbums(played)
-      })
+    // KAMP-615: the server ranks + limits (only top-N albums enriched), instead
+    // of us fetching the whole library and slicing here on every track change.
+    getTopAlbums('most_played', count > 0 ? count : 0)
+      .then(setAlbums)
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [count, currentTrackId, serverStatus])

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -45,6 +45,10 @@ export type TraceStyle = 'clean' | 'glowy' | 'trippy'
 export type PrefsTab = 'about' | 'general' | 'tagging' | 'services' | 'extensions'
 
 type LibraryState = {
+  // False until the first loadLibrary() resolves, so AlbumGrid can distinguish
+  // "still loading" from a genuinely empty library and not flash the empty
+  // message during the initial fetch (KAMP-615).
+  loaded: boolean
   albums: Album[]
   artists: string[]
   genres: string[]
@@ -409,6 +413,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   player: initialPlayer,
   preMuteVolume: 100,
   library: {
+    loaded: false,
     albums: [],
     artists: [],
     genres: [],
@@ -1071,6 +1076,11 @@ export const useStore = create<PlayerStore>((set, get) => ({
         return {
           library: {
             ...s.library,
+            // Set only on success — loadLibrary also runs at mount before the
+            // WS connects (that attempt usually fails); flipping loaded on
+            // failure would let the empty message flash. The WS-connect retry
+            // sets it true once the fetch actually resolves (KAMP-615).
+            loaded: true,
             albums,
             artists,
             genres,

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3884,6 +3884,72 @@ class TestRenameGenre:
         index.close()
 
 
+class TestAlbumGenreMaps:
+    """LibraryIndex._album_genre_maps() — the KAMP-615 genre-pass optimization.
+
+    Guards both correctness (genres surface on named albums and missing-album
+    entries, NOCASE-ordered, deduplicated) and the two properties that make it
+    fast: genres_by_album is distinct-collapsed (one entry per album+genre, not
+    per track), and genres_by_track covers ONLY missing-album (album='') tracks.
+    """
+
+    def _track(self, tmp_path: Path, name: str, album: str, genres: list[str]) -> Track:
+        t = _sample_track(tmp_path / f"{name}.mp3")
+        t.title = name
+        t.album = album
+        t.album_artist = "AA"
+        t.genres = genres
+        return t
+
+    def test_named_album_genres_are_deduped_and_nocase_sorted(
+        self, tmp_path: Path
+    ) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        # Two tracks in one album share a genre and each add one; the album's
+        # genre list must be the deduped union, sorted case-insensitively.
+        index.upsert_many(
+            [
+                self._track(tmp_path, "t1", "One", ["Rock", "ambient"]),
+                self._track(tmp_path, "t2", "One", ["Rock", "Zeuhl"]),
+            ]
+        )
+        album = next(a for a in index.albums() if a.album == "One")
+        index.close()
+        assert album.genres == ["ambient", "Rock", "Zeuhl"]
+
+    def test_missing_album_track_carries_its_genres(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = self._track(tmp_path, "lone", "", ["Jazz", "Blues"])
+        index.upsert_track(t)
+        entry = next(a for a in index.albums() if a.missing_album)
+        index.close()
+        assert entry.genres == ["Blues", "Jazz"]
+
+    def test_genre_maps_scope_row_counts(self, tmp_path: Path) -> None:
+        # Perf-guard: genres_by_album is keyed by album (not track), and
+        # genres_by_track covers only the missing-album track — even though far
+        # more (track, genre) rows exist. This locks in the reason the pass is
+        # fast; a revert to the full-scan/all-tracks form fails here.
+        index = LibraryIndex(tmp_path / "library.db")
+        index.upsert_many(
+            [
+                self._track(tmp_path, "a1", "Alpha", ["Rock", "Pop"]),
+                self._track(tmp_path, "a2", "Alpha", ["Rock", "Pop"]),
+                self._track(tmp_path, "b1", "Beta", ["Jazz"]),
+                self._track(tmp_path, "m1", "", ["Noise", "Drone"]),
+            ]
+        )
+        by_album, by_track = index._album_genre_maps()
+        index.close()
+        # One key per named album; each list is the distinct-collapsed union.
+        alpha_id = next(k for k, v in by_album.items() if set(v) == {"Pop", "Rock"})
+        assert by_album[alpha_id] == ["Pop", "Rock"]  # 2 rows, not 4
+        assert len(by_album) == 2  # Alpha + Beta only; missing album excluded
+        # Only the one missing-album track is present, not all four tracks.
+        assert len(by_track) == 1
+        assert next(iter(by_track.values())) == ["Drone", "Noise"]
+
+
 # ---------------------------------------------------------------------------
 # Sort and record_played
 # ---------------------------------------------------------------------------

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3950,6 +3950,94 @@ class TestAlbumGenreMaps:
         assert next(iter(by_track.values())) == ["Drone", "Noise"]
 
 
+class TestTopAlbums:
+    """LibraryIndex.top_albums() — the KAMP-615 fast path for the home modules.
+
+    Verifies it returns the same top-N named albums the old
+    ``albums(sort=metric)`` + client filter/slice produced, plus its scoping
+    behaviour (limit, day-window, named-only, genres).
+    """
+
+    def _seed(self, tmp_path: Path) -> LibraryIndex:
+        index = LibraryIndex(tmp_path / "library.db")
+        specs = [
+            ("hot", "Zappa", "Hot Rats", ["Rock"]),
+            ("foley", "Amon Tobin", "Foley Room", ["Electronic"]),
+            ("apos", "Zappa", "Apostrophe", ["Rock", "Comedy"]),
+        ]
+        for name, aa, album, genres in specs:
+            p = tmp_path / f"{name}.mp3"
+            _make_mp3(p, artist=aa, album_artist=aa, album=album, title=name)
+            t = _sample_track(p)
+            t.title, t.album_artist, t.album, t.genres = name, aa, album, genres
+            index.upsert_track(t)
+        return index
+
+    def test_most_played_matches_old_filter_slice(self, tmp_path: Path) -> None:
+        index = self._seed(tmp_path)
+        index.record_played(tmp_path / "apos.mp3")
+        index.record_played(tmp_path / "apos.mp3")  # Apostrophe avg 2.0
+        index.record_played(tmp_path / "hot.mp3")  # Hot Rats avg 1.0
+        old = [
+            (a.album_artist, a.album, a.genres)
+            for a in index.albums(sort="most_played")
+            if a.play_count_avg > 0 and not a.missing_album
+        ]
+        new = [
+            (a.album_artist, a.album, a.genres) for a in index.top_albums("most_played")
+        ]
+        index.close()
+        assert new == old
+        assert new[0][1] == "Apostrophe"  # highest avg first
+        assert new[0][2] == ["Comedy", "Rock"]  # genres carried, NOCASE-sorted
+
+    def test_limit_caps_results(self, tmp_path: Path) -> None:
+        index = self._seed(tmp_path)
+        for name in ("apos", "hot", "foley"):
+            index.record_played(tmp_path / f"{name}.mp3")
+        top1 = index.top_albums("most_played", limit=1)
+        index.close()
+        assert len(top1) == 1
+
+    def test_unplayed_albums_excluded(self, tmp_path: Path) -> None:
+        index = self._seed(tmp_path)
+        index.record_played(tmp_path / "hot.mp3")
+        top = index.top_albums("most_played")
+        index.close()
+        assert [a.album for a in top] == ["Hot Rats"]  # only the played album
+
+    def test_missing_album_track_never_appears(self, tmp_path: Path) -> None:
+        # A played standalone (untagged) track shows in albums() but not here —
+        # these are album modules (documented KAMP-615 scope).
+        index = LibraryIndex(tmp_path / "library.db")
+        p = tmp_path / "lone.mp3"
+        _make_mp3(p, artist="X", album_artist="X", title="Lone")
+        t = _sample_track(p)
+        t.title, t.album = "Lone", ""
+        index.upsert_track(t)
+        index.record_played(p)
+        assert any(a.missing_album for a in index.albums(sort="most_played"))
+        top = index.top_albums("most_played")
+        index.close()
+        assert top == []
+
+    def test_last_played_since_window(self, tmp_path: Path) -> None:
+        index = self._seed(tmp_path)
+        index.record_track_started(tmp_path / "apos.mp3")
+        # since far in the future excludes everything; since 0 includes the play.
+        future = index.top_albums("last_played", since=32503680000.0)  # year 3000
+        recent = index.top_albums("last_played")
+        index.close()
+        assert future == []
+        assert [a.album for a in recent] == ["Apostrophe"]
+
+    def test_unknown_metric_raises(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        with pytest.raises(ValueError, match="unknown top-albums metric"):
+            index.top_albums("bogus")
+        index.close()
+
+
 # ---------------------------------------------------------------------------
 # Sort and record_played
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -295,6 +295,38 @@ class TestAlbumsEndpoint:
         album = c.get("/api/v1/albums").json()[0]
         assert album["art_version"] == pytest.approx(1234567.0)
 
+    def test_top_albums_passes_metric_limit_since(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        # KAMP-615: limit=0/since=0 map to None (no cap / no window).
+        mock_index.top_albums.return_value = [_album("Artist", "Record")]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        data = c.get("/api/v1/albums/top?metric=most_played&limit=5").json()
+        assert len(data) == 1 and data[0]["album"] == "Record"
+        mock_index.top_albums.assert_called_once_with(
+            "most_played", limit=5, since=None
+        )
+
+    def test_top_albums_since_forwarded(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.top_albums.return_value = []
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        c.get("/api/v1/albums/top?metric=last_played&since=1000.5")
+        mock_index.top_albums.assert_called_once_with(
+            "last_played", limit=None, since=1000.5
+        )
+
+    def test_top_albums_unknown_metric_is_422(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        mock_index.top_albums.side_effect = ValueError("unknown top-albums metric: 'x'")
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        c = TestClient(app)
+        assert c.get("/api/v1/albums/top?metric=x").status_code == 422
+
     def test_direction_param_forwarded_to_index(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## KAMP-615: 'no items in library' shows for ~12 seconds after splash screen

Fixes the slow, false-empty library load. Same backend root cause as KAMP-614: concurrent whole-library `albums()` calls melting down under a GIL-bound genre pass.

### Problem
On launch the library grid showed "No albums in library." for ~12s. Startup fires several concurrent `GET /api/v1/albums` calls across sorts (the ticket log shows 6 / 3 sorts). Each runs `index.albums()`, whose genre pass (KAMP-550) scanned **all ~78k `track_genres` rows** into a GIL-holding Python loop; 8 concurrent measured at **18.0s**. On top of that, the home modules each fetched the *entire* album list just to show a top-N, repeatedly (on every track change).

### Fix — three commits

**1. Backend genre-pass optimization** (`library.py`)
Split the genre pass into two SQL-aggregated queries (`_album_genre_maps()`): `SELECT DISTINCT album_id, name` (≈78k rows → ≈3.6k) for album genres, and track-level genres only for missing-album (`album=''`) tracks. Byte-identical output; a `, g.name` tie-break keeps ordering deterministic across SQLite versions. **Measured: single 248→127ms; 8 concurrent 18.0s → 1.7s (10x).**

**2. Frontend loading gate** (`store.ts`, `AlbumGrid.tsx`)
Add a `library.loaded` flag set true **only** on `loadLibrary` success, and show "Loading…" instead of the empty message while `!loaded` (mirrors PlaylistView). Stops the false empty flash; a genuinely empty library still shows "No albums in library."

**3. `top_albums` fast path** (`library.py`, `server.py`, home modules)
Top Albums / Last Played previously fetched the whole `albums()` result and sliced client-side — on every track change. New `LibraryIndex.top_albums(metric, limit, since)` ranks off the denormalized `albums` columns (`play_count_avg` / `last_played_at`) and enriches only the top-N; new `GET /api/v1/albums/top` endpoint + `getTopAlbums()`. Named albums only (untagged tracks never appeared meaningfully in these album modules — documented, tested). Column projection and the `AlbumInfo` row-mapping are factored into shared pieces so there's still one construction site. **Measured: single 192→62ms (3x); 4 concurrent 749→75ms (10x); startup burst (1 grid `albums()` + 2 `top_albums()`) 788→208ms vs 4× full `albums()`.** Output verified identical to the old fetch-all-then-slice.

### Net result
Startup load: **~12s → ~200ms** on dev SQLite (larger gain on the bundled older SQLite), and the recurring per-track-change module cost drops from a full-library scan to ~62ms with no concurrency meltdown.

### Investigated but dropped
A lighter `albums()` main union (base tables instead of the `tracks_with_stats` view) measured only ~5% once noise was removed and touches KAMP-552 landmine SQL — **reverted, not worth the risk**.

### Testing
- New `TestAlbumGenreMaps`, `TestTopAlbums`, and `/api/v1/albums/top` endpoint tests (parity vs the old approach, limit, day-window, missing-album exclusion, unknown-metric 422, row-count perf guards).
- Full backend suite: **2645 passed, 9 skipped, coverage 93.78%**. Pre-commit black + mypy clean; `kamp_ui` typecheck + lint clean.
- No frontend unit-test runner; UI changes manually verified.

### Manual test plan
- Cold launch: after splash fades, grid briefly shows "Loading…" then albums — noticeably faster; daemon log shows the concurrent `/api/v1/albums` calls resolving quickly and only cheap `/api/v1/albums/top` calls for the modules.
- Top Albums / Last Played populate correctly and update on track changes (now via the cheap endpoint).
- Genre correctness on album cards / genre filter unchanged.
- Genuinely empty library shows "No albums in library." (not a stuck "Loading…").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
