### PR TITLE
KAMP-636: fix Bandcamp downloads on Windows (cookie the CDN leg)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -118,11 +118,17 @@ The only reliable fix for any `bandcamp.com` request in an affected environment 
 ## macOS CFRunLoop constraint
 Any macOS API that dispatches callbacks on the main GCD queue (`dispatch_get_main_queue()`) will not work in the kamp Python server process. The main thread runs asyncio/uvicorn, which does not pump a CFRunLoop. Affected APIs include: `MPRemoteCommandCenter`, `NSDistributedNotificationCenter`, `NSTimer`, and any delegate/target-action pattern that assumes an AppKit main loop. Features requiring these APIs must live in the Electron main process (which has a real CFRunLoop) or in a dedicated helper subprocess.
 
-## Bandcamp CDN downloads (popplers5)
-`popplers5.bandcamp.com` requires valid Bandcamp session cookies to serve a ZIP. Without cookies it returns HTTP 200 with an HTML error page.
+## Bandcamp CDN downloads (popplers5) — KAMP-636
 
-- **Dev mode:** pass the authenticated `requests.Session` directly to `_download_file`. The session carries cookies; `requests` follows any redirect automatically. Do not attempt an "activate then download cookieless" pattern — it is intermittent and unreliable.
-- **Frozen mode:** the `requests.Session` has a PyInstaller OpenSSL fingerprint Cloudflare blocks (see above). Route through Electron's proxy: call `_resolve_cdn_redirect(cdn_url, _ProxySession)` to follow the popplers5 → bcbits.com redirect via `net.fetch`, then download from the bcbits.com pre-signed URL with a plain cookieless `requests.Session` (bcbits.com URLs are time-limited tokens that do not need cookies).
+**The CDN host is not the Cloudflare-protected host.** `popplers5.bandcamp.com` is plain nginx (`Server: nginx`, genuine 404s, no `cf-*` headers) and answers `requests` on every platform, PyInstaller and Windows dev included. Only `bandcamp.com` itself is bot-managed. So the proxy gate above applies to **API/page traffic only** — never extend it to the CDN leg, which cannot round-trip a multi-hundred-MB body through the JSON relay anyway.
+
+What popplers5 *does* require is the Bandcamp session cookies, and it serves the ZIP **directly** — there is no popplers5 → bcbits.com redirect to chase. `_download_item` therefore uses one path on every platform: `_cdn_download_session(session)` returns the dev `requests.Session` as-is, or rebuilds a cookie-bearing plain session from the `_ProxySession`'s stored `session_data`.
+
+Two dead ends, both shipped and both broken — do not retry either:
+- **"Activate, then download cookieless."** An authenticated GET does not entitle a later cookieless GET. It is intermittent at best.
+- **"HEAD through Electron to launder a pre-signed bcbits URL."** popplers5 issues no redirect, so the HEAD returns the input URL unchanged and the cookieless download proceeds against popplers5 — which bounces to bandcamp.com, whose reply to our TLS fingerprint is the Cloudflare challenge page. That page then gets written to disk and fails the ZIP/audio sniff.
+
+**Debugging tell:** a failed download whose recorded `size_bytes` is ~3 KB (3038 at time of writing) *is* the Cloudflare challenge page — the byte count is stable, so compare it against a plain `requests` GET to `https://bandcamp.com/` from the same interpreter. `content-type: text/html; charset=utf-8` is the challenge; popplers5's own error pages are bare `text/html`. That distinction is the fastest way to tell "wrong host answered" from "CDN said no", and `_download_file` now names the post-redirect URL in the error so the hop is visible without reproducing.
 
 ## Diagnosis discipline: ask before assuming
 Before proposing or implementing a fix, verify the actual failure mode from logs or a direct question. In TASK-173 multiple sessions were spent fixing things that were not broken (downloads, onboarding completion, the watch-folder/library wiring) because the diagnosis was assumed rather than confirmed. The cost: rewrites of working components, regressions introduced and then reverted, and a much longer path to the real two-line fix.

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -138,12 +138,17 @@ class _ProxySession:
     Only GET and POST are needed by bandcamp.py.  The ``stream`` and
     ``allow_redirects`` kwargs accepted by requests.Session are silently
     consumed — Electron follows redirects automatically.
