### PR TITLE
fix: _ensure_track_source reads dropped tracks columns, aborting watch-folder scans

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -2928,10 +2928,16 @@ class LibraryIndex:
             "SELECT 1 FROM track_sources WHERE track_id = ? LIMIT 1", (track_id,)
         ).fetchone():
             return
+        # KAMP-552 dropped file_path/source/sale_item_id (and the per-source
+        # columns) from *tracks*; read them from the tracks_with_stats view, which
+        # re-derives them from the preferred track_sources row (and, while a legacy
+        # column still exists on a pre-552 DB mid-migration, COALESCEs back to it).
+        # Reading FROM tracks here raised "no such column: file_path" and aborted
+        # every re-scan that merged into a source-less survivor.
         r = self._conn.execute(
             "SELECT file_path, source, sale_item_id, ext, duration, embedded_art,"
             " file_mtime, is_available, stream_url, stream_url_expires_at"
-            " FROM tracks WHERE id = ?",
+            " FROM tracks_with_stats WHERE id = ?",
             (track_id,),
         ).fetchone()
         if r is None:
@@ -2939,6 +2945,12 @@ class LibraryIndex:
         uri, kind, provider, provider_item_id = _derive_source_fields(
             r["file_path"], r["source"], r["sale_item_id"]
         )
+        if not uri:
+            # Post-552 a source-less track derives nothing (its legacy columns are
+            # gone); the view yields file_path=''. There is no source to recover —
+            # bail rather than insert a bogus empty-uri row (which would also poison
+            # the uri-UNIQUE collision guard below for every other such track).
+            return
         if self._conn.execute(
             "SELECT 1 FROM track_sources WHERE uri = ?", (uri,)
         ).fetchone():

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -807,6 +807,53 @@ class TestLibraryIndex:
         assert index.has_remote_album_tracks("s7") is True
         index.close()
 
+    def test_scan_merges_into_source_less_incumbent(self, tmp_path: Path) -> None:
+        """A scan that merges into a source-less incumbent must not crash.
+
+        Regression: on the post-552 schema (file_path/sale_item_id dropped from
+        tracks), _ensure_track_source read those columns straight off *tracks* and
+        raised ``no such column: file_path`` whenever it ran — i.e. whenever the
+        merge survivor had no track_sources row at all. That aborted the whole
+        library re-scan, so watch-folder files never appeared. Here the incumbent
+        is a tracks row with an album link but zero sources; scanning a matching
+        file must merge cleanly and leave the survivor holding the file source.
+        """
+        index = LibraryIndex(tmp_path / "library.db")
+        # NB: deliberately NOT _readd_legacy_track_columns — this must reproduce
+        # the real post-552 schema where the legacy tracks columns are gone.
+        c = index._conn
+        c.execute(
+            "INSERT INTO albums (album_artist, album) VALUES ('The Artist','The Album')"
+        )
+        alb = c.execute("SELECT id FROM albums").fetchone()[0]
+        # An incumbent canonical with an album link but NO track_sources row.
+        c.execute(
+            "INSERT INTO tracks (title, artist, album_artist, album, album_id,"
+            " track_number, disc_number) VALUES ('A Song','The Artist','The Artist',"
+            " 'The Album', ?, 1, 1)",
+            (alb,),
+        )
+        incumbent_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        c.commit()
+
+        # Scan a local file for the same album+track: it must merge, not crash.
+        index.upsert_many([_sample_track(tmp_path / "track1.mp3")])
+
+        n_tracks = c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        surviving_id = c.execute("SELECT id FROM tracks").fetchone()[0]
+        kinds = sorted(
+            r["kind"]
+            for r in c.execute(
+                "SELECT kind FROM track_sources WHERE track_id = ?", (surviving_id,)
+            )
+        )
+        # One row survives (the incumbent), now carrying the scanned file source.
+        assert n_tracks == 1
+        assert surviving_id == incumbent_id
+        assert kinds == ["file"]
+        assert index.preferred_source(incumbent_id)["kind"] == "file"
+        index.close()
+
     def test_remove_download_refuses_when_no_stream_source(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Problem

Watch-folder imports silently failed to appear in the library. The daemon log showed:

```
ERROR kamp_daemon.watcher  Unhandled error in library re-scan
  ...
  File "kamp_core/library.py", line 2931, in _ensure_track_source
sqlite3.OperationalError: no such column: file_path
```

## Root cause

KAMP-552 (v50→v51) dropped `file_path`, `source`, `sale_item_id` and the per-source columns from `tracks`, moving identity into `track_sources` and re-deriving it through the `tracks_with_stats` view. Every reader was rewired to the view — **except `_ensure_track_source`**, which still `SELECT`ed those columns straight off `tracks`.

That function only runs when a merge survivor has **no `track_sources` row**, so the stale query lay dormant until a scan merged a newly-scanned file into a source-less incumbent (`_reconcile_scanned_tracks` → `_merge_track_into` → `_ensure_track_source`). SQLite then raised `no such column: file_path`, which aborted the entire re-scan — so nothing got indexed.

## Fix

- Read the fields from `tracks_with_stats` instead of `tracks`. The view re-derives them from the preferred `track_sources` row, and COALESCEs back to the legacy columns while they still exist (pre-552 DB mid-migration) — so the behaviour is correct across **all** schema versions.
- Bail when the derived uri is empty: post-552 a source-less track has nothing to recover, and inserting an empty-uri row would poison the uri-UNIQUE collision guard. The merge then re-parents the scanned file's own source onto the survivor.

## Test

New red/green regression test `test_scan_merges_into_source_less_incumbent`, deliberately on the real post-552 schema (no legacy columns re-added): an incumbent track with an album link but zero sources; scanning a matching file must merge cleanly and leave the survivor holding the file source. Fails with `no such column: file_path` before the fix, passes after.

## Verification

- Full suite: **2684 passed, 9 skipped**, coverage **93.80%**
- `black --check` ✓, `mypy` ✓

## Ticket

⚠️ The Jira connector wasn't authorized in the session this was written in, so no KAMP ticket was filed. Needs a KAMP issue created and this PR/branch aligned to it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)