### PR TITLE
KAMP-634: match search album cards by canonical album_id, not track tag

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -654,6 +654,10 @@ class Track:
     genres: list[str] = field(default_factory=list, compare=False)
     label: str = field(default="")
     id: int = field(default=0, compare=False)
+    # KAMP-634: canonical album FK (albums.id). Identity lookups should key on this,
+    # never the mutable album/album_artist tag. 0 when unknown (missing-album tracks,
+    # synthetic rows). compare=False: identity is `id`, not this denormalized FK.
+    album_id: int = field(default=0, compare=False)
     date_added: float | None = field(default=None, compare=False)
     last_played: float | None = field(default=None, compare=False)
     favorite: bool = field(default=False, compare=False)
@@ -8605,6 +8609,11 @@ def _row_to_track(row: sqlite3.Row) -> Track:
         embedded_art=bool(row["embedded_art"]),
         mb_release_id=row["mb_release_id"],
         mb_recording_id=row["mb_recording_id"],
+        # KAMP-634: carry the canonical album FK so identity lookups (e.g. search
+        # album matching) never key on the mutable album TAG. Guarded because a
+        # few callers build from partial/synthetic rows without the column; every
+        # row is a sqlite3.Row (row_factory), so .keys() is always valid.
+        album_id=row["album_id"] if "album_id" in row.keys() else 0,
         genre=row["genre"],
         label=row["label"],
         date_added=row["date_added"],

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3188,10 +3188,18 @@ def create_app(
         # otherwise be dropped from the album cards even though its tracks matched.
         fts_keys = {(t.album_artist.lower(), t.album.lower()) for t in fts_tracks}
         fts_ids = {t.id for t in fts_tracks if not t.album}
+        # KAMP-634: match named albums by canonical album_id (rename-safe) in
+        # ADDITION to the tag key — after an album rename the track tag diverges
+        # from the albums-row key and the tag branch alone drops the card. OR (not
+        # replace) so any matched track lacking album_id (e.g. a remote track)
+        # still resolves its album via the retained tag branch. Missing-album
+        # AlbumInfo entries have album_id 0 (falsy) and fall to the id branch below.
+        fts_album_ids = {t.album_id for t in fts_tracks if t.album_id}
         albums = [
             AlbumOut.from_album_info(a)
             for a in index.albums(sort=sort)
-            if (a.album_artist.lower(), a.album.lower()) in fts_keys
+            if (a.album_id and a.album_id in fts_album_ids)
+            or (a.album_artist.lower(), a.album.lower()) in fts_keys
             or (a.missing_album and a.missing_track_id in fts_ids)
         ]
         albums.sort(key=lambda a: not a.favorite)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3118,6 +3118,15 @@ class TestSearch:
         index.close()
         assert results == []
 
+    def test_search_track_carries_album_id(self, tmp_path: Path) -> None:
+        # KAMP-634: _row_to_track populates the canonical album FK so search album
+        # matching can key on album_id (rename-safe) rather than the mutable tag.
+        index = self._index_with_genres(tmp_path)
+        results = index.search("Blue Train")
+        index.close()
+        assert results
+        assert results[0].album_id > 0
+
     def test_genre_edit_updates_search(self, tmp_path: Path) -> None:
         # apply_genres reindexes FTS so an edit is immediately searchable and the
         # old genre stops matching.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1830,6 +1830,26 @@ class TestSearchEndpoint:
         assert len(data["albums"]) == 1
         assert data["albums"][0]["album_artist"] == "SUNN O)))"
 
+    def test_renamed_album_matches_by_canonical_album_id(
+        self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
+    ) -> None:
+        """KAMP-634: after a rename the matched track's tag ('The Ecstatic')
+        diverges from the album's canonical key ('The Ecstatic (Deluxe)'); the
+        album card still surfaces because the match keys on canonical album_id.
+        The tag branch alone would drop it, and an unrelated album is not pulled in."""
+        t = _track(1, album="The Ecstatic", artist="yasiin bey")
+        t.album_id = 42
+        matched = _album("yasiin bey", "The Ecstatic (Deluxe)")
+        matched.album_id = 42
+        unrelated = _album("Someone Else", "Other Record")
+        unrelated.album_id = 99
+        mock_index.search.return_value = [t]
+        mock_index.albums.return_value = [matched, unrelated]
+        app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
+        res = TestClient(app).get("/api/v1/search?q=ecstatic")
+        data = res.json()
+        assert [a["album"] for a in data["albums"]] == ["The Ecstatic (Deluxe)"]
+
     def test_albums_deduplicated_when_multiple_tracks_match(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:


### PR DESCRIPTION
## KAMP-634: search album results match on track tag, not canonical album identity

Third in the renamed-album identity family (after KAMP-613 playlist, KAMP-633 queue), on the backend search path.

### Problem
`search_library` kept a canonical album card only if the matched **tracks' mutable album TAG** key was in `fts_keys`. After a rename the albums-row key ("The Ecstatic (Deluxe)") diverges from the track tag ("The Ecstatic"), so the album was **dropped** from search results even though its tracks matched the query.

### Fix (OR, not replace)
Add a canonical-`album_id` match branch **alongside** the existing tag and missing-album branches — a strict superset:
```python
fts_album_ids = {t.album_id for t in fts_tracks if t.album_id}
albums = [AlbumOut.from_album_info(a) for a in index.albums(sort=sort)
          if (a.album_id and a.album_id in fts_album_ids)          # KAMP-634: rename-safe
          or (a.album_artist.lower(), a.album.lower()) in fts_keys  # retained (KAMP-545 casing)
          or (a.missing_album and a.missing_track_id in fts_ids)]
```
- Renamed albums now surface via canonical id; **no album that appears today disappears** — a matched track lacking `album_id` (e.g. a remote track) still resolves via the retained tag branch, so there's no new false-negative surface, and the KAMP-545 NOCASE fallback is kept.
- `Track` gains an `album_id` field (canonical `albums.id`, `compare=False`), populated by `_row_to_track` from the row it already selects (guarded read; every row is a `sqlite3.Row`, so `.keys()` is always valid). Additive — nothing read `Track.album_id` before.
- `AlbumInfo.album_id` is the canonical id for named albums and `0` for missing entries, so the truthiness gate routes named→id branch and missing→missing branch correctly.

Deliberately does **not** remove the tag/NOCASE fallback or touch `get_album_art`/`tracks_for_album`/schema. Dropping the tag fallback once all sources reliably carry `album_id` is a future cleanup (alongside KAMP-633).

### Testing
- `test_renamed_album_matches_by_canonical_album_id` (server): tag ≠ canonical, same `album_id` → album surfaces by id; an unrelated album is not pulled in.
- `test_search_track_carries_album_id` (library): `_row_to_track` populates `album_id` on search hits.
- Full backend suite: **2650 passed, 9 skipped, coverage 93.78%**. black + mypy clean.

Manual test plan:
- Search "ecstatic"/"bestiary" (renamed albums) → the album card appears with correct art and navigates to the populated album.
- Regression: search a normal album → still appears/works; search an untagged track → its missing-album card still appears; results gain no spurious albums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
