### PR TITLE
KAMP-637: prepare each queued download, not just the first of a drain

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -118,11 +118,17 @@ The only reliable fix for any `bandcamp.com` request in an affected environment 
 ## macOS CFRunLoop constraint
 Any macOS API that dispatches callbacks on the main GCD queue (`dispatch_get_main_queue()`) will not work in the kamp Python server process. The main thread runs asyncio/uvicorn, which does not pump a CFRunLoop. Affected APIs include: `MPRemoteCommandCenter`, `NSDistributedNotificationCenter`, `NSTimer`, and any delegate/target-action pattern that assumes an AppKit main loop. Features requiring these APIs must live in the Electron main process (which has a real CFRunLoop) or in a dedicated helper subprocess.
 
-## Bandcamp CDN downloads (popplers5)
-`popplers5.bandcamp.com` requires valid Bandcamp session cookies to serve a ZIP. Without cookies it returns HTTP 200 with an HTML error page.
+## Bandcamp CDN downloads (popplers5) — KAMP-636
 
-- **Dev mode:** pass the authenticated `requests.Session` directly to `_download_file`. The session carries cookies; `requests` follows any redirect automatically. Do not attempt an "activate then download cookieless" pattern — it is intermittent and unreliable.
-- **Frozen mode:** the `requests.Session` has a PyInstaller OpenSSL fingerprint Cloudflare blocks (see above). Route through Electron's proxy: call `_resolve_cdn_redirect(cdn_url, _ProxySession)` to follow the popplers5 → bcbits.com redirect via `net.fetch`, then download from the bcbits.com pre-signed URL with a plain cookieless `requests.Session` (bcbits.com URLs are time-limited tokens that do not need cookies).
+**The CDN host is not the Cloudflare-protected host.** `popplers5.bandcamp.com` is plain nginx (`Server: nginx`, genuine 404s, no `cf-*` headers) and answers `requests` on every platform, PyInstaller and Windows dev included. Only `bandcamp.com` itself is bot-managed. So the proxy gate above applies to **API/page traffic only** — never extend it to the CDN leg, which cannot round-trip a multi-hundred-MB body through the JSON relay anyway.
+
+What popplers5 *does* require is the Bandcamp session cookies, and it serves the ZIP **directly** — there is no popplers5 → bcbits.com redirect to chase. `_download_item` therefore uses one path on every platform: `_cdn_download_session(session)` returns the dev `requests.Session` as-is, or rebuilds a cookie-bearing plain session from the `_ProxySession`'s stored `session_data`.
+
+Two dead ends, both shipped and both broken — do not retry either:
+- **"Activate, then download cookieless."** An authenticated GET does not entitle a later cookieless GET. It is intermittent at best.
+- **"HEAD through Electron to launder a pre-signed bcbits URL."** popplers5 issues no redirect, so the HEAD returns the input URL unchanged and the cookieless download proceeds against popplers5 — which bounces to bandcamp.com, whose reply to our TLS fingerprint is the Cloudflare challenge page. That page then gets written to disk and fails the ZIP/audio sniff.
+
+**Debugging tell:** a failed download whose recorded `size_bytes` is ~3 KB (3038 at time of writing) *is* the Cloudflare challenge page — the byte count is stable, so compare it against a plain `requests` GET to `https://bandcamp.com/` from the same interpreter. `content-type: text/html; charset=utf-8` is the challenge; popplers5's own error pages are bare `text/html`. That distinction is the fastest way to tell "wrong host answered" from "CDN said no", and `_download_file` now names the post-redirect URL in the error so the hop is visible without reproducing.
 
 ## Diagnosis discipline: ask before assuming
 Before proposing or implementing a fix, verify the actual failure mode from logs or a direct question. In TASK-173 multiple sessions were spent fixing things that were not broken (downloads, onboarding completion, the watch-folder/library wiring) because the diagnosis was assumed rather than confirmed. The cost: rewrites of working components, regressions introduced and then reverted, and a much longer path to the real two-line fix.

--- a/claude.md
+++ b/claude.md
@@ -130,6 +130,16 @@ Two dead ends, both shipped and both broken — do not retry either:
 
 **Debugging tell:** a failed download whose recorded `size_bytes` is ~3 KB (3038 at time of writing) *is* the Cloudflare challenge page — the byte count is stable, so compare it against a plain `requests` GET to `https://bandcamp.com/` from the same interpreter. `content-type: text/html; charset=utf-8` is the challenge; popplers5's own error pages are bare `text/html`. That distinction is the fastest way to tell "wrong host answered" from "CDN said no", and `_download_file` now names the post-redirect URL in the error so the hop is visible without reproducing.
 
