### PR TITLE
KAMP-651: preview playback — isolated second mpv engine + in-card mini-player

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -23,7 +23,7 @@ import os
 import re
 import threading
 from pathlib import Path
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING, cast
 
 from fastapi import FastAPI, HTTPException, Response
 
@@ -38,6 +38,25 @@ logger = logging.getLogger(__name__)
 #: ``download.queue`` snapshot idiom rather than streaming per-item deltas —
 #: a reconnecting client then needs no replay, just the REST snapshot.
 CRATE_EVENT = "discovery.crate"
+
+#: Preview transport state (KAMP-651). Pushed on transitions rather than per
+#: frame; the UI interpolates position between them from position_updated_at.
+PREVIEW_EVENT = "discovery.preview"
+
+#: What GET .../preview/state returns when no preview engine exists at all —
+#: the same shape the player publishes, so the UI has one branch, not two.
+_IDLE_PREVIEW: dict[str, Any] = {
+    "state": "idle",
+    "item_id": None,
+    "track_num": None,
+    "title": "",
+    "position": 0.0,
+    "position_updated_at": 0.0,
+    "duration": 0.0,
+    "buffering": False,
+    "tracks": [],
+    "error": None,
+}
 
 #: Records in a full crate. Mirrors discovery_builder.CRATE_SIZE, duplicated
 #: rather than imported because kamp_core does not depend on kamp_daemon.
@@ -133,6 +152,7 @@ def register_discovery_routes(
     on_build_start: Callable[[], None] | None = None,
     art_cache_dir: Path | None = None,
     fetch_bytes: Callable[[str], bytes | None] | None = None,
+    preview: Any = None,
 ) -> None:
     """Register the Discovery Crate routes on *app*.
 
@@ -140,6 +160,12 @@ def register_discovery_routes(
     reporting progress. It updates the status and broadcasts in one step so
     "changed the state but forgot to notify" is not representable — the failure
     that presents as a backend which works and a UI that never moves.
+
+    *preview* is a ``kamp_daemon.discovery_preview.PreviewPlayer``, taken as
+    ``Any`` because kamp_core does not depend on kamp_daemon. It is optional so
+    the routes still register (and 503) in a test app that has no engine.
+    Also exposes ``app.state.discovery_preview_snapshot`` for the WS accept
+    frame and ``app.state.stop_preview`` for the main transport.
     """
     _status: dict[str, Any] = dict(_INITIAL_STATUS)
     # Guards _status and the single-build flag together. Builds are serialized
