### PR TITLE
KAMP-613: playlist album view resolves renamed albums via canonical identity

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -7909,43 +7909,69 @@ class LibraryIndex:
                    t.release_date, t.track_number, t.disc_number, t.ext, t.embedded_art,
                    t.mb_release_id, t.mb_recording_id, t.genre, t.label,
                    t.favorite, t.play_count, t.last_played, t.date_added,
-                   t.source, t.is_available, t.duration
+                   t.source, t.is_available, t.duration,
+                   -- KAMP-613: canonical album identity from the albums row (keyed on
+                   -- album_id), so the UI can build album cards whose art/nav resolve
+                   -- correctly after a rename — NOT from the track's mutable album tag.
+                   -- LEFT JOIN so untagged tracks (album_id NULL) are not dropped.
+                   t.album_id,
+                   a.album_artist AS canonical_album_artist,
+                   a.album        AS canonical_album,
+                   a.display_album, a.display_album_artist, a.art_version
             FROM playlist_tracks pt
             JOIN tracks_with_stats t ON t.id = pt.track_id
+            LEFT JOIN albums a ON a.id = t.album_id
             WHERE pt.playlist_id = ?
             ORDER BY pt.position ASC
             """,
             (playlist_id,),
         ).fetchall()
-        return [
-            {
-                "playlist_track_id": r["playlist_track_id"],
-                "position": r["position"],
-                "id": r["id"],
-                "file_path": r["file_path"],
-                "title": r["title"],
-                "artist": r["artist"],
-                "album_artist": r["album_artist"],
-                "album": r["album"],
-                "release_date": r["release_date"],
-                "track_number": r["track_number"],
-                "disc_number": r["disc_number"],
-                "ext": r["ext"],
-                "embedded_art": bool(r["embedded_art"]),
-                "mb_release_id": r["mb_release_id"],
-                "mb_recording_id": r["mb_recording_id"],
-                "genre": r["genre"],
-                "label": r["label"],
-                "favorite": bool(r["favorite"]),
-                "play_count": r["play_count"],
-                "last_played": r["last_played"],
-                "date_added": r["date_added"],
-                "source": r["source"],
-                "is_available": bool(r["is_available"]),
-                "duration": r["duration"],
-            }
-            for r in rows
-        ]
+        return [self._playlist_track_row_to_dict(r) for r in rows]
+
+    @staticmethod
+    def _playlist_track_row_to_dict(r: sqlite3.Row) -> dict[str, Any]:
+        """Map a playlist / magic-playlist track row to the PlaylistTrackOut dict.
+
+        Shared by get_playlist_tracks and get_magic_playlist_tracks so the two
+        never drift (KAMP-554 sibling-divergence trap). KAMP-613 identity
+        contract: ``album_artist``/``album`` are the track's mutable TAG — for
+        track-row display only, NEVER album identity; ``canonical_*`` (from the
+        albums row via album_id) is the art/nav key; ``display_*`` is render-only.
+        ``album_id``/``canonical_*`` are NULL for untagged (missing-album) tracks.
+        """
+        return {
+            "playlist_track_id": r["playlist_track_id"],
+            "position": r["position"],
+            "id": r["id"],
+            "file_path": r["file_path"],
+            "title": r["title"],
+            "artist": r["artist"],
+            "album_artist": r["album_artist"],
+            "album": r["album"],
+            "release_date": r["release_date"],
+            "track_number": r["track_number"],
+            "disc_number": r["disc_number"],
+            "ext": r["ext"],
+            "embedded_art": bool(r["embedded_art"]),
+            "mb_release_id": r["mb_release_id"],
+            "mb_recording_id": r["mb_recording_id"],
+            "genre": r["genre"],
+            "label": r["label"],
+            "favorite": bool(r["favorite"]),
+            "play_count": r["play_count"],
+            "last_played": r["last_played"],
+            "date_added": r["date_added"],
+            "source": r["source"],
+            "is_available": bool(r["is_available"]),
+            "duration": r["duration"],
+            # KAMP-613: canonical album identity (album_id -> albums row).
+            "album_id": r["album_id"],
+            "canonical_album_artist": r["canonical_album_artist"],
+            "canonical_album": r["canonical_album"],
+            "display_album": r["display_album"],
+            "display_album_artist": r["display_album_artist"],
+            "album_art_version": r["art_version"],
+        }
 
     def add_track_to_playlist(self, playlist_id: int, file_path: str) -> None:
         """Append a track to the end of a playlist.
