### PR TITLE
KAMP-642: default the Bandcamp-labels-as-genres option to off

### DIFF
--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -53,9 +53,12 @@ class TaggingConfig:
     # never slows or fails a download. Users can turn it off in Tagging prefs.
     lastfm_genres: bool = True
     # KAMP-588: apply the artist-supplied Bandcamp album labels as genre tags.
-    # Default ON. When off, the labels are still cached (so a later toggle-on
-    # applies them without a re-scrape) but never written to the library.
-    bandcamp_genres: bool = True
+    # Default OFF — unlike Last.fm's canonical genres, Bandcamp labels are free
+    # text the artist chose, so applying them unasked sprays one-off tags across
+    # the genre list. Off is the safe default; opting in is one click. The labels
+    # are cached either way, so a later toggle-on applies them without a
+    # re-scrape, and existing installs keep whatever value they already stored.
+    bandcamp_genres: bool = False
 
 
 @dataclass
@@ -107,7 +110,7 @@ _CONFIG_DEFAULTS: dict[str, str] = {
     "artwork.max_bytes": "1000000",
     "artwork.save_format": "embedded",
     "tagging.lastfm_genres": "true",
-    "tagging.bandcamp_genres": "true",
+    "tagging.bandcamp_genres": "false",
     "library.path_template": "{album_artist}/{year} - {album}/{track:02d} - {title}.{ext}",
     "bandcamp.format": "mp3-v0",
     "bandcamp.poll_interval_minutes": "0",

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -1252,11 +1252,13 @@ export function PreferencesDialog({
                       initialValue={configValues?.['tagging.lastfm_genres'] ?? true}
                       onSave={handleSave}
                     />
+                    {/* initialValue fallback must match _CONFIG_DEFAULTS in
+                        kamp_daemon/config.py — this one is off by default. */}
                     <BoolRow
                       label="Use bandcamp album labels as genres"
                       configKey="tagging.bandcamp_genres"
                       hint="Use artist supplied labels on bandcamp items as additional genre tags."
-                      initialValue={configValues?.['tagging.bandcamp_genres'] ?? true}
+                      initialValue={configValues?.['tagging.bandcamp_genres'] ?? false}
                       onSave={handleSave}
                     />
                     <div className="prefs-row">

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,9 +80,16 @@ class TestLoad:
         config = Config.load(db)
         assert config.tagging.lastfm_genres is False
 
-    def test_tagging_bandcamp_genres_default_true(self, db: LibraryIndex) -> None:
-        # Bandcamp album labels are applied as genres by default.
+    def test_tagging_bandcamp_genres_default_false(self, db: LibraryIndex) -> None:
+        # Bandcamp album labels are opt-in: artist-supplied labels are free text,
+        # so applying them unasked pollutes the genre list.
         Config.write_defaults(db)
+        config = Config.load(db)
+        assert config.tagging.bandcamp_genres is False
+
+    def test_tagging_bandcamp_genres_loads_true(self, db: LibraryIndex) -> None:
+        Config.write_defaults(db)
+        db.set_setting("tagging.bandcamp_genres", "true")
         config = Config.load(db)
         assert config.tagging.bandcamp_genres is True
 

--- a/tests/test_genre_backfill.py
+++ b/tests/test_genre_backfill.py
@@ -26,7 +26,10 @@ def _config() -> Config:
         musicbrainz=MusicBrainzConfig(),
         artwork=ArtworkConfig(min_dimension=1000, max_bytes=1_000_000),
         library=LibraryConfig(path_template=""),
-        tagging=TaggingConfig(lastfm_genres=True),
+        # Both sources on: the backfill tests below exercise the Last.fm and the
+        # cached-Bandcamp-label paths, so state them explicitly rather than
+        # inheriting the dataclass defaults (bandcamp_genres ships off).
+        tagging=TaggingConfig(lastfm_genres=True, bandcamp_genres=True),
     )
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1180,7 +1180,9 @@ class TestKnownBandcampBranch:
         self, tmp_path: Path, config: Config
     ) -> None:
         # KAMP-588: cached Bandcamp tags are stamped as native multi-value genres
-        # onto the downloaded files during ingest.
+        # onto the downloaded files during ingest. Opt in explicitly — the toggle
+        # ships off (see the disabled case below).
+        config.tagging.bandcamp_genres = True
         config.paths.watch_folder.mkdir(parents=True)
         config.paths.library.mkdir(parents=True)
         db = tmp_path / "lib.db"


### PR DESCRIPTION
[KAMP-642](https://eightyeighteyes.atlassian.net/browse/KAMP-642)

The Tagging preference **"Use bandcamp album labels as genres"** (KAMP-588) shipped on. Artist-supplied Bandcamp labels are free text, unlike Last.fm's canonical genres, so applying them unasked sprays one-off tags across the genre list. This flips the default to off — opting in is one click.

## Changes

The setting has two defaults that must agree, plus a UI fallback:

- `kamp_daemon/config.py` — `TaggingConfig.bandcamp_genres` dataclass default → `False`
- `kamp_daemon/config.py` — `_CONFIG_DEFAULTS["tagging.bandcamp_genres"]` → `"false"`
- `kamp_ui/.../PreferencesDialog.tsx` — the `??` fallback used before config loads → `false`, with a comment pointing at `_CONFIG_DEFAULTS` so the two don't drift

## Scope: fresh installs only

`Config.load` back-fills a default just once, when the key is absent, and this key has been present since KAMP-588 — so every existing install keeps the `"true"` already in its settings table and sees no behavior change. No migration, deliberately: overwriting the value would clobber a setting some users turned on on purpose.

The labels are cached either way (`set_collection_keywords`), so a later toggle-on applies them without a re-scrape.

## Test changes

Three fixtures were silently inheriting the old dataclass default and are now explicit that they want the feature on — that drift was the only substantive work here:

- `tests/test_genre_backfill.py` `_config()` — the backfill tests exercise the cached-Bandcamp-label path
- `tests/test_pipeline.py::test_writes_cached_bandcamp_genres_to_files` — asserts labels are stamped into files, so it opts in (its `..._not_written_to_files` sibling already set `False` explicitly)

`tests/test_config.py` gets the red/green pair: `..._default_false` plus a new `..._loads_true` so both directions of the stored value are covered.

## Verification

- Full suite: **2653 passed, 23 skipped**, coverage **93.78%** (unchanged — no lines added)
- `black --check` clean, `mypy` clean (45 source files), both renderer typechecks clean
- README scanned: it documents no genre-toggle behavior, so no doc drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KAMP-642]: https://eightyeighteyes.atlassian.net/browse/KAMP-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