+## The Bandcamp collection endpoint is the scarce resource — KAMP-637
+
+`_fetch_collection` (visible + hidden, paginated) is the call Bandcamp rate-limits hardest. Three of them inside a minute earns a 429, and once limited *everything* fails — the whole download queue cascades to "Album download failed: HTTP 429". Per-item download pages, by contrast, are cheap. Every KAMP-575/637-era design decision follows from that asymmetry.
+
+- **A "nothing is missing" guard is not enough to make a prefetch safe to call in a loop.** Some queued items have no `redownload_url` in the collection response at all, so `missing` never empties and every item buys another full collection fetch. `prefetch_redownload_urls` therefore takes a caller-owned `attempted` set: only an id it has *never* tried justifies a fetch. Mark ids attempted **after** the fetch succeeds — a 429 is transient, and burning them on a failed attempt strands them on the slow per-item path for the rest of the drain. Drop ids that have left the queue so a re-queued retry is tried afresh.
+- **Running the prefetch once per *drain* is a bug, not an optimisation.** Anything enqueued while a drain is in flight kept a NULL URL, which (a) starved `backfill_download_sizes` — it only sizes rows that have a stored URL, so the queue showed no size *ever* — and (b) forced each such item through its own collection re-fetch at download time, which is both the visible "download takes ages to start" and the 429 source. `process_next_download` now takes a `prepare` callback that runs before the item is claimed (while it is still `queued`, the state the prefetch filters on).
+- **Watch the ordering:** `prepare` must run *before* `next_queued_download`. Once an item is marked `downloading` it is invisible to `download_redownload_urls()`, which only returns `queued` rows.
+
+**Measuring bandcamp.com traffic on Windows:** Electron fetches `/api/v1/bandcamp/session-cookies` exactly once per relayed request, so `grep -c session-cookies` on the dev log is a faithful 1:1 counter of outbound requests. Useful baseline: a full stream sync runs at **every app start** and walked 773 albums for ~60 requests in about a minute — budget for that before blaming the download path for a 429.
+
 ## Diagnosis discipline: ask before assuming
 Before proposing or implementing a fix, verify the actual failure mode from logs or a direct question. In TASK-173 multiple sessions were spent fixing things that were not broken (downloads, onboarding completion, the watch-folder/library wiring) because the diagnosis was assumed rather than confirmed. The cost: rewrites of working components, regressions introduced and then reverted, and a much longer path to the real two-line fix.
 

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1130,6 +1130,8 @@ def _cmd_daemon(
     # nudge the worker; ordering lives in the DB, not the in-memory queue.
 
     def _download_worker() -> None:
+        import time
+
         from .bandcamp import _make_requests_session, prefetch_redownload_urls
         from .syncer import process_next_download
 
@@ -1150,23 +1152,49 @@ def _cmd_daemon(
             except _queue_mod.Empty:
                 pass
 
+        # After a failed prefetch (usually a 429), wait this long before trying the
+        # collection endpoint again. Without it, running the prefetch per item would
+        # retry a rate-limited fetch on every item and re-create the 429 storm.
+        _PREFETCH_FAILURE_COOLDOWN = 120.0
+        _prefetch_failed_at = 0.0
+        # provider_item_ids already put through a collection fetch — see
+        # prefetch_redownload_urls. Owned here so it survives across items.
+        _prefetch_attempted: set[str] = set()
+
         def _prefetch_urls() -> None:
-            # One collection fetch per drain to fill any missing redownload_urls, so
+            # Fill any missing redownload_urls with a single collection fetch, so
             # every item downloads via the fast path (no per-item collection re-fetch
             # — the 429 storm). This also populates URLs the size-backfill needs, so
             # it too avoids the collection endpoint. Best-effort: a failure just
             # leaves the per-item fallback to resolve URLs.
+            #
+            # KAMP-637: this runs before EVERY item, not once per drain. Items
+            # enqueued while a drain is already in flight kept a NULL URL, which
+            # both starved the size-backfill (it only sizes rows that have one, so
+            # the queue showed no size at all) and forced each of those items
+            # through the slow per-item collection re-fetch at download time.
+            # prefetch_redownload_urls does no network I/O unless a queued id it
+            # has never tried is missing a URL, so the per-item call is a cheap
+            # indexed query in the common case.
+            nonlocal _prefetch_failed_at
+            if time.monotonic() - _prefetch_failed_at < _PREFETCH_FAILURE_COOLDOWN:
+                return
             try:
                 session_data = index.get_session("bandcamp")
                 if session_data:
                     n = prefetch_redownload_urls(
-                        index, _make_requests_session(session_data)
+                        index,
+                        _make_requests_session(session_data),
+                        attempted=_prefetch_attempted,
                     )
                     if n:
                         _logger.info("Prefetched %d download URL(s) for the queue", n)
             except Exception:
+                _prefetch_failed_at = time.monotonic()
                 _logger.warning(
-                    "Download URL prefetch failed; falling back to per-item resolution",
+                    "Download URL prefetch failed; falling back to per-item "
+                    "resolution for the next %.0fs",
+                    _PREFETCH_FAILURE_COOLDOWN,
                     exc_info=True,
                 )
 
@@ -1183,12 +1211,15 @@ def _cmd_daemon(
             if index.next_queued_download() is None:
                 _wait_for_work()
                 continue
-            # Draining: fill any missing URLs once for the whole batch, then drain
-            # via the fast path (no per-item collection re-fetch).
-            _prefetch_urls()
+            # Draining: process_next_download fills any missing URLs (prepare)
+            # before claiming each item, so every item — including one enqueued
+            # mid-drain — downloads via the fast path with a size already probed.
             while (
                 process_next_download(
-                    index, _album_download_trigger_ref[0], on_state=_on_state
+                    index,
+                    _album_download_trigger_ref[0],
+                    on_state=_on_state,
+                    prepare=_prefetch_urls,
                 )
                 is not None
             ):

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1527,34 +1527,76 @@ def get_download_size_bytes(
             blob.get("download_items") or blob.get("digital_items") or []
         )
         if not items:
+            logger.debug("size probe: no download_items for %s", redownload_url)
             return None
         downloads: dict[str, Any] = items[0].get("downloads") or {}
         fmt_data = downloads.get(fmt)
         if not isinstance(fmt_data, dict):
+            logger.debug(
+                "size probe: format %r absent for %s (have: %s)",
+                fmt,
+                redownload_url,
+                ", ".join(downloads) or "none",
+            )
             return None
-        return _parse_size_mb(fmt_data.get("size_mb"))
+        size = _parse_size_mb(fmt_data.get("size_mb"))
+        if size is None:
+            # KAMP-637: an unparseable/absent size_mb is indistinguishable from a
+            # network failure without this — which is how a silent, permanent
+            # "no sizes ever" went unnoticed.
+            logger.debug(
+                "size probe: unusable size_mb=%r for %s",
+                fmt_data.get("size_mb"),
+                redownload_url,
+            )
+        return size
     except Exception:
+        logger.debug("size probe failed for %s", redownload_url, exc_info=True)
         return None
 
 
-def prefetch_redownload_urls(index: "LibraryIndex", session: _AnySession) -> int:
+def prefetch_redownload_urls(
+    index: "LibraryIndex",
+    session: _AnySession,
+    *,
+    attempted: set[str] | None = None,
+) -> int:
     """Fill missing redownload_urls on queued rows with a SINGLE collection fetch.
 
-    The download worker calls this once per drain (KAMP-575) so it can then download
-    every item via the fast path — no per-item collection re-fetch, which was the
-    429 storm. Rows that already have a URL (freshly enqueued with it) are left
-    alone, so this is a no-op (and does no network I/O) once URLs are populated.
+    The download worker calls this before each item (KAMP-637) so it can then
+    download every one via the fast path — no per-item collection re-fetch, which
+    was the 429 storm (KAMP-575). Rows that already have a URL (freshly enqueued
+    with it) are left alone, so this is a no-op — and does no network I/O — once
+    URLs are populated.
+
+    *attempted* is a caller-owned set of provider_item_ids already put through a
+    collection fetch. Some queued items simply have no redownload_url in the
+    collection, so without this they would stay "missing" forever and buy a fresh
+    fetch of the rate-limited collection endpoint on every item — the same storm
+    in a new costume. Only an id we have never tried justifies another fetch. Ids
+    that have left the queue are dropped from the set, so a re-queued retry is
+    tried afresh.
 
     Returns the number of rows populated. Best-effort: the caller catches failures;
     a 429 here just leaves rows unfilled so the per-item fallback runs (with the
     size-backfill paused, it has room). Never raises for a "nothing to do" case.
     """
-    missing = {pid for pid, url in index.download_redownload_urls().items() if not url}
-    if not missing:
+    queued = index.download_redownload_urls()
+    missing = {pid for pid, url in queued.items() if not url}
+    if attempted is not None:
+        attempted &= set(queued)  # rows that left the queue may be tried again
+        if not missing - attempted:
+            return 0
+    elif not missing:
         return 0
 
     fan_id, _username = _get_fan_info(session)
     collection = _fetch_collection(fan_id, session, index)
+    if attempted is not None:
+        # Marked only after the fetch succeeds: a 429 is transient, and burning
+        # these ids on a failed attempt would strand them on the slow per-item
+        # path for the rest of the drain.
+        attempted |= missing
     n = 0
     for item in collection:
         sid = item.get("sale_item_id")

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -138,12 +138,17 @@ class _ProxySession:
     Only GET and POST are needed by bandcamp.py.  The ``stream`` and
     ``allow_redirects`` kwargs accepted by requests.Session are silently
     consumed — Electron follows redirects automatically.
+
+    *session_data* is the stored Bandcamp session.  Electron does not need it
+    (the proxy-fetch handler pulls cookies from the daemon on every call), but
+    the CDN download leg does — see :func:`_cdn_download_session`.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, session_data: dict[str, Any] | None = None) -> None:
         self.headers: dict[str, str] = {"User-Agent": _UA}
         # cookies is not used — Electron's session.defaultSession holds them.
         self.cookies: Any = None
+        self.session_data: dict[str, Any] = session_data or {}
 
     def _fetch(
         self,
@@ -191,9 +196,6 @@ class _ProxySession:
 
     def post(self, url: str, **kwargs: Any) -> _ProxyResponse:
         return self._fetch("POST", url, **kwargs)
-
-    def head(self, url: str, **kwargs: Any) -> _ProxyResponse:
-        return self._fetch("HEAD", url, **kwargs)
 
 
 # Alias json.dumps to avoid shadowing in _ProxySession._fetch
@@ -805,9 +807,15 @@ def _make_requests_session(
     if _needs_proxy_session():
         # Electron's session.defaultSession does *not* need to be pre-populated
         # with cookies: the proxy-fetch handler in kamp_ui/src/main/index.ts
-        # pulls them from the daemon's session storage on every call.
-        return _ProxySession()
+        # pulls them from the daemon's session storage on every call.  The
+        # session data still rides along for the CDN leg (_cdn_download_session).
+        return _ProxySession(session_data)
 
+    return _cookie_session(session_data)
+
+
+def _cookie_session(session_data: dict[str, Any]) -> _requests.Session:
+    """Build a plain ``requests.Session`` carrying the cookies from *session_data*."""
     session = _requests.Session()
     session.headers["User-Agent"] = _UA
     for cookie in session_data.get("cookies", []):
@@ -818,6 +826,26 @@ def _make_requests_session(
             path=cookie.get("path", "/"),
         )
     return session
+
+
+def _cdn_download_session(session: _AnySession) -> _requests.Session:
+    """Return a ``requests.Session`` to fetch the CDN payload with (KAMP-636).
+
+    The CDN host (popplers5.bandcamp.com) is plain nginx — it is *not* behind
+    the Cloudflare bot management that forces bandcamp.com API/page traffic
+    through Electron, so ``requests`` downloads it fine on every platform,
+    frozen bundle included.  What it does require is the Bandcamp session
+    cookies: without them popplers5 bounces the request to bandcamp.com, whose
+    answer to a non-browser TLS fingerprint is a ~3 KB Cloudflare challenge
+    page that then gets written to disk as the "ZIP".
+
+    In proxy mode the caller holds a :class:`_ProxySession`, which cannot
+    stream a large body (its payload round-trips through JSON), so build a
+    cookie-bearing plain session from the session data it carries.
+    """
+    if isinstance(session, _requests.Session):
+        return session
+    return _cookie_session(session.session_data)
 
 
 def _validate_session(session_data: dict[str, Any]) -> bool:
@@ -1589,35 +1617,6 @@ def backfill_download_sizes(
     return sized
 
 
-def _resolve_cdn_redirect(cdn_url: str, session: _AnySession) -> str:
-    """Authenticate the popplers5 CDN URL so that a subsequent cookieless download works.
-
-    popplers5.bandcamp.com serves ZIP content when accessed with valid Bandcamp
-    session cookies; without cookies it returns an HTML error page (HTTP 200).
-    An authenticated GET+stream (no body read) appears to activate the signed
-    URL server-side, allowing the follow-up cookieless download from
-    ``_download_file`` to succeed.  In practice popplers5 does not issue a
-    redirect — it serves directly — so the returned URL is the same as the
-    input.
-
-    In frozen mode ``session`` is a ``_ProxySession`` that routes through
-    Electron's net.fetch (which carries the Bandcamp cookies automatically).
-    """
-    if isinstance(session, _requests.Session):
-        resp = session.get(cdn_url, stream=True, allow_redirects=True, timeout=30)
-        try:
-            final_url: str = resp.url
-        finally:
-            resp.close()
-        logger.debug("_resolve_cdn_redirect: %s → %s", cdn_url, final_url)
-        return final_url
-    # Frozen mode: HEAD via Electron carries Bandcamp cookies to follow the
-    # popplers5 → bcbits.com redirect. HEAD avoids downloading the full ZIP
-    # here — the caller only needs the final URL.
-    proxy_resp = session.head(cdn_url, timeout=30)
-    return proxy_resp.url or cdn_url
-
-
 def _download_item(
     item: dict[str, Any],
     bc_config: BandcampConfig,
@@ -1645,21 +1644,15 @@ def _download_item(
     logger.info("Downloading %r by %r…", item_title, band_name)
     cdn_url = _get_cdn_url(redownload_url, bc_config.format, session)
 
-    if isinstance(session, _requests.Session):
-        # Dev mode: the requests.Session carries Bandcamp cookies.
-        # popplers5 requires cookies to serve the ZIP; pass the authenticated
-        # session directly so requests follows any redirect automatically.
-        return _download_file(
-            cdn_url, dest_base, session, bc_config.format, on_progress=on_progress
-        )
-    # Frozen mode: Electron's net.fetch carries cookies and follows the
-    # popplers5 → bcbits.com redirect via the proxy HEAD call.
-    # Download from bcbits.com directly — its pre-signed URLs need no cookies.
-    final_url = _resolve_cdn_redirect(cdn_url, session)
-    dl_session = _requests.Session()
-    dl_session.headers["User-Agent"] = _UA
+    # popplers5 requires the Bandcamp cookies to serve the ZIP, and answers
+    # directly (no bcbits redirect to chase), so the same cookie-bearing
+    # requests.Session works on every platform — see _cdn_download_session.
     return _download_file(
-        final_url, dest_base, dl_session, bc_config.format, on_progress=on_progress
+        cdn_url,
+        dest_base,
+        _cdn_download_session(session),
+        bc_config.format,
+        on_progress=on_progress,
     )
 
 
@@ -1745,11 +1738,17 @@ def _download_file(
         ) as resp:
             resp.raise_for_status()
             content_type = resp.headers.get("Content-Type", "")
+            # The URL the bytes actually came from. A CDN request that lost its
+            # cookies is redirected back to bandcamp.com, which answers with an
+            # HTML page — reporting only the requested URL hides that hop and
+            # made KAMP-636 look like a popplers5 fault.
+            final_url = str(resp.url)
             logger.debug(
-                "_download_file: status=%d content-type=%r url=%s",
+                "_download_file: status=%d content-type=%r url=%s final=%s",
                 resp.status_code,
                 content_type,
                 cdn_url,
+                final_url,
             )
             # KAMP-436/566: report byte-progress as (downloaded, total) so the
             # album card can reveal its art bottom-up and the Downloads view can
@@ -1794,10 +1793,15 @@ def _download_file(
         else:
             # Neither ZIP nor audio: the CDN served an HTML error page with
             # HTTP 200 (e.g. missing cookies on popplers5).
+            served_by = (
+                f" (served by {final_url})"
+                if final_url and final_url != cdn_url
+                else ""
+            )
             raise BandcampAPIError(
                 f"CDN response is neither a ZIP nor audio "
                 f"(first-bytes={magic!r}, content-type={content_type!r}) — "
-                f"url={cdn_url}"
+                f"url={cdn_url}{served_by}"
             )
 
         tmp.rename(final)

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -218,6 +218,7 @@ def process_next_download(
     *,
     provider: str = "bandcamp",
     on_state: Callable[[str, str], None] | None = None,
+    prepare: Callable[[], None] | None = None,
     retry_delays: Sequence[int] = (5, 10, 20),
     sleep: Callable[[float], None] = time.sleep,
 ) -> str | None:
@@ -233,8 +234,15 @@ def process_next_download(
     *on_state* (if given) is called ``(provider_item_id, state)`` on each
     transition ('downloading' | 'done' | 'failed') for WebSocket broadcast.
 
+    *prepare* (if given) runs before the next item is claimed — while every
+    pending row is still 'queued', which is the state the URL prefetch filters
+    on. It runs per item, not once per batch, because items enqueued while a
+    drain is already in flight need preparing too (KAMP-637).
+
     Returns the processed provider_item_id, or None when the queue is empty.
     """
+    if prepare is not None:
+        prepare()
     pid = index.next_queued_download(provider=provider)
     if pid is None:
         return None

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import html as html_lib
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -3841,6 +3842,21 @@ class TestGetDownloadSizeBytes:
             is None
         )
 
+    def test_logs_why_an_unusable_size_mb_yielded_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """KAMP-637: a present-but-unparseable size_mb must be distinguishable
+        from a network failure in the log — silence is how "no sizes, ever" hid."""
+        blob = {"download_items": [{"downloads": {"flac": {"size_mb": "lots"}}}]}
+        with caplog.at_level(logging.DEBUG, logger="kamp_daemon.bandcamp"):
+            result = get_download_size_bytes(
+                "https://bc/download?x", "flac", self._session(blob)
+            )
+
+        assert result is None
+        assert "size probe" in caplog.text
+        assert "lots" in caplog.text
+
     def test_none_on_network_error(self) -> None:
         session = MagicMock()
         session.get.side_effect = RuntimeError("boom")
@@ -3892,6 +3908,83 @@ class TestPrefetchRedownloadUrls:
         index.set_download_redownload_url.assert_called_once_with(
             "111", "https://dl/111"
         )
+
+    # -- attempted-set guard (KAMP-637) -------------------------------------
+    # The prefetch now runs before every item, not once per drain. Bandcamp's
+    # collection endpoint is the rate-limited one, and some queued items simply
+    # have no redownload_url there — so an unresolvable item must not buy a
+    # fresh collection fetch on every single item. That is the 429 storm.
+
+    def test_unresolvable_item_is_not_refetched(self, mocker: MockerFixture) -> None:
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"999": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection", return_value=[])
+        attempted: set[str] = set()
+
+        first = prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        second = prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+
+        assert (first, second) == (0, 0)
+        fetch.assert_called_once()  # the second call must not hit the network
+
+    def test_newly_queued_item_earns_a_fetch(self, mocker: MockerFixture) -> None:
+        """An id we have never tried is exactly what justifies another fetch —
+        that is how items enqueued mid-drain get their URL."""
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"999": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            return_value=[{"sale_item_id": 222, "redownload_url": "https://dl/222"}],
+        )
+        attempted: set[str] = set()
+
+        prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        index.download_redownload_urls.return_value = {"999": None, "222": None}
+        n = prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+
+        assert n == 1
+        assert fetch.call_count == 2
+
+    def test_failed_fetch_leaves_ids_retryable(self, mocker: MockerFixture) -> None:
+        """A 429 is transient — it must not burn the ids and strand them on the
+        slow per-item path for the rest of the drain."""
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"999": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch(
+            "kamp_daemon.bandcamp._fetch_collection",
+            side_effect=BandcampAPIError("HTTP 429"),
+        )
+        attempted: set[str] = set()
+
+        with pytest.raises(BandcampAPIError):
+            prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        assert attempted == set()
+
+        with pytest.raises(BandcampAPIError):
+            prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        assert fetch.call_count == 2
+
+    def test_attempted_forgets_ids_that_left_the_queue(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A row that leaves the queue and comes back (retry) is tried again."""
+        index = MagicMock()
+        index.download_redownload_urls.return_value = {"999": None}
+        mocker.patch("kamp_daemon.bandcamp._get_fan_info", return_value=(1, "u"))
+        fetch = mocker.patch("kamp_daemon.bandcamp._fetch_collection", return_value=[])
+        attempted: set[str] = set()
+
+        prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        index.download_redownload_urls.return_value = {}  # drained
+        prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        assert attempted == set()
+
+        index.download_redownload_urls.return_value = {"999": None}  # re-queued
+        prefetch_redownload_urls(index, MagicMock(), attempted=attempted)
+        assert fetch.call_count == 2
 
 
 class TestBackfillDownloadSizes:

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -16,7 +16,7 @@ from kamp_daemon.bandcamp import (
     BandcampAPIError,
     CookieError,
     NeedsLoginError,
-    _ProxyResponse,
+    _cdn_download_session,
     _download_file,
     _download_item,
     _parse_content_length,
@@ -29,7 +29,6 @@ from kamp_daemon.bandcamp import (
     _get_fan_info,
     _make_requests_session,
     _paginate,
-    _resolve_cdn_redirect,
     _session_from_cookie_file,
     _username_from_logout_cookie,
     _validate_session,
@@ -1519,64 +1518,56 @@ class TestDownloadItem:
         "redownload_url": "https://bandcamp.com/download?sitem_id=42",
     }
 
-    def test_dev_mode_uses_authenticated_session(self, tmp_path: Path) -> None:
-        """Dev mode passes the authenticated requests.Session to _download_file directly."""
-        import requests as _req
-
+    def _capture_download(self, tmp_path: Path, session: Any) -> list[tuple[str, Any]]:
+        """Run _download_item with _download_file stubbed; return its (url, session) args."""
         watch_folder = tmp_path / "watch"
         watch_folder.mkdir()
-        session = _req.Session()
-        calls: list[tuple[str, Any]] = []
-
-        with patch("kamp_daemon.bandcamp._get_cdn_url", return_value=self._CDN):
-            with patch("kamp_daemon.bandcamp._resolve_cdn_redirect") as mock_resolve:
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: (
-                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
-                    ),
-                ):
-                    _download_item(
-                        self._ITEM, _bc_config(tmp_path), watch_folder, session
-                    )
-
-        mock_resolve.assert_not_called()
-        assert len(calls) == 1
-        assert calls[0][0] == self._CDN
-        assert calls[0][1] is session
-
-    def test_frozen_mode_resolves_redirect_and_uses_plain_session(
-        self, tmp_path: Path
-    ) -> None:
-        """Frozen mode calls _resolve_cdn_redirect and downloads with a plain session."""
-        watch_folder = tmp_path / "watch"
-        watch_folder.mkdir()
-        frozen_session = MagicMock()  # not a requests.Session → frozen-mode branch
-        final_url = "https://bcbits.com/download/album?token=abc"
         calls: list[tuple[str, Any]] = []
 
         with patch("kamp_daemon.bandcamp._get_cdn_url", return_value=self._CDN):
             with patch(
-                "kamp_daemon.bandcamp._resolve_cdn_redirect", return_value=final_url
-            ) as mock_resolve:
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: (
-                        calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
-                    ),
-                ):
-                    _download_item(
-                        self._ITEM, _bc_config(tmp_path), watch_folder, frozen_session
-                    )
+                "kamp_daemon.bandcamp._download_file",
+                side_effect=lambda url, dest, sess, fmt, on_progress=None: (
+                    calls.append((url, sess)) or dest.with_name(dest.name + ".zip")
+                ),
+            ):
+                _download_item(self._ITEM, _bc_config(tmp_path), watch_folder, session)
+        return calls
 
-        mock_resolve.assert_called_once_with(self._CDN, frozen_session)
-        assert len(calls) == 1
-        assert calls[0][0] == final_url
-        # dl_session is a fresh plain Session, not the proxy session
+    def test_dev_mode_uses_authenticated_session(self, tmp_path: Path) -> None:
+        """Dev mode passes the authenticated requests.Session to _download_file directly."""
         import requests as _req
 
-        assert isinstance(calls[0][1], _req.Session)
-        assert calls[0][1] is not frozen_session
+        session = _req.Session()
+        calls = self._capture_download(tmp_path, session)
+
+        assert len(calls) == 1
+        assert calls[0][0] == self._CDN
+        assert calls[0][1] is session
+
+    def test_proxy_mode_downloads_cdn_with_cookie_bearing_session(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-636: proxy mode downloads the CDN URL directly, with the cookies.
+
+        popplers5 is not Cloudflare-protected, so ``requests`` handles the CDN
+        leg fine — but cookieless it bounces to bandcamp.com and we save the
+        challenge page.  The download session must carry the Bandcamp cookies.
+        """
+        import requests as _req
+
+        from kamp_daemon.bandcamp import _ProxySession
+
+        proxy = _ProxySession(_make_session_data())
+        calls = self._capture_download(tmp_path, proxy)
+
+        assert len(calls) == 1
+        # No laundered bcbits URL — the popplers5 CDN URL is fetched as-is.
+        assert calls[0][0] == self._CDN
+        dl_session = calls[0][1]
+        assert isinstance(dl_session, _req.Session)
+        assert dl_session is not proxy
+        assert dl_session.cookies.get("js_logged_in", domain=".bandcamp.com") == "1"
 
     def test_raises_when_no_redownload_url(self, tmp_path: Path) -> None:
         watch_folder = tmp_path / "watch"
@@ -1604,18 +1595,17 @@ class TestDownloadItem:
             return_value="https://cdn.example.com/f",
         ):
             with patch(
-                "kamp_daemon.bandcamp._resolve_cdn_redirect",
-                return_value="https://cdn.example.com/f",
+                "kamp_daemon.bandcamp._download_file",
+                side_effect=lambda url, dest, sess, fmt, on_progress=None: dest.with_name(
+                    dest.name + ".zip"
+                ),
             ):
-                with patch(
-                    "kamp_daemon.bandcamp._download_file",
-                    side_effect=lambda url, dest, sess, fmt, on_progress=None: dest.with_name(
-                        dest.name + ".zip"
-                    ),
-                ):
-                    path = _download_item(
-                        item, _bc_config(tmp_path), watch_folder, MagicMock()
-                    )
+                path = _download_item(
+                    item,
+                    _bc_config(tmp_path),
+                    watch_folder,
+                    _make_requests_session(_make_session_data()),
+                )
         assert "/" not in path.name
         assert ":" not in path.name
 
@@ -1645,7 +1635,10 @@ class TestParseContentLength:
 
 class TestDownloadFile:
     def _make_resp(
-        self, chunks: list[bytes], content_type: str = "application/zip"
+        self,
+        chunks: list[bytes],
+        content_type: str = "application/zip",
+        url: str = "",
     ) -> MagicMock:
         resp = MagicMock()
         resp.__enter__ = lambda s: s
@@ -1653,6 +1646,7 @@ class TestDownloadFile:
         resp.raise_for_status = MagicMock()
         resp.headers = {"Content-Type": content_type}
         resp.iter_content.return_value = chunks
+        resp.url = url  # requests reports the post-redirect URL here
         return resp
 
     def test_writes_chunked_response_to_dest(self, tmp_path: Path) -> None:
@@ -1755,6 +1749,42 @@ class TestDownloadFile:
 
         assert not (tmp_path / "album.zip").exists()
         assert not (tmp_path / "album.part").exists()
+
+    def test_error_names_the_host_that_actually_served_the_body(
+        self, tmp_path: Path
+    ) -> None:
+        """KAMP-636: a CDN request bounced to bandcamp.com must say so.
+
+        Reporting only the requested popplers5 URL hid the redirect and made a
+        cookie problem look like a CDN fault.
+        """
+        dest_base = tmp_path / "album"
+        cdn = "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"<!DOCTYPE html><html>challenge</html>"],
+            content_type="text/html; charset=utf-8",
+            url="https://bandcamp.com/login",
+        )
+
+        with pytest.raises(
+            BandcampAPIError, match="served by https://bandcamp.com/login"
+        ):
+            _download_file(cdn, dest_base, session, "mp3-v0")
+
+    def test_error_omits_served_by_when_no_redirect(self, tmp_path: Path) -> None:
+        """No redirect → no redundant 'served by' clause."""
+        dest_base = tmp_path / "album"
+        cdn = "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
+        session = MagicMock()
+        session.get.return_value = self._make_resp(
+            [b"<html>nope</html>"], content_type="text/html", url=cdn
+        )
+
+        with pytest.raises(BandcampAPIError) as excinfo:
+            _download_file(cdn, dest_base, session, "mp3-v0")
+
+        assert "served by" not in str(excinfo.value)
 
     # -- byte-progress reporting (KAMP-436) ---------------------------------
 
@@ -2094,89 +2124,38 @@ class TestProxySession:
 
         assert patched.call_args[1]["headers"] is None
 
-    def test_head_method_sends_head_to_proxy(self) -> None:
-        from kamp_daemon.bandcamp import _PROXY_FETCH_URL, _ProxySession
-
-        sess = _ProxySession()
-        bcbits_url = "https://p4.bcbits.com/download/album/abc/mp3-v0/123?token=x"
-        mock_post = MagicMock()
-        mock_post.raise_for_status.return_value = None
-        mock_post.json.return_value = {
-            "status": 200,
-            "body": "",
-            "content_type": "application/octet-stream",
-            "url": bcbits_url,
-        }
-
-        with patch(
-            "kamp_daemon.bandcamp._requests.post", return_value=mock_post
-        ) as patched:
-            resp = sess.head(
-                "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1"
-            )
-
-        payload = patched.call_args[1]["json"]
-        assert payload["method"] == "HEAD"
-        assert "popplers5.bandcamp.com" in payload["url"]
-        assert patched.call_args[0][0] == _PROXY_FETCH_URL
-        assert resp.url == bcbits_url
-
 
 # ---------------------------------------------------------------------------
-# _resolve_cdn_redirect
+# _cdn_download_session
 # ---------------------------------------------------------------------------
 
 
-class TestResolveCdnRedirect:
-    _popplers_url = (
-        "https://popplers5.bandcamp.com/download/album?enc=mp3-v0&id=1&sig=abc"
-    )
-    _bcbits_url = (
-        "https://p4.bcbits.com/download/album/hash/mp3-v0/1?id=1&sig=x&token=t"
-    )
+class TestCdnDownloadSession:
+    """KAMP-636: the CDN leg always downloads with cookies, never through the proxy."""
 
-    def test_dev_mode_follows_redirect(self) -> None:
-        """GET+stream follows the popplers5 redirect; final URL comes from resp.url."""
+    def test_returns_the_dev_session_unchanged(self) -> None:
         import requests
 
-        mock_resp = MagicMock(spec=requests.Response)
-        mock_resp.url = self._bcbits_url
-        session = MagicMock(spec=requests.Session)
-        session.get.return_value = mock_resp
+        session = requests.Session()
+        assert _cdn_download_session(session) is session
 
-        result = _resolve_cdn_redirect(self._popplers_url, session)
+    def test_proxy_session_yields_cookie_bearing_plain_session(self) -> None:
+        import requests
 
-        session.get.assert_called_once_with(
-            self._popplers_url, stream=True, allow_redirects=True, timeout=30
-        )
-        assert result == self._bcbits_url
-
-    def test_frozen_mode_uses_proxy_head(self) -> None:
-        """_ProxySession.head routes through Electron; final URL comes from resp.url."""
         from kamp_daemon.bandcamp import _ProxySession
 
-        proxy_resp = _ProxyResponse(
-            status_code=200, text="", content_type="", url=self._bcbits_url
-        )
-        sess = MagicMock(spec=_ProxySession)
-        sess.head.return_value = proxy_resp
+        result = _cdn_download_session(_ProxySession(_make_session_data()))
 
-        result = _resolve_cdn_redirect(self._popplers_url, sess)
+        assert isinstance(result, requests.Session)
+        assert result.cookies.get("js_logged_in", domain=".bandcamp.com") == "1"
 
-        sess.head.assert_called_once_with(self._popplers_url, timeout=30)
-        assert result == self._bcbits_url
-
-    def test_frozen_mode_falls_back_when_url_none(self) -> None:
-        """Falls back to the original popplers5 URL when proxy returns url=None."""
+    def test_proxy_session_without_session_data(self) -> None:
+        """A cookie-less _ProxySession still yields a usable (empty) session."""
         from kamp_daemon.bandcamp import _ProxySession
 
-        proxy_resp = _ProxyResponse(status_code=200, text="", content_type="", url=None)
-        sess = MagicMock(spec=_ProxySession)
-        sess.head.return_value = proxy_resp
+        result = _cdn_download_session(_ProxySession())
 
-        result = _resolve_cdn_redirect(self._popplers_url, sess)
-
-        assert result == self._popplers_url
+        assert len(list(result.cookies)) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1061,6 +1061,51 @@ class TestProcessNextDownload:
         assert process_next_download(index, lambda pid: None) is None
         index.close()
 
+    def test_prepare_runs_before_every_item(self, tmp_path: Path) -> None:
+        """KAMP-637: *prepare* runs per item, so rows enqueued mid-drain are prepared.
+
+        The URL prefetch used to run once per drain. Anything enqueued while that
+        drain was in flight kept a NULL redownload_url, which both starved the
+        size-backfill (it only sizes rows that have one) and forced the item's
+        own slow per-item collection re-fetch at download time.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        for sid in ("a", "b"):
+            index.enqueue_download(sid)
+
+        calls: list[str] = []
+
+        def _prepare() -> None:
+            calls.append("prepare")
+
+        for _ in range(2):
+            process_next_download(index, lambda pid: None, prepare=_prepare)
+
+        assert len(calls) == 2
+        index.close()
+
+    def test_prepare_runs_before_the_item_is_claimed(self, tmp_path: Path) -> None:
+        """*prepare* must see the item still 'queued' — that is the row state the
+        URL prefetch filters on, so running it after the claim would miss it."""
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        seen: list[list[tuple[str, str]]] = []
+
+        process_next_download(
+            index,
+            lambda pid: None,
+            prepare=lambda: seen.append(self._states(index)),
+        )
+
+        assert seen == [[("a", "queued")]]
+        index.close()
+
+    def test_prepare_is_optional(self, tmp_path: Path) -> None:
+        index = LibraryIndex(tmp_path / "library.db")
+        index.enqueue_download("a")
+        assert process_next_download(index, lambda pid: None) == "a"
+        index.close()
+
     def test_failure_is_captured_and_batch_continues(self, tmp_path: Path) -> None:
         index = LibraryIndex(tmp_path / "library.db")
         for sid in ("a", "b"):


### PR DESCRIPTION
> Stacked on #717 — please land that first. Base will retarget to `main` automatically once #717 merges.

## Problem

On Windows the download queue showed **no File Size at all**, and every item stalled at the start while it probed.

## Root cause

The URL prefetch ran once per drain, before the inner loop. Anything enqueued while that drain was in flight kept a NULL `redownload_url`, which caused two things:

1. **The size-backfill was starved.** `backfill_download_sizes` only sizes rows that have a stored URL, so `get_download_size_bytes` was never called. Evidence: `SELECT count(*) FROM download_queue WHERE size_is_estimate=1 AND size_bytes IS NOT NULL` returned **0** — no queued item on this machine had *ever* received an estimate — while the backfill worker logged no failures at all. It was running and silently sizing nothing.
2. **Each such item re-fetched the collection at download time**, via the per-item fallback. That paginated fetch is both the visible slow start and the 429 source.

## Fix

- `process_next_download` takes a `prepare` callback, run **before the item is claimed** — while it is still `queued`, which is the state the URL prefetch filters on. Ordering matters: once an item is marked `downloading` it is invisible to `download_redownload_urls()`.
- `prefetch_redownload_urls` takes a caller-owned `attempted` set. Some queued items have no `redownload_url` in the collection response at all, so `missing` never empties and a naive per-item prefetch buys a fresh fetch of the rate-limited collection endpoint on *every* item — the KAMP-575 storm in a new costume. Only an id never tried justifies a fetch. Ids are marked attempted **after** the fetch succeeds, so a transient 429 stays retryable; ids that leave the queue are dropped so a re-queued retry is tried afresh.
- The worker owns the attempted set plus a 120s cooldown after a failed prefetch.
- `get_download_size_bytes` now logs *why* it returned `None`. Its blanket `except Exception: return None` is exactly how a permanent, silent "no sizes, ever" went unnoticed.

## Verification

Through the UI on Windows against the real account:

| | before | after |
|---|---|---|
| albums | 5 | 6 |
| collection fetches | 5 | **3** |
| 429s | all 5 items failed | **0** |
| gap between later downloads | stall per item | **~6s** |

A queued row carried a **25.5 MB estimate (`est=1`) before its turn to download** — the first estimate ever recorded on this machine.

CI steps locally: 2639 passed / 23 skipped, coverage 93.78%, `black --check` and `mypy` clean.

## Notes

- An earlier revision of this branch ran the prefetch per item *without* the attempted-set guard. It reproduced the 429 storm (three collection fetches in 52s, then a cascade that failed every queued album). The guard and its four tests — including the transient-429-stays-retryable case — exist because of that.
- Running `pytest tests/test_syncer.py tests/test_bandcamp.py` together fails 75 tests on `main` as well as here; it is `pytest-randomly` ordering, pre-existing, and does not affect the full-suite run. Confirmed against a clean worktree at the base commit.
- KAMP-638 was filed separately for the Windows-only 422s seen in the same logs: `_validate_proxy_url` rejects Bandcamp custom artist domains, making 6 of 787 albums unstreamable. Not touched here — those requests never reach Bandcamp, so they are not a 429 source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)