### PR TITLE
KAMP-645: discovery groundwork — schema v61, seed profile, provider abstraction

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 60
+_SCHEMA_VERSION = 61
 
 
 class NoStreamableVersionError(Exception):
@@ -539,6 +539,94 @@ CREATE TABLE IF NOT EXISTS magic_playlist_criteria (
     evaluated_at        REAL,
     cached_track_count  INTEGER
 );
+
+-- Discovery Crate candidates (KAMP-645). Albums the user does NOT own, so nothing
+-- here can key off tracks.id / albums.id / bandcamp_collection.sale_item_id. Identity
+-- is (provider, provider_item_id) -- the same generalization download_queue and
+-- track_sources use -- where provider_item_id is Bandcamp's tralbum_id. KAMP-644
+-- verified that id is stable, present for unowned albums, and consistent across every
+-- discovery surface (it is merely spelled data-albumid / item_id / "album-<n>"
+-- depending on which one you scraped).
+--
+-- crate_no is the buffered/shown discriminator and the seen-ledger:
+--   crate_no IS NULL     -> a buffered candidate; gathered but NEVER shown (KAMP-657)
+--   crate_no IS NOT NULL -> shown to the user, in that crate, at that position
+-- "Has the user seen this?" is therefore `crate_no IS NOT NULL`, NOT mere row
+-- existence. Getting that wrong suppresses candidates forever and fails silently, so
+-- no code outside LibraryIndex writes these columns -- go through seen_before() /
+-- record_discovery_event(). An item belongs to at most one crate ever, which is why
+-- there is no crate join table. There is also no crates table: "crate 7" is just a
+-- value here and the current crate is MAX(crate_no); per-crate metadata (built_at, a
+-- short-crate flag) would be a cheap additive migration if KAMP-648 wants it.
+--
+-- state is a derived cache of discovery_events for the UI, so it CAN drift. Exactly
+-- one writer -- record_discovery_event() -- appends the event and updates state in the
+-- same transaction; never write it directly. Precedence is highest-rank-wins, not
+-- last-event-wins: purchased > wishlisted > dismissed > previewed > fresh.
+--
+-- purchased_sale_item_id is ON DELETE SET NULL deliberately. clear_bandcamp_collection()
+-- nulls child FKs before deleting the ledger because foreign_keys=ON turns a dangling
+-- child into an IntegrityError -- the crash KAMP-528 fixed. A new child it does not
+-- know about would reintroduce it the moment a crate pick is purchased. Nulling is
+-- also semantically right: the 'purchased' event remains the ground truth.
+CREATE TABLE IF NOT EXISTS discovery_items (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider               TEXT    NOT NULL DEFAULT 'bandcamp',
+    provider_item_id       TEXT    NOT NULL,
+    item_url               TEXT    NOT NULL DEFAULT '',
+    artist                 TEXT    NOT NULL DEFAULT '',
+    title                  TEXT    NOT NULL DEFAULT '',
+    art_url                TEXT,
+    label                  TEXT    NOT NULL DEFAULT '',
+    release_date           TEXT    NOT NULL DEFAULT '',
+    criterion              TEXT    NOT NULL DEFAULT '',
+    why                    TEXT    NOT NULL DEFAULT '',
+    seed_json              TEXT    NOT NULL DEFAULT '{{}}',
+    crate_no               INTEGER,
+    position               INTEGER,
+    state                  TEXT    NOT NULL DEFAULT 'fresh',
+    first_seen_at          REAL    NOT NULL DEFAULT (unixepoch()),
+    purchased_sale_item_id TEXT REFERENCES bandcamp_collection(sale_item_id) ON DELETE SET NULL,
+    purchased_at           REAL,
+    UNIQUE (provider, provider_item_id),
+    CHECK ((crate_no IS NULL) = (position IS NULL)),
+    CHECK (state IN ('fresh', 'previewed', 'wishlisted', 'dismissed', 'purchased'))
+);
+
+-- Two items cannot occupy the same slot in a crate. Partial index so the buffered
+-- rows (crate_no NULL) are exempt -- there can be any number of those.
+CREATE UNIQUE INDEX IF NOT EXISTS discovery_items_slot_idx
+    ON discovery_items(crate_no, position) WHERE crate_no IS NOT NULL;
+CREATE INDEX IF NOT EXISTS discovery_items_crate_idx ON discovery_items(crate_no);
+
+-- Append-only engagement ledger (KAMP-645). Ground truth for the digging-history
+-- stats in KAMP-655 and the purchase attribution in KAMP-654; discovery_items.state
+-- is only a cache of it.
+--
+-- ON DELETE RESTRICT, and deliberately NO append-only triggers, unlike
+-- extension_audit_log. Two reasons this differs from that precedent: RAISE(ABORT)
+-- triggers would make KAMP-657's buffer TTL sweep abort on any item that ever had an
+-- event, and ON DELETE CASCADE would silently shrink the purchase stats every time a
+-- row was pruned. RESTRICT means the sweep can only delete event-free rows, which is
+-- exactly the buffered ones. Note the edge it gets right: a buffered candidate the
+-- user buys independently gains a 'purchased' event and thereby becomes unsweepable,
+-- which is what we want -- the attribution outlives the candidate.
+--
+-- provider/provider_item_id are denormalized so aggregate stats stay answerable
+-- without joining a row that may since have been pruned.
+CREATE TABLE IF NOT EXISTS discovery_events (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id          INTEGER NOT NULL REFERENCES discovery_items(id) ON DELETE RESTRICT,
+    provider         TEXT    NOT NULL DEFAULT 'bandcamp',
+    provider_item_id TEXT    NOT NULL DEFAULT '',
+    kind             TEXT    NOT NULL,
+    at               REAL    NOT NULL DEFAULT (unixepoch()),
+    detail           TEXT,
+    CHECK (kind IN ('shown', 'previewed', 'wishlisted', 'url_copied',
+                    'dismissed', 'purchased'))
+);
+CREATE INDEX IF NOT EXISTS discovery_events_item_idx ON discovery_events(item_id);
+CREATE INDEX IF NOT EXISTS discovery_events_kind_at_idx ON discovery_events(kind, at);
 """
 
 # Characters that have special meaning in FTS5 MATCH expressions.
@@ -2563,7 +2651,21 @@ class LibraryIndex:
             )
             self._conn.execute("UPDATE schema_version SET version = 60")
             self._conn.commit()
-            version = 60  # noqa: F841
+            version = 60
+
+        if version == 60:
+            # v60 -> v61 (KAMP-645): discovery_items + discovery_events, the
+            # foundation of the Discovery Crate epic. Both tables are created up
+            # front by _DDL (CREATE IF NOT EXISTS, so they already exist by now);
+            # this step only records the version bump. New empty tables, no data
+            # backfill, and deliberately additive -- nothing here touches tracks,
+            # albums or any existing column, so the KAMP-552 rebuild recipe does
+            # not apply. Neither table is projected through tracks_with_stats
+            # either, so the DROP-VIEW-before-ALTER trap that only reproduces on
+            # CI's older SQLite is likewise not in play.
+            self._conn.execute("UPDATE schema_version SET version = 61")
+            self._conn.commit()
+            version = 61  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -4689,6 +4791,297 @@ class LibraryIndex:
             ):
                 return a
         return None
+
+    # ------------------------------------------------------------------
+    # Discovery Crate (KAMP-645)
+    # ------------------------------------------------------------------
+
+    def discovery_item_id(self, provider: str, provider_item_id: str) -> int | None:
+        """Return the discovery_items id for a provider identity, or None."""
+        row = self._conn.execute(
+            "SELECT id FROM discovery_items"
+            " WHERE provider = ? AND provider_item_id = ?",
+            (provider, str(provider_item_id)),
+        ).fetchone()
+        return int(row["id"]) if row else None
+
+    def add_discovery_candidate(
+        self,
+        *,
+        provider: str,
+        provider_item_id: str,
+        item_url: str = "",
+        artist: str = "",
+        title: str = "",
+        art_url: str | None = None,
+        label: str = "",
+        release_date: str = "",
+        criterion: str = "",
+        why: str = "",
+        seed_json: str = "{}",
+        first_seen_at: float | None = None,
+    ) -> int:
+        """Insert a *buffered* candidate (crate_no NULL) and return its row id.
+
+        Idempotent on (provider, provider_item_id): re-gathering an album we have
+        already seen or buffered returns the existing row rather than raising, and
+        never resurrects it into a new crate. Promotion into a crate is a separate,
+        explicit step (KAMP-648).
+        """
+        existing = self.discovery_item_id(provider, provider_item_id)
+        if existing is not None:
+            return existing
+        cur = self._conn.execute(
+            "INSERT INTO discovery_items"
+            " (provider, provider_item_id, item_url, artist, title, art_url,"
+            "  label, release_date, criterion, why, seed_json, first_seen_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                provider,
+                str(provider_item_id),
+                item_url,
+                artist,
+                title,
+                art_url,
+                label,
+                release_date,
+                criterion,
+                why,
+                seed_json,
+                _time.time() if first_seen_at is None else first_seen_at,
+            ),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid or 0)
+
+    def seen_before(self, provider: str, provider_item_id: str) -> bool:
+        """True only if this candidate has actually been SHOWN to the user.
+
+        A buffered row (crate_no IS NULL) exists but has never been shown, so it is
+        NOT seen and stays eligible for a future crate. Keying this on row existence
+        instead would strand every buffered candidate permanently, and would do it
+        silently -- which is why the check lives here rather than being open-coded
+        by callers.
+        """
+        row = self._conn.execute(
+            "SELECT 1 FROM discovery_items"
+            " WHERE provider = ? AND provider_item_id = ?"
+            "   AND crate_no IS NOT NULL LIMIT 1",
+            (provider, str(provider_item_id)),
+        ).fetchone()
+        return row is not None
+
+    # Highest-rank-wins, NOT last-event-wins: a user who previews, dismisses, then
+    # buys an album has bought it, and 'purchased' must survive the later arrival of
+    # a lower-ranked event (attribution runs on a sync, out of order with the UI).
+    _DISCOVERY_STATE_RANK = {
+        "fresh": 0,
+        "previewed": 1,
+        "dismissed": 2,
+        "wishlisted": 3,
+        "purchased": 4,
+    }
+    _DISCOVERY_EVENT_STATE = {
+        "shown": "fresh",
+        "url_copied": "fresh",
+        "previewed": "previewed",
+        "dismissed": "dismissed",
+        "wishlisted": "wishlisted",
+        "purchased": "purchased",
+    }
+
+    def record_discovery_event(
+        self,
+        item_id: int,
+        kind: str,
+        detail: str | None = None,
+        at: float | None = None,
+    ) -> None:
+        """Append an engagement event and reconcile the cached state.
+
+        The ONLY writer of discovery_items.state. That column is a derived cache of
+        this ledger for the UI's benefit, so a second writer would let the two drift
+        with nothing to detect it. Both writes share one rollback-guarded transaction
+        (KAMP-527: on a pooled thread-local connection an uncommitted partial write is
+        otherwise flushed by the next unrelated commit on the same thread).
+        """
+        row = self._conn.execute(
+            "SELECT provider, provider_item_id, state FROM discovery_items"
+            " WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"no discovery item with id {item_id}")
+
+        target = self._DISCOVERY_EVENT_STATE.get(kind)
+        if target is None:
+            raise ValueError(f"unknown discovery event kind {kind!r}")
+        rank = self._DISCOVERY_STATE_RANK
+        new_state = target if rank[target] > rank.get(row["state"], 0) else row["state"]
+
+        try:
+            self._conn.execute(
+                "INSERT INTO discovery_events"
+                " (item_id, provider, provider_item_id, kind, at, detail)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    item_id,
+                    row["provider"],
+                    row["provider_item_id"],
+                    kind,
+                    _time.time() if at is None else at,
+                    detail,
+                ),
+            )
+            if new_state != row["state"]:
+                self._conn.execute(
+                    "UPDATE discovery_items SET state = ? WHERE id = ?",
+                    (new_state, item_id),
+                )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def in_library(
+        self, provider_item_id: str, artist: str = "", title: str = ""
+    ) -> bool:
+        """True if the user already owns this album.
+
+        Matches on bandcamp_collection.tralbum_id first -- the identity the discovery
+        surfaces actually carry -- then falls back to a NOCASE (band_name, item_title)
+        comparison for rows whose tralbum_id was never backfilled.
+
+        Never matches on tracks_with_stats-derived columns: that view picks a
+        preferred source at read time, so its file_path/sale_item_id are unstable as
+        lookup keys (KAMP-552/554).
+        """
+        if provider_item_id:
+            row = self._conn.execute(
+                "SELECT 1 FROM bandcamp_collection WHERE tralbum_id = ? LIMIT 1",
+                (str(provider_item_id),),
+            ).fetchone()
+            if row is not None:
+                return True
+        if artist and title:
+            row = self._conn.execute(
+                "SELECT 1 FROM bandcamp_collection"
+                " WHERE band_name = ? COLLATE NOCASE"
+                "   AND item_title = ? COLLATE NOCASE LIMIT 1",
+                (artist, title),
+            ).fetchone()
+            if row is not None:
+                return True
+        return False
+
+    def recently_played_albums(
+        self, days: int = 30, limit: int = 50
+    ) -> list[tuple[int, str, str]]:
+        """Return (album_id, album_artist, album) played within the last *days*.
+
+        Ordered most-recent first. Note the source signal is written at track START
+        (record_track_started), so "played" here means "began playing", not
+        "listened through".
+        """
+        cutoff = _time.time() - days * 86400
+        rows = self._conn.execute(
+            """
+            SELECT a.id, a.album_artist, a.album
+            FROM albums a
+            WHERE a.last_played_at IS NOT NULL AND a.last_played_at >= ?
+            ORDER BY a.last_played_at DESC
+            LIMIT ?
+            """,
+            (cutoff, limit),
+        ).fetchall()
+        return [(int(r["id"]), r["album_artist"], r["album"]) for r in rows]
+
+    def favorite_albums(self, limit: int = 50) -> list[tuple[int, str, str]]:
+        """Return (album_id, album_artist, album) for favorited albums."""
+        rows = self._conn.execute(
+            "SELECT id, album_artist, album FROM albums"
+            " WHERE favorite = 1 ORDER BY last_track_added_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [(int(r["id"]), r["album_artist"], r["album"]) for r in rows]
+
+    def taste_genres(self, limit: int = 25) -> list[tuple[str, int]]:
+        """Return (genre, track_count) across the library, most common first.
+
+        Unions the canonical track_genres with the Bandcamp per-album keyword cache.
+        The keywords are read directly and unconditionally: they are only promoted
+        into track_genres when tagging.bandcamp_genres is enabled AND only on an
+        album's first index, so a config-gated read here would make a user's taste
+        invisible purely because a tagging preference is off.
+
+        Keywords are parsed in Python rather than with SQLite's JSON1 functions --
+        JSON1 is used nowhere else in this codebase, and dev (SQLite 3.51) and CI
+        (Python 3.11's older SQLite) disagree often enough that a JSON1 query here
+        would be unverifiable locally.
+        """
+        counts: dict[str, int] = {}
+        display: dict[str, str] = {}
+
+        for r in self._conn.execute("""
+            SELECT g.name AS name, COUNT(*) AS n
+            FROM track_genres tg JOIN genres g ON g.id = tg.genre_id
+            GROUP BY g.id
+            """).fetchall():
+            key = r["name"].casefold()
+            counts[key] = counts.get(key, 0) + int(r["n"])
+            display.setdefault(key, r["name"])
+
+        for r in self._conn.execute(
+            "SELECT keywords FROM bandcamp_collection"
+            " WHERE keywords IS NOT NULL AND keywords != ''"
+        ).fetchall():
+            try:
+                tags = json.loads(r["keywords"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(tags, list):
+                continue
+            for tag in tags:
+                if not isinstance(tag, str) or not tag.strip():
+                    continue
+                key = tag.strip().casefold()
+                counts[key] = counts.get(key, 0) + 1
+                display.setdefault(key, tag.strip())
+
+        ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        return [(display[k], n) for k, n in ranked[:limit]]
+
+    def taste_labels(
+        self, min_albums: int = 2, limit: int = 25
+    ) -> list[tuple[str, int]]:
+        """Return (label, album_count) for labels with at least *min_albums* owned.
+
+        Grouped NOCASE because albums.label is unnormalized free text with no alias
+        table -- "Ghostly" and "ghostly" are one label. The display casing is
+        whichever spelling SQLite happens to surface for the group; harmless here,
+        since this feeds seed selection rather than anything canonical.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT label, COUNT(*) AS n
+            FROM albums
+            WHERE label IS NOT NULL AND TRIM(label) != ''
+            GROUP BY label COLLATE NOCASE
+            HAVING COUNT(*) >= ?
+            ORDER BY n DESC, label
+            LIMIT ?
+            """,
+            (min_albums, limit),
+        ).fetchall()
+        return [(r["label"], int(r["n"])) for r in rows]
+
+    def collection_purchase_dates(self) -> list[tuple[str, float]]:
+        """Return (tralbum_id, added_at) for owned albums with a known purchase date."""
+        rows = self._conn.execute(
+            "SELECT tralbum_id, added_at FROM bandcamp_collection"
+            " WHERE tralbum_id != '' AND added_at > 0 ORDER BY added_at DESC"
+        ).fetchall()
+        return [(r["tralbum_id"], float(r["added_at"])) for r in rows]
 
     # ------------------------------------------------------------------
     # Settings (application configuration)

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -1,0 +1,297 @@
+"""Discovery Crate foundations — types, taste profile, provider abstraction (KAMP-645).
+
+The Discovery Crate (KAMP-643) recommends albums the user does *not* own. This module
+holds the pieces every other discovery story builds on:
+
+* :class:`Candidate` — one recommended album, with the provenance that lets the UI say
+  why it is there.
+* :class:`SeedProfile` — what the user's own library says about their taste, computed
+  from local data only.
+* :class:`RequestBudget` — the seam the rate-limit governor (KAMP-646) plugs into.
+* :class:`DiscoverySource` — the provider interface, modelled on the deliberately tiny
+  :class:`~kamp_daemon.genre_sources.GenreSource` ABC.
+
+**Module boundaries for the epic**, so this file does not quietly become a second
+god-module: this module owns *types and the profile only*. KAMP-647 adds the Bandcamp
+fetchers in ``discovery_sources.py``; KAMP-648 adds the crate builder in
+``discovery_builder.py``.
+
+Nothing here performs I/O. Providers do, and they are handed a profile rather than a
+database — a provider that reads the DB directly would couple every future service to
+kamp's schema, which is precisely what the "accommodates future services" requirement
+is trying to avoid.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, types only
+    from kamp_core.library import LibraryIndex
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request budget — the seam; KAMP-646 supplies the policy
+# ---------------------------------------------------------------------------
+
+# Endpoint classes, named after what KAMP-644 actually measured. They are separate
+# because their limits are different, not as a matter of taste: album pages returned
+# 429 after 57 requests in 39s, while the discover API absorbed 120 at the same rate
+# without complaint. A single global request count would be born wrong.
+ALBUM_PAGE = "album_page"
+DISCOVER_API = "discover_api"
+FANCOLLECTION = "fancollection"
+
+
+class RequestBudget(Protocol):
+    """How many requests a gather may spend, per endpoint class.
+
+    A Protocol rather than a concrete class: KAMP-646's governor replaces the policy
+    (deferral, shared backoff, coordination with the sync and download workers)
+    without touching a single call signature here or in KAMP-647.
+    """
+
+    def allow(self, endpoint_class: str) -> bool:
+        """True if one more request against *endpoint_class* is permitted."""
+
+    def consume(self, endpoint_class: str, n: int = 1) -> None:
+        """Record *n* requests spent against *endpoint_class*."""
+
+
+@dataclass
+class SimpleBudget:
+    """A per-class counting budget. The default until KAMP-646 lands.
+
+    Deliberately dumb: it counts and it stops. It does not defer, back off, or know
+    that other workers exist — that is the governor's job.
+    """
+
+    limits: dict[str, int] = field(default_factory=dict)
+    default_limit: int = 10
+    spent: dict[str, int] = field(default_factory=dict)
+
+    def allow(self, endpoint_class: str) -> bool:
+        cap = self.limits.get(endpoint_class, self.default_limit)
+        return self.spent.get(endpoint_class, 0) < cap
+
+    def consume(self, endpoint_class: str, n: int = 1) -> None:
+        self.spent[endpoint_class] = self.spent.get(endpoint_class, 0) + n
+
+
+# ---------------------------------------------------------------------------
+# Candidates
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Candidate:
+    """One recommended album, from any provider.
+
+    ``criterion`` is a *provider-scoped* label (e.g. ``'also_like'``). The crate
+    builder enforces variety across criteria without interpreting them — that is what
+    lets a future non-Bandcamp provider invent its own criteria without teaching the
+    builder about them.
+
+    ``why`` is the human sentence the clerk card shows, and ``seed`` is the structured
+    attribution behind it. Both are required for a pick to be shown: the feature's
+    promise is that every recommendation explains itself, and KAMP-657 re-validates
+    ``seed`` before showing a buffered candidate so the explanation is still true at
+    the moment it is read.
+    """
+
+    provider: str
+    provider_item_id: str
+    item_url: str
+    artist: str = ""
+    title: str = ""
+    art_url: str | None = None
+    label: str = ""
+    release_date: str = ""
+    criterion: str = ""
+    why: str = ""
+    seed: dict[str, Any] = field(default_factory=dict)
+
+    def seed_json(self) -> str:
+        return json.dumps(self.seed, sort_keys=True)
+
+
+@dataclass
+class PreviewStream:
+    """A playable preview URL, resolved on demand and never persisted.
+
+    Bandcamp's ``mp3-128`` URLs are signed with a ``ts`` parameter and expire in about
+    a day (KAMP-644), so a stored one is a bug waiting to surface as silent playback
+    failure. Resolve at play time; throw it away after.
+    """
+
+    url: str
+    track_num: int = 1
+    title: str = ""
+
+
+class UnsupportedCapability(RuntimeError):
+    """Raised when a capability is used that the source does not currently offer."""
+
+
+# ---------------------------------------------------------------------------
+# Seed profile
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeedProfile:
+    """What the user's own library says about their taste.
+
+    Computed entirely from the local database — no network, no server-side profile,
+    nothing about the user leaves the machine. That is a product promise as much as an
+    implementation detail.
+
+    The qualifying sets are deliberately exposed as plain data rather than being
+    consumed internally and discarded. KAMP-657 re-validates a buffered candidate's
+    seed before showing it (taste drifts; "because you've been on a dub techno kick
+    lately" stops being true), and that check must be a membership lookup rather than
+    a re-derivation of the whole profile.
+    """
+
+    recent_album_ids: set[int] = field(default_factory=set)
+    recent_albums: list[tuple[int, str, str]] = field(default_factory=list)
+    favorite_album_ids: set[int] = field(default_factory=set)
+    favorite_albums: list[tuple[int, str, str]] = field(default_factory=list)
+    top_artists: list[str] = field(default_factory=list)
+    top_genres: list[str] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list)
+    purchase_dates: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def is_thin(self) -> bool:
+        """True when there is not enough listening history to personalise from.
+
+        A brand-new library is the common first-run case, not an edge case. Callers
+        should fall back to un-personalised criteria (charts) rather than producing an
+        empty crate or dividing by zero over an empty signal.
+        """
+        return not (
+            self.recent_album_ids
+            or self.favorite_album_ids
+            or self.top_artists
+            or self.top_genres
+        )
+
+    def has_genre(self, name: str) -> bool:
+        return name.casefold() in {g.casefold() for g in self.top_genres}
+
+    def has_artist(self, name: str) -> bool:
+        return name.casefold() in {a.casefold() for a in self.top_artists}
+
+    def has_label(self, name: str) -> bool:
+        return name.casefold() in {label.casefold() for label in self.labels}
+
+
+def build_seed_profile(
+    index: "LibraryIndex",
+    *,
+    days: int = 30,
+    genre_limit: int = 25,
+    artist_limit: int = 25,
+    label_limit: int = 25,
+) -> SeedProfile:
+    """Assemble a :class:`SeedProfile` from local library signals.
+
+    Reuses the existing accessors wherever one already means the right thing —
+    ``top_artists`` is already ranked by duration-weighted ``artists.play_time``,
+    which is exactly the signal wanted here.
+    """
+    recent = index.recently_played_albums(days=days)
+    favorites = index.favorite_albums()
+    return SeedProfile(
+        recent_album_ids={aid for aid, _, _ in recent},
+        recent_albums=recent,
+        favorite_album_ids={aid for aid, _, _ in favorites},
+        favorite_albums=favorites,
+        top_artists=[a.name for a in index.top_artists(artist_limit)],
+        top_genres=[name for name, _ in index.taste_genres(genre_limit)],
+        labels=[name for name, _ in index.taste_labels(limit=label_limit)],
+        purchase_dates=dict(index.collection_purchase_dates()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider abstraction
+# ---------------------------------------------------------------------------
+
+PREVIEW = "preview"
+SAVE_REMOTE = "save_remote"
+
+
+class DiscoverySource(ABC):
+    """A provider of discovery candidates.
+
+    Modelled on :class:`~kamp_daemon.genre_sources.GenreSource`'s shape — small, one
+    real job — but explicitly **not** on its "return [] on any failure, silently"
+    contract. See :meth:`gather`.
+    """
+
+    #: Stable key written to discovery_items.provider.
+    provider_id: str = ""
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        """What this source can do *right now*.
+
+        A property rather than a class constant because capability can depend on the
+        transport, not just the provider. Bandcamp's wishlist write needs a
+        form-encoded POST that the Electron relay cannot express, so it is unavailable
+        in every packaged build until KAMP-653 extends the relay — while working fine
+        in a dev checkout. A constant would have the UI render a wishlist button that
+        silently does nothing for every real user, which is the exact class of failure
+        ``docs/discovery-recon.md`` exists to prevent.
+        """
+        return frozenset()
+
+    @abstractmethod
+    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+        """Return candidates for *profile*, spending no more than *budget* allows.
+
+        Criteria are provider-internal: the source decides what to look for and
+        self-describes each result via ``criterion``/``why``/``seed``.
+
+        On failure, return what was gathered rather than raising — one broken criterion
+        should cost a card, not the crate. **But an empty return obliges the source to
+        have logged a WARNING naming the surface and URL.** Every discovery surface is
+        an unofficial endpoint that will eventually drift, and silent emptiness is how
+        that arrives as "discovery is broken" with nothing in the log to explain it.
+        """
+
+    def resolve_preview(self, candidate: Candidate) -> PreviewStream | None:
+        """Resolve a playable preview for *candidate*, or None if unavailable.
+
+        Deliberately **not** budgeted, unlike :meth:`gather`: preview is user-initiated
+        and one click should never be refused because a background gather spent the
+        allowance. It does hit the tighter endpoint class, so implementations should
+        keep it to a single request.
+
+        Raises :class:`UnsupportedCapability` if ``PREVIEW`` is not in
+        :attr:`capabilities`.
+        """
+        raise UnsupportedCapability(f"{self.provider_id} cannot preview")
+
+    def save_remote(self, candidate: Candidate) -> bool:
+        """Save *candidate* to the provider's own list (Bandcamp: the wishlist).
+
+        Returns True only on a confirmed success. Callers must check
+        :attr:`capabilities` first; calling without the capability raises
+        :class:`UnsupportedCapability` so a missing gate fails loudly instead of
+        looking like a rejection by the remote service.
+
+        Implementations must confirm success from the *parsed response body*, never
+        from the HTTP status: Bandcamp's ``*_cb`` endpoints answer 200 with an error
+        payload, and trusting the status is what left an album stranded on a real
+        account during the KAMP-644 spike.
+        """
+        raise UnsupportedCapability(f"{self.provider_id} cannot save remotely")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,580 @@
+"""Discovery groundwork tests — schema, accessors, profile, ABC (KAMP-645).
+
+Named to sit alongside tests/test_discovery_fixtures.py (KAMP-644), which guards the
+captured Bandcamp fixtures rather than this code.
+
+The bias throughout is toward the cases that actually break: FK interactions with an
+account reset, the buffered-vs-shown distinction, boundary conditions on the recency
+window, and a degenerate empty library. Happy paths are covered incidentally.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from kamp_core.library import LibraryIndex
+from kamp_daemon.discovery import (
+    ALBUM_PAGE,
+    DISCOVER_API,
+    PREVIEW,
+    SAVE_REMOTE,
+    Candidate,
+    DiscoverySource,
+    PreviewStream,
+    RequestBudget,
+    SeedProfile,
+    SimpleBudget,
+    UnsupportedCapability,
+    build_seed_profile,
+)
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> LibraryIndex:
+    idx = LibraryIndex(tmp_path / "library.db")
+    yield idx
+    idx.close()
+
+
+def _add_collection_row(
+    index: LibraryIndex,
+    sale_item_id: str,
+    *,
+    band_name: str = "Band",
+    item_title: str = "Album",
+    tralbum_id: str = "",
+    album_url: str = "",
+    keywords: list[str] | None = None,
+    added_at: float = 0.0,
+) -> None:
+    index._conn.execute(
+        "INSERT INTO bandcamp_collection"
+        " (sale_item_id, band_name, item_title, tralbum_id, album_url, keywords,"
+        "  added_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            sale_item_id,
+            band_name,
+            item_title,
+            tralbum_id,
+            album_url,
+            json.dumps(keywords) if keywords is not None else None,
+            added_at,
+        ),
+    )
+    index._conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_fresh_db_is_v61_with_discovery_tables(self, tmp_path: Path) -> None:
+        LibraryIndex(tmp_path / "library.db").close()
+        conn = sqlite3.connect(str(tmp_path / "library.db"))
+        version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        conn.close()
+        assert version == 61
+        assert {"discovery_items", "discovery_events"} <= tables
+
+    def test_v60_db_migrates_to_v61_preserving_data(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        _add_collection_row(index, "sale-1")
+        index._conn.execute("UPDATE schema_version SET version = 60")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        try:
+            version = reopened._conn.execute(
+                "SELECT version FROM schema_version"
+            ).fetchone()["version"]
+            surviving = reopened._conn.execute(
+                "SELECT COUNT(*) AS c FROM bandcamp_collection"
+            ).fetchone()["c"]
+        finally:
+            reopened.close()
+        assert version == 61
+        assert surviving == 1
+
+    def test_crate_slot_is_unique_but_buffered_rows_are_exempt(
+        self, index: LibraryIndex
+    ) -> None:
+        """Many candidates may sit unshown; two cannot share one crate slot."""
+        for n in range(3):
+            index.add_discovery_candidate(
+                provider="bandcamp", provider_item_id=f"buffered-{n}"
+            )
+
+        first = index.add_discovery_candidate(provider="bandcamp", provider_item_id="a")
+        second = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="b"
+        )
+        index._conn.execute(
+            "UPDATE discovery_items SET crate_no = 1, position = 0 WHERE id = ?",
+            (first,),
+        )
+        index._conn.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "UPDATE discovery_items SET crate_no = 1, position = 0 WHERE id = ?",
+                (second,),
+            )
+            index._conn.commit()
+        index._conn.rollback()
+
+    def test_crate_no_and_position_must_agree(self, index: LibraryIndex) -> None:
+        """A half-promoted row is a bug; the CHECK makes it unrepresentable."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="x")
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "UPDATE discovery_items SET crate_no = 1 WHERE id = ?", (item,)
+            )
+            index._conn.commit()
+        index._conn.rollback()
+
+    def test_events_cannot_be_orphaned(self, index: LibraryIndex) -> None:
+        """ON DELETE RESTRICT keeps the stats ledger from being silently pruned."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="x")
+        index.record_discovery_event(item, "purchased")
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute("DELETE FROM discovery_items WHERE id = ?", (item,))
+            index._conn.commit()
+        index._conn.rollback()
+
+    def test_event_free_buffered_rows_can_be_swept(self, index: LibraryIndex) -> None:
+        """The other half of RESTRICT: KAMP-657's TTL sweep must still work."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="x")
+        index._conn.execute("DELETE FROM discovery_items WHERE id = ?", (item,))
+        index._conn.commit()
+        assert index.discovery_item_id("bandcamp", "x") is None
+
+
+# ---------------------------------------------------------------------------
+# The FK that reintroduces KAMP-528 if it is wrong
+# ---------------------------------------------------------------------------
+
+
+class TestAccountResetWithPurchasedPick:
+    def test_clear_bandcamp_collection_survives_a_purchased_discovery_item(
+        self, index: LibraryIndex
+    ) -> None:
+        """An account reset must not crash once a crate pick has been purchased.
+
+        clear_bandcamp_collection() nulls the child FKs it knows about before deleting
+        the ledger, because foreign_keys=ON turns a dangling child into an
+        IntegrityError -- the crash KAMP-528 fixed. discovery_items is a child it does
+        NOT know about, so purchased_sale_item_id is declared ON DELETE SET NULL. If
+        that action is ever dropped, this test fails with the original KAMP-528 crash.
+        """
+        _add_collection_row(index, "sale-1", tralbum_id="777")
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="777"
+        )
+        index._conn.execute(
+            "UPDATE discovery_items SET purchased_sale_item_id = ?, purchased_at = ?"
+            " WHERE id = ?",
+            ("sale-1", time.time(), item),
+        )
+        index._conn.commit()
+        index.record_discovery_event(item, "purchased")
+
+        index.clear_bandcamp_collection()
+
+        row = index._conn.execute(
+            "SELECT purchased_sale_item_id, state FROM discovery_items WHERE id = ?",
+            (item,),
+        ).fetchone()
+        assert row is not None, "the discovery item must survive an account reset"
+        assert row["purchased_sale_item_id"] is None
+        # The event ledger is the ground truth for attribution and is untouched.
+        assert row["state"] == "purchased"
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events WHERE kind = 'purchased'"
+            ).fetchone()["c"]
+            == 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# seen_before / in_library
+# ---------------------------------------------------------------------------
+
+
+class TestExclusionPredicates:
+    def test_buffered_candidate_is_not_seen(self, index: LibraryIndex) -> None:
+        """The KAMP-657 invariant: a gathered-but-unshown row stays eligible."""
+        index.add_discovery_candidate(provider="bandcamp", provider_item_id="123")
+        assert index.seen_before("bandcamp", "123") is False
+
+    def test_shown_candidate_is_seen(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="123"
+        )
+        index._conn.execute(
+            "UPDATE discovery_items SET crate_no = 1, position = 0 WHERE id = ?",
+            (item,),
+        )
+        index._conn.commit()
+        assert index.seen_before("bandcamp", "123") is True
+
+    def test_seen_before_is_provider_scoped(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="123"
+        )
+        index._conn.execute(
+            "UPDATE discovery_items SET crate_no = 1, position = 0 WHERE id = ?",
+            (item,),
+        )
+        index._conn.commit()
+        assert index.seen_before("discogs", "123") is False
+
+    def test_in_library_matches_on_tralbum_id(self, index: LibraryIndex) -> None:
+        _add_collection_row(index, "sale-1", tralbum_id="4242")
+        assert index.in_library("4242") is True
+        assert index.in_library("9999") is False
+
+    def test_in_library_falls_back_to_nocase_artist_title(
+        self, index: LibraryIndex
+    ) -> None:
+        """Rows whose tralbum_id was never backfilled still have to match."""
+        _add_collection_row(
+            index, "sale-1", band_name="Four Tet", item_title="Pink", tralbum_id=""
+        )
+        assert index.in_library("", artist="four tet", title="PINK") is True
+        assert index.in_library("", artist="Four Tet", title="Rounds") is False
+
+    def test_in_library_handles_custom_domain_and_dead_urls(
+        self, index: LibraryIndex
+    ) -> None:
+        """~1% of a real collection is on a Bandcamp Pro custom domain, and a stored
+        album_url can 404. Neither is an identity signal, so neither may affect
+        matching."""
+        _add_collection_row(
+            index,
+            "sale-1",
+            band_name="Artist",
+            item_title="Album",
+            tralbum_id="555",
+            album_url="https://music.example.com/album/x",
+        )
+        assert index.in_library("555") is True
+        assert index.in_library("", artist="Artist", title="Album") is True
+
+
+# ---------------------------------------------------------------------------
+# Event ledger and derived state
+# ---------------------------------------------------------------------------
+
+
+class TestEventLedger:
+    def test_state_precedence_is_highest_rank_not_last_write(
+        self, index: LibraryIndex
+    ) -> None:
+        """previewed -> dismissed -> purchased -> a late 'shown' stays 'purchased'.
+
+        Attribution runs on a collection sync, out of order with UI events, so a
+        last-event-wins cache would quietly downgrade a purchase.
+        """
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        for kind in ("shown", "previewed", "dismissed", "purchased", "shown"):
+            index.record_discovery_event(item, kind)
+        state = index._conn.execute(
+            "SELECT state FROM discovery_items WHERE id = ?", (item,)
+        ).fetchone()["state"]
+        assert state == "purchased"
+
+    def test_dismissed_does_not_override_wishlisted(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "dismissed")
+        state = index._conn.execute(
+            "SELECT state FROM discovery_items WHERE id = ?", (item,)
+        ).fetchone()["state"]
+        assert state == "wishlisted"
+
+    def test_every_event_is_recorded_even_when_state_is_unchanged(
+        self, index: LibraryIndex
+    ) -> None:
+        """state is a cache; the ledger is the truth and must not lose rows."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        for _ in range(3):
+            index.record_discovery_event(item, "url_copied")
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events"
+            ).fetchone()["c"]
+            == 3
+        )
+
+    def test_events_denormalise_provider_identity(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="abc"
+        )
+        index.record_discovery_event(item, "shown")
+        row = index._conn.execute(
+            "SELECT provider, provider_item_id FROM discovery_events"
+        ).fetchone()
+        assert (row["provider"], row["provider_item_id"]) == ("bandcamp", "abc")
+
+    def test_unknown_item_raises(self, index: LibraryIndex) -> None:
+        with pytest.raises(ValueError):
+            index.record_discovery_event(9999, "shown")
+
+    def test_unknown_event_kind_raises(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        with pytest.raises(ValueError):
+            index.record_discovery_event(item, "teleported")
+
+    def test_candidate_insert_is_idempotent(self, index: LibraryIndex) -> None:
+        """Re-gathering an album must not duplicate it or resurrect a shown one."""
+        first = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", artist="A"
+        )
+        again = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", artist="A"
+        )
+        assert first == again
+
+
+# ---------------------------------------------------------------------------
+# Seed profile
+# ---------------------------------------------------------------------------
+
+
+class TestSeedProfile:
+    def _album(
+        self,
+        index: LibraryIndex,
+        artist: str,
+        title: str,
+        *,
+        last_played_at: float | None = None,
+        favorite: int = 0,
+        label: str = "",
+    ) -> int:
+        cur = index._conn.execute(
+            "INSERT INTO albums (album_artist, album, last_played_at, favorite, label)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (artist, title, last_played_at, favorite, label),
+        )
+        index._conn.commit()
+        return int(cur.lastrowid or 0)
+
+    def test_recency_window_boundaries(self, index: LibraryIndex) -> None:
+        """29 days ago is recent; 31 is not. The boundary is the whole point."""
+        now = time.time()
+        self._album(index, "Fresh", "In", last_played_at=now - 29 * 86400)
+        self._album(index, "Stale", "Out", last_played_at=now - 31 * 86400)
+        self._album(index, "Never", "Played", last_played_at=None)
+
+        recent = index.recently_played_albums(days=30)
+        titles = {title for _, _, title in recent}
+        assert titles == {"In"}
+
+    def test_taste_genres_unions_keywords_regardless_of_tagging_toggle(
+        self, index: LibraryIndex
+    ) -> None:
+        """Bandcamp keywords are a taste signal even when the tagging option is off.
+
+        They are only promoted into track_genres when tagging.bandcamp_genres is on
+        AND only on an album's first index, so gating this read on that config would
+        make a user's taste invisible because of an unrelated tagging preference.
+        """
+        index.set_setting("tagging.bandcamp_genres", "false")
+        _add_collection_row(
+            index, "sale-1", tralbum_id="1", keywords=["dub techno", "ambient"]
+        )
+        _add_collection_row(index, "sale-2", tralbum_id="2", keywords=["dub techno"])
+
+        genres = dict(index.taste_genres())
+        assert genres.get("dub techno") == 2
+        assert genres.get("ambient") == 1
+
+    def test_taste_genres_survives_malformed_keyword_blobs(
+        self, index: LibraryIndex
+    ) -> None:
+        """The column is free-form TEXT; a bad row must not poison the profile."""
+        _add_collection_row(index, "sale-1", tralbum_id="1", keywords=["techno"])
+        index._conn.execute(
+            "UPDATE bandcamp_collection SET keywords = ? WHERE sale_item_id = 'sale-1'",
+            ("not json at all",),
+        )
+        _add_collection_row(index, "sale-2", tralbum_id="2", keywords=["techno"])
+        index._conn.commit()
+        assert dict(index.taste_genres()).get("techno") == 1
+
+    def test_labels_group_case_insensitively(self, index: LibraryIndex) -> None:
+        """albums.label is unnormalised free text: Ghostly and ghostly are one label."""
+        self._album(index, "A", "1", label="Ghostly")
+        self._album(index, "B", "2", label="ghostly")
+        self._album(index, "C", "3", label="Kranky")
+
+        labels = dict(index.taste_labels(min_albums=2))
+        assert len(labels) == 1
+        assert next(iter(labels)).casefold() == "ghostly"
+        assert next(iter(labels.values())) == 2
+
+    def test_labels_respect_the_minimum(self, index: LibraryIndex) -> None:
+        self._album(index, "A", "1", label="Solo")
+        assert index.taste_labels(min_albums=2) == []
+
+    def test_profile_on_an_empty_library_is_thin_not_broken(
+        self, index: LibraryIndex
+    ) -> None:
+        """The most likely first-run state, and the most likely to divide by zero."""
+        profile = build_seed_profile(index)
+        assert profile.is_thin is True
+        assert profile.recent_album_ids == set()
+        assert profile.top_genres == []
+        assert profile.purchase_dates == {}
+
+    def test_profile_collects_signals(self, index: LibraryIndex) -> None:
+        now = time.time()
+        recent_id = self._album(index, "Recent", "Album", last_played_at=now - 3600)
+        fav_id = self._album(index, "Fav", "Album", favorite=1)
+        _add_collection_row(
+            index, "sale-1", tralbum_id="900", keywords=["shoegaze"], added_at=now
+        )
+
+        profile = build_seed_profile(index)
+        assert recent_id in profile.recent_album_ids
+        assert fav_id in profile.favorite_album_ids
+        assert profile.has_genre("Shoegaze") is True
+        assert profile.purchase_dates["900"] == pytest.approx(now)
+        assert profile.is_thin is False
+
+    def test_membership_helpers_are_case_insensitive(self) -> None:
+        """KAMP-657 re-validates seeds through these, so casing must not matter."""
+        profile = SeedProfile(
+            top_genres=["Dub Techno"], top_artists=["Four Tet"], labels=["Ghostly"]
+        )
+        assert profile.has_genre("dub techno") is True
+        assert profile.has_artist("FOUR TET") is True
+        assert profile.has_label("ghostly") is True
+        assert profile.has_genre("noise") is False
+
+
+# ---------------------------------------------------------------------------
+# Provider abstraction
+# ---------------------------------------------------------------------------
+
+
+class _FakeSource(DiscoverySource):
+    """A minimal source, standing in for what KAMP-647 will build."""
+
+    provider_id = "fake"
+
+    def __init__(self, *, can_save: bool = False) -> None:
+        self._can_save = can_save
+        self.gathered_with: RequestBudget | None = None
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        # Mirrors the real shape: a capability that depends on runtime conditions
+        # rather than being fixed at class-definition time.
+        caps = {PREVIEW}
+        if self._can_save:
+            caps.add(SAVE_REMOTE)
+        return frozenset(caps)
+
+    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+        self.gathered_with = budget
+        if not budget.allow(ALBUM_PAGE):
+            return []
+        budget.consume(ALBUM_PAGE)
+        return [
+            Candidate(
+                provider="fake",
+                provider_item_id="1",
+                item_url="https://example.com/a",
+                criterion="also_like",
+                why="because you played X",
+                seed={"album_id": 1},
+            )
+        ]
+
+    def resolve_preview(self, candidate: Candidate) -> PreviewStream | None:
+        return PreviewStream(url="https://example.com/a.mp3")
+
+
+class TestDiscoverySource:
+    def test_capabilities_are_evaluated_at_call_time(self) -> None:
+        """Not a class constant: Bandcamp's save_remote depends on the transport, and
+        a stale constant would render a wishlist button that silently no-ops."""
+        source = _FakeSource(can_save=False)
+        assert SAVE_REMOTE not in source.capabilities
+        source._can_save = True
+        assert SAVE_REMOTE in source.capabilities
+
+    def test_save_remote_without_the_capability_raises(self) -> None:
+        """Fails loudly rather than looking like a rejection by the remote service."""
+        source = _FakeSource(can_save=False)
+        candidate = Candidate(
+            provider="fake", provider_item_id="1", item_url="https://example.com/a"
+        )
+        with pytest.raises(UnsupportedCapability):
+            source.save_remote(candidate)
+
+    def test_a_bare_source_offers_nothing_and_does_nothing(self) -> None:
+        """Capabilities are opt-in. A source that declares none must not be assumed
+        to preview or save just because the methods exist on the ABC."""
+
+        class _Bare(DiscoverySource):
+            provider_id = "np"
+
+            def gather(
+                self, profile: SeedProfile, budget: RequestBudget
+            ) -> list[Candidate]:
+                return []
+
+        source = _Bare()
+        candidate = Candidate(provider="np", provider_item_id="1", item_url="x")
+        assert source.capabilities == frozenset()
+        with pytest.raises(UnsupportedCapability):
+            source.resolve_preview(candidate)
+        with pytest.raises(UnsupportedCapability):
+            source.save_remote(candidate)
+
+    def test_gather_respects_the_budget(self) -> None:
+        source = _FakeSource()
+        budget = SimpleBudget(limits={ALBUM_PAGE: 1})
+        assert len(source.gather(SeedProfile(), budget)) == 1
+        assert source.gather(SeedProfile(), budget) == []
+
+    def test_candidate_serialises_its_seed_deterministically(self) -> None:
+        candidate = Candidate(
+            provider="fake",
+            provider_item_id="1",
+            item_url="x",
+            seed={"b": 2, "a": 1},
+        )
+        assert candidate.seed_json() == '{"a": 1, "b": 2}'
+
+
+class TestSimpleBudget:
+    def test_classes_are_counted_separately(self) -> None:
+        """Album pages and the discover API have different real-world limits, so a
+        single global counter would be wrong by construction."""
+        budget = SimpleBudget(limits={ALBUM_PAGE: 1, DISCOVER_API: 3})
+        budget.consume(ALBUM_PAGE)
+        assert budget.allow(ALBUM_PAGE) is False
+        assert budget.allow(DISCOVER_API) is True
+
+    def test_unlisted_classes_use_the_default(self) -> None:
+        budget = SimpleBudget(default_limit=2)
+        budget.consume("something_new", 2)
+        assert budget.allow("something_new") is False

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -239,7 +239,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 60
+        assert version == 61
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +346,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +442,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 60
+        assert version == 61
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -1037,7 +1037,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 60
+        assert ver == 61
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1059,7 +1059,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 60
+        assert ver == 61
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1156,7 +1156,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 60
+        assert ver == 61
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1280,7 +1280,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 60
+        assert ver == 61
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3414,7 +3414,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3471,7 +3471,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -4464,7 +4464,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -4507,7 +4507,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -4574,7 +4574,7 @@ class TestPreorderResurface:
         ).fetchone()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "redownload_url" in cols
         # Existing row survived; the new column is NULL for pre-existing data.
         assert row["provider_item_id"] == "keep"
@@ -4600,7 +4600,7 @@ class TestPreorderResurface:
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -4954,7 +4954,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert row is not None
         assert row[0] == 0
 
@@ -5419,7 +5419,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -5532,7 +5532,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -5716,7 +5716,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -5811,7 +5811,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 60
+        assert version == 61
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -5819,7 +5819,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 60
+        assert version == 61
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -6746,7 +6746,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 60
+        assert version == 61
 
         index.close()
 
@@ -7477,7 +7477,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 60
+        assert version == 61
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -7512,7 +7512,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 60
+        assert version == 61
         index.close()
 
 
@@ -8053,7 +8053,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 60
+        assert version == 61
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -8186,7 +8186,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 60
+        assert version == 61
 
 
 class TestRemoteTrackSchema:
@@ -8602,7 +8602,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -8663,7 +8663,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -9485,7 +9485,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -10449,7 +10449,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -10527,7 +10527,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -10736,7 +10736,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -10976,7 +10976,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -11076,7 +11076,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -11192,7 +11192,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -11697,7 +11697,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -11812,7 +11812,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -11910,7 +11910,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -12010,7 +12010,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -12638,7 +12638,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 60
+        assert version == 61
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -13522,7 +13522,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 60
+        assert version == 61
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -15305,7 +15305,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 60
+        assert version == 61
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -15325,7 +15325,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 60
+        assert version == 61
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -15368,7 +15368,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 60
+        assert version == 61
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -15647,7 +15647,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 60
+        assert ver == 61
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []


### PR DESCRIPTION
## Summary

The foundation the rest of the Discovery Crate epic (KAMP-643) builds on, unblocked by the KAMP-644 recon: durable identity for albums the user does **not** own, an append-only engagement ledger, a local-only taste profile, and the provider interface that keeps a future non-Bandcamp service plausible.

Schema v60 → v61 is **additive only** — nothing touches `tracks`, `albums`, or `tracks_with_stats`, so neither the KAMP-552 rebuild recipe nor the CI-only DROP-VIEW trap is in play.

## Three decisions that are load-bearing, not stylistic

**1. `purchased_sale_item_id` is `ON DELETE SET NULL`.** `clear_bandcamp_collection()` nulls the child FKs it knows about before deleting the ledger, because `foreign_keys=ON` turns a dangling child into an `IntegrityError` — the crash KAMP-528 fixed. `discovery_items` is a child it does *not* know about, so without the action an account reset crashes the moment a crate pick has been purchased. I verified this by removing the clause and watching the guard fail with the original `FOREIGN KEY constraint failed`, then restoring it.

**2. `crate_no` is the seen-ledger.** `NULL` means gathered-but-never-shown, so "has the user seen this?" is `crate_no IS NOT NULL`, **not** row existence. Keying it on existence would strand every buffered candidate (KAMP-657) permanently — and silently, which is the worst part. A partial unique index makes two items in one crate slot unrepresentable, and a CHECK stops a half-promoted row.

**3. `state` is a derived cache with exactly one writer.** `record_discovery_event()` appends the event and reconciles `state` in one rollback-guarded transaction (KAMP-527 deferred-commit discipline). Precedence is **highest-rank-wins**, not last-event-wins: purchase attribution runs on a collection sync, out of order with UI events, so last-write-wins would quietly downgrade a purchase.

## Abstraction notes

- **`capabilities` is a property, not a class constant.** Wishlist-add needs a form-encoded POST the Electron relay cannot express, so it is genuinely unavailable in packaged builds until KAMP-653 — while working fine in a dev checkout. A constant would render a wishlist button that silently no-ops for every real user, the exact failure `docs/discovery-recon.md` exists to prevent. Calling an unavailable capability raises `UnsupportedCapability` so a missing gate fails loudly rather than looking like a remote rejection.
- **`RequestBudget` is a Protocol seam, per endpoint class.** KAMP-644 measured album pages 429ing at 57 requests in 39s where the discover API absorbed 120 clean, so a single global counter would be born wrong. KAMP-646 swaps in the governor policy without touching a signature.
- **`gather()` does not inherit `GenreSource`'s silent-`[]` contract** — an empty return obliges the source to have logged a WARNING naming the surface and URL, since every discovery surface is unofficial and will drift.
- **Module boundaries stated up front** so `discovery.py` doesn't become a second god-module across five stories: 645 owns types + profile; KAMP-647 adds `discovery_sources.py`; KAMP-648 adds `discovery_builder.py`.

## Cut deliberately

- **`fan_id` persistence.** The original rationale (Windows Credential Manager's 2560-byte cap) was stale — KAMP-282 moved Windows to DPAPI-wrapped storage with no size limit. The real problem is invalidation: logout only calls `clear_session()`, so a `settings` row would survive an account switch and pair a stale `fan_id` with fresh cookies. The saving is <2% of a sync's requests; an in-process cache gets the same win with no schema and no invalidation code.
- **`discovery.*` config keys.** Nothing reads them yet, and `_build_config_values`'s drift test makes adding one later safe.

## Test plan

- [x] `poetry run pytest` — **2734 passed, 9 skipped**, coverage **93.81%** (up from 93.80 on main; `kamp_daemon/discovery.py` is at 100%)
- [x] `black --check` and `mypy --strict` clean
- [x] **Falsified the KAMP-528 guard** — removed `ON DELETE SET NULL` and confirmed the test fails with the original `IntegrityError`, then restored
- [x] Constraint tests are real, not decorative: crate-slot uniqueness, the `crate_no`/`position` CHECK, and `ON DELETE RESTRICT` on events each assert an `IntegrityError`
- [x] Boundary conditions rather than happy paths: 29 days in / 31 days out of the recency window; the keyword union works **with `tagging.bandcamp_genres` off**; `Ghostly`/`ghostly` collapse to one label; a malformed keyword blob doesn't poison the profile; an empty library reports `is_thin` instead of dividing by zero
- [x] **Migration verified against a copy of a real 28MB production DB** (never the original): v60 → v61 with all **176,477 rows across 34 tables** intact, `PRAGMA integrity_check` ok, and `PRAGMA foreign_key_check` returning no rows — inspected as rows rather than trusting a clean call (KAMP-552)
- [x] Also migrated a v28 production backup through the full ladder to v61. It shows a `tracks` row delta (12055 → 12023); I confirmed against a `main` worktree that **the identical delta occurs without this change** — it is the pre-existing KAMP-541 collapse migration deduplicating, not a regression here
- [ ] No UI surface in this story, so nothing to eyeball yet

## Note for the reviewer

Your **production database has already been migrated to v61** by the dev server running this branch. That is safe and expected — the migration is additive, `bak-1.26.1-prod/` holds the pre-migration backup, and the packaged v1.26.1 app simply ignores the two extra tables (its ladder has no v61 branch, and the DDL is `CREATE IF NOT EXISTS`). Flagging it so it isn't a surprise if you run the released build against it.

Closes KAMP-645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
