### PR TITLE
KAMP-632: hide magic playlists from 'Add to Playlist' in album/queue menus

### DIFF
--- a/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/AlbumContextMenu.tsx
@@ -265,16 +265,21 @@ export function AlbumContextMenu({ x, y, album, onClose }: Props): React.JSX.Ele
             </button>
           )}
           <ContextMenuSubmenu label="Add to Playlist">
-            {playlists.map((pl) => (
-              <button
-                key={pl.id}
-                className="track-context-menu-item"
-                onClick={() => handleAddToPlaylist(pl.id)}
-              >
-                {truncateTitle(pl.title)}
-              </button>
-            ))}
-            {playlists.length > 0 && <div className="track-context-menu-divider" />}
+            {/* KAMP-632: magic (criteria-based) playlists are populated by their
+                criteria, so adding to them is a no-op — exclude them, matching
+                TrackContextMenu. */}
+            {playlists
+              .filter((pl) => !pl.criteria)
+              .map((pl) => (
+                <button
+                  key={pl.id}
+                  className="track-context-menu-item"
+                  onClick={() => handleAddToPlaylist(pl.id)}
+                >
+                  {truncateTitle(pl.title)}
+                </button>
+              ))}
+            {playlists.some((pl) => !pl.criteria) && <div className="track-context-menu-divider" />}
             <button className="track-context-menu-item" onClick={handleNewPlaylist}>
               New Playlist
             </button>

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -226,16 +226,22 @@ export function QueueContextMenu({
                 </button>
               )}
               <ContextMenuSubmenu label="Add to Playlist">
-                {playlists.map((pl) => (
-                  <button
-                    key={pl.id}
-                    className="track-context-menu-item"
-                    onClick={() => handleAddToPlaylist(pl.id)}
-                  >
-                    {truncateTitle(pl.title)}
-                  </button>
-                ))}
-                {playlists.length > 0 && <div className="track-context-menu-divider" />}
+                {/* KAMP-632: exclude magic (criteria-based) playlists — adding to
+                    them is a no-op; matches TrackContextMenu. */}
+                {playlists
+                  .filter((pl) => !pl.criteria)
+                  .map((pl) => (
+                    <button
+                      key={pl.id}
+                      className="track-context-menu-item"
+                      onClick={() => handleAddToPlaylist(pl.id)}
+                    >
+                      {truncateTitle(pl.title)}
+                    </button>
+                  ))}
+                {playlists.some((pl) => !pl.criteria) && (
+                  <div className="track-context-menu-divider" />
+                )}
                 <button className="track-context-menu-item" onClick={handleNewPlaylist}>
                   New Playlist
                 </button>


### PR DESCRIPTION
## KAMP-632: magic playlists appear in 'Add to Playlist' context menu

### Problem
Magic (criteria-based) playlists are populated by their criteria, so adding tracks to them is a no-op. `TrackContextMenu` already excludes them from its "Add to Playlist" submenu, but the album-card and queue context menus listed every playlist — so magic playlists wrongly appeared there. (The "sibling handlers where one got the fix and the others didn't" pattern.)

### Fix
Mirror the existing filter into `AlbumContextMenu.tsx` and `QueueContextMenu.tsx`: `.filter((pl) => !pl.criteria)` before the `.map`, and gate the divider on `playlists.some((pl) => !pl.criteria)` (was `playlists.length > 0`). Only static playlists are now listed; "New Playlist" is unchanged.

### Testing
`npm run typecheck` + `npm run lint` clean. kamp_ui has no unit-test runner — manual verification.

Manual test plan:
- With a magic playlist and a static playlist present: right-click an album card → Add to Playlist → only the static playlist(s) listed; New Playlist present; divider shows. Same from a queue item.
- Only magic playlists present → submenu shows just "New Playlist", no divider.
- Regression: the track context menu's Add to Playlist behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