@@ -255,6 +281,76 @@ def register_discovery_routes(
         wishlist afterwards.
         """
         return _record(item_id, "url_copied")
+
+    # ------------------------------------------------------------------
+    # Preview (KAMP-651)
+    # ------------------------------------------------------------------
+
+    def _preview_or_503() -> Any:
+        if preview is None:
+            raise HTTPException(status_code=503, detail="preview is unavailable")
+        return preview
+
+    def _push_preview(snapshot: dict[str, Any]) -> None:
+        broadcast({"type": PREVIEW_EVENT, **snapshot})
+
+    # The player is built before create_app, so it cannot be handed this
+    # directly; the daemon looks it up here at call time instead (the same
+    # deferred-lookup the notify_* helpers use).
+    app.state.discovery_preview_publish = _push_preview
+
+    if preview is not None:
+        # The player owns its own state; this is only how it reaches clients.
+        app.state.discovery_preview_snapshot = preview.snapshot
+        # The main transport always wins. Exposed for the player endpoints in
+        # server.py, following the drain_for_track_async precedent.
+        app.state.stop_preview = preview.release_for_main
+
+    @app.get("/api/v1/discovery/preview/state")
+    def get_preview_state() -> dict[str, Any]:
+        """The reconnect path. ``_broadcast`` no-ops with no client attached, so
+        a renderer reload mid-preview would otherwise leave audible audio with
+        no controls anywhere on screen."""
+        if preview is None:
+            return dict(_IDLE_PREVIEW)
+        return cast(dict[str, Any], preview.snapshot())
+
+    @app.post("/api/v1/discovery/preview/play")
+    def preview_play(req: dict[str, Any]) -> dict[str, Any]:
+        """Start previewing an item, optionally at a given track."""
+        item_id = req.get("item_id")
+        if not isinstance(item_id, int):
+            raise HTTPException(status_code=422, detail="item_id must be an integer")
+        track_num = req.get("track_num")
+        return cast(
+            dict[str, Any],
+            _preview_or_503().play(
+                item_id, track_num if isinstance(track_num, int) else None
+            ),
+        )
+
+    @app.post("/api/v1/discovery/preview/{action}")
+    def preview_action(
+        action: str, req: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """pause / resume / toggle / stop / next / prev / seek.
+
+        One route rather than six near-identical ones; the action allowlist is
+        what keeps it from being an arbitrary method call.
+        """
+        player = _preview_or_503()
+        if action in ("pause", "resume", "toggle", "stop"):
+            return cast(dict[str, Any], getattr(player, action)())
+        if action == "next":
+            return cast(dict[str, Any], player.step(1))
+        if action == "prev":
+            return cast(dict[str, Any], player.step(-1))
+        if action == "seek":
+            position = (req or {}).get("position")
+            if not isinstance(position, (int, float)):
+                raise HTTPException(status_code=422, detail="position must be a number")
+            return cast(dict[str, Any], player.seek(float(position)))
+        raise HTTPException(status_code=404, detail=f"unknown preview action: {action}")
 
     # ------------------------------------------------------------------
     # Album art (KAMP-649)

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1096,7 +1096,7 @@ class MpvPlaybackEngine:
         """Spawn an mpv and connect to it.
 
         *metering* off drops the astats filter graph and the ffmpeg log level
-        that feed :attr:`on_audio_level`. The Crate's preview engine (KAMP-651)
+        that feed :attr:`on_audio_level`. the Crate's preview engine (KAMP-651)
         turns it off: its levels must never reach the main VU meter, and without
         it mpv writes ~20 lines a second into a pipe for nobody. Leaving
         ``on_audio_level`` unset would also suppress the meter, but only because

--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1092,8 +1092,19 @@ class MpvPlaybackEngine:
     so the misdirected seek is visible for at most one frame.
     """
 
-    def __init__(self, mpv_bin: str = "mpv") -> None:
+    def __init__(self, mpv_bin: str = "mpv", *, metering: bool = True) -> None:
+        """Spawn an mpv and connect to it.
+
+        *metering* off drops the astats filter graph and the ffmpeg log level
+        that feed :attr:`on_audio_level`. The Crate's preview engine (KAMP-651)
+        turns it off: its levels must never reach the main VU meter, and without
+        it mpv writes ~20 lines a second into a pipe for nobody. Leaving
+        ``on_audio_level`` unset would also suppress the meter, but only because
+        the stdout reader always drains — this removes the traffic instead of
+        relying on that.
+        """
         self.state = PlaybackState()
+        self._metering = metering
         # had_lookahead is True when mpv transitioned gaplessly (slot 1 became
         # slot 0) at this eof; False when mpv went idle. The callback uses this
         # to decide whether to issue engine.play(next_path) — calling play()
@@ -1177,6 +1188,25 @@ class MpvPlaybackEngine:
                 _FADE_SCRIPT,
             )
 
+        # The metering pair is optional; everything else is load-bearing. In
+        # particular --script and both @kampfade/@kampmute filters must survive,
+        # because pause/resume/stop/mute are pure script-messages and are silent
+        # no-ops without them (KAMP-519).
+        metering_args = (
+            [
+                # Surface ametadata=print output (AV_LOG_VERBOSE) on stdout so
+                # _stdout_reader_loop can parse per-channel RMS at ~20 Hz
+                # without polling the IPC socket.
+                "--msg-level=ffmpeg=v",
+                # %N% is mpv's percent-encoding for the graph value; N is the
+                # byte length computed from _LEVEL_FILTER_GRAPH so it stays
+                # accurate if the filter string ever changes.
+                f"--af=lavfi=graph=%{len(_LEVEL_FILTER_GRAPH)}%{_LEVEL_FILTER_GRAPH}",
+            ]
+            if self._metering
+            else []
+        )
+
         self._proc = subprocess.Popen(
             [
                 self._mpv_bin,
@@ -1190,14 +1220,7 @@ class MpvPlaybackEngine:
                 # subprocess via MPRemoteCommandCenter (registered by the process
                 # that owns MPNowPlayingInfoCenter, which is now the helper).
                 "--input-media-keys=no",
-                # Surface ametadata=print output (AV_LOG_VERBOSE) on stdout so
-                # _stdout_reader_loop can parse per-channel RMS at ~20 Hz
-                # without polling the IPC socket.
-                "--msg-level=ffmpeg=v",
-                # %N% is mpv's percent-encoding for the graph value; N is the
-                # byte length computed from _LEVEL_FILTER_GRAPH so it stays
-                # accurate if the filter string ever changes.
-                f"--af=lavfi=graph=%{len(_LEVEL_FILTER_GRAPH)}%{_LEVEL_FILTER_GRAPH}",
+                *metering_args,
                 # Persistent afade gain stage for click-free pause/stop/resume fades,
                 # appended AFTER the analysis chain so the ametadata parser is untouched.
                 # Parked at unity (start_time far in the future); the kamp_fade.lua
@@ -1573,8 +1596,19 @@ class MpvPlaybackEngine:
 
     def shutdown(self) -> None:
         if self._proc is not None:
-            self._proc.terminate()
+            proc = self._proc
             self._proc = None
+            proc.terminate()
+            # Reap it. Dropping the Popen without waiting leaves a zombie until
+            # some later subprocess call happens to sweep it, which is harmless
+            # for the one engine that lives as long as the daemon but not for
+            # the Crate's preview engine (KAMP-651), which is spawned and killed
+            # repeatedly as it idles out. Bounded so a wedged mpv cannot stall
+            # daemon shutdown; the Win32 Job Object below is the backstop.
+            try:
+                proc.wait(timeout=2.0)
+            except Exception:  # noqa: BLE001 - including TimeoutExpired
+                pass
         # Releasing the Job handle triggers KILL_ON_JOB_CLOSE, a backstop in
         # case mpv didn't exit on terminate(). Win32-only; None on POSIX.
         if self._job is not None:

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -53,7 +53,10 @@ from kamp_core.library import (
     _canonical_track_uri,
     extract_art,
 )
-from kamp_core.discovery_api import register_discovery_routes
+from kamp_core.discovery_api import (
+    PREVIEW_EVENT as CRATE_PREVIEW_EVENT,
+    register_discovery_routes,
+)
 from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 from kamp_core.proxy_hosts import ALLOWED_PROXY_HOSTS, host_allowed
 
@@ -1092,6 +1095,10 @@ def create_app(
     on_genre_backfill_start: Callable[[], None] | None = None,
     on_genre_backfill_cancel: Callable[[], None] | None = None,
     on_crate_build_start: Callable[[], None] | None = None,
+    # kamp_daemon.discovery_preview.PreviewPlayer; Any because kamp_core does
+    # not depend on kamp_daemon. Never assign this to `engine` — create_app
+    # wires main-player callbacks onto whatever it is given.
+    preview_player: Any = None,
     on_allowlist_changed: Callable[[], None] | None = None,
     get_default_allowlist: Callable[[], list[str]] | None = None,
     dl_queue: _queue.Queue[str] | None = None,
@@ -1475,6 +1482,34 @@ def create_app(
         token = request.headers.get("X-Kamp-Token") or request.query_params.get("token")
         if token != auth_token:
             return Response(status_code=401)
+        return await call_next(request)
+
+    # KAMP-651: the main transport always wins over a Crate preview.
+    #
+    # A middleware rather than a call in each handler: there are ~15 endpoints
+    # under /api/v1/player that start or alter playback, several of them only
+    # conditionally, and forgetting one would leave preview audio playing
+    # underneath the user's own music with no obvious cause. One rule cannot be
+    # forgotten by the next endpoint anyone adds.
+    #
+    # Volume and mute are the deliberate exceptions: they are not a demand for
+    # the floor, they are a change to how loud everything is, so they are
+    # mirrored onto the preview instead of stopping it.
+    _PREVIEW_SAFE_PLAYER_PATHS = ("/api/v1/player/volume", "/api/v1/player/mute")
+
+    @app.middleware("http")
+    async def _preview_yields_to_transport(request: Request, call_next: Any) -> Any:
+        if (
+            request.method == "POST"
+            and request.url.path.startswith("/api/v1/player/")
+            and request.url.path not in _PREVIEW_SAFE_PLAYER_PATHS
+        ):
+            stop = getattr(app.state, "stop_preview", None)
+            if stop is not None:
+                try:
+                    stop()
+                except Exception:  # noqa: BLE001 - never break the transport
+                    logger.warning("could not stop the preview", exc_info=True)
         return await call_next(request)
 
     # Restrict to origins kamp actually serves; wildcard would allow any page
@@ -4040,11 +4075,18 @@ def create_app(
     @app.post("/api/v1/player/volume")
     def set_volume(req: VolumeRequest) -> dict[str, Any]:
         engine.volume = req.volume
+        # A Crate preview runs on its own engine with its own volume, so without
+        # this the slider would move everything except what you can currently
+        # hear (KAMP-651).
+        if preview_player is not None:
+            preview_player.set_volume(req.volume)
         return {"ok": True}
 
     @app.post("/api/v1/player/mute")
     def set_mute(req: MuteRequest) -> dict[str, Any]:
         engine.muted = req.muted
+        if preview_player is not None:
+            preview_player.set_muted(req.muted)
         return {"ok": True}
 
     @app.post("/api/v1/player/next")
@@ -4593,6 +4635,17 @@ def create_app(
         # proxy request before the Electron preload established its WS connection.
         for pending_event in list(_pending_proxy_fetches.values()):
             await ws.send_json(pending_event)
+        # KAMP-651: a preview is daemon-owned and survives a renderer reload, so
+        # a reconnecting client has to be told about audio that is already
+        # playing. _broadcast no-ops with no client attached, and the preview
+        # only pushes on transitions, so without this the mini-player would be
+        # missing while its audio kept going.
+        _preview_snapshot = getattr(app.state, "discovery_preview_snapshot", None)
+        if _preview_snapshot is not None:
+            try:
+                await ws.send_json({"type": CRATE_PREVIEW_EVENT, **_preview_snapshot()})
+            except Exception:  # noqa: BLE001 - a bad frame must not drop the socket
+                logger.warning("could not send the preview snapshot", exc_info=True)
         last_library_version: int = _state["library_version"]
         try:
             while True:
@@ -4651,6 +4704,7 @@ def create_app(
         broadcast=_broadcast,
         on_build_start=on_crate_build_start,
         art_cache_dir=art_cache_dir,
+        preview=preview_player,
     )
 
     return app

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -573,6 +573,8 @@ def _cmd_daemon(
 
     from kamp_core.library import LibraryIndex, Track
     from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
+
+    from .discovery_preview import PreviewPlayer
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
     from kamp_core.server import create_app, resolve_playback_uri
     from kamp_daemon.config import config_set as _config_set
@@ -1072,6 +1074,44 @@ def _cmd_daemon(
 
         threading.Thread(target=_run, daemon=True, name="crate-builder").start()
 
+    # --- KAMP-651: Crate preview, on its own isolated mpv ---
+    def _preview_engine() -> Any:
+        # metering off: this engine's levels must never reach the main VU meter,
+        # and without it mpv writes ~20 lines a second into a pipe for nobody.
+        return MpvPlaybackEngine(mpv_bin=_resolve_mpv_binary(), metering=False)
+
+    def _preview_source() -> Any:
+        """A Bandcamp source for preview, or None when not connected."""
+        session_data = index.get_session("bandcamp")
+        if not session_data:
+            return None
+        try:
+            from .bandcamp import _make_requests_session
+            from .discovery_sources import BandcampDiscoverySource
+
+            return BandcampDiscoverySource(_make_requests_session(session_data))
+        except Exception:
+            _logger.exception("preview: could not build a Bandcamp session")
+            return None
+
+    def _preview_notify(snapshot: dict[str, Any]) -> None:
+        # Deferred lookup: the player is built before create_app, so the
+        # broadcaster does not exist yet at construction time.
+        publish = getattr(app.state, "discovery_preview_publish", None)
+        if publish is not None:
+            publish(snapshot)
+
+    # NOTE the name: _state_saver and create_app both close over `engine`, so
+    # this must never be bound to that name or the preview would become the
+    # main player as far as the rest of the daemon is concerned.
+    preview_player = PreviewPlayer(
+        index,
+        main_engine=engine,
+        engine_factory=_preview_engine,
+        source_factory=_preview_source,
+        notify=_preview_notify,
+    )
+
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")
     _bc_ever_connected = index.get_setting("bandcamp.ever_connected") == "true"
@@ -1146,6 +1186,7 @@ def _cmd_daemon(
         on_genre_backfill_start=_on_genre_backfill_start,
         on_genre_backfill_cancel=_on_genre_backfill_cancel,
         on_crate_build_start=_on_crate_build_start,
+        preview_player=preview_player,
         on_allowlist_changed=_on_allowlist_changed,
         get_default_allowlist=_genre_sources.default_allowlist_names,
         dl_queue=_dl_queue,
@@ -1619,23 +1660,30 @@ def _cmd_daemon(
     # indefinite stall; any ops not drained survive in the DB for startup drain.
     from kamp_core.deferred_ops import drain_all as _drain_all_shutdown
 
-    _drain_all_shutdown(
-        index,
-        lib_watcher,
-        app.state.notify_deferred_op_completed,
-        app.state.notify_library_changed,
-        timeout_secs=5.0,
-        is_locked=_is_locked,
-    )
+    # The engines are torn down in a finally so an exception anywhere above --
+    # a wedged deferred-op drain, a watcher that will not stop -- cannot leave
+    # an mpv running with no parent. There are two of them now (KAMP-651), so
+    # the exposure doubled.
+    try:
+        _drain_all_shutdown(
+            index,
+            lib_watcher,
+            app.state.notify_deferred_op_completed,
+            app.state.notify_library_changed,
+            timeout_secs=5.0,
+            is_locked=_is_locked,
+        )
 
-    if lib_watcher is not None:
-        lib_watcher.stop()
-    # Stop the scrobbler's HTTP worker thread BEFORE the engine so any final
-    # scrobble queued by a closing on_track_ended has a chance to land. The
-    # 2-second join cap makes a hung Last.fm endpoint never stall shutdown.
-    if _scrobbler_ref[0] is not None:
-        _scrobbler_ref[0].shutdown(timeout=2.0)
-    engine.shutdown()
+        if lib_watcher is not None:
+            lib_watcher.stop()
+        # Stop the scrobbler's HTTP worker thread BEFORE the engine so any final
+        # scrobble queued by a closing on_track_ended has a chance to land. The
+        # 2-second join cap makes a hung Last.fm endpoint never stall shutdown.
+        if _scrobbler_ref[0] is not None:
+            _scrobbler_ref[0].shutdown(timeout=2.0)
+    finally:
+        preview_player.shutdown()
+        engine.shutdown()
     # Flush any accumulated artist play time before closing the DB.
     _flush_elapsed()
     index.close()

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -1200,6 +1200,32 @@ def _get_download_links(
 # Stream URL resolution
 # ---------------------------------------------------------------------------
 
+#: How long Bandcamp honours a signed CDN URL, in seconds.
+_STREAM_URL_TTL = 86400.0
+
+
+def stream_url_expiry(url: str) -> float:
+    """Unix time *url* stops working.
+
+    ``ts=`` in the signed CDN URL is the creation timestamp; the token is
+    hmac(ts + path + secret), so ts cannot be changed independently. Bandcamp
+    rejects the URL once ts is older than ~24 hours, so the true expiry is
+    ts + 86400. Reading the URL's own ts is more accurate than ``time.time()``
+    because it reflects when Bandcamp signed it, not when we fetched the page --
+    which may itself have come from a cache.
+
+    Falls back to now + 24h for a URL with no ts, which is the conservative
+    direction only if the URL is fresh; callers should treat it as a hint.
+    """
+    try:
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        ts = qs.get("ts")
+        if ts:
+            return float(ts[0]) + _STREAM_URL_TTL
+    except Exception:  # noqa: BLE001 - a malformed URL is not worth raising over
+        pass
+    return time.time() + _STREAM_URL_TTL
+
 
 def fetch_stream_url(
     album_url: str,
@@ -1242,19 +1268,7 @@ def fetch_stream_url(
                     f"fetch_stream_url: no mp3 stream URL for track {track_number} "
                     f"in {album_url}"
                 )
-            # ts= in the signed CDN URL is the creation timestamp; the token
-            # is hmac(ts + path + secret) so ts cannot be changed independently.
-            # Bandcamp rejects the URL once ts is older than ~24 hours, so the
-            # true expiry is ts + 86400.  Using the URL-embedded ts is more
-            # accurate than time.time() because it reflects when Bandcamp
-            # actually signed the URL, not when we fetched the page.
-            try:
-                _qs = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
-                _ts = _qs.get("ts")
-                expires_at = float(_ts[0]) + 86400 if _ts else time.time() + 86400
-            except Exception:
-                expires_at = time.time() + 86400
-            return url, expires_at
+            return url, stream_url_expiry(url)
 
     raise BandcampAPIError(
         f"fetch_stream_url: track_num={track_number} not found in {album_url} "

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time as _time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
@@ -153,11 +154,25 @@ class PreviewStream:
     Bandcamp's ``mp3-128`` URLs are signed with a ``ts`` parameter and expire in about
     a day (KAMP-644), so a stored one is a bug waiting to surface as silent playback
     failure. Resolve at play time; throw it away after.
+
+    "Never persisted" means never written to the database. KAMP-651 does keep a
+    resolved list **in memory for the session**, keyed on ``expires_at`` so it is
+    dropped before it can go stale -- otherwise every next/prev inside one album
+    would cost another album-page fetch.
     """
 
     url: str
     track_num: int = 1
     title: str = ""
+    duration: float = 0.0
+    #: Unix time this URL stops working. Derived from the URL's own ``ts``, which
+    #: is when Bandcamp signed it -- more accurate than our fetch time, since the
+    #: page itself may have been served from a cache.
+    expires_at: float = 0.0
+
+    @property
+    def is_expired(self) -> bool:
+        return bool(self.expires_at) and _time.time() >= self.expires_at
 
 
 class UnsupportedCapability(RuntimeError):
@@ -315,18 +330,28 @@ class DiscoverySource(ABC):
         that arrives as "discovery is broken" with nothing in the log to explain it.
         """
 
-    def resolve_preview(self, candidate: Candidate) -> PreviewStream | None:
-        """Resolve a playable preview for *candidate*, or None if unavailable.
+    def preview_tracks(self, candidate: Candidate) -> list[PreviewStream]:
+        """Every playable track of *candidate*, in track order. May be empty.
 
-        Deliberately **not** budgeted, unlike :meth:`gather`: preview is user-initiated
-        and one click should never be refused because a background gather spent the
-        allowance. It does hit the tighter endpoint class, so implementations should
-        keep it to a single request.
+        The primary preview API, and the one implementations should override:
+        :meth:`resolve_preview` is derived from it so there is a single parser
+        rather than two that can disagree.
+
+        Deliberately **not** budgeted, unlike :meth:`gather`: preview is
+        user-initiated and one click should never be refused because a background
+        gather spent the allowance. Implementations must also not *wait* on the
+        rate-limit governor here — it is documented as a non-playback tool, and a
+        cooldown would hang a click for up to five minutes. Report the outcome to
+        it instead, so a crate build backs off without a listener paying for it.
 
         Raises :class:`UnsupportedCapability` if ``PREVIEW`` is not in
         :attr:`capabilities`.
         """
         raise UnsupportedCapability(f"{self.provider_id} cannot preview")
+
+    def resolve_preview(self, candidate: Candidate) -> PreviewStream | None:
+        """The first playable track of *candidate*, or None if there is none."""
+        return next(iter(self.preview_tracks(candidate)), None)
 
     def save_remote(self, candidate: Candidate) -> bool:
         """Save *candidate* to the provider's own list (Bandcamp: the wishlist).

--- a/kamp_daemon/discovery_bandcamp_parsers.py
+++ b/kamp_daemon/discovery_bandcamp_parsers.py
@@ -155,6 +155,25 @@ def _attr(body: str, name: str) -> str:
     return html_lib.unescape(match.group(1)) if match else ""
 
 
+def _audio_url(raw: str) -> str | None:
+    """Pull a playable mp3 out of a recommendation's ``data-audiourl``.
+
+    The attribute is a JSON *object* keyed by format (``{"mp3-128": "..."}``),
+    not a bare URL -- reading it as a string yields something unplayable that
+    would only fail at the point of pressing play.
+    """
+    if not raw:
+        return None
+    try:
+        files = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(files, dict):
+        return None
+    url = files.get("mp3-128") or files.get("mp3-v0")
+    return url if isinstance(url, str) and url else None
+
+
 def parse_also_like(html: str) -> ParseResult:
     """Parse the album page's recommendation block.
 
@@ -180,6 +199,12 @@ def parse_also_like(html: str) -> ParseResult:
                 "title": _attr(body, "data-albumtitle"),
                 "artist_id": _attr(body, "data-artistid"),
                 "art_url": art.group(0) + "0.jpg" if art else None,
+                # An inline mp3-128 for the album's first track, present on every
+                # recommendation KAMP-644 measured (48/48). Kept so a preview can
+                # start playing immediately instead of waiting out a cold engine
+                # spawn plus an album-page fetch; the full track list still needs
+                # the page, but the listener does not wait for it.
+                "audio_url": _audio_url(_attr(body, "data-audiourl")),
                 "supporters": _clean_text(supporters.group(1)) if supporters else "",
                 "fan_comment": _clean_text(comment.group(1)) if comment else "",
             }

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -1,0 +1,498 @@
+"""Crate preview playback on a second, isolated mpv (KAMP-651).
+
+The epic's hardest promise is that previewing a record does not break the queue
+you were already listening to. This keeps that promise by *construction* rather
+than by discipline: the preview runs on its own :class:`MpvPlaybackEngine`, which
+mints its own IPC socket and so is a genuinely separate mpv process. It is never
+handed to ``create_app`` — which unconditionally assigns three callbacks to
+whatever engine it is given — and it is never bound to the name the daemon's
+state-saver closes over. So the queue, the scrobbler, ``track_stats``, the 5s
+session persistence and the OS now-playing widget cannot see it.
+
+The one deviation from "wire no callbacks": this does wire a preview-*local*
+``on_track_end`` and ``on_file_loaded``. The reason for the rule is avoiding
+contact with the machinery above, and these touch none of it — without them the
+preview could not know a track had ended and the UI would show it playing
+forever.
+
+Threading: one ``RLock`` covers constructing, tearing down and commanding the
+engine. Construction spawns mpv synchronously and can block for seconds or
+raise, so two racing first-previews would otherwise build two engines and orphan
+one (there is no Job Object on POSIX, and the socket tmpdir is only unlinked by
+``shutdown()``). :meth:`snapshot` deliberately takes no lock — it reads a
+whole-object reference that is only ever replaced, never mutated in place — so
+polling the UI's own state can never stall behind a cold spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time as _time
+from typing import TYPE_CHECKING, Any, Callable
+
+from .discovery import Candidate, PreviewStream
+
+if TYPE_CHECKING:  # pragma: no cover - types only
+    from kamp_core.library import LibraryIndex
+    from kamp_core.playback import MpvPlaybackEngine
+
+    from .discovery import DiscoverySource
+
+logger = logging.getLogger(__name__)
+
+#: How long the preview engine may sit idle before its mpv is killed. Spawning
+#: costs a second or two, so this trades a rare slow first click for not holding
+#: an audio device open all session.
+IDLE_TIMEOUT_SECS = 300.0
+
+#: Below this many seconds a preview is a misclick, not a listen. It matters
+#: because the first 'previewed' event flips discovery_items.state from 'fresh'
+#: irreversibly (the rank is monotonic), so a half-second slip would relabel a
+#: card forever and inflate KAMP-655's engagement stats.
+MIN_PREVIEW_SECS = 10.0
+
+IDLE = "idle"
+PREPARING = "preparing"
+PLAYING = "playing"
+PAUSED = "paused"
+
+_IDLE_STATE: dict[str, Any] = {
+    "state": IDLE,
+    "item_id": None,
+    "track_num": None,
+    "title": "",
+    "position": 0.0,
+    "position_updated_at": 0.0,
+    "duration": 0.0,
+    "buffering": False,
+    "tracks": [],
+    "error": None,
+}
+
+
+class PreviewPlayer:
+    """Owns the preview engine, the main-engine handoff, and preview state."""
+
+    def __init__(
+        self,
+        index: "LibraryIndex",
+        *,
+        main_engine: "MpvPlaybackEngine",
+        engine_factory: Callable[[], "MpvPlaybackEngine"],
+        source_factory: Callable[[], "DiscoverySource | None"],
+        notify: Callable[[dict[str, Any]], None] | None = None,
+        idle_timeout: float = IDLE_TIMEOUT_SECS,
+        now: Callable[[], float] = _time.time,
+    ) -> None:
+        self._index = index
+        self._main = main_engine
+        self._engine_factory = engine_factory
+        self._source_factory = source_factory
+        self._notify = notify
+        self._idle_timeout = idle_timeout
+        self._now = now
+
+        self._lock = threading.RLock()
+        self._engine: "MpvPlaybackEngine | None" = None
+        self._idle_timer: threading.Timer | None = None
+        self._state: dict[str, Any] = dict(_IDLE_STATE)
+
+        # Resolved tracks per discovery item. In memory only: PreviewStream's
+        # docstring forbids *persisting* a signed URL, and this respects that --
+        # but re-fetching the album page for every next/prev would be a request
+        # per button press, so the list is kept for as long as its URLs live.
+        self._tracks: dict[int, list[PreviewStream]] = {}
+
+        # Captured BEFORE main is paused and never read back: pause() is a
+        # ~0.4s fade (a script-message the Lua schedules), so main.state.playing
+        # is still True immediately after the call and would lie.
+        self._main_was_playing = False
+
+        # Seconds listened for the item currently loaded, and when the current
+        # playing stretch began (None while paused).
+        self._listened = 0.0
+        self._playing_since: float | None = None
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        """The current preview state. Lock-free by design — see the module docstring."""
+        snap = dict(self._state)
+        engine = self._engine
+        # Position is pulled rather than pushed: the engine has no position
+        # callback, and the UI interpolates between snapshots.
+        if engine is not None and snap["state"] in (PLAYING, PAUSED):
+            snap["position"] = float(engine.state.position)
+            snap["position_updated_at"] = self._now()
+        return snap
+
+    def _publish(self, **fields: Any) -> dict[str, Any]:
+        """Replace the state wholesale and push it. Never mutates in place, so
+        :meth:`snapshot` can read without a lock."""
+        state = dict(self._state)
+        state.update(fields)
+        self._state = state
+        snap = self.snapshot()
+        if self._notify is not None:
+            self._notify(snap)
+        return snap
+
+    # ------------------------------------------------------------------
+    # Engine lifecycle
+    # ------------------------------------------------------------------
+
+    def _ensure_engine(self) -> "MpvPlaybackEngine":
+        """Return the engine, building it if this is the first preview.
+
+        Caller must hold the lock: construction is slow and racing it would
+        orphan an mpv that nothing holds a reference to.
+        """
+        if self._engine is None:
+            logger.info("preview: spawning the preview engine")
+            engine = self._engine_factory()
+            engine.on_track_end = self._on_track_end
+            engine.on_file_loaded = self._on_file_loaded
+            # Deliberately NOT on_play_state_changed or on_audio_level: the
+            # first belongs to the main player's WS state, the second to the
+            # main VU meter. Neither should ever hear from this engine.
+            self._engine = engine
+            self._apply_main_audio_settings()
+        return self._engine
+
+    def _apply_main_audio_settings(self) -> None:
+        """Match the user's volume and mute on the preview engine.
+
+        A fresh engine starts at volume 100 unmuted regardless of what the user
+        set, because nothing is passed on the mpv command line and PlaybackState
+        simply defaults. Without this, someone listening at 30 -- or muted --
+        gets a preview at full blast.
+        """
+        engine = self._engine
+        if engine is None:
+            return
+        try:
+            engine.volume = int(self._main.state.volume)
+            if self._main.state.muted:
+                engine.muted = True
+        except Exception:  # noqa: BLE001 - a wedged engine must not break preview
+            logger.warning(
+                "preview: could not mirror main audio settings", exc_info=True
+            )
+
+    def set_volume(self, volume: int) -> None:
+        """Follow a main-player volume change while a preview is alive."""
+        with self._lock:
+            if self._engine is not None:
+                self._engine.volume = volume
+
+    def set_muted(self, muted: bool) -> None:
+        with self._lock:
+            if self._engine is not None:
+                self._engine.muted = muted
+
+    def _arm_idle_timer(self) -> None:
+        self._cancel_idle_timer()
+        timer = threading.Timer(self._idle_timeout, self._idle_kill)
+        timer.daemon = True
+        self._idle_timer = timer
+        timer.start()
+
+    def _cancel_idle_timer(self) -> None:
+        if self._idle_timer is not None:
+            self._idle_timer.cancel()
+            self._idle_timer = None
+
+    def _idle_kill(self) -> None:
+        with self._lock:
+            self._idle_timer = None
+            if self._engine is None or self._state["state"] != IDLE:
+                return
+            logger.info("preview: idle, shutting the preview engine down")
+            self._teardown_engine()
+
+    def _teardown_engine(self) -> None:
+        """Caller must hold the lock."""
+        engine, self._engine = self._engine, None
+        if engine is not None:
+            try:
+                engine.shutdown()
+            except Exception:  # noqa: BLE001 - teardown must not raise
+                logger.warning("preview: engine shutdown failed", exc_info=True)
+
+    def shutdown(self) -> None:
+        """Tear everything down. Safe to call more than once."""
+        with self._lock:
+            self._cancel_idle_timer()
+            self._record_listened()
+            self._teardown_engine()
+            self._state = dict(_IDLE_STATE)
+
+    # ------------------------------------------------------------------
+    # Transport
+    # ------------------------------------------------------------------
+
+    def play(self, item_id: int, track_num: int | None = None) -> dict[str, Any]:
+        """Start (or switch to) a preview of *item_id*.
+
+        Resolving the track list can take a round trip, so the state goes to
+        ``preparing`` first: the cold path is an engine spawn plus an album-page
+        fetch plus buffering, and a UI with no state for that looks broken.
+        """
+        with self._lock:
+            self._cancel_idle_timer()
+            if self._state["item_id"] != item_id:
+                self._record_listened()
+
+            item = self._index.discovery_item(item_id)
+            if item is None:
+                return self._publish(state=IDLE, error="not_found")
+
+            self._publish(
+                state=PREPARING,
+                item_id=item_id,
+                title="",
+                error=None,
+                buffering=True,
+                position=0.0,
+                duration=0.0,
+            )
+
+            try:
+                tracks = self._resolve(item_id, item)
+            except _RateLimited:
+                return self._publish(state=IDLE, buffering=False, error="rate_limited")
+            if not tracks:
+                return self._publish(state=IDLE, buffering=False, error="unavailable")
+
+            track = self._pick(tracks, track_num)
+            if track is None:
+                return self._publish(state=IDLE, buffering=False, error="unavailable")
+
+            self._take_over_from_main()
+            engine = self._ensure_engine()
+            engine.play(track.url)
+
+            self._listened = 0.0
+            self._playing_since = self._now()
+            return self._publish(
+                state=PLAYING,
+                item_id=item_id,
+                track_num=track.track_num,
+                title=track.title,
+                duration=track.duration,
+                buffering=True,
+                position=0.0,
+                tracks=[
+                    {"track_num": t.track_num, "title": t.title, "duration": t.duration}
+                    for t in tracks
+                ],
+            )
+
+    def pause(self) -> dict[str, Any]:
+        with self._lock:
+            if self._engine is None or self._state["state"] != PLAYING:
+                return self.snapshot()
+            self._engine.pause()
+            self._accumulate()
+            return self._publish(state=PAUSED)
+
+    def resume(self) -> dict[str, Any]:
+        with self._lock:
+            if self._engine is None or self._state["state"] != PAUSED:
+                return self.snapshot()
+            self._take_over_from_main()
+            self._engine.resume()
+            self._playing_since = self._now()
+            return self._publish(state=PLAYING)
+
+    def toggle(self) -> dict[str, Any]:
+        return self.pause() if self._state["state"] == PLAYING else self.resume()
+
+    def stop(self) -> dict[str, Any]:
+        """End the preview and give the main player back."""
+        with self._lock:
+            if self._engine is not None:
+                try:
+                    self._engine.unload()
+                except Exception:  # noqa: BLE001
+                    logger.warning("preview: unload failed", exc_info=True)
+            self._record_listened()
+            self._hand_back_to_main()
+            self._arm_idle_timer()
+            return self._publish(
+                state=IDLE,
+                item_id=None,
+                track_num=None,
+                title="",
+                position=0.0,
+                duration=0.0,
+                buffering=False,
+                tracks=[],
+                error=None,
+            )
+
+    def seek(self, position: float) -> dict[str, Any]:
+        with self._lock:
+            if self._engine is None or self._state["state"] == IDLE:
+                return self.snapshot()
+            self._engine.seek(max(0.0, position))
+            return self._publish(position=max(0.0, position))
+
+    def step(self, delta: int) -> dict[str, Any]:
+        """Move *delta* tracks within the album currently previewing."""
+        with self._lock:
+            item_id = self._state["item_id"]
+            current = self._state["track_num"]
+            if item_id is None or current is None:
+                return self.snapshot()
+            tracks = self._tracks.get(int(item_id)) or []
+            nums = [t.track_num for t in tracks]
+            if current not in nums:
+                return self.snapshot()
+            target = nums.index(current) + delta
+            if not 0 <= target < len(nums):
+                # Off either end is a stop, not a wrap: a preview is a listen
+                # through one record, not a loop.
+                return self.stop()
+            return self.play(int(item_id), nums[target])
+
+    # ------------------------------------------------------------------
+    # Main-engine handoff
+    # ------------------------------------------------------------------
+
+    def _take_over_from_main(self) -> None:
+        """Pause the main player if it is playing, remembering that it was."""
+        # Captured before the call: pause() only sends a script-message and the
+        # Lua schedules the real pause ~0.4s later, so reading state.playing
+        # afterwards would still say True.
+        if self._main_was_playing:
+            return  # already holding the floor
+        if self._main.state.playing:
+            self._main_was_playing = True
+            self._main.pause()
+
+    def _hand_back_to_main(self) -> None:
+        if self._main_was_playing:
+            self._main_was_playing = False
+            self._main.resume()
+
+    def release_for_main(self) -> None:
+        """Stop the preview because the main transport was used.
+
+        The main transport always wins. Called from the player endpoints, so it
+        must not resume main afterwards -- main is about to do whatever the user
+        just asked for.
+        """
+        with self._lock:
+            if self._state["state"] == IDLE and self._engine is None:
+                return
+            if self._engine is not None:
+                try:
+                    self._engine.unload()
+                except Exception:  # noqa: BLE001
+                    pass
+            self._record_listened()
+            self._main_was_playing = False
+            self._arm_idle_timer()
+            self._publish(
+                state=IDLE,
+                item_id=None,
+                track_num=None,
+                title="",
+                position=0.0,
+                duration=0.0,
+                buffering=False,
+                tracks=[],
+                error=None,
+            )
+
+    # ------------------------------------------------------------------
+    # Engine callbacks — preview-local, touching nothing the main player owns
+    # ------------------------------------------------------------------
+
+    def _on_file_loaded(self) -> None:
+        self._publish(buffering=False)
+
+    def _on_track_end(self, _had_lookahead: bool) -> None:
+        # Advance within the album; stepping past the last track stops.
+        try:
+            self.step(1)
+        except Exception:  # noqa: BLE001 - a callback must never kill the reader thread
+            logger.warning("preview: advance failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve(self, item_id: int, item: dict[str, Any]) -> list[PreviewStream]:
+        cached = self._tracks.get(item_id)
+        if cached and not any(t.is_expired for t in cached):
+            return cached
+
+        source = self._source_factory()
+        if source is None:
+            return []
+        candidate = Candidate(
+            provider=str(item.get("provider") or "bandcamp"),
+            provider_item_id=str(item.get("provider_item_id") or ""),
+            item_url=str(item.get("item_url") or ""),
+            artist=str(item.get("artist") or ""),
+            title=str(item.get("title") or ""),
+        )
+        try:
+            tracks = source.preview_tracks(candidate)
+        except Exception as exc:  # noqa: BLE001
+            # A 429 is worth telling the user about; everything else is just
+            # "this one will not play".
+            if type(exc).__name__ == "RateLimitedError":
+                raise _RateLimited from exc
+            logger.warning("preview: could not resolve %s", candidate.item_url)
+            return []
+        if tracks:
+            self._tracks[item_id] = tracks
+        return tracks
+
+    @staticmethod
+    def _pick(
+        tracks: list[PreviewStream], track_num: int | None
+    ) -> PreviewStream | None:
+        if track_num is None:
+            return tracks[0]
+        for track in tracks:
+            if track.track_num == track_num:
+                return track
+        return tracks[0]
+
+    def _accumulate(self) -> None:
+        if self._playing_since is not None:
+            self._listened += max(0.0, self._now() - self._playing_since)
+            self._playing_since = None
+
+    def _record_listened(self) -> None:
+        """Write one 'previewed' event for the item just finished with.
+
+        One event per preview *session*, not per track: a five-track listen is
+        one engagement, and KAMP-655 counting it as five would overstate the
+        feature's own numbers.
+        """
+        self._accumulate()
+        item_id = self._state.get("item_id")
+        listened, self._listened = self._listened, 0.0
+        if item_id is None or listened < MIN_PREVIEW_SECS:
+            return
+        try:
+            self._index.record_discovery_event(
+                int(item_id),
+                "previewed",
+                detail=json.dumps({"seconds": round(listened, 1)}),
+            )
+        except Exception:  # noqa: BLE001 - stats are not worth failing playback over
+            logger.warning("preview: could not record the event", exc_info=True)
+
+
+class _RateLimited(RuntimeError):
+    """Internal: the origin rate-limited the album-page fetch."""

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -355,34 +355,69 @@ class BandcampDiscoverySource(DiscoverySource):
     # Preview
     # ------------------------------------------------------------------
 
-    def resolve_preview(self, candidate: Candidate) -> PreviewStream | None:
-        """Resolve a playable preview from the candidate's own album page.
+    def preview_tracks(self, candidate: Candidate) -> list[PreviewStream]:
+        """Every playable track on the candidate's own album page.
 
-        Deliberately unbudgeted (see the ABC): preview is user-initiated, and a
-        click should never be refused because a background gather spent the
-        allowance. Kept to a single request.
+        One request for the whole album, so stepping through tracks costs
+        nothing further while the URLs are alive.
+
+        **Does not wait on the governor**, unlike every other request this class
+        makes. ``bandcamp_ratelimit`` documents itself as a non-playback tool for
+        exactly this reason: ``wait_turn`` blocks until a 60/120/300s cooldown
+        expires, and a listener who clicked play would get a hang with nothing on
+        screen to explain it. The outcome is still reported, so a 429 earned here
+        makes the *crate builder* back off -- the cost lands on the background
+        work rather than on the click.
         """
