### PR TITLE
KAMP-633: queue album cards + Go to Album key on canonical album_id, not tag

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -7977,6 +7977,28 @@ class LibraryIndex:
             "album_art_version": r["art_version"],
         }
 
+    def album_identity_for_ids(self, album_ids: "set[int]") -> "dict[int, sqlite3.Row]":
+        """Batch-fetch canonical album identity rows keyed by ``albums.id`` (KAMP-633).
+
+        Returns ``{album_id: row}`` where each row carries the canonical
+        ``album_artist``/``album`` (the art/nav identity key, NOT the track's
+        mutable tag), the ``display_*`` overrides, and ``art_version``.  Used by
+        ``_tracks_out``/``_track_out`` (server.py) to stamp canonical album
+        identity onto ``TrackOut`` so the queue cards and "Go to Album" resolve
+        correctly after a rename — mirroring the KAMP-613 playlist join.
+
+        Empty input short-circuits: a bare ``IN ()`` is a SQLite syntax error.
+        """
+        if not album_ids:
+            return {}
+        placeholders = ",".join("?" * len(album_ids))
+        rows = self._conn.execute(
+            "SELECT id, album_artist, album, display_album, display_album_artist,"
+            f" art_version FROM albums WHERE id IN ({placeholders})",
+            list(album_ids),
+        ).fetchall()
+        return {r["id"]: r for r in rows}
+
     def add_track_to_playlist(self, playlist_id: int, file_path: str) -> None:
         """Append a track to the end of a playlist.
 

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -249,9 +249,30 @@ class TrackOut(BaseModel):
     is_available: bool = True
     duration: float = 0.0
     sources: list[SourceOut] = []
+    # KAMP-633: canonical album identity so any TrackOut consumer (queue album
+    # cards, "Go to Album") can resolve art/navigation to the real album after a
+    # rename. IDENTITY CONTRACT (mirrors PlaylistTrackOut): `album_artist`/`album`
+    # above are the track's display-or-tag value (row display only, NEVER album
+    # identity); `canonical_*` (from the albums row via album_id) is the art/nav
+    # key; `display_*` is render-only. All null for untagged (missing-album)
+    # tracks — the UI routes those through the track id path (KAMP-554).
+    album_id: int | None = None
+    canonical_album_artist: str | None = None
+    canonical_album: str | None = None
+    display_album: str | None = None
+    display_album_artist: str | None = None
+    album_art_version: float | None = None
 
     @classmethod
-    def from_track(cls, t: Track, sources: "list[Any] | None" = None) -> "TrackOut":
+    def from_track(
+        cls,
+        t: Track,
+        sources: "list[Any] | None" = None,
+        album: "Any | None" = None,
+    ) -> "TrackOut":
+        # *album* is the canonical albums row (from LibraryIndex.album_identity_for_ids)
+        # for t.album_id, or None when the track is untagged / unresolved. Its
+        # presence stamps the canonical identity fields; absence leaves them None.
         return cls(
             id=t.id,
             title=t.title,
@@ -274,6 +295,14 @@ class TrackOut(BaseModel):
             is_available=t.is_available,
             duration=t.duration,
             sources=[SourceOut.from_row(r) for r in (sources or [])],
+            album_id=(t.album_id or None) if album is not None else None,
+            canonical_album_artist=album["album_artist"] if album is not None else None,
+            canonical_album=album["album"] if album is not None else None,
+            display_album=album["display_album"] if album is not None else None,
+            display_album_artist=(
+                album["display_album_artist"] if album is not None else None
+            ),
+            album_art_version=album["art_version"] if album is not None else None,
         )
 
 
@@ -940,15 +969,31 @@ def _tracks_out(index: LibraryIndex, tracks: "list[Track]") -> list[TrackOut]:
     One sources_for_track_ids call for the whole list (no N+1). Synthetic queue
     restore stubs (id=0) are excluded from the batch and get an empty sources
     list. Use this instead of a bare `[TrackOut.from_track(t) for t in ...]`.
+
+    KAMP-633: canonical album identity is batch-resolved in one query
+    (album_identity_for_ids) so album cards / "Go to Album" don't key on the tag.
     """
     src_map = index.sources_for_track_ids([t.id for t in tracks if t.id])
