### PR TITLE
KAMP-652: wishlist read — exclusion filter + already-wishlisted state

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -575,6 +575,7 @@ def _cmd_daemon(
     from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
     from .discovery_preview import PreviewPlayer
+    from .wishlist import WishlistCache, mark_wishlisted_crate_items
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
     from kamp_core.server import create_app, resolve_playback_uri
     from kamp_daemon.config import config_set as _config_set
@@ -955,6 +956,8 @@ def _cmd_daemon(
 
     def _on_bandcamp_disconnect() -> None:
         index.clear_session("bandcamp")
+        # The wishlist ids belong to an account that can change (KAMP-652).
+        _wishlist_cache.invalidate()
 
     def _on_bandcamp_sync_trigger() -> None:
         from .syncer import NeedsLoginError
@@ -1036,6 +1039,28 @@ def _cmd_daemon(
         _genre_backfill_cancel.set()
 
     # --- KAMP-648: Discovery Crate build ---
+    def _warm_wishlist(session: Any) -> None:
+        """Refresh the wishlist cache. Cheap when fresh, silent when it fails."""
+        try:
+            from .bandcamp import _get_fan_info
+
+            # fan_id is not persisted anywhere -- _get_fan_info re-reads it from
+            # collection_summary -- so it costs one request on top of the walk.
+            # Only paid when the cache is actually stale, since refresh() bails
+            # before this on a fresh cache.
+            if _wishlist_cache.is_fresh:
+                return
+            fan_id, _ = _get_fan_info(session)
+            _wishlist_cache.refresh(session, fan_id)
+            # The crate on screen was assembled against whatever was cached at
+            # the time -- nothing at all, on the first build after launch. Mark
+            # anything in it that turns out to be wishlisted so the rail shows a
+            # heart rather than presenting it as new.
+            mark_wishlisted_crate_items(index, _wishlist_cache.ids)
+            app.state.discovery_publish({})
+        except Exception:
+            _logger.warning("wishlist warm-up failed", exc_info=True)
+
     def _on_crate_build_start() -> None:
         """Assemble a crate on a background thread.
 
@@ -1062,8 +1087,25 @@ def _cmd_daemon(
                     _logger.info("crate build: not connected to Bandcamp")
                     publish({"state": "error"})
                     return
-                source = BandcampDiscoverySource(_make_requests_session(session_data))
-                build_crate(index, source, publish=publish)
+                session = _make_requests_session(session_data)
+                source = BandcampDiscoverySource(session)
+
+                # Warm the wishlist behind this build, never in front of it: a
+                # real wishlist is 9 pages / ~40s (KAMP-652), and waiting for it
+                # would park the UI on "building" -- the KAMP-639 failure the
+                # builder already refuses to commit. So this crate is filtered by
+                # whatever is cached (nothing, on the very first build) and every
+                # crate after it gets the full set.
+                threading.Thread(
+                    target=_warm_wishlist,
+                    args=(session,),
+                    daemon=True,
+                    name="wishlist-warm",
+                ).start()
+
+                build_crate(
+                    index, source, publish=publish, wishlist_ids=_wishlist_cache.ids
+                )
             except Exception:
                 # build_crate does not raise, so reaching here means the session
                 # or import failed. Publish a terminal state regardless: the
@@ -1111,6 +1153,11 @@ def _cmd_daemon(
         source_factory=_preview_source,
         notify=_preview_notify,
     )
+
+    # KAMP-652: wishlist ids for crate exclusion. Walked in the background and
+    # cached for an hour -- see kamp_daemon/wishlist.py for why it must never sit
+    # on the crate path.
+    _wishlist_cache = WishlistCache()
 
     # Bandcamp username comes only from the session (set after Electron login flow).
     _bc_session = index.get_session("bandcamp")

--- a/kamp_daemon/wishlist.py
+++ b/kamp_daemon/wishlist.py
@@ -1,0 +1,242 @@
+"""Reading the Bandcamp wishlist, for crate exclusion (KAMP-652).
+
+The Discovery Crate must never offer a record the user has already set aside.
+The discover surface reports ``is_wishlisted`` itself, but album-page
+recommendations and discography entries — about half a crate — carry no such
+flag, so those need the wishlist itself.
+
+**This is the endpoint Bandcamp rate-limits hardest.** It is the same
+``fancollection`` family as the collection walk that earned the 429 cascade
+behind KAMP-637/639, and it is *not one request*: a measured real account is
+**824 items across 9 pages**, which at the governor's 5s ``FANCOLLECTION``
+spacing is roughly 40 seconds. Everything in this module follows from that:
+
+* the walk runs in the background and never blocks a crate build;
+* its result is cached for an hour rather than re-walked per crate;
+* the governor is *consulted* and never waited on — a background thread that
+  sleeps 300s inside a cooldown is how the collection endpoint ends up back on
+  a blocking path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time as _time
+from typing import TYPE_CHECKING, Any, Callable
+
+from .bandcamp_ratelimit import BandcampGovernor, get_governor
+from .discovery import FANCOLLECTION
+
+if TYPE_CHECKING:  # pragma: no cover - types only
+    from .bandcamp import _AnySession
+
+logger = logging.getLogger(__name__)
+
+WISHLIST_URL = "https://bandcamp.com/api/fancollection/1/wishlist_items"
+
+#: Rows per page. Matches ``_COLLECTION_PAGE_BATCH``; the API honours 100 and
+#: returns exactly that many, so a smaller value only multiplies the page count
+#: against the endpoint that limits hardest (KAMP-639).
+PAGE_SIZE = 100
+
+#: Stop after this many pages. A very large wishlist would otherwise walk for
+#: minutes; truncating is fine for an exclusion filter, silently truncating is
+#: not, so this logs when it bites.
+MAX_PAGES = 30
+
+#: How long a walk's result stands. Long enough that nine pages amortise across
+#: many crates, short enough that *un*-wishlisting something in a browser is not
+#: suppressed for the rest of the session -- exclusion is supposed to reflect
+#: the state at assembly time, not at launch.
+CACHE_TTL_SECS = 3600.0
+
+
+def fetch_wishlist_album_ids(
+    session: "_AnySession",
+    fan_id: int,
+    *,
+    governor: BandcampGovernor | None = None,
+    max_pages: int = MAX_PAGES,
+    now: Callable[[], float] = _time.time,
+) -> set[str]:
+    """Every album id in the fan's wishlist. Returns what it got; never raises.
+
+    A partial result is strictly better than none for an exclusion filter, so a
+    failure mid-walk keeps the pages already collected.
+    """
+    gov = governor or get_governor()
+    ids: set[str] = set()
+
+    # The first page needs a seeded token as much as any other. Omitting it
+    # returns **zero rows with no error** -- indistinguishable from an empty
+    # wishlist, which is exactly how this looked the first time it was measured.
+    token = f"{int(now())}:0:a::"
+
+    for page in range(max_pages):
+        if page > 0:
+            # Spacing between pages only. wait_turn would also honour a 60/120/300s
+            # cooldown, which is the one thing a background walk must not do --
+            # see the module docstring.
+            gov.wait_turn(FANCOLLECTION)
+        try:
+            resp = session.post(
+                WISHLIST_URL,
+                json={
+                    "fan_id": fan_id,
+                    "count": PAGE_SIZE,
+                    "older_than_token": token,
+                },
+                timeout=30,
+                headers={"Content-Type": "application/json"},
+            )
+        except Exception:  # noqa: BLE001 - a failed nicety is not an error state
+            logger.warning("wishlist: page %d failed", page + 1, exc_info=True)
+            return ids
+
+        status = resp.status_code
+        if status == 429:
+            # Report so the crate builder and download drain back off too, then
+            # keep what we have.
+            gov.report_429(FANCOLLECTION)
+            logger.warning("wishlist: rate-limited after %d page(s)", page)
+            return ids
+        if status != 200:
+            # Deliberately NOT clearing the session the way _paginate does on a
+            # 401/403: logging the user out of Bandcamp because a discovery
+            # nicety got a 403 is wildly out of proportion to what failed.
+            logger.warning("wishlist: HTTP %d on page %d", status, page + 1)
+            return ids
+        gov.report_ok(FANCOLLECTION)
+
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            logger.warning("wishlist: unparseable page %d", page + 1)
+            return ids
+
+        items: list[dict[str, Any]] = body.get("items") or []
+        for item in items:
+            # Albums only. A wishlist holds individual tracks too (11 of 824 on
+            # the measured account), and normalise_item_id flattens `track-N`
+            # and `album-N` to the same string -- so a wishlisted track would
+            # silently suppress an unrelated album sharing its numeric id.
+            if item.get("tralbum_type") != "a":
+                continue
+            tralbum_id = item.get("tralbum_id") or item.get("item_id")
+            if tralbum_id is not None:
+                ids.add(str(tralbum_id))
+
+        # Terminate the way the shipped collection walk does. Note it does not
+        # trust `more_available`; neither does this.
+        if len(items) < PAGE_SIZE:
+            return ids
+        token = str(body.get("last_token") or "")
+        if not token:
+            return ids
+
+    logger.warning(
+        "wishlist: stopped at the %d-page cap with %d albums; exclusion is partial",
+        max_pages,
+        len(ids),
+    )
+    return ids
+
+
+class WishlistCache:
+    """The wishlist ids, walked rarely and read often.
+
+    Locked because KAMP-653's ``add`` will arrive on a request thread while a
+    crate build reads on another; builds are serialised today, so this is not
+    yet reachable, but the lock is cheaper than remembering later.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl: float = CACHE_TTL_SECS,
+        now: Callable[[], float] = _time.time,
+    ) -> None:
+        self._ttl = ttl
+        self._now = now
+        self._lock = threading.Lock()
+        self._ids: set[str] = set()
+        self._fetched_at: float | None = None
+        self._walking = False
+
+    @property
+    def ids(self) -> set[str]:
+        """A copy of what is known right now — empty before the first walk.
+
+        Deliberately does not block on a walk in progress: a crate built without
+        the wishlist is better than a crate the user waits 40 seconds for.
+        """
+        with self._lock:
+            return set(self._ids)
+
+    @property
+    def is_fresh(self) -> bool:
+        with self._lock:
+            return (
+                self._fetched_at is not None
+                and self._now() - self._fetched_at < self._ttl
+            )
+
+    def add(self, tralbum_id: str) -> None:
+        """Record a wishlist addition kamp made itself (KAMP-653).
+
+        Covers only kamp's own writes. A wishlist change made in a browser is
+        invisible until the next walk, which is why the per-item check on the
+        preview fetch exists.
+        """
+        with self._lock:
+            self._ids.add(str(tralbum_id))
+
+    def invalidate(self) -> None:
+        """Drop everything — the ids belong to an account that can change."""
+        with self._lock:
+            self._ids = set()
+            self._fetched_at = None
+
+    def refresh(
+        self,
+        session: "_AnySession",
+        fan_id: int,
+        *,
+        governor: BandcampGovernor | None = None,
+    ) -> None:
+        """Walk and replace, unless the data is fresh or a walk is in flight."""
+        gov = governor or get_governor()
+        with self._lock:
+            if self._walking:
+                return
+            if (
+                self._fetched_at is not None
+                and self._now() - self._fetched_at < self._ttl
+            ):
+                return
+            # Consulted, never waited on: a cooldown means skip this round and
+            # try on the next build, rather than parking a thread for minutes on
+            # the endpoint that limits hardest.
+            if gov.blocked_for(FANCOLLECTION) > 0:
+                logger.info("wishlist: skipping the walk, endpoint is cooling down")
+                return
+            self._walking = True
+
+        try:
+            ids = fetch_wishlist_album_ids(session, fan_id, governor=gov)
+        finally:
+            with self._lock:
+                self._walking = False
+
+        if not ids:
+            # An empty result is far more likely to be a failed walk than an
+            # empty wishlist, and replacing good data with nothing would quietly
+            # turn the filter off.
+            logger.info("wishlist: walk returned nothing; keeping what we had")
+            return
+
+        with self._lock:
+            self._ids = ids
+            self._fetched_at = self._now()
+        logger.info("wishlist: %d albums cached", len(ids))

--- a/kamp_daemon/wishlist.py
+++ b/kamp_daemon/wishlist.py
@@ -29,6 +29,8 @@ from .bandcamp_ratelimit import BandcampGovernor, get_governor
 from .discovery import FANCOLLECTION
 
 if TYPE_CHECKING:  # pragma: no cover - types only
+    from kamp_core.library import LibraryIndex
+
     from .bandcamp import _AnySession
 
 logger = logging.getLogger(__name__)
@@ -117,10 +119,15 @@ def fetch_wishlist_album_ids(
 
         items: list[dict[str, Any]] = body.get("items") or []
         for item in items:
-            # Albums only. A wishlist holds individual tracks too (11 of 824 on
+            # Albums only. A wishlist holds individual tracks too (11 of 825 on
             # the measured account), and normalise_item_id flattens `track-N`
             # and `album-N` to the same string -- so a wishlisted track would
             # silently suppress an unrelated album sharing its numeric id.
+            #
+            # Measured on a real account: `item_type` and `tralbum_type` agree on
+            # every row (814 album/a, 11 track/t, zero disagreements), and
+            # item_id == tralbum_id throughout. Either field would do; this uses
+            # tralbum_* because that is the identity the candidate side keys on.
             if item.get("tralbum_type") != "a":
                 continue
             tralbum_id = item.get("tralbum_id") or item.get("item_id")
@@ -141,6 +148,37 @@ def fetch_wishlist_album_ids(
         len(ids),
     )
     return ids
+
+
+def mark_wishlisted_crate_items(index: "LibraryIndex", ids: set[str]) -> int:
+    """Flag any record in the current crate that turns out to be wishlisted.
+
+    The crate is assembled against whatever the cache held at the time, so an
+    item can be shown before the wishlist is known -- the very first crate after
+    launch is built with nothing cached at all. Rather than leave those looking
+    new, the walk marks them once it completes, and the rail draws its heart.
+
+    Only ever moves a record forward: ``record_discovery_event`` is
+    highest-rank-wins, so an already-purchased pick is not demoted, and calling
+    this twice writes a second event but no second state change.
+    """
+    crate_no = index.latest_crate_no()
+    if crate_no is None or not ids:
+        return 0
+    marked = 0
+    for item in index.crate_items(crate_no):
+        if item["state"] == "wishlisted":
+            continue
+        if str(item["provider_item_id"]) not in ids:
+            continue
+        try:
+            index.record_discovery_event(int(item["id"]), "wishlisted")
+            marked += 1
+        except Exception:  # noqa: BLE001 - a badge is not worth failing over
+            logger.warning("wishlist: could not mark item %s", item["id"])
+    if marked:
+        logger.info("wishlist: marked %d crate item(s) as already wishlisted", marked)
+    return marked
 
 
 class WishlistCache:

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -8,17 +8,26 @@ tracks, rows carrying tralbum_id/tralbum_type.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
+from kamp_core.library import LibraryIndex
 from kamp_daemon.discovery import FANCOLLECTION
 from kamp_daemon.wishlist import (
     PAGE_SIZE,
     WishlistCache,
     fetch_wishlist_album_ids,
 )
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> Iterator[LibraryIndex]:
+    idx = LibraryIndex(tmp_path / "library.db")
+    yield idx
+    idx.close()
 
 
 def _row(tralbum_id: int, tralbum_type: str = "a") -> dict[str, Any]:
@@ -152,6 +161,51 @@ class TestWalkFailures:
     def test_an_unparseable_page_is_not_fatal(self) -> None:
         session = FakeSession([FakeResponse(ValueError("not json"))])
         assert fetch_wishlist_album_ids(session, 1, governor=_gov()) == set()
+
+
+class TestMarkingCrateItems:
+    """The crate on screen was assembled against whatever was cached at the
+    time — nothing at all, on the first build after launch."""
+
+    def _crate(self, index: Any, ids: list[str]) -> list[int]:
+        rows = []
+        for position, provider_item_id in enumerate(ids):
+            row = index.add_discovery_candidate(
+                provider="bandcamp", provider_item_id=provider_item_id, title="X"
+            )
+            index.place_in_crate(row, 1, position)
+            rows.append(row)
+        return rows
+
+    def test_a_wishlisted_item_gets_the_state(self, index: Any) -> None:
+        from kamp_daemon.wishlist import mark_wishlisted_crate_items
+
+        self._crate(index, ["1", "2", "3"])
+        assert mark_wishlisted_crate_items(index, {"2"}) == 1
+        states = {r["provider_item_id"]: r["state"] for r in index.crate_items(1)}
+        assert states == {"1": "fresh", "2": "wishlisted", "3": "fresh"}
+
+    def test_marking_is_idempotent(self, index: Any) -> None:
+        from kamp_daemon.wishlist import mark_wishlisted_crate_items
+
+        self._crate(index, ["1"])
+        mark_wishlisted_crate_items(index, {"1"})
+        assert mark_wishlisted_crate_items(index, {"1"}) == 0
+
+    def test_a_purchased_pick_is_not_demoted(self, index: Any) -> None:
+        """record_discovery_event is highest-rank-wins, and this must not fight
+        it: bought outranks wishlisted."""
+        from kamp_daemon.wishlist import mark_wishlisted_crate_items
+
+        rows = self._crate(index, ["1"])
+        index.record_discovery_event(rows[0], "purchased")
+        mark_wishlisted_crate_items(index, {"1"})
+        assert index.crate_items(1)[0]["state"] == "purchased"
+
+    def test_no_crate_is_harmless(self, index: Any) -> None:
+        from kamp_daemon.wishlist import mark_wishlisted_crate_items
+
+        assert mark_wishlisted_crate_items(index, {"1"}) == 0
 
 
 class TestCache:

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -1,0 +1,234 @@
+"""Wishlist read + cache tests (KAMP-652).
+
+No fixture file: the spike captures pages anonymously on purpose (public repo),
+and a wishlist payload is inherently personal. These payloads are hand-built
+from a measured real response — 824 items over 9 pages, 813 albums and 11
+tracks, rows carrying tralbum_id/tralbum_type.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from kamp_daemon.discovery import FANCOLLECTION
+from kamp_daemon.wishlist import (
+    PAGE_SIZE,
+    WishlistCache,
+    fetch_wishlist_album_ids,
+)
+
+
+def _row(tralbum_id: int, tralbum_type: str = "a") -> dict[str, Any]:
+    return {
+        "tralbum_id": tralbum_id,
+        "tralbum_type": tralbum_type,
+        "item_id": tralbum_id,
+        "band_name": "Band",
+        "item_title": "Album",
+    }
+
+
+def _page(rows: list[dict[str, Any]], last_token: str = "tok") -> dict[str, Any]:
+    return {"items": rows, "last_token": last_token, "more_available": True}
+
+
+class FakeResponse:
+    def __init__(self, body: Any = None, status_code: int = 200) -> None:
+        self._body = body if body is not None else {}
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        if isinstance(self._body, Exception):
+            raise self._body
+        return self._body
+
+
+class FakeSession:
+    """Replays canned pages and records what was asked for."""
+
+    def __init__(self, pages: list[Any]) -> None:
+        self.pages = pages
+        self.posts: list[dict[str, Any]] = []
+
+    def post(self, url: str, json: Any = None, timeout: int = 30, headers: Any = None):
+        self.posts.append(dict(json or {}))
+        page = self.pages[min(len(self.posts) - 1, len(self.pages) - 1)]
+        if isinstance(page, Exception):
+            raise page
+        return page if isinstance(page, FakeResponse) else FakeResponse(page)
+
+
+def _gov() -> MagicMock:
+    gov = MagicMock()
+    gov.blocked_for.return_value = 0.0
+    return gov
+
+
+class TestWalk:
+    def test_the_first_page_carries_a_seeded_token(self) -> None:
+        """Omitting it returns zero rows with NO error — indistinguishable from
+        an empty wishlist, and exactly how this looked when first measured."""
+        session = FakeSession([_page([_row(1)], last_token="")])
+        fetch_wishlist_album_ids(session, 42, governor=_gov(), now=lambda: 1000.0)
+
+        sent = session.posts[0]
+        assert sent["older_than_token"] == "1000:0:a::"
+        assert sent["fan_id"] == 42
+        assert sent["count"] == PAGE_SIZE
+
+    def test_paginates_until_a_short_page(self) -> None:
+        pages = [_page([_row(i) for i in range(PAGE_SIZE)]), _page([_row(999)])]
+        ids = fetch_wishlist_album_ids(FakeSession(pages), 1, governor=_gov())
+        assert "999" in ids
+        assert len(ids) == PAGE_SIZE + 1
+
+    def test_stops_on_a_falsy_token_even_with_a_full_page(self) -> None:
+        """The shipped collection walk does not trust more_available; nor does
+        this — a full page with no token is the end."""
+        full = _page([_row(i) for i in range(PAGE_SIZE)], last_token="")
+        session = FakeSession([full, _page([_row(12345)])])
+        ids = fetch_wishlist_album_ids(session, 1, governor=_gov())
+        assert len(session.posts) == 1
+        assert "12345" not in ids
+
+    def test_only_albums_enter_the_set(self) -> None:
+        """A wishlist holds tracks too, and normalise_item_id flattens
+        `track-N` and `album-N` to the same string — so a wishlisted track would
+        silently suppress an unrelated album sharing its numeric id."""
+        page = _page([_row(1, "a"), _row(2, "t"), _row(3, "a")], last_token="")
+        ids = fetch_wishlist_album_ids(FakeSession([page]), 1, governor=_gov())
+        assert ids == {"1", "3"}
+
+    def test_pages_after_the_first_are_governor_spaced(self) -> None:
+        gov = _gov()
+        pages = [_page([_row(i) for i in range(PAGE_SIZE)]), _page([_row(999)])]
+        fetch_wishlist_album_ids(FakeSession(pages), 1, governor=gov)
+        # Spacing between pages, but never before the first — that would add
+        # latency to a walk that is already the most expensive call available.
+        assert gov.wait_turn.call_count == 1
+        gov.wait_turn.assert_called_with(FANCOLLECTION)
+
+    def test_the_page_cap_truncates_and_says_so(self, caplog: Any) -> None:
+        full = _page([_row(i) for i in range(PAGE_SIZE)])
+        ids = fetch_wishlist_album_ids(
+            FakeSession([full]), 1, governor=_gov(), max_pages=3
+        )
+        assert len(ids) == PAGE_SIZE
+        assert "partial" in caplog.text
+
+
+class TestWalkFailures:
+    def test_a_429_keeps_what_was_already_collected(self) -> None:
+        """A partial exclusion beats none, and discarding pages would make the
+        most expensive call in the design also the most wasteful."""
+        gov = _gov()
+        pages = [
+            FakeResponse(_page([_row(i) for i in range(PAGE_SIZE)])),
+            FakeResponse(status_code=429),
+        ]
+        ids = fetch_wishlist_album_ids(FakeSession(pages), 1, governor=gov)
+        assert len(ids) == PAGE_SIZE
+        gov.report_429.assert_called_once_with(FANCOLLECTION)
+
+    @pytest.mark.parametrize("status", [401, 403, 302, 500])
+    def test_a_rejection_never_clears_the_session(self, status: int) -> None:
+        """_paginate clears the Bandcamp session on 401/403. Logging the user
+        out because a discovery nicety got a 403 is wildly disproportionate, so
+        this returns empty and leaves the session alone."""
+        session = FakeSession([FakeResponse(status_code=status)])
+        assert fetch_wishlist_album_ids(session, 1, governor=_gov()) == set()
+
+    def test_a_network_error_returns_what_it_had(self) -> None:
+        pages = [
+            FakeResponse(_page([_row(i) for i in range(PAGE_SIZE)])),
+            RuntimeError("connection reset"),
+        ]
+        ids = fetch_wishlist_album_ids(FakeSession(pages), 1, governor=_gov())
+        assert len(ids) == PAGE_SIZE
+
+    def test_an_unparseable_page_is_not_fatal(self) -> None:
+        session = FakeSession([FakeResponse(ValueError("not json"))])
+        assert fetch_wishlist_album_ids(session, 1, governor=_gov()) == set()
+
+
+class TestCache:
+    def _cache(self, t: list[float]) -> WishlistCache:
+        return WishlistCache(ttl=100.0, now=lambda: t[0])
+
+    def test_empty_before_the_first_walk(self) -> None:
+        cache = WishlistCache()
+        assert cache.ids == set()
+        assert cache.is_fresh is False
+
+    def test_refresh_populates_and_marks_fresh(self) -> None:
+        t = [1000.0]
+        cache = self._cache(t)
+        page = _page([_row(1), _row(2)], last_token="")
+        cache.refresh(FakeSession([page]), 42, governor=_gov())
+        assert cache.ids == {"1", "2"}
+        assert cache.is_fresh is True
+
+    def test_a_fresh_cache_is_not_re_walked(self) -> None:
+        """Nine pages amortised across many crates is the whole point."""
+        t = [1000.0]
+        cache = self._cache(t)
+        session = FakeSession([_page([_row(1)], last_token="")])
+        cache.refresh(session, 42, governor=_gov())
+        cache.refresh(session, 42, governor=_gov())
+        assert len(session.posts) == 1
+
+    def test_an_expired_cache_is_re_walked(self) -> None:
+        """Un-wishlisting in a browser must not be suppressed forever."""
+        t = [1000.0]
+        cache = self._cache(t)
+        session = FakeSession([_page([_row(1)], last_token="")])
+        cache.refresh(session, 42, governor=_gov())
+        t[0] += 101.0
+        cache.refresh(session, 42, governor=_gov())
+        assert len(session.posts) == 2
+
+    def test_a_cooldown_skips_the_walk_without_a_request(self) -> None:
+        """Consulted, never waited on — a background thread parked for 300s on
+        this endpoint is how it ends up back on a blocking path."""
+        gov = _gov()
+        gov.blocked_for.return_value = 300.0
+        session = FakeSession([_page([_row(1)], last_token="")])
+        WishlistCache().refresh(session, 42, governor=gov)
+        assert session.posts == []
+        gov.wait_turn.assert_not_called()
+
+    def test_a_failed_walk_keeps_the_previous_ids(self) -> None:
+        """An empty result is far likelier to be a failed walk than an empty
+        wishlist; replacing good data with nothing turns the filter off."""
+        t = [1000.0]
+        cache = self._cache(t)
+        cache.refresh(
+            FakeSession([_page([_row(1)], last_token="")]), 42, governor=_gov()
+        )
+        t[0] += 101.0
+        cache.refresh(FakeSession([FakeResponse(status_code=500)]), 42, governor=_gov())
+        assert cache.ids == {"1"}
+
+    def test_add_records_kamps_own_write(self) -> None:
+        cache = WishlistCache()
+        cache.add("77")
+        assert "77" in cache.ids
+
+    def test_invalidate_drops_everything(self) -> None:
+        """The ids belong to an account that can change."""
+        cache = WishlistCache()
+        cache.refresh(
+            FakeSession([_page([_row(1)], last_token="")]), 42, governor=_gov()
+        )
+        cache.invalidate()
+        assert cache.ids == set()
+        assert cache.is_fresh is False
+
+    def test_ids_returns_a_copy(self) -> None:
+        cache = WishlistCache()
+        cache.add("1")
+        cache.ids.add("2")
+        assert cache.ids == {"1"}


### PR DESCRIPTION
## Summary

A crate never offers a record you have already set aside. The discover surface reports `is_wishlisted` itself, but album-page recommendations and discography entries — about half a crate — carried no such flag until now.

| Commit | What |
| --- | --- |
| C1 | The paginated wishlist read + `WishlistCache` |
| C2 | Background warm-up, invalidation, and marking what the walk finds |

Filed as a Side; taken as an **LP** with @tterry's agreement, because measuring the real thing first changed the shape.

## Measure first, design second

I walked the real wishlist before designing against it, and the numbers decided most of this: **825 items, 814 albums and 11 tracks, across 9 pages**. Verified live through the shipped code path at **37.3 seconds**.

**So the walk never touches the crate path.** Waiting ~40s for it would park the UI on "building" — the exact failure `build_crate` already refuses to commit (KAMP-639: a pause that isn't visible is a hang). It runs on its own thread *behind* the build, so the first crate after launch is filtered by library + the discover surface's own flag, and every crate after it gets the full 814. Cached an hour, so nine pages amortise instead of repeating per crate.

This is the same `fancollection` family whose walks earned the 429 cascade behind KAMP-637/639, which is also why the governor is **consulted and never waited on**: a background thread parked 300s inside a cooldown is how the collection endpoint ends up back on a blocking path.

## Three traps the measurement caught

**The first page needs a seeded `older_than_token` too.** Omitting it returns **zero rows with no error** — indistinguishable from an empty wishlist, and precisely how this looked on my first run. I nearly concluded the wishlist was empty.

**Only albums may enter the set.** A wishlist holds individual tracks, and `normalise_item_id` flattens `track-N` and `album-N` to the same string — so a wishlisted *track* would silently suppress an unrelated *album* sharing its numeric id. A second measurement settled which field to trust: `item_type` and `tralbum_type` agree on **every** row (814 album/a, 11 track/t, zero disagreements), and `item_id == tralbum_id` throughout. That's recorded in the code so nobody re-walks nine pages to find out.

**`_paginate` is deliberately not reused.** It calls `index.clear_session("bandcamp")` on a 401/403. Logging the user out of Bandcamp because a discovery *nicety* got a 403 is wildly out of proportion to what failed. Only its termination idiom is copied — and note the shipped code does not trust `more_available`, so neither does this.

## Corrections to the ticket

- **`fan_id` is not persisted.** The ticket cites KAMP-645 for it; nothing stores it, and `_get_fan_info()` re-reads it from `collection_summary`. So a walk is 1 + ceil(N/100) requests. Only paid when the cache is actually stale.
- **The discover surface already self-excludes** (`discovery_sources.py:302-307`, tested). My own first reading of this said that free exclusion was being thrown away; it was not, and I was wrong.
- **"Surface the already-wishlisted state" had a renderer and no producer.** `CrateSleeve.tsx` has drawn a ♥ for `state === 'wishlisted'` since KAMP-650 with nothing writing it. This ticket writes it for the *discovered* case; KAMP-653 adds the user-initiated half.

## Degradation

A partial exclusion beats none, so a 429 or a dropped connection keeps the pages already collected, and an empty walk result leaves the previous ids in place rather than quietly turning the filter off. Any failure at all still builds the crate.

## Test plan

- [x] `poetry run pytest` — **3046 passed, 9 skipped, 3 deselected**, coverage **93.75%**
- [x] `black`, `mypy` clean
- [x] Falsified both measured traps: removing the seeded token and removing the album-type filter each fail the test that claims to cover them
- [x] Pagination terminates on a short page **and** on a falsy token; a 401/403/302 never clears the session; a cooldown skips the walk with no request issued; the page cap truncates and logs
- [x] Marking is idempotent and never demotes an already-purchased pick
- [x] **Live against the real account**: 9 pages / 37.3s / 814 albums; second refresh 0.000s; the 11 tracks correctly excluded

## Deliberately not done

**Per-item wishlist state from the preview fetch.** `preview_tracks` already fetches the candidate's own album page, and `fan_tralbum_data.is_wishlisted` rides on that same response — a zero-request way to catch the one case the cache structurally cannot, the user wishlisting in a browser mid-session. It needs a shape change to the `DiscoverySource` ABC to surface a per-album flag from a per-track return, and KAMP-653 is already touching exactly this area for the write half. Better bundled there than half-fitted here. The hour TTL bounds that window meanwhile.

## Manual test plan

- Dig a crate from a cold start — it must appear as promptly as it does today; the walk is behind it, not in front of it. The log will show `wishlist: 814 albums cached` about 40s later.
- Dig a second crate a minute after that, and confirm nothing in it is in your Bandcamp wishlist.
- Wishlist an album in a browser, then dig twice more within the hour: it will still be offered until the cache expires. That's the known bound above, not a bug.
- Disconnect and reconnect Bandcamp, then dig: no stale exclusions from the previous account.

Closes KAMP-652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
