### PR TITLE
KAMP-598: fix phantom focus ring on click+shortcut; consistent accent focus rings

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -366,6 +366,17 @@ export default function App(): React.JSX.Element {
       const tag = (e.target as HTMLElement).tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
 
+      // KAMP-598: these are global shortcuts, not input for the focused control.
+      // A mouse click leaves DOM focus on the clicked element without making it
+      // :focus-visible; the next keypress would promote it and paint a focus
+      // ring. Drop that leftover focus so no ring appears — but only when the
+      // element is NOT already :focus-visible, so a genuine keyboard (Tab) focus
+      // keeps its position and ring.
+      const active = document.activeElement as HTMLElement | null
+      if (active && active !== document.body && !active.matches(':focus-visible')) {
+        active.blur()
+      }
+
       switch (e.key) {
         case '?':
           setShowShortcuts((prev) => !prev)

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -31,6 +31,15 @@ import { useExtensionState } from './hooks/useExtensionState'
 import type { UnifiedPanel } from './hooks/usePanelLayout'
 import type { ExtensionInfo } from '../../shared/kampAPI'
 
+// KAMP-598: track whether focus was last established by the mouse (a click) vs
+// the keyboard (Tab). A mouse click leaves DOM focus on the clicked element
+// without a ring; the global transport shortcuts blur it so no phantom
+// :focus-visible ring appears on the next keypress. We track modality ourselves
+// rather than reading :focus-visible at keydown time — Chromium promotes the
+// element to :focus-visible while processing the keydown, *before* our handler
+// runs, so that check reads true and is unreliable here.
+let _focusFromMouse = false
+
 // ---------------------------------------------------------------------------
 // Register built-in panels before the component mounts.
 // Each call is idempotent — safe across HMR and React StrictMode re-runs.
@@ -341,6 +350,16 @@ export default function App(): React.JSX.Element {
     return disconnect
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // KAMP-598: any pointer press means the focus it establishes is mouse-driven,
+  // so the transport shortcuts should blur it rather than let it grow a ring.
+  useEffect(() => {
+    const onPointerDown = (): void => {
+      _focusFromMouse = true
+    }
+    window.addEventListener('pointerdown', onPointerDown, true)
+    return () => window.removeEventListener('pointerdown', onPointerDown, true)
+  }, [])
+
   // Global keyboard shortcuts
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent): void {
@@ -363,18 +382,23 @@ export default function App(): React.JSX.Element {
         return
       }
 
+      // Tab moves focus via the keyboard — from here on, focus is keyboard-driven
+      // and its ring should stay (KAMP-598).
+      if (e.key === 'Tab') {
+        _focusFromMouse = false
+        return
+      }
+
       const tag = (e.target as HTMLElement).tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
 
       // KAMP-598: these are global shortcuts, not input for the focused control.
-      // A mouse click leaves DOM focus on the clicked element without making it
-      // :focus-visible; the next keypress would promote it and paint a focus
-      // ring. Drop that leftover focus so no ring appears — but only when the
-      // element is NOT already :focus-visible, so a genuine keyboard (Tab) focus
-      // keeps its position and ring.
-      const active = document.activeElement as HTMLElement | null
-      if (active && active !== document.body && !active.matches(':focus-visible')) {
-        active.blur()
+      // If the focused element was focused by a mouse click (not Tab), drop that
+      // leftover focus so the keypress can't promote it to a :focus-visible ring.
+      // Genuine keyboard focus (_focusFromMouse === false) is left alone.
+      if (_focusFromMouse) {
+        const active = document.activeElement as HTMLElement | null
+        if (active && active !== document.body) active.blur()
       }
 
       switch (e.key) {

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -660,9 +660,70 @@ html[data-platform='win32'] .view-tabs {
 .track-row:focus-visible,
 .seek-bar:focus-visible,
 .volume-slider:focus-visible,
-.view-tabs button:focus-visible {
+.view-tabs button:focus-visible,
+/* KAMP-598: sweep the focusable controls that had no :focus-visible rule (they
+   showed Chromium's yellow UA ring) onto the accent ring. Extends the existing
+   central allowlist above; purely additive — nothing here overrides an existing
+   ring, a text-input outline:none, or a non-focus (drag / new-arrival) outline.
+   Elements inside overflow/tight containers get an inset offset in the next
+   block so the ring isn't clipped. */
+.library-collection-tab:focus-visible,
+.toolbar-dropdown-trigger:focus-visible,
+.toolbar-dropdown-item:focus-visible,
+.toolbar-dropdown-clear:focus-visible,
+.track-context-menu-item:focus-visible,
+.volume-icon--btn:focus-visible,
+.album-secondary-btn:focus-visible,
+.album-download-btn:focus-visible,
+.meta-field-copy-btn:focus-visible,
+.panel-tab:focus-visible,
+.bandcamp-btn:focus-visible,
+.collection-close-btn:focus-visible,
+.prefs-btn:focus-visible,
+.prefs-link-btn:focus-visible,
+.prefs-select:focus-visible,
+.prefs-ext-remove-confirm:focus-visible,
+.genre-merge-btn:focus-visible,
+.genre-admin-add:focus-visible,
+.modal-btn:focus-visible,
+.mb-modal__btn:focus-visible,
+.mb-modal__nav-btn:focus-visible,
+.mb-modal__close-btn:focus-visible,
+.art-modal__choose-file-btn:focus-visible,
+.art-modal__cov-link:focus-visible,
+.magic-btn:focus-visible,
+.magic-close-btn:focus-visible,
+.magic-add-rule-btn:focus-visible,
+.magic-add-group-btn:focus-visible,
+.magic-remove-btn:focus-visible,
+.magic-select:focus-visible,
+.module-config-field select:focus-visible,
+.base-kamp-add-module:focus-visible,
+.base-kamp-add-module select:focus-visible,
+.base-kamp-remove-btn:focus-visible,
+.style-rail-control select:focus-visible,
+.onboarding-primary-btn:focus-visible,
+.onboarding-skip-btn:focus-visible,
+.setup-change-btn:focus-visible,
+.update-banner-link:focus-visible,
+.update-notes-modal__btn:focus-visible,
+.update-notes-modal__site-link:focus-visible,
+.shortcuts-close-btn:focus-visible,
+.download-card-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* KAMP-598: inset ring for controls inside overflow:hidden / tight containers,
+   where a 2px OUTWARD outline would be clipped (audited cases). */
+.view-mode-btn:focus-visible,
+.hero-art-btn:focus-visible,
+.search-clear:focus-visible,
+.track-title:focus-visible,
+.track-artist:focus-visible,
+.track-album:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 /* Active / press feedback ------------------------------------------------- */


### PR DESCRIPTION
## KAMP-598: focus ring appears on click+Space; ring styling inconsistent

Two parts.

### 1. No phantom ring after mouse-click-then-shortcut (the reported bug)
Clicking a control leaves DOM focus on it; pressing a global shortcut (Space/Arrow/q/c) makes Chromium promote it to `:focus-visible` and paint a ring on the last-clicked element.

The fix tracks input modality ourselves rather than reading `:focus-visible` at keydown time (an early attempt guarded on `!matches(':focus-visible')`, but Chromium promotes the element to `:focus-visible` *while processing the keydown, before* our handler runs, so the guard read `true` and skipped the blur). Now: a `pointerdown` sets a "focus from mouse" flag; a `Tab` keydown clears it; the transport shortcut blurs the focused element only when focus came from the mouse. Genuine keyboard (Tab) focus keeps its ring. **Verified working.**

### 2. Consistent accent focus ring (additive sweep)
Many focusable controls had no `:focus-visible` rule and fell back to Chromium's yellow UA ring (e.g. the Albums/Playlists library subtabs), while others showed the accent ring. Extended the existing central `:focus-visible` allowlist in `layout.css` with the audited orphan selectors so they get the accent ring. Purely additive — it only turns an already-present ring from yellow to accent; it deletes/edits nothing, so intentional inset offsets, the 1px prefs rings, text-input `outline: none`, and the drag / new-arrival (non-focus) outlines are all untouched. Controls inside `overflow: hidden` / tight containers (now-playing track/artist/album links, grid/list view-mode toggle, hero art button, search clear) use an inset `outline-offset: -2px` so the ring isn't clipped.

Scope was confirmed with the maintainer: sweep all yellow orphans additively; the full global-rule consolidation (which would delete load-bearing inset offsets and risk a11y regressions on native controls) was deliberately declined for a testless UI.

### Testing
`npm run typecheck` + `npm run lint` clean. kamp_ui has no unit-test runner — manual verification.

Manual test plan:
- Click a control → Space → pause toggles, **no ring** (verified). Tab to a control (ring shows) → Space → pause toggles, **ring stays** (verified).
- Tab through the app — subtabs, Sort/Source/Filter dropdowns, context-menu items, now-playing metadata links, modal buttons, preferences controls, home-module selects — all show the **accent** ring, none yellow.
- Inset cases (now-playing track/artist/album, grid/list toggle, hero art, search ✕) show a clean, un-clipped accent ring.
- No regressions: text inputs keep their border/background focus; existing accent rings unchanged; drag-over and new-arrival gold outlines unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