-    return [TrackOut.from_track(t, src_map.get(t.id, [])) for t in tracks]
+    album_map = index.album_identity_for_ids({t.album_id for t in tracks if t.album_id})
+    return [
+        TrackOut.from_track(t, src_map.get(t.id, []), album_map.get(t.album_id))
+        for t in tracks
+    ]
 
 
 def _track_out(index: LibraryIndex, track: Track) -> TrackOut:
-    """Serialize a single track to TrackOut with its sources (KAMP-537)."""
+    """Serialize a single track to TrackOut with its sources (KAMP-537).
+
+    KAMP-633: also resolves the canonical album row; skips the lookup entirely
+    for untagged tracks (album_id 0) so no needless query fires.
+    """
+    album = (
+        index.album_identity_for_ids({track.album_id}).get(track.album_id)
+        if track.album_id
+        else None
+    )
     return TrackOut.from_track(
-        track, index.sources_for_track_ids([track.id]).get(track.id, [])
+        track, index.sources_for_track_ids([track.id]).get(track.id, []), album
     )
 
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -40,6 +40,17 @@ export type Track = {
   // KAMP-552: identity is the canonical `id`; the delivery paths/uris live here
   // (there is no more track-level file_path).
   sources: TrackSource[]
+  // KAMP-633: canonical album identity from the albums row (via album_id). The
+  // sibling `album`/`album_artist` are the track's display-or-tag value — NEVER
+  // use them to key album identity (art/nav); use canonical_* for that and
+  // display_* for rendering. All null for untagged (missing-album) tracks, which
+  // the UI routes through the track id path (KAMP-554).
+  album_id: number | null
+  canonical_album_artist: string | null
+  canonical_album: string | null
+  display_album: string | null
+  display_album_artist: string | null
+  album_art_version: number | null
 }
 
 // The uri a track is reached by: prefer a local file source, else the first
@@ -170,16 +181,8 @@ export type PlaylistTrack = Track & {
   position: number
   last_played: number | null
   date_added: number | null
-  // KAMP-613: canonical album identity from the albums row (via album_id). The
-  // inherited `album`/`album_artist` are the track's mutable TAG — NEVER use them
-  // to key album identity (art/nav); use canonical_* for that and display_* for
-  // rendering. All null for untagged (missing-album) tracks.
-  album_id: number | null
-  canonical_album_artist: string | null
-  canonical_album: string | null
-  display_album: string | null
-  display_album_artist: string | null
-  album_art_version: number | null
+  // Canonical album identity (album_id, canonical_*, display_*, album_art_version)
+  // is inherited from the base Track type (KAMP-633).
 }
 
 // Configurable base URL: defaults to localhost but can be overridden via

