### PR TITLE
KAMP-604: apply Bandcamp labels as genres only on an album's first index

### DIFF
--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -595,10 +595,14 @@ def sync_collection_stream(
                     # All tracks share the album keywords. Cache BEFORE any strip
                     # below so the labels persist even when applying them is off.
                     index.set_collection_keywords(str(sid), tracks[0].genres)
-                    # When applying Bandcamp labels as genres is disabled, drop them
-                    # from the tracks before upsert so they never reach the library
-                    # (the cache above still holds them for a later toggle-on).
-                    if not apply_bandcamp_genres:
+                    # Apply Bandcamp labels as genres ONLY on an album's first index.
+                    # When the toggle is off, or on any later re-sync (pre-order
+                    # re-inspection / date backfill of an album we already have),
+                    # strip them before upsert so upsert_many's empty-incoming skip
+                    # preserves the user's genre edits (KAMP-604). The keyword cache
+                    # above still holds the labels for an explicit re-trigger (the
+                    # KAMP-591 genre backfill) or a later toggle-on.
+                    if not apply_bandcamp_genres or not is_new_album:
                         for _t in tracks:
                             _t.genres = []
                     index.upsert_many(tracks)

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2791,6 +2791,133 @@ class TestSyncCollectionStream:
         upserted = index.upsert_many.call_args[0][0]
         assert upserted[0].genres == []
 
+    def _genre_track(self, genres: list[str], n: int = 1) -> Any:
+        from pathlib import Path as _Path
+
+        from kamp_core.library import Track
+
+        return Track(
+            file_path=_Path(f"bandcamp://1/{n}"),
+            title=f"T{n}",
+            artist="A",
+            album_artist="A",
+            album="Album",
+            release_date="2020",
+            track_number=n,
+            disc_number=1,
+            ext="mp3",
+            embedded_art=False,
+            mb_release_id="",
+            mb_recording_id="",
+            source="bandcamp",
+            genres=genres,
+        )
+
+    def test_preorder_resync_preserves_user_genre_edits(self, tmp_path: Path) -> None:
+        # KAMP-604 (headline red-before-green): a pre-order first-indexed with the
+        # toggle on gets its Bandcamp labels as genres; after the user edits those
+        # genres, a later re-sync (still a pre-order, is_new_album False) must NOT
+        # clobber the edit. Real LibraryIndex so upsert_many's empty-incoming skip
+        # is exercised end to end.
+        from kamp_core.library import LibraryIndex
+
+        item = _preorder_item(1)
+        watch_folder = tmp_path / "watch"
+        config = _bc_config(tmp_path)
+        index = LibraryIndex(tmp_path / "lib.db")
+
+        def _sync() -> None:
+            with (
+                patch(
+                    "kamp_daemon.bandcamp._ensure_session",
+                    return_value=_make_session_data(),
+                ),
+                patch(
+                    "kamp_daemon.bandcamp._make_requests_session",
+                    return_value=_make_requests_mock([item]),
+                ),
+                patch(
+                    "kamp_daemon.bandcamp.fetch_album_tracks",
+                    side_effect=lambda *a, **k: [
+                        self._genre_track(["shoegaze", "dream pop"])
+                    ],
+                ),
+            ):
+                sync_collection_stream(
+                    config, watch_folder, index, apply_bandcamp_genres=True
+                )
+
+        # First index (is_new_album True): Bandcamp labels applied.
+        _sync()
+        tid = index._conn.execute("SELECT id FROM tracks").fetchone()["id"]
+        assert set(index.genres_for_track(tid)) == {"shoegaze", "dream pop"}
+
+        # User removes a genre.
+        index.apply_genres([tid], ["shoegaze"], mode="replace")
+        assert index.genres_for_track(tid) == ["shoegaze"]
+
+        # Re-sync of the same pre-order must preserve the edit, not revert it.
+        _sync()
+        result = index.genres_for_track(tid)
+        index.close()
+        assert result == ["shoegaze"]
+
+    def test_preorder_resync_strips_bandcamp_genres(self, tmp_path: Path) -> None:
+        # KAMP-604: re-sync of an already-indexed pre-order (is_new_album False)
+        # strips the fetched Bandcamp genres before upsert (so upsert_many's
+        # empty-incoming skip preserves the user's edits) while still refreshing
+        # the keyword cache. This is the (apply=True, is_new=False) strip branch.
+        track = self._genre_track(["shoegaze", "dream pop"])
+        _result, index = self._run(
+            tmp_path,
+            [_item(1)],
+            already_have_tracks=True,
+            fake_tracks=[track],
+            existing_state={"1": "preorder"},
+            apply_bandcamp_genres=True,
+        )
+        index.set_collection_keywords.assert_called_once_with(
+            "1", ["shoegaze", "dream pop"]
+        )
+        assert index.upsert_many.call_args[0][0][0].genres == []
+
+    def test_date_backfill_resync_does_not_reapply_genres(self, tmp_path: Path) -> None:
+        # KAMP-604: the strip generalizes beyond pre-orders — a non-pre-order album
+        # re-fetched only for year-only date backfill (is_new_album False) also
+        # stops re-applying Bandcamp genres, preserving the stored set.
+        track = self._genre_track(["shoegaze"])
+        _result, index = self._run(
+            tmp_path,
+            [_item(1)],
+            already_have_tracks=True,  # existing album -> is_new_album False
+            fake_tracks=[track],  # fetch triggers via needs_backfill (MagicMock)
+            apply_bandcamp_genres=True,
+        )
+        index.upsert_many.assert_called_once()
+        assert index.upsert_many.call_args[0][0][0].genres == []
+
+    def test_graduated_preorder_new_track_lands_genreless(self, tmp_path: Path) -> None:
+        # KAMP-604 Q3 (deliberate): when a re-inspected pre-order gains a newly
+        # released track, is_new_album is album-granular, so ALL fetched tracks
+        # (the pre-existing ones and the new one) are stripped. Album-mates keep
+        # their user-edited genres via the empty-incoming skip; the new track
+        # lands genre-less. Accepted trade-off — the album genre union is
+        # unchanged (union with the empty set is a no-op).
+        tracks = [
+            self._genre_track(["shoegaze"], n=1),
+            self._genre_track(["shoegaze"], n=2),  # the newly-released track
+        ]
+        _result, index = self._run(
+            tmp_path,
+            [_item(1)],
+            already_have_tracks=True,
+            fake_tracks=tracks,
+            existing_state={"1": "preorder"},
+            apply_bandcamp_genres=True,
+        )
+        upserted = index.upsert_many.call_args[0][0]
+        assert [t.genres for t in upserted] == [[], []]
+
     def test_batch_indexed_callback_fires_per_new_batch(self, tmp_path: Path) -> None:
         """batch_indexed_callback fires once per album batch that has new tracks."""
         from kamp_core.library import Track


### PR DESCRIPTION
## KAMP-604: apply Bandcamp labels as genres only on an album's first index

### Problem
With "use bandcamp labels as genres" ON, every Bandcamp sync re-inspected pre-order albums, re-fetched their tracks (genres populated from Bandcamp keyword labels), and `upsert_many` re-applied them — clobbering any genre the user had added or removed. Repro: pre-order + toggle on → remove a genre → sync → it reverts.

### Fix
In `sync_collection_stream` (`kamp_daemon/bandcamp.py`), apply the fetched Bandcamp genres at upsert **only when the album is being indexed for the first time with the toggle on**. On any later re-sync (pre-order re-inspection or year-only date backfill of an album we already have), strip the incoming genres before upsert so `_upsert_many`'s empty-incoming skip **preserves the user's stored genres**.

One-line skip-condition change at the existing strip site:
```python
# was: if not apply_bandcamp_genres:
if not apply_bandcamp_genres or not is_new_album:
    for _t in tracks:
        _t.genres = []
```
- `is_new_album` (KAMP-618 — no prior remote tracks for the sale_item_id) is the album-level "first index" signal; **no new column**.
- `set_collection_keywords` (KAMP-588 cache) still runs on every re-fetch, so the explicit genre backfill (KAMP-591 / "Update Library Genres") remains the deliberate way to re-apply labels.
- No `kamp_core/library.py` change — `_upsert_many` already skips empty-incoming genres for existing stream tracks and overwrites on non-empty.

### Intended behavior changes (beyond the pre-order repro — flagging for review)
- Bandcamp genre **updates** no longer flow via sync after first index; a keyword the artist adds later is picked up only by the manual backfill. Consistent with "first-index only."
- A non-pre-order album re-fetched solely for year-only date backfill also stops re-applying genres — for those old albums this **preserves** their existing set (more correct, not a regression).
- **Q3 (deliberate):** a pre-order that gains a newly-released track inserts that new track **genre-less** while its album-mates keep their user-edited genres. Accepted per the ticket's own recommendation; the album genre union is unaffected (∪∅ is a no-op).

### Reality Checker
Consulted during planning; confirmed the skip condition is correct (De Morgan of "apply only when `apply_bandcamp_genres AND is_new_album`"), the strip survives the scalar-`genre` fallback, no second Bandcamp-genre path bypasses it (`new_album_keys` → `enrich_albums` is Last.fm-only), and no KAMP-436 callback concern. It surfaced the Q3 decision, the branch-coverage operand pair, and the two behavior-change disclosures — all folded in.

### Testing (`tests/test_bandcamp.py`, `TestSyncCollectionStream`)
- **Headline (red-before-green), real `LibraryIndex`:** first-index a pre-order (labels applied) → user edits a genre → re-sync → the edit **survives** (previously reverted).
- Re-sync of an already-indexed pre-order strips the fetched genres **and** still caches the keywords.
- Date-backfill re-sync of a non-pre-order album does **not** re-apply genres.
- Graduated pre-order (existing + newly-released track) → all fetched genres stripped; the new track lands genre-less (Q3).
- First-index-applies (`apply=True, is_new=True` don't-strip branch) and toggle-off-strips are covered by existing tests.
- Full backend suite: **2660 passed, 9 skipped, coverage 93.79%**. black + mypy clean.

### Out of scope (follow-up)
The KAMP-588 download-time keyword stamping (`pipeline_impl.py`/`tagger.py`) can re-overwrite edits when a graduated pre-order is downloaded — a separate vector for a separate ticket.

### Manual test plan
Precondition: "use bandcamp labels as genres" ON; a Bandcamp pre-order in the collection.
- **Preservation:** open a pre-order, remove (or add) a genre → sync → the edit persists (no revert).
- **First index still applies:** a brand-new pre-order appears on sync → its Bandcamp labels show as genres.
- **Explicit re-trigger:** after editing, run "Update Library Genres" → labels re-apply (merge).
- **Toggle interplay:** toggle OFF → first-index a pre-order (no genres); toggle ON + backfill → labels apply from cache.
- **Regression:** a normal remote album still indexes; never-edited albums unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
