### PR TITLE
KAMP-547: portal duplicate/collision modals to fix album-card flicker

### DIFF
--- a/kamp_ui/src/renderer/src/components/CollisionModal.tsx
+++ b/kamp_ui/src/renderer/src/components/CollisionModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 
 type Props = {
   targetPath: string
@@ -24,7 +25,11 @@ export function CollisionModal({
 
   const filename = targetPath.split(/[/\\]/).pop() ?? targetPath
 
-  return (
+  // KAMP-547: portal to document.body so the fixed-position backdrop renders at
+  // the viewport regardless of a transformed/filtered ancestor establishing a
+  // containing block for position:fixed. Mirrors ContextMenu.tsx / the duplicate
+  // modal fix.
+  return createPortal(
     // Click-away backdrop = implicit Cancel.
     <div className="modal-backdrop" role="presentation" onClick={onCancel}>
       <div
@@ -53,6 +58,7 @@ export function CollisionModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/kamp_ui/src/renderer/src/components/DuplicatePlaylistTrackModal.tsx
+++ b/kamp_ui/src/renderer/src/components/DuplicatePlaylistTrackModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { truncateTitle } from '../utils/truncateTitle'
 
 type Props = {
@@ -26,7 +27,12 @@ export function DuplicatePlaylistTrackModal({
 
   const displayName = truncateTitle(playlistName, 40)
 
-  return (
+  // KAMP-547: portal to document.body so the fixed-position backdrop renders at
+  // the viewport, not inside whatever mounts the modal — an album card with a
+  // filter/transform highlight becomes the containing block for position:fixed
+  // and (with the card's overflow:hidden) clips the backdrop, causing a
+  // hover-driven flicker. Mirrors ContextMenu.tsx.
+  return createPortal(
     <div className="modal-backdrop" role="presentation" onClick={onCancel}>
       <div
         className="modal collision-modal"
@@ -56,6 +62,7 @@ export function DuplicatePlaylistTrackModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }


### PR DESCRIPTION
## KAMP-547: duplicate-tracks warning modal flickers between album card and main div

### Problem
"Add to Playlist" from an album card's context menu, when it hits duplicates, showed the confirmation modal flickering between being clipped inside the card and covering the screen — on cards with a new-arrival decoration.

Root cause: `DuplicatePlaylistTrackModal` renders plain JSX (no portal), so its `position: fixed` `.modal-backdrop` mounts inside `.album-card`. A hover-gated highlight style (`vaporwave:hover { filter: … }`) makes the card the containing block for `position: fixed` descendants; with `.album-card { overflow: hidden }` the backdrop gets clipped into the card. The backdrop is then a DOM child of the card, so hovering it toggles the card's `:hover` filter → the backdrop snaps in/out → flicker.

### Fix
Wrap the modal's return in `createPortal(…, document.body)` so the backdrop always renders at the viewport — robust to any containing-block-establishing ancestor property (`filter`/`transform`/`perspective`/`will-change`/`contain`), not just the one highlight style. Mirrors the existing `ContextMenu.tsx` pattern. The fix is in the shared modal component, so it covers all consumers (album/track/queue context menus) at once. React keeps synthetic-event bubbling through portals, so the backdrop `onClick` cancel, the inner `stopPropagation`, and the document Escape listener are unchanged.

Also portaled `CollisionModal` — the other non-portaled `.modal-backdrop` reachable from context menus. This is **hardening** against the identical latent defect (its consumers aren't inside a fixed-capturing ancestor today), not a reproduced bug. The other six `.modal-backdrop` components are app-level and left as-is.

### Testing
`npm run typecheck` + `npm run lint` clean. kamp_ui has no unit-test runner — verified manually.

Manual test plan:
- Album with new-arrival decoration (vaporwave) → right-click → add to new playlist → right-click same album → add to that playlist → duplicate modal renders once, centered, full-screen backdrop, **no flicker**.
- Escape closes it; backdrop click cancels; "yeah I'm sure" and "just the unique songs" both add and close cleanly (no lingering context menu).
- Repeat on a non-decorated card and a couple other highlight styles (regression).
- CollisionModal (hardening): trigger a track-level collision → cancel/overwrite/skip/Escape all work portaled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