+
+    *session_data* is the stored Bandcamp session.  Electron does not need it
+    (the proxy-fetch handler pulls cookies from the daemon on every call), but
+    the CDN download leg does — see :func:`_cdn_download_session`.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, session_data: dict[str, Any] | None = None) -> None:
         self.headers: dict[str, str] = {"User-Agent": _UA}
         # cookies is not used — Electron's session.defaultSession holds them.
         self.cookies: Any = None
+        self.session_data: dict[str, Any] = session_data or {}
 
     def _fetch(
         self,
@@ -191,9 +196,6 @@ class _ProxySession:
 
     def post(self, url: str, **kwargs: Any) -> _ProxyResponse:
         return self._fetch("POST", url, **kwargs)
-
-    def head(self, url: str, **kwargs: Any) -> _ProxyResponse:
-        return self._fetch("HEAD", url, **kwargs)
 
 
 # Alias json.dumps to avoid shadowing in _ProxySession._fetch
@@ -805,9 +807,15 @@ def _make_requests_session(
     if _needs_proxy_session():
         # Electron's session.defaultSession does *not* need to be pre-populated
         # with cookies: the proxy-fetch handler in kamp_ui/src/main/index.ts
-        # pulls them from the daemon's session storage on every call.
-        return _ProxySession()
+        # pulls them from the daemon's session storage on every call.  The
+        # session data still rides along for the CDN leg (_cdn_download_session).
+        return _ProxySession(session_data)
 
+    return _cookie_session(session_data)
+
+
+def _cookie_session(session_data: dict[str, Any]) -> _requests.Session:
+    """Build a plain ``requests.Session`` carrying the cookies from *session_data*."""
     session = _requests.Session()
     session.headers["User-Agent"] = _UA
     for cookie in session_data.get("cookies", []):
@@ -818,6 +826,26 @@ def _make_requests_session(
             path=cookie.get("path", "/"),
         )
     return session
+
+
+def _cdn_download_session(session: _AnySession) -> _requests.Session:
+    """Return a ``requests.Session`` to fetch the CDN payload with (KAMP-636).
+
+    The CDN host (popplers5.bandcamp.com) is plain nginx — it is *not* behind
+    the Cloudflare bot management that forces bandcamp.com API/page traffic
+    through Electron, so ``requests`` downloads it fine on every platform,
+    frozen bundle included.  What it does require is the Bandcamp session
+    cookies: without them popplers5 bounces the request to bandcamp.com, whose
+    answer to a non-browser TLS fingerprint is a ~3 KB Cloudflare challenge
+    page that then gets written to disk as the "ZIP".
+
+    In proxy mode the caller holds a :class:`_ProxySession`, which cannot
+    stream a large body (its payload round-trips through JSON), so build a
+    cookie-bearing plain session from the session data it carries.
+    """
+    if isinstance(session, _requests.Session):
+        return session
+    return _cookie_session(session.session_data)
 
 
 def _validate_session(session_data: dict[str, Any]) -> bool:
@@ -1589,35 +1617,6 @@ def backfill_download_sizes(
     return sized
 
 
-def _resolve_cdn_redirect(cdn_url: str, session: _AnySession) -> str:
-    """Authenticate the popplers5 CDN URL so that a subsequent cookieless download works.
-
-    popplers5.bandcamp.com serves ZIP content when accessed with valid Bandcamp
-    session cookies; without cookies it returns an HTML error page (HTTP 200).
-    An authenticated GET+stream (no body read) appears to activate the signed
-    URL server-side, allowing the follow-up cookieless download from
-    ``_download_file`` to succeed.  In practice popplers5 does not issue a
-    redirect — it serves directly — so the returned URL is the same as the
-    input.
-
-    In frozen mode ``session`` is a ``_ProxySession`` that routes through
-    Electron's net.fetch (which carries the Bandcamp cookies automatically).
-    """
-    if isinstance(session, _requests.Session):
-        resp = session.get(cdn_url, stream=True, allow_redirects=True, timeout=30)
-        try:
-            final_url: str = resp.url
-        finally:
-            resp.close()
-        logger.debug("_resolve_cdn_redirect: %s → %s", cdn_url, final_url)
-        return final_url
-    # Frozen mode: HEAD via Electron carries Bandcamp cookies to follow the
-    # popplers5 → bcbits.com redirect. HEAD avoids downloading the full ZIP
-    # here — the caller only needs the final URL.
-    proxy_resp = session.head(cdn_url, timeout=30)
-    return proxy_resp.url or cdn_url
-
-
 def _download_item(
     item: dict[str, Any],
     bc_config: BandcampConfig,
@@ -1645,21 +1644,15 @@ def _download_item(
     logger.info("Downloading %r by %r…", item_title, band_name)
     cdn_url = _get_cdn_url(redownload_url, bc_config.format, session)
 
-    if isinstance(session, _requests.Session):
-        # Dev mode: the requests.Session carries Bandcamp cookies.
-        # popplers5 requires cookies to serve the ZIP; pass the authenticated
-        # session directly so requests follows any redirect automatically.
-        return _download_file(
-            cdn_url, dest_base, session, bc_config.format, on_progress=on_progress
-        )
-    # Frozen mode: Electron's net.fetch carries cookies and follows the
-    # popplers5 → bcbits.com redirect via the proxy HEAD call.
-    # Download from bcbits.com directly — its pre-signed URLs need no cookies.
-    final_url = _resolve_cdn_redirect(cdn_url, session)
-    dl_session = _requests.Session()
-    dl_session.headers["User-Agent"] = _UA
+    # popplers5 requires the Bandcamp cookies to serve the ZIP, and answers
+    # directly (no bcbits redirect to chase), so the same cookie-bearing
+    # requests.Session works on every platform — see _cdn_download_session.
     return _download_file(
-        final_url, dest_base, dl_session, bc_config.format, on_progress=on_progress
+        cdn_url,
+        dest_base,
+        _cdn_download_session(session),
+        bc_config.format,
+        on_progress=on_progress,
     )
 
 
@@ -1745,11 +1738,17 @@ def _download_file(
         ) as resp:
             resp.raise_for_status()
             content_type = resp.headers.get("Content-Type", "")
+            # The URL the bytes actually came from. A CDN request that lost its
+            # cookies is redirected back to bandcamp.com, which answers with an
+            # HTML page — reporting only the requested URL hides that hop and
+            # made KAMP-636 look like a popplers5 fault.
+            final_url = str(resp.url)
             logger.debug(
-                "_download_file: status=%d content-type=%r url=%s",
+                "_download_file: status=%d content-type=%r url=%s final=%s",
                 resp.status_code,
                 content_type,
                 cdn_url,
+                final_url,
             )
             # KAMP-436/566: report byte-progress as (downloaded, total) so the
             # album card can reveal its art bottom-up and the Downloads view can
@@ -1794,10 +1793,15 @@ def _download_file(
         else:
             # Neither ZIP nor audio: the CDN served an HTML error page with
             # HTTP 200 (e.g. missing cookies on popplers5).
+            served_by = (
+                f" (served by {final_url})"
+                if final_url and final_url != cdn_url
+                else ""
+            )
             raise BandcampAPIError(
                 f"CDN response is neither a ZIP nor audio "
                 f"(first-bytes={magic!r}, content-type={content_type!r}) — "
-                f"url={cdn_url}"
+                f"url={cdn_url}{served_by}"
             )
 
         tmp.rename(final)

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -16,7 +16,7 @@ from kamp_daemon.bandcamp import (
     BandcampAPIError,
     CookieError,
     NeedsLoginError,
-    _ProxyResponse,
+    _cdn_download_session,
     _download_file,
     _download_item,
     _parse_content_length,
@@ -29,7 +29,6 @@ from kamp_daemon.bandcamp import (
     _get_fan_info,
     _make_requests_session,
     _paginate,
-    _resolve_cdn_redirect,
     _session_from_cookie_file,
     _username_from_logout_cookie,
     _validate_session,
@@ -1519,64 +1518,56 @@ class TestDownloadItem:
         "redownload_url": "https://bandcamp.com/download?sitem_id=42",
     }
 
-    def test_dev_mode_uses_authenticated_session(self, tmp_path: Path) -> None:
-        """Dev mode passes the authenticated requests.Session to _download_file directly."""
-        import requests as _req
-
+    def _capture_download(self, tmp_path: Path, session: Any) -> list[tuple[str, Any]]:
+        """Run _download_item with _download_file stubbed; return its (url, session) args."""
         watch_folder = tmp_path / "watch"
         watch_folder.mkdir()
-        session = _req.Session()
-        calls: list[tuple[str, Any]] = []
-
-        with patch("kamp_daemon.bandcamp._get_cdn_url", return_value=self._CDN):
-            with patch("kamp_daemon.bandcamp._resolve_cdn_redirect") as mock_resolve:
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: (
-                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
-                    ),
-                ):
-                    _download_item(
-                        self._ITEM, _bc_config(tmp_path), watch_folder, session
-                    )
-
-        mock_resolve.assert_not_called()
-        assert len(calls) == 1
-        assert calls[0][0] == self._CDN
-        assert calls[0][1] is session
-
-    def test_frozen_mode_resolves_redirect_and_uses_plain_session(
-        self, tmp_path: Path
-    ) -> None:
-        """Frozen mode calls _resolve_cdn_redirect and downloads with a plain session."""
-        watch_folder = tmp_path / "watch"
-        watch_folder.mkdir()
-        frozen_session = MagicMock()  # not a requests.Session → frozen-mode branch
-        final_url = "https://bcbits.com/download/album?token=abc"
         calls: list[tuple[str, Any]] = []
 
         with patch("kamp_daemon.bandcamp._get_cdn_url", return_value=self._CDN):
             with patch(
-                "kamp_daemon.bandcamp._resolve_cdn_redirect", return_value=final_url
-            ) as mock_resolve:
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: (
-                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
-                    ),
-                ):
-                    _download_item(
-                        self._ITEM, _bc_config(tmp_path), watch_folder, frozen_session
-                    )
+                "kamp_daemon.bandcamp._download_file",
+                side_effect=lambda url, dest, sess, fmt, on_progress=None: (
+                    calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
+                ),
+            ):
+                _download_item(self._ITEM, _bc_config(tmp_path), watch_folder, session)
+        return calls
 
-        mock_resolve.assert_called_once_with(self._CDN, frozen_session)
-        assert len(calls) == 1
-        assert calls[0][0] == final_url
-        # dl_session is a fresh plain Session, not the proxy session
+    def test_dev_mode_uses_authenticated_session(self, tmp_path: Path) -> None:
+        """Dev mode passes the authenticated requests.Session to _download_file directly."""
         import requests as _req
 
-        assert isinstance(calls[0][1], _req.Session)
-        assert calls[0][1] is not frozen_session
+        session = _req.Session()
+        calls = self._capture_download(tmp_path, session)
+
+        assert len(calls) == 1
+        assert calls[0][0] == self._CDN
+        assert calls[0][1] is session
+
+    def test_proxy_mode_downloads_cdn_with_cookie_bearing_session(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-636: proxy mode downloads the CDN URL directly, with the cookies.
+
+        popplers5 is not Cloudflare-protected, so ``requests`` handles the CDN
+        leg fine — but cookieless it bounces to bandcamp.com and we save the
+        challenge page.  The download session must carry the Bandcamp cookies.
+        """
+        import requests as _req
+
+        from kamp_daemon.bandcamp import _ProxySession
+
+        proxy = _ProxySession(_make_session_data())
+        calls = self._capture_download(tmp_path, proxy)
+
+        assert len(calls) == 1
+        # No laundered bcbits URL — the popplers5 CDN URL is fetched as-is.
+        assert calls[0][0] == self._CDN
+        dl_session = calls[0][1]
+        assert isinstance(dl_session, _req.Session)
+        assert dl_session is not proxy
+        assert dl_session.cookies.get("js_logged_in", domain=".bandcamp.com") == "1"
 
     def test_raises_when_no_redownload_url(self, tmp_path: Path) -> None:
         watch_folder = tmp_path / "watch"
@@ -1604,18 +1595,17 @@ class TestDownloadItem:
             return_value="https://cdn.example.com/f",
         ):
             with patch(
-                "kamp_daemon.bandcamp._resolve_cdn_redirect",
-                return_value="https://cdn.example.com/f",
+                "kamp_daemon.bandcamp._download_file",
+                side_effect=lambda url, dest, sess, fmt, on_progress=None: dest.with_name(
+                    dest.name + ".zip"
+                ),
             ):
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: dest.with_name(
-                        dest.name + ".zip"
-                    ),
-                ):
-                    path = _download_item(
-                        item, _bc_config(tmp_path), watch_folder, MagicMock()
-                    )
+                path = _download_item(
+                    item,
+                    _bc_config(tmp_path),
+                    watch_folder,
+                    _make_requests_session(_make_session_data()),
+                )
         assert "/" not in path.name
         assert ":" not in path.name
 
@@ -1645,7 +1635,10 @@ class TestParseContentLength:
 
 class TestDownloadFile:
     def _make_resp(
-        self, chunks: list[bytes], content_type: str = "application/zip"
+        self,
+        chunks: list[bytes],
+        content_type: str = "application/zip",
+        url: str = "",
     ) -> MagicMock:
         resp = MagicMock()
         resp.__enter__ = lambda s: s
@@ -1653,6 +1646,7 @@ class TestDownloadFile:
         resp.raise_for_status = MagicMock()
         resp.headers = {"Content-Type": content_type}
         resp.iter_content.return_value = chunks
+        resp.url = url  # requests reports the post-redirect URL here
         return resp
 
     def test_writes_chunked_response_to_dest(self, tmp_path: Path) -> None:
@@ -1755,6 +1749,42 @@ class TestDownloadFile:
 
         assert not (tmp_path / "album.zip").exists()
         assert not (tmp_path / "album.part").exists()
+
+    def test_error_names_the_host_that_actually_served_the_body(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-636: a CDN request bounced to bandcamp.com must say so.
+
+        Reporting only the requested popplers5 URL hid the redirect and made a
+        cookie problem look like a CDN fault.
+        """
+        dest_base = tmp_path / "album"
+        cdn = "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"<!DOCTYPE html><html>challenge</html>"],
+            content_type="text/html; charset=utf-8",
+            url="https://bandcamp.com/login",
+        )
+
+        with pytest.raises(
+            BandcampAPIError, match="served by https://bandcamp.com/login"
+        ):
+            _download_file(cdn, dest_base, session, "mp3-v0")
+
+    def test_error_omits_served_by_when_no_redirect(self, tmp_path: Path) -> None:
+        """No redirect → no redundant 'served by' clause."""
+        dest_base = tmp_path / "album"
+        cdn = "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"<html>nope</html>"], content_type="text/html", url=cdn
+        )
+
+        with pytest.raises(BandcampAPIError) as excinfo:
+            _download_file(cdn, dest_base, session, "mp3-v0")
+
+        assert "served by" not in str(excinfo.value)
 
     # -- byte-progress reporting (KAMP-436) ---------------------------------
 
@@ -2094,89 +2124,38 @@ class TestProxySession:
 
         assert patched.call_args[1]["headers"] is None
 
-    def test_head_method_sends_head_to_proxy(self) -> None:
-        from kamp_daemon.bandcamp import _PROXY_FETCH_URL, _ProxySession
-
-        sess = _ProxySession()
-        bcbits_url = "https://p4.bcbits.com/download/album/abc/mp3-v0/123?token=x"
-        mock_post = MagicMock()
-        mock_post.raise_for_status.return_value = None
-        mock_post.json.return_value = {
-            "status": 200,
-            "body": "",
-            "content_type": "application/octet-stream",
-            "url": bcbits_url,
-        }
-
-        with patch(
-            "kamp_daemon.bandcamp._requests.post", return_value=mock_post
-        ) as patched:
-            resp = sess.head(
-                "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
-            )
-
-        payload = patched.call_args[1]["json"]
-        assert payload["method"] == "HEAD"
-        assert "popplers5.bandcamp.com" in payload["url"]
-        assert patched.call_args[0][0] == _PROXY_FETCH_URL
-        assert resp.url == bcbits_url
-
 
 # ---------------------------------------------------------------------------
-# _resolve_cdn_redirect
+# _cdn_download_session
 # ---------------------------------------------------------------------------
 
 
-class TestResolveCdnRedirect:
-    _popplers_url = (
-        "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1&sig=abc"
-    )
-    _bcbits_url = (
-        "https://p4.bcbits.com/download/album/hash/mp3-v0/1?id=1&sig=x&token=t"
-    )
+class TestCdnDownloadSession:
+    """KAMP-636: the CDN leg always downloads with cookies, never through the proxy."""
 
-    def test_dev_mode_follows_redirect(self) -> None:
-        """GET+stream follows the popplers5 redirect; final URL comes from resp.url."""
+    def test_returns_the_dev_session_unchanged(self) -> None:
         import requests
 
-        mock_resp = MagicMock(spec=requests.Response)
-        mock_resp.url = self._bcbits_url
-        session = MagicMock(spec=requests.Session)
-        session.get.return_value = mock_resp
+        session = requests.Session()
+        assert _cdn_download_session(session) is session
 
-        result = _resolve_cdn_redirect(self._popplers_url, session)
+    def test_proxy_session_yields_cookie_bearing_plain_session(self) -> None:
+        import requests
 
-        session.get.assert_called_once_with(
-            self._popplers_url, stream=True, allow_redirects=True, timeout=30
-        )
-        assert result == self._bcbits_url
-
-    def test_frozen_mode_uses_proxy_head(self) -> None:
-        """_ProxySession.head routes through Electron; final URL comes from resp.url."""
         from kamp_daemon.bandcamp import _ProxySession
 
-        proxy_resp = _ProxyResponse(
-            status_code=200, text="", content_type="", url=self._bcbits_url
-        )
-        sess = MagicMock(spec=_ProxySession)
-        sess.head.return_value = proxy_resp
+        result = _cdn_download_session(_ProxySession(_make_session_data()))
 
-        result = _resolve_cdn_redirect(self._popplers_url, sess)
+        assert isinstance(result, requests.Session)
+        assert result.cookies.get("js_logged_in", domain=".bandcamp.com") == "1"
 
-        sess.head.assert_called_once_with(self._popplers_url, timeout=30)
-        assert result == self._bcbits_url
-
-    def test_frozen_mode_falls_back_when_url_none(self) -> None:
-        """Falls back to the original popplers5 URL when proxy returns url=None."""
+    def test_proxy_session_without_session_data(self) -> None:
+        """A cookie-less _ProxySession still yields a usable (empty) session."""
         from kamp_daemon.bandcamp import _ProxySession
 
-        proxy_resp = _ProxyResponse(status_code=200, text="", content_type="", url=None)
-        sess = MagicMock(spec=_ProxySession)
-        sess.head.return_value = proxy_resp
+        result = _cdn_download_session(_ProxySession())
 
-        result = _resolve_cdn_redirect(self._popplers_url, sess)
-
-        assert result == self._popplers_url
+        assert len(list(result.cookies)) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Every Bandcamp album download on Windows failed with:

```
Album download failed: CDN response is neither a ZIP nor audio
(first-bytes=b'<!DO', content-type='text/html; charset=utf-8')
 — url=https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=33097008
```

## Root cause

`_needs_proxy_session()` is True on win32, so `_download_item` took the frozen-mode branch:

1. `_resolve_cdn_redirect()` HEADs the popplers5 URL through Electron, expecting a popplers5 → bcbits.com redirect.
2. It then downloads the result with a deliberately **cookieless** `requests.Session` (the assumption being a bcbits pre-signed token needs no cookies).

popplers5 issues no redirect — it serves directly — so step 1 returned the input URL unchanged and the cookieless GET went to popplers5, which bounced it to bandcamp.com, whose reply to our TLS fingerprint is a 3038-byte Cloudflare challenge page. That page was written to disk as the "ZIP".

**Proof:** the failed `download_queue` rows recorded `size_bytes = 3038`, byte-identical to the challenge page a plain `requests` GET to `https://bandcamp.com/` returns from the Windows venv, right down to the `text/html; charset=utf-8` content type.

**Key finding:** `popplers5.bandcamp.com` is *not* behind Cloudflare — it answers plain `requests` with genuine nginx responses (`Server: nginx`, real 404s), with and without cookies. Only `bandcamp.com` itself is bot-managed. The CDN leg needed cookies, not a proxy.

## Fix

`_download_item` now uses one path on every platform via `_cdn_download_session()`: the dev `requests.Session` as-is, or a cookie-bearing plain session rebuilt from the `_ProxySession`'s stored `session_data`. This is what macOS/Linux dev already did successfully.

- Deletes `_resolve_cdn_redirect` and the now-unused `_ProxySession.head`, with their tests.
- `_download_file` reports the post-redirect URL in the error, so a bounce off the CDN is visible without reproducing.
- Rewrites the CLAUDE.md popplers5 section, which had been prescribing the broken cookieless pattern, and records both dead ends so they aren't retried.

## Verification

End-to-end on Windows 11 against the real Bandcamp account — five albums (Beth Orton, Adrianne Lenker, Wednesday, Andrew Sa, Iron & Wine) downloaded, unzipped, tagged and filed into the library.

CI steps run locally: 2631 passed / 23 skipped, coverage 93.77% (`bandcamp.py` at 94%, no new uncovered lines), `black --check` and `mypy` clean.

## Note

One retry failed with `HTTP 429` — Bandcamp rate-limiting the download *page*, aggravated by the diagnostic probes plus a concurrent collection sync. Pre-existing behaviour with its own backoff; it succeeded on retry. Separately, KAMP-637 was filed for the queue pre-probe never producing size estimates on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)