### PR TITLE
KAMP-646: Bandcamp rate-limit governor + calibrated crate budget

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1137,6 +1137,8 @@ def _cmd_daemon(
             _make_requests_session,
             prefetch_redownload_urls,
         )
+        from .bandcamp_ratelimit import get_governor as _get_governor
+        from .discovery import FANCOLLECTION as _FANCOLLECTION
         from .syncer import RateLimited, process_next_download
 
         def _on_state(provider_item_id: str, state: str) -> None:
@@ -1253,6 +1255,12 @@ def _cmd_daemon(
                 # Publish the deadline so the UI can say "resuming in N", not
                 # leave every row reading "queued" while nothing happens.
                 app.state.set_download_pause(time.time() + pause)
+                # KAMP-646: tell the governor too, so discovery holds off on the
+                # one endpoint class it shares with this drain (the collection
+                # endpoint, which the wishlist walk uses). Album-page work is
+                # deliberately unaffected — the measured limits differ by ~2x, so
+                # pausing it here would cost time without buying protection.
+                _get_governor().report_429(_FANCOLLECTION)
                 try:
                     time.sleep(pause)
                 finally:

--- a/kamp_daemon/bandcamp_ratelimit.py
+++ b/kamp_daemon/bandcamp_ratelimit.py
@@ -1,0 +1,213 @@
+"""Rate-limit safety net for kamp's own bandcamp.com requests (KAMP-646).
+
+Discovery (KAMP-643) is a new consumer of an origin that several workers already
+share. This module keeps *discovery's* requests underneath the ceiling KAMP-644
+measured, so that a crate build — or a bug in one — cannot earn an account-wide
+429 that would cascade into the download queue.
+
+**Scope, deliberately narrow.** This governs only the requests whose callers ask it
+to. It does not, and cannot, gate:
+
+* the stream sync and album download, which run in ``spawn`` subprocesses
+  (:func:`kamp_daemon.syncer._spawn_worker`) and so cannot see this object at all;
+* playback stream-URL resolution, which is the *same* endpoint class but runs
+  inside an HTTP handler (``kamp_core/server.py``) and on the gapless-lookahead
+  path. A backoff there would stall the next track or hang a request. **Do not
+  wire this into playback.** Same reasoning as ``resolve_preview`` being
+  budget-exempt in :mod:`kamp_daemon.discovery`.
+
+**Why per endpoint class.** KAMP-644 measured materially different limits: album
+pages returned 429 after 57 requests in 39s (~87/min), while ``discover_web``
+absorbed 120 at the same rate without complaint. One global number would be
+simultaneously too strict for one and too loose for the other.
+
+Bandcamp offers no ``Retry-After`` even on the direct transport, and the Electron
+relay cannot surface response headers at all, so the cooldown ladder here is the
+only backoff signal available.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import threading
+import time
+from typing import Protocol
+
+from .discovery import ALBUM_PAGE, DISCOVER_API, FANCOLLECTION
+
+logger = logging.getLogger(__name__)
+
+# Minimum gap between two of *our* requests in the same class. Chosen against the
+# measured ceilings with roughly 2x headroom: 1.5s pins album pages at <=40/min
+# against a limit that appeared at ~87/min. Spacing is the only mechanism that
+# bounds a *pathological loop* — a budget bounds a single crate, spacing bounds
+# everything, including a bug.
+_MIN_SPACING = {
+    ALBUM_PAGE: 1.5,
+    DISCOVER_API: 1.0,
+    # The collection endpoint is the one that rate-limits hardest (three walks in
+    # a minute earns a 429), and crate building never touches it. Only the
+    # wishlist walk does.
+    FANCOLLECTION: 5.0,
+}
+_DEFAULT_SPACING = 2.0
+
+# Escalating cooldown after an observed 429, per class. Mirrors the ladder the
+# download drain already uses, so a user sees consistent pause lengths.
+_COOLDOWNS = (60.0, 120.0, 300.0)
+
+
+class Clock(Protocol):
+    """Time source and interruptible wait, injected so tests never really sleep.
+
+    One object rather than two callables on purpose: a fake ``sleep`` paired with
+    a separately-faked ``monotonic`` is the standard way to write a wait loop that
+    never advances its own clock, which then spins forever and hangs the suite.
+    Binding the two together makes that mistake unrepresentable.
+    """
+
+    def now(self) -> float:
+        """Monotonic seconds."""
+
+    def wait(self, timeout: float) -> bool:
+        """Wait up to *timeout*. Return True if interrupted (i.e. shutting down)."""
+
+
+class RealClock:
+    """Production clock. ``wait`` is bound to a shutdown event, not ``time.sleep``.
+
+    That is what makes a long cooldown safe: a stopping daemon interrupts the wait
+    immediately rather than sitting out the remaining five minutes.
+    """
+
+    def __init__(self, stop: threading.Event | None = None) -> None:
+        self._stop = stop or threading.Event()
+
+    def now(self) -> float:
+        return time.monotonic()
+
+    def wait(self, timeout: float) -> bool:
+        return self._stop.wait(timeout)
+
+
+class BandcampGovernor:
+    """Spacing and cooldown for kamp-issued bandcamp.com requests.
+
+    Thread-safe. Callers declare the endpoint class themselves — the governor
+    never inspects a URL to guess it. Sniffing the host would misclassify the
+    Bandcamp Pro custom domains that ~1% of a real collection uses, and would
+    invite a relay-level 422 (a URL that never reached Bandcamp at all) to be
+    treated as an origin rate limit.
+    """
+
+    def __init__(self, clock: Clock | None = None) -> None:
+        # A spawn subprocess importing this module would get a brand-new instance
+        # with no history — a governor that silently governs nothing. Fail loudly
+        # instead; the children have their own hand-rolled backoff and are not
+        # meant to use this.
+        if multiprocessing.parent_process() is not None:
+            raise RuntimeError(
+                "BandcampGovernor is parent-process only: a subprocess instance "
+                "would carry no backoff state and silently govern nothing."
+            )
+        self._clock = clock or RealClock()
+        self._lock = threading.Lock()
+        self._last_request_at: dict[str, float] = {}
+        self._blocked_until: dict[str, float] = {}
+        self._strikes: dict[str, int] = {}
+
+    def wait_turn(self, endpoint_class: str) -> bool:
+        """Block until it is polite to issue a request in *endpoint_class*.
+
+        Returns False if the wait was interrupted by shutdown, in which case the
+        caller must NOT issue the request.
+
+        The lock is never held across a wait: the deadline is computed under it,
+        released, waited on, then re-checked. Holding it would let a slow consumer
+        block :meth:`report_429` from an unrelated thread, which is how a safety
+        net turns into the outage it was meant to prevent.
+        """
+        while True:
+            with self._lock:
+                now = self._clock.now()
+                spacing = _MIN_SPACING.get(endpoint_class, _DEFAULT_SPACING)
+                ready_at = max(
+                    self._blocked_until.get(endpoint_class, 0.0),
+                    self._last_request_at.get(endpoint_class, 0.0) + spacing,
+                )
+                if now >= ready_at:
+                    # Reserve the slot before releasing, so two threads in the
+                    # same class cannot both decide it is their turn.
+                    self._last_request_at[endpoint_class] = now
+                    return True
+                delay = ready_at - now
+
+            if self._clock.wait(delay):
+                logger.debug("wait_turn(%s) interrupted by shutdown", endpoint_class)
+                return False
+
+    def report_429(self, endpoint_class: str) -> float:
+        """Record an observed rate limit and return the cooldown applied.
+
+        Per class rather than account-wide: the measured limits differ by roughly
+        2x, so pausing album pages because the collection endpoint complained
+        would cost real time for no protection. What this does buy is the class
+        the download queue and the wishlist walk genuinely share.
+        """
+        with self._lock:
+            strikes = self._strikes.get(endpoint_class, 0)
+            cooldown = _COOLDOWNS[min(strikes, len(_COOLDOWNS) - 1)]
+            self._strikes[endpoint_class] = strikes + 1
+            self._blocked_until[endpoint_class] = self._clock.now() + cooldown
+        logger.warning(
+            "Bandcamp rate-limited on %s — holding that class for %.0fs",
+            endpoint_class,
+            cooldown,
+        )
+        return cooldown
+
+    def report_ok(self, endpoint_class: str) -> None:
+        """Record a clean result, resetting that class's escalation."""
+        with self._lock:
+            self._strikes.pop(endpoint_class, None)
+
+    def blocked_for(self, endpoint_class: str) -> float:
+        """Seconds remaining on *endpoint_class*'s cooldown, 0.0 when free."""
+        with self._lock:
+            return max(
+                0.0, self._blocked_until.get(endpoint_class, 0.0) - self._clock.now()
+            )
+
+    def reset(self) -> None:
+        """Forget all backoff state.
+
+        Called on logout: a 429 is scoped to the account, so a new session starts
+        clean. Deliberately NOT called on config reload, which fires on unrelated
+        preference changes — otherwise a user could clear a live backoff by
+        toggling a checkbox.
+        """
+        with self._lock:
+            self._last_request_at.clear()
+            self._blocked_until.clear()
+            self._strikes.clear()
+
+
+_governor: BandcampGovernor | None = None
+_governor_lock = threading.Lock()
+
+
+def get_governor() -> BandcampGovernor:
+    """Return the process-wide governor, creating it on first use."""
+    global _governor
+    with _governor_lock:
+        if _governor is None:
+            _governor = BandcampGovernor()
+        return _governor
+
+
+def reset_governor() -> None:
+    """Drop the singleton. For logout, and for test isolation."""
+    global _governor
+    with _governor_lock:
+        _governor = None

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -66,10 +66,13 @@ class RequestBudget(Protocol):
 
 @dataclass
 class SimpleBudget:
-    """A per-class counting budget. The default until KAMP-646 lands.
+    """A per-class counting budget.
 
     Deliberately dumb: it counts and it stops. It does not defer, back off, or know
-    that other workers exist — that is the governor's job.
+    that other workers exist — spacing and cooldown are
+    :class:`~kamp_daemon.bandcamp_ratelimit.BandcampGovernor`'s job. The two are
+    kept separate on purpose: ``allow`` is a predicate and must never block, so a
+    caller can ask "could I afford this?" without committing to a wait.
     """
 
     limits: dict[str, int] = field(default_factory=dict)
@@ -82,6 +85,27 @@ class SimpleBudget:
 
     def consume(self, endpoint_class: str, n: int = 1) -> None:
         self.spent[endpoint_class] = self.spent.get(endpoint_class, 0) + n
+
+
+def crate_budget() -> SimpleBudget:
+    """The per-class request allowance for building one crate (KAMP-646).
+
+    Calibrated from KAMP-644, which measured a varied crate at 3-6 requests
+    total — so these caps carry roughly 2x margin rather than being a target.
+
+    ``FANCOLLECTION`` is 0 on purpose, and is a tripwire rather than a limit:
+    crate building must never touch the collection endpoint, which is both the
+    most expensive call available and the one that rate-limits hardest. An
+    accidental walk should fail a test loudly instead of quietly earning a 429
+    that cascades into the download queue.
+
+    ``default_limit=0`` likewise denies any endpoint class nobody has thought
+    about, so a new fetcher must declare its class deliberately.
+    """
+    return SimpleBudget(
+        limits={ALBUM_PAGE: 8, DISCOVER_API: 6, FANCOLLECTION: 0},
+        default_limit=0,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bandcamp_ratelimit.py
+++ b/tests/test_bandcamp_ratelimit.py
@@ -1,0 +1,257 @@
+"""Tests for the Bandcamp rate-limit governor (KAMP-646).
+
+Everything runs against a virtual clock, so the suite never actually sleeps and
+the timing assertions are exact rather than flaky.
+
+The fake clock is deliberately self-limiting: a regression that turns wait_turn
+into a spin loop raises with a useful message instead of hanging CI, which is the
+usual way a hand-rolled fake clock fails.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from kamp_daemon.bandcamp_ratelimit import (
+    _COOLDOWNS,
+    _MIN_SPACING,
+    BandcampGovernor,
+    RealClock,
+    get_governor,
+    reset_governor,
+)
+from kamp_daemon.discovery import ALBUM_PAGE, DISCOVER_API, FANCOLLECTION
+
+
+class FakeClock:
+    """Virtual time. ``wait`` advances the clock instead of blocking."""
+
+    def __init__(self, *, interrupt_after: int | None = None, max_waits: int = 50):
+        self.t = 1000.0
+        self.waits: list[float] = []
+        self._interrupt_after = interrupt_after
+        self._max_waits = max_waits
+
+    def now(self) -> float:
+        return self.t
+
+    def wait(self, timeout: float) -> bool:
+        self.waits.append(timeout)
+        if len(self.waits) > self._max_waits:
+            raise AssertionError(
+                f"wait() called {len(self.waits)} times — wait_turn is spinning "
+                "rather than converging on a deadline"
+            )
+        if (
+            self._interrupt_after is not None
+            and len(self.waits) >= self._interrupt_after
+        ):
+            return True  # shutting down
+        self.t += timeout
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singleton():
+    """The module-level governor would otherwise leak backoff across tests."""
+    reset_governor()
+    yield
+    reset_governor()
+
+
+def _governor(**kw) -> tuple[BandcampGovernor, FakeClock]:
+    clock = FakeClock(**kw)
+    return BandcampGovernor(clock=clock), clock
+
+
+class TestSpacing:
+    def test_first_request_in_a_class_is_immediate(self) -> None:
+        gov, clock = _governor()
+        assert gov.wait_turn(ALBUM_PAGE) is True
+        assert clock.waits == []
+
+    def test_second_request_waits_the_class_floor(self) -> None:
+        """Spacing is what bounds a pathological loop; a budget only bounds a crate."""
+        gov, clock = _governor()
+        gov.wait_turn(ALBUM_PAGE)
+        start = clock.now()
+        gov.wait_turn(ALBUM_PAGE)
+        assert clock.now() - start == pytest.approx(_MIN_SPACING[ALBUM_PAGE])
+
+    def test_classes_are_spaced_independently(self) -> None:
+        """Album pages 429'd at ~87/min while discover absorbed 120 clean, so a
+        shared spacer would be wrong for both."""
+        gov, clock = _governor()
+        gov.wait_turn(ALBUM_PAGE)
+        start = clock.now()
+        assert gov.wait_turn(DISCOVER_API) is True
+        assert clock.now() == start, "a different class must not inherit the wait"
+
+    def test_unknown_class_gets_the_default_spacing(self) -> None:
+        gov, clock = _governor()
+        gov.wait_turn("something_new")
+        start = clock.now()
+        gov.wait_turn("something_new")
+        assert clock.now() > start
+
+    def test_spacing_keeps_us_under_the_measured_ceiling(self) -> None:
+        """The floor must imply a rate below the 87/min that actually produced a 429."""
+        implied_per_minute = 60.0 / _MIN_SPACING[ALBUM_PAGE]
+        assert implied_per_minute < 87.0
+
+
+class TestCooldown:
+    def test_429_blocks_that_class(self) -> None:
+        gov, clock = _governor()
+        cooldown = gov.report_429(ALBUM_PAGE)
+        assert cooldown == _COOLDOWNS[0]
+        assert gov.blocked_for(ALBUM_PAGE) == pytest.approx(_COOLDOWNS[0])
+
+        start = clock.now()
+        assert gov.wait_turn(ALBUM_PAGE) is True
+        assert clock.now() - start == pytest.approx(_COOLDOWNS[0])
+
+    def test_429_does_not_block_other_classes(self) -> None:
+        """Per class, not account-wide: the limits differ by ~2x, so pausing album
+        pages because the collection endpoint complained costs time and buys nothing."""
+        gov, clock = _governor()
+        gov.report_429(FANCOLLECTION)
+        start = clock.now()
+        assert gov.wait_turn(ALBUM_PAGE) is True
+        assert clock.now() == start
+        assert gov.blocked_for(ALBUM_PAGE) == 0.0
+
+    def test_cooldown_escalates_then_saturates(self) -> None:
+        gov, _ = _governor()
+        assert [gov.report_429(ALBUM_PAGE) for _ in range(4)] == [
+            _COOLDOWNS[0],
+            _COOLDOWNS[1],
+            _COOLDOWNS[2],
+            _COOLDOWNS[2],
+        ]
+
+    def test_report_ok_resets_the_escalation(self) -> None:
+        gov, _ = _governor()
+        gov.report_429(ALBUM_PAGE)
+        gov.report_429(ALBUM_PAGE)
+        gov.report_ok(ALBUM_PAGE)
+        assert gov.report_429(ALBUM_PAGE) == _COOLDOWNS[0]
+
+    def test_report_ok_on_one_class_leaves_another_escalated(self) -> None:
+        gov, _ = _governor()
+        gov.report_429(ALBUM_PAGE)
+        gov.report_ok(DISCOVER_API)
+        assert gov.report_429(ALBUM_PAGE) == _COOLDOWNS[1]
+
+    def test_reset_clears_everything(self) -> None:
+        """Called on logout — a 429 is account-scoped, so a new session starts clean."""
+        gov, _ = _governor()
+        gov.report_429(ALBUM_PAGE)
+        gov.reset()
+        assert gov.blocked_for(ALBUM_PAGE) == 0.0
+        assert gov.report_429(ALBUM_PAGE) == _COOLDOWNS[0]
+
+
+class TestShutdown:
+    def test_interrupted_wait_returns_false(self) -> None:
+        """A stopping daemon must not sit out a five-minute cooldown, and the caller
+        must not issue the request it was waiting for."""
+        gov, _ = _governor(interrupt_after=1)
+        gov.report_429(ALBUM_PAGE)
+        assert gov.wait_turn(ALBUM_PAGE) is False
+
+    def test_real_clock_wait_is_interruptible(self) -> None:
+        stop = threading.Event()
+        clock = RealClock(stop)
+        stop.set()
+        assert clock.wait(30.0) is True  # returns at once, not in 30s
+
+    def test_real_clock_reports_no_interrupt_on_timeout(self) -> None:
+        assert RealClock(threading.Event()).wait(0.001) is False
+
+    def test_real_clock_is_monotonic_not_wall_clock(self) -> None:
+        """Spacing arithmetic must survive a system clock adjustment, so now() has
+        to be a monotonic source rather than time.time()."""
+        clock = RealClock()
+        first = clock.now()
+        clock.wait(0.002)
+        assert clock.now() >= first
+
+
+class TestConcurrency:
+    def test_report_429_is_not_blocked_by_a_waiting_thread(self) -> None:
+        """The lock must not be held across the wait.
+
+        If wait_turn waited while holding the lock, a slow consumer would block an
+        unrelated thread's rate-limit report — a safety net causing the outage it
+        exists to prevent.
+
+        The report runs on a *separate thread* with a join timeout on purpose: a
+        held lock is a deadlock, and calling report_429 inline would hang the suite
+        instead of failing it. This way the regression reports itself.
+        """
+        gov, clock = _governor()
+        done = threading.Event()
+        entered = threading.Event()
+        # Whether the other thread's report landed *while* we were mid-wait. That
+        # is the invariant: checking only that it eventually completes would pass
+        # even with the lock held, since the lock is released once the wait ends.
+        landed_during_wait: list[bool] = []
+
+        original_wait = clock.wait
+
+        def instrumented_wait(timeout: float) -> bool:
+            entered.set()  # wait_turn is now mid-wait
+            landed_during_wait.append(done.wait(0.5))
+            return original_wait(timeout)
+
+        clock.wait = instrumented_wait  # type: ignore[method-assign]
+
+        def reporter() -> None:
+            entered.wait(1.0)
+            gov.report_429(DISCOVER_API)  # blocks here if wait_turn holds the lock
+            done.set()
+
+        thread = threading.Thread(target=reporter)
+        thread.start()
+        gov.report_429(ALBUM_PAGE)
+        gov.wait_turn(ALBUM_PAGE)
+        thread.join(timeout=2.0)
+
+        assert not thread.is_alive()
+        assert landed_during_wait == [True], (
+            "report_429 did not complete while wait_turn was waiting — "
+            "wait_turn is holding the lock across the wait"
+        )
+
+    def test_two_threads_in_one_class_do_not_share_a_slot(self) -> None:
+        """The slot is reserved before the lock is released, so two callers cannot
+        both conclude it is their turn at the same instant."""
+        gov, clock = _governor()
+        gov.wait_turn(ALBUM_PAGE)
+        first = clock.now()
+        gov.wait_turn(ALBUM_PAGE)
+        second = clock.now()
+        gov.wait_turn(ALBUM_PAGE)
+        assert second - first == pytest.approx(_MIN_SPACING[ALBUM_PAGE])
+        assert clock.now() - second == pytest.approx(_MIN_SPACING[ALBUM_PAGE])
+
+
+class TestSingleton:
+    def test_get_governor_is_stable_and_resettable(self) -> None:
+        assert get_governor() is get_governor()
+        first = get_governor()
+        reset_governor()
+        assert get_governor() is not first
+
+    def test_refuses_to_construct_in_a_subprocess(self, monkeypatch) -> None:
+        """A spawn child would get a stateless instance that silently governs
+        nothing; the sync and download children have their own backoff instead."""
+        monkeypatch.setattr(
+            "kamp_daemon.bandcamp_ratelimit.multiprocessing.parent_process",
+            lambda: object(),
+        )
+        with pytest.raises(RuntimeError, match="parent-process only"):
+            BandcampGovernor()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -21,6 +21,7 @@ from kamp_core.library import LibraryIndex
 from kamp_daemon.discovery import (
     ALBUM_PAGE,
     DISCOVER_API,
+    FANCOLLECTION,
     PREVIEW,
     SAVE_REMOTE,
     Candidate,
@@ -31,6 +32,7 @@ from kamp_daemon.discovery import (
     SimpleBudget,
     UnsupportedCapability,
     build_seed_profile,
+    crate_budget,
 )
 
 
@@ -563,6 +565,31 @@ class TestDiscoverySource:
             seed={"b": 2, "a": 1},
         )
         assert candidate.seed_json() == '{"a": 1, "b": 2}'
+
+
+class TestCrateBudget:
+    def test_caps_carry_margin_over_the_measured_crate_cost(self) -> None:
+        """KAMP-644 measured a varied crate at 3-6 requests; these are ~2x that."""
+        budget = crate_budget()
+        assert budget.limits[ALBUM_PAGE] >= 6
+        assert budget.limits[DISCOVER_API] >= 4
+
+    def test_collection_endpoint_is_a_tripwire_not_a_limit(self) -> None:
+        """Crate building must never walk the collection endpoint — it is both the
+        most expensive call and the one that rate-limits hardest. A zero cap makes
+        an accidental walk fail loudly here instead of quietly earning a 429."""
+        assert crate_budget().allow(FANCOLLECTION) is False
+
+    def test_unknown_endpoint_classes_are_denied(self) -> None:
+        """A new fetcher must declare its class deliberately rather than inheriting
+        a permissive default."""
+        assert crate_budget().allow("some_new_surface") is False
+
+    def test_budget_is_fresh_per_crate(self) -> None:
+        first = crate_budget()
+        first.consume(ALBUM_PAGE, 8)
+        assert first.allow(ALBUM_PAGE) is False
+        assert crate_budget().allow(ALBUM_PAGE) is True
 
 
 class TestSimpleBudget:


### PR DESCRIPTION
## Summary

A cheap safety net that keeps discovery's own bandcamp.com requests under the ceiling KAMP-644 measured, so a crate build — or a bug in one — cannot earn an account-wide 429 that cascades into the download queue.

Everything is **per endpoint class**, because the measured limits differ by ~2x: album pages returned 429 after 57 requests in 39s, while `discover_web` absorbed 120 at the same rate clean. One global number would be simultaneously too strict for one and too loose for the other.

- `kamp_daemon/bandcamp_ratelimit.py` (new) — per-class spacing, per-class escalating cooldown (60/120/300, reset on a clean result), `reset()` for logout.
- `crate_budget()` in `discovery.py` — `ALBUM_PAGE: 8`, `DISCOVER_API: 6`, `FANCOLLECTION: 0`, deny-by-default.
- One line in `__main__.py`'s existing `except RateLimited` handler.

## Two deliberate departures from the ticket

Both are evidence-driven, and the AC has been amended on KAMP-646 rather than quietly diverging.

**1. The `busy()` retrofit is cut.** Sorting producers by *endpoint class* rather than by process shows the sync and download drains share **no class with crate building** — they use the collection and download-page endpoints; discovery uses album pages, which is the class that actually 429'd. Bracketing them would buy nothing against the measured limit, while holding the bracket for the length of a full queue drain (hours) and across the popplers5 transfer, which carries zero origin load. Sync additionally has no 429 detection to publish — its error path raises a bare `RuntimeError` — so `report_429()` there would mean inventing classification inside the machinery the ticket says not to rewrite. Both sites also live in `__main__.py`, which is excluded from coverage, inside a closure no test references.

Replaced by a one-line hook at the 429 site that already exists, where a real deadline is already computed and published. It protects the one class the drain and discovery genuinely share (`FANCOLLECTION`, which KAMP-652's wishlist walk will use).

**2. The ticket's premise was wrong.** It says all Bandcamp traffic comes from daemon threads and "the download subprocess only talks to popplers5". In fact both sync and download run in spawn subprocesses that hit bandcamp.com. The in-process singleton is still correct — but only because it governs discovery's own requests, so it now **refuses to construct in a child** rather than silently governing nothing.

## Design notes

- **Spacing is the piece that earns its place.** A budget bounds one crate; spacing bounds a pathological loop. 1.5s pins album pages at ≤40/min against a ceiling seen at ~87/min.
- **The `FANCOLLECTION: 0` cap is a tripwire, not a limit.** Crate building must never walk the collection endpoint — the most expensive call available and the one that rate-limits hardest — so an accidental walk fails a test instead of quietly earning a 429.
- **Clock injection is one object** (`now()` + interruptible `wait()`), not two callables. That makes a fake which never advances its own clock — and therefore spins forever — unrepresentable, and it binds production waits to a shutdown event so a stopping daemon never sits out a five-minute cooldown.
- **The lock is never held across a wait.** A governor that blocked while holding its own lock could stall an unrelated thread's rate-limit report — a safety net causing the outage it exists to prevent.
- **Playback is explicitly out of scope** and documented as such in the module: stream-URL resolution is the same endpoint class but runs inside an HTTP handler, where a backoff would stall the next track.

## Test plan

- [x] `poetry run pytest` — **2756 passed, 9 skipped**, coverage **93.84%** (up from 93.81 on main); `bandcamp_ratelimit.py` at **100%**
- [x] `black --check` and `mypy --strict` clean
- [x] 19 governor tests run against a **virtual clock** — the suite never actually sleeps, and the fake clock is self-limiting so a spin regression fails fast with a message instead of hanging CI
- [x] **The lock-discipline test was falsified.** I made `wait_turn` hold the lock across its wait; the first version of the test *still passed* (it only caught a permanent deadlock, and the lock is released once the wait ends). Tightened it to assert the other thread's report lands *while* the wait is in progress, re-falsified, and confirmed it now fails
- [x] Spacing, cooldown escalation/reset, class independence, shutdown interruption, subprocess guard, and budget caps all covered
- [x] Existing sync and download tests untouched and passing — the only change to existing code is one added line

## Manual check

Nothing to look at; no UI surface. The one real-world behaviour worth an eye is that the **download queue still pauses and resumes exactly as before** after a rate limit, since that handler is the only existing code path touched.

Closes KAMP-646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