@@ -8194,8 +8220,16 @@ class LibraryIndex:
                    tracks.embedded_art, tracks.mb_release_id, tracks.mb_recording_id,
                    tracks.genre, tracks.label, tracks.favorite, tracks.play_count,
                    tracks.last_played, tracks.date_added,
-                   tracks.source, tracks.is_available, tracks.duration
+                   tracks.source, tracks.is_available, tracks.duration,
+                   -- KAMP-613: canonical album identity from the albums row (see
+                   -- _playlist_track_row_to_dict). Aliased `a` so it never collides
+                   -- with the criteria's own optional `albums` join above.
+                   tracks.album_id,
+                   a.album_artist AS canonical_album_artist,
+                   a.album        AS canonical_album,
+                   a.display_album, a.display_album_artist, a.art_version
             FROM tracks_with_stats AS tracks {album_join}
+            LEFT JOIN albums a ON a.id = tracks.album_id
             WHERE {where_fragment} AND tracks.is_available = 1
             ORDER BY tracks.id
         """
@@ -8209,35 +8243,7 @@ class LibraryIndex:
             (len(rows), _t.time(), playlist_id),
         )
         self._conn.commit()
-        return [
-            {
-                "playlist_track_id": None,
-                "position": 0,
-                "id": r["id"],
-                "file_path": r["file_path"],
-                "title": r["title"],
-                "artist": r["artist"],
-                "album_artist": r["album_artist"],
-                "album": r["album"],
-                "release_date": r["release_date"],
-                "track_number": r["track_number"],
-                "disc_number": r["disc_number"],
-                "ext": r["ext"],
-                "embedded_art": bool(r["embedded_art"]),
-                "mb_release_id": r["mb_release_id"],
-                "mb_recording_id": r["mb_recording_id"],
-                "genre": r["genre"],
-                "label": r["label"],
-                "favorite": bool(r["favorite"]),
-                "play_count": r["play_count"],
-                "last_played": r["last_played"],
-                "date_added": r["date_added"],
-                "source": r["source"],
-                "is_available": bool(r["is_available"]),
-                "duration": r["duration"],
-            }
-            for r in rows
-        ]
+        return [self._playlist_track_row_to_dict(r) for r in rows]
 
     def get_playlist_module_content(
         self,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -791,6 +791,18 @@ class PlaylistTrackOut(BaseModel):
     is_available: bool
     duration: float
     sources: list[SourceOut] = []
+    # KAMP-613: canonical album identity so the playlist album view can resolve
+    # art/navigation to the real album after a rename. IDENTITY CONTRACT:
+    # `album_artist`/`album` above are the track's mutable TAG (row display only,
+    # NEVER album identity); `canonical_*` (from the albums row via album_id) is
+    # the art/nav key; `display_*` is render-only. All null for untagged
+    # (missing-album) tracks — the UI routes those through the track_id path.
+    album_id: int | None = None
+    canonical_album_artist: str | None = None
+    canonical_album: str | None = None
+    display_album: str | None = None
+    display_album_artist: str | None = None
+    album_art_version: float | None = None
 
 
 class CreatePlaylistRequest(BaseModel):

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -170,6 +170,16 @@ export type PlaylistTrack = Track & {
   position: number
   last_played: number | null
   date_added: number | null
+  // KAMP-613: canonical album identity from the albums row (via album_id). The
+  // inherited `album`/`album_artist` are the track's mutable TAG — NEVER use them
+  // to key album identity (art/nav); use canonical_* for that and display_* for
+  // rendering. All null for untagged (missing-album) tracks.
+  album_id: number | null
+  canonical_album_artist: string | null
+  canonical_album: string | null
+  display_album: string | null
+  display_album_artist: string | null
+  album_art_version: number | null
 }
 
 // Configurable base URL: defaults to localhost but can be overridden via

--- a/kamp_ui/src/renderer/src/components/PlaylistView.tsx
+++ b/kamp_ui/src/renderer/src/components/PlaylistView.tsx
@@ -284,21 +284,53 @@ export function PlaylistView(): React.JSX.Element | null {
     )
     const seen = new Map<string, Album>()
     for (const t of displayTracks) {
-      const albumArtist = t.album_artist || t.artist
-      const key = `${albumArtist}::${t.album}`
+      // KAMP-613: key album cards on the CANONICAL album identity (the albums row,
+      // via album_id), never the track's mutable tag — otherwise art/navigation
+      // resolve to the pre-rename key and break (404 art + blank album). Untagged
+      // tracks (no album_id) have no albums row: route each to its own
+      // missing-album card keyed by track id, exactly like the library grid.
+      if (t.album_id == null || t.canonical_album == null) {
+        const key = `id:${t.id}`
+        if (!seen.has(key)) {
+          seen.set(key, {
+            album_artist: t.album_artist || t.artist,
+            album: t.title, // missing-album cards display the track title
+            release_date: t.release_date,
+            track_count: 1,
+            has_art: t.embedded_art || t.source !== 'local',
+            missing_album: true,
+            track_id: t.id,
+            art_version: null,
+            added_at: null,
+            last_played_at: null,
+            play_count_avg: 0,
+            favorite: false,
+            has_favorite_track: t.favorite,
+            source: t.source === 'bandcamp' ? 'bandcamp' : 'local',
+            has_remote_tracks: t.source !== 'local',
+            genres: []
+          })
+        }
+        continue
+      }
+      const albumArtist = t.canonical_album_artist ?? t.album_artist
+      const album = t.canonical_album
+      const key = `${albumArtist}::${album}`
       if (!seen.has(key)) {
         seen.set(key, {
           album_artist: albumArtist,
-          album: t.album,
+          album,
+          // display_* render the (possibly renamed) name; album/album_artist above
+          // stay canonical for art/nav.
+          display_album: t.display_album ?? undefined,
+          display_album_artist: t.display_album_artist ?? undefined,
           release_date: t.release_date,
           track_count: 1,
           // Non-local tracks have server-side art even without embedded art.
           has_art: t.embedded_art || t.source !== 'local',
           missing_album: false,
-          // track_id is the unique key only for missing_album=true cards; this is
-          // a real album synthesised from a playlist track, so leave it null.
           track_id: null,
-          art_version: null,
+          art_version: t.album_art_version,
           added_at: null,
           last_played_at: null,
           play_count_avg: 0,
@@ -327,7 +359,12 @@ export function PlaylistView(): React.JSX.Element | null {
     if (displayMode !== 'albums') return new Map()
     const map = new Map<string, number[]>()
     for (const t of displayTracks) {
-      const key = `${t.album_artist || t.artist}::${t.album}`
+      // Must match the album-card key derived in albumGroups / albumKey (KAMP-613):
+      // canonical identity for real albums, track id for missing-album tracks.
+      const key =
+        t.album_id == null || t.canonical_album == null
+          ? `id:${t.id}`
+          : `${t.canonical_album_artist ?? t.album_artist}::${t.canonical_album}`
       const ids = map.get(key)
       if (ids) {
         ids.push(t.id)
@@ -736,13 +773,16 @@ export function PlaylistView(): React.JSX.Element | null {
       {displayMode === 'albums' ? (
         <div className="track-list-body">
           <div className="album-grid" style={{ padding: 10 }}>
-            {albumGroups.map((a) => (
-              <AlbumCard
-                key={`${a.album_artist}::${a.album}`}
-                album={a}
-                dragTrackIds={albumTrackIds.get(`${a.album_artist}::${a.album}`)}
-              />
-            ))}
+            {albumGroups.map((a) => {
+              // Match the key derived in albumTrackIds (KAMP-613): missing-album
+              // cards key on track id; real albums on canonical artist::album.
+              const albumKey = a.missing_album
+                ? `id:${a.track_id}`
+                : `${a.album_artist}::${a.album}`
+              return (
+                <AlbumCard key={albumKey} album={a} dragTrackIds={albumTrackIds.get(albumKey)} />
+              )
+            })}
           </div>
           {albumGroups.length === 0 && (
             <div className="album-grid-empty">

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -12150,6 +12150,93 @@ class TestPlaylists:
         assert result is None
 
 
+class TestPlaylistTracksCanonicalAlbum:
+    """KAMP-613: playlist track rows carry canonical album identity (from the
+    albums row via album_id), distinct from the track's mutable album tag, so the
+    UI album view resolves art/navigation to the renamed album."""
+
+    def _index_with_renamed_album(self, tmp_path: Path) -> tuple[LibraryIndex, int]:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "ecstatic.mp3")
+        t.artist = "yasiin bey"
+        t.album_artist = "yasiin bey"
+        t.album = "The Ecstatic (Deluxe)"
+        index.upsert_track(t)
+        # Display rename (KAMP-467): sets albums.display_album; albums.album stays.
+        index.update_album_display(
+            "yasiin bey", "The Ecstatic (Deluxe)", "The Ecstatic", None
+        )
+        # Simulate the repro's external-retag drift: the track TAG becomes the short
+        # name while the albums row keeps "(Deluxe)" as its canonical key.
+        album_id = index._album_id("yasiin bey", "The Ecstatic (Deluxe)")
+        assert album_id is not None
+        index._conn.execute(
+            "UPDATE tracks SET album = 'The Ecstatic' WHERE album_id = ?", (album_id,)
+        )
+        index._conn.commit()
+        return index, album_id
+
+    def test_static_playlist_track_carries_canonical_identity(
+        self, tmp_path: Path
+    ) -> None:
+        index, album_id = self._index_with_renamed_album(tmp_path)
+        pl = index.create_playlist("Mix")
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "ecstatic.mp3"))
+        rows = index.get_playlist_tracks(pl["id"])
+        index.close()
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["album"] == "The Ecstatic"  # tag drifted to the short name
+        assert row["canonical_album"] == "The Ecstatic (Deluxe)"  # albums-row key
+        assert row["canonical_album_artist"] == "yasiin bey"
+        assert row["display_album"] == "The Ecstatic"
+        assert row["album_id"] == album_id  # present, not None
+
+    def test_magic_playlist_track_carries_canonical_identity(
+        self, tmp_path: Path
+    ) -> None:
+        index, album_id = self._index_with_renamed_album(tmp_path)
+        playlist_id = index.create_magic_playlist(
+            "Magic",
+            MagicCriteria(
+                groups=[
+                    Group(
+                        conditions=[
+                            Condition(field="track.artist", op="is", value="yasiin bey")
+                        ],
+                        match="all",
+                        negate=False,
+                    )
+                ],
+                match="all",
+            ),
+        )
+        rows = index.get_magic_playlist_tracks(playlist_id)
+        index.close()
+
+        assert len(rows) == 1
+        assert rows[0]["canonical_album"] == "The Ecstatic (Deluxe)"
+        assert rows[0]["display_album"] == "The Ecstatic"
+        assert rows[0]["album_id"] == album_id
+
+    def test_untagged_track_survives_left_join(self, tmp_path: Path) -> None:
+        # A missing-album (album='') track has no albums row / album_id; the LEFT
+        # JOIN must NOT drop it, and its canonical fields come back null.
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "lone.mp3")
+        t.album = ""
+        index.upsert_track(t)
+        pl = index.create_playlist("Mix")
+        index.add_track_to_playlist(pl["id"], str(tmp_path / "lone.mp3"))
+        rows = index.get_playlist_tracks(pl["id"])
+        index.close()
+
+        assert len(rows) == 1  # survived the LEFT JOIN
+        assert rows[0]["album_id"] is None
+        assert rows[0]["canonical_album"] is None
+
+
 class TestMagicPlaylists:
     def _criteria(self) -> MagicCriteria:
         return MagicCriteria(


### PR DESCRIPTION
## KAMP-613: magic playlist album view doesn't correctly reference renamed albums

### Problem
A playlist's "album view" synthesized album cards keyed on each track's mutable **album TAG**. Art (`get_album_art`) and navigation (`tracks_for_album`→`_album_id`) resolve via the albums-table canonical `(album_artist, album)` NOCASE key, so after a rename they diverge — the card shows the right name but its art 404s (default image) and clicking it lands on a blank album.

Confirmed on a copy of the production DB (repro albums "The Ecstatic", "Bestiary"): `albums.album = "The Ecstatic (Deluxe)"`, `display_album = "The Ecstatic"`, while the tracks carry `album = "The Ecstatic"` and the correct `album_id`. The library grid works because its cards come from `/api/v1/albums` (the albums table) and carry the canonical key for art/nav while only *displaying* `display_album`.

### Fix (Approach A — thread canonical identity to the UI)
- **`library.py`**: both playlist-tracks queries `LEFT JOIN albums ON albums.id = album_id` (LEFT so untagged tracks aren't dropped) and return `album_id`, canonical `album_artist`/`album`, `display_album`/`display_album_artist`, `art_version`. The row→dict mapping is now a shared `_playlist_track_row_to_dict` so the static and magic paths can't drift (KAMP-554).
- **`server.py`**: `PlaylistTrackOut` carries the new nullable fields, with an identity-contract comment (tag = row display only; `canonical_*` = art/nav; `display_*` = render-only).
- **`PlaylistView.tsx`**: `albumGroups`/`albumTrackIds` synthesize cards from the canonical identity; untagged (`album_id` NULL) tracks route through the missing-album `track_id` path, matching the library grid. Art/nav/drag inherit the canonical key from the `Album` object.

Deliberately does **not** touch `get_album_art`/`tracks_for_album` (they already resolve on the canonical key — the library grid proves it) and does **not** repair the `albums.album` vs tag divergence (KAMP-467/523 provenance by design; `album_id` is identity).

### Testing
- New `TestPlaylistTracksCanonicalAlbum`: canonical identity distinct from the tag (static + magic playlists), `album_id` present, and an untagged (`album=''`) track surviving the LEFT JOIN.
- Full backend suite: **2648 passed, 9 skipped, coverage 93.78%**. Pre-commit black + mypy clean; `kamp_ui` typecheck + lint clean.
- kamp_ui has no unit-test runner — album view verified manually.

Manual test plan:
- With a renamed album (e.g. "The Ecstatic", "Bestiary") that qualifies for a magic playlist: open the playlist → album view → card shows the renamed name, the **real art**, and clicking it navigates to the **populated** album.
- Same for a **static** playlist containing a renamed album.
- Regression: a normal album in a playlist album view still shows art/navigates; the track-LIST view still shows the track tag; dragging an album card from the playlist to the queue adds the right album; an **untagged** track still appears (not dropped) as its own card.

### Follow-up (this release)
The queue panel groups album cards by the same tag key — the same bug on the broader `TrackOut` model. Tracked as a fast-follow ticket (kept separate for blast-radius isolation, per review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
