### PR TITLE
KAMP-650: The Crate view — rail UI, clerk cards, states, keyboard model

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -39,6 +39,10 @@ logger = logging.getLogger(__name__)
 #: a reconnecting client then needs no replay, just the REST snapshot.
 CRATE_EVENT = "discovery.crate"
 
+#: Records in a full crate. Mirrors discovery_builder.CRATE_SIZE, duplicated
+#: rather than imported because kamp_core does not depend on kamp_daemon.
+CRATE_SIZE = 10
+
 #: States a build can end in. Reaching one releases the single-build lock, so
 #: this set is load-bearing: a state missing from it would wedge the feature on
 #: "already building" until the daemon restarted.
@@ -77,6 +81,7 @@ _INITIAL_STATUS: dict[str, Any] = {
     "short": False,
     "paused_until": 0.0,
     "hints": [],
+    "thin": False,
 }
 
 
@@ -156,7 +161,19 @@ def register_discovery_routes(
         if crate_no is None:
             crate_no = index.latest_crate_no()
             snap["crate_no"] = crate_no
-        snap["items"] = index.crate_items(crate_no) if crate_no is not None else []
+        items = index.crate_items(crate_no) if crate_no is not None else []
+        snap["items"] = items
+        if snap.get("state") != "building":
+            # The status is in-memory; the crate is not. After a daemon restart
+            # _status is still _INITIAL_STATUS while items holds a full crate, so
+            # a restored crate of ten reported filled=0 and a genuinely short one
+            # reported short=False -- wrong fill progress on every launch, and the
+            # quiet short-crate note suppressed. Derive both from what is actually
+            # there. Only while a build is in flight does the builder's own count
+            # win, since then it is ahead of the rows and this crate_no may still
+            # be the previous crate's.
+            snap["filled"] = len(items)
+            snap["short"] = bool(items) and len(items) < CRATE_SIZE
         return snap
 
     def _publish(fields: dict[str, Any]) -> None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -3411,7 +3411,7 @@ def create_app(
     @app.post("/api/v1/ui/active-view")
     def set_active_view(req: dict[str, Any]) -> dict[str, Any]:
         view = req.get("view", "library")
-        if view not in ("library", "now-playing", "home", "downloads"):
+        if view not in ("library", "now-playing", "home", "downloads", "crate"):
             raise HTTPException(status_code=422, detail="Invalid view")
         _state["ui_active_view"] = view
         if on_ui_state_set is not None:

--- a/kamp_daemon/config.py
+++ b/kamp_daemon/config.py
@@ -202,7 +202,9 @@ _CONFIG_KEY_CHOICES: dict[str, frozenset[str]] = {
         {"mp3-v0", "mp3-320", "flac", "aac-hi", "vorbis", "alac", "wav"}
     ),
     "bandcamp.collection_mode": frozenset({"stream", "download"}),
-    "ui.active_view": frozenset({"library", "now-playing", "home", "downloads"}),
+    "ui.active_view": frozenset(
+        {"library", "now-playing", "home", "downloads", "crate"}
+    ),
     "ui.sort_order": frozenset(
         {"album_artist", "album", "date_added", "last_played", "release_date"}
     ),

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -115,6 +115,10 @@ def build_crate(
         # name what is being dug through without the builder knowing any
         # provider's criteria.
         hints=list(profile.top_genres[:_HINT_LIMIT]),
+        # A brand-new library yields seeds for nothing but the chart, so the crate
+        # is real but un-personalised. The UI says so in one line rather than
+        # letting the picks imply a taste read we did not make.
+        thin=profile.is_thin,
     )
 
     try:

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { ExtensionPanel } from './components/ExtensionPanel'
 import { LibraryView } from './components/LibraryView'
 import { NowPlayingView } from './components/NowPlayingView'
 import { DownloadsView } from './components/DownloadsView'
+import { CrateView } from './components/CrateView'
 import { PreferencesDialog } from './components/PreferencesDialog'
 import { QueuePanel } from './components/QueuePanel'
 import { BandcampButton } from './components/BandcampButton'
@@ -73,6 +74,14 @@ registerBuiltInPanel({
   component: DownloadsView
 })
 registerBuiltInPanel({
+  id: 'kamp.crate',
+  // User-facing name (KAMP-643); `discovery` stays the code/API namespace.
+  title: 'The Crate',
+  defaultSlot: 'main',
+  compatibleSlots: ['main'],
+  component: CrateView
+})
+registerBuiltInPanel({
   id: 'kamp.collection',
   title: 'Collection',
   defaultSlot: 'left',
@@ -125,6 +134,11 @@ export default function App(): React.JSX.Element {
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const activeView = useStore((s) => s.activeView)
   const setActiveView = useStore((s) => s.setActiveView)
+  // KAMP-650: gates The Crate tab. Null until loadConfig() resolves — see the
+  // ringPanels filter and the force-switch effect below, both of which have to
+  // distinguish "not loaded yet" from "disconnected".
+  const configValuesForCrate = useStore((s) => s.configValues)
+  const bandcampConnected = configValuesForCrate?.['bandcamp.connected'] ?? false
   const togglePlayPause = useStore((s) => s.togglePlayPause)
   const next = useStore((s) => s.next)
   const prev = useStore((s) => s.prev)
@@ -264,6 +278,7 @@ export default function App(): React.JSX.Element {
           void loadQueue()
           void loadConfig()
           void useStore.getState().loadDownloads() // KAMP-568: seed Downloads view
+          void useStore.getState().loadCrate() // KAMP-650: seed The Crate
           // Reconcile pip state in case deferred_op.completed was missed
           // while the WS was disconnected.
           void getDeferredOps().then((ops) => {
@@ -344,6 +359,11 @@ export default function App(): React.JSX.Element {
         // rather than looking like a stalled queue.
         (items, pausedUntil) => {
           useStore.getState().setDownloadQueue(items, pausedUntil)
+        },
+        // KAMP-650: full crate snapshot → The Crate store slice. Fires once per
+        // placed record during a build, so the rail fills in as it is dug.
+        (snapshot) => {
+          useStore.getState().setCrate(snapshot)
         }
       )
     }
@@ -459,6 +479,18 @@ export default function App(): React.JSX.Element {
     if (!window.api.onCycleView) return
     return window.api.onCycleView((direction) => cycleViewRef.current(direction))
   }, [])
+
+  // KAMP-650: leave The Crate if Bandcamp gets disconnected while you are in it.
+  // The tab is filtered out of ringPanels when disconnected, and cycleView
+  // early-returns when the current view is not a ring member, so without this
+  // Ctrl+Tab goes dead. Gated on configValues being loaded: it is null until
+  // loadConfig() resolves and `?? false` reads that as disconnected, so an
+  // ungated switch would bounce a connected user out of the Crate on every
+  // launch — ui.active_view is persisted, so relaunching into it is normal.
+  useEffect(() => {
+    if (configValuesForCrate === null) return
+    if (activeView === 'crate' && !bandcampConnected) void setActiveView('library')
+  }, [configValuesForCrate, bandcampConnected, activeView, setActiveView])
 
   // Discover and load frontend extensions.
   // extState.disabledIds is captured at mount; re-runs if the disabled set changes
@@ -594,7 +626,14 @@ export default function App(): React.JSX.Element {
   // The view-cycle ring (KAMP-560) is exactly the rendered top-level tabs: main-slot
   // panels minus modal views. Downloads (KAMP-585) is an icon, not a tab, so it is
   // excluded. Single source of truth — used by both the rail render and cycleView.
-  const ringPanels = mainPanels.filter((panel) => panel.id !== 'kamp.downloads')
+  // The Crate (KAMP-650) is additionally gated on Bandcamp: with no account there
+  // is nothing to dig. `configValues` is null until loadConfig() resolves and
+  // `?? false` reads that as disconnected, so the tab appears a beat after launch
+  // rather than flickering out — and the force-switch below is gated on the same
+  // null so a connected user is never bounced out of the Crate on startup.
+  const ringPanels = mainPanels.filter(
+    (panel) => panel.id !== 'kamp.downloads' && (panel.id !== 'kamp.crate' || bandcampConnected)
+  )
 
   // Determine whether a given main-slot panel tab is active.
   const isActiveMain = (panel: UnifiedPanel): boolean => {
@@ -603,6 +642,7 @@ export default function App(): React.JSX.Element {
     if (panel.kind === 'builtin' && panel.id === 'kamp.library') return activeView === 'library'
     if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing')
       return activeView === 'now-playing'
+    if (panel.kind === 'builtin' && panel.id === 'kamp.crate') return activeView === 'crate'
     return false
   }
 
@@ -619,6 +659,9 @@ export default function App(): React.JSX.Element {
       if (selectedArtist !== null || selectedAlbum !== null) selectArtist(null)
     } else if (panel.kind === 'builtin' && panel.id === 'kamp.now-playing') {
       void setActiveView('now-playing')
+      setActiveExtPanel(null)
+    } else if (panel.kind === 'builtin' && panel.id === 'kamp.crate') {
+      void setActiveView('crate')
       setActiveExtPanel(null)
     } else if (panel.kind === 'extension') {
       setActiveExtPanel(panel.id)
@@ -684,6 +727,7 @@ export default function App(): React.JSX.Element {
     const isLibraryPane = !searchQuery && !activeExtPanel && activeView === 'library'
     const isNowPlayingPane = !searchQuery && !activeExtPanel && activeView === 'now-playing'
     const isDownloadsPane = !searchQuery && !activeExtPanel && activeView === 'downloads'
+    const isCratePane = !searchQuery && !activeExtPanel && activeView === 'crate'
     return (
       <>
         {/* key=panel.id forces a fresh component+DOM node on extension panel
@@ -701,6 +745,9 @@ export default function App(): React.JSX.Element {
         </div>
         <div className={isDownloadsPane ? 'view-pane view-pane--active' : 'view-pane'}>
           <DownloadsView active={isDownloadsPane} />
+        </div>
+        <div className={isCratePane ? 'view-pane view-pane--active' : 'view-pane'}>
+          <CrateView active={isCratePane} />
         </div>
       </>
     )

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -211,6 +211,31 @@ async function post<T>(path: string, body?: unknown): Promise<T> {
   return res.json() as Promise<T>
 }
 
+// Like post(), but surfaces the server's `detail` the way del()/patch() do.
+// post() has ~30 call sites and throws a bare "409 Conflict — <path>", which
+// loses the one thing worth telling the user (KAMP-650).
+async function postWithDetail<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers:
+      body !== undefined ? _authHeaders({ 'Content-Type': 'application/json' }) : _authHeaders(),
+    body: body !== undefined ? JSON.stringify(body) : undefined
+  })
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const json = (await res.json()) as { detail?: string }
+      if (json.detail) message = json.detail
+    } catch {
+      // JSON parse failed — fall back to the HTTP status message.
+    }
+    const err = new Error(message) as Error & { status?: number }
+    err.status = res.status
+    throw err
+  }
+  return res.json() as Promise<T>
+}
+
 async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`, { headers: _authHeaders(), signal })
   if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`)
@@ -398,8 +423,12 @@ export const scanLibrary = (): Promise<ScanResult> => post('/api/v1/library/scan
 export const setLibraryPath = (path: string): Promise<{ ok: boolean }> =>
   post('/api/v1/config/library-path', { path })
 
+// Keep in step with the allowlists in kamp_core/server.py and kamp_daemon/config.py:
+// a view the server rejects silently reverts to library on the next relaunch.
+export type ActiveView = 'library' | 'now-playing' | 'home' | 'downloads' | 'crate'
+
 export type UiState = {
-  active_view: 'library' | 'now-playing' | 'home' | 'downloads'
+  active_view: ActiveView
   sort_order:
     | 'album_artist'
     | 'album'
@@ -412,9 +441,8 @@ export type UiState = {
 }
 
 export const getUiState = (): Promise<UiState> => get('/api/v1/ui')
-export const setActiveViewApi = (
-  view: 'library' | 'now-playing' | 'home' | 'downloads'
-): Promise<{ ok: boolean }> => post('/api/v1/ui/active-view', { view })
+export const setActiveViewApi = (view: ActiveView): Promise<{ ok: boolean }> =>
+  post('/api/v1/ui/active-view', { view })
 export const setSortOrderApi = (
   sortOrder:
     | 'album_artist'
@@ -535,6 +563,60 @@ export const retryDownload = (id: string): Promise<{ ok: boolean }> =>
 
 export const cancelDownload = (id: string): Promise<{ ok: boolean }> =>
   del(`/api/v1/downloads/${encodeURIComponent(id)}`)
+
+// ---------------------------------------------------------------------------
+// The Crate (KAMP-650) — /api/v1/discovery surface
+// ---------------------------------------------------------------------------
+
+// One recommended album; mirrors LibraryIndex.crate_items(). Also the item shape
+// of the `discovery.crate` WS snapshot.
+export type CrateItem = {
+  id: number // AUTOINCREMENT and never reused — the key for /items/{id}/* and art
+  provider: string
+  provider_item_id: string
+  item_url: string
+  artist: string
+  title: string
+  art_url: string | null // nullable — gate crateArtUrl() on this being set
+  label: string
+  release_date: string
+  criterion: string // provider-scoped label, e.g. 'also_like'; never shown raw
+  why: string // the clerk-card line
+  seed: Record<string, unknown> // parsed seed_json; {} when the blob was malformed
+  crate_no: number | null
+  position: number | null
+  state: 'fresh' | 'previewed' | 'wishlisted' | 'dismissed' | 'purchased'
+  first_seen_at: number
+}
+
+export type CrateState = 'idle' | 'building' | 'ready' | 'empty' | 'error' | 'paused'
+
+// The whole crate in one payload. `filled`/`short` are authoritative: the daemon
+// derives them from the stored rows whenever no build is running, so they are
+// still right after a restart (KAMP-650).
+export type CrateSnapshot = {
+  state: CrateState
+  crate_no: number | null
+  filled: number
+  short: boolean
+  paused_until: number // Unix seconds; 0 when running
+  hints: string[] // the user's top genres, for the digging status lines
+  thin: boolean // a library with no listening history yet — chart picks only
+  items: CrateItem[]
+}
+
+export const getCrate = (): Promise<CrateSnapshot> => get('/api/v1/discovery/crate')
+
+// 409 while a crate is already building — postWithDetail keeps the server's
+// message ("a crate is already building") instead of a bare status line.
+export const newCrate = (): Promise<{ started: boolean }> =>
+  postWithDetail('/api/v1/discovery/crate/new')
+
+export const dismissCrateItem = (itemId: number): Promise<{ ok: boolean }> =>
+  post(`/api/v1/discovery/items/${itemId}/dismiss`)
+
+export const crateItemUrlCopied = (itemId: number): Promise<{ ok: boolean }> =>
+  post(`/api/v1/discovery/items/${itemId}/url-copied`)
 
 // ---------------------------------------------------------------------------
 // Player
@@ -1030,6 +1112,12 @@ export type DownloadQueueMessage = {
   // which is indistinguishable from a hang.
   paused_until?: number
 }
+// KAMP-650: the whole crate in one snapshot, broadcast on every build transition
+// and on every per-item event. Same shape as GET /api/v1/discovery/crate, which
+// is the source of truth on mount and reconnect — _broadcast no-ops with no
+// client attached, so a client that missed the build has to ask.
+export type DiscoveryCrateMessage = { type: 'discovery.crate' } & CrateSnapshot
+
 export type ServerMessage =
   | StateMessage
   | TrackChangedMessage
@@ -1041,6 +1129,7 @@ export type ServerMessage =
   | MagicPlaylistUpdatedMessage
   | PipelineStageMessage
   | DownloadQueueMessage
+  | DiscoveryCrateMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -1070,7 +1159,9 @@ export function connectStateStream(
   onAlbumPipelineStage?: (saleItemId: string | null, stage: string, committed: boolean) => void,
   // KAMP-568: full download-queue snapshot for the Downloads view. Appended last
   // so the existing positional callbacks keep their indices.
-  onDownloadQueue?: (items: DownloadItem[], pausedUntil: number) => void
+  onDownloadQueue?: (items: DownloadItem[], pausedUntil: number) => void,
+  // KAMP-650: full crate snapshot for The Crate view. Appended last, same reason.
+  onDiscoveryCrate?: (snapshot: CrateSnapshot) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -1092,8 +1183,10 @@ export function connectStateStream(
       else if (msg.type === 'magic_playlist.updated') onMagicPlaylistUpdated?.(msg.id)
       else if (msg.type === 'pipeline.stage')
         onAlbumPipelineStage?.(msg.sale_item_id ?? null, msg.stage, msg.committed ?? false)
-      else if (msg.type === 'download.queue')
-        onDownloadQueue?.(msg.items, msg.paused_until ?? 0)
+      else if (msg.type === 'download.queue') onDownloadQueue?.(msg.items, msg.paused_until ?? 0)
+      // DiscoveryCrateMessage is CrateSnapshot plus `type`, so it satisfies the
+      // callback as-is; the discriminator rides along inertly.
+      else if (msg.type === 'discovery.crate') onDiscoveryCrate?.(msg)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -1,0 +1,380 @@
+/* The Crate (KAMP-650) — focus card + crate rail.
+ *
+ * Every colour comes from a theme token. There are eight palettes and --accent
+ * swings from indigo to magenta to green, so a hardcoded hex would look wrong in
+ * seven of them. Sleeve states are distinguished by opacity, border weight and a
+ * glyph rather than by hue, for the same reason.
+ *
+ * All motion lives inside a prefers-reduced-motion: no-preference wrapper, and
+ * nothing animates height (the project rule — Electron makes it jerky).
+ */
+
+.crate-view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 20px 24px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.crate-banner {
+  border: 1px solid var(--border);
+  background: var(--surface-hover);
+  color: var(--text-dim);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+/* --- Empty / error composition ------------------------------------------- */
+
+.crate-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 64px 16px;
+  text-align: center;
+}
+
+.crate-empty-glyph {
+  font-size: 40px;
+  color: var(--text-dim);
+  opacity: 0.5;
+}
+
+.crate-empty-title {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.crate-empty-hint {
+  color: var(--text-dim);
+  font-size: 13px;
+  max-width: 42ch;
+}
+
+/* --- Focus card ----------------------------------------------------------- */
+
+.crate-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.crate-focus {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.crate-focus--digging {
+  min-height: 220px;
+  align-items: center;
+  justify-content: center;
+}
+
+.crate-focus-art {
+  flex: 0 0 auto;
+  width: 220px;
+  aspect-ratio: 1;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: 32px;
+}
+
+/* Same contract as .album-art: no JS fallback branch — an item with no art_url
+   (or a 404 the <img> reports) simply never gets .has-art and the glyph shows. */
+.crate-focus-art:not(.has-art)::before {
+  content: '♪';
+}
+
+.crate-focus-art-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: var(--bg);
+}
+
+.crate-focus-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.crate-focus-artist {
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.crate-focus-title {
+  color: var(--text);
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.crate-focus-position {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+/* The clerk card: a shelf tag, not body copy. Deliberately set apart from the
+   title block so the reason reads as something written by hand and slipped into
+   the sleeve. */
+.crate-clerk-card {
+  margin: 4px 0 2px;
+  padding: 7px 10px;
+  border-left: 2px solid var(--accent);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.4;
+  max-width: 52ch;
+}
+
+/* --- Actions -------------------------------------------------------------- */
+
+.crate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.crate-action {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.crate-action:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.crate-action--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.crate-action:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.crate-dig-btn {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.crate-dig-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.crate-dig-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* --- The rail ------------------------------------------------------------- */
+
+.crate-rail {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 10px 0 4px;
+  margin: 0;
+}
+
+.crate-rail:focus {
+  outline: none;
+}
+
+.crate-sleeve {
+  position: relative;
+  width: 72px;
+  cursor: pointer;
+  /* Static per-slot tilt from the component, so a rail reads as records in a bin
+     rather than a grid. Combined with the pull-out below in one transform. */
+  transform: rotate(var(--crate-tilt, 0deg));
+  transform-origin: bottom center;
+}
+
+.crate-sleeve-art {
+  aspect-ratio: 1;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: 18px;
+}
+
+.crate-sleeve-art:not(.has-art)::before {
+  content: '♪';
+}
+
+.crate-sleeve-art-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Focused: pulled out of the bin and outlined. Border weight and position carry
+   the state, not colour, so it survives every palette. */
+.crate-sleeve--focused {
+  transform: rotate(0deg) translateY(-8px);
+}
+
+.crate-sleeve--focused .crate-sleeve-art {
+  border-color: var(--accent);
+  border-width: 2px;
+}
+
+/* Dug (previewed / wishlisted / purchased) — no longer new, but not rejected. */
+.crate-sleeve--dug .crate-sleeve-art {
+  border-style: solid;
+  border-color: var(--text-dim);
+}
+
+.crate-sleeve--passed {
+  opacity: 0.35;
+}
+
+.crate-sleeve--wishlisted .crate-sleeve-art {
+  border-color: var(--accent);
+}
+
+.crate-sleeve-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--text-on-accent);
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+}
+
+.crate-sleeve--empty {
+  cursor: default;
+}
+
+.crate-sleeve--empty .crate-sleeve-art {
+  border-style: dashed;
+  background: transparent;
+  opacity: 0.5;
+}
+
+.crate-footer {
+  display: flex;
+  justify-content: center;
+  padding-top: 4px;
+}
+
+/* --- Undo toast ----------------------------------------------------------- */
+
+.crate-undo-toast {
+  position: fixed;
+  right: 16px;
+  bottom: calc(var(--transport-h) + 16px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  z-index: 900;
+  overflow: hidden;
+}
+
+.crate-undo-text {
+  color: var(--text-dim);
+}
+
+.crate-undo-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--accent);
+  border-radius: 3px;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.crate-undo-bar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  width: 100%;
+  background: var(--accent);
+  transform-origin: left center;
+}
+
+/* --- Motion --------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: no-preference) {
+  .crate-sleeve {
+    transition:
+      transform 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .crate-focus-art-img {
+    animation: crateArtIn 200ms ease both;
+  }
+
+  .crate-undo-bar {
+    animation: crateUndoBar linear forwards;
+  }
+
+  @keyframes crateArtIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes crateUndoBar {
+    from {
+      transform: scaleX(1);
+    }
+    to {
+      transform: scaleX(0);
+    }
+  }
+}

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -653,6 +653,10 @@ html[data-platform='win32'] .view-tabs {
 
 .collection-list li:focus-visible,
 .album-card:focus-visible,
+.crate-sleeve:focus-visible,
+.crate-action:focus-visible,
+.crate-dig-btn:focus-visible,
+.crate-undo-btn:focus-visible,
 .transport-btn:focus-visible,
 .back-btn:focus-visible,
 .play-all-btn:focus-visible,

--- a/kamp_ui/src/renderer/src/assets/main.css
+++ b/kamp_ui/src/renderer/src/assets/main.css
@@ -15,6 +15,7 @@
 @import './track-list.css';
 @import './queue.css';
 @import './downloads.css';
+@import './crate.css';
 @import './preferences.css';
 @import './extensions.css';
 @import './base-kamp.css';

--- a/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
@@ -1,0 +1,98 @@
+// One sleeve in the crate rail (KAMP-650).
+//
+// Sleeves are deliberately small and quiet: the rail is for orientation, the
+// focus card is where you actually read. State is conveyed by opacity, border
+// weight and a corner glyph rather than by hue — there is exactly one --accent
+// token and it swings from indigo to magenta to green across the eight themes,
+// so four hue-coded states could not stay legible in all of them.
+import React, { useState } from 'react'
+import { crateArtUrl } from '../api/client'
+import type { CrateItem } from '../api/client'
+
+// Static per-slot tilt so a rail of sleeves reads as records in a bin rather
+// than a grid. Derived from the index, not random, so it never jumps between
+// renders. Alternating sign, ~1-2 degrees.
+function tiltFor(index: number): number {
+  const magnitude = 1 + (index % 3) * 0.5
+  return index % 2 === 0 ? -magnitude : magnitude
+}
+
+export function CrateSleeve({
+  item,
+  index,
+  total,
+  focused,
+  passed,
+  onFocus
+}: {
+  item: CrateItem
+  index: number
+  total: number
+  focused: boolean
+  // Passed locally but not yet committed — the 5s Undo window.
+  passed: boolean
+  onFocus: (index: number) => void
+}): React.JSX.Element {
+  const [artFailed, setArtFailed] = useState(false)
+  const showArt = Boolean(item.art_url) && !artFailed
+
+  const classes = ['crate-sleeve']
+  if (focused) classes.push('crate-sleeve--focused')
+  if (passed || item.state === 'dismissed') classes.push('crate-sleeve--passed')
+  if (item.state === 'wishlisted') classes.push('crate-sleeve--wishlisted')
+  if (item.state !== 'fresh' && item.state !== 'dismissed') classes.push('crate-sleeve--dug')
+
+  return (
+    <li
+      className={classes.join(' ')}
+      role="option"
+      aria-selected={focused}
+      aria-setsize={total}
+      aria-posinset={index + 1}
+      aria-label={`${item.title} by ${item.artist}`}
+      // Roving tabindex: only the focused sleeve is reachable by Tab, and the
+      // arrow keys move which one that is. Keeping real DOM focus in the rail is
+      // what lets the view scope its key handling to its own container instead
+      // of listening on document (which would pre-empt every modal's Escape).
+      tabIndex={focused ? 0 : -1}
+      onClick={() => onFocus(index)}
+      style={{ '--crate-tilt': `${tiltFor(index)}deg` } as React.CSSProperties}
+    >
+      <div className={`crate-sleeve-art${showArt ? ' has-art' : ''}`}>
+        {showArt && (
+          <img
+            className="crate-sleeve-art-img"
+            src={crateArtUrl(item.id)}
+            alt=""
+            loading="lazy"
+            onError={() => setArtFailed(true)}
+          />
+        )}
+      </div>
+      {(passed || item.state === 'dismissed') && (
+        <span className="crate-sleeve-badge" aria-hidden="true">
+          ✕
+        </span>
+      )}
+      {item.state === 'wishlisted' && (
+        <span className="crate-sleeve-badge" aria-hidden="true">
+          ♥
+        </span>
+      )}
+    </li>
+  )
+}
+
+// An unfilled slot, shown while a crate is being dug so the rail has its full
+// shape from the first moment rather than growing a sleeve at a time.
+export function CrateSlot({ index }: { index: number }): React.JSX.Element {
+  return (
+    <li
+      className="crate-sleeve crate-sleeve--empty"
+      aria-hidden="true"
+      style={{ '--crate-tilt': `${tiltFor(index)}deg` } as React.CSSProperties}
+    >
+      <div className="crate-sleeve-art" />
+    </li>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -1,0 +1,24 @@
+// The Crate (KAMP-650) — a crate of ten records to dig through.
+//
+// User-facing name is "The Crate"; `discovery` stays the code/API namespace.
+// The whole crate arrives in one `discovery.crate` snapshot and is seeded from
+// GET /api/v1/discovery/crate on every WS (re)connect, since _broadcast no-ops
+// with no client attached.
+//
+// Plumbing only in this commit — the rail, the focus card and the keyboard model
+// land in the commits that follow.
+import React from 'react'
+import { useStore } from '../store'
+
+export function CrateView({ active = false }: { active?: boolean }): React.JSX.Element {
+  const crate = useStore((s) => s.crate)
+  void active
+
+  return (
+    <div className="crate-view">
+      <p className="crate-empty-hint">
+        {crate ? `Crate ${crate.crate_no ?? '—'}` : 'No crate yet.'}
+      </p>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -151,24 +151,35 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
 
   // The crate's own keys live on the view container, NOT on document. App's
   // global handler is a window listener and the React root sits below document
-  // in the bubble path, so stopPropagation here wins for Left/Right/W/X/C. A
-  // document listener would also win — and would pre-empt the Escape handling of
-  // every modal opened afterwards, since those are document listeners too and
-  // registration order decides.
+  // in the bubble path, so stopPropagation here wins. A document listener would
+  // also win — and would pre-empt the Escape handling of every modal opened
+  // afterwards, since those are document listeners too and registration order
+  // decides.
   //
-  // Space is deliberately NOT claimed. The ticket reserves it for preview, but
-  // preview lands in KAMP-651; swallowing it now would remove play/pause from a
-  // whole view of a music player for no gain.
+  // Digging is , and . rather than the arrows. The arrows are transport
+  // prev/next track globally, and taking them for the length of a whole view
+  // would strand a listener mid-album — the same objection that keeps Space
+  // unclaimed here (the ticket reserves it for preview, which is KAMP-651;
+  // swallowing it now would remove play/pause from a view of a music player for
+  // nothing).
+  //
+  // The arrows still work *inside the rail*, because that is the listbox
+  // contract a screen-reader user expects of a role="option" list and the scope
+  // is the widget rather than the view.
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-    const tag = (e.target as HTMLElement).tagName
-    if (tag === 'INPUT' || tag === 'TEXTAREA') return
+    const target = e.target as HTMLElement
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return
     if (e.metaKey || e.ctrlKey || e.altKey) return
 
-    if (e.key === 'ArrowRight') {
+    const inRail = railRef.current?.contains(target) ?? false
+    const isNext = e.key === '.' || (inRail && e.key === 'ArrowRight')
+    const isPrev = e.key === ',' || (inRail && e.key === 'ArrowLeft')
+
+    if (isNext) {
       e.preventDefault()
       e.stopPropagation()
       if (visible.length > 0) focusSleeve(Math.min(focusIndex + 1, visible.length - 1))
-    } else if (e.key === 'ArrowLeft') {
+    } else if (isPrev) {
       e.preventDefault()
       e.stopPropagation()
       if (visible.length > 0) focusSleeve(Math.max(focusIndex - 1, 0))

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -261,7 +261,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
 
       <div className="crate-stage">
         {current ? (
-          <article className="crate-focus" aria-live="polite">
+          <article className="crate-focus">
             <div className={`crate-focus-art${current.art_url ? ' has-art' : ''}`}>
               {current.art_url && (
                 <img
@@ -346,6 +346,14 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         </ul>
 
         <div className="crate-footer">{digButton}</div>
+
+        {/* The clerk card lives on the focus card, so arrowing the rail would
+            otherwise never announce it: the option's own aria-label and
+            aria-posinset already carry identity and position. Announcing only
+            the reason keeps this from double-reading every record. */}
+        <div className="sr-only" role="status" aria-live="polite">
+          {current ? `Record ${focusIndex + 1} of ${visible.length}. ${current.why}` : ''}
+        </div>
       </div>
 
       {undoItem && (

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -5,20 +5,358 @@
 // GET /api/v1/discovery/crate on every WS (re)connect, since _broadcast no-ops
 // with no client attached.
 //
-// Plumbing only in this commit — the rail, the focus card and the keyboard model
-// land in the commits that follow.
-import React from 'react'
+// Copy here follows the brand guardrails: the clerk's voice, concrete and dry,
+// and never the vocabulary of a recommender (algorithm, curated, personalized,
+// "made for you", match %, feed, radio, smart). The `why` line is the server's
+// and is rendered verbatim — it is the promise that every pick explains itself.
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../store'
+import { crateArtUrl } from '../api/client'
+import type { CrateItem } from '../api/client'
+import { CrateSleeve, CrateSlot } from './CrateSleeve'
+import { useTooltip } from '../hooks/useTooltip'
+import { TOOLTIPS } from '../tooltipStrings'
+
+const CRATE_SIZE = 10
+// How long a passed record can be brought back. The dismiss POST is held for
+// this long rather than sent and reversed: 'dismissed' is terminal server-side.
+const UNDO_MS = 5000
+
+function formatPause(seconds: number): string {
+  const total = Math.ceil(seconds)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return mins > 0 ? `${mins}:${String(secs).padStart(2, '0')}` : `${secs}s`
+}
 
 export function CrateView({ active = false }: { active?: boolean }): React.JSX.Element {
   const crate = useStore((s) => s.crate)
-  void active
+  const pendingDismissals = useStore((s) => s.crateDismissPending)
+  const newCrate = useStore((s) => s.newCrate)
+  const deferCrateDismiss = useStore((s) => s.deferCrateDismiss)
+  const undoCrateDismiss = useStore((s) => s.undoCrateDismiss)
+  const commitCrateDismiss = useStore((s) => s.commitCrateDismiss)
+  const flushCrateDismissals = useStore((s) => s.flushCrateDismissals)
+  const copyCrateItemUrl = useStore((s) => s.copyCrateItemUrl)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const tooltip = useTooltip()
+
+  const [focused, setFocused] = useState(0)
+  const [undoItem, setUndoItem] = useState<CrateItem | null>(null)
+  const undoTimerRef = useRef<number | null>(null)
+  const railRef = useRef<HTMLUListElement | null>(null)
+  const [pauseRemaining, setPauseRemaining] = useState(0)
+
+  const items = useMemo(() => crate?.items ?? [], [crate])
+  const state = crate?.state ?? 'idle'
+  const building = state === 'building'
+  // Never derived from `filled` outside a live build: the daemon's status is
+  // in-memory, so a restored crate reports the builder's last count. The
+  // snapshot derives both from the stored rows when idle (KAMP-650).
+  const visible = items.filter((item) => !pendingDismissals.includes(item.id))
+  const hasCrate = items.length > 0
+
+  // Rate-limit countdown, ticked locally so the daemon publishes the deadline
+  // once rather than broadcasting every second (the KAMP-639 downloads pattern).
+  const pausedUntil = crate?.paused_until ?? 0
+  useEffect(() => {
+    const tick = (): void =>
+      setPauseRemaining(pausedUntil ? Math.max(0, pausedUntil - Date.now() / 1000) : 0)
+    tick()
+    if (!pausedUntil) return
+    const id = window.setInterval(tick, 1000)
+    return () => window.clearInterval(id)
+  }, [pausedUntil])
+
+  // Clamped during render rather than corrected in an effect: the crate grows
+  // while a build streams and shrinks as records are passed, so the stored index
+  // can briefly point past the end. Deriving avoids a re-render round trip and
+  // the intermediate frame where the focus card would be blank.
+  const focusIndex = visible.length === 0 ? 0 : Math.min(focused, visible.length - 1)
+  const current = visible[focusIndex] ?? null
+
+  // Any held dismiss must be sent before this view stops being able to send it.
+  // Without this, passing a record and immediately switching views loses it.
+  useEffect(() => {
+    if (active) return
+    void flushCrateDismissals()
+  }, [active, flushCrateDismissals])
+  useEffect(() => {
+    return () => {
+      void useStore.getState().flushCrateDismissals()
+    }
+  }, [])
+
+  const clearUndoTimer = useCallback((): void => {
+    if (undoTimerRef.current !== null) {
+      window.clearTimeout(undoTimerRef.current)
+      undoTimerRef.current = null
+    }
+  }, [])
+
+  const pass = useCallback(
+    (item: CrateItem): void => {
+      // Commit whatever was already waiting — only one Undo is offered at a time,
+      // and the previous one's window is over the moment a new pass happens.
+      if (undoItem && undoItem.id !== item.id) void commitCrateDismiss(undoItem.id)
+      clearUndoTimer()
+      deferCrateDismiss(item.id)
+      setUndoItem(item)
+      undoTimerRef.current = window.setTimeout(() => {
+        undoTimerRef.current = null
+        setUndoItem(null)
+        void commitCrateDismiss(item.id)
+      }, UNDO_MS)
+    },
+    [clearUndoTimer, commitCrateDismiss, deferCrateDismiss, undoItem]
+  )
+
+  const undo = useCallback((): void => {
+    if (!undoItem) return
+    clearUndoTimer()
+    undoCrateDismiss(undoItem.id)
+    setUndoItem(null)
+  }, [clearUndoTimer, undoCrateDismiss, undoItem])
+
+  // Preview ("Give it a spin") is KAMP-651 — there is no preview route yet — so
+  // the primary action is the honest one available now: the album's own page.
+  const openOnBandcamp = useCallback((item: CrateItem): void => {
+    if (item.item_url) window.api.openExternal(item.item_url)
+  }, [])
+
+  const focusSleeve = useCallback((index: number): void => {
+    setFocused(index)
+    // Move real DOM focus with the selection so the roving tabindex stays
+    // coherent and the container keeps receiving keys.
+    const rail = railRef.current
+    const option = rail?.querySelectorAll<HTMLElement>('[role="option"]')[index]
+    option?.focus()
+  }, [])
+
+  // Escape leaves the view. Deliberately a window listener, matching
+  // DownloadsView: modals listen on document, which runs first, so Escape closes
+  // an open dialog rather than dropping the user out of the Crate underneath it.
+  useEffect(() => {
+    if (!active) return
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      const prev = useStore.getState().previousView
+      void setActiveView(prev && prev !== 'crate' ? prev : 'library')
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [active, setActiveView])
+
+  // The crate's own keys live on the view container, NOT on document. App's
+  // global handler is a window listener and the React root sits below document
+  // in the bubble path, so stopPropagation here wins for Left/Right/W/X/C. A
+  // document listener would also win — and would pre-empt the Escape handling of
+  // every modal opened afterwards, since those are document listeners too and
+  // registration order decides.
+  //
+  // Space is deliberately NOT claimed. The ticket reserves it for preview, but
+  // preview lands in KAMP-651; swallowing it now would remove play/pause from a
+  // whole view of a music player for no gain.
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const tag = (e.target as HTMLElement).tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (visible.length > 0) focusSleeve(Math.min(focusIndex + 1, visible.length - 1))
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (visible.length > 0) focusSleeve(Math.max(focusIndex - 1, 0))
+    } else if (e.key === 'x' || e.key === 'X') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (current) pass(current)
+    } else if (e.key === 'c' || e.key === 'C') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (current) void copyCrateItemUrl(current)
+    } else if (e.key === 'w' || e.key === 'W') {
+      // Claimed so it does not fall through to a global shortcut, but wishlist
+      // itself is unavailable until KAMP-653 extends the Electron relay.
+      e.preventDefault()
+      e.stopPropagation()
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Compositions
+  // ---------------------------------------------------------------------------
+
+  const banner = ((): React.JSX.Element | null => {
+    if (pauseRemaining > 0)
+      return (
+        <div className="crate-banner" role="status">
+          The distributor&rsquo;s on the phone — back in {formatPause(pauseRemaining)}.
+        </div>
+      )
+    if (state === 'ready' && crate?.short)
+      return (
+        <div className="crate-banner" role="status">
+          Short crate today — Bandcamp asked us to slow down.
+        </div>
+      )
+    if (crate?.thin && hasCrate)
+      return (
+        <div className="crate-banner" role="status">
+          Nothing on your shelves to go on yet, so this one is what&rsquo;s selling.
+        </div>
+      )
+    return null
+  })()
+
+  const digButton = (
+    <button
+      className="crate-dig-btn"
+      onClick={() => void newCrate()}
+      disabled={building || pauseRemaining > 0}
+    >
+      {hasCrate ? 'Dig up another crate' : 'Dig up a crate'}
+    </button>
+  )
+
+  if (!hasCrate && !building) {
+    return (
+      <div className="crate-view crate-view--empty">
+        {banner}
+        <div className="crate-empty">
+          <div className="crate-empty-glyph" aria-hidden="true">
+            ⬓
+          </div>
+          {state === 'error' ? (
+            <>
+              <p className="crate-empty-title">Couldn&rsquo;t get a crate together.</p>
+              <p className="crate-empty-hint">
+                Bandcamp might be having a moment. Worth another go.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="crate-empty-title">Nothing in the crate yet.</p>
+              <p className="crate-empty-hint">
+                Ten records pulled from the racks, based on what you already play.
+              </p>
+            </>
+          )}
+          {digButton}
+        </div>
+      </div>
+    )
+  }
+
+  const slots = building ? Math.max(CRATE_SIZE - visible.length, 0) : 0
 
   return (
-    <div className="crate-view">
-      <p className="crate-empty-hint">
-        {crate ? `Crate ${crate.crate_no ?? '—'}` : 'No crate yet.'}
-      </p>
+    <div className="crate-view" onKeyDown={onKeyDown}>
+      {banner}
+
+      <div className="crate-stage">
+        {current ? (
+          <article className="crate-focus" aria-live="polite">
+            <div className={`crate-focus-art${current.art_url ? ' has-art' : ''}`}>
+              {current.art_url && (
+                <img
+                  className="crate-focus-art-img"
+                  src={crateArtUrl(current.id)}
+                  alt=""
+                  key={current.id}
+                />
+              )}
+            </div>
+            <div className="crate-focus-meta">
+              <p className="crate-focus-artist">{current.artist}</p>
+              <h2 className="crate-focus-title">{current.title}</h2>
+              {current.why && (
+                <p className="crate-clerk-card" {...tooltip(TOOLTIPS.CRATE_WHY)}>
+                  {current.why}
+                </p>
+              )}
+              <p className="crate-focus-position">
+                Record {focusIndex + 1} of {visible.length}
+                {current.release_date ? ` · ${current.release_date.slice(0, 4)}` : ''}
+              </p>
+              <div className="crate-actions">
+                <button
+                  className="crate-action crate-action--primary"
+                  onClick={() => openOnBandcamp(current)}
+                  disabled={!current.item_url}
+                >
+                  Open on Bandcamp
+                </button>
+                <button
+                  className="crate-action"
+                  disabled
+                  {...tooltip(TOOLTIPS.CRATE_WISHLIST_SOON)}
+                >
+                  Wishlist it
+                </button>
+                <button
+                  className="crate-action"
+                  onClick={() => void copyCrateItemUrl(current)}
+                  {...tooltip(TOOLTIPS.CRATE_COPY)}
+                >
+                  Copy link
+                </button>
+                <button
+                  className="crate-action"
+                  onClick={() => pass(current)}
+                  {...tooltip(TOOLTIPS.CRATE_PASS)}
+                >
+                  Pass
+                </button>
+              </div>
+            </div>
+          </article>
+        ) : (
+          <div className="crate-focus crate-focus--digging">
+            <p className="crate-empty-hint">Digging through the racks…</p>
+          </div>
+        )}
+
+        <ul
+          className="crate-rail"
+          role="listbox"
+          aria-label="The Crate"
+          ref={railRef}
+          tabIndex={-1}
+        >
+          {visible.map((item, index) => (
+            <CrateSleeve
+              key={item.id}
+              item={item}
+              index={index}
+              total={visible.length}
+              focused={index === focusIndex}
+              passed={pendingDismissals.includes(item.id)}
+              onFocus={focusSleeve}
+            />
+          ))}
+          {Array.from({ length: slots }, (_unused, i) => (
+            <CrateSlot key={`slot-${i}`} index={visible.length + i} />
+          ))}
+        </ul>
+
+        <div className="crate-footer">{digButton}</div>
+      </div>
+
+      {undoItem && (
+        <div className="crate-undo-toast" role="status">
+          <span className="crate-undo-text">Passed on {undoItem.title}.</span>
+          <button className="crate-undo-btn" onClick={undo}>
+            Undo
+          </button>
+          <div className="crate-undo-bar" style={{ animationDuration: `${UNDO_MS}ms` }} />
+        </div>
+      )}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -39,6 +39,15 @@ const GROUPS: Group[] = [
     shortcuts: [{ keys: ['Shift', 'click'], description: 'Range select in Next Up' }]
   },
   {
+    label: 'The Crate',
+    shortcuts: [
+      { keys: ['←', '→'], description: 'Previous / next record' },
+      { keys: ['C'], description: 'Copy link' },
+      { keys: ['X'], description: 'Pass', note: 'Undo for 5 seconds' },
+      { keys: ['Esc'], description: 'Leave the crate' }
+    ]
+  },
+  {
     label: 'View',
     shortcuts: [
       { keys: [mod, '+'], description: 'Zoom in' },

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -41,7 +41,11 @@ const GROUPS: Group[] = [
   {
     label: 'The Crate',
     shortcuts: [
-      { keys: ['←', '→'], description: 'Previous / next record' },
+      {
+        keys: [',', '.'],
+        description: 'Previous / next record',
+        note: 'Arrows stay on the transport; ← → also work inside the rail'
+      },
       { keys: ['C'], description: 'Copy link' },
       { keys: ['X'], description: 'Pass', note: 'Undo for 5 seconds' },
       { keys: ['Esc'], description: 'Leave the crate' }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -10,9 +10,12 @@ import { create } from 'zustand'
 import * as api from './api/client'
 import type { RepeatMode } from './api/client'
 import type {
+  ActiveView,
   Album,
   AlbumTagsCollision,
   ConfigValues,
+  CrateItem,
+  CrateSnapshot,
   CriteriaDoc,
   DownloadItem,
   PlayerState,
@@ -86,10 +89,10 @@ type PlayerStore = {
   peakDb: number | null
 
   configuredLibraryPath: string | null
-  activeView: 'library' | 'now-playing' | 'home' | 'downloads'
+  activeView: ActiveView
   // Last view active before the current one, used so Esc in Downloads can return
   // to where the user came from. In-memory only (not persisted to daemon UI state).
-  previousView: 'library' | 'now-playing' | 'home' | 'downloads' | null
+  previousView: ActiveView | null
   moduleOrder: string[]
   hiddenModules: string[]
   moduleDisplayStyles: Record<string, DisplayStyle>
@@ -167,6 +170,16 @@ type PlayerStore = {
   // Null when the queue is idle (bar hidden). Maintained in setDownloadQueue (done/
   // total) and setAlbumProgress (live floor); the bar just renders `floor`.
   downloadBatch: { seenIds: string[]; total: number; done: number; floor: number } | null
+  // KAMP-650: the current Discovery Crate. Seeded by loadCrate() on every WS
+  // (re)connect and kept live by the `discovery.crate` event. Null until the
+  // first snapshot arrives, which the view renders as "not dug yet" rather than
+  // as an error.
+  crate: CrateSnapshot | null
+  // Items passed locally but whose dismiss POST has not been sent yet. Pass is
+  // deferred rather than optimistic because 'dismissed' is terminal server-side
+  // (discovery_events has no un-dismiss kind and the state rank is monotonic),
+  // so an Undo has to happen before the request, not after it.
+  crateDismissPending: number[]
   flashToast: string | null
   // KAMP-571: tone for the current flashToast; 'error' renders the red variant.
   flashToastTone: 'error' | null
@@ -185,7 +198,7 @@ type PlayerStore = {
   ) => Promise<void>
   setSortDir: (dir: 'asc' | 'desc') => Promise<void>
   setLibraryFilter: (filters: string[]) => void
-  setActiveView: (view: 'library' | 'now-playing' | 'home' | 'downloads') => Promise<void>
+  setActiveView: (view: ActiveView) => Promise<void>
   setModuleOrder: (ids: string[]) => void
   hideModule: (id: string) => void
   showModule: (id: string) => void
@@ -210,6 +223,19 @@ type PlayerStore = {
   reorderDownloadQueue: (orderedQueuedIds: string[]) => Promise<void>
   retryDownload: (providerItemId: string) => Promise<void>
   cancelDownload: (providerItemId: string) => Promise<void>
+  // KAMP-650: The Crate
+  loadCrate: () => Promise<void>
+  setCrate: (snapshot: CrateSnapshot) => void
+  newCrate: () => Promise<void>
+  // Marks an item passed locally and holds the POST. Call commitCrateDismiss to
+  // send it or undoCrateDismiss to cancel — see crateDismissPending.
+  deferCrateDismiss: (itemId: number) => void
+  undoCrateDismiss: (itemId: number) => void
+  commitCrateDismiss: (itemId: number) => Promise<void>
+  // Sends every held dismiss at once. Must be called when the view unmounts or
+  // the user navigates away, or a pass made in the last few seconds is lost.
+  flushCrateDismissals: () => Promise<void>
+  copyCrateItemUrl: (item: CrateItem) => Promise<void>
   showFlashToast: (msg: string, tone?: 'error') => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
@@ -541,6 +567,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadQueue: [],
   downloadPausedUntil: 0,
   downloadBatch: null,
+  crate: null,
+  crateDismissPending: [],
   flashToast: null,
   flashToastTone: null,
   styleRailVisible: false,
@@ -882,6 +910,72 @@ export const useStore = create<PlayerStore>((set, get) => ({
       const msg = err instanceof Error ? err.message : 'Could not cancel download'
       get().showFlashToast(msg)
       void get().loadDownloads()
+    }
+  },
+  // ---------------------------------------------------------------------------
+  // The Crate (KAMP-650)
+  // ---------------------------------------------------------------------------
+  loadCrate: async () => {
+    try {
+      set({ crate: await api.getCrate() })
+    } catch {
+      // Best-effort, like loadDownloads: the WS snapshot populates on the next
+      // transition, and a crate that never loads renders as "not dug yet".
+    }
+  },
+  setCrate: (snapshot) => set({ crate: snapshot }),
+  newCrate: async () => {
+    try {
+      await api.newCrate()
+      // No optimistic state: the builder publishes state:'building' immediately,
+      // and inventing a local 'building' would race a 409 we already lost.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not dig a crate'
+      get().showFlashToast(msg)
+    }
+  },
+  deferCrateDismiss: (itemId) =>
+    set((s) => ({
+      crateDismissPending: s.crateDismissPending.includes(itemId)
+        ? s.crateDismissPending
+        : [...s.crateDismissPending, itemId]
+    })),
+  undoCrateDismiss: (itemId) =>
+    set((s) => ({ crateDismissPending: s.crateDismissPending.filter((id) => id !== itemId) })),
+  commitCrateDismiss: async (itemId) => {
+    // Already undone while the timer was running.
+    if (!get().crateDismissPending.includes(itemId)) return
+    set((s) => ({ crateDismissPending: s.crateDismissPending.filter((id) => id !== itemId) }))
+    try {
+      await api.dismissCrateItem(itemId)
+      // The daemon re-broadcasts the whole snapshot after a dismiss, so the
+      // authoritative state arrives on its own.
+    } catch {
+      // The pass is lost rather than wrongly shown as kept — reload so the UI
+      // matches the server instead of quietly disagreeing with it.
+      void get().loadCrate()
+    }
+  },
+  flushCrateDismissals: async () => {
+    const pending = get().crateDismissPending
+    if (pending.length === 0) return
+    set({ crateDismissPending: [] })
+    await Promise.all(
+      pending.map((id) =>
+        api.dismissCrateItem(id).catch(() => {
+          // Best-effort on the way out; loadCrate() on the next mount reconciles.
+        })
+      )
+    )
+  },
+  copyCrateItemUrl: async (item) => {
+    try {
+      await navigator.clipboard.writeText(item.item_url)
+      get().showFlashToast('Link copied.')
+      // Recorded as engagement; deliberately does not change the item's state.
+      void api.crateItemUrlCopied(item.id).catch(() => {})
+    } catch {
+      get().showFlashToast('Could not copy the link', 'error')
     }
   },
   showFlashToast: (msg, tone) => {

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -47,6 +47,13 @@ export const TOOLTIPS = {
   // Downloads
   DOWNLOADS_VIEW: 'Downloads',
 
+  // The Crate (KAMP-650). The clerk card's tooltip is the plain mechanical
+  // answer to "why am I seeing this?" — the shelf tag is the short version.
+  CRATE_WHY: 'Picked from your own library and listening — nothing leaves this machine',
+  CRATE_WISHLIST_SOON: 'Wishlisting from Kamp is coming — copy the link for now',
+  CRATE_COPY: 'Copy link (C)',
+  CRATE_PASS: 'Pass (X)',
+
   // Track / album favorites
   ALBUM_FAVORITE_ADD: 'Add to favorites',
   ALBUM_FAVORITE_REMOVE: 'Remove from favorites'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -316,6 +316,14 @@ class TestConfigSet:
         config = Config.load(db)
         assert config.ui.active_view == "home"
 
+    def test_ui_active_view_crate_is_valid(self, db: LibraryIndex) -> None:
+        """Both allowlists must agree — server.py accepts the POST, config.py is
+        what survives a restart."""
+        Config.write_defaults(db)
+        config_set(db, "ui.active_view", "crate")
+        config = Config.load(db)
+        assert config.ui.active_view == "crate"
+
     def test_ui_sort_order_valid(self, db: LibraryIndex) -> None:
         Config.write_defaults(db)
         config_set(db, "ui.sort_order", "last_played")

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -128,6 +128,40 @@ class TestCrateSnapshot:
         assert pushed["type"] == CRATE_EVENT
         assert {k: v for k, v in pushed.items() if k != "type"} == rest
 
+    def test_a_restored_crate_reports_what_is_actually_in_it(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The status is in-memory and the crate is not, so after a daemon restart
+        _status is still _INITIAL_STATUS while items holds a full crate.
+
+        Reporting filled=0 for a crate of ten made the UI's fill progress wrong on
+        every launch, and short=False for a crate that really is short suppressed
+        the quiet note. Both are derived from items whenever no build is running.
+        """
+        _stock(index, 1, count=10)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["state"] == "idle"
+        assert body["filled"] == 10
+        assert body["short"] is False
+
+    def test_a_restored_short_crate_still_reads_as_short(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1, count=4)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["filled"] == 4
+        assert body["short"] is True
+
+    def test_a_live_build_keeps_its_own_progress(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """While building, filled counts what has landed so far and must NOT be
+        overwritten by the (already larger) row count of a previous crate."""
+        _stock(index, 1, count=10)
+        harness.publish({"state": "building", "filled": 3, "short": False})
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["filled"] == 3
+
     def test_publishing_pushes_to_clients(self, harness: _Harness) -> None:
         harness.publish({"state": "building", "hints": ["dub techno"]})
         assert harness.events[-1]["state"] == "building"

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -414,6 +414,35 @@ class TestPublication:
         # 0 on the opening 'building' push, then one per row as it is committed.
         assert filled == list(range(CRATE_SIZE + 1))
 
+    def test_a_thin_profile_is_announced(self, index: LibraryIndex) -> None:
+        """A brand-new library gets a real crate, but an un-personalised one — the
+        UI says so rather than letting chart picks imply a taste read."""
+        publisher = _Publisher()
+        _build(
+            index,
+            _FakeSource(_spread({"best_seller": 12})),
+            publish=publisher,
+            profile=SeedProfile(),
+        )
+        assert publisher.pushes[0]["thin"] is True
+
+    def test_a_real_profile_is_not_thin(self, index: LibraryIndex) -> None:
+        publisher = _Publisher()
+        _build(
+            index,
+            _FakeSource(_spread({"a": 12})),
+            publish=publisher,
+            profile=SeedProfile(top_genres=["dub techno"]),
+        )
+        assert publisher.pushes[0]["thin"] is False
+
+    def test_crate_size_matches_the_api_layer(self) -> None:
+        """CRATE_SIZE is spelled twice — kamp_core cannot import kamp_daemon — and
+        a drift would make the API call a full crate short."""
+        from kamp_core.discovery_api import CRATE_SIZE as API_CRATE_SIZE
+
+        assert API_CRATE_SIZE == CRATE_SIZE
+
     def test_hints_carry_the_profile_genres(self, index: LibraryIndex) -> None:
         """KAMP-650 rotates status lines naming what is being dug through.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2110,6 +2110,13 @@ class TestUiStateEndpoints:
         assert resp.status_code == 200
         assert client.get("/api/v1/ui").json()["active_view"] == "downloads"
 
+    def test_set_active_view_crate_persists(self, client: TestClient) -> None:
+        """The Crate view (KAMP-650). Without this the round-trip 422s and the
+        view silently reverts to library on every relaunch."""
+        resp = client.post("/api/v1/ui/active-view", json={"view": "crate"})
+        assert resp.status_code == 200
+        assert client.get("/api/v1/ui").json()["active_view"] == "crate"
+
     def test_set_active_view_invalid_returns_422(self, client: TestClient) -> None:
         resp = client.post("/api/v1/ui/active-view", json={"view": "bogus"})
         assert resp.status_code == 422


### PR DESCRIPTION
## Summary

The Crate is visible. A tab appears when Bandcamp is connected, showing a focus card and a rail of ten sleeves you dig through, each one saying in the clerk's voice why it is there.

| Commit | What |
| --- | --- |
| C1 | Backend: make the snapshot honest after a restart; publish `thin`; accept `"crate"` |
| C2 | Plumbing — types, WS variant + dispatch, REST helpers, store slice, scaffolding |
| C3 | The crate — focus card, rail, clerk card, states, actions, keyboard |
| C4 | Screen-reader announcement |
| C5 | Dig with `,` / `.` so the arrows stay on the transport |

## Scope: this was a Box Set, not a 2xLP

Split with @tterry's agreement. The end-of-crate ceremony is now **KAMP-663**, and the split is not arbitrary — **its session tally cannot be computed from the crate snapshot**. `discovery_items.state` is highest-rank-wins, so a record previewed and then passed reads only `dismissed`; `url_copied` maps to `fresh` by design; and `previewed` is structurally 0 until KAMP-651 ships preview at all. An honest tally needs KAMP-655's `discovery_events` ledger, so KAMP-663 depends on it.

## Four findings that changed the ticket

**Undo cannot work server-side.** `discovery_events.kind` is CHECK-constrained to six kinds with no un-dismiss, and the state rank is monotonic, so `dismissed` is terminal. Worse, `dismiss` re-broadcasts the whole snapshot, so an optimistic local revert is clobbered within milliseconds. Pass therefore **holds its POST** for the 5s window and sends it when the toast expires — and flushes held dismissals when the view goes inactive and on unmount, or a pass made just before switching views would vanish silently.

**`filled` and `short` were stale after a daemon restart** — my defect from KAMP-648, fixed here rather than papered over. `_snapshot()` backfilled only `crate_no` and `items`, so a restored ten-item crate reported `filled: 0` and a genuinely short one reported `short: false`. Both are now derived from the stored rows whenever no build is in flight; a live build keeps its own count, which is ahead of the rows.

**A `document` keydown handler would have broken Escape for every modal.** Fifteen components listen on document-bubble; same target and phase means registration order wins, and a handler registered at view activation precedes every modal opened afterwards. The crate's keys live on the **view container** instead — the React root sits below document in the bubble path, so `stopPropagation` still beats App's window handler for the arrows and W/X/C, without pre-empting anything. Escape stays a window listener so a dialog opened from the Crate closes rather than dropping you out of the view beneath it.

That decision also settled the a11y one. I had planned `aria-activedescendant` since `GenreChipsInput` is the repo's only precedent — but that pattern exists there because a combobox must keep DOM focus in its `<input>`, which doesn't transfer. **Roving tabindex**, as the ticket originally asked, keeps focus inside the rail, which is exactly what makes container-scoped key handling work. The ticket was right and my deviation was wrong.

**Space is deliberately not claimed.** The ticket reserves it for preview, but preview is KAMP-651 — `preventDefault`ing it for a no-op would remove play/pause from a whole view of a music player. "Reserved" is honoured by binding nothing else to it.

**Digging is `,` and `.`, not the arrows** (C5). The arrows are global prev/next *track*, and claiming them for the length of a whole view strands a listener mid-album — the same objection that keeps Space unclaimed, so the ticket's Left/Right binding was inconsistent with its own Space reasoning. `,`/`.` are unclaimed (only `Cmd+,` is taken, and the handler bails on modifiers). The arrows still work **inside the rail**, scoped by a containment check on the event target: that is the listbox contract a screen-reader user expects of a `role="option"` list, and scoping it to the widget rather than the view leaves the transport alone everywhere else.

## Other decisions

- **The primary action is "Open on Bandcamp."** "Give it a spin" is preview copy and there is no preview route yet; wishlist renders disabled with a tooltip until KAMP-653. Rather than ship two dead buttons, the honest available action gets the primary slot.
- **Sleeve states use opacity, border weight and a glyph — never hue.** There is one `--accent` token and it swings from indigo to magenta to green across the eight palettes, so four hue-coded states could not stay legible in all of them.
- **The live region announces the position and the reason only.** Options already carry identity via `aria-label` and position via `aria-setsize`/`aria-posinset`, so repeating both would read every arrow press twice — but the clerk card lives on the focus card and would otherwise never be announced.
- **The force-switch out of the Crate is gated on `configValues !== null`.** It is null until `loadConfig()` resolves and `?? false` reads that as disconnected, so an ungated switch would bounce a connected user out on every launch — `ui.active_view` is persisted, so relaunching into the Crate is normal.
- `newCrate` uses a new `postWithDetail` so the 409 arrives as "a crate is already building"; `post()` has ~30 call sites and could not be changed in place.

## Test plan

- [x] `poetry run pytest` — **2952 passed, 9 skipped, 3 deselected**, coverage **93.95%**
- [x] `black --check`, `mypy`, `npm run typecheck`, `npm run lint` all clean
- [x] Falsified the snapshot fix: disabling the derivation fails both restored-crate tests
- [x] `"crate"` round-trips through both allowlists — `server.py` validates the POST, `config.py` is what survives a restart, and a view accepted by one and not the other silently reverts
- [x] `thin` rides the building publish; `CRATE_SIZE` is asserted equal across the two modules that must spell it separately
- [x] No hardcoded colours in `crate.css`; all motion inside a `prefers-reduced-motion: no-preference` wrapper
- [x] No banned vocabulary in any user-visible string (the only grep hits are the comment that lists them)

There is **no renderer test runner in `kamp_ui`**, so everything visual is for your eye.

## Manual test plan

- **Tab gating** — connect/disconnect Bandcamp in Preferences; the tab appears and disappears without a restart. From a cold start, confirm it appears once config loads **without bouncing you out of whatever view you were in**.
- **Building** — "Dig up a crate": ten slots, sleeves landing one at a time.
- **Ready** — art on every card, a clerk line that reads like a shelf tag, at most one honestly-labelled chart pick.
- **Keyboard only** — `,`/`.` move along the rail, C copies, X passes, Esc leaves. Confirm **Space still plays and pauses, and ←/→ still skip tracks** while you are in the Crate — then click a sleeve and confirm ←/→ move along the rail once focus is *in* the rail. Open Preferences from inside the Crate and confirm **Esc closes the dialog** rather than leaving the view.
- **Pass + Undo** — the sleeve dims and the card advances at once; Undo within 5s restores it and it is still there after a reload. Pass and *immediately* switch views — the dismissal must still stick.
- **Persistence** — switch views and back; quit and relaunch.
- **Paused** — dig repeatedly until Bandcamp 429s; expect the countdown banner, not a hang.
- **Themes** — check the rail states stay legible on a light-accent and a dark-accent palette.

Closes KAMP-650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
