### PR TITLE
KAMP-625: dismiss tooltip on right-click; close Bandcamp menu on Escape

### DIFF
--- a/kamp_ui/src/renderer/src/assets/queue.css
+++ b/kamp_ui/src/renderer/src/assets/queue.css
@@ -346,7 +346,12 @@
 /* Right-click context menu on track rows */
 .track-context-menu {
   position: fixed;
-  z-index: 1000;
+  /* KAMP-625: above the tooltip (.kamp-tooltip, 9000) and modals (900-1100) — a
+     context menu is an active interaction and must never be occluded. The
+     tooltip is also dismissed on contextmenu (TooltipProvider), so this is
+     belt-and-suspenders for a tooltip that arms after the menu opens. Caveat:
+     if context-menu items ever gain tooltips, those would render under the menu. */
+  z-index: 9500;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 4px;

--- a/kamp_ui/src/renderer/src/components/BandcampButton.tsx
+++ b/kamp_ui/src/renderer/src/components/BandcampButton.tsx
@@ -19,16 +19,25 @@ export function BandcampButton(): React.JSX.Element | null {
     return window.api.bandcamp.onSyncStatus(setSyncState)
   }, [])
 
-  // Close context menu on outside click.
+  // Close context menu on outside click or Escape (KAMP-625: this custom menu
+  // rolled its own dismissal and — unlike the shared ContextMenu — was missing
+  // the Escape key handler).
   useEffect(() => {
     if (!menuOpen) return
-    const handler = (e: MouseEvent): void => {
+    const onMouseDown = (e: MouseEvent): void => {
       if (anchorRef.current && !anchorRef.current.contains(e.target as Node)) {
         setMenuOpen(false)
       }
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
   }, [menuOpen])
 
   const connected = configValues?.['bandcamp.connected'] ?? false

--- a/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
+++ b/kamp_ui/src/renderer/src/components/TooltipProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { TooltipContext } from '../hooks/useTooltip'
 
@@ -120,6 +120,32 @@ export function TooltipProvider({ children }: { children: React.ReactNode }): Re
     clearTimeout(showTimerRef.current)
     if (phaseRef.current === 'delay') phaseRef.current = 'hidden'
   }, [])
+
+  // KAMP-625: tear the tooltip down immediately (right-click). Clears ALL three
+  // timers — including a pending `show` (phase 'delay', armed <500ms ago) that
+  // would otherwise pop a tooltip over the just-opened context menu — plus the
+  // aria attribute, phase, and display, mirroring the fade timer's terminal
+  // cleanup. Leaving any timer set would resurrect the tooltip (cf. KAMP-391).
+  const hideNow = useCallback(() => {
+    clearTimeout(showTimerRef.current)
+    clearTimeout(hideTimerRef.current)
+    clearTimeout(fadeTimerRef.current)
+    if (targetRef.current) {
+      targetRef.current.removeAttribute('aria-describedby')
+      targetRef.current = null
+    }
+    phaseRef.current = 'hidden'
+    setDisplay(null)
+  }, [])
+
+  // Dismiss on any right-click so the context menu is never occluded. Capture
+  // phase so a child onContextMenu that stopPropagation()s can't starve us; the
+  // handler only clears tooltip state (never preventDefault/stopPropagation), so
+  // the app's own menu-opening handlers still run in the same event.
+  useEffect(() => {
+    document.addEventListener('contextmenu', hideNow, true)
+    return () => document.removeEventListener('contextmenu', hideNow, true)
+  }, [hideNow])
 
   // Clamp the tooltip horizontally so it never overflows the viewport edges.
   useLayoutEffect(() => {


### PR DESCRIPTION
## KAMP-625: context menu appears beneath tooltip (+ Bandcamp menu Escape)

### Problem
Right-clicking a control while its tooltip is showing drew the context menu *beneath* the tooltip (tooltip z-index 9000 vs menu 1000), and `TooltipProvider` had no `contextmenu` handling, so the tooltip lingered through its full ~3.5s cycle over the menu.

### Fix
1. **Dismiss the tooltip on right-click** (`TooltipProvider.tsx`): a new `hideNow()` clears all three timers (show/hide/fade), removes `aria-describedby`, resets phase to hidden, and nulls the display — mirroring the fade timer's terminal cleanup but immediate. Clearing the pending `show` timer is the key case: a right-click <500ms after hover-enter would otherwise pop a tooltip over the just-opened menu (and a stale timer is the KAMP-391 resurrection trap). Wired to a `document` `contextmenu` listener in **capture phase** so a child `onContextMenu` that `stopPropagation()`s can't starve it; the handler only clears tooltip state (never `preventDefault`/`stopPropagation`), so the app's own menu-opening handlers still run. Keyboard-invoked menus (Shift+F10) dispatch a real `contextmenu` event, so they're covered.
2. **Belt-and-suspenders z-index** (`queue.css`): `.track-context-menu` 1000 → 9500 (above the tooltip and modals). Commented with the "if menu items ever get tooltips" caveat.

### Also fixed (found during verification)
3. **Bandcamp context menu now closes on Escape** (`BandcampButton.tsx`). The Bandcamp button rolls its own `.bandcamp-context-menu` (not the shared `ContextMenu`) and only had an outside-click close, so Escape didn't dismiss it while it worked for every other menu. Added an Escape `keydown` handler alongside the existing `mousedown` one.

### Testing
`npm run typecheck` + `npm run lint` clean. kamp_ui has no unit-test runner — manual verification.

Manual test plan:
- Hover the Bandcamp button → wait for tooltip → right-click → tooltip vanishes, menu fully visible.
- Right-click **<500ms** after hovering (before the tooltip shows) → menu opens clean, no tooltip pops 500ms later.
- Right-click while a tooltip is mid-fade → dismisses cleanly.
- Right-click a component whose `onContextMenu` stops propagation (track row / album card) → tooltip still dismisses (capture-phase).
- Shift+F10 while a tooltip is visible → tooltip dismissed, menu shown.
- **Bandcamp menu Escape:** open the Bandcamp options menu → press Escape → menu closes. Outside-click still closes it too.
- No regression: tooltips still appear after 500ms, hot-switch, fade, and clamp at the window edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