-        from .bandcamp import parse_tralbum
+        from .bandcamp import parse_tralbum, stream_url_expiry
 
-        if not self._governor.wait_turn("album_page"):
-            return None
+        # item_url is remote data read back out of discovery_items, so it gets
+        # the same host check the art proxy applies (KAMP-649). A Bandcamp Pro
+        # custom domain also lands here, and is unfetchable in packaged builds.
+        if not _is_fetchable(candidate.item_url):
+            logger.debug("discovery: preview host not fetchable %s", candidate.item_url)
+            return []
+
         try:
             resp = self._session.get(candidate.item_url, timeout=30)
-            if resp.status_code != 200:
-                return None
-            tralbum = parse_tralbum(resp.text)
         except Exception:  # noqa: BLE001 - a failed preview is not an error state
             logger.warning("discovery: preview fetch failed for %s", candidate.item_url)
-            return None
+            return []
+
+        status = resp.status_code
+        if status == 429:
+            self._governor.report_429("album_page")
+            raise RateLimitedError(f"429 from {candidate.item_url}")
+        if status != 200:
+            logger.warning(
+                "discovery: preview HTTP %d from %s", status, candidate.item_url
+            )
+            return []
+        self._governor.report_ok("album_page")
+
+        tralbum = parse_tralbum(resp.text)
         if not tralbum:
