### PR TITLE
KAMP-648: crate builder worker + discovery API/WS

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -1,0 +1,166 @@
+"""Discovery Crate REST + WebSocket surface (KAMP-648).
+
+A separate module from :mod:`kamp_core.server` on purpose. ``create_app`` is
+already 4,600 lines; growing it by another view's worth of routes makes it worse,
+and refactoring it is not this story's job. So the closure style is preserved
+exactly — routes close over ``index`` and a ``broadcast`` callable handed in by
+``create_app`` — and only the file changes.
+
+Nothing here imports :mod:`kamp_daemon`. The rate-limit cooldown reaches the UI
+as a ``paused_until`` timestamp written by the builder, which already holds the
+governor, so this layer needs no knowledge of rate limiting at all. That is a
+deliberate departure from the signature sketched on the ticket, which passed a
+governor in.
+
+KAMP-649 adds the crate art proxy to this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, TYPE_CHECKING
+
+from fastapi import FastAPI, HTTPException
+
+if TYPE_CHECKING:  # pragma: no cover - types only
+    from kamp_core.library import LibraryIndex
+
+logger = logging.getLogger(__name__)
+
+#: WebSocket event name. One event carries the whole crate, mirroring the
+#: ``download.queue`` snapshot idiom rather than streaming per-item deltas —
+#: a reconnecting client then needs no replay, just the REST snapshot.
+CRATE_EVENT = "discovery.crate"
+
+#: States a build can end in. Reaching one releases the single-build lock, so
+#: this set is load-bearing: a state missing from it would wedge the feature on
+#: "already building" until the daemon restarted.
+_TERMINAL_STATES = frozenset({"ready", "empty", "error", "paused", "idle"})
+
+_INITIAL_STATUS: dict[str, Any] = {
+    "state": "idle",
+    "crate_no": None,
+    "filled": 0,
+    "short": False,
+    "paused_until": 0.0,
+    "hints": [],
+}
+
+
+def register_discovery_routes(
+    app: FastAPI,
+    *,
+    index: "LibraryIndex",
+    broadcast: Callable[[dict[str, Any]], None],
+    on_build_start: Callable[[], None] | None = None,
+) -> None:
+    """Register the Discovery Crate routes on *app*.
+
+    Exposes ``app.state.discovery_publish``: the builder's single channel for
+    reporting progress. It updates the status and broadcasts in one step so
+    "changed the state but forgot to notify" is not representable — the failure
+    that presents as a backend which works and a UI that never moves.
+    """
+    _status: dict[str, Any] = dict(_INITIAL_STATUS)
+    # Guards _status and the single-build flag together. Builds are serialized
+    # for a correctness reason, not just tidiness: two builders would compute the
+    # same next_crate_no() and collide on the partial unique index over
+    # (crate_no, position).
+    _lock = threading.Lock()
+    _building = [False]
+
+    def _snapshot() -> dict[str, Any]:
+        """The payload both the REST endpoint and the WS event carry.
+
+        One function rather than two agreeing call sites, so "REST snapshot
+        equals WS snapshot shape" holds by construction.
+        """
+        with _lock:
+            snap = dict(_status)
+        crate_no = snap.get("crate_no")
+        if crate_no is None:
+            crate_no = index.latest_crate_no()
+            snap["crate_no"] = crate_no
+        snap["items"] = index.crate_items(crate_no) if crate_no is not None else []
+        return snap
+
+    def _publish(fields: dict[str, Any]) -> None:
+        """Merge *fields* into the status and push the result to every client."""
+        with _lock:
+            _status.update(fields)
+            if fields.get("state") in _TERMINAL_STATES:
+                _building[0] = False
+        broadcast({"type": CRATE_EVENT, **_snapshot()})
+
+    app.state.discovery_publish = _publish
+
+    # ------------------------------------------------------------------
+    # Crate
+    # ------------------------------------------------------------------
+
+    @app.get("/api/v1/discovery/crate")
+    def get_crate() -> dict[str, Any]:
+        """The current crate plus build status — the reconnect path.
+
+        ``_broadcast`` no-ops when no WebSocket client is attached, so this is
+        the source of truth on mount and after a reconnect, not a convenience.
+        Returns the same shape as the ``discovery.crate`` event minus its
+        ``type`` discriminator, exactly as ``GET /api/v1/downloads`` relates to
+        ``download.queue``.
+        """
+        return _snapshot()
+
+    @app.post("/api/v1/discovery/crate/new")
+    def new_crate() -> dict[str, Any]:
+        """Start a build. 409 while one is already running.
+
+        The flag is set here, synchronously, under the lock — deliberately
+        unlike ``start_genre_backfill``, which tests a flag only the worker
+        thread ever sets, so two rapid POSTs both spawn a thread and both are
+        told they started. Harmless for an hours-long backfill; for a crate the
+        loser's spinner would simply never resolve.
+        """
+        if on_build_start is None:
+            raise HTTPException(status_code=503, detail="discovery is unavailable")
+        with _lock:
+            if _building[0]:
+                raise HTTPException(
+                    status_code=409, detail="a crate is already building"
+                )
+            _building[0] = True
+        try:
+            on_build_start()
+        except Exception:
+            with _lock:
+                _building[0] = False
+            logger.exception("discovery: could not start a crate build")
+            raise HTTPException(status_code=500, detail="could not start the build")
+        return {"started": True}
+
+    # ------------------------------------------------------------------
+    # Per-item engagement
+    # ------------------------------------------------------------------
+
+    def _record(item_id: int, kind: str) -> dict[str, Any]:
+        try:
+            index.record_discovery_event(item_id, kind)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        _publish({})  # state unchanged; the item's cached state moved
+        return {"ok": True}
+
+    @app.post("/api/v1/discovery/items/{item_id}/dismiss")
+    def dismiss_item(item_id: int) -> dict[str, Any]:
+        """Pass on a record. Recorded, never deleted — the ledger is history."""
+        return _record(item_id, "dismissed")
+
+    @app.post("/api/v1/discovery/items/{item_id}/url-copied")
+    def url_copied(item_id: int) -> dict[str, Any]:
+        """The always-available action while wishlist-write is unbuilt (KAMP-653).
+
+        Recorded as engagement but deliberately does NOT move the item's state:
+        copying a link is not passing on it, and the user may still preview or
+        wishlist afterwards.
+        """
+        return _record(item_id, "url_copied")

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4961,19 +4961,7 @@ class LibraryIndex:
         new_state = target if rank[target] > rank.get(row["state"], 0) else row["state"]
 
         try:
-            self._conn.execute(
-                "INSERT INTO discovery_events"
-                " (item_id, provider, provider_item_id, kind, at, detail)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
-                (
-                    item_id,
-                    row["provider"],
-                    row["provider_item_id"],
-                    kind,
-                    _time.time() if at is None else at,
-                    detail,
-                ),
-            )
+            self._append_event(item_id, row, kind, at, detail)
             if new_state != row["state"]:
                 self._conn.execute(
                     "UPDATE discovery_items SET state = ? WHERE id = ?",
@@ -4983,6 +4971,122 @@ class LibraryIndex:
         except Exception:
             self._conn.rollback()
             raise
+
+    def _append_event(
+        self,
+        item_id: int,
+        row: sqlite3.Row,
+        kind: str,
+        at: float | None = None,
+        detail: str | None = None,
+    ) -> None:
+        """Append one row to discovery_events. Does NOT commit.
+
+        Split out so place_in_crate() can put the promotion and its 'shown' event in
+        a single transaction without duplicating the INSERT. The duplication would
+        not be cosmetic: provider/provider_item_id are denormalized here so KAMP-655
+        can still count an event whose item was later pruned, and their column
+        defaults are '' -- a hand-rolled INSERT that forgot them would zero the
+        digging-history stats with nothing to notice it.
+        """
+        self._conn.execute(
+            "INSERT INTO discovery_events"
+            " (item_id, provider, provider_item_id, kind, at, detail)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                item_id,
+                row["provider"],
+                row["provider_item_id"],
+                kind,
+                _time.time() if at is None else at,
+                detail,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Crate assembly (KAMP-648)
+    # ------------------------------------------------------------------
+
+    def next_crate_no(self) -> int:
+        """The number the next crate should take.
+
+        COALESCE because MAX() over an empty table is NULL, not 0 -- the first crate
+        must be 1 rather than None, which the CHECK constraint would reject anyway.
+        """
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(crate_no), 0) + 1 AS n FROM discovery_items"
+        ).fetchone()
+        return int(row["n"])
+
+    def latest_crate_no(self) -> int | None:
+        """The most recent crate's number, or None if none has ever been built."""
+        row = self._conn.execute(
+            "SELECT MAX(crate_no) AS n FROM discovery_items"
+        ).fetchone()
+        return None if row["n"] is None else int(row["n"])
+
+    def place_in_crate(self, item_id: int, crate_no: int, position: int) -> None:
+        """Promote a buffered candidate into a crate slot and record it as shown.
+
+        Both writes share one transaction. A slot collision must not leave a
+        'shown' event behind for a record the user never saw -- that event is the
+        ground truth KAMP-655 counts, and discovery_items.state is only a cache of
+        it, so a stranded row is undetectable after the fact.
+
+        Serialization is load-bearing rather than defensive: the partial unique
+        index on (crate_no, position) is all that stops two concurrent builders
+        from computing the same next_crate_no() and interleaving their slots. The
+        single-build lock in the daemon is what keeps that from being reachable.
+
+        Setting crate_no and position in one UPDATE satisfies the
+        CHECK ((crate_no IS NULL) = (position IS NULL)) constraint.
+        """
+        row = self._conn.execute(
+            "SELECT provider, provider_item_id FROM discovery_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"no discovery item with id {item_id}")
+        try:
+            self._conn.execute(
+                "UPDATE discovery_items SET crate_no = ?, position = ? WHERE id = ?",
+                (crate_no, position, item_id),
+            )
+            # 'shown' maps to state 'fresh' (rank 0), so record_discovery_event's
+            # state reconciliation would be a no-op here -- only the ledger write
+            # is needed.
+            self._append_event(item_id, row, "shown")
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def crate_items(self, crate_no: int) -> list[dict[str, Any]]:
+        """The cards of one crate, in slot order.
+
+        Carries everything a card renders so the UI needs no second lookup, and
+        parses seed_json here so every consumer sees the same shape. A malformed
+        blob costs that card its structured provenance, not the whole snapshot --
+        ``why`` is stored separately and still reads correctly.
+        """
+        rows = self._conn.execute(
+            "SELECT id, provider, provider_item_id, item_url, artist, title,"
+            "       art_url, label, release_date, criterion, why, seed_json,"
+            "       crate_no, position, state, first_seen_at"
+            " FROM discovery_items WHERE crate_no = ? ORDER BY position",
+            (crate_no,),
+        ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            item = dict(row)
+            raw = item.pop("seed_json", None)
+            try:
+                seed = json.loads(raw) if raw else {}
+            except (ValueError, TypeError):
+                seed = {}
+            item["seed"] = seed if isinstance(seed, dict) else {}
+            out.append(item)
+        return out
 
     def in_library(
         self, provider_item_id: str, artist: str = "", title: str = ""

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -53,6 +53,7 @@ from kamp_core.library import (
     _canonical_track_uri,
     extract_art,
 )
+from kamp_core.discovery_api import register_discovery_routes
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
 # ---------------------------------------------------------------------------
@@ -1090,6 +1091,7 @@ def create_app(
     on_bandcamp_sync_all_trigger: Callable[[], None] | None = None,
     on_genre_backfill_start: Callable[[], None] | None = None,
     on_genre_backfill_cancel: Callable[[], None] | None = None,
+    on_crate_build_start: Callable[[], None] | None = None,
     on_allowlist_changed: Callable[[], None] | None = None,
     get_default_allowlist: Callable[[], list[str]] | None = None,
     dl_queue: _queue.Queue[str] | None = None,
@@ -4637,5 +4639,17 @@ def create_app(
             pass
         finally:
             _ws_queues.discard(q)
+
+    # Discovery Crate routes live in their own module (KAMP-648) rather than
+    # inline: this function is already 3,500 lines and another view's worth of
+    # endpoints makes it worse. They still close over the same objects, so the
+    # style is unchanged -- only the file is. The auth middleware above wraps
+    # every route regardless of which module registered it.
+    register_discovery_routes(
+        app,
+        index=index,
+        broadcast=_broadcast,
+        on_build_start=on_crate_build_start,
+    )
 
     return app

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1033,6 +1033,45 @@ def _cmd_daemon(
     def _on_genre_backfill_cancel() -> None:
         _genre_backfill_cancel.set()
 
+    # --- KAMP-648: Discovery Crate build ---
+    def _on_crate_build_start() -> None:
+        """Assemble a crate on a background thread.
+
+        Returns immediately; the endpoint has already claimed the single-build
+        slot, and everything after this reaches the UI through
+        ``discovery_publish``.
+
+        The Bandcamp session is read per build rather than captured at startup,
+        so logging in or out mid-session is picked up without a daemon restart
+        (same reason as ``_on_genre_backfill_start``). No memory or global-state
+        argument for a subprocess here, and one would forfeit the shared
+        governor -- a plain thread is right.
+        """
+
+        def _run() -> None:
+            publish = app.state.discovery_publish
+            try:
+                from .bandcamp import _make_requests_session
+                from .discovery_builder import build_crate
+                from .discovery_sources import BandcampDiscoverySource
+
+                session_data = index.get_session("bandcamp")
+                if not session_data:
+                    _logger.info("crate build: not connected to Bandcamp")
+                    publish({"state": "error"})
+                    return
+                source = BandcampDiscoverySource(_make_requests_session(session_data))
+                build_crate(index, source, publish=publish)
+            except Exception:
+                # build_crate does not raise, so reaching here means the session
+                # or import failed. Publish a terminal state regardless: the
+                # endpoint's build flag is only released by one, so a silent
+                # death would wedge every later dig on 409.
+                _logger.exception("Unhandled error in crate build")
+                publish({"state": "error"})
+
+        threading.Thread(target=_run, daemon=True, name="crate-builder").start()
+
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")
     _bc_ever_connected = index.get_setting("bandcamp.ever_connected") == "true"
@@ -1106,6 +1145,7 @@ def _cmd_daemon(
         on_bandcamp_sync_all_trigger=_on_bandcamp_sync_all_trigger,
         on_genre_backfill_start=_on_genre_backfill_start,
         on_genre_backfill_cancel=_on_genre_backfill_cancel,
+        on_crate_build_start=_on_crate_build_start,
         on_allowlist_changed=_on_allowlist_changed,
         get_default_allowlist=_genre_sources.default_allowlist_names,
         dl_queue=_dl_queue,

--- a/kamp_daemon/bandcamp_ratelimit.py
+++ b/kamp_daemon/bandcamp_ratelimit.py
@@ -183,12 +183,17 @@ class BandcampGovernor:
             )
 
     def reset(self) -> None:
-        """Forget all backoff state.
+        """Forget all backoff state. **Test isolation only.**
 
-        Called on logout: a 429 is scoped to the account, so a new session starts
-        clean. Deliberately NOT called on config reload, which fires on unrelated
-        preference changes — otherwise a user could clear a live backoff by
-        toggling a checkbox.
+        KAMP-646 wrote this expecting logout to call it, reasoning that a 429 is
+        scoped to the account. KAMP-648 deliberately left it unwired: the limit
+        is scoped to the IP at least as much as the account, so clearing a live
+        cooldown because someone signed out and back in asks Bandcamp for
+        another 429 and earns a longer one. Waiting costs 300s at worst.
+
+        Also not called on config reload, which fires on unrelated preference
+        changes — otherwise a user could clear a live backoff by toggling a
+        checkbox.
         """
         with self._lock:
             self._last_request_at.clear()
@@ -210,7 +215,7 @@ def get_governor() -> BandcampGovernor:
 
 
 def reset_governor() -> None:
-    """Drop the singleton. For logout, and for test isolation."""
+    """Drop the singleton. Test isolation only — see :meth:`BandcampGovernor.reset`."""
     global _governor
     with _governor_lock:
         _governor = None

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -284,6 +284,23 @@ class DiscoverySource(ABC):
         """
         return frozenset()
 
+    @property
+    def criterion_caps(self) -> dict[str, int]:
+        """How many picks from a given criterion a single crate should prefer.
+
+        The crate builder enforces variety across ``criterion`` labels without
+        interpreting them, which is what lets a future provider invent its own
+        criteria. But "at most one best-seller per crate" genuinely does require
+        knowing which label is the chart — so the *provider* names it here and the
+        builder honours it as opaque data.
+
+        A cap is a preference, not a ceiling: KAMP-648 backfills past it rather
+        than shipping a short crate, because a brand-new library's only available
+        criterion is the chart and a hard cap would hand that user a one-item
+        crate.
+        """
+        return {}
+
     @abstractmethod
     def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
         """Return candidates for *profile*, spending no more than *budget* allows.

--- a/kamp_daemon/discovery_bandcamp_parsers.py
+++ b/kamp_daemon/discovery_bandcamp_parsers.py
@@ -100,6 +100,34 @@ def tag_slug(name: str) -> str:
     return re.sub(r"-{2,}", "-", slug).strip("-")
 
 
+#: Bandcamp's art CDN pattern, matching ``fetch_album_art_bytes``' spelling
+#: (``kamp_daemon/bandcamp.py``): ``a<art_id>_<size>.jpg``, size 0 = original.
+_ART_URL = "https://f4.bcbits.com/img/a{art_id}_0.jpg"
+
+
+def art_url_from_image(raw: Any) -> str | None:
+    """Build a CDN art URL from whatever a surface calls its cover image.
+
+    The HTML surfaces embed a finished URL, but the discover API returns
+    ``primary_image`` as an **object** — ``{"image_id": ..., "is_art": true}`` —
+    so passing it straight through stored a dict in a TEXT column. SQLite refused
+    the bind, and because a failed row is skipped rather than fatal, every
+    discover-surface candidate silently vanished from the crate while the album
+    pages carried on working. Tolerant of all three shapes on purpose: this is
+    remote data whose spelling has already changed once.
+    """
+    if isinstance(raw, dict):
+        if not raw.get("is_art", True):
+            return None
+        raw = raw.get("image_id")
+    if raw is None or raw == "":
+        return None
+    text = str(raw)
+    if text.startswith("http"):
+        return text
+    return _ART_URL.format(art_id=text)
+
+
 def strip_tracking(url: str) -> str:
     """Drop Bandcamp's ``?from=`` attribution parameter from an item URL.
 
@@ -230,7 +258,7 @@ def parse_discover_results(payload: str | dict[str, Any]) -> ParseResult:
                 "item_url": strip_tracking(row.get("item_url") or ""),
                 "artist": row.get("band_name") or row.get("album_artist") or "",
                 "title": row.get("title") or "",
-                "art_url": row.get("primary_image") or None,
+                "art_url": art_url_from_image(row.get("primary_image")),
                 "release_date": row.get("release_date") or "",
                 "is_owned": bool(row.get("is_owned")),
                 "is_wishlisted": bool(row.get("is_wishlisted")),

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -1,0 +1,296 @@
+"""Crate assembly — candidates in, a crate of ten out (KAMP-648).
+
+This is the orchestration layer of the Discovery Crate (KAMP-643). KAMP-647's
+:class:`~kamp_daemon.discovery_sources.BandcampDiscoverySource` produces roughly
+sixty candidates for a handful of requests; this module decides which ten the
+user actually sees, in what order, and writes them down.
+
+**No threads and no FastAPI here.** The daemon owns the thread (mirroring
+``_on_genre_backfill_start``) and :mod:`kamp_core.discovery_api` owns the routes.
+Keeping this a plain function is what lets the whole selection policy be tested
+against a fake source with no network, no event loop and no app.
+
+Everything the UI learns goes through the injected ``publish`` callable, which
+updates the status and broadcasts it in one step. A bare mutable dict was the
+obvious alternative and was rejected: it makes "mutated the state but forgot to
+notify" representable, which is the failure mode that turns a working backend
+into a UI that never updates.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import TYPE_CHECKING, Any, Callable, Protocol, Sequence
+
+from .discovery import (
+    ALBUM_PAGE,
+    ARTIST_PAGE,
+    DISCOVER_API,
+    Candidate,
+    DiscoverySource,
+    RequestBudget,
+    SeedProfile,
+    build_seed_profile,
+    crate_budget,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - types only
+    from kamp_core.library import LibraryIndex
+
+logger = logging.getLogger(__name__)
+
+#: Records in a crate. Ten is the epic's number, and it is a product decision
+#: rather than a tuning knob: a crate you can finish in a sitting is the whole
+#: affordance.
+CRATE_SIZE = 10
+
+#: The endpoint classes discovery spends. Each carries its own cooldown, so a
+#: single "am I rate limited" answer has to consider all of them.
+_ENDPOINT_CLASSES = (ALBUM_PAGE, DISCOVER_API, ARTIST_PAGE)
+
+#: How many genres to hand the UI for its "flipping through ..." status lines.
+_HINT_LIMIT = 5
+
+
+class _Governor(Protocol):
+    def blocked_for(self, endpoint_class: str) -> float: ...
+
+
+Publish = Callable[[dict[str, Any]], None]
+
+
+def build_crate(
+    index: "LibraryIndex",
+    source: DiscoverySource,
+    *,
+    publish: Publish,
+    governor: _Governor | None = None,
+    profile: SeedProfile | None = None,
+    budget: RequestBudget | None = None,
+    wishlist_ids: set[str] | None = None,
+    rng: random.Random | None = None,
+    size: int = CRATE_SIZE,
+    now: Callable[[], float] | None = None,
+) -> dict[str, Any]:
+    """Assemble, persist and publish one crate. Returns the final status.
+
+    Never raises: a broken provider costs a crate, not the daemon thread that
+    called it. Every exit path publishes a terminal state, because a status left
+    on ``building`` is indistinguishable from a hang.
+    """
+    clock = now or time.time
+    rng = rng or random.Random()
+    governor = governor or _default_governor()
+
+    # Read the cooldown BEFORE gathering, and refuse rather than wait. wait_turn()
+    # blocks silently until a 60/120/300s cooldown expires, and the build *after*
+    # a rate-limited one never sees a 429 of its own -- it simply sits inside its
+    # first fetch with nothing on screen. That is the KAMP-639 failure exactly:
+    # a pause that isn't visible is a hang. Refusing keeps the longest possible
+    # wait inside a build down to one spacing interval, which is also why no
+    # cancel endpoint is needed.
+    blocked = max(governor.blocked_for(cls) for cls in _ENDPOINT_CLASSES)
+    if blocked > 0:
+        logger.info("discovery: crate build deferred, %.0fs of cooldown left", blocked)
+        return _publish(
+            publish,
+            state="paused",
+            paused_until=clock() + blocked,
+            detail="",
+        )
+
+    if profile is None:
+        profile = build_seed_profile(index)
+
+    _publish(
+        publish,
+        state="building",
+        paused_until=0.0,
+        filled=0,
+        crate_no=None,
+        short=False,
+        # Genres come from the local profile, not the provider: it lets the UI
+        # name what is being dug through without the builder knowing any
+        # provider's criteria.
+        hints=list(profile.top_genres[:_HINT_LIMIT]),
+    )
+
+    try:
+        candidates = source.gather(profile, budget or crate_budget())
+    except Exception:  # noqa: BLE001 - a provider must not take the daemon with it
+        logger.exception("discovery: gather failed")
+        return _publish(publish, state="error")
+
+    picks = select_crate(
+        candidates,
+        index=index,
+        caps=source.criterion_caps,
+        size=size,
+        rng=rng,
+        wishlist_ids=wishlist_ids,
+    )
+    if not picks:
+        # Do not burn a crate number on nothing. An empty crate is a distinct
+        # state from a short one -- the UI offers a retry rather than a tally.
+        logger.warning(
+            "discovery: no candidates survived exclusion (%d gathered)",
+            len(candidates),
+        )
+        return _publish(publish, state="empty", crate_no=None)
+
+    crate_no = index.next_crate_no()
+    for position, candidate in enumerate(picks):
+        try:
+            item_id = index.add_discovery_candidate(
+                provider=candidate.provider,
+                provider_item_id=candidate.provider_item_id,
+                item_url=candidate.item_url,
+                artist=candidate.artist,
+                title=candidate.title,
+                art_url=candidate.art_url,
+                label=candidate.label,
+                release_date=candidate.release_date,
+                criterion=candidate.criterion,
+                why=candidate.why,
+                seed_json=candidate.seed_json(),
+            )
+            index.place_in_crate(item_id, crate_no, position)
+        except Exception:  # noqa: BLE001 - one bad row costs a card, not the crate
+            logger.exception(
+                "discovery: could not place %s in crate %d",
+                candidate.item_url,
+                crate_no,
+            )
+            continue
+        _publish(publish, crate_no=crate_no, filled=position + 1)
+
+    short = len(picks) < size
+    if short:
+        logger.info("discovery: short crate %d (%d/%d)", crate_no, len(picks), size)
+    return _publish(publish, state="ready", crate_no=crate_no, short=short)
+
+
+def select_crate(
+    candidates: Sequence[Candidate],
+    *,
+    index: "LibraryIndex",
+    caps: dict[str, int] | None = None,
+    size: int = CRATE_SIZE,
+    rng: random.Random | None = None,
+    wishlist_ids: set[str] | None = None,
+) -> list[Candidate]:
+    """Pick up to *size* candidates, excluded and varied. Pure apart from reads.
+
+    Exclusion runs here, at assembly, rather than at capture: a candidate may
+    have been bought or wishlisted since it was gathered, and a buffered one
+    (KAMP-657) may have been sitting for weeks.
+    """
+    rng = rng or random.Random()
+    caps = caps or {}
+    wishlist_ids = wishlist_ids or set()
+
+    groups = _group_by_criterion(
+        c
+        for c in candidates
+        if not _excluded(c, index=index, wishlist_ids=wishlist_ids)
+    )
+    if not groups:
+        return []
+
+    # Shuffle the group order per crate. criteria_for() preserves REGISTRY order
+    # and gather() iterates it, so without this slot 0 is the same criterion in
+    # every crate for the life of the install -- a poor look for a feature whose
+    # entire affordance is dealing another one.
+    order = list(groups)
+    rng.shuffle(order)
+
+    picks = _deal(groups, order, size, caps)
+    if len(picks) < size:
+        # A cap is a preference, not a ceiling: honouring one to the point of
+        # shrinking the crate is how a brand-new library (whose only criterion is
+        # the chart) would get a one-item crate. Backfill from what the caps held
+        # back, uncapped criteria having already been exhausted by _deal.
+        picks.extend(_deal(groups, order, size - len(picks), caps={}, skip=picks))
+    return picks
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _deal(
+    groups: dict[str, list[Candidate]],
+    order: list[str],
+    size: int,
+    caps: dict[str, int],
+    skip: list[Candidate] | None = None,
+) -> list[Candidate]:
+    """Round-robin one card per criterion until *size* or nothing is left.
+
+    Round-robin is what enforces "a criterion may repeat but a crate must span
+    several" without the builder interpreting a single label -- which is what
+    keeps a future non-Bandcamp provider from having to teach it their criteria.
+    """
+    taken = {id(c) for c in (skip or [])}
+    counts: dict[str, int] = {}
+    picks: list[Candidate] = []
+    while len(picks) < size:
+        progressed = False
+        for criterion in order:
+            if len(picks) >= size:
+                break
+            cap = caps.get(criterion)
+            if cap is not None and counts.get(criterion, 0) >= cap:
+                continue
+            for candidate in groups[criterion]:
+                if id(candidate) in taken:
+                    continue
+                taken.add(id(candidate))
+                counts[criterion] = counts.get(criterion, 0) + 1
+                picks.append(candidate)
+                progressed = True
+                break
+        if not progressed:
+            break
+    return picks
+
+
+def _group_by_criterion(
+    candidates: "Sequence[Candidate] | Any",
+) -> dict[str, list[Candidate]]:
+    """Group preserving first-seen order; dict insertion order is the run order."""
+    groups: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        groups.setdefault(candidate.criterion, []).append(candidate)
+    return groups
+
+
+def _excluded(
+    candidate: Candidate, *, index: "LibraryIndex", wishlist_ids: set[str]
+) -> bool:
+    """The three exclusion classes the epic requires.
+
+    A miss here is the feature's worst failure: recommending someone a record
+    they already own reads as the clerk not knowing his own shop.
+    """
+    if candidate.provider_item_id in wishlist_ids:
+        return True
+    if index.seen_before(candidate.provider, candidate.provider_item_id):
+        return True
+    return index.in_library(
+        candidate.provider_item_id, candidate.artist, candidate.title
+    )
+
+
+def _publish(publish: Publish, **fields: Any) -> dict[str, Any]:
+    publish(fields)
+    return fields
+
+
+def _default_governor() -> _Governor:
+    from .bandcamp_ratelimit import get_governor  # noqa: PLC0415 - import cycle
+
+    return get_governor()

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -141,7 +141,12 @@ def build_crate(
         return _publish(publish, state="empty", crate_no=None)
 
     crate_no = index.next_crate_no()
-    for position, candidate in enumerate(picks):
+    # Position counts what actually landed, not what was picked. A row that
+    # fails to persist must not leave a hole in the slot sequence -- the rail
+    # renders by position, so a gap is a blank sleeve the user can focus and
+    # never fill.
+    placed = 0
+    for candidate in picks:
         try:
             item_id = index.add_discovery_candidate(
                 provider=candidate.provider,
@@ -156,7 +161,7 @@ def build_crate(
                 why=candidate.why,
                 seed_json=candidate.seed_json(),
             )
-            index.place_in_crate(item_id, crate_no, position)
+            index.place_in_crate(item_id, crate_no, placed)
         except Exception:  # noqa: BLE001 - one bad row costs a card, not the crate
             logger.exception(
                 "discovery: could not place %s in crate %d",
@@ -164,11 +169,17 @@ def build_crate(
                 crate_no,
             )
             continue
-        _publish(publish, crate_no=crate_no, filled=position + 1)
+        placed += 1
+        _publish(publish, crate_no=crate_no, filled=placed)
 
-    short = len(picks) < size
+    if placed == 0:
+        # next_crate_no() is a read, so nothing was consumed by trying.
+        logger.warning("discovery: crate %d persisted nothing", crate_no)
+        return _publish(publish, state="empty", crate_no=None)
+
+    short = placed < size
     if short:
-        logger.info("discovery: short crate %d (%d/%d)", crate_no, len(picks), size)
+        logger.info("discovery: short crate %d (%d/%d)", crate_no, placed, size)
     return _publish(publish, state="ready", crate_no=crate_no, short=short)
 
 

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -101,6 +101,17 @@ class BandcampDiscoverySource(DiscoverySource):
         """
         return frozenset({PREVIEW})
 
+    @property
+    def criterion_caps(self) -> dict[str, int]:
+        """One chart pick per crate.
+
+        ``best_seller`` is the only criterion carrying no personal claim, and the
+        brand guardrails forbid letting un-personalised content dominate a crate
+        that presents itself as dug for you. Every other criterion may repeat as
+        the round-robin allows.
+        """
+        return {"best_seller": 1}
+
     # ------------------------------------------------------------------
     # The only place that touches the network
     # ------------------------------------------------------------------

--- a/kamp_ui/package-lock.json
+++ b/kamp_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kamp",
-  "version": "1.25.1",
+  "version": "1.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kamp",
-      "version": "1.25.1",
+      "version": "1.26.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -353,6 +353,147 @@ class TestEventLedger:
 
 
 # ---------------------------------------------------------------------------
+# Crate assembly accessors (KAMP-648)
+# ---------------------------------------------------------------------------
+
+
+class TestCrateAssembly:
+    def _buffered(self, index: LibraryIndex, item_id: str, **kw: object) -> int:
+        return index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id=item_id, **kw  # type: ignore[arg-type]
+        )
+
+    def test_first_crate_is_numbered_one(self, index: LibraryIndex) -> None:
+        """MAX() over an empty table is NULL, not 0 — COALESCE or crate 'None'."""
+        assert index.next_crate_no() == 1
+        assert index.latest_crate_no() is None
+
+    def test_crate_numbers_increment(self, index: LibraryIndex) -> None:
+        index.place_in_crate(self._buffered(index, "1"), 1, 0)
+        assert index.next_crate_no() == 2
+        assert index.latest_crate_no() == 1
+        index.place_in_crate(self._buffered(index, "2"), 2, 0)
+        assert index.next_crate_no() == 3
+        assert index.latest_crate_no() == 2
+
+    def test_placing_marks_seen_and_records_shown(self, index: LibraryIndex) -> None:
+        """Promotion is what makes a candidate 'seen' — row existence is not."""
+        item = self._buffered(index, "abc")
+        assert index.seen_before("bandcamp", "abc") is False
+        index.place_in_crate(item, 1, 3)
+
+        assert index.seen_before("bandcamp", "abc") is True
+        row = index._conn.execute(
+            "SELECT crate_no, position, state FROM discovery_items WHERE id = ?",
+            (item,),
+        ).fetchone()
+        assert (row["crate_no"], row["position"]) == (1, 3)
+        # 'shown' maps to 'fresh' (rank 0), so the cached state must not move.
+        assert row["state"] == "fresh"
+
+        event = index._conn.execute(
+            "SELECT kind, provider, provider_item_id FROM discovery_events"
+        ).fetchone()
+        # Denormalised identity is what KAMP-655's stats read after a row is pruned;
+        # a hand-rolled INSERT that skipped it would leave the columns at ''.
+        assert (event["kind"], event["provider"], event["provider_item_id"]) == (
+            "shown",
+            "bandcamp",
+            "abc",
+        )
+
+    def test_unknown_item_raises(self, index: LibraryIndex) -> None:
+        with pytest.raises(ValueError):
+            index.place_in_crate(9999, 1, 0)
+
+    def test_duplicate_slot_is_refused(self, index: LibraryIndex) -> None:
+        """The partial unique index is all that serialises two builders.
+
+        It fails on the UPDATE, before the event write, so nothing is stranded —
+        but the promotion must not stick either.
+        """
+        index.place_in_crate(self._buffered(index, "1"), 1, 0)
+        loser = self._buffered(index, "2")
+        with pytest.raises(sqlite3.IntegrityError):
+            index.place_in_crate(loser, 1, 0)
+
+        row = index._conn.execute(
+            "SELECT crate_no, position FROM discovery_items WHERE id = ?", (loser,)
+        ).fetchone()
+        assert (row["crate_no"], row["position"]) == (None, None)
+
+    def test_a_failed_event_write_unpromotes_the_item(
+        self, index: LibraryIndex, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The half-written state that actually matters: promoted, never recorded.
+
+        The UPDATE lands first, so if the 'shown' insert then fails without a
+        rollback the item is left in the crate with no ledger entry — invisible to
+        the digging stats, and permanently suppressed by seen_before(), which keys
+        on crate_no. Both writes must share one transaction.
+        """
+        item = self._buffered(index, "1")
+
+        def _boom(*_a: object, **_kw: object) -> None:
+            raise sqlite3.OperationalError("ledger unavailable")
+
+        monkeypatch.setattr(index, "_append_event", _boom)
+        with pytest.raises(sqlite3.OperationalError):
+            index.place_in_crate(item, 1, 0)
+
+        row = index._conn.execute(
+            "SELECT crate_no, position FROM discovery_items WHERE id = ?", (item,)
+        ).fetchone()
+        assert (row["crate_no"], row["position"]) == (None, None)
+        assert index.seen_before("bandcamp", "1") is False
+
+    def test_crate_items_are_ordered_by_position(self, index: LibraryIndex) -> None:
+        for position, item_id in ((2, "c"), (0, "a"), (1, "b")):
+            index.place_in_crate(
+                self._buffered(index, item_id, title=item_id.upper()), 7, position
+            )
+        titles = [row["title"] for row in index.crate_items(7)]
+        assert titles == ["A", "B", "C"]
+
+    def test_crate_items_carry_the_card_fields(self, index: LibraryIndex) -> None:
+        """The snapshot must be renderable without a second lookup per card."""
+        item = self._buffered(
+            index,
+            "42",
+            item_url="https://band.bandcamp.com/album/x",
+            artist="Band",
+            title="X",
+            art_url="https://f4.bcbits.com/img/a1_10.jpg",
+            criterion="also_like",
+            why="Filed next to something you played.",
+            seed_json='{"kind": "album"}',
+        )
+        index.place_in_crate(item, 1, 0)
+        row = index.crate_items(1)[0]
+        assert row["id"] == item
+        assert row["artist"] == "Band"
+        assert row["criterion"] == "also_like"
+        assert row["why"].startswith("Filed next to")
+        assert row["state"] == "fresh"
+        assert row["seed"] == {"kind": "album"}
+
+    def test_crate_items_survive_unparseable_seed_json(
+        self, index: LibraryIndex
+    ) -> None:
+        """A bad seed blob must cost provenance, not the whole crate snapshot."""
+        item = self._buffered(index, "1")
+        index._conn.execute(
+            "UPDATE discovery_items SET seed_json = ? WHERE id = ?", ("{oops", item)
+        )
+        index._conn.commit()
+        index.place_in_crate(item, 1, 0)
+        assert index.crate_items(1)[0]["seed"] == {}
+
+    def test_empty_crate_reads_as_empty(self, index: LibraryIndex) -> None:
+        assert index.crate_items(99) == []
+
+
+# ---------------------------------------------------------------------------
 # Seed profile
 # ---------------------------------------------------------------------------
 

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -1,0 +1,255 @@
+"""Discovery Crate REST + WS surface tests (KAMP-648).
+
+Most tests register the routes on a bare FastAPI app with a recording broadcast,
+so the snapshot the WebSocket would carry is inspectable — create_app's
+``_broadcast`` deliberately no-ops with no client attached, which would hide
+exactly the parity this story has to guarantee. One test goes the long way
+through ``create_app`` to prove the routes are actually wired and that the auth
+middleware covers a module it knows nothing about.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from kamp_core.discovery_api import CRATE_EVENT, register_discovery_routes
+from kamp_core.library import LibraryIndex
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> Iterator[LibraryIndex]:
+    idx = LibraryIndex(tmp_path / "library.db")
+    yield idx
+    idx.close()
+
+
+class _Harness:
+    def __init__(self, index: LibraryIndex, on_build_start: Any = None) -> None:
+        self.events: list[dict[str, Any]] = []
+        self.build_calls = 0
+        self.app = FastAPI()
+
+        def _default_start() -> None:
+            self.build_calls += 1
+
+        register_discovery_routes(
+            self.app,
+            index=index,
+            broadcast=self.events.append,
+            on_build_start=(
+                _default_start if on_build_start is None else on_build_start
+            ),
+        )
+        self.client = TestClient(self.app)
+
+    @property
+    def publish(self) -> Any:
+        return self.app.state.discovery_publish
+
+
+@pytest.fixture
+def harness(index: LibraryIndex) -> _Harness:
+    return _Harness(index)
+
+
+def _stock(index: LibraryIndex, crate_no: int, count: int = 3) -> None:
+    for position in range(count):
+        item = index.add_discovery_candidate(
+            provider="bandcamp",
+            provider_item_id=f"{crate_no}-{position}",
+            artist=f"Artist {position}",
+            title=f"Title {position}",
+            criterion="also_like",
+            why="because",
+            seed_json='{"kind": "album"}',
+        )
+        index.place_in_crate(item, crate_no, position)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestCrateSnapshot:
+    def test_first_launch_is_an_empty_crate_not_an_error(
+        self, harness: _Harness
+    ) -> None:
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["state"] == "idle"
+        assert body["items"] == []
+        assert body["crate_no"] is None
+        assert body["paused_until"] == 0.0
+
+    def test_snapshot_returns_the_latest_crate_after_a_restart(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The status is in-memory; the crate is not. A fresh daemon must still
+        serve the last crate, which is the whole reconnect path."""
+        _stock(index, 1)
+        _stock(index, 2, count=2)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["crate_no"] == 2
+        assert [item["title"] for item in body["items"]] == ["Title 0", "Title 1"]
+
+    def test_rest_and_ws_snapshots_are_the_same_shape(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1)
+        harness.publish({"state": "ready", "crate_no": 1})
+        pushed = harness.events[-1]
+        rest = harness.client.get("/api/v1/discovery/crate").json()
+
+        assert pushed["type"] == CRATE_EVENT
+        assert {k: v for k, v in pushed.items() if k != "type"} == rest
+
+    def test_publishing_pushes_to_clients(self, harness: _Harness) -> None:
+        harness.publish({"state": "building", "hints": ["dub techno"]})
+        assert harness.events[-1]["state"] == "building"
+        assert harness.events[-1]["hints"] == ["dub techno"]
+
+
+# ---------------------------------------------------------------------------
+# Build lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLifecycle:
+    def test_new_crate_starts_a_build(self, harness: _Harness) -> None:
+        assert harness.client.post("/api/v1/discovery/crate/new").status_code == 200
+        assert harness.build_calls == 1
+
+    def test_a_second_build_is_refused_while_one_runs(self, harness: _Harness) -> None:
+        """The flag is set synchronously in the route, not by the worker thread.
+
+        start_genre_backfill tests a flag only its worker sets, so two rapid
+        POSTs both spawn a thread and both are told they started. For a crate
+        that leaves the loser's spinner unresolved.
+        """
+        harness.client.post("/api/v1/discovery/crate/new")
+        second = harness.client.post("/api/v1/discovery/crate/new")
+        assert second.status_code == 409
+        assert harness.build_calls == 1
+
+    @pytest.mark.parametrize("state", ["ready", "empty", "error", "paused"])
+    def test_every_terminal_state_releases_the_lock(
+        self, harness: _Harness, state: str
+    ) -> None:
+        """A state missing from the terminal set wedges the feature on 409 until
+        the daemon restarts, so each one is pinned individually."""
+        harness.client.post("/api/v1/discovery/crate/new")
+        harness.publish({"state": state})
+        assert harness.client.post("/api/v1/discovery/crate/new").status_code == 200
+        assert harness.build_calls == 2
+
+    def test_a_non_terminal_state_does_not_release_the_lock(
+        self, harness: _Harness
+    ) -> None:
+        harness.client.post("/api/v1/discovery/crate/new")
+        harness.publish({"state": "building", "filled": 4})
+        assert harness.client.post("/api/v1/discovery/crate/new").status_code == 409
+
+    def test_a_failed_start_releases_the_lock(self, index: LibraryIndex) -> None:
+        """Otherwise one transient failure disables digging until restart."""
+
+        def _boom() -> None:
+            raise RuntimeError("no session")
+
+        harness = _Harness(index, on_build_start=_boom)
+        assert harness.client.post("/api/v1/discovery/crate/new").status_code == 500
+        # Not a 409 the second time round.
+        assert harness.client.post("/api/v1/discovery/crate/new").status_code == 500
+
+    def test_no_callback_reports_unavailable(self, index: LibraryIndex) -> None:
+        app = FastAPI()
+        register_discovery_routes(
+            app, index=index, broadcast=lambda _e: None, on_build_start=None
+        )
+        assert TestClient(app).post("/api/v1/discovery/crate/new").status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Per-item engagement
+# ---------------------------------------------------------------------------
+
+
+class TestItemEvents:
+    def _item(self, index: LibraryIndex) -> int:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="x", title="X"
+        )
+        index.place_in_crate(item, 1, 0)
+        return item
+
+    def test_dismiss_records_and_moves_state(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        item = self._item(index)
+        assert (
+            harness.client.post(f"/api/v1/discovery/items/{item}/dismiss").status_code
+            == 200
+        )
+        assert index.crate_items(1)[0]["state"] == "dismissed"
+
+    def test_copying_a_link_is_not_passing_on_it(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """url_copied is engagement, not rejection — the user may still preview
+        or wishlist afterwards, so the card must not grey out."""
+        item = self._item(index)
+        harness.client.post(f"/api/v1/discovery/items/{item}/url-copied")
+        assert index.crate_items(1)[0]["state"] == "fresh"
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events WHERE kind = 'url_copied'"
+            ).fetchone()["c"]
+            == 1
+        )
+
+    def test_an_item_event_pushes_a_fresh_snapshot(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        item = self._item(index)
+        harness.events.clear()
+        harness.client.post(f"/api/v1/discovery/items/{item}/dismiss")
+        assert harness.events[-1]["items"][0]["state"] == "dismissed"
+
+    def test_unknown_item_is_a_404(self, harness: _Harness) -> None:
+        assert (
+            harness.client.post("/api/v1/discovery/items/999/dismiss").status_code
+            == 404
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wiring into create_app
+# ---------------------------------------------------------------------------
+
+
+class TestServerWiring:
+    def _app(self, index: LibraryIndex, **kw: Any) -> Any:
+        from kamp_core.server import create_app
+
+        engine = MagicMock()
+        queue = MagicMock()
+        queue.current.return_value = None
+        queue.peek_next.return_value = None
+        return create_app(index=index, engine=engine, queue=queue, **kw)
+
+    def test_routes_are_registered_by_create_app(self, index: LibraryIndex) -> None:
+        client = TestClient(self._app(index))
+        assert client.get("/api/v1/discovery/crate").status_code == 200
+
+    def test_auth_middleware_covers_the_new_module(self, index: LibraryIndex) -> None:
+        """The middleware is declared in server.py and knows nothing about
+        discovery_api; it must still wrap routes registered from there."""
+        client = TestClient(self._app(index, auth_token="secret"))
+        assert client.get("/api/v1/discovery/crate").status_code == 401
+        ok = client.get("/api/v1/discovery/crate", headers={"X-Kamp-Token": "secret"})
+        assert ok.status_code == 200

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -11,6 +11,7 @@ rate limit that presents as a hang.
 from __future__ import annotations
 
 import random
+import sqlite3
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -355,6 +356,42 @@ class TestDegradation:
         assert status["state"] == "error"
         assert index.latest_crate_no() is None
 
+    def test_a_row_that_will_not_persist_leaves_no_gap(
+        self, index: LibraryIndex, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One bad row costs a card, not the crate — and not a blank slot.
+
+        The rail renders by position, so skipping a position would leave a
+        sleeve the user can focus and never fill.
+        """
+        real = index.place_in_crate
+        calls = {"n": 0}
+
+        def _flaky(item_id: int, crate_no: int, position: int) -> None:
+            calls["n"] += 1
+            if calls["n"] == 3:
+                raise sqlite3.OperationalError("disk full")
+            real(item_id, crate_no, position)
+
+        monkeypatch.setattr(index, "place_in_crate", _flaky)
+        status = _build(index, _FakeSource(_spread({"a": 12})))
+
+        positions = [row["position"] for row in index.crate_items(1)]
+        assert positions == list(range(CRATE_SIZE - 1))
+        # short must reflect what landed, not what was picked.
+        assert status["short"] is True
+
+    def test_a_crate_that_persists_nothing_is_empty_not_ready(
+        self, index: LibraryIndex, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail(*_a: object, **_kw: object) -> None:
+            raise sqlite3.OperationalError("disk full")
+
+        monkeypatch.setattr(index, "place_in_crate", _fail)
+        status = _build(index, _FakeSource(_spread({"a": 12})))
+        assert status["state"] == "empty"
+        assert index.latest_crate_no() is None
+
 
 # ---------------------------------------------------------------------------
 # Status publication
@@ -391,6 +428,23 @@ class TestPublication:
             profile=SeedProfile(top_genres=["dub techno", "ambient"]),
         )
         assert publisher.pushes[0]["hints"] == ["dub techno", "ambient"]
+
+    def test_the_process_governor_is_used_by_default(
+        self, index: LibraryIndex, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without this the builder would run unspaced against the endpoint class
+        that actually 429s, and never see the download drain's reported limits."""
+        import kamp_daemon.bandcamp_ratelimit as ratelimit
+
+        monkeypatch.setattr(ratelimit, "get_governor", lambda: _FakeGovernor(30.0))
+        status = build_crate(
+            index,
+            _FakeSource(_spread({"a": 12})),
+            publish=_Publisher(),
+            now=lambda: 0.0,
+        )
+        assert status["state"] == "paused"
+        assert status["paused_until"] == pytest.approx(30.0)
 
     def test_paused_until_clears_on_a_clean_build(self, index: LibraryIndex) -> None:
         publisher = _Publisher()

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -1,0 +1,399 @@
+"""Crate builder tests (KAMP-648).
+
+Everything here runs against a fake DiscoverySource — the builder's job is
+selection, exclusion and persistence, and none of that should need a network or
+even a Bandcamp-shaped candidate. The bias is toward the outcomes that are
+visibly wrong to a user: a crate that collapses to one item, a crate that
+recommends records they already own, a crate that repeats last week's, and a
+rate limit that presents as a hang.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from kamp_core.library import LibraryIndex
+from kamp_daemon.discovery import (
+    ALBUM_PAGE,
+    ARTIST_PAGE,
+    DISCOVER_API,
+    Candidate,
+    DiscoverySource,
+    RequestBudget,
+    SeedProfile,
+)
+from kamp_daemon.discovery_builder import CRATE_SIZE, build_crate
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> Iterator[LibraryIndex]:
+    idx = LibraryIndex(tmp_path / "library.db")
+    yield idx
+    idx.close()
+
+
+def _candidate(item_id: str, criterion: str = "also_like", **kw: Any) -> Candidate:
+    return Candidate(
+        provider="fake",
+        provider_item_id=item_id,
+        item_url=f"https://band.bandcamp.com/album/{item_id}",
+        artist=kw.pop("artist", f"Artist {item_id}"),
+        title=kw.pop("title", f"Title {item_id}"),
+        criterion=criterion,
+        why=f"because {criterion}",
+        seed={"kind": criterion},
+        **kw,
+    )
+
+
+def _spread(counts: dict[str, int]) -> list[Candidate]:
+    """Candidates grouped by criterion, ids unique across the whole spread."""
+    out: list[Candidate] = []
+    n = 0
+    for criterion, count in counts.items():
+        for _ in range(count):
+            n += 1
+            out.append(_candidate(str(n), criterion))
+    return out
+
+
+class _FakeSource(DiscoverySource):
+    provider_id = "fake"
+
+    def __init__(
+        self,
+        candidates: list[Candidate],
+        caps: dict[str, int] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._candidates = candidates
+        self._caps = caps or {}
+        self._error = error
+        self.gather_calls = 0
+
+    @property
+    def criterion_caps(self) -> dict[str, int]:
+        return self._caps
+
+    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+        self.gather_calls += 1
+        if self._error is not None:
+            raise self._error
+        return list(self._candidates)
+
+
+class _FakeGovernor:
+    """Only the surface the builder uses."""
+
+    def __init__(self, blocked: float = 0.0) -> None:
+        self.blocked = blocked
+
+    def blocked_for(self, endpoint_class: str) -> float:
+        return self.blocked
+
+
+class _Publisher:
+    """Stands in for the API layer's publish(), recording every push."""
+
+    def __init__(self) -> None:
+        #: Accumulated status after each push — what a client would see.
+        self.pushes: list[dict[str, Any]] = []
+        #: Exactly the fields each call changed.
+        self.raw: list[dict[str, Any]] = []
+        self.status: dict[str, Any] = {}
+
+    def __call__(self, fields: dict[str, Any]) -> None:
+        self.raw.append(dict(fields))
+        self.status.update(fields)
+        self.pushes.append(dict(self.status))
+
+
+def _build(
+    index: LibraryIndex,
+    source: DiscoverySource,
+    *,
+    governor: Any = None,
+    publish: Any = None,
+    **kw: Any,
+) -> dict[str, Any]:
+    return build_crate(
+        index,
+        source,
+        governor=governor or _FakeGovernor(),
+        publish=publish or _Publisher(),
+        **kw,
+    )
+
+
+def _titles(index: LibraryIndex, crate_no: int) -> list[str]:
+    return [row["title"] for row in index.crate_items(crate_no)]
+
+
+def _criteria(index: LibraryIndex, crate_no: int) -> list[str]:
+    return [row["criterion"] for row in index.crate_items(crate_no)]
+
+
+# ---------------------------------------------------------------------------
+# Selection and variety
+# ---------------------------------------------------------------------------
+
+
+class TestSelection:
+    def test_builds_a_full_crate_of_ten(self, index: LibraryIndex) -> None:
+        source = _FakeSource(_spread({"a": 8, "b": 8, "c": 8}))
+        status = _build(index, source)
+        assert status["state"] == "ready"
+        assert status["crate_no"] == 1
+        assert len(index.crate_items(1)) == CRATE_SIZE
+
+    def test_positions_are_dense_and_ordered(self, index: LibraryIndex) -> None:
+        _build(index, _FakeSource(_spread({"a": 8, "b": 8})))
+        positions = [row["position"] for row in index.crate_items(1)]
+        assert positions == list(range(CRATE_SIZE))
+
+    def test_crate_spans_several_criteria(self, index: LibraryIndex) -> None:
+        """Round-robin, not first-come: one prolific criterion must not fill it."""
+        source = _FakeSource(_spread({"a": 30, "b": 4, "c": 4}))
+        _build(index, source)
+        used = _criteria(index, 1)
+        assert set(used) == {"a", "b", "c"}
+        # 'a' has enough to fill the crate on its own; round-robin holds it to
+        # roughly a third.
+        assert used.count("a") <= 4
+
+    def test_a_criterion_may_repeat(self, index: LibraryIndex) -> None:
+        """Variety means spanning several, not one card each."""
+        _build(index, _FakeSource(_spread({"a": 8, "b": 8})))
+        used = _criteria(index, 1)
+        assert used.count("a") > 1 and used.count("b") > 1
+
+
+class TestCriterionCaps:
+    def test_chart_pick_is_capped_when_other_criteria_exist(
+        self, index: LibraryIndex
+    ) -> None:
+        source = _FakeSource(
+            _spread({"also_like": 8, "genre_top": 8, "best_seller": 8}),
+            caps={"best_seller": 1},
+        )
+        _build(index, source)
+        assert _criteria(index, 1).count("best_seller") == 1
+
+    def test_a_cap_never_shrinks_the_crate(self, index: LibraryIndex) -> None:
+        """The thin-profile case: a brand-new library yields only chart picks.
+
+        criteria_for() returns just best_seller for an empty library, so a cap
+        honoured unconditionally would hand a first-run user a one-item crate.
+        The cap is a preference, and backfilling past it is what keeps the crate
+        full.
+        """
+        source = _FakeSource(_spread({"best_seller": 20}), caps={"best_seller": 1})
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
+
+    def test_capped_candidates_are_used_last(self, index: LibraryIndex) -> None:
+        """Backfill must exhaust the uncapped criteria before overrunning a cap."""
+        source = _FakeSource(
+            _spread({"also_like": 4, "best_seller": 20}), caps={"best_seller": 1}
+        )
+        _build(index, source)
+        used = _criteria(index, 1)
+        assert used.count("also_like") == 4
+        assert used.count("best_seller") == 6
+
+
+class TestOrdering:
+    def test_group_order_varies_between_crates(self, tmp_path: Path) -> None:
+        """Without a shuffle, slot 0 is the same criterion in every crate forever.
+
+        criteria_for() preserves REGISTRY order and gather() iterates it, so the
+        group sequence is otherwise fixed for the life of the install.
+        """
+        firsts = set()
+        for seed in range(12):
+            idx = LibraryIndex(tmp_path / f"crate-{seed}.db")
+            try:
+                _build(
+                    idx,
+                    _FakeSource(_spread({"a": 8, "b": 8, "c": 8})),
+                    rng=random.Random(seed),
+                )
+                firsts.add(_criteria(idx, 1)[0])
+            finally:
+                idx.close()
+        assert len(firsts) > 1
+
+    def test_ordering_is_deterministic_for_a_given_seed(self, tmp_path: Path) -> None:
+        def run(path: Path) -> list[str]:
+            idx = LibraryIndex(path)
+            try:
+                _build(
+                    idx,
+                    _FakeSource(_spread({"a": 8, "b": 8, "c": 8})),
+                    rng=random.Random(7),
+                )
+                return _criteria(idx, 1)
+            finally:
+                idx.close()
+
+        assert run(tmp_path / "one.db") == run(tmp_path / "two.db")
+
+
+# ---------------------------------------------------------------------------
+# Exclusions — a miss here is a brand bug, not a cosmetic one
+# ---------------------------------------------------------------------------
+
+
+class TestExclusions:
+    def _own(
+        self, index: LibraryIndex, tralbum_id: str, artist: str, title: str
+    ) -> None:
+        index._conn.execute(
+            "INSERT INTO bandcamp_collection"
+            " (sale_item_id, band_name, item_title, tralbum_id, added_at)"
+            " VALUES (?, ?, ?, ?, 0)",
+            (f"sale-{tralbum_id}", artist, title, tralbum_id),
+        )
+        index._conn.commit()
+
+    def test_owned_by_tralbum_id_is_excluded(self, index: LibraryIndex) -> None:
+        self._own(index, "1", "Artist 1", "Title 1")
+        _build(index, _FakeSource(_spread({"a": 12})))
+        assert "Title 1" not in _titles(index, 1)
+
+    def test_owned_by_artist_title_fallback_is_excluded(
+        self, index: LibraryIndex
+    ) -> None:
+        """Collection rows whose tralbum_id was never backfilled still count."""
+        self._own(index, "", "artist 2", "title 2")  # NOCASE match
+        _build(index, _FakeSource(_spread({"a": 12})))
+        assert "Title 2" not in _titles(index, 1)
+
+    def test_wishlisted_is_excluded(self, index: LibraryIndex) -> None:
+        _build(index, _FakeSource(_spread({"a": 12})), wishlist_ids={"3"})
+        assert "Title 3" not in _titles(index, 1)
+
+    def test_a_previous_crate_is_never_repeated(self, index: LibraryIndex) -> None:
+        """The seen-ledger is cross-crate; the same source must yield new items."""
+        candidates = _spread({"a": 25})
+        _build(index, _FakeSource(candidates))
+        _build(index, _FakeSource(candidates))
+        first, second = index.crate_items(1), index.crate_items(2)
+        assert len(second) == CRATE_SIZE
+        assert not {r["provider_item_id"] for r in first} & {
+            r["provider_item_id"] for r in second
+        }
+
+    def test_buffered_rows_stay_eligible(self, index: LibraryIndex) -> None:
+        """seen_before keys on crate_no, not row existence (KAMP-645/657)."""
+        index.add_discovery_candidate(provider="fake", provider_item_id="1")
+        _build(index, _FakeSource(_spread({"a": 12})))
+        assert "1" in {r["provider_item_id"] for r in index.crate_items(1)}
+
+
+# ---------------------------------------------------------------------------
+# Degradation — short crates and rate limits are normal, not errors
+# ---------------------------------------------------------------------------
+
+
+class TestDegradation:
+    def test_short_crate_persists_what_was_found(self, index: LibraryIndex) -> None:
+        status = _build(index, _FakeSource(_spread({"a": 3})))
+        assert status["state"] == "ready"
+        assert status["short"] is True
+        assert len(index.crate_items(1)) == 3
+
+    def test_an_empty_gather_is_not_a_crate(self, index: LibraryIndex) -> None:
+        """No crate number is burned when there is nothing to put in it."""
+        status = _build(index, _FakeSource([]))
+        assert status["state"] == "empty"
+        assert index.latest_crate_no() is None
+        assert index.next_crate_no() == 1
+
+    def test_cooldown_refuses_to_build_at_all(self, index: LibraryIndex) -> None:
+        """A pause that is not visible is a hang (KAMP-639).
+
+        wait_turn() blocks silently for up to 300s after a 429, and the *next*
+        build never sees a 429 of its own — it just sits there. So the cooldown
+        has to be read before gathering and surfaced instead.
+        """
+        source = _FakeSource(_spread({"a": 12}))
+        publisher = _Publisher()
+        status = _build(
+            index,
+            source,
+            governor=_FakeGovernor(blocked=42.0),
+            publish=publisher,
+            now=lambda: 1000.0,
+        )
+        assert source.gather_calls == 0
+        assert status["state"] == "paused"
+        assert status["paused_until"] == pytest.approx(1042.0)
+        assert index.latest_crate_no() is None
+
+    def test_paused_until_is_the_longest_cooldown(self, index: LibraryIndex) -> None:
+        """Discovery spans three endpoint classes with independent cooldowns."""
+
+        class _Uneven:
+            def blocked_for(self, endpoint_class: str) -> float:
+                return {ALBUM_PAGE: 5.0, DISCOVER_API: 90.0, ARTIST_PAGE: 0.0}[
+                    endpoint_class
+                ]
+
+        status = _build(index, _FakeSource([]), governor=_Uneven(), now=lambda: 0.0)
+        assert status["paused_until"] == pytest.approx(90.0)
+
+    def test_a_failing_gather_reports_error_without_crashing(
+        self, index: LibraryIndex
+    ) -> None:
+        status = _build(index, _FakeSource([], error=RuntimeError("boom")))
+        assert status["state"] == "error"
+        assert index.latest_crate_no() is None
+
+
+# ---------------------------------------------------------------------------
+# Status publication
+# ---------------------------------------------------------------------------
+
+
+class TestPublication:
+    def test_building_is_announced_before_the_slow_part(
+        self, index: LibraryIndex
+    ) -> None:
+        publisher = _Publisher()
+        _build(index, _FakeSource(_spread({"a": 12})), publish=publisher)
+        assert publisher.pushes[0]["state"] == "building"
+        assert publisher.pushes[-1]["state"] == "ready"
+
+    def test_each_item_is_published_as_it_lands(self, index: LibraryIndex) -> None:
+        publisher = _Publisher()
+        _build(index, _FakeSource(_spread({"a": 12})), publish=publisher)
+        filled = [f["filled"] for f in publisher.raw if "filled" in f]
+        # 0 on the opening 'building' push, then one per row as it is committed.
+        assert filled == list(range(CRATE_SIZE + 1))
+
+    def test_hints_carry_the_profile_genres(self, index: LibraryIndex) -> None:
+        """KAMP-650 rotates status lines naming what is being dug through.
+
+        The genres come from the local profile rather than the provider, so the
+        copy stays true without teaching the builder any provider's criteria.
+        """
+        publisher = _Publisher()
+        _build(
+            index,
+            _FakeSource(_spread({"a": 12})),
+            publish=publisher,
+            profile=SeedProfile(top_genres=["dub techno", "ambient"]),
+        )
+        assert publisher.pushes[0]["hints"] == ["dub techno", "ambient"]
+
+    def test_paused_until_clears_on_a_clean_build(self, index: LibraryIndex) -> None:
+        publisher = _Publisher()
+        publisher.status["paused_until"] = 999.0
+        _build(index, _FakeSource(_spread({"a": 12})), publish=publisher)
+        assert publisher.status["paused_until"] == 0.0

--- a/tests/test_discovery_parsers.py
+++ b/tests/test_discovery_parsers.py
@@ -15,6 +15,7 @@ import pytest
 
 from kamp_daemon.discovery_bandcamp_parsers import (
     FACET_FAMILIES,
+    art_url_from_image,
     normalise_item_id,
     parse_also_like,
     parse_discography,
@@ -116,6 +117,23 @@ class TestDiscoverResults:
         for item in parse_discover_results(discover_results).items:
             assert isinstance(item["is_owned"], bool)
             assert isinstance(item["is_wishlisted"], bool)
+
+    def test_art_url_is_built_from_the_image_object(
+        self, discover_results: str
+    ) -> None:
+        """This surface returns primary_image as an OBJECT, not a URL.
+
+        Passing it through stored a dict in a TEXT column; SQLite refused the
+        bind, and since the builder skips a row it cannot persist rather than
+        failing the crate, every discover-surface candidate silently vanished
+        while the album-page ones carried on. The fixture had the object shape
+        all along — nothing asserted the type.
+        """
+        items = parse_discover_results(discover_results).items
+        assert items
+        for item in items:
+            assert item["art_url"].startswith("https://f4.bcbits.com/img/a")
+            assert item["art_url"].endswith(".jpg")
 
     def test_exclusion_flags_are_honoured_when_true(self) -> None:
         """The captured fixture is anonymous, so both flags are always false in it.
@@ -323,6 +341,62 @@ class TestFixturesStillMatchReality:
         result = parse_discography(self._live_get(url), base_url=url)
         assert result.marker_present, "the music grid has moved or gone"
         assert len(result) > 0
+
+
+class TestItemFieldTypes:
+    """Every parser must emit the same field types, whatever surface it read.
+
+    The builder writes these straight into TEXT columns, so a field that is not
+    a string is a persistence failure — and a skipped row, being non-fatal, takes
+    the whole surface down quietly. Asserting the contract across all three
+    parsers is cheap; the discover surface already broke it once.
+    """
+
+    def _all_items(self, album_page: str, discover_results: str) -> list[dict]:
+        url = "https://band.bandcamp.com/music"
+        return [
+            *parse_also_like(album_page).items,
+            *parse_discover_results(discover_results).items,
+            *parse_discography(_fixture("artist_discography"), base_url=url).items,
+        ]
+
+    def test_art_url_is_a_string_or_none(
+        self, album_page: str, discover_results: str
+    ) -> None:
+        items = self._all_items(album_page, discover_results)
+        assert items
+        for item in items:
+            assert item["art_url"] is None or isinstance(item["art_url"], str)
+
+    def test_text_fields_are_strings(
+        self, album_page: str, discover_results: str
+    ) -> None:
+        for item in self._all_items(album_page, discover_results):
+            for field in ("provider_item_id", "item_url", "title"):
+                assert isinstance(item[field], str), field
+
+
+class TestArtUrlFromImage:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # The discover API's object form — the shape that broke persistence.
+            ({"image_id": 123, "is_art": True}, "https://f4.bcbits.com/img/a123_0.jpg"),
+            ({"image_id": 9, "is_art": False}, None),
+            ({}, None),
+            (456, "https://f4.bcbits.com/img/a456_0.jpg"),
+            ("789", "https://f4.bcbits.com/img/a789_0.jpg"),
+            # Already a URL (the HTML surfaces): pass through untouched.
+            (
+                "https://f4.bcbits.com/img/a1_16.jpg",
+                "https://f4.bcbits.com/img/a1_16.jpg",
+            ),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_tolerates_every_shape_bandcamp_uses(self, raw, expected) -> None:
+        assert art_url_from_image(raw) == expected
 
 
 class TestNormalisation:


### PR DESCRIPTION
## Summary

The layer that turns a pile of candidates into *a crate of ten*: selection, exclusion, persistence, and the REST/WS surface KAMP-650's UI will consume. Five commits, each independently revertible.

| Commit | What |
| --- | --- |
| C1 | Crate assembly accessors on `LibraryIndex` + a shared no-commit `_append_event` |
| C2 | `discovery_builder.py` — variety, exclusion, degradation |
| C3 | `kamp_core/discovery_api.py` — the routes and the shared snapshot |
| C4 | Daemon wiring + governor docstring correction |
| C5 | Discover art-URL fix (found by running it for real — see below) |

## Two corrections to the ticket

- **The `busy()` AC is struck.** `governor.busy()` does not exist and deliberately never will — KAMP-646 cut that bracket with evidence, and the coupling that does exist is the 429 hook already wired at the download drain.
- **`register_discovery_routes` takes no governor**, unlike the signature sketched in the description. `paused_until` is written by the builder, which already holds one, so `kamp_core` stays free of any rate-limit knowledge. Album art is KAMP-649's and lands in this same new module.

## Design

**Variety without interpreting labels.** Group by `criterion`, deal one per group in rotation. The "max one best-seller" rule genuinely does require knowing which label is the chart, so the *provider* declares it via a new `criterion_caps` property and the builder honours it as opaque data.

**A cap is a preference, not a ceiling — and this is the part that matters.** `criteria_for()` returns *only* `best_seller` for a brand-new library, so honouring a cap of 1 unconditionally would have handed a first-run user a **one-item crate**: exactly the degenerate outcome the ticket's own comment forbids. Backfilling past the cap once uncapped criteria are exhausted fixes that and softens the late-crate exhaustion case with one rule.

**Group order is shuffled per crate.** `criteria_for` preserves `REGISTRY` order and `gather` iterates it, so without a shuffle slot 0 is `also_like` in every crate for the life of the install — poor for a feature whose whole affordance is dealing another one.

**The cooldown is read before gathering and the build refuses rather than waits.** `wait_turn` blocks silently for up to 300s, and the build *after* a rate-limited one never sees a 429 of its own — it just sits there. That is the KAMP-639 "a pause that isn't visible is a hang" failure. Refusing also caps in-build waiting at one spacing interval, which is why there is no cancel endpoint: `RealClock`'s stop Event is never set in production, so a cancel would mean threading shutdown state into the governor.

**One `_snapshot()` feeds both REST and WS**, so "REST snapshot equals WS snapshot shape" holds by construction. The status is in-memory but the crate is not, so a snapshot with no build in flight falls back to `latest_crate_no()` — the restart and reconnect path, and `_broadcast` no-ops with no client attached.

**The single-build flag is set synchronously in the route**, deliberately unlike `start_genre_backfill`, which tests a flag only its worker thread sets and so tells two racing POSTs they both started. Serialization is load-bearing rather than tidy: two builders would compute the same `next_crate_no()` and collide on the partial unique index.

**Only the ten winners are persisted.** Buffering the ~40 surplus candidates is KAMP-657's, together with the TTL sweep and pool cap that stop it growing unbounded; inserting them here would leak rows until that lands.

## The bug that only a real run could find

Everything above passed 2,900 tests. Then I built two real crates against a copy of the production library, and they came back with **4 items from 2 criteria instead of 10 from 5**.

The discover API returns `primary_image` as an **object** — `{"image_id", "is_art"}` — not a URL. The parser passed the dict straight into a TEXT column, SQLite refused the bind, and because the builder skips a row it cannot persist rather than failing the crate, **every discover-surface candidate vanished silently** while the album-page ones carried on working. The captured fixture had the object shape all along; nothing asserted the type.

Two things came out of it: `art_url_from_image` (tolerant of object, bare id and finished URL — this is remote data whose spelling has already changed once), and a field-type contract test across all three parsers, since the builder writes these fields directly into TEXT columns.

Coverage also caught a smaller one before it shipped: a row that failed to persist left a **hole in the position sequence**, and the rail renders by position, so that is a blank sleeve the user can focus and never fill. `short` was also computed from what was picked rather than what landed.

## Test plan

- [x] `poetry run pytest` — **2911 passed, 9 skipped, 3 deselected**, coverage **93.91%** (main: 93.81%)
- [x] `black --check` and `mypy` clean
- [x] New modules at **100%** (`discovery_api`) and **99%** (`discovery_builder`)
- [x] Builder tested entirely against a fake `DiscoverySource` — no network, no event loop, no app
- [x] Falsified the load-bearing tests rather than trusting them green: removing the cap backfill, replacing round-robin with take-first-N, narrowing the terminal-state set, and dropping the `place_in_crate` rollback each fail the tests that claim to cover them. One rollback test was **vacuous on first write** (the UPDATE fails before the event insert is reached) and was rewritten to inject the failure that actually matters — promoted but never recorded, which `seen_before` then suppresses forever
- [x] Every terminal state is pinned individually, since one missing from the set wedges the feature on 409 until the daemon restarts
- [x] Auth middleware verified to cover routes registered from a module it knows nothing about
- [x] **Two real crates built against a copy of the production library**: 10/10 each, all five criteria, zero owned albums, zero overlap between crates, art and provenance on every card

## Filed, not fixed

**KAMP-661** — cross-crate exhaustion. `_run_criterion` stops after the first productive seed, seeds are stable, and `"cursor": None` is hard-coded, so ~5 crates exhausts the distinct candidate space and every later crate is short *by construction* — silently, since a short crate is a normal outcome. Needs seed rotation and discover pagination; out of scope here.

## Manual check

No Crate view yet, so this is API-level. With the daemon running and Bandcamp connected:

- `POST /api/v1/discovery/crate/new`, then `GET /api/v1/discovery/crate` — ten items spanning several criteria, at most one chart pick, each with a `why` that reads like a shelf tag.
- POST `crate/new` twice quickly — the second must 409.
- Build a second crate — no album should repeat, and nothing in either should already be in your library.
- Nothing playback-related is touched.

Closes KAMP-648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
