### PR TITLE
KAMP-631: fix letterbox seam (opaque themed compositor layers)

### DIFF
--- a/kamp_ui/src/main/index.ts
+++ b/kamp_ui/src/main/index.ts
@@ -17,7 +17,8 @@ import { createInterface } from 'readline'
 import * as http from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
-import { theme } from '../shared/theme'
+import { theme, themes } from '../shared/theme'
+import type { ThemeName } from '../shared/theme'
 import { discoverExtensions, installExtension, uninstallExtension } from './extensions'
 import { readManifest } from './communityManifest'
 
@@ -982,8 +983,22 @@ app.whenReady().then(async () => {
     void shell.openExternal(url)
   })
 
-  ipcMain.on('kamp:set-bg-color', (_event, color: string) => {
-    BrowserWindow.getAllWindows()[0]?.setBackgroundColor(color)
+  // KAMP-631: sync the native window chrome to the active palette. Deriving
+  // both the background and the Windows titlebar overlay from the shared themes
+  // table here (rather than passing colors in) keeps a single source of truth —
+  // the create-vs-update divergence that left the native bg pinned to the
+  // default '#141414' (the letterbox seam) is exactly what a second copy caused.
+  // Called from both startup (main.tsx) and interactive switches (store.setTheme).
+  ipcMain.on('kamp:sync-theme-chrome', (_event, name: string) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) return
+    const t = themes[name as ThemeName] ?? theme
+    win.setBackgroundColor(t.bg)
+    // setTitleBarOverlay throws on a window created without an overlay (macOS/
+    // Linux have none), so guard to win32 where the window is created with one.
+    if (process.platform === 'win32') {
+      win.setTitleBarOverlay({ color: t.bg, symbolColor: t.text })
+    }
   })
 
   ipcMain.handle('update:dismiss', (_event, version: string) => {

--- a/kamp_ui/src/preload/index.d.ts
+++ b/kamp_ui/src/preload/index.d.ts
@@ -27,7 +27,7 @@ declare global {
       showItemInFolder: (filePath: string) => void
       openPath: (path: string) => void
       openExternal: (url: string) => void
-      setBgColor: (color: string) => void
+      syncThemeChrome: (name: string) => void
     }
     KampAPI: KampAPI
   }

--- a/kamp_ui/src/preload/index.ts
+++ b/kamp_ui/src/preload/index.ts
@@ -102,7 +102,10 @@ const api = {
   // KAMP-558: open a folder (e.g. the Music Library) in Finder/Explorer.
   openPath: (path: string): void => ipcRenderer.send('shell:open-path', path),
   openExternal: (url: string): void => ipcRenderer.send('shell:open-external', url),
-  setBgColor: (color: string): void => ipcRenderer.send('kamp:set-bg-color', color)
+  // KAMP-631: sync native window chrome (background + Windows titlebar overlay)
+  // to a theme. The main process derives the colors from the shared themes table
+  // so there is one source of truth; the renderer just names the active theme.
+  syncThemeChrome: (name: string): void => ipcRenderer.send('kamp:sync-theme-chrome', name)
 }
 
 const kampAPI = buildKampAPI()

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -427,6 +427,13 @@ html[data-platform='win32'] .view-tabs {
   position: relative;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+  /* KAMP-631: overflow-y:auto promotes this to its own compositor layer. Without
+     an opaque background, its transparent pixels reveal Chromium's compositor
+     base color (= BrowserWindow.backgroundColor, pinned to the default theme's
+     #141414) rather than the themed page bg — a "letterbox" seam on non-default
+     palettes, next to the toolbars/search bar that DO paint var(--bg). Painting
+     the layer itself opaque-themed fixes it independent of the native surface. */
+  background: var(--bg);
 }
 
 /* View panes: always mounted so img elements survive view switches and cached

--- a/kamp_ui/src/renderer/src/assets/search.css
+++ b/kamp_ui/src/renderer/src/assets/search.css
@@ -64,6 +64,9 @@
   flex-direction: column;
   overflow-y: auto;
   height: 100%;
+  /* KAMP-631: own scroll container -> own compositor layer; opaque themed bg so
+     its transparent pixels don't reveal Chromium's base color as a seam. */
+  background: var(--bg);
 }
 
 .search-view-toolbar {

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -947,6 +947,10 @@
   /* Containing block for the bokeh canvas (KAMP-561); clip the canvas blur bleed. */
   position: relative;
   overflow: hidden;
+  /* KAMP-631: the bokeh canvas's filter:blur(28px) promotes a compositor layer;
+     an opaque themed backdrop here keeps its transparent pixels from revealing
+     Chromium's base color (default #141414) as a seam on non-default palettes. */
+  background: var(--bg);
 }
 
 /* Ambient album-color bokeh behind the art (KAMP-561). The blur unifies the orbs

--- a/kamp_ui/src/renderer/src/assets/track-list.css
+++ b/kamp_ui/src/renderer/src/assets/track-list.css
@@ -963,6 +963,15 @@
   pointer-events: none;
   z-index: 0;
   filter: blur(28px);
+  /* KAMP-631: filter:blur promotes this canvas to its own compositor layer, and
+     the canvas bitmap is mostly transparent (cleared, with orbs blended over).
+     Without an opaque backing the layer's transparent pixels reveal Chromium's
+     compositor base color (= the default theme's #141414), showing as a neutral
+     seam on non-default palettes. An opaque themed backing behind the bitmap
+     removes it; the orbs still composite over it exactly as before. Confirmed
+     against the parent .now-playing bg not being enough (the promoted layer
+     composites against the base, not the parent paint). */
+  background: var(--bg);
 }
 
 .now-playing-art {

--- a/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
+++ b/kamp_ui/src/renderer/src/components/nowplaying/BokehBackground.tsx
@@ -17,6 +17,11 @@ function accentHex(): string {
   return getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#7c86e1'
 }
 
+// Themed window background, read the same reliable way as accentHex (KAMP-631).
+function bgHex(): string {
+  return getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() || '#141414'
+}
+
 // Inner component: only mounted when the toggle is on, so "off" means zero canvas
 // and zero GPU. All effect hooks live here (always run while mounted).
 function BokehCanvas({ active, artUrl }: Props): React.JSX.Element {
@@ -53,6 +58,15 @@ function BokehCanvas({ active, artUrl }: Props): React.JSX.Element {
       engineRef.current = null
     }
   }, [])