-            return None
+            logger.warning("discovery: no tralbum on %s", candidate.item_url)
+            return []
+
+        # A standalone single-track page exposes its lone track with
+        # track_num=None; it is #1 everywhere else in kamp, so match that here.
+        is_single = tralbum.get("item_type") == "track"
+        out: list[PreviewStream] = []
         for track in tralbum.get("trackinfo") or []:
             files = track.get("file") or {}
             url = files.get("mp3-128") or files.get("mp3-v0")
-            if url:
-                return PreviewStream(
+            if not url:
+                continue  # unreleased / pre-order tracks carry no stream
+            out.append(
+                PreviewStream(
                     url=url,
-                    track_num=int(track.get("track_num") or 1),
+                    track_num=int(track.get("track_num") or (1 if is_single else 1)),
                     title=track.get("title") or "",
+                    duration=float(track.get("duration") or 0.0),
+                    expires_at=stream_url_expiry(url),
                 )
-        return None
+            )
+        if not out:
+            logger.info("discovery: nothing streamable on %s", candidate.item_url)
+        return out

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -279,6 +279,7 @@ export default function App(): React.JSX.Element {
           void loadConfig()
           void useStore.getState().loadDownloads() // KAMP-568: seed Downloads view
           void useStore.getState().loadCrate() // KAMP-650: seed The Crate
+          void useStore.getState().loadPreview() // KAMP-651: seed the preview
           // Reconcile pip state in case deferred_op.completed was missed
           // while the WS was disconnected.
           void getDeferredOps().then((ops) => {
@@ -364,6 +365,11 @@ export default function App(): React.JSX.Element {
         // placed record during a build, so the rail fills in as it is dug.
         (snapshot) => {
           useStore.getState().setCrate(snapshot)
+        },
+        // KAMP-651: preview transport state. Daemon-owned, so a reconnect
+        // carries whatever is already playing rather than starting from idle.
+        (state) => {
+          useStore.getState().setPreview(state)
         }
       )
     }

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -76,7 +76,7 @@ registerBuiltInPanel({
 registerBuiltInPanel({
   id: 'kamp.crate',
   // User-facing name (KAMP-643); `discovery` stays the code/API namespace.
-  title: 'The Crate',
+  title: 'Crate',
   defaultSlot: 'main',
   compatibleSlots: ['main'],
   component: CrateView
@@ -134,7 +134,7 @@ export default function App(): React.JSX.Element {
   const configuredLibraryPath = useStore((s) => s.configuredLibraryPath)
   const activeView = useStore((s) => s.activeView)
   const setActiveView = useStore((s) => s.setActiveView)
-  // KAMP-650: gates The Crate tab. Null until loadConfig() resolves — see the
+  // KAMP-650: gates the Crate tab. Null until loadConfig() resolves — see the
   // ringPanels filter and the force-switch effect below, both of which have to
   // distinguish "not loaded yet" from "disconnected".
   const configValuesForCrate = useStore((s) => s.configValues)
@@ -278,7 +278,7 @@ export default function App(): React.JSX.Element {
           void loadQueue()
           void loadConfig()
           void useStore.getState().loadDownloads() // KAMP-568: seed Downloads view
-          void useStore.getState().loadCrate() // KAMP-650: seed The Crate
+          void useStore.getState().loadCrate() // KAMP-650: seed the Crate
           void useStore.getState().loadPreview() // KAMP-651: seed the preview
           // Reconcile pip state in case deferred_op.completed was missed
           // while the WS was disconnected.
@@ -361,7 +361,7 @@ export default function App(): React.JSX.Element {
         (items, pausedUntil) => {
           useStore.getState().setDownloadQueue(items, pausedUntil)
         },
-        // KAMP-650: full crate snapshot → The Crate store slice. Fires once per
+        // KAMP-650: full crate snapshot → the Crate store slice. Fires once per
         // placed record during a build, so the rail fills in as it is dug.
         (snapshot) => {
           useStore.getState().setCrate(snapshot)
@@ -486,7 +486,7 @@ export default function App(): React.JSX.Element {
     return window.api.onCycleView((direction) => cycleViewRef.current(direction))
   }, [])
 
-  // KAMP-650: leave The Crate if Bandcamp gets disconnected while you are in it.
+  // KAMP-650: leave the Crate if Bandcamp gets disconnected while you are in it.
   // The tab is filtered out of ringPanels when disconnected, and cycleView
   // early-returns when the current view is not a ring member, so without this
   // Ctrl+Tab goes dead. Gated on configValues being loaded: it is null until
@@ -632,7 +632,7 @@ export default function App(): React.JSX.Element {
   // The view-cycle ring (KAMP-560) is exactly the rendered top-level tabs: main-slot
   // panels minus modal views. Downloads (KAMP-585) is an icon, not a tab, so it is
   // excluded. Single source of truth — used by both the rail render and cycleView.
-  // The Crate (KAMP-650) is additionally gated on Bandcamp: with no account there
+  // Crate (KAMP-650) is additionally gated on Bandcamp: with no account there
   // is nothing to dig. `configValues` is null until loadConfig() resolves and
   // `?? false` reads that as disconnected, so the tab appears a beat after launch
   // rather than flickering out — and the force-switch below is gated on the same

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -618,6 +618,42 @@ export const dismissCrateItem = (itemId: number): Promise<{ ok: boolean }> =>
 export const crateItemUrlCopied = (itemId: number): Promise<{ ok: boolean }> =>
   post(`/api/v1/discovery/items/${itemId}/url-copied`)
 
+// --- Preview (KAMP-651) ----------------------------------------------------
+// Preview runs on a second, isolated mpv so it cannot disturb the queue. It is
+// daemon-owned and survives a renderer reload, which is why there is a state
+// endpoint as well as an event.
+
+export type PreviewTrack = { track_num: number; title: string; duration: number }
+
+export type PreviewState = {
+  state: 'idle' | 'preparing' | 'playing' | 'paused'
+  item_id: number | null
+  track_num: number | null
+  title: string
+  // position is a sample, not a stream: the daemon publishes on transitions and
+  // the UI interpolates from position_updated_at rather than being told 4x/sec.
+  position: number
+  position_updated_at: number
+  duration: number
+  buffering: boolean
+  tracks: PreviewTrack[]
+  // 'not_found' | 'unavailable' | 'rate_limited' — a rate limit and an album
+  // with nothing streamable want different words on screen.
+  error: string | null
+}
+
+export const getPreviewState = (): Promise<PreviewState> => get('/api/v1/discovery/preview/state')
+
+export const previewPlay = (itemId: number, trackNum?: number): Promise<PreviewState> =>
+  post('/api/v1/discovery/preview/play', { item_id: itemId, track_num: trackNum ?? null })
+
+export const previewAction = (
+  action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev'
+): Promise<PreviewState> => post(`/api/v1/discovery/preview/${action}`)
+
+export const previewSeek = (position: number): Promise<PreviewState> =>
+  post('/api/v1/discovery/preview/seek', { position })
+
 // ---------------------------------------------------------------------------
 // Player
 // ---------------------------------------------------------------------------
@@ -1118,6 +1154,10 @@ export type DownloadQueueMessage = {
 // client attached, so a client that missed the build has to ask.
 export type DiscoveryCrateMessage = { type: 'discovery.crate' } & CrateSnapshot
 
+// KAMP-651: preview transport state. Pushed on transitions, not per frame —
+// see PreviewState.position.
+export type DiscoveryPreviewMessage = { type: 'discovery.preview' } & PreviewState
+
 export type ServerMessage =
   | StateMessage
   | TrackChangedMessage
@@ -1130,6 +1170,7 @@ export type ServerMessage =
   | PipelineStageMessage
   | DownloadQueueMessage
   | DiscoveryCrateMessage
+  | DiscoveryPreviewMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -1161,7 +1202,9 @@ export function connectStateStream(
   // so the existing positional callbacks keep their indices.
   onDownloadQueue?: (items: DownloadItem[], pausedUntil: number) => void,
   // KAMP-650: full crate snapshot for The Crate view. Appended last, same reason.
-  onDiscoveryCrate?: (snapshot: CrateSnapshot) => void
+  onDiscoveryCrate?: (snapshot: CrateSnapshot) => void,
+  // KAMP-651: preview transport state. Appended last, same reason.
+  onDiscoveryPreview?: (state: PreviewState) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -1187,6 +1230,7 @@ export function connectStateStream(
       // DiscoveryCrateMessage is CrateSnapshot plus `type`, so it satisfies the
       // callback as-is; the discriminator rides along inertly.
       else if (msg.type === 'discovery.crate') onDiscoveryCrate?.(msg)
+      else if (msg.type === 'discovery.preview') onDiscoveryPreview?.(msg)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -565,7 +565,7 @@ export const cancelDownload = (id: string): Promise<{ ok: boolean }> =>
   del(`/api/v1/downloads/${encodeURIComponent(id)}`)
 
 // ---------------------------------------------------------------------------
-// The Crate (KAMP-650) — /api/v1/discovery surface
+// Crate (KAMP-650) — /api/v1/discovery surface
 // ---------------------------------------------------------------------------
 
 // One recommended album; mirrors LibraryIndex.crate_items(). Also the item shape
@@ -1201,7 +1201,7 @@ export function connectStateStream(
   // KAMP-568: full download-queue snapshot for the Downloads view. Appended last
   // so the existing positional callbacks keep their indices.
   onDownloadQueue?: (items: DownloadItem[], pausedUntil: number) => void,
-  // KAMP-650: full crate snapshot for The Crate view. Appended last, same reason.
+  // KAMP-650: full crate snapshot for the Crate view. Appended last, same reason.
   onDiscoveryCrate?: (snapshot: CrateSnapshot) => void,
   // KAMP-651: preview transport state. Appended last, same reason.
   onDiscoveryPreview?: (state: PreviewState) => void

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -343,6 +343,151 @@
   transform-origin: left center;
 }
 
+/* --- Preview mini-player (KAMP-651) --------------------------------------- */
+
+/* Its own strip rather than the TransportBar: the whole promise is that the
+   main transport keeps showing the user's own queue, so two players on screen
+   is the point. */
+.crate-preview {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  max-width: 52ch;
+}
+
+.crate-preview-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.crate-preview-chip {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 2px;
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.crate-preview-title {
+  color: var(--text);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crate-preview-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.crate-preview-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  border-radius: 3px;
+  min-width: 28px;
+  padding: 3px 6px;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.crate-preview-btn:hover {
+  background: var(--surface-hover);
+}
+
+.crate-preview-btn--play {
+  min-width: 34px;
+}
+
+.crate-preview-seek {
+  flex: 1;
+  min-width: 0;
+  accent-color: var(--accent);
+}
+
+.crate-preview-clock {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.crate-preview-bar {
+  margin-top: 8px;
+  height: 2px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.crate-preview-bar-fill {
+  height: 100%;
+  background: var(--accent);
+}
+
+.crate-preview-error {
+  margin-top: 8px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+/* --- Track list ----------------------------------------------------------- */
+
+.crate-tracklist {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  max-width: 52ch;
+}
+
+.crate-track {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  padding: 4px 6px;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.crate-track:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.crate-track--current {
+  color: var(--text);
+  background: var(--accent-dim);
+}
+
+.crate-track-num {
+  min-width: 1.6em;
+  font-variant-numeric: tabular-nums;
+}
+
+.crate-track-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crate-track-time {
+  font-variant-numeric: tabular-nums;
+}
+
 /* --- Motion --------------------------------------------------------------- */
 
 @media (prefers-reduced-motion: no-preference) {

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -345,6 +345,25 @@
 
 /* --- Preview mini-player (KAMP-651) --------------------------------------- */
 
+/* The preview's reserved space. Held open whether or not anything is playing,
+   because rendering the strip into the normal flow grew the whole card and
+   pushed the rail down the page the moment a preview started. Sized for the
+   strip plus a scrolling track list, so a 3-track single and a 20-track album
+   occupy exactly the same room. */
+.crate-preview-slot {
+  min-height: 236px;
+  max-width: 52ch;
+  display: flex;
+  flex-direction: column;
+}
+
+.crate-preview-placeholder {
+  margin: auto 0;
+  color: var(--text-dim);
+  font-size: 12px;
+  opacity: 0.7;
+}
+
 /* Its own strip rather than the TransportBar: the whole promise is that the
    main transport keeps showing the user's own queue, so two players on screen
    is the point. */
@@ -439,11 +458,15 @@
 
 /* --- Track list ----------------------------------------------------------- */
 
+/* Bounded and scrolling: track counts vary wildly and an unbounded list is
+   what pushed the rail off the bottom on a long record. */
 .crate-tracklist {
   list-style: none;
   margin: 10px 0 0;
   padding: 0;
   max-width: 52ch;
+  max-height: 132px;
+  overflow-y: auto;
 }
 
 .crate-track {

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -10,12 +10,28 @@
  */
 
 .crate-view {
+  /* One number for the content column. The rail is the widest thing in the
+     view (10 sleeves + gaps ≈ 810px), so this is sized from it rather than
+     from the card — set it too narrow and the rail wraps to two rows. */
+  --crate-width: 880px;
+
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding: 16px 20px 24px;
   min-height: 0;
   overflow-y: auto;
+}
+
+/* Everything sits in one centred column rather than hugging the left edge.
+   Only the blocks are centred — text inside the card stays left-aligned,
+   because centred body copy reads badly and the clerk card is a shelf tag. */
+.crate-banner,
+.crate-stage,
+.crate-empty {
+  width: 100%;
+  max-width: var(--crate-width);
+  margin-inline: auto;
 }
 
 .crate-banner {
@@ -69,6 +85,9 @@
   display: flex;
   gap: 20px;
   align-items: flex-start;
+  /* The card is narrower than the rail, so centring the pair keeps the two
+     visually stacked instead of the card sitting off to one side. */
+  justify-content: center;
 }
 
 .crate-focus--digging {
@@ -202,6 +221,7 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+  justify-content: center;
   list-style: none;
   padding: 10px 0 4px;
   margin: 0;

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -1,4 +1,4 @@
-/* The Crate (KAMP-650) — focus card + crate rail.
+/* Crate (KAMP-650) — focus card + crate rail.
  *
  * Every colour comes from a theme token. There are eight palettes and --accent
  * swings from indigo to magenta to green, so a hardcoded hex would look wrong in

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -655,6 +655,8 @@ html[data-platform='win32'] .view-tabs {
 .album-card:focus-visible,
 .crate-sleeve:focus-visible,
 .crate-action:focus-visible,
+.crate-preview-btn:focus-visible,
+.crate-track:focus-visible,
 .crate-dig-btn:focus-visible,
 .crate-undo-btn:focus-visible,
 .transport-btn:focus-visible,

--- a/kamp_ui/src/renderer/src/components/CratePreviewStrip.tsx
+++ b/kamp_ui/src/renderer/src/components/CratePreviewStrip.tsx
@@ -1,0 +1,95 @@
+// The in-card preview mini-player (KAMP-651).
+//
+// Deliberately its own strip rather than reusing the TransportBar: the whole
+// promise of preview is that the main transport keeps showing the user's own
+// queue, untouched. Two players on screen is the point, not a redundancy.
+//
+// Position is interpolated locally. The daemon publishes on transitions only —
+// a sample plus the moment it was taken — so the bar can move smoothly without
+// the daemon broadcasting several times a second.
+import React, { useEffect, useState } from 'react'
+import type { PreviewState } from '../api/client'
+import { formatClock } from '../utils/formatClock'
+
+export function CratePreviewStrip({
+  preview,
+  onToggle,
+  onStep,
+  onSeek
+}: {
+  preview: PreviewState
+  onToggle: () => void
+  onStep: (delta: number) => void
+  onSeek: (position: number) => void
+}): React.JSX.Element {
+  const [now, setNow] = useState(() => Date.now() / 1000)
+
+  // Tick only while actually playing — a paused or buffering preview has a
+  // fixed position, and a timer running against nothing is just wakeups.
+  useEffect(() => {
+    if (preview.state !== 'playing' || preview.buffering) return
+    const id = window.setInterval(() => setNow(Date.now() / 1000), 250)
+    return () => window.clearInterval(id)
+  }, [preview.state, preview.buffering])
+
+  // Extrapolate from the last sample. Clamped to the track length so a stalled
+  // stream cannot march the bar off the end — the daemon's next transition
+  // corrects it.
+  const elapsed =
+    preview.state === 'playing' && !preview.buffering
+      ? Math.max(0, now - preview.position_updated_at)
+      : 0
+  const position = Math.min(preview.position + elapsed, preview.duration || Infinity)
+  const pct = preview.duration > 0 ? Math.min(100, (position / preview.duration) * 100) : 0
+
+  const playing = preview.state === 'playing'
+  const preparing = preview.state === 'preparing' || preview.buffering
+
+  return (
+    <div className="crate-preview" role="group" aria-label="Preview">
+      <div className="crate-preview-head">
+        <span className="crate-preview-chip">PREVIEW</span>
+        <span className="crate-preview-title">
+          {preparing ? 'Cueing it up…' : preview.title || `Track ${preview.track_num ?? 1}`}
+        </span>
+      </div>
+
+      <div className="crate-preview-controls">
+        <button
+          className="crate-preview-btn"
+          onClick={() => onStep(-1)}
+          aria-label="Previous track"
+        >
+          ‹‹
+        </button>
+        <button
+          className="crate-preview-btn crate-preview-btn--play"
+          onClick={onToggle}
+          aria-label={playing ? 'Pause preview' : 'Play preview'}
+        >
+          {playing ? '❙❙' : '▶'}
+        </button>
+        <button className="crate-preview-btn" onClick={() => onStep(1)} aria-label="Next track">
+          ››
+        </button>
+
+        <input
+          className="crate-preview-seek"
+          type="range"
+          min={0}
+          max={Math.max(1, Math.floor(preview.duration))}
+          value={Math.floor(position)}
+          onChange={(e) => onSeek(Number(e.target.value))}
+          aria-label="Seek preview"
+        />
+        <span className="crate-preview-clock">
+          {formatClock(position)} / {formatClock(preview.duration)}
+        </span>
+      </div>
+
+      <div className="crate-preview-bar" aria-hidden="true">
+        <div className="crate-preview-bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -440,13 +440,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           </div>
         )}
 
-        <ul
-          className="crate-rail"
-          role="listbox"
-          aria-label="Crate"
-          ref={railRef}
-          tabIndex={-1}
-        >
+        <ul className="crate-rail" role="listbox" aria-label="Crate" ref={railRef} tabIndex={-1}>
           {visible.map((item, index) => (
             <CrateSleeve
               key={item.id}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -14,6 +14,8 @@ import { useStore } from '../store'
 import { crateArtUrl } from '../api/client'
 import type { CrateItem } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
+import { CratePreviewStrip } from './CratePreviewStrip'
+import { formatClock } from '../utils/formatClock'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
 
@@ -39,6 +41,10 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const flushCrateDismissals = useStore((s) => s.flushCrateDismissals)
   const copyCrateItemUrl = useStore((s) => s.copyCrateItemUrl)
   const setActiveView = useStore((s) => s.setActiveView)
+  const preview = useStore((s) => s.preview)
+  const previewPlay = useStore((s) => s.previewPlay)
+  const previewAction = useStore((s) => s.previewAction)
+  const previewSeek = useStore((s) => s.previewSeek)
   const tooltip = useTooltip()
 
   const [focused, setFocused] = useState(0)
@@ -74,6 +80,29 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // the intermediate frame where the focus card would be blank.
   const focusIndex = visible.length === 0 ? 0 : Math.min(focused, visible.length - 1)
   const current = visible[focusIndex] ?? null
+
+  // Preview state for the record on screen. The engine plays one item at a
+  // time, so a preview belonging to another card must not light this one up.
+  const previewingThis = Boolean(
+    current && preview && preview.item_id === current.id && preview.state !== 'idle'
+  )
+  const previewPlaying = previewingThis && preview?.state === 'playing'
+  const previewPreparing = previewingThis && preview?.state === 'preparing'
+
+  // Not memoized: `current` is derived from the filtered crate on every render,
+  // so a useCallback here cannot keep a stable identity anyway.
+  const togglePreview = (): void => {
+    if (!current) return
+    if (previewingThis) void previewAction('toggle')
+    else void previewPlay(current.id)
+  }
+
+  // Leaving the view stops the preview: audio with no visible controls is the
+  // one outcome worse than no preview at all.
+  useEffect(() => {
+    if (active) return
+    if (useStore.getState().preview?.state !== 'idle') void previewAction('stop')
+  }, [active, previewAction])
 
   // Any held dismiss must be sent before this view stops being able to send it.
   // Without this, passing a record and immediately switching views loses it.
@@ -118,8 +147,8 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     setUndoItem(null)
   }, [clearUndoTimer, undoCrateDismiss, undoItem])
 
-  // Preview ("Give it a spin") is KAMP-651 — there is no preview route yet — so
-  // the primary action is the honest one available now: the album's own page.
+  // The album's own page, for buying it or reading the notes — preview now
+  // handles listening (KAMP-651).
   const openOnBandcamp = useCallback((item: CrateItem): void => {
     if (item.item_url) window.api.openExternal(item.item_url)
   }, [])
@@ -142,12 +171,20 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       if (e.key !== 'Escape') return
       const tag = (e.target as HTMLElement).tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      // Two-stage, by state rather than by counting presses: a running preview
+      // is the innermost thing Escape can dismiss, so it goes first and the
+      // view stays put. This handler is on window, and modals listen on
+      // document, so a dialog opened over the Crate still wins outright.
+      if (useStore.getState().preview?.state !== 'idle') {
+        void previewAction('stop')
+        return
+      }
       const prev = useStore.getState().previousView
       void setActiveView(prev && prev !== 'crate' ? prev : 'library')
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [active, setActiveView])
+  }, [active, setActiveView, previewAction])
 
   // The crate's own keys live on the view container, NOT on document. App's
   // global handler is a window listener and the React root sits below document
@@ -196,7 +233,27 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       // itself is unavailable until KAMP-653 extends the Electron relay.
       e.preventDefault()
       e.stopPropagation()
+    } else if (e.key === ' ') {
+      // Now that preview exists, Space is the Crate's (KAMP-651). KAMP-650
+      // deliberately left it global, because claiming it for a no-op would have
+      // removed play/pause from a whole view of a music player.
+      e.preventDefault()
+      e.stopPropagation()
+      togglePreview()
     }
+  }
+
+  // App blurs the focused element on any key it handles when focus came from
+  // the mouse (KAMP-598), which lands focus on document.body — outside this
+  // container, so none of the handlers above would fire again. Click a sleeve,
+  // press a global key, and digging went silently dead. Taking focus back the
+  // moment it falls to nothing fixes that; focus moving into a dialog names
+  // that dialog as relatedTarget, so modals are left alone.
+  const onBlurCapture = (e: React.FocusEvent<HTMLDivElement>): void => {
+    if (e.relatedTarget !== null || !active) return
+    const rail = railRef.current
+    const option = rail?.querySelectorAll<HTMLElement>('[role="option"]')[focusIndex]
+    option?.focus()
   }
 
   // ---------------------------------------------------------------------------
@@ -267,7 +324,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const slots = building ? Math.max(CRATE_SIZE - visible.length, 0) : 0
 
   return (
-    <div className="crate-view" onKeyDown={onKeyDown}>
+    <div className="crate-view" onKeyDown={onKeyDown} onBlurCapture={onBlurCapture}>
       {banner}
 
       <div className="crate-stage">
@@ -298,6 +355,18 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               <div className="crate-actions">
                 <button
                   className="crate-action crate-action--primary"
+                  onClick={togglePreview}
+                  disabled={previewPreparing}
+                  {...tooltip(TOOLTIPS.CRATE_PREVIEW)}
+                >
+                  {previewPreparing
+                    ? 'Cueing it up…'
+                    : previewPlaying
+                      ? 'Hold on'
+                      : 'Give it a spin'}
+                </button>
+                <button
+                  className="crate-action"
                   onClick={() => openOnBandcamp(current)}
                   disabled={!current.item_url}
                 >
@@ -325,6 +394,44 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   Pass
                 </button>
               </div>
+
+              {previewingThis && preview && (
+                <CratePreviewStrip
+                  preview={preview}
+                  onToggle={togglePreview}
+                  onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
+                  onSeek={(position) => void previewSeek(position)}
+                />
+              )}
+
+              {previewingThis && preview && preview.tracks.length > 0 && (
+                <ol className="crate-tracklist">
+                  {preview.tracks.map((track) => (
+                    <li key={track.track_num}>
+                      <button
+                        className={`crate-track${
+                          track.track_num === preview.track_num ? ' crate-track--current' : ''
+                        }`}
+                        onClick={() => void previewPlay(current.id, track.track_num)}
+                      >
+                        <span className="crate-track-num">{track.track_num}</span>
+                        <span className="crate-track-title">
+                          {track.title || `Track ${track.track_num}`}
+                        </span>
+                        <span className="crate-track-time">{formatClock(track.duration)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ol>
+              )}
+
+              {previewingThis && preview?.error && (
+                <p className="crate-preview-error" role="status">
+                  {preview.error === 'rate_limited'
+                    ? 'Bandcamp asked us to slow down — try again shortly.'
+                    : 'No preview for this one.'}
+                </p>
+              )}
             </div>
           </article>
         ) : (

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -1,6 +1,6 @@
-// The Crate (KAMP-650) — a crate of ten records to dig through.
+// Crate (KAMP-650) — a crate of ten records to dig through.
 //
-// User-facing name is "The Crate"; `discovery` stays the code/API namespace.
+// User-facing name is "Crate"; `discovery` stays the code/API namespace.
 // The whole crate arrives in one `discovery.crate` snapshot and is seeded from
 // GET /api/v1/discovery/crate on every WS (re)connect, since _broadcast no-ops
 // with no client attached.
@@ -443,7 +443,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         <ul
           className="crate-rail"
           role="listbox"
-          aria-label="The Crate"
+          aria-label="Crate"
           ref={railRef}
           tabIndex={-1}
         >

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -395,43 +395,58 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 </button>
               </div>
 
-              {previewingThis && preview && (
-                <CratePreviewStrip
-                  preview={preview}
-                  onToggle={togglePreview}
-                  onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
-                  onSeek={(position) => void previewSeek(position)}
-                />
-              )}
+              {/* The preview's own space, always present. Rendering the strip
+                  and track list into the normal flow made the whole card grow
+                  when a preview started, shoving the rail down the page — and
+                  the track list is unbounded, so a long record shoved it hard.
+                  The slot reserves the room; the list scrolls inside it. */}
+              <div className="crate-preview-slot">
+                {previewingThis && preview ? (
+                  <>
+                    <CratePreviewStrip
+                      preview={preview}
+                      onToggle={togglePreview}
+                      onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
+                      onSeek={(position) => void previewSeek(position)}
+                    />
 
-              {previewingThis && preview && preview.tracks.length > 0 && (
-                <ol className="crate-tracklist">
-                  {preview.tracks.map((track) => (
-                    <li key={track.track_num}>
-                      <button
-                        className={`crate-track${
-                          track.track_num === preview.track_num ? ' crate-track--current' : ''
-                        }`}
-                        onClick={() => void previewPlay(current.id, track.track_num)}
-                      >
-                        <span className="crate-track-num">{track.track_num}</span>
-                        <span className="crate-track-title">
-                          {track.title || `Track ${track.track_num}`}
-                        </span>
-                        <span className="crate-track-time">{formatClock(track.duration)}</span>
-                      </button>
-                    </li>
-                  ))}
-                </ol>
-              )}
+                    {preview.tracks.length > 0 && (
+                      <ol className="crate-tracklist">
+                        {preview.tracks.map((track) => (
+                          <li key={track.track_num}>
+                            <button
+                              className={`crate-track${
+                                track.track_num === preview.track_num ? ' crate-track--current' : ''
+                              }`}
+                              onClick={() => void previewPlay(current.id, track.track_num)}
+                            >
+                              <span className="crate-track-num">{track.track_num}</span>
+                              <span className="crate-track-title">
+                                {track.title || `Track ${track.track_num}`}
+                              </span>
+                              <span className="crate-track-time">
+                                {formatClock(track.duration)}
+                              </span>
+                            </button>
+                          </li>
+                        ))}
+                      </ol>
+                    )}
 
-              {previewingThis && preview?.error && (
-                <p className="crate-preview-error" role="status">
-                  {preview.error === 'rate_limited'
-                    ? 'Bandcamp asked us to slow down — try again shortly.'
-                    : 'No preview for this one.'}
-                </p>
-              )}
+                    {preview.error && (
+                      <p className="crate-preview-error" role="status">
+                        {preview.error === 'rate_limited'
+                          ? 'Bandcamp asked us to slow down — try again shortly.'
+                          : 'No preview for this one.'}
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p className="crate-preview-placeholder">
+                    Space to hear it — your queue stays where it is.
+                  </p>
+                )}
+              </div>
             </div>
           </article>
         ) : (

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -46,9 +46,14 @@ const GROUPS: Group[] = [
         description: 'Previous / next record',
         note: 'Arrows stay on the transport; ← → also work inside the rail'
       },
+      {
+        keys: ['Space'],
+        description: 'Preview / hold',
+        note: 'Your queue pauses and comes back'
+      },
       { keys: ['C'], description: 'Copy link' },
       { keys: ['X'], description: 'Pass', note: 'Undo for 5 seconds' },
-      { keys: ['Esc'], description: 'Leave the crate' }
+      { keys: ['Esc'], description: 'Stop the preview, then leave the crate' }
     ]
   },
   {

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -39,7 +39,7 @@ const GROUPS: Group[] = [
     shortcuts: [{ keys: ['Shift', 'click'], description: 'Range select in Next Up' }]
   },
   {
-    label: 'The Crate',
+    label: 'Crate',
     shortcuts: [
       {
         keys: [',', '.'],

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -228,7 +228,7 @@ type PlayerStore = {
   reorderDownloadQueue: (orderedQueuedIds: string[]) => Promise<void>
   retryDownload: (providerItemId: string) => Promise<void>
   cancelDownload: (providerItemId: string) => Promise<void>
-  // KAMP-650: The Crate
+  // KAMP-650: the Crate
   loadCrate: () => Promise<void>
   setCrate: (snapshot: CrateSnapshot) => void
   newCrate: () => Promise<void>
@@ -926,7 +926,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
     }
   },
   // ---------------------------------------------------------------------------
-  // The Crate (KAMP-650)
+  // Crate (KAMP-650)
   // ---------------------------------------------------------------------------
   loadCrate: async () => {
     try {

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -16,6 +16,7 @@ import type {
   ConfigValues,
   CrateItem,
   CrateSnapshot,
+  PreviewState,
   CriteriaDoc,
   DownloadItem,
   PlayerState,
@@ -180,6 +181,10 @@ type PlayerStore = {
   // (discovery_events has no un-dismiss kind and the state rank is monotonic),
   // so an Undo has to happen before the request, not after it.
   crateDismissPending: number[]
+  // KAMP-651: preview transport state. Daemon-owned — it survives a renderer
+  // reload, so this is seeded from GET .../preview/state on every WS connect
+  // and kept live by the `discovery.preview` event, never invented locally.
+  preview: PreviewState | null
   flashToast: string | null
   // KAMP-571: tone for the current flashToast; 'error' renders the red variant.
   flashToastTone: 'error' | null
@@ -236,6 +241,13 @@ type PlayerStore = {
   // the user navigates away, or a pass made in the last few seconds is lost.
   flushCrateDismissals: () => Promise<void>
   copyCrateItemUrl: (item: CrateItem) => Promise<void>
+  // KAMP-651: preview transport. Every action returns the authoritative state,
+  // so none of these guess locally.
+  loadPreview: () => Promise<void>
+  setPreview: (state: PreviewState) => void
+  previewPlay: (itemId: number, trackNum?: number) => Promise<void>
+  previewAction: (action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev') => Promise<void>
+  previewSeek: (position: number) => Promise<void>
   showFlashToast: (msg: string, tone?: 'error') => void
   setRecentlyAddedCount: (n: number) => void
   setRecentlyAddedDays: (n: number) => void
@@ -569,6 +581,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadBatch: null,
   crate: null,
   crateDismissPending: [],
+  preview: null,
   flashToast: null,
   flashToastTone: null,
   styleRailVisible: false,
@@ -976,6 +989,40 @@ export const useStore = create<PlayerStore>((set, get) => ({
       void api.crateItemUrlCopied(item.id).catch(() => {})
     } catch {
       get().showFlashToast('Could not copy the link', 'error')
+    }
+  },
+  // --- Preview (KAMP-651) ---------------------------------------------------
+  loadPreview: async () => {
+    try {
+      set({ preview: await api.getPreviewState() })
+    } catch {
+      // Best-effort; the discovery.preview event repopulates on the next
+      // transition, and a null preview simply renders no mini-player.
+    }
+  },
+  setPreview: (state) => set({ preview: state }),
+  previewPlay: async (itemId, trackNum) => {
+    try {
+      set({ preview: await api.previewPlay(itemId, trackNum) })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not start the preview'
+      get().showFlashToast(msg, 'error')
+    }
+  },
+  previewAction: async (action) => {
+    try {
+      set({ preview: await api.previewAction(action) })
+    } catch {
+      // A failed transport call leaves the daemon authoritative; re-read rather
+      // than showing a state the preview engine does not agree with.
+      void get().loadPreview()
+    }
+  },
+  previewSeek: async (position) => {
+    try {
+      set({ preview: await api.previewSeek(position) })
+    } catch {
+      void get().loadPreview()
     }
   },
   showFlashToast: (msg, tone) => {

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -47,7 +47,7 @@ export const TOOLTIPS = {
   // Downloads
   DOWNLOADS_VIEW: 'Downloads',
 
-  // The Crate (KAMP-650). The clerk card's tooltip is the plain mechanical
+  // Crate (KAMP-650). The clerk card's tooltip is the plain mechanical
   // answer to "why am I seeing this?" — the shelf tag is the short version.
   CRATE_WHY: 'Picked from your own library and listening — nothing leaves this machine',
   CRATE_WISHLIST_SOON: 'Wishlisting from Kamp is coming — copy the link for now',

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -51,6 +51,7 @@ export const TOOLTIPS = {
   // answer to "why am I seeing this?" — the shelf tag is the short version.
   CRATE_WHY: 'Picked from your own library and listening — nothing leaves this machine',
   CRATE_WISHLIST_SOON: 'Wishlisting from Kamp is coming — copy the link for now',
+  CRATE_PREVIEW: 'Play a preview (Space) — your queue stays put',
   CRATE_COPY: 'Copy link (C)',
   CRATE_PASS: 'Pass (X)',
 

--- a/kamp_ui/src/renderer/src/utils/formatClock.ts
+++ b/kamp_ui/src/renderer/src/utils/formatClock.ts
@@ -1,0 +1,9 @@
+// m:ss for track and preview times (KAMP-651).
+//
+// Lives outside the component files because a module that exports components
+// must export nothing else, or Fast Refresh stops working for it.
+export function formatClock(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
+  const total = Math.floor(seconds)
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`
+}

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -555,6 +555,172 @@ class TestRealArtFetch:
         assert _fetch_art_bytes("https://f4.bcbits.com/img/a1_10.jpg") is None
 
 
+class FakePreview:
+    """The PreviewPlayer surface the routes touch."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self.state: dict[str, Any] = {"state": "idle", "item_id": None}
+
+    def snapshot(self) -> dict[str, Any]:
+        return dict(self.state)
+
+    def play(self, item_id: int, track_num: int | None = None) -> dict[str, Any]:
+        self.calls.append(("play", (item_id, track_num)))
+        self.state = {"state": "playing", "item_id": item_id}
+        return self.snapshot()
+
+    def _simple(self, name: str) -> dict[str, Any]:
+        self.calls.append((name, None))
+        return self.snapshot()
+
+    def pause(self) -> dict[str, Any]:
+        return self._simple("pause")
+
+    def resume(self) -> dict[str, Any]:
+        return self._simple("resume")
+
+    def toggle(self) -> dict[str, Any]:
+        return self._simple("toggle")
+
+    def stop(self) -> dict[str, Any]:
+        return self._simple("stop")
+
+    def step(self, delta: int) -> dict[str, Any]:
+        self.calls.append(("step", delta))
+        return self.snapshot()
+
+    def seek(self, position: float) -> dict[str, Any]:
+        self.calls.append(("seek", position))
+        return self.snapshot()
+
+    def release_for_main(self) -> None:
+        self.calls.append(("release_for_main", None))
+
+    def set_volume(self, v: int) -> None:
+        self.calls.append(("set_volume", v))
+
+    def set_muted(self, m: bool) -> None:
+        self.calls.append(("set_muted", m))
+
+
+def _preview_app(index: LibraryIndex, preview: Any) -> Any:
+    app = FastAPI()
+    register_discovery_routes(
+        app, index=index, broadcast=lambda _e: None, preview=preview
+    )
+    return TestClient(app)
+
+
+class TestPreviewRoutes:
+    def test_play_starts_a_preview(self, index: LibraryIndex) -> None:
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        body = client.post(
+            "/api/v1/discovery/preview/play", json={"item_id": 7, "track_num": 2}
+        ).json()
+        assert body["state"] == "playing"
+        assert preview.calls == [("play", (7, 2))]
+
+    def test_play_requires_an_integer_item(self, index: LibraryIndex) -> None:
+        client = _preview_app(index, FakePreview())
+        assert client.post("/api/v1/discovery/preview/play", json={}).status_code == 422
+
+    @pytest.mark.parametrize("action", ["pause", "resume", "toggle", "stop"])
+    def test_simple_actions(self, index: LibraryIndex, action: str) -> None:
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        assert client.post(f"/api/v1/discovery/preview/{action}").status_code == 200
+        assert preview.calls == [(action, None)]
+
+    @pytest.mark.parametrize("action,delta", [("next", 1), ("prev", -1)])
+    def test_stepping(self, index: LibraryIndex, action: str, delta: int) -> None:
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        client.post(f"/api/v1/discovery/preview/{action}")
+        assert preview.calls == [("step", delta)]
+
+    def test_seek_requires_a_number(self, index: LibraryIndex) -> None:
+        client = _preview_app(index, FakePreview())
+        assert (
+            client.post(
+                "/api/v1/discovery/preview/seek", json={"position": "soon"}
+            ).status_code
+            == 422
+        )
+
+    def test_an_unknown_action_is_404_not_an_arbitrary_call(
+        self, index: LibraryIndex
+    ) -> None:
+        """One route serves several verbs, so the allowlist is what stops it
+        being a remote method call on the player."""
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        assert client.post("/api/v1/discovery/preview/shutdown").status_code == 404
+        assert preview.calls == []
+
+    def test_state_is_the_reconnect_path(self, index: LibraryIndex) -> None:
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        client.post("/api/v1/discovery/preview/play", json={"item_id": 3})
+        body = client.get("/api/v1/discovery/preview/state").json()
+        assert body["item_id"] == 3
+
+    def test_no_engine_reports_unavailable_but_still_answers_state(
+        self, index: LibraryIndex
+    ) -> None:
+        """The routes register either way so the UI has one code path; state
+        returns the idle shape rather than an error the view must special-case."""
+        client = _preview_app(index, None)
+        assert client.post("/api/v1/discovery/preview/stop").status_code == 503
+        assert client.get("/api/v1/discovery/preview/state").json()["state"] == "idle"
+
+
+class TestMainTransportWins:
+    """Any main-transport POST stops a preview — except volume and mute, which
+    are a change to how loud everything is, not a demand for the floor."""
+
+    def _app(self, index: LibraryIndex, preview: Any) -> Any:
+        from kamp_core.server import create_app
+
+        engine = MagicMock()
+        engine.state = MagicMock(playing=False, position=0.0, duration=0.0, volume=100)
+        queue = MagicMock()
+        queue.current.return_value = None
+        queue.peek_next.return_value = None
+        return TestClient(
+            create_app(index=index, engine=engine, queue=queue, preview_player=preview)
+        )
+
+    @pytest.mark.parametrize(
+        "path", ["/api/v1/player/pause", "/api/v1/player/resume", "/api/v1/player/stop"]
+    )
+    def test_transport_posts_stop_the_preview(
+        self, index: LibraryIndex, path: str
+    ) -> None:
+        preview = FakePreview()
+        self._app(index, preview).post(path)
+        assert ("release_for_main", None) in preview.calls
+
+    def test_volume_mirrors_instead_of_stopping(self, index: LibraryIndex) -> None:
+        """Otherwise the slider moves everything except what you can hear."""
+        preview = FakePreview()
+        self._app(index, preview).post("/api/v1/player/volume", json={"volume": 40})
+        assert ("set_volume", 40) in preview.calls
+        assert ("release_for_main", None) not in preview.calls
+
+    def test_mute_mirrors_instead_of_stopping(self, index: LibraryIndex) -> None:
+        preview = FakePreview()
+        self._app(index, preview).post("/api/v1/player/mute", json={"muted": True})
+        assert ("set_muted", True) in preview.calls
+        assert ("release_for_main", None) not in preview.calls
+
+    def test_a_get_does_not_stop_the_preview(self, index: LibraryIndex) -> None:
+        preview = FakePreview()
+        self._app(index, preview).get("/api/v1/player/state")
+        assert preview.calls == []
+
+
 class TestArtHostAllowlist:
     def test_art_hosts_are_a_subset_of_the_proxy_allowlist(self) -> None:
         """Two lists that must not drift apart: anything the art proxy will fetch

--- a/tests/test_discovery_parsers.py
+++ b/tests/test_discovery_parsers.py
@@ -74,6 +74,29 @@ class TestAlsoLike:
         assert any("fans who also own" in i["supporters"] for i in items)
         assert any(i["fan_comment"] for i in items)
 
+    def test_inline_audio_url_is_unwrapped_from_its_json(self, album_page: str) -> None:
+        """data-audiourl is a JSON object keyed by format, not a bare URL.
+
+        Reading it as a string yields something unplayable that would only fail
+        at the point of pressing play (KAMP-651). Every recommendation carries
+        one, which is what lets a preview start before the album page loads.
+        """
+        items = parse_also_like(album_page).items
+        assert items
+        for item in items:
+            assert item["audio_url"], "every recommendation should carry an mp3"
+            assert item["audio_url"].startswith("https://")
+            assert not item["audio_url"].startswith("{")
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "not json", "[]", "{}", '{"flac": "https://x/y.flac"}', '{"mp3-128": ""}'],
+    )
+    def test_unusable_audio_url_is_none(self, raw: str) -> None:
+        from kamp_daemon.discovery_bandcamp_parsers import _audio_url
+
+        assert _audio_url(raw) is None
+
     def test_tracking_parameter_is_stripped(self, album_page: str) -> None:
         """Bandcamp appends ?from=<seed>, so the same album reached from two seeds
         would otherwise look like two albums and defeat cross-seed dedupe."""

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -1,0 +1,533 @@
+"""Crate preview playback tests (KAMP-651).
+
+The whole feature is a promise about what it does *not* touch, so most of these
+assert absences: the queue, the scrobbler, track_stats, the persisted session and
+the main VU meter must all be untouched, and the main player must come back
+exactly as it was left.
+
+No real mpv anywhere — the engine is a fake with the same surface.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from kamp_core.library import LibraryIndex
+from kamp_core.playback import PlaybackState
+from kamp_daemon.discovery import Candidate, PreviewStream
+from kamp_daemon.discovery_preview import (
+    IDLE,
+    MIN_PREVIEW_SECS,
+    PAUSED,
+    PLAYING,
+    PreviewPlayer,
+)
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> Iterator[LibraryIndex]:
+    idx = LibraryIndex(tmp_path / "library.db")
+    yield idx
+    idx.close()
+
+
+class FakeEngine:
+    """Only the surface PreviewPlayer uses."""
+
+    def __init__(self) -> None:
+        self.state = PlaybackState()
+        self.on_track_end: Any = None
+        self.on_file_loaded: Any = None
+        self.on_play_state_changed: Any = None
+        self.on_audio_level: Any = None
+        self.played: list[str] = []
+        self.calls: list[str] = []
+        self.shutdown_count = 0
+
+    def play(self, path: str) -> None:
+        self.played.append(str(path))
+        self.calls.append("play")
+        self.state.playing = True
+
+    def pause(self) -> None:
+        self.calls.append("pause")
+        # Deliberately does NOT flip state.playing yet: the real pause() only
+        # sends a script-message, and kamp_fade.lua applies the real pause about
+        # 0.4s later. state.playing follows mpv's observed property, so it lags.
+        self._pending_pause = True
+
+    def settle(self) -> None:
+        """Land a scheduled fade — what the real engine does ~0.4s after pause()."""
+        if getattr(self, "_pending_pause", False):
+            self._pending_pause = False
+            self.state.playing = False
+
+    def resume(self) -> None:
+        self.calls.append("resume")
+        self._pending_pause = False
+        self.state.playing = True
+
+    def unload(self) -> None:
+        self.calls.append("unload")
+        self.state.playing = False
+
+    def seek(self, position: float) -> None:
+        self.calls.append(f"seek:{position}")
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
+
+    @property
+    def volume(self) -> int:
+        return self.state.volume
+
+    @volume.setter
+    def volume(self, value: int) -> None:
+        self.state.volume = value
+
+    @property
+    def muted(self) -> bool:
+        return self.state.muted
+
+    @muted.setter
+    def muted(self, value: bool) -> None:
+        self.state.muted = value
+
+
+class FakeSource:
+    def __init__(self, tracks: list[PreviewStream] | None = None, error: Any = None):
+        self.tracks = tracks if tracks is not None else [_stream(1), _stream(2)]
+        self.error = error
+        self.calls = 0
+
+    def preview_tracks(self, candidate: Candidate) -> list[PreviewStream]:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return list(self.tracks)
+
+
+class RateLimitedError(RuntimeError):
+    """Name-matched by PreviewPlayer without importing the source module."""
+
+
+def _stream(num: int, expires_at: float = 4_000_000_000.0) -> PreviewStream:
+    return PreviewStream(
+        url=f"https://cdn/{num}.mp3",
+        track_num=num,
+        title=f"Track {num}",
+        duration=100.0,
+        expires_at=expires_at,
+    )
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _item(index: LibraryIndex, item_id: str = "1") -> int:
+    row = index.add_discovery_candidate(
+        provider="bandcamp",
+        provider_item_id=item_id,
+        item_url="https://a.bandcamp.com/album/x",
+        artist="Band",
+        title="Album",
+    )
+    # Next free slot — two items cannot share one (the partial unique index).
+    position = index._conn.execute(
+        "SELECT COUNT(*) AS c FROM discovery_items WHERE crate_no = 1"
+    ).fetchone()["c"]
+    index.place_in_crate(row, 1, position)
+    return row
+
+
+class Harness:
+    def __init__(
+        self,
+        index: LibraryIndex,
+        source: FakeSource | None = None,
+        main_playing: bool = False,
+    ) -> None:
+        self.index = index
+        self.main = FakeEngine()
+        self.main.state.playing = main_playing
+        self.engines: list[FakeEngine] = []
+        self.events: list[dict[str, Any]] = []
+        self.source = source if source is not None else FakeSource()
+        self.clock = _Clock()
+
+        def _factory() -> FakeEngine:
+            # Real construction blocks in _ipc.open(timeout=5.0) while mpv comes
+            # up. Modelling that is what makes the concurrency test meaningful:
+            # an instant factory never lets the GIL switch inside the
+            # check-then-build, so the test would pass with no lock at all.
+            import time
+
+            time.sleep(0.02)
+            engine = FakeEngine()
+            self.engines.append(engine)
+            return engine
+
+        self.player = PreviewPlayer(
+            index,
+            main_engine=self.main,  # type: ignore[arg-type]
+            engine_factory=_factory,  # type: ignore[arg-type]
+            source_factory=lambda: self.source,  # type: ignore[arg-type,return-value]
+            notify=self.events.append,
+            idle_timeout=0.05,
+            now=self.clock,
+        )
+
+    @property
+    def engine(self) -> FakeEngine:
+        return self.engines[-1]
+
+
+# ---------------------------------------------------------------------------
+# Isolation — the whole point of the story
+# ---------------------------------------------------------------------------
+
+
+class TestIsolation:
+    def test_the_preview_engine_gets_no_main_callbacks(
+        self, index: LibraryIndex
+    ) -> None:
+        """on_play_state_changed drives the main player's WS state and the OS
+        widget; on_audio_level drives the main VU meter. Neither should ever
+        hear from the preview engine."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        assert h.engine.on_play_state_changed is None
+        assert h.engine.on_audio_level is None
+        # These two are preview-local and deliberately wired.
+        assert h.engine.on_track_end is not None
+        assert h.engine.on_file_loaded is not None
+
+    def test_preview_never_touches_track_stats_or_the_queue(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.clock.t += 60
+        h.player.stop()
+
+        assert (
+            index._conn.execute("SELECT COUNT(*) AS c FROM track_stats").fetchone()["c"]
+            == 0
+        )
+        assert not index.load_queue_state()
+
+    def test_the_main_engine_is_never_asked_to_play(self, index: LibraryIndex) -> None:
+        """Preview audio must come out of the second engine, always."""
+        h = Harness(index, main_playing=True)
+        h.player.play(_item(index))
+        assert h.main.played == []
+        assert h.engine.played == ["https://cdn/1.mp3"]
+
+
+# ---------------------------------------------------------------------------
+# The handoff
+# ---------------------------------------------------------------------------
+
+
+class TestHandoff:
+    def test_a_playing_queue_is_paused_and_resumed(self, index: LibraryIndex) -> None:
+        h = Harness(index, main_playing=True)
+        h.player.play(_item(index))
+        assert "pause" in h.main.calls
+
+        h.player.stop()
+        assert "resume" in h.main.calls
+
+    def test_a_paused_queue_is_left_alone(self, index: LibraryIndex) -> None:
+        """Resuming a queue the user had already paused would be kamp starting
+        playback nobody asked for."""
+        h = Harness(index, main_playing=False)
+        h.player.play(_item(index))
+        h.player.stop()
+        assert h.main.calls == []
+
+    def test_the_flag_is_captured_before_the_fade(self, index: LibraryIndex) -> None:
+        """pause() only sends a script-message; the Lua applies the real pause
+        ~0.4s later, so state.playing still reads True right after the call.
+        Reading it back instead of capturing it first would strand main paused."""
+        h = Harness(index, main_playing=True)
+        h.player.play(_item(index))
+        # Immediately after the call the fade has not landed yet.
+        assert h.main.state.playing is True
+        # ...and now it has, which is the state any real stop() sees.
+        h.main.settle()
+        assert h.main.state.playing is False
+
+        h.player.stop()
+        assert h.main.calls.count("resume") == 1
+
+    def test_switching_records_does_not_double_pause(self, index: LibraryIndex) -> None:
+        h = Harness(index, main_playing=True)
+        first, second = _item(index, "1"), _item(index, "2")
+        h.player.play(first)
+        h.player.play(second)
+        assert h.main.calls.count("pause") == 1
+
+    def test_the_main_transport_wins_and_is_not_resumed(
+        self, index: LibraryIndex
+    ) -> None:
+        """release_for_main must not resume: main is about to do whatever the
+        user just pressed, and resuming first would fight it."""
+        h = Harness(index, main_playing=True)
+        h.player.play(_item(index))
+        h.main.calls.clear()
+
+        h.player.release_for_main()
+        assert "resume" not in h.main.calls
+        assert h.player.snapshot()["state"] == IDLE
+
+
+# ---------------------------------------------------------------------------
+# Audio settings
+# ---------------------------------------------------------------------------
+
+
+class TestAudioSettings:
+    def test_volume_is_mirrored_at_spawn(self, index: LibraryIndex) -> None:
+        """A fresh engine defaults to 100 with nothing on the command line, so
+        without this someone listening at 30 gets a preview at full blast."""
+        h = Harness(index)
+        h.main.state.volume = 30
+        h.player.play(_item(index))
+        assert h.engine.volume == 30
+
+    def test_mute_is_mirrored_at_spawn(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.main.state.muted = True
+        h.player.play(_item(index))
+        assert h.engine.muted is True
+
+    def test_a_volume_change_mid_preview_follows(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.set_volume(12)
+        assert h.engine.volume == 12
+
+    def test_volume_changes_are_harmless_with_no_engine(
+        self, index: LibraryIndex
+    ) -> None:
+        Harness(index).player.set_volume(50)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_the_engine_is_not_spawned_until_the_first_preview(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        assert h.engines == []
+        h.player.play(_item(index))
+        assert len(h.engines) == 1
+
+    def test_concurrent_first_previews_build_exactly_one_engine(
+        self, index: LibraryIndex
+    ) -> None:
+        """Construction spawns mpv synchronously, so a race would leave an
+        orphan process nothing holds a reference to — and on POSIX there is no
+        Job Object to reap it."""
+        h = Harness(index)
+        item = _item(index)
+        barrier = threading.Barrier(4)
+
+        def _go() -> None:
+            barrier.wait()
+            h.player.play(item)
+
+        threads = [threading.Thread(target=_go) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert len(h.engines) == 1
+
+    def test_idle_kill_tears_down_and_a_later_play_respawns(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.player.stop()
+
+        deadline = _wait_for(lambda: h.engines[0].shutdown_count == 1)
+        assert deadline, "the idle timer never fired"
+
+        h.player.play(item)
+        assert len(h.engines) == 2
+
+    def test_a_playing_preview_is_not_idle_killed(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        import time
+
+        time.sleep(0.15)
+        assert h.engines[0].shutdown_count == 0
+
+    def test_shutdown_is_idempotent(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.shutdown()
+        h.player.shutdown()
+        assert h.engines[0].shutdown_count == 1
+
+
+def _wait_for(pred: Any, timeout: float = 2.0) -> bool:
+    import time
+
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Transport and track stepping
+# ---------------------------------------------------------------------------
+
+
+class TestTransport:
+    def test_the_track_list_is_published_for_the_card(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        state = h.player.play(_item(index))
+        assert [t["track_num"] for t in state["tracks"]] == [1, 2]
+        assert state["title"] == "Track 1"
+
+    def test_stepping_costs_no_extra_fetch(self, index: LibraryIndex) -> None:
+        """One album-page fetch buys the whole record; next/prev must not each
+        cost another request against the class that rate-limits hardest."""
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.player.step(1)
+        h.player.step(-1)
+        assert h.source.calls == 1
+
+    def test_stepping_past_the_end_stops(self, index: LibraryIndex) -> None:
+        """A preview is a listen through one record, not a loop."""
+        h = Harness(index)
+        h.player.play(_item(index), track_num=2)
+        assert h.player.step(1)["state"] == IDLE
+
+    def test_pause_and_resume(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        assert h.player.pause()["state"] == PAUSED
+        assert h.player.resume()["state"] == PLAYING
+
+    def test_an_expired_cache_is_refetched(self, index: LibraryIndex) -> None:
+        """Signed URLs die after about a day; a stale one would fail silently at
+        the point of pressing play."""
+        h = Harness(index, source=FakeSource([_stream(1, expires_at=1.0)]))
+        item = _item(index)
+        h.player.play(item)
+        h.player.play(item)
+        assert h.source.calls == 2
+
+    def test_a_live_cache_is_reused(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.player.play(item)
+        assert h.source.calls == 1
+
+
+class TestFailures:
+    def test_an_unknown_item_reports_not_found(self, index: LibraryIndex) -> None:
+        assert Harness(index).player.play(9999)["error"] == "not_found"
+
+    def test_an_album_with_no_audio_reports_unavailable(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index, source=FakeSource(tracks=[]))
+        assert h.player.play(_item(index))["error"] == "unavailable"
+
+    def test_a_rate_limit_is_distinguishable(self, index: LibraryIndex) -> None:
+        """ "Bandcamp asked us to slow down" and "this album will not play" want
+        different words on screen."""
+        h = Harness(index, source=FakeSource(error=RateLimitedError("429")))
+        assert h.player.play(_item(index))["error"] == "rate_limited"
+
+    def test_a_broken_source_does_not_raise(self, index: LibraryIndex) -> None:
+        h = Harness(index, source=FakeSource(error=ValueError("boom")))
+        assert h.player.play(_item(index))["error"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Engagement events
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewedEvents:
+    def _events(self, index: LibraryIndex) -> list[Any]:
+        return index._conn.execute(
+            "SELECT kind, detail FROM discovery_events WHERE kind = 'previewed'"
+        ).fetchall()
+
+    def test_a_real_listen_is_recorded_once_with_its_seconds(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.clock.t += 45
+        h.player.stop()
+
+        rows = self._events(index)
+        assert len(rows) == 1
+        assert json.loads(rows[0]["detail"])["seconds"] == pytest.approx(45.0)
+
+    def test_a_misclick_records_nothing(self, index: LibraryIndex) -> None:
+        """The first 'previewed' event flips state off 'fresh' irreversibly, so
+        a half-second slip must not relabel the card forever."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.clock.t += MIN_PREVIEW_SECS / 2
+        h.player.stop()
+        assert self._events(index) == []
+        assert index.crate_items(1)[0]["state"] == "fresh"
+
+    def test_a_multi_track_listen_is_one_event(self, index: LibraryIndex) -> None:
+        """Per-track events would make KAMP-655 count one album as five."""
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item)
+        h.clock.t += 30
+        h.player.step(1)
+        h.clock.t += 30
+        h.player.stop()
+        assert len(self._events(index)) == 1
+
+    def test_paused_time_is_not_counted(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.clock.t += 20
+        h.player.pause()
+        h.clock.t += 600
+        h.player.stop()
+        assert json.loads(self._events(index)[0]["detail"])["seconds"] == pytest.approx(
+            20.0
+        )

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -10,6 +10,7 @@ import gzip
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -482,3 +483,140 @@ class TestCapabilities:
             )
             is None
         )
+
+
+def _album_html(tracks: list[dict[str, Any]], item_type: str = "album") -> str:
+    import html as html_lib
+
+    blob = {"item_type": item_type, "trackinfo": tracks}
+    return f'<div data-tralbum="{html_lib.escape(json.dumps(blob), quote=True)}">'
+
+
+def _candidate(url: str = "https://a.bandcamp.com/album/x") -> Candidate:
+    return Candidate(provider="bandcamp", provider_item_id="1", item_url=url)
+
+
+class TestPreviewTracks:
+    def test_returns_every_playable_track_in_order(self) -> None:
+        """One request buys the whole album, so next/prev costs nothing more."""
+        html = _album_html(
+            [
+                {
+                    "track_num": 1,
+                    "title": "One",
+                    "duration": 60.5,
+                    "file": {"mp3-128": "https://cdn/1.mp3?ts=1000"},
+                },
+                {
+                    "track_num": 2,
+                    "title": "Two",
+                    "duration": 90.0,
+                    "file": {"mp3-128": "https://cdn/2.mp3?ts=1000"},
+                },
+            ]
+        )
+        tracks = _source(FakeSession(get_body=html)).preview_tracks(_candidate())
+        assert [t.track_num for t in tracks] == [1, 2]
+        assert [t.title for t in tracks] == ["One", "Two"]
+        assert tracks[0].duration == 60.5
+
+    def test_expiry_comes_from_the_urls_own_timestamp(self) -> None:
+        """ts is when Bandcamp signed the URL — more accurate than fetch time,
+        since the page itself may have been served from a cache."""
+        html = _album_html(
+            [{"track_num": 1, "file": {"mp3-128": "https://cdn/1.mp3?ts=1000000"}}]
+        )
+        tracks = _source(FakeSession(get_body=html)).preview_tracks(_candidate())
+        assert tracks[0].expires_at == 1000000 + 86400
+
+    def test_unreleased_tracks_are_skipped_not_fatal(self) -> None:
+        """A pre-order album has tracks with no stream; the rest still play."""
+        html = _album_html(
+            [
+                {"track_num": 1, "title": "Teaser", "file": {}},
+                {
+                    "track_num": 2,
+                    "title": "Real",
+                    "file": {"mp3-128": "https://cdn/2.mp3"},
+                },
+            ]
+        )
+        tracks = _source(FakeSession(get_body=html)).preview_tracks(_candidate())
+        assert [t.title for t in tracks] == ["Real"]
+
+    def test_single_track_page_is_numbered_one(self) -> None:
+        """item_type='track' pages expose track_num=None (KAMP-526)."""
+        html = _album_html(
+            [
+                {
+                    "track_num": None,
+                    "title": "Lone",
+                    "file": {"mp3-128": "https://cdn/1.mp3"},
+                }
+            ],
+            item_type="track",
+        )
+        tracks = _source(FakeSession(get_body=html)).preview_tracks(_candidate())
+        assert tracks[0].track_num == 1
+
+    def test_resolve_preview_is_the_first_of_the_list(self) -> None:
+        """One parser, not two that can disagree."""
+        # ts= pins expires_at so the two calls are comparable; without it the
+        # fallback is time.time() and they differ by microseconds.
+        html = _album_html(
+            [
+                {
+                    "track_num": 1,
+                    "title": "One",
+                    "file": {"mp3-128": "https://cdn/1.mp3?ts=1000"},
+                },
+                {
+                    "track_num": 2,
+                    "title": "Two",
+                    "file": {"mp3-128": "https://cdn/2.mp3?ts=1000"},
+                },
+            ]
+        )
+        source = _source(FakeSession(get_body=html))
+        assert (
+            source.resolve_preview(_candidate())
+            == source.preview_tracks(_candidate())[0]
+        )
+
+    def test_a_custom_domain_is_refused_without_fetching(self) -> None:
+        """item_url is remote data read back out of discovery_items."""
+        session = FakeSession(get_body=_album_html([]))
+        source = _source(session)
+        assert (
+            source.preview_tracks(_candidate("https://evil.example.com/album/x")) == []
+        )
+        assert session.gets == []
+
+
+class TestPreviewNeverWaitsOnTheGovernor:
+    """bandcamp_ratelimit documents itself as a non-playback tool.
+
+    wait_turn blocks until a 60/120/300s cooldown expires, so a listener who
+    clicked play would get a hang with nothing on screen. The outcome is still
+    reported, so a 429 earned here makes the crate builder back off instead.
+    """
+
+    def test_a_cooldown_does_not_delay_a_click(self) -> None:
+        governor = MagicMock()
+        governor.blocked_for.return_value = 300.0
+        html = _album_html([{"track_num": 1, "file": {"mp3-128": "https://cdn/1.mp3"}}])
+        source = BandcampDiscoverySource(FakeSession(get_body=html), governor=governor)
+
+        assert len(source.preview_tracks(_candidate())) == 1
+        governor.wait_turn.assert_not_called()
+        governor.report_ok.assert_called_once_with("album_page")
+
+    def test_a_429_is_reported_and_raised(self) -> None:
+        governor = MagicMock()
+        session = FakeSession()
+        session.get_status = 429
+        source = BandcampDiscoverySource(session, governor=governor)
+        with pytest.raises(RateLimitedError):
+            source.preview_tracks(_candidate())
+        governor.report_429.assert_called_once_with("album_page")
+        governor.wait_turn.assert_not_called()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import subprocess
 import json
 import logging
 import time
@@ -2476,6 +2477,70 @@ class TestMpvPlaybackEngine:
         popen_args, _ = mock_popen.call_args
         cmd = popen_args[0]
         assert "--msg-level=ffmpeg=v" in cmd
+
+    def _spawn_argv(self, monkeypatch: pytest.MonkeyPatch, **kw: object) -> list[str]:
+        monkeypatch.setattr("kamp_core.playback.sys.platform", "darwin")
+        fake_proc = MagicMock()
+        fake_proc.stdout = io.BytesIO(b"")
+        with (
+            patch(
+                "kamp_core.playback.subprocess.Popen", return_value=fake_proc
+            ) as mock_popen,
+            patch("kamp_core.playback._WindowsJobObject"),
+            patch("kamp_core.playback._make_ipc_transport", return_value=MagicMock()),
+            patch("kamp_core.playback.threading.Thread"),
+        ):
+            MpvPlaybackEngine(**kw)  # type: ignore[arg-type]
+        args, _ = mock_popen.call_args
+        return list(args[0])
+
+    def test_metering_off_drops_only_the_metering_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Crate's preview engine runs without metering (KAMP-651).
+
+        What must survive is the reason KAMP-519 exists: pause/resume/stop/mute
+        are pure script-messages, so --script and both afade filters are not
+        optional decoration — without them the transport is silently dead.
+        --input-media-keys=no must survive too, or a second mpv installs an
+        IOKit HID tap and steals media keys from the now-playing helper.
+        """
+        cmd = self._spawn_argv(monkeypatch, metering=False)
+
+        assert not any(c.startswith("--af=lavfi=graph=") for c in cmd)
+        assert "--msg-level=ffmpeg=v" not in cmd
+
+        assert any(c.startswith("--script=") for c in cmd)
+        assert any(c.startswith("--af-append=@kampfade:") for c in cmd)
+        assert any(c.startswith("--af-append=@kampmute:") for c in cmd)
+        assert "--input-media-keys=no" in cmd
+        assert "--idle=yes" in cmd
+
+    def test_metering_is_on_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cmd = self._spawn_argv(monkeypatch)
+        assert "--msg-level=ffmpeg=v" in cmd
+        assert any(c.startswith("--af=lavfi=graph=") for c in cmd)
+
+    def test_shutdown_reaps_the_child(self) -> None:
+        """Dropping the Popen without waiting leaves a zombie — harmless for the
+        one long-lived engine, not for a preview engine spawned and killed on
+        every idle-out."""
+        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
+            engine = MpvPlaybackEngine()
+        proc = MagicMock()
+        engine._proc = proc
+        engine.shutdown()
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once()
+
+    def test_shutdown_survives_a_wedged_child(self) -> None:
+        """A mpv that will not die must not stall daemon shutdown."""
+        with patch("kamp_core.playback.MpvPlaybackEngine._start_mpv"):
+            engine = MpvPlaybackEngine()
+        proc = MagicMock()
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="mpv", timeout=2.0)
+        engine._proc = proc
+        engine.shutdown()  # must not raise
 
     def test_start_mpv_stdout_is_piped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """mpv stdout must be PIPE so _stdout_reader_loop can read ametadata output."""

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -2497,7 +2497,7 @@ class TestMpvPlaybackEngine:
     def test_metering_off_drops_only_the_metering_flags(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The Crate's preview engine runs without metering (KAMP-651).
+        """The Crate preview engine runs without metering (KAMP-651).
 
         What must survive is the reason KAMP-519 exists: pause/resume/stop/mute
         are pure script-messages, so --script and both afade filters are not


### PR DESCRIPTION
## Summary

Preview a record from the Crate without breaking the queue you were already listening to — the epic's hardest promise. Preview runs on a **second, fully isolated mpv**, so the main transport keeps showing your own music, untouched, the whole time.

| Commit | What |
| --- | --- |
| C1 | Preview resolution: full track list, governor fix, host check, inline mp3 |
| C2 | Engine `metering` flag; `shutdown()` reaps the child |
| C3 | `PreviewPlayer` — isolated engine, handoff, engagement events |
| C4 | Preview API, WS event, and the main-transport rule |
| C5 | Mini-player, track list, Space/Esc, and a focus fix |
| C6 | Rename "The Crate" → "Crate" |

Scoped as an LP; taken as a **2xLP** with @tterry's agreement, because the findings below were not in the ticket.

## The isolation is structural, not disciplinary

Each `MpvPlaybackEngine` mints its own IPC socket (`mkdtemp` on POSIX, a `token_hex` named pipe on Windows), so two instances really are two processes. The preview engine is **never passed to `create_app`** — which unconditionally assigns three callbacks to whatever engine it is given — and never bound to the name `_state_saver` closes over. The tests assert those absences rather than trusting the arrangement.

One deviation from the ticket's "wire no callbacks": `on_track_end` and `on_file_loaded` *are* wired, preview-locally. The rule exists to avoid contact with the queue/scrobbler/stats/widget and these touch none of it; without them the preview cannot know a track ended and the UI would show it playing forever.

## Three defects this story surfaced

**`resolve_preview` waited on the rate-limit governor** — against that module's own docstring, which says "Do not wire this into playback" and names `resolve_preview` as the case. `wait_turn` blocks until a 60/120/300s cooldown expires, so a click would have hung with nothing on screen. It now *reports* the outcome without waiting, so a 429 makes the crate builder back off instead of the listener paying for it. My defect from KAMP-647; nothing had ever called the function until now.

**Preview would have played at full volume.** `PlaybackState.volume` defaults to 100 and no `--volume`/`--ao` is passed at spawn, so a second engine ignores the user's setting entirely. Someone listening at 30 — or muted — would have been blasted. Volume and mute are now mirrored at spawn and on every change.

**The Crate's keys died after a mouse click** — shipped in KAMP-650. `App.tsx` blurs the focused element on any key it handles when focus came from the mouse, landing focus on `document.body`, outside the crate container, so none of its handlers fire again. Click a sleeve, press a global key, and `,` `.` `X` `C` went silently dead. Space is exactly the key that triggers it, so this story could not avoid it.

## Decisions worth review

**"Main transport always wins" is a middleware, not 15 call sites.** There are ~15 POST endpoints under `/api/v1/player/`, several starting playback only conditionally; forgetting one would leave preview audio under the user's own music with no obvious cause, and one rule can't be forgotten by whoever adds the sixteenth. **Volume and mute are deliberate exceptions** — they mirror onto the preview rather than stopping it, or the slider would move everything except what you can hear.

**The handoff flag is captured before `pause()`, never read back.** `pause()` only sends a `script-message`; `kamp_fade.lua` applies the real pause ~0.4s later, so `state.playing` still reads True immediately after and False by the time any real `stop()` runs. Reading it back would strand your queue paused.

**Position is interpolated locally**, from a sample plus its timestamp, so a smooth seek bar costs no per-frame broadcast. Clamped to track length, and the ticker only runs while playing, so a stall can't march the bar off the end.

**`previewed` is one event per session** with accumulated seconds above a 10s floor: the first such event flips `discovery_items.state` off `fresh` irreversibly, so a misclick would relabel a card forever, and per-track events would make KAMP-655 count one album as five.

## Test plan

- [x] `poetry run pytest` — **3020 passed, 9 skipped, 3 deselected**, coverage **93.72%**
- [x] `black`, `mypy`, `npm run typecheck`, `npm run lint` clean
- [x] Isolation asserted directly: no main callbacks on the preview engine, no `track_stats` rows, no queue state, main never asked to play
- [x] **Two tests were vacuous on first write and both mattered.** The concurrency test passed with *no lock at all* — an instant fake factory never lets the GIL switch inside the check-then-build; with a factory that blocks the way real mpv construction does, it produced four engines. And the handoff test passed against the buggy read-it-back version until the fake modelled `pause()`'s *delayed* flip
- [x] `metering=False` drops only the two metering flags — `--script`, both afade filters and `--input-media-keys=no` are asserted present, since without them the transport is silently dead (KAMP-519) and a second mpv steals media keys
- [x] Preview action route is an allowlist, so one route serving several verbs is not a remote method call
- [x] No banned vocabulary; no hex literals in `crate.css`

## Manual test plan

**Real-device audio is mandatory** — `--ao=null` hides every buffer-timing bug (KAMP-508).

- **The promise** — start a queue playing, go to the Crate, press Space. The queue pauses, the TransportBar still shows *your* track, a mini-player appears in the card. Stop: the queue resumes where it was.
- **Volume** — set kamp low, then preview. It must match, not blast. Repeat muted.
- **The focus bug** — click a sleeve, press Space, then press `,`. Digging must still work.
- **Esc** — first stops the preview, second leaves the view. Open Preferences from inside the Crate: Esc must close the dialog.
- **Main wins** — preview, then hit play on the TransportBar. The preview stops.
- **Media keys** — with a preview playing, play/pause controls the main queue.
- **Reload mid-preview** — audio keeps playing and the mini-player comes back.
- **Leaving** — switch views mid-preview; audio stops.
- **Cold latency** — first preview after launch: watch what the card shows between the click and the first sample.
- **The name** — the tab reads **Crate**, and so does the shortcuts overlay.

Closes KAMP-651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
