### PR TITLE
KAMP-649: crate art proxy — daemon endpoint + disk cache

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -17,11 +17,17 @@ KAMP-649 adds the crate art proxy to this module.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import re
 import threading
+from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
+
+from kamp_core.proxy_hosts import ART_HOSTS, host_allowed
 
 if TYPE_CHECKING:  # pragma: no cover - types only
     from kamp_core.library import LibraryIndex
@@ -38,6 +44,32 @@ CRATE_EVENT = "discovery.crate"
 #: "already building" until the daemon restarted.
 _TERMINAL_STATES = frozenset({"ready", "empty", "error", "paused", "idle"})
 
+# Bandcamp's art CDN encodes the rendition in the filename: a<id>_<code>.jpg.
+#
+# Only the two aspect-preserving codes are offered, and the exclusions are the
+# point rather than an oversight. Measured against the live CDN: _0 is the
+# artist's original (197 KB to 7.2 MB, any aspect); _10 caps the long edge at
+# 1200px and preserves aspect (125-440 KB). _5/_16/_2 force 700x700 -- for a
+# 635x611 original they *upscale it and square it* -- and _16 is additionally the
+# same pixels as _5 at ~40% fewer bytes. kamp does not degrade covers, so those
+# renditions are not reachable through this endpoint at all.
+ART_SIZES: frozenset[int] = frozenset({0, 10})
+DEFAULT_ART_SIZE = 10
+
+_BCBITS_SIZE = re.compile(r"_(\d+)\.jpg$")
+
+_ART_TIMEOUT = 10.0  # a static CDN on the render path, not the 30s API budget
+_MAX_ART_BYTES = 16 * 1024 * 1024
+
+# The URL is keyed on (item id, size) and both are write-once -- discovery_items.id
+# is AUTOINCREMENT so ids are never reused, and add_discovery_candidate never
+# updates art_url -- so the response really is immutable.
+_ART_CACHE_CONTROL = "public, max-age=31536000, immutable"
+# Failures get a short positive TTL rather than no-store: art_url is write-once,
+# so a miss stays a miss, and without this ten cards remounting on a tab switch
+# is a fetch storm against the CDN.
+_ART_MISS_CACHE_CONTROL = "public, max-age=300"
+
 _INITIAL_STATUS: dict[str, Any] = {
     "state": "idle",
     "crate_no": None,
@@ -48,12 +80,54 @@ _INITIAL_STATUS: dict[str, Any] = {
 }
 
 
+def sized_art_url(art_url: str, size: int) -> str:
+    """Swap the bcbits rendition code in *art_url*, or return it untouched.
+
+    Parsers store ``_0`` (content identity); the delivery size is a presentation
+    decision made here. A URL that does not carry a rendition suffix is left
+    alone rather than guessed at.
+    """
+    return _BCBITS_SIZE.sub(f"_{size}.jpg", art_url)
+
+
+def _fetch_art_bytes(url: str) -> bytes | None:
+    """Download cover art from the CDN with a plain, unauthenticated session.
+
+    f4.bcbits.com serves art publicly with no cookies and is not behind the bot
+    management that guards bandcamp.com itself (KAMP-636), so this deliberately
+    does not go through the Electron relay -- and must not, since the relay
+    carries session cookies an image request has no need of.
+    """
+    import requests  # noqa: PLC0415 - keeps kamp_core import-light
+
+    try:
+        resp = requests.get(url, timeout=_ART_TIMEOUT, stream=True)
+        if resp.status_code != 200:
+            logger.debug("crate art: HTTP %d from %s", resp.status_code, url)
+            return None
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_content(64 * 1024):
+            total += len(chunk)
+            if total > _MAX_ART_BYTES:
+                # Remote data: read it bounded rather than trusting the host.
+                logger.warning("crate art: oversized response from %s", url)
+                return None
+            chunks.append(chunk)
+        return b"".join(chunks)
+    except Exception as exc:  # noqa: BLE001 - a missing cover is not an error
+        logger.debug("crate art: fetch failed for %s: %s", url, exc)
+        return None
+
+
 def register_discovery_routes(
     app: FastAPI,
     *,
     index: "LibraryIndex",
     broadcast: Callable[[dict[str, Any]], None],
     on_build_start: Callable[[], None] | None = None,
+    art_cache_dir: Path | None = None,
+    fetch_bytes: Callable[[str], bytes | None] | None = None,
 ) -> None:
     """Register the Discovery Crate routes on *app*.
 
@@ -164,3 +238,89 @@ def register_discovery_routes(
         wishlist afterwards.
         """
         return _record(item_id, "url_copied")
+
+    # ------------------------------------------------------------------
+    # Album art (KAMP-649)
+    # ------------------------------------------------------------------
+
+    _fetch = fetch_bytes or _fetch_art_bytes
+
+    @app.get("/api/v1/discovery/art")
+    def get_crate_art(item_id: int, s: int = DEFAULT_ART_SIZE) -> Response:
+        """Proxy and cache cover art for one crate pick.
+
+        The renderer CSP does not allow f4.bcbits.com, and ``/api/v1/album-art``
+        resolves through the user's collection, so it cannot serve an album they
+        do not own. Proxying here keeps CSP untouched and gets the disk cache for
+        free. No auth work is needed in the UI: Electron injects X-Kamp-Token on
+        every local-API request including <img src>.
+
+        Every failure is a 404 or 400 rather than a 5xx -- the UI renders a
+        placeholder either way, and a missing cover is not a server fault.
+        """
+        if s not in ART_SIZES:
+            raise HTTPException(status_code=400, detail=f"Unsupported art size: {s}")
+        if art_cache_dir is None:
+            raise HTTPException(status_code=404, detail="No art found")
+
+        row = index.discovery_item(item_id)
+        art_url = (row or {}).get("art_url") or ""
+        if not art_url:
+            raise HTTPException(status_code=404, detail="No art found")
+
+        # The stored URL is remote data: art_url_from_image passes through any
+        # string starting with http, so an arbitrary host can reach the database.
+        # 400 rather than _validate_proxy_url's 422 -- that path validates a
+        # client-supplied URL, where blaming the caller is right; here the caller
+        # sent a perfectly good item id and our own stored data is at fault.
+        if not host_allowed(art_url, ART_HOSTS):
+            logger.warning("crate art: refusing host for item %d: %s", item_id, art_url)
+            raise HTTPException(status_code=400, detail="Art host not allowed")
+
+        url = sized_art_url(art_url, s)
+        # Keyed on content identity, NOT provider_item_id: that column is only
+        # unique paired with provider, and it is unvalidated remote text, so a
+        # crafted data-albumid would write outside the cache directory. Hashing
+        # the URL also lets two providers listing the same album share one file.
+        key = hashlib.sha256(url.encode()).hexdigest()
+        # A subdirectory so discovery art stays separable from collection art.
+        # NOTE: neither cache is pruned today (see the sibling writer in
+        # kamp_daemon/bandcamp.py); when a sweep is added it will meet this
+        # directory entry at the top level of art_cache and must not unlink it.
+        cache_dir = art_cache_dir / "discovery"
+        cache_path = cache_dir / f"{key}.jpg"
+        if cache_path.exists():
+            return Response(
+                content=cache_path.read_bytes(),
+                media_type="image/jpeg",
+                headers={"Cache-Control": _ART_CACHE_CONTROL},
+            )
+
+        data = _fetch(url)
+        if not data:
+            raise HTTPException(
+                status_code=404,
+                detail="No art found",
+                headers={"Cache-Control": _ART_MISS_CACHE_CONTROL},
+            )
+
+        # Written atomically: a focus card and its rail sleeve are the *same*
+        # item, so concurrent requests for one URL are the common case and a
+        # half-written file would be served as a broken image.
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            tmp = cache_dir / f"{key}.{os.getpid()}.{threading.get_ident()}.tmp"
+            try:
+                tmp.write_bytes(data)
+                os.replace(tmp, cache_path)
+            finally:
+                tmp.unlink(missing_ok=True)
+        except OSError:
+            # A full or read-only disk costs caching, not the image.
+            logger.warning("crate art: could not cache %s", cache_path, exc_info=True)
+
+        return Response(
+            content=data,
+            media_type="image/jpeg",
+            headers={"Cache-Control": _ART_CACHE_CONTROL},
+        )

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5061,6 +5061,21 @@ class LibraryIndex:
             self._conn.rollback()
             raise
 
+    def discovery_item(self, item_id: int) -> dict[str, Any] | None:
+        """One discovery candidate by row id, or None.
+
+        Deliberately not filtered on crate_no: a buffered row (KAMP-657) has art
+        worth showing too, and restricting this to promoted rows would make the
+        art proxy fail in a way that looks like a missing cover.
+        """
+        row = self._conn.execute(
+            "SELECT id, provider, provider_item_id, item_url, artist, title,"
+            "       art_url, crate_no, position, state"
+            " FROM discovery_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
     def crate_items(self, crate_no: int) -> list[dict[str, Any]]:
         """The cards of one crate, in slot order.
 

--- a/kamp_core/proxy_hosts.py
+++ b/kamp_core/proxy_hosts.py
@@ -1,0 +1,39 @@
+"""Which remote hosts kamp will talk to, and the one rule for deciding (KAMP-649).
+
+The host-matching rule was written twice before this module existed — once in
+``kamp_core.server`` for the Electron proxy relay, once in
+``kamp_daemon.discovery_sources`` with a comment noting it mirrored the first. A
+third copy was about to be added for the crate art proxy, so it lives here now
+and everyone imports it.
+
+The rule is exact-match-or-subdomain, and the *exact* half is load-bearing: a
+bare suffix test rejects ``bandcamp.com`` itself, which is where the discover API
+lives, while a bare ``in`` test would accept ``evilbandcamp.com``.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+#: Hosts that may be reached through Electron's ``net.fetch``, which carries the
+#: user's Bandcamp session cookies. Anything not listed here could be used by a
+#: malicious extension or local process to exfiltrate those cookies.
+ALLOWED_PROXY_HOSTS: frozenset[str] = frozenset(
+    {"bandcamp.com", "f4.bcbits.com", "t4.bcbits.com"}
+)
+
+#: Hosts the crate art proxy will fetch images from. A strict subset of
+#: ALLOWED_PROXY_HOSTS: the art CDN serves covers publicly with no cookies, while
+#: bandcamp.com is an authenticated surface with no business answering an <img>.
+#: Narrower is deliberate — the stored art_url is remote data, and
+#: ``art_url_from_image`` passes through any string that starts with ``http``.
+ART_HOSTS: frozenset[str] = frozenset({"f4.bcbits.com", "t4.bcbits.com"})
+
+#: Hosts discovery will fetch pages and API responses from.
+FETCHABLE_HOSTS: frozenset[str] = frozenset({"bandcamp.com"})
+
+
+def host_allowed(url: str, hosts: frozenset[str]) -> bool:
+    """True if *url*'s host is one of *hosts* or a subdomain of one."""
+    host = (urlparse(url).hostname or "").lower()
+    return any(host == h or host.endswith(f".{h}") for h in hosts)

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -4650,6 +4650,7 @@ def create_app(
         index=index,
         broadcast=_broadcast,
         on_build_start=on_crate_build_start,
+        art_cache_dir=art_cache_dir,
     )
 
     return app

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -55,6 +55,7 @@ from kamp_core.library import (
 )
 from kamp_core.discovery_api import register_discovery_routes
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
+from kamp_core.proxy_hosts import ALLOWED_PROXY_HOSTS, host_allowed
 
 # ---------------------------------------------------------------------------
 # Playback URI resolution
@@ -870,10 +871,10 @@ class ReorderPlaylistRequest(BaseModel):
 # Only requests targeting these hostnames (or subdomains) may be forwarded to
 # Electron's net.fetch, which carries Bandcamp session cookies.  This prevents
 # a malicious extension or local process from exfiltrating credentials to an
-# arbitrary host.
-_ALLOWED_PROXY_HOSTS: frozenset[str] = frozenset(
-    {"bandcamp.com", "f4.bcbits.com", "t4.bcbits.com"}
-)
+# arbitrary host.  Defined in kamp_core.proxy_hosts so the discovery fetchers and
+# the crate art proxy share one rule rather than three copies of it (KAMP-649);
+# re-exported here because it was this module's name first.
+_ALLOWED_PROXY_HOSTS = ALLOWED_PROXY_HOSTS
 
 # SVG template for playlist placeholder art (KAMP-441).
 # __TITLE__ is substituted with the (possibly-truncated) playlist title at request time.
@@ -999,11 +1000,10 @@ def _track_out(index: LibraryIndex, track: Track) -> TrackOut:
 
 
 def _validate_proxy_url(url: str) -> str:
-    parsed = urlparse(url)
-    host = parsed.hostname or ""
-    if not any(host == h or host.endswith(f".{h}") for h in _ALLOWED_PROXY_HOSTS):
+    if not host_allowed(url, _ALLOWED_PROXY_HOSTS):
         raise HTTPException(
-            status_code=422, detail=f"Proxy URL host not allowed: {host}"
+            status_code=422,
+            detail=f"Proxy URL host not allowed: {urlparse(url).hostname or ''}",
         )
     return url
 

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import logging
 import time as _time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+
+from kamp_core.proxy_hosts import FETCHABLE_HOSTS, host_allowed
 
 from .bandcamp_ratelimit import BandcampGovernor, get_governor
 from .discovery import (
@@ -53,19 +54,15 @@ logger = logging.getLogger(__name__)
 
 DISCOVER_API_URL = "https://bandcamp.com/api/discover/1/discover_web"
 
-# Mirrors _validate_proxy_url's rule in kamp_core/server.py exactly:
-# `host == h or host.endswith("." + h)`. Approximating it with a bare suffix test
-# would reject `bandcamp.com` itself — which is where the discover API lives.
-#
-# A Bandcamp Pro custom domain matches neither, so a candidate pointing at one is
-# unfetchable in every packaged build (~1% of a real collection) and is skipped
-# rather than attempted.
-_FETCHABLE_HOSTS = ("bandcamp.com",)
-
 
 def _is_fetchable(url: str) -> bool:
-    host = (urlparse(url).hostname or "").lower()
-    return any(host == h or host.endswith(f".{h}") for h in _FETCHABLE_HOSTS)
+    """True if discovery may fetch *url*.
+
+    A Bandcamp Pro custom domain matches nothing in FETCHABLE_HOSTS, so a
+    candidate pointing at one is unfetchable in every packaged build (~1% of a
+    real collection) and is skipped rather than attempted.
+    """
+    return host_allowed(url, FETCHABLE_HOSTS)
 
 
 class RateLimitedError(RuntimeError):

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -302,6 +302,20 @@ export const playlistArtUrl = (playlistId: number, version?: number): string => 
   return version != null ? `${base}?v=${version}` : base
 }
 
+// Returns the URL for a Discovery Crate pick's cover art (KAMP-649).
+// The renderer CSP does not allow f4.bcbits.com and /api/v1/album-art only
+// serves albums the user owns, so crate art is proxied and cached by the daemon.
+// Gate on the crate item's own art_url being non-null before rendering — an item
+// with no art 404s here, and ten cards firing doomed requests is avoidable.
+// The server returns 404 for a missing or unfetchable cover — handle with onError.
+// size is a Bandcamp rendition code: 10 (default) caps the long edge at 1200px
+// preserving aspect; 0 is the artist's original upload, which can be several MB.
+// Only those two are accepted — the 700px codes square and upscale small covers.
+export const crateArtUrl = (itemId: number, size?: 0 | 10): string => {
+  const base = `${BASE_URL}/api/v1/discovery/art?item_id=${itemId}`
+  return size != null ? `${base}&s=${size}` : base
+}
+
 export type Artist = {
   name: string
   play_time: number // total elapsed playback seconds

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -492,6 +492,34 @@ class TestCrateAssembly:
     def test_empty_crate_reads_as_empty(self, index: LibraryIndex) -> None:
         assert index.crate_items(99) == []
 
+    def test_single_item_lookup_carries_the_art_fields(
+        self, index: LibraryIndex
+    ) -> None:
+        """The art proxy resolves one item by id without loading a whole crate."""
+        item = self._buffered(
+            index,
+            "42",
+            artist="Band",
+            title="X",
+            art_url="https://f4.bcbits.com/img/a1_0.jpg",
+        )
+        row = index.discovery_item(item)
+        assert row is not None
+        assert row["provider"] == "bandcamp"
+        assert row["provider_item_id"] == "42"
+        assert row["art_url"] == "https://f4.bcbits.com/img/a1_0.jpg"
+
+    def test_single_item_lookup_works_before_promotion(
+        self, index: LibraryIndex
+    ) -> None:
+        """Buffered rows (crate_no NULL) must resolve too — KAMP-657 will show
+        art for candidates that have never been in a crate."""
+        item = self._buffered(index, "1", art_url="https://f4.bcbits.com/img/a2_0.jpg")
+        assert index.discovery_item(item) is not None
+
+    def test_unknown_item_lookup_is_none(self, index: LibraryIndex) -> None:
+        assert index.discovery_item(9999) is None
+
 
 # ---------------------------------------------------------------------------
 # Seed profile

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -30,13 +30,25 @@ def index(tmp_path: Path) -> Iterator[LibraryIndex]:
 
 
 class _Harness:
-    def __init__(self, index: LibraryIndex, on_build_start: Any = None) -> None:
+    def __init__(
+        self,
+        index: LibraryIndex,
+        on_build_start: Any = None,
+        art_cache_dir: Path | None = None,
+        art_bytes: bytes | None = b"JPEGDATA",
+    ) -> None:
         self.events: list[dict[str, Any]] = []
         self.build_calls = 0
+        self.fetched: list[str] = []
+        self.art_bytes = art_bytes
         self.app = FastAPI()
 
         def _default_start() -> None:
             self.build_calls += 1
+
+        def _fetch(url: str) -> bytes | None:
+            self.fetched.append(url)
+            return self.art_bytes
 
         register_discovery_routes(
             self.app,
@@ -45,6 +57,8 @@ class _Harness:
             on_build_start=(
                 _default_start if on_build_start is None else on_build_start
             ),
+            art_cache_dir=art_cache_dir,
+            fetch_bytes=_fetch,
         )
         self.client = TestClient(self.app)
 
@@ -56,6 +70,11 @@ class _Harness:
 @pytest.fixture
 def harness(index: LibraryIndex) -> _Harness:
     return _Harness(index)
+
+
+@pytest.fixture
+def art_dir(tmp_path: Path) -> Path:
+    return tmp_path / "art_cache"
 
 
 def _stock(index: LibraryIndex, crate_no: int, count: int = 3) -> None:
@@ -225,6 +244,290 @@ class TestItemEvents:
             harness.client.post("/api/v1/discovery/items/999/dismiss").status_code
             == 404
         )
+
+
+# ---------------------------------------------------------------------------
+# Art proxy (KAMP-649)
+# ---------------------------------------------------------------------------
+
+ART = "https://f4.bcbits.com/img/a123_0.jpg"
+
+
+def _candidate(
+    index: LibraryIndex,
+    art_url: str | None = ART,
+    provider_item_id: str = "1",
+    provider: str = "bandcamp",
+) -> int:
+    return index.add_discovery_candidate(
+        provider=provider,
+        provider_item_id=provider_item_id,
+        artist="Band",
+        title="X",
+        art_url=art_url,
+    )
+
+
+class TestArtProxy:
+    def _get(self, harness: _Harness, item_id: int, **params: Any) -> Any:
+        query = "".join(f"&{k}={v}" for k, v in params.items())
+        return harness.client.get(f"/api/v1/discovery/art?item_id={item_id}{query}")
+
+    def test_cache_miss_fetches_and_stores(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        resp = self._get(harness, _candidate(index))
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        assert resp.content == b"JPEGDATA"
+        assert len(harness.fetched) == 1
+        assert list((art_dir / "discovery").glob("*.jpg"))
+
+    def test_cache_hit_does_not_fetch(self, index: LibraryIndex, art_dir: Path) -> None:
+        """The AC's 'cache hit -> no network', asserted on the seam itself."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        item = _candidate(index)
+        self._get(harness, item)
+        harness.fetched.clear()
+
+        resp = self._get(harness, item)
+        assert resp.status_code == 200
+        assert resp.content == b"JPEGDATA"
+        assert harness.fetched == []
+
+    def test_art_is_served_immutable(self, index: LibraryIndex, art_dir: Path) -> None:
+        """Safe because discovery_items.id is AUTOINCREMENT (never reused) and
+        add_discovery_candidate never updates art_url — so id -> art is
+        write-once."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        resp = self._get(harness, _candidate(index))
+        assert "immutable" in resp.headers["cache-control"]
+
+    def test_two_items_with_the_same_art_share_one_file(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        """The key is content identity, so a re-listed album is fetched once."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        first = _candidate(index, provider_item_id="1")
+        second = _candidate(index, provider_item_id="2", provider="other")
+        self._get(harness, first)
+        self._get(harness, second)
+
+        assert len(list((art_dir / "discovery").glob("*.jpg"))) == 1
+        assert len(harness.fetched) == 1
+
+    # -- sizes ---------------------------------------------------------
+
+    def test_default_size_is_the_aspect_preserving_1200(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        self._get(harness, _candidate(index))
+        assert harness.fetched == ["https://f4.bcbits.com/img/a123_10.jpg"]
+
+    def test_size_zero_serves_the_untouched_original(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        self._get(harness, _candidate(index), s=0)
+        assert harness.fetched == [ART]
+
+    @pytest.mark.parametrize("size", [5, 16, 2, 9, 7, 999, -1])
+    def test_squaring_and_unknown_sizes_are_refused(
+        self, index: LibraryIndex, art_dir: Path, size: int
+    ) -> None:
+        """5/16/2 are not cheaper versions of the artwork — they force 700x700
+        and upscale a smaller original. kamp does not degrade covers, so they are
+        excluded from the allowlist rather than merely unused."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        resp = self._get(harness, _candidate(index), s=size)
+        assert resp.status_code == 400
+        assert harness.fetched == []
+
+    def test_sizes_differ_in_the_cache(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        item = _candidate(index)
+        self._get(harness, item)
+        self._get(harness, item, s=0)
+        assert len(list((art_dir / "discovery").glob("*.jpg"))) == 2
+
+    def test_a_url_without_a_size_suffix_is_left_alone(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        odd = "https://f4.bcbits.com/img/cover.png"
+        self._get(harness, _candidate(index, art_url=odd))
+        assert harness.fetched == [odd]
+
+    # -- failure matrix ------------------------------------------------
+
+    def test_unknown_item_is_404(self, index: LibraryIndex, art_dir: Path) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        assert self._get(harness, 9999).status_code == 404
+
+    def test_item_without_art_is_404(self, index: LibraryIndex, art_dir: Path) -> None:
+        """art_url is nullable and every parser can produce None."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        resp = self._get(harness, _candidate(index, art_url=None))
+        assert resp.status_code == 404
+        assert harness.fetched == []
+
+    def test_no_cache_dir_is_404_not_500(self, index: LibraryIndex) -> None:
+        harness = _Harness(index, art_cache_dir=None)
+        assert self._get(harness, _candidate(index)).status_code == 404
+
+    def test_disallowed_host_is_refused_without_fetching(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        """art_url_from_image passes through any string starting with http, so an
+        arbitrary host really can reach the database."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        evil = _candidate(index, art_url="https://evil.example.com/a_0.jpg")
+        resp = self._get(harness, evil)
+        assert resp.status_code == 400
+        assert harness.fetched == []
+
+    def test_bandcamp_com_itself_is_not_an_art_host(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        """ART_HOSTS is deliberately narrower than the proxy allowlist."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+        item = _candidate(index, art_url="https://bandcamp.com/img/a1_0.jpg")
+        assert self._get(harness, item).status_code == 400
+
+    def test_lookalike_host_is_refused(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir)
+        item = _candidate(index, art_url="https://evilf4.bcbits.com.bad/a_0.jpg")
+        assert self._get(harness, item).status_code == 400
+
+    def test_a_failed_fetch_writes_nothing(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        harness = _Harness(index, art_cache_dir=art_dir, art_bytes=None)
+        resp = self._get(harness, _candidate(index))
+        assert resp.status_code == 404
+        assert not list((art_dir / "discovery").glob("*.jpg"))
+
+    def test_a_failed_fetch_is_briefly_cached(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        """art_url is write-once, so a 404 stays a 404 — without this, ten cards
+        remounting on every tab switch is a fetch storm."""
+        harness = _Harness(index, art_cache_dir=art_dir, art_bytes=None)
+        resp = self._get(harness, _candidate(index))
+        assert "max-age" in resp.headers.get("cache-control", "")
+
+    # -- the traversal the ticket's suggested cache key would have opened --
+
+    def test_a_hostile_provider_item_id_cannot_escape_the_cache_dir(
+        self, index: LibraryIndex, art_dir: Path
+    ) -> None:
+        """normalise_item_id returns the raw string when it does not match
+        ^(album|track)-\\d+$, so provider_item_id is unvalidated remote text.
+        Keying the cache file on it would let a crafted data-albumid write
+        anywhere; the key is a hash of the art URL instead.
+        """
+        harness = _Harness(index, art_cache_dir=art_dir)
+        item = _candidate(index, provider_item_id="../../../../tmp/pwned")
+        assert self._get(harness, item).status_code == 200
+
+        written = list(art_dir.rglob("*.jpg"))
+        assert len(written) == 1
+        assert written[0].parent == art_dir / "discovery"
+        assert not (art_dir.parent / "pwned.jpg").exists()
+
+
+class TestArtCacheFailures:
+    def test_an_unwritable_cache_costs_caching_not_the_image(
+        self, index: LibraryIndex, art_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A full or read-only disk must not turn every crate card into a gap."""
+        harness = _Harness(index, art_cache_dir=art_dir)
+
+        def _boom(*_a: object, **_kw: object) -> None:
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        resp = harness.client.get(f"/api/v1/discovery/art?item_id={_candidate(index)}")
+        assert resp.status_code == 200
+        assert resp.content == b"JPEGDATA"
+
+
+class _FakeResponse:
+    def __init__(self, status: int = 200, chunks: list[bytes] | None = None) -> None:
+        self.status_code = status
+        self._chunks = chunks if chunks is not None else [b"JPEG", b"DATA"]
+
+    def iter_content(self, _size: int) -> list[bytes]:
+        return self._chunks
+
+
+class TestRealArtFetch:
+    """The unstubbed CDN path — the seam every other test replaces."""
+
+    def _patch(self, monkeypatch: pytest.MonkeyPatch, resp: Any) -> list[dict]:
+        calls: list[dict] = []
+
+        def _get(url: str, **kw: Any) -> Any:
+            calls.append({"url": url, **kw})
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+
+        monkeypatch.setattr("requests.get", _get)
+        return calls
+
+    def test_streams_a_successful_response(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kamp_core.discovery_api import _fetch_art_bytes
+
+        calls = self._patch(monkeypatch, _FakeResponse())
+        assert _fetch_art_bytes("https://f4.bcbits.com/img/a1_10.jpg") == b"JPEGDATA"
+        # A static CDN on the render path, not the 30s Bandcamp API budget.
+        assert calls[0]["timeout"] == 10.0
+        assert calls[0]["stream"] is True
+
+    def test_non_200_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from kamp_core.discovery_api import _fetch_art_bytes
+
+        self._patch(monkeypatch, _FakeResponse(status=404))
+        assert _fetch_art_bytes("https://f4.bcbits.com/img/a1_10.jpg") is None
+
+    def test_an_oversized_body_is_refused_mid_stream(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Remote data is read bounded rather than trusted — the cap has to bite
+        while streaming, since a hostile host can lie about Content-Length."""
+        from kamp_core.discovery_api import _MAX_ART_BYTES, _fetch_art_bytes
+
+        chunk = b"x" * (1024 * 1024)
+        huge = [chunk] * (_MAX_ART_BYTES // len(chunk) + 2)
+        self._patch(monkeypatch, _FakeResponse(chunks=huge))
+        assert _fetch_art_bytes("https://f4.bcbits.com/img/a1_10.jpg") is None
+
+    def test_a_network_error_is_none_not_a_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kamp_core.discovery_api import _fetch_art_bytes
+
+        self._patch(monkeypatch, RuntimeError("connection reset"))
+        assert _fetch_art_bytes("https://f4.bcbits.com/img/a1_10.jpg") is None
+
+
+class TestArtHostAllowlist:
+    def test_art_hosts_are_a_subset_of_the_proxy_allowlist(self) -> None:
+        """Two lists that must not drift apart: anything the art proxy will fetch
+        must also be something the relay would have permitted."""
+        from kamp_core.proxy_hosts import ALLOWED_PROXY_HOSTS, ART_HOSTS
+
+        assert ART_HOSTS < ALLOWED_PROXY_HOSTS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Crate cards can have art. `GET /api/v1/discovery/art?item_id=<id>` fetches a candidate's cover from the CDN once and serves it from disk after — no CSP change, no auth work in the UI.

| Commit | What |
| --- | --- |
| C1 | `kamp_core/proxy_hosts.py` — one shared host-allowlist rule |
| C2 | `LibraryIndex.discovery_item(item_id)` |
| C3 | The endpoint, the disk cache, and `crateArtUrl` |

## Three corrections to the ticket

**"Reuse whatever policy the existing remote-art cache has" — there is no policy.** `art_cache` is written by the sync-time prefetch and by `_remote_art_response`, and pruned nowhere. So this ticket adds none either: inventing a private policy for discovery art while the larger collection cache has none would be solving the wrong half. Filed as **KAMP-662**, which matters more now that the numbers are known — collection art is bounded by collection size, discovery art grows with every crate forever.

**`provider_item_id` is unsafe as the cache key.** It is only unique paired with `provider`, and it is unvalidated remote text: `normalise_item_id` returns the raw string when it does not match `^(album|track)-\d+$`, and the only caller guard is a falsy check. A crafted `data-albumid` writes outside the cache directory. The key is `sha256` of the sized URL instead — real content identity, so two providers listing one album also share a file. There is a regression test that puts `../../../../tmp/pwned` in `provider_item_id`.

**Auth needed no work.** `kamp_ui/src/main/index.ts` already injects `X-Kamp-Token` into every local-API request *including `<img src>`*, with a comment saying so. This was the item most likely to fail silently in the packaged build.

## Art size — measured, not assumed

The first draft of this proposed `_16`, and @tterry pushed back that it is the worst quality and that high-quality artwork is part of kamp's story. That was right, and the measurements back it further than the objection did.

| album | `_0` (stored) | `_10` (shipped) | `_5` | `_16` |
| --- | --- | --- | --- | --- |
| Foo Fighters | 3000×3000, 3.5 MB | 1200×1200, 437 KB | 700×700, 169 KB | 700×700, 126 KB |
| Frankie Rose | 3780×3780, 5.0 MB | 1200×1200, 277 KB | 700×700, 107 KB | 700×700, 64 KB |
| **JG HYMNS** | **635×611**, 197 KB | 635×611, 125 KB | **700×700** | **700×700** |

`_5` and `_16` are the same pixels at ~40% different bytes, so `_16` is strictly the more compressed one. More importantly, look at JG HYMNS: both 700-codes **upscale a 635×611 original and square it**. They are not a cheaper rendition of the artwork, they are a worse one — so they are excluded from the endpoint's allowlist rather than merely unused, and requesting them is a 400.

`_10` is the only code besides `_0` that never squares or upscales. Confirmed on a real crate: covers stayed at 500×500 and 350×350, and one came through at 1200×800. `?s=0` remains reachable for the artist's original if KAMP-650 wants it on the focus card.

## Also

- Files land in `art_cache/discovery/` — a subdirectory, so KAMP-662 can treat discovery art as disposable without touching collection art, and so the traversal blast radius was contained even before the key was fixed.
- **Atomic write** (temp + `os.replace`). A focus card and its rail sleeve are the *same item*, so concurrent requests for one URL are the common case; `server.py:3173` uses a bare `write_bytes` and this deliberately does not copy it.
- Failures are 404/400, never 5xx — a missing cover is not a server fault. Misses carry a short `max-age` rather than `no-store`, because `art_url` is write-once and ten cards remounting on a tab switch would otherwise be a fetch storm.
- 10s timeout (a static CDN on the render path, not the 30s Bandcamp API budget) and a streamed size cap, since a host can lie about `Content-Length`.
- **For KAMP-650:** `crate_items` already returns `art_url`, so gate on it being non-null and render the placeholder directly rather than firing ten requests that 404.

The C1 extraction is behaviour-neutral: the host rule was already written twice (`server.py`, and `discovery_sources.py` with a comment admitting it mirrored the first), and this endpoint would have made three. `ART_HOSTS` is a strict subset — the art CDN serves covers publicly with no cookies, while `bandcamp.com` is an authenticated surface with no business answering an `<img>`.

## Test plan

- [x] `poetry run pytest` — **2944 passed, 9 skipped, 3 deselected**, coverage **93.95%** (main: 93.91%)
- [x] `black --check`, `mypy`, and `npm run typecheck` clean
- [x] `kamp_core/discovery_api.py` at **100%**, `proxy_hosts.py` at **100%**
- [x] Full failure matrix: unknown item, NULL `art_url`, no cache dir, disallowed host, `bandcamp.com` itself, lookalike host, CDN non-200, oversized body, network error, unwritable disk
- [x] Falsified rather than trusted green: swapping the cache key back to `provider_item_id` fails the traversal test, and replacing the host matcher with a naive substring test fails the lookalike-host test
- [x] 500 pre-existing server and discovery-source tests pass unchanged after the C1 extraction
- [x] **Live end-to-end against real crate rows**: all 10 covers served, 2.7 MB total, cache hit returns `immutable`, no stray files at the cache root, and 16/5/999 all refuse

## Manual check

No Crate view yet (KAMP-650), so this is API-level:

- Build a crate, take an `item_id` from `GET /api/v1/discovery/crate`, open `http://127.0.0.1:47483/api/v1/discovery/art?item_id=<id>` — a cover up to 1200px in its true aspect ratio, second load from disk. Compare `&s=0` to confirm the default is not visibly degraded.
- Confirm files landed in `<state dir>/art_cache/discovery/` and nothing new appeared at the top level of `art_cache/`.

Closes KAMP-649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