+
+  // KAMP-631: keep the vignette bg in sync with the palette. Runs on mount (so a
+  // fresh non-default palette is correct) and on every theme switch (which the
+  // engine's resize-only refresh would otherwise miss). Reading --bg here, in a
+  // post-commit effect, is the same reliable pattern accentHex uses.
+  const selectedTheme = useStore((s) => s.selectedTheme)
+  useEffect(() => {
+    engineRef.current?.setBg(bgHex())
+  }, [selectedTheme])
 
   // Recompute the palette on each track/art change; crossfade in the engine. Guard
   // against skip races (abort the in-flight fetch, ignore a stale resolution).

--- a/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
+++ b/kamp_ui/src/renderer/src/components/nowplaying/bokehEngine.ts
@@ -198,6 +198,16 @@ export class BokehEngine {
     if (v) this.bg = v
   }
 
+  // Push the themed --bg from React (KAMP-631). refreshBg only runs on
+  // construction/resize, so a palette switch — which changes --bg without
+  // resizing the canvas — would otherwise leave the vignette darkening the
+  // edges with the PREVIOUS theme's bg (a neutral seam on the exposed sides
+  // when the pane is wide). The caller reads --bg post-commit, where the value
+  // is reliable, and re-applies it on every theme change.
+  setBg(v: string): void {
+    if (v) this.bg = v
+  }
+
   private currentColors(): RGB[] {
     if (this.paletteT >= 1) return this.to
     const t = smoothstep(this.paletteT)

--- a/kamp_ui/src/renderer/src/main.tsx
+++ b/kamp_ui/src/renderer/src/main.tsx
@@ -12,6 +12,11 @@ import type { ThemeName } from '../../shared/theme'
 // theme.ts is the single source of truth — no themes.css needed.
 const savedTheme = (localStorage.getItem('kamp:selected-theme') as ThemeName | null) ?? 'kamp'
 applyTheme(savedTheme, document.documentElement)
+// KAMP-631: also sync the native window chrome to the saved palette. The window
+// is created with the DEFAULT theme bg, so without this a saved non-default
+// palette leaves the native bg (and Windows titlebar) mismatched — it bleeds
+// through transparent surfaces as a letterbox seam. Mirrors store.setTheme.
+window.api.syncThemeChrome(savedTheme)
 
 // Expose the platform to CSS so platform-specific chrome (e.g. right padding
 // on .view-tabs that clears the Windows titleBarOverlay) can target it.

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -26,7 +26,7 @@ import type {
   Track
 } from './api/client'
 import type { DisplayStyle } from './components/modules/registry'
-import { themes, applyTheme } from '../../shared/theme'
+import { applyTheme } from '../../shared/theme'
 import type { ThemeName } from '../../shared/theme'
 import type { MagicPlaylistContents, MagicPlaylistSort } from './api/client'
 
@@ -992,7 +992,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   setTheme: (name) => {
     localStorage.setItem('kamp:selected-theme', name)
     applyTheme(name, document.documentElement)
-    window.api.setBgColor(themes[name].bg)
+    window.api.syncThemeChrome(name)
     set({ selectedTheme: name })
   },
 


### PR DESCRIPTION
## KAMP-631: Letterbox background seam on non-default palettes

On any non-default palette, a neutral `#141414` "letterbox" seam showed on the search view and Now Playing.

### Root cause (confirmed in DevTools)
The seam is **Chromium's compositor base color**, which equals `BrowserWindow.backgroundColor` — pinned to the **default** theme's `#141414`. Any element promoted to its own compositor layer that has transparent pixels composites against that base color rather than the themed page background:
- `.main-content` / `.search-view` — `overflow-y: auto` scroll layers with no background (the search-view seam).
- `.now-playing-bokeh` — the KAMP-561 bokeh canvas; `filter: blur(28px)` promotes it to a layer and its bitmap is mostly transparent (the Now Playing seam). Verified: setting the canvas background to magenta tinted the whole pane pink; `var(--bg)` removed the seam.

It's invisible on the default palette because there the themed bg already equals `#141414`.

### Fix
Give every such composited container an **opaque `var(--bg)` background** so its layer never exposes the base color:
- `.main-content`, `.search-view`, `.now-playing` (layout.css / search.css / track-list.css)
- `.now-playing-bokeh` — the bokeh blur layer itself (the promoted layer composites against the base, so the parent's themed bg wasn't enough).

Plus two complementary correctness fixes:
- **Bokeh vignette tracks the palette:** `drawVignette` darkened edges toward a cached `this.bg` that only refreshed on construction/resize, never on a theme switch. Added `BokehEngine.setBg()` driven from a theme-keyed React effect so the vignette follows the palette.
- **Native chrome single source of truth:** `syncThemeChrome(name)` derives the window `backgroundColor` + Windows `titleBarOverlay` (color + symbol color from the theme's `text` token) from the shared `themes` table, called from startup and interactive switches. Prevents the resize edge-flash on non-default palettes and fixes the Windows titlebar overlay (previously stuck at the default). ThemePicker's CSS-only hover preview is intentionally not wired to native chrome. The win32 titlebar path is guarded and unverified locally (mac-only reviewers).

### Testing
`npm run typecheck` + `npm run lint` clean. No backend/coverage impact. kamp_ui has no unit-test runner — verified manually (incl. DevTools confirmation of the reveal mechanism).

Manual test plan:
- Non-default palette (strawberry-switchblade / golden-smog), Now Playing with glow on + queue closed → no seam; switch palettes → vignette follows.
- Search view, queue closed → no seam.
- Default `kamp` palette unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
