### PR TITLE
KAMP-555: dismiss search overlay on Go to Album / Go to Artist

### DIFF
--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -48,6 +48,7 @@ export function QueueContextMenu({
   const selectAlbum = useStore((s) => s.selectAlbum)
   const selectArtist = useStore((s) => s.selectArtist)
   const setActiveView = useStore((s) => s.setActiveView)
+  const setSearchQuery = useStore((s) => s.setSearchQuery)
   const clearQueue = useStore((s) => s.clearQueue)
   const clearRemainingQueue = useStore((s) => s.clearRemainingQueue)
   const removeFromQueue = useStore((s) => s.removeFromQueue)
@@ -161,6 +162,9 @@ export function QueueContextMenu({
                     has_remote_tracks: false,
                     genres: []
                   }
+                  // KAMP-555: dismiss the search overlay so the updated library
+                  // view is visible. No-op when search isn't open.
+                  void setSearchQuery('')
                   void setActiveView('library')
                   void selectAlbum(found)
                   onClose()
@@ -181,6 +185,7 @@ export function QueueContextMenu({
               <button
                 className="track-context-menu-item"
                 onClick={() => {
+                  void setSearchQuery('') // KAMP-555: dismiss search overlay
                   void setActiveView('library')
                   setCollectionType('albums')
                   selectArtist(track.album_artist)

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -55,6 +55,7 @@ export function TrackContextMenu({
   const selectAlbum = useStore((s) => s.selectAlbum)
   const selectArtist = useStore((s) => s.selectArtist)
   const setActiveView = useStore((s) => s.setActiveView)
+  const setSearchQuery = useStore((s) => s.setSearchQuery)
 
   const [duplicateModal, setDuplicateModal] = useState<DuplicateModalState | null>(null)
 
@@ -213,6 +214,10 @@ export function TrackContextMenu({
                     has_remote_tracks: false,
                     genres: []
                   }
+                  // KAMP-555: dismiss the search overlay so the updated library
+                  // view is visible (App renders SearchView whenever searchQuery
+                  // is non-empty). No-op when search isn't open.
+                  void setSearchQuery('')
                   void setActiveView('library')
                   void selectAlbum(found)
                   onClose()
@@ -233,6 +238,7 @@ export function TrackContextMenu({
               <button
                 className="track-context-menu-item"
                 onClick={() => {
+                  void setSearchQuery('') // KAMP-555: dismiss search overlay
                   void setActiveView('library')
                   setCollectionType('albums')
                   selectArtist(track.album_artist)


### PR DESCRIPTION
## KAMP-555: 'Go to Album' from context menu on track search results doesn't do anything

### Problem
Right-clicking a track in search results → "Go to Album" (or "Go to Artist") did nothing visible. The handlers set the view + selection but never cleared `searchQuery`, and `App` renders `{searchQuery && <SearchView />}` on top of every main pane (panes gated on `!searchQuery`) — so the search overlay stayed over the correctly-updated library view. (Navigating to Library afterward then reset the selection via `activateMain`, explaining the "not set to the album" second symptom.)

### Fix
Add `void setSearchQuery('')` to the "Go to Album" and "Go to Artist" handlers in both `TrackContextMenu.tsx` and `QueueContextMenu.tsx` (the queue panel can be open while search is active). This is the same idempotent dismiss already used by SearchView `onAfterSelect`, the SearchBar clear button, and the Escape handler — a no-op when search isn't open.

### Testing
`npm run typecheck` + `npm run lint` clean. kamp_ui has no unit-test runner — verified manually.

Manual test plan:
- Search "jazz" → right-click a track result → "Go to Album" → search closes, album view shows.
- Same → "Go to Artist" → search closes, artist's albums show.
- Queue panel open with a search active → right-click a queued track → "Go to Album"/"Go to Artist" → search closes, target view shows.
- Regression: "Go to Album"/"Go to Artist" from an ordinary library track list (no search) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