--- a/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueAlbumCard.tsx
@@ -3,8 +3,13 @@ import { artUrl } from '../api/client'
 import type { Track } from '../api/client'
 
 interface QueueAlbumCardProps {
+  // KAMP-633: albumArtist/album are the CANONICAL albums-row key (art + nav);
+  // displayAlbum/displayAlbumArtist are the render-only label (may be renamed).
   albumArtist: string
   album: string
+  displayAlbum: string
+  displayAlbumArtist: string
+  artVersion: number | null
   tracks: Track[]
   trackIndices: number[]
   isDragging: boolean
@@ -21,6 +26,9 @@ interface QueueAlbumCardProps {
 export function QueueAlbumCard({
   albumArtist,
   album,
+  displayAlbum,
+  displayAlbumArtist,
+  artVersion,
   tracks,
   trackIndices,
   isDragging,
@@ -34,7 +42,9 @@ export function QueueAlbumCard({
   const [artLoaded, setArtLoaded] = useState(false)
   const [artError, setArtError] = useState(false)
   const firstTrack = tracks[0]
-  const src = artUrl(albumArtist, album, { trackId: firstTrack?.id ?? null })
+  // Art resolves on the canonical key + version (KAMP-633); the label shows the
+  // display name.
+  const src = artUrl(albumArtist, album, { trackId: firstTrack?.id ?? null, version: artVersion })
 
   return (
     <li
@@ -68,8 +78,8 @@ export function QueueAlbumCard({
         {(!artLoaded || artError) && <span className="queue-album-card-art-placeholder">♪</span>}
       </div>
       <div className="queue-album-card-info">
-        <span className="queue-album-card-name">{album}</span>
-        <span className="queue-album-card-artist">{albumArtist}</span>
+        <span className="queue-album-card-name">{displayAlbum}</span>
+        <span className="queue-album-card-artist">{displayAlbumArtist}</span>
       </div>
       <span className="queue-album-card-count">{tracks.length}</span>
     </li>

--- a/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/QueueContextMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from './TransportIcons'
 import type { Track } from '../api/client'
 import { getPlaylistTracks } from '../api/client'
+import { albumForTrackNav } from '../utils/albumFromTrack'
 import { DuplicatePlaylistTrackModal } from './DuplicatePlaylistTrackModal'
 
 interface Props {
@@ -139,29 +140,9 @@ export function QueueContextMenu({
               <button
                 className="track-context-menu-item"
                 onClick={() => {
-                  const found = albums.find(
-                    (a) =>
-                      (a.album === track.album || a.display_album === track.album) &&
-                      (a.album_artist === track.album_artist ||
-                        a.display_album_artist === track.album_artist)
-                  ) ?? {
-                    album_artist: track.album_artist,
-                    album: track.album,
-                    release_date: '',
-                    track_count: 0,
-                    has_art: false,
-                    missing_album: false,
-                    track_id: null,
-                    art_version: null,
-                    added_at: null,
-                    last_played_at: null,
-                    play_count_avg: 0,
-                    favorite: false,
-                    has_favorite_track: false,
-                    source: 'local',
-                    has_remote_tracks: false,
-                    genres: []
-                  }
+                  // KAMP-633: resolve by CANONICAL album identity (album_id), not
+                  // the mutable tag — otherwise a renamed album lands on a blank page.
+                  const found = albumForTrackNav(track, albums)
                   // KAMP-555: dismiss the search overlay so the updated library
                   // view is visible. No-op when search isn't open.
                   void setSearchQuery('')

--- a/kamp_ui/src/renderer/src/components/QueuePanel.tsx
+++ b/kamp_ui/src/renderer/src/components/QueuePanel.tsx
@@ -8,9 +8,47 @@ import { FavoriteIcon, WarnIcon, GoToAlbumIcon, QueueIcon } from './TransportIco
 import type { Track } from '../api/client'
 import { computeNewOrder } from '../utils/computeNewOrder'
 
-type NextUpItem =
-  | { kind: 'track'; track: Track; queueIdx: number }
-  | { kind: 'album'; albumArtist: string; album: string; tracks: Track[]; trackIndices: number[] }
+// KAMP-633: group album runs by CANONICAL album identity (the albums row via
+// album_id), never the mutable track tag — otherwise art/nav resolve to the
+// pre-rename key and break. Untagged tracks (no album_id) never group: keyed on
+// the queue index so they render as individual rows and synthetic queue-restore
+// stubs (id 0) never collide on a shared key.
+function albumRunKey(t: Track, queueIdx: number): string {
+  return t.album_id != null && t.canonical_album != null
+    ? `id:${t.album_id}`
+    : `missing:${queueIdx}`
+}
+
+// Canonical album_artist/album for art + navigation (the albums-row key).
+const canonicalAlbumArtist = (t: Track): string => t.canonical_album_artist ?? t.album_artist
+const canonicalAlbum = (t: Track): string => t.canonical_album ?? t.album
+
+// AlbumRun carries canonical identity (art/nav) plus the display name (render).
+type AlbumRun = {
+  albumArtist: string
+  album: string
+  displayAlbum: string
+  displayAlbumArtist: string
+  artVersion: number | null
+  tracks: Track[]
+  trackIndices: number[]
+}
+
+// Build the album-card fields for a run from its first track: canonical for
+// art/nav, display_* (falling back to canonical) for the visible label.
+function albumRunFrom(track: Track): Omit<AlbumRun, 'tracks' | 'trackIndices'> {
+  const albumArtist = canonicalAlbumArtist(track)
+  const album = canonicalAlbum(track)
+  return {
+    albumArtist,
+    album,
+    displayAlbum: track.display_album ?? album,
+    displayAlbumArtist: track.display_album_artist ?? albumArtist,
+    artVersion: track.album_art_version
+  }
+}
+
+type NextUpItem = { kind: 'track'; track: Track; queueIdx: number } | ({ kind: 'album' } & AlbumRun)
 
 const QUEUE_WIDTH_KEY = 'kamp:queue-width'
 const QUEUE_WIDTH_DEFAULT = 280
@@ -135,34 +173,35 @@ export function QueuePanel(): React.JSX.Element {
   const nextUpItems = useMemo((): NextUpItem[] => {
     if (!albumGroupingActive || position < 0) return []
     const nowPlayingTrack = tracks[position]
-    const straddleKey = nowPlayingTrack
-      ? `${nowPlayingTrack.album_artist}\0${nowPlayingTrack.album}`
-      : ''
+    const straddleKey = nowPlayingTrack ? albumRunKey(nowPlayingTrack, position) : ''
 
     const result: NextUpItem[] = []
-    let run: {
-      key: string
-      albumArtist: string
-      album: string
-      tracks: Track[]
-      trackIndices: number[]
-    } | null = null
+    let run: ({ key: string } & AlbumRun) | null = null
 
     // Flush the open run: a single track renders as a row, two or more as an album card.
     const flush = (): void => {
       if (!run) return
-      if (run.tracks.length < 2) {
-        result.push({ kind: 'track', track: run.tracks[0], queueIdx: run.trackIndices[0] })
+      const r = run
+      if (r.tracks.length < 2) {
+        result.push({ kind: 'track', track: r.tracks[0], queueIdx: r.trackIndices[0] })
       } else {
-        const { albumArtist, album, tracks: t, trackIndices } = run
-        result.push({ kind: 'album', albumArtist, album, tracks: t, trackIndices })
+        result.push({
+          kind: 'album',
+          albumArtist: r.albumArtist,
+          album: r.album,
+          displayAlbum: r.displayAlbum,
+          displayAlbumArtist: r.displayAlbumArtist,
+          artVersion: r.artVersion,
+          tracks: r.tracks,
+          trackIndices: r.trackIndices
+        })
       }
       run = null
     }
 
     for (let i = position + 1; i < tracks.length; i++) {
       const track = tracks[i]
-      const key = `${track.album_artist}\0${track.album}`
+      const key = albumRunKey(track, i)
       // Straddle (now-playing) album tracks always render individually and break any run.
       if (key === straddleKey) {
         flush()
@@ -176,13 +215,7 @@ export function QueuePanel(): React.JSX.Element {
         run.trackIndices.push(i)
       } else {
         flush()
-        run = {
-          key,
-          albumArtist: track.album_artist,
-          album: track.album,
-          tracks: [track],
-          trackIndices: [i]
-        }
+        run = { key, ...albumRunFrom(track), tracks: [track], trackIndices: [i] }
       }
     }
     flush()
@@ -190,33 +223,27 @@ export function QueuePanel(): React.JSX.Element {
   }, [albumGroupingActive, tracks, position])
 
   // Straddle group for the Now Playing album card: contiguous run of tracks around
-  // `position` that share the same album key. Used only in album view.
-  const nowPlayingAlbumCard = useMemo((): {
-    albumArtist: string
-    album: string
-    tracks: Track[]
-    trackIndices: number[]
-  } | null => {
+  // `position` that share the same canonical album key. Used only in album view.
+  const nowPlayingAlbumCard = useMemo((): AlbumRun | null => {
     if (!albumGroupingActive || position < 0) return null
     const nowPlayingTrack = tracks[position]
     if (!nowPlayingTrack) return null
-    const key = `${nowPlayingTrack.album_artist}\0${nowPlayingTrack.album}`
+    // An untagged now-playing track has no canonical album — render it as a row,
+    // not a blank album card with default art (KAMP-633).
+    if (nowPlayingTrack.album_id == null || nowPlayingTrack.canonical_album == null) return null
+    const key = albumRunKey(nowPlayingTrack, position)
 
     let start = position
-    while (start > 0 && `${tracks[start - 1].album_artist}\0${tracks[start - 1].album}` === key) {
+    while (start > 0 && albumRunKey(tracks[start - 1], start - 1) === key) {
       start--
     }
     let end = position
-    while (
-      end + 1 < tracks.length &&
-      `${tracks[end + 1].album_artist}\0${tracks[end + 1].album}` === key
-    ) {
+    while (end + 1 < tracks.length && albumRunKey(tracks[end + 1], end + 1) === key) {
       end++
     }
 
     return {
-      albumArtist: nowPlayingTrack.album_artist,
-      album: nowPlayingTrack.album,
+      ...albumRunFrom(nowPlayingTrack),
       tracks: tracks.slice(start, end + 1),
       trackIndices: Array.from({ length: end - start + 1 }, (_, i) => start + i)
     }
@@ -678,6 +705,9 @@ export function QueuePanel(): React.JSX.Element {
         key={`album:${item.albumArtist}\0${item.album}\0${item.trackIndices[0]}`}
         albumArtist={item.albumArtist}
         album={item.album}
+        displayAlbum={item.displayAlbum}
+        displayAlbumArtist={item.displayAlbumArtist}
+        artVersion={item.artVersion}
         tracks={item.tracks}
         trackIndices={item.trackIndices}
         isDragging={false}
@@ -844,6 +874,9 @@ export function QueuePanel(): React.JSX.Element {
                   key={`now-playing-album:${nowPlayingAlbumCard.albumArtist}\0${nowPlayingAlbumCard.album}`}
                   albumArtist={nowPlayingAlbumCard.albumArtist}
                   album={nowPlayingAlbumCard.album}
+                  displayAlbum={nowPlayingAlbumCard.displayAlbum}
+                  displayAlbumArtist={nowPlayingAlbumCard.displayAlbumArtist}
+                  artVersion={nowPlayingAlbumCard.artVersion}
                   tracks={nowPlayingAlbumCard.tracks}
                   trackIndices={nowPlayingAlbumCard.trackIndices}
                   isDragging={false}

--- a/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
+++ b/kamp_ui/src/renderer/src/components/TrackContextMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from './TransportIcons'
 import type { Track } from '../api/client'
 import { getPlaylistTracks, trackUri } from '../api/client'
+import { albumForTrackNav } from '../utils/albumFromTrack'
 import { truncateTitle } from '../utils/truncateTitle'
 import { DuplicatePlaylistTrackModal } from './DuplicatePlaylistTrackModal'
 
@@ -194,26 +195,9 @@ export function TrackContextMenu({
               <button
                 className="track-context-menu-item"
                 onClick={() => {
-                  const found = albums.find(
-                    (a) => a.album_artist === track.album_artist && a.album === track.album
-                  ) ?? {
-                    album_artist: track.album_artist,
-                    album: track.album,
-                    release_date: '',
-                    track_count: 0,
-                    has_art: false,
-                    missing_album: false,
-                    track_id: null,
-                    art_version: null,
-                    added_at: null,
-                    last_played_at: null,
-                    play_count_avg: 0,
-                    favorite: false,
-                    has_favorite_track: false,
-                    source: 'local',
-                    has_remote_tracks: false,
-                    genres: []
-                  }
+                  // KAMP-633: resolve by CANONICAL album identity (album_id), not
+                  // the mutable tag — otherwise a renamed album lands on a blank page.
+                  const found = albumForTrackNav(track, albums)
                   // KAMP-555: dismiss the search overlay so the updated library
                   // view is visible (App renders SearchView whenever searchQuery
                   // is non-empty). No-op when search isn't open.

--- a/kamp_ui/src/renderer/src/utils/albumFromTrack.ts
+++ b/kamp_ui/src/renderer/src/utils/albumFromTrack.ts
@@ -1,0 +1,62 @@
+import type { Album, Track } from '../api/client'
+
+// KAMP-633: resolve the Album to navigate to (for "Go to Album") from a track,
+// keyed on CANONICAL album identity (the albums row via album_id), never the
+// track's mutable album TAG. After a rename the tag diverges from the canonical
+// key that art (get_album_art) and navigation (tracks_for_album) resolve on, so
+// a tag match lands on a blank album page — this keys on canonical instead.
+//
+// Untagged tracks (no album_id) route to a missing-album card keyed by track id
+// (KAMP-554). When the real library Album is loaded, prefer it (full metadata /
+// favorite state); otherwise synthesize a minimal one from the canonical fields.
+//
+// Shared by TrackContextMenu and QueueContextMenu so the two never drift
+// (KAMP-554 sibling-divergence trap).
+export function albumForTrackNav(track: Track, albums: Album[]): Album {
+  if (track.album_id == null || track.canonical_album == null) {
+    return {
+      album_artist: track.album_artist || track.artist,
+      album: track.title, // missing-album cards display the track title
+      release_date: track.release_date,
+      track_count: 1,
+      has_art: track.embedded_art || track.source !== 'local',
+      missing_album: true,
+      track_id: track.id,
+      art_version: null,
+      added_at: null,
+      last_played_at: null,
+      play_count_avg: 0,
+      favorite: false,
+      has_favorite_track: track.favorite,
+      source: track.source === 'bandcamp' ? 'bandcamp' : 'local',
+      has_remote_tracks: track.source !== 'local',
+      genres: []
+    }
+  }
+  const albumArtist = track.canonical_album_artist ?? track.album_artist
+  const album = track.canonical_album
+  return (
+    albums.find((a) => a.album_artist === albumArtist && a.album === album) ?? {
+      album_artist: albumArtist,
+      album,
+      // display_* render the (possibly renamed) name; album/album_artist stay
+      // canonical for art/nav.
+      display_album: track.display_album ?? undefined,
+      display_album_artist: track.display_album_artist ?? undefined,
+      release_date: track.release_date,
+      track_count: 0,
+      has_art: track.embedded_art || track.source !== 'local',
+      missing_album: false,
+      track_id: null,
+      art_version: track.album_art_version,
+      added_at: null,
+      last_played_at: null,
+      play_count_avg: 0,
+      favorite: false,
+      has_favorite_track: track.favorite,
+      source: track.source === 'bandcamp' ? 'bandcamp' : 'local',
+      has_remote_tracks: track.source !== 'local',
+      genres: []
+    }
+  )
+}

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -12246,6 +12246,40 @@ class TestPlaylistTracksCanonicalAlbum:
         assert rows[0]["canonical_album"] is None
 
 
+class TestAlbumIdentityForIds:
+    """KAMP-633: batch canonical album lookup used to stamp TrackOut identity
+    (queue album cards / "Go to Album") without keying on the mutable track tag."""
+
+    def test_returns_canonical_rows_keyed_by_id(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        t = _sample_track(tmp_path / "ecstatic.mp3")
+        t.album_artist = "yasiin bey"
+        t.album = "The Ecstatic (Deluxe)"
+        index.upsert_track(t)
+        # Display rename (KAMP-467): albums.display_album set; albums.album stays.
+        index.update_album_display(
+            "yasiin bey", "The Ecstatic (Deluxe)", "The Ecstatic", None
+        )
+        album_id = index._album_id("yasiin bey", "The Ecstatic (Deluxe)")
+        assert album_id is not None
+
+        result = index.album_identity_for_ids({album_id})
+        index.close()
+
+        assert set(result) == {album_id}
+        row = result[album_id]
+        assert row["album"] == "The Ecstatic (Deluxe)"  # canonical key, not the tag
+        assert row["album_artist"] == "yasiin bey"
+        assert row["display_album"] == "The Ecstatic"
+
+    def test_empty_set_short_circuits(self, tmp_path: Path) -> None:
+        # A bare `IN ()` is a SQLite syntax error; the guard returns {} without
+        # touching the DB (hit by all-untagged track lists).
+        index = LibraryIndex(tmp_path / "library.db")
+        assert index.album_identity_for_ids(set()) == {}
+        index.close()
+
+
 class TestMagicPlaylists:
     def _criteria(self) -> MagicCriteria:
         return MagicCriteria(

--- a/tests/test_mb_lookup_endpoint.py
+++ b/tests/test_mb_lookup_endpoint.py
@@ -60,6 +60,9 @@ def mock_index() -> MagicMock:
     index = MagicMock()
     index.albums.return_value = []
     index.tracks_for_album.return_value = []
+    # Real dict (not a MagicMock) so TrackOut serializes with null canonical album
+    # identity instead of un-indexable mocks (KAMP-633).
+    index.album_identity_for_ids.return_value = {}
     return index
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,6 +72,10 @@ def mock_index() -> MagicMock:
     index.list_all_magic_criteria.return_value = []
     # Default: empty download queue so download.queue snapshots serialize (KAMP-566).
     index.download_queue_items.return_value = []
+    # Default: no canonical album rows so TrackOut serializes with null canonical
+    # identity (KAMP-633). Real dict (not a MagicMock) so `.get()` yields None and
+    # from_track leaves the canonical fields None; tests needing them override.
+    index.album_identity_for_ids.return_value = {}
     return index
 
 
@@ -4621,6 +4625,112 @@ class TestPatchAlbumMetaEndpoint:
         )
         out = TrackOut.from_track(stub)
         assert out.reachable is False
+
+    def _tagged_track(self, album_id: int) -> "Any":
+        from pathlib import Path as _Path
+
+        from kamp_core.library import Track as _Track
+
+        return _Track(
+            file_path=_Path("/m/whales.mp3"),
+            title="Whales",
+            artist="Hail Mary Mallon",
+            album_artist="Hail Mary Mallon",
+            album="Bestiary",  # tag drifted from the canonical albums-row name
+            release_date="",
+            track_number=1,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=True,
+            mb_release_id="",
+            mb_recording_id="",
+            source="local",
+            id=7,
+            album_id=album_id,
+        )
+
+    _CANON_ROW = {
+        "id": 42,
+        "album_artist": "Hail Mary Mallon",
+        "album": "Bestiary (Bonus Track Version)",
+        "display_album": None,
+        "display_album_artist": None,
+        "art_version": 1234.0,
+    }
+
+    def test_tracks_out_stamps_canonical_album_identity(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """KAMP-633: _tracks_out resolves canonical album identity via album_id;
+        the tag `album` is preserved while canonical_* comes from the albums row."""
+        from kamp_core.server import _tracks_out
+
+        mock_index.sources_for_track_ids.return_value = {}
+        mock_index.album_identity_for_ids.return_value = {42: self._CANON_ROW}
+        out = _tracks_out(mock_index, [self._tagged_track(42)])[0]
+
+        assert out.album == "Bestiary"  # tag preserved (row display only)
+        assert out.album_id == 42
+        assert out.canonical_album == "Bestiary (Bonus Track Version)"
+        assert out.canonical_album_artist == "Hail Mary Mallon"
+        assert out.album_art_version == 1234.0
+        mock_index.album_identity_for_ids.assert_called_once_with({42})
+
+    def test_tracks_out_untagged_track_has_null_canonical(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """An untagged track (album_id 0) yields all-null canonical fields and the
+        batch lookup is called with the empty set (its guard short-circuits)."""
+        from kamp_core.server import _tracks_out
+
+        mock_index.sources_for_track_ids.return_value = {}
+        mock_index.album_identity_for_ids.return_value = {}
+        out = _tracks_out(mock_index, [self._tagged_track(0)])[0]
+
+        assert out.album_id is None
+        assert out.canonical_album is None
+        assert out.canonical_album_artist is None
+        assert out.album_art_version is None
+        mock_index.album_identity_for_ids.assert_called_once_with(set())
+
+    def test_track_out_skips_album_lookup_when_untagged(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """_track_out fires no album query for an untagged track (album_id 0)."""
+        from kamp_core.server import _track_out
+
+        mock_index.sources_for_track_ids.return_value = {}
+        out = _track_out(mock_index, self._tagged_track(0))
+
+        assert out.album_id is None
+        assert out.canonical_album is None
+        mock_index.album_identity_for_ids.assert_not_called()
+
+    def test_track_out_resolves_album_lookup_when_tagged(
+        self,
+        mock_index: MagicMock,
+        mock_engine: MagicMock,
+        mock_queue: MagicMock,
+    ) -> None:
+        """_track_out stamps canonical identity from the single-id album lookup."""
+        from kamp_core.server import _track_out
+
+        mock_index.sources_for_track_ids.return_value = {}
+        mock_index.album_identity_for_ids.return_value = {42: self._CANON_ROW}
+        out = _track_out(mock_index, self._tagged_track(42))
+
+        assert out.canonical_album == "Bestiary (Bonus Track Version)"
+        assert out.album_id == 42
+        mock_index.album_identity_for_ids.assert_called_once_with({42})
 
     def test_album_out_includes_source_and_has_remote_tracks(
         self,


### PR DESCRIPTION
## KAMP-633: queue album cards + "Go to Album" key on canonical album_id, not the tag

Queue-panel analog of KAMP-613 (playlist) / KAMP-634 (search), plus the "Go to Album" context-menu action folded in (reproduced live: right-click a Hail Mary Mallon track → Go to Album → blank page).

### Problem
The queue panel grouped tracks into album cards keyed on the mutable album **TAG** (`${album_artist}\0${album}`), and the "Go to Album" track/queue context-menu actions matched the canonical albums list by that same tag. After an album rename the tag diverges from the canonical `albums`-row `(album_artist, album)` key that art (`get_album_art`) and navigation (`tracks_for_album`) resolve on — so queue cards showed **default art** and "Go to Album" landed on a **blank album page**.

### Fix (mirror KAMP-613, Approach A)
Resolve canonical album identity at the `TrackOut` choke point so every consumer keys on `album_id`, never the tag.

**Backend**
- `library.py`: `album_identity_for_ids(ids)` batch-fetches canonical album rows (`album_artist`/`album`/`display_*`/`art_version`) keyed by `albums.id`. **Empty set short-circuits to `{}`** — a bare `IN ()` is a SQLite syntax error.
- `server.py`: `TrackOut` gains 6 nullable canonical fields (`album_id`, `canonical_album_artist`/`album`, `display_album`/`_artist`, `album_art_version`) mirroring `PlaylistTrackOut`, same identity-contract comment. `from_track` takes an optional resolved albums row; **`_tracks_out` batch-resolves in one query**, `_track_out` skips the lookup for untagged tracks (`album_id` 0). Every `TrackOut` endpoint (queue, search, now-playing current/next, top tracks, patch results, WS `player.state`) funnels through these two helpers — verified no bare `TrackOut(...)` construction exists.

**Frontend**
- `client.ts`: the 6 canonical fields move onto the base `Track` type; `PlaylistTrack` inherits them (dedupe).
- `QueuePanel`: album runs (Next-Up + Now-Playing straddle) group by canonical `id:<album_id>`; art/nav use the canonical key + `art_version`; the label shows the display name. Untagged/stub tracks key on the **queue index** (`missing:<idx>`) so synthetic queue-restore stubs (`id` 0) never collide, and an untagged now-playing track renders as a **row**, not a blank album card.
- `QueueAlbumCard`: art via canonical key + `art_version`; label via display name.
- `TrackContextMenu` + `QueueContextMenu` "Go to Album": resolve the target album via a **shared `albumForTrackNav()` helper** (canonical identity; missing-album `track_id` path for untagged) instead of a tag match — one helper so the two siblings never drift (KAMP-554).

### Reality Checker
Consulted during planning; caught and fixed pre-ship: the `IN ()` crash on all-untagged lists, the `missing:0` stub collision (→ queue index), the untagged now-playing card (→ null), and a scope trim (SearchView/TopTracks thumbnails dropped).

### Out of scope (deferred follow-up)
`SearchView`, `TopTracksModule`, `MagicPlaylistModule`, and `NowPlayingView` track-thumbnail art still key on the tag (wrong art after a rename, but **no** blank-nav). Now that `Track` carries canonical identity, each is a one-line fix — filed for a fast-follow to keep this PR tight.

### Testing
- `album_identity_for_ids`: canonical rows keyed by id + empty-set guard.
- `TrackOut` carries canonical identity after a rename (tag ≠ canonical, same `album_id`); untagged → all-null; `_track_out` skips the lookup at `album_id` 0 and resolves it otherwise.
- Two endpoint `mock_index` fixtures default `album_identity_for_ids` to `{}` so `TrackOut` serializes with null canonical identity.
- Full backend suite: **2656 passed, 9 skipped, coverage 93.79%**. black + mypy clean; kamp_ui typecheck + lint clean.

### Manual test plan
Precondition: an album whose canonical name differs from its track tag (e.g. the Hail Mary Mallon "Bestiary" repro). Restart the app so the new backend serves.
- **Queue Next-Up card:** queue 2+ tracks of the renamed album → card shows correct art + name; drag/reorder resolves correctly.
- **Now-Playing straddle card:** play into the renamed album → straddle card shows correct art/name.
- **Untagged tracks:** queue tracks with an empty album tag → each renders as an individual row (no bogus card); a queue-restore stub run doesn't merge into one card.
- **Go to Album (track row):** right-click a renamed album's track in search / library / queue → lands on the populated album with art (no ghost).
- **Go to Album (queue row):** same via the queue context menu.
- **Regressions:** a never-renamed album still groups/navigates; the `text/kamp-album` drop from a library album card onto the queue still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
