### PR TITLE
KAMP-653: wishlist write — crumb-authenticated collect/uncollect + UI toggle

### DIFF
--- a/docs/discovery-recon.md
+++ b/docs/discovery-recon.md
@@ -91,7 +91,8 @@ direct-transport "go" into a shipped-build failure:
 
 | Constraint | Consequence |
 | --- | --- |
-| `_fetch(..., *, headers, json, timeout, **_kwargs)` — no `data=` | A form-encoded POST is silently sent with an empty body. If Bandcamp's wishlist write is form-encoded, wishlist-add is blocked in every shipped build until `_ProxySession`, the server model, and the Electron handler are extended. |
+| `_fetch(..., *, headers, json, timeout, **_kwargs)` — no `data=` | A form-encoded POST is silently sent with an empty body. **Fixed in KAMP-653** by giving `_fetch` a `data=` branch; the server model and Electron handler needed no change at all, see the correction below. |
+| A manually-set `Referer` is **unsettable** through the relay | Chromium rejects it: `net.request` returns `net::ERR_BLOCKED_BY_CLIENT` and the call never leaves the machine. `Origin` passes through untouched. Any request shape that depends on a Referer works on the direct transport and can never work in a shipped build (KAMP-653). |
 | `_ProxyResponse` exposes status/text/content_type/url/ok only | No `Retry-After`, no `Set-Cookie`. Rate-limit calibration through the relay is blind by construction. |
 | No `.content` (text only) | Binary responses cannot round-trip. |
 | GET/POST only; redirects auto-followed, opaque | Redirect chains cannot be inspected. |
@@ -130,7 +131,7 @@ collection items; the account was left exactly as found.
 | Best sellers | **go** (it is a discover slice) | direct + relay |
 | Artist discography | **go** | direct |
 | Wishlist read | **go** | direct |
-| Wishlist add/remove | **go on direct, NO-GO on the relay** | both |
+| Wishlist add/remove | **go** (see the KAMP-653 correction) | ~~both~~ direct only; re-proven on both by KAMP-653 |
 | "Over 10 years old" via the time facet | **no-go** (workaround below) | direct |
 | Anniversary (specific month/year) | **no-go** | direct |
 | Label pages / Label-Mates | **unknown** — not reached in the timebox | — |
@@ -271,21 +272,47 @@ was returned to its original state.
   `uncollect_item_cb` are present, so add *and* remove are available.
 - `POST https://bandcamp.com/collect_item_cb` with
   `{fan_id, item_id, item_type:"album", band_id, crumb}` plus
-  `X-Requested-With: XMLHttpRequest` and a `Referer`.
+  `X-Requested-With: XMLHttpRequest` and `Origin: https://bandcamp.com`
+  (**not** a `Referer` — see the correction above).
+- `band_id` is `data-tralbum`'s **`current.band_id`**, never `current.selling_band_id`;
+  they differ on label-released albums. **Sending the wrong one returns HTTP 200 with
+  `{"ok":true}` and silently does nothing** — verified by deliberately sending
+  `selling_band_id` and watching the album fail to appear. So `ok:true` is only
+  trustworthy for a `band_id` read off the album's own page, and there must be no
+  fallback to `selling_band_id`: it would report success and change nothing.
+- `collect_item_cb` is **idempotent** — repeating an add for an already-wishlisted
+  album answers `{"ok":true}` rather than erroring.
 - **The body must be form-encoded.** The identical call with a JSON body returns
   HTTP 200 carrying
   `{"error":true,"ok":false,"exception":"…InsistError… old or no crumb specified …"}`.
   Form-encoded returns `{"ok":true}` and the album page then reports
   `is_wishlisted: true`.
 
-> **This is the blocker for KAMP-653, and it is a kamp problem rather than a Bandcamp
-> one.** `_ProxySession._fetch` accepts only `json=`; a `data=` kwarg falls into
-> `**_kwargs` and is silently dropped, and the relay's wire format carries a single
-> `body` string with a JSON content type. Since every shipped build routes through the
-> relay, **wishlist-add cannot work in any packaged build today**. Making it work means
-> extending `_ProxySession`, the proxy-fetch request model in `kamp_core/server.py`,
-> and the Electron handler in `kamp_ui/src/main/index.ts` to carry a form-encoded body
-> and content type. That work belongs in KAMP-653 and should be sized into it.
+> **CORRECTION (KAMP-653): the "NO-GO on the relay" verdict above was wrong, and it was
+> wrong in the exact way this document warns against.** It described *this script's*
+> relay helper, not the relay. `RelayTransport` had no `post_form` method at all,
+> hard-coded `Content-Type: application/json`, and its `post_json` did not even accept
+> a `headers=` kwarg — so `wishlist-roundtrip --transport relay` would have raised a
+> `TypeError` before reaching Bandcamp. Every form-encoded fallback was additionally
+> gated on `args.transport == "direct"`. **The relay was never handed a form body.**
+> Recorded here rather than quietly amended, because the failure is the interesting
+> part: a verdict is only as good as the transport it was proven on, and "proven on:
+> both" was itself the unproven claim.
+>
+> What is actually true, re-measured live on both transports:
+>
+> - The relay wire format is `{url, method, headers, body}` with the content type
+>   riding in `headers`. `kamp_core/server.py`, `kampAPI.ts` and `index.ts` forward
+>   both verbatim. **Only `_ProxySession._fetch` needed a `data=` branch** — one Python
+>   function, not the three layers claimed above.
+> - Chunked encoding is not a risk: `net.request` defaults `chunkedEncoding: false`
+>   and buffers the body, so one `write()`/`end()` emits a `Content-Length` request.
+> - **The header set recorded below cannot work in a shipped build.** Bandcamp insists
+>   on an origin *or* a referrer (`InsistError: expected either an origin or a referrer
+>   header` with neither), but Chromium blocks a manually-set `Referer` outright. Send
+>   `Origin: https://bandcamp.com` and no `Referer`; that satisfies both. The original
+>   "`*_cb` endpoints are referer-checked" note was borrowed from jQuery's `$.ajax`
+>   defaults rather than measured.
 
 **Trap for whoever implements it: these endpoints answer HTTP 200 on failure.**
 Success must be read from the parsed body (`ok: true` and no `error`), never the

--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -81,6 +81,20 @@ DEFAULT_ART_SIZE = 10
 
 _BCBITS_SIZE = re.compile(r"_(\d+)\.jpg$")
 
+# Why a wishlist write failed, as a status. Five distinguishable outcomes rather
+# than a blanket 502, because the UI says something different for each and a
+# single code would flatten "Bandcamp asked us to slow down" and "you have been
+# logged out" into the same shrug. The reason string travels as `detail`; the
+# renderer owns the wording.
+_WISHLIST_STATUS: dict[str, int] = {
+    "unknown_item": 404,
+    "not_connected": 503,
+    "unsupported": 501,
+    "needs_login": 401,
+    "rate_limited": 429,
+    "rejected": 502,
+}
+
 _ART_TIMEOUT = 10.0  # a static CDN on the render path, not the 30s API budget
 _MAX_ART_BYTES = 16 * 1024 * 1024
 
@@ -153,6 +167,7 @@ def register_discovery_routes(
     art_cache_dir: Path | None = None,
     fetch_bytes: Callable[[str], bytes | None] | None = None,
     preview: Any = None,
+    wishlist_write: Callable[[dict[str, Any], bool], str] | None = None,
 ) -> None:
     """Register the Discovery Crate routes on *app*.
 
@@ -274,13 +289,56 @@ def register_discovery_routes(
 
     @app.post("/api/v1/discovery/items/{item_id}/url-copied")
     def url_copied(item_id: int) -> dict[str, Any]:
-        """The always-available action while wishlist-write is unbuilt (KAMP-653).
+        """The fallback action, and the one offered when a wishlist write fails.
 
         Recorded as engagement but deliberately does NOT move the item's state:
         copying a link is not passing on it, and the user may still preview or
         wishlist afterwards.
         """
         return _record(item_id, "url_copied")
+
+    # ------------------------------------------------------------------
+    # Wishlist write (KAMP-653)
+    # ------------------------------------------------------------------
+
+    def _wishlist(item_id: int, *, add: bool) -> dict[str, Any]:
+        """Write to the provider's wishlist, then record it — in that order.
+
+        Nothing is written locally until the provider confirms. The feature's one
+        promise is that the heart means the record really is on your Bandcamp
+        wishlist, so an optimistic write would be the feature lying.
+
+        The remote call itself is injected, because it needs ``Candidate`` and a
+        provider session and kamp_core cannot import kamp_daemon — the same reason
+        ``preview`` is injected. It answers with a machine reason and no
+        user-facing prose: the daemon does not write brand voice, and the renderer
+        maps the reason to the clerk's line.
+        """
+        item = index.discovery_item(item_id)
+        if item is None:
+            raise HTTPException(status_code=404, detail="unknown_item")
+        if wishlist_write is None:
+            raise HTTPException(status_code=503, detail="not_connected")
+
+        reason = wishlist_write(dict(item), add)
+        if reason != "ok":
+            raise HTTPException(
+                status_code=_WISHLIST_STATUS.get(reason, 502), detail=reason
+            )
+
+        # Confirmed by the provider. Only now does any of it become true locally.
+        _record(item_id, "wishlisted" if add else "unwishlisted")
+        return {"ok": True, "wishlisted": add}
+
+    @app.post("/api/v1/discovery/items/{item_id}/wishlist")
+    def wishlist_item(item_id: int) -> dict[str, Any]:
+        """Put this record on the user's Bandcamp wishlist."""
+        return _wishlist(item_id, add=True)
+
+    @app.post("/api/v1/discovery/items/{item_id}/unwishlist")
+    def unwishlist_item(item_id: int) -> dict[str, Any]:
+        """Take it back off again."""
+        return _wishlist(item_id, add=False)
 
     # ------------------------------------------------------------------
     # Preview (KAMP-651)

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -91,7 +91,7 @@ def _maybe_unprotect(text: str) -> str:
 
 _AUDIO_SUFFIXES = frozenset({".mp3", ".m4a", ".flac", ".ogg"})
 
-_SCHEMA_VERSION = 61
+_SCHEMA_VERSION = 62
 
 
 class NoStreamableVersionError(Exception):
@@ -564,6 +564,13 @@ CREATE TABLE IF NOT EXISTS magic_playlist_criteria (
 -- same transaction; never write it directly. Precedence is highest-rank-wins, not
 -- last-event-wins: purchased > wishlisted > dismissed > previewed > fresh.
 --
+-- Highest-rank-wins is no longer the whole story (KAMP-653). 'unwishlisted' RETRACTS
+-- an earlier 'wishlisted', so it is the one event that can move state downward, and a
+-- rank comparison cannot express that. It recomputes from the ledger instead -- which
+-- is what this comment has always claimed state is, so the retraction path makes the
+-- claim true rather than bending it. The append-only kinds keep the cheap rank
+-- comparison; only a retraction pays for a re-read.
+--
 -- purchased_sale_item_id is ON DELETE SET NULL deliberately. clear_bandcamp_collection()
 -- nulls child FKs before deleting the ledger because foreign_keys=ON turns a dangling
 -- child into an IntegrityError -- the crash KAMP-528 fixed. A new child it does not
@@ -623,7 +630,7 @@ CREATE TABLE IF NOT EXISTS discovery_events (
     at               REAL    NOT NULL DEFAULT (unixepoch()),
     detail           TEXT,
     CHECK (kind IN ('shown', 'previewed', 'wishlisted', 'url_copied',
-                    'dismissed', 'purchased'))
+                    'dismissed', 'purchased', 'unwishlisted'))
 );
 CREATE INDEX IF NOT EXISTS discovery_events_item_idx ON discovery_events(item_id);
 CREATE INDEX IF NOT EXISTS discovery_events_kind_at_idx ON discovery_events(kind, at);
@@ -2706,7 +2713,57 @@ class LibraryIndex:
             # CI's older SQLite is likewise not in play.
             self._conn.execute("UPDATE schema_version SET version = 61")
             self._conn.commit()
-            version = 61  # noqa: F841
+            version = 61
+
+        if version == 61:
+            # v61 -> v62 (KAMP-653): widen discovery_events.kind to accept
+            # 'unwishlisted'. SQLite cannot ALTER a CHECK, so the table is rebuilt.
+            #
+            # Far simpler than the KAMP-552 recipe, and for one reason worth stating
+            # so nobody copies that ceremony in here: discovery_events is a LEAF. It
+            # references discovery_items, but nothing references it, so DROP TABLE
+            # cascades to nothing and the foreign_keys=OFF dance is unnecessary.
+            # _DDL already carries the widened CHECK, so a fresh DB never runs this.
+            before = self._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events"
+            ).fetchone()["c"]
+            self._conn.executescript(
+                "CREATE TABLE discovery_events_new ("
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " item_id INTEGER NOT NULL"
+                "   REFERENCES discovery_items(id) ON DELETE RESTRICT,"
+                " provider TEXT NOT NULL DEFAULT 'bandcamp',"
+                " provider_item_id TEXT NOT NULL DEFAULT '',"
+                " kind TEXT NOT NULL,"
+                " at REAL NOT NULL DEFAULT (unixepoch()),"
+                " detail TEXT,"
+                " CHECK (kind IN ('shown', 'previewed', 'wishlisted', 'url_copied',"
+                "                 'dismissed', 'purchased', 'unwishlisted')));"
+                # id copied verbatim: nothing keys on an event id today, but a
+                # renumbering rebuild is exactly the kind of silent trap that only
+                # surfaces once something does.
+                " INSERT INTO discovery_events_new"
+                "   (id, item_id, provider, provider_item_id, kind, at, detail)"
+                " SELECT id, item_id, provider, provider_item_id, kind, at, detail"
+                "   FROM discovery_events;"
+                " DROP TABLE discovery_events;"
+                " ALTER TABLE discovery_events_new RENAME TO discovery_events;"
+                # DROP TABLE took the indexes with it.
+                " CREATE INDEX IF NOT EXISTS discovery_events_item_idx"
+                "   ON discovery_events(item_id);"
+                " CREATE INDEX IF NOT EXISTS discovery_events_kind_at_idx"
+                "   ON discovery_events(kind, at);"
+            )
+            after = self._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events"
+            ).fetchone()["c"]
+            if after != before:  # pragma: no cover - defensive
+                raise RuntimeError(
+                    f"v62 rebuild lost events: {before} before, {after} after"
+                )
+            self._conn.execute("UPDATE schema_version SET version = 62")
+            self._conn.commit()
+            version = 62  # noqa: F841
 
     def _create_artist_name_nocase_index(self) -> None:
         """Enforce case-insensitive uniqueness on artists.name (KAMP-545).
@@ -4930,6 +4987,10 @@ class LibraryIndex:
         "wishlisted": "wishlisted",
         "purchased": "purchased",
     }
+    #: Events that take an earlier event back, mapped to the state they cancel.
+    #: The only way state can move downward, and the reason a rank comparison is
+    #: not sufficient on its own (KAMP-653).
+    _DISCOVERY_EVENT_RETRACTS = {"unwishlisted": "wishlisted"}
 
     def record_discovery_event(
         self,
@@ -4954,14 +5015,25 @@ class LibraryIndex:
         if row is None:
             raise ValueError(f"no discovery item with id {item_id}")
 
+        retracts = kind in self._DISCOVERY_EVENT_RETRACTS
         target = self._DISCOVERY_EVENT_STATE.get(kind)
-        if target is None:
+        if target is None and not retracts:
             raise ValueError(f"unknown discovery event kind {kind!r}")
-        rank = self._DISCOVERY_STATE_RANK
-        new_state = target if rank[target] > rank.get(row["state"], 0) else row["state"]
 
         try:
             self._append_event(item_id, row, kind, at, detail)
+            if retracts:
+                # Recomputed AFTER the append, so the retraction is part of the
+                # ledger it is derived from.
+                new_state = self._state_from_ledger(item_id)
+            else:
+                rank = self._DISCOVERY_STATE_RANK
+                assert target is not None  # narrowed by the guard above
+                new_state = (
+                    target
+                    if rank[target] > rank.get(row["state"], 0)
+                    else str(row["state"])
+                )
             if new_state != row["state"]:
                 self._conn.execute(
                     "UPDATE discovery_items SET state = ? WHERE id = ?",
@@ -4971,6 +5043,35 @@ class LibraryIndex:
         except Exception:
             self._conn.rollback()
             raise
+
+    def _state_from_ledger(self, item_id: int) -> str:
+        """Derive state from the whole event history. Does NOT commit.
+
+        Only used on the retraction path -- every other kind can be folded in with
+        a rank comparison against the cached value, and re-reading the ledger for
+        those would make the common case pay for the rare one.
+
+        Ordered by (at, id) rather than by insertion: attribution back-dates a
+        'purchased' event to the sale time, so row order and event order genuinely
+        disagree, and a retraction must cancel the wishlist that preceded it *in
+        time* rather than the one that happened to be inserted first.
+        """
+        live: set[str] = set()
+        for event in self._conn.execute(
+            "SELECT kind FROM discovery_events WHERE item_id = ? ORDER BY at, id",
+            (item_id,),
+        ):
+            kind = str(event["kind"])
+            cancelled = self._DISCOVERY_EVENT_RETRACTS.get(kind)
+            if cancelled is not None:
+                live.discard(cancelled)
+                continue
+            state = self._DISCOVERY_EVENT_STATE.get(kind)
+            if state is not None:
+                live.add(state)
+        if not live:
+            return "fresh"
+        return max(live, key=lambda s: self._DISCOVERY_STATE_RANK.get(s, 0))
 
     def _append_event(
         self,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1099,6 +1099,11 @@ def create_app(
     # not depend on kamp_daemon. Never assign this to `engine` — create_app
     # wires main-player callbacks onto whatever it is given.
     preview_player: Any = None,
+    # (item, add) -> machine reason. Performs the Bandcamp wishlist write and
+    # answers "ok" or why not. Injected for the same reason preview_player is:
+    # it needs Candidate and a provider session, and kamp_core cannot import
+    # kamp_daemon.
+    wishlist_write: Callable[[dict[str, Any], bool], str] | None = None,
     on_allowlist_changed: Callable[[], None] | None = None,
     get_default_allowlist: Callable[[], list[str]] | None = None,
     dl_queue: _queue.Queue[str] | None = None,
@@ -4705,6 +4710,7 @@ def create_app(
         on_build_start=on_crate_build_start,
         art_cache_dir=art_cache_dir,
         preview=preview_player,
+        wishlist_write=wishlist_write,
     )
 
     return app

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -575,7 +575,7 @@ def _cmd_daemon(
     from kamp_core.playback import MpvPlaybackEngine, PlaybackQueue
 
     from .discovery_preview import PreviewPlayer
-    from .wishlist import WishlistCache, mark_wishlisted_crate_items
+    from .wishlist import WishlistCache, mark_wishlisted_crate_items, write_wishlist
     from kamp_core.scrobbler import Scrobbler, authenticate as _lastfm_authenticate
     from kamp_core.server import create_app, resolve_playback_uri
     from kamp_daemon.config import config_set as _config_set
@@ -1061,6 +1061,16 @@ def _cmd_daemon(
         except Exception:
             _logger.warning("wishlist warm-up failed", exc_info=True)
 
+    def _on_wishlist_write(item: dict[str, Any], add: bool) -> str:
+        """Write one crate item to the Bandcamp wishlist. Returns a machine reason.
+
+        Builds the source per call for the same reason the crate build does: the
+        session is read fresh so logging in or out mid-session is picked up
+        without a daemon restart. That costs a keychain read, which is fine on a
+        click and is exactly why the crate snapshot does not do it.
+        """
+        return write_wishlist(_discovery_source(), item, add=add, cache=_wishlist_cache)
+
     def _on_crate_build_start() -> None:
         """Assemble a crate on a background thread.
 
@@ -1122,8 +1132,13 @@ def _cmd_daemon(
         # and without it mpv writes ~20 lines a second into a pipe for nobody.
         return MpvPlaybackEngine(mpv_bin=_resolve_mpv_binary(), metering=False)
 
-    def _preview_source() -> Any:
-        """A Bandcamp source for preview, or None when not connected."""
+    def _discovery_source() -> Any:
+        """A Bandcamp source, or None when not connected.
+
+        Shared by preview and the wishlist write rather than written twice: two
+        factories are two chances to disagree about what "connected" means, and
+        the capability property they expose is what gates both features.
+        """
         session_data = index.get_session("bandcamp")
         if not session_data:
             return None
@@ -1133,7 +1148,7 @@ def _cmd_daemon(
 
             return BandcampDiscoverySource(_make_requests_session(session_data))
         except Exception:
-            _logger.exception("preview: could not build a Bandcamp session")
+            _logger.exception("discovery: could not build a Bandcamp session")
             return None
 
     def _preview_notify(snapshot: dict[str, Any]) -> None:
@@ -1150,7 +1165,7 @@ def _cmd_daemon(
         index,
         main_engine=engine,
         engine_factory=_preview_engine,
-        source_factory=_preview_source,
+        source_factory=_discovery_source,
         notify=_preview_notify,
     )
 
@@ -1233,6 +1248,7 @@ def _cmd_daemon(
         on_genre_backfill_start=_on_genre_backfill_start,
         on_genre_backfill_cancel=_on_genre_backfill_cancel,
         on_crate_build_start=_on_crate_build_start,
+        wishlist_write=_on_wishlist_write,
         preview_player=preview_player,
         on_allowlist_changed=_on_allowlist_changed,
         get_default_allowlist=_genre_sources.default_allowlist_names,

--- a/kamp_daemon/bandcamp.py
+++ b/kamp_daemon/bandcamp.py
@@ -167,6 +167,7 @@ class _ProxySession:
         *,
         headers: dict[str, str] | None = None,
         json: Any = None,
+        data: Any = None,
         timeout: int | float = 30,
         **_kwargs: Any,
     ) -> _ProxyResponse:
@@ -175,8 +176,24 @@ class _ProxySession:
             req_headers.update(headers)
         body: str | None = None
         if json is not None:
-            req_headers["Content-Type"] = "application/json"
+            req_headers.setdefault("Content-Type", "application/json")
             body = _json_dumps(json)
+        elif data is not None:
+            # Form encoding, which Bandcamp's collect_item_cb / uncollect_item_cb
+            # require: the identical call with a JSON body answers HTTP 200
+            # carrying an InsistError about a missing crumb (KAMP-644).
+            #
+            # The relay carries this fine — the wire format is
+            # {url, method, headers, body} with the content type riding in
+            # headers, and server.py, kampAPI.ts and index.ts all forward both
+            # verbatim. Nothing else needed changing; the recon's claim that the
+            # server model and the Electron handler also needed extending was
+            # measured against a spike helper that had no form path at all.
+            #
+            # setdefault, not assignment: headers= was merged above, so a caller
+            # that supplied its own content type should keep it.
+            req_headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
+            body = _urlencode(data)
 
         # The proxy relay chain adds significant latency: the request goes
         # subprocess → server → WS → Electron → net.fetch(bandcamp.com) → back.
@@ -193,8 +210,10 @@ class _ProxySession:
             timeout=proxy_timeout,
         )
         resp.raise_for_status()
-        data: dict[str, Any] = resp.json()
-        status = data["status"]
+        # Named `result`, not `data`: the request body kwarg is now called `data`,
+        # the same shadowing hazard the _json_dumps alias above exists for.
+        result: dict[str, Any] = resp.json()
+        status = result["status"]
         if status >= 400:
             # Log what Bandcamp actually said. A 429 surfaced only as
             # "Album download failed: HTTP 429" tells us nothing about WHICH
@@ -205,14 +224,14 @@ class _ProxySession:
                 method,
                 url,
                 status,
-                data.get("content_type", "?"),
-                data.get("body", ""),
+                result.get("content_type", "?"),
+                result.get("body", ""),
             )
         return _ProxyResponse(
             status_code=status,
-            text=data["body"],
-            content_type=data.get("content_type", "text/html"),
-            url=data.get("url"),
+            text=result["body"],
+            content_type=result.get("content_type", "text/html"),
+            url=result.get("url"),
         )
 
     def get(self, url: str, **kwargs: Any) -> _ProxyResponse:
@@ -222,8 +241,9 @@ class _ProxySession:
         return self._fetch("POST", url, **kwargs)
 
 
-# Alias json.dumps to avoid shadowing in _ProxySession._fetch
+# Aliased because _ProxySession._fetch shadows both names with its own kwargs.
 _json_dumps = json.dumps
+_urlencode = urllib.parse.urlencode
 
 # Union type accepted by all internal helpers that take an HTTP session.
 _AnySession = Union[_requests.Session, _ProxySession]

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -289,13 +289,17 @@ class DiscoverySource(ABC):
     def capabilities(self) -> frozenset[str]:
         """What this source can do *right now*.
 
-        A property rather than a class constant because capability can depend on the
-        transport, not just the provider. Bandcamp's wishlist write needs a
-        form-encoded POST that the Electron relay cannot express, so it is unavailable
-        in every packaged build until KAMP-653 extends the relay — while working fine
-        in a dev checkout. A constant would have the UI render a wishlist button that
-        silently does nothing for every real user, which is the exact class of failure
-        ``docs/discovery-recon.md`` exists to prevent.
+        A property rather than a class constant because capability can depend on
+        runtime state — the transport, the credentials, what the remote service is
+        currently willing to do — not just on which provider this is. A constant
+        would let the UI render a control that silently does nothing, which is the
+        class of failure ``docs/discovery-recon.md`` exists to prevent.
+
+        The original example here was Bandcamp's wishlist write, which was thought
+        to be inexpressible through the Electron relay. It was not: the relay
+        carries a form body fine and KAMP-653 ships the write on every platform.
+        The property still earns its keep, because a source with no Bandcamp
+        session can do neither.
         """
         return frozenset()
 
@@ -365,5 +369,23 @@ class DiscoverySource(ABC):
         from the HTTP status: Bandcamp's ``*_cb`` endpoints answer 200 with an error
         payload, and trusting the status is what left an album stranded on a real
         account during the KAMP-644 spike.
+
+        Idempotent by contract. Saving something already saved is a success, not an
+        error — the user's intent is satisfied either way, and the alternative is an
+        error message for a record that is sitting exactly where they wanted it.
+        """
+        raise UnsupportedCapability(f"{self.provider_id} cannot save remotely")
+
+    def unsave_remote(self, candidate: Candidate) -> bool:
+        """Take *candidate* back off the provider's list. The inverse of
+        :meth:`save_remote`, and gated by the same :data:`SAVE_REMOTE` capability.
+
+        One capability for both directions because a provider that can add to a
+        remote list can generally remove from it — Bandcamp serves both from one
+        crumb mechanism. Splitting them would be inventing a distinction no
+        provider has yet made.
+
+        Same rules as :meth:`save_remote`: confirm from the parsed body, and treat
+        removing something already absent as a success.
         """
         raise UnsupportedCapability(f"{self.provider_id} cannot save remotely")

--- a/kamp_daemon/discovery_bandcamp_parsers.py
+++ b/kamp_daemon/discovery_bandcamp_parsers.py
@@ -316,6 +316,115 @@ _DISCO_TITLE = re.compile(r'<p class="title">\s*(.*?)\s*(?:<|$)', re.DOTALL)
 _DISCO_ART = re.compile(r"https://f4\.bcbits\.com/img/a(\d+)_")
 
 
+# ---------------------------------------------------------------------------
+# Wishlist write material (KAMP-653)
+# ---------------------------------------------------------------------------
+
+_CRUMBS = re.compile(r'id="js-crumbs-data"[^>]*data-crumbs="([^"]*)"')
+_TRALBUM = re.compile(r'data-tralbum="([^"]+)"')
+_PAGEDATA = re.compile(r'id="pagedata"[^>]*data-blob="([^"]+)"')
+
+
+def _escaped_json(match: re.Match[str] | None) -> Any:
+    """Decode one HTML-escaped JSON attribute, or None if it will not decode."""
+    if match is None:
+        return None
+    try:
+        return json.loads(html_lib.unescape(match.group(1)))
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_crumbs(html: str) -> dict[str, str]:
+    """The per-action CSRF tokens on any logged-in page.
+
+    Shaped ``|<action>|<epoch>|<hmac>=`` and keyed by the endpoint they authorise
+    (``collect_item_cb``, ``uncollect_item_cb``). Short-lived: a stale one earns
+    HTTP 403 with a fresh crumb in the error body, which is the documented
+    refresh path.
+
+    Returns ``{}`` for a logged-out page, which ships ``data-crumbs="{}"`` — the
+    tag is present either way, so its presence is not a logged-in check.
+    """
+    blob = _escaped_json(_CRUMBS.search(html))
+    if not isinstance(blob, dict):
+        return {}
+    return {str(k): str(v) for k, v in blob.items()}
+
+
+def parse_band_id(html: str) -> str | None:
+    """The band that ``collect_item_cb`` collects under.
+
+    From ``data-tralbum``'s ``current.band_id`` — the same blob
+    :func:`kamp_daemon.bandcamp.parse_tralbum` reads for the track list.
+
+    **Never ``current.selling_band_id``, and never a fallback to it.** The two
+    diverge on label-released albums, and sending the wrong one returns HTTP 200
+    carrying ``{"ok":true}`` while doing nothing at all — verified live by sending
+    it deliberately. A fallback would therefore report success and change nothing,
+    which is worse than failing: the UI would show a done-state for a record that
+    never left the shop.
+    """
+    blob = _escaped_json(_TRALBUM.search(html))
+    if not isinstance(blob, dict):
+        return None
+    current = blob.get("current")
+    band_id = current.get("band_id") if isinstance(current, dict) else None
+    return None if band_id is None else str(band_id)
+
+
+def parse_is_wishlisted(html: str) -> bool | None:
+    """Whether the logged-in fan already has this album wishlisted.
+
+    ``None`` when the page cannot say — an anonymous page carries
+    ``fan_tralbum_data: null``. Deliberately tri-state: collapsing that to False
+    would turn "we were not logged in" into a confident "not wishlisted", which
+    the caller would act on.
+    """
+    blob = _escaped_json(_PAGEDATA.search(html))
+    if not isinstance(blob, dict):
+        return None
+    fan_data = blob.get("fan_tralbum_data")
+    if not isinstance(fan_data, dict):
+        return None
+    value = fan_data.get("is_wishlisted")
+    return None if value is None else bool(value)
+
+
+def parse_collect_ok(body: str) -> bool:
+    """Did a ``*_cb`` call actually succeed?
+
+    **Never trust the HTTP status here.** These endpoints answer 200 with an error
+    payload — a JSON-encoded request comes back 200 carrying
+    ``{"error":true,"ok":false,"exception":"...InsistError..."}``. Checking the
+    status alone reports success for a call that did nothing, which is precisely
+    how the KAMP-644 spike left an album stranded on a real account.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    return bool(parsed.get("ok")) and not parsed.get("error")
+
+
+def parse_fresh_crumb(body: str) -> str | None:
+    """The replacement crumb Bandcamp hands back when ours was stale.
+
+    A 403 carrying ``{"error":"invalid_crumb","crumb":"<fresh>"}`` is a documented,
+    recoverable flow — the site's own ``Crumb.ajax`` retries on exactly this.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("error") != "invalid_crumb":
+        return None
+    crumb = parsed.get("crumb")
+    return str(crumb) if crumb else None
+
+
 def parse_discography(html: str, *, base_url: str = "") -> ParseResult:
     """Parse an artist's ``/music`` grid.
 

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -22,7 +22,9 @@ from kamp_core.proxy_hosts import FETCHABLE_HOSTS, host_allowed
 
 from .bandcamp_ratelimit import BandcampGovernor, get_governor
 from .discovery import (
+    ALBUM_PAGE,
     PREVIEW,
+    SAVE_REMOTE,
     Candidate,
     DiscoverySource,
     PreviewStream,
@@ -32,8 +34,13 @@ from .discovery import (
 from .discovery_bandcamp_parsers import (
     ParseResult,
     parse_also_like,
+    parse_band_id,
+    parse_collect_ok,
+    parse_crumbs,
     parse_discography,
     parse_discover_results,
+    parse_fresh_crumb,
+    parse_is_wishlisted,
     release_year,
     tag_slug,
 )
@@ -53,6 +60,12 @@ if TYPE_CHECKING:  # pragma: no cover - types only
 logger = logging.getLogger(__name__)
 
 DISCOVER_API_URL = "https://bandcamp.com/api/discover/1/discover_web"
+
+# The wishlist write pair. Both live on bandcamp.com itself rather than on the
+# album's own host, so a Bandcamp Pro custom domain is no obstacle to the POST --
+# only to the album-page GET that supplies the crumb and band_id.
+COLLECT_URL = "https://bandcamp.com/collect_item_cb"
+UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
 
 
 def _is_fetchable(url: str) -> bool:
@@ -89,14 +102,17 @@ class BandcampDiscoverySource(DiscoverySource):
 
     @property
     def capabilities(self) -> frozenset[str]:
-        """Preview only, for now.
+        """Preview and the wishlist write, both of which need a session.
 
-        ``save_remote`` (wishlist-add) is deliberately absent: it needs a
-        form-encoded POST that the Electron relay cannot express, so it would be
-        dead in every packaged build until KAMP-653 extends the relay. Declaring
-        it here would render a wishlist button that silently does nothing.
+        ``SAVE_REMOTE`` covers add *and* remove: Bandcamp serves both from one
+        crumb mechanism, so a source that can do one can do the other.
+
+        It was withheld until KAMP-653 on the belief that the write needed a
+        form-encoded POST the Electron relay could not express. The relay carries
+        one fine — the earlier verdict was measured against a spike helper with no
+        form path at all — so it is now available on every platform.
         """
-        return frozenset({PREVIEW})
+        return frozenset({PREVIEW, SAVE_REMOTE})
 
     @property
     def criterion_caps(self) -> dict[str, int]:
@@ -421,3 +437,179 @@ class BandcampDiscoverySource(DiscoverySource):
         if not out:
             logger.info("discovery: nothing streamable on %s", candidate.item_url)
         return out
+
+    # ------------------------------------------------------------------
+    # Wishlist write (KAMP-653)
+    # ------------------------------------------------------------------
+
+    def save_remote(self, candidate: Candidate) -> bool:
+        """Put *candidate* in the fan's Bandcamp wishlist."""
+        return self._collect(candidate, COLLECT_URL, "collect_item_cb", want=True)
+
+    def unsave_remote(self, candidate: Candidate) -> bool:
+        """Take *candidate* back out of the fan's Bandcamp wishlist."""
+        return self._collect(candidate, UNCOLLECT_URL, "uncollect_item_cb", want=False)
+
+    def _collect(
+        self, candidate: Candidate, url: str, crumb_key: str, *, want: bool
+    ) -> bool:
+        """One crumb-authenticated wishlist mutation. Add and remove differ only
+        in the endpoint, the crumb key, and which end state counts as done.
+
+        Two requests: a GET of the album's own page, then the POST. The GET is not
+        overhead — it is the only source of all three things the POST needs. The
+        crumb lives in a meta tag on it, ``band_id`` lives in its ``data-tralbum``
+        blob, and ``fan_tralbum_data.is_wishlisted`` says whether the work is
+        already done. There is no cheaper way to learn any of them.
+
+        Raises :class:`RateLimitedError` if the album-page class is cooling down —
+        a refusal the caller can explain, rather than a request that will 429.
+
+        Deliberately does *not* re-check :attr:`capabilities`: this class only
+        exists when a session does, so the check would be unreachable. The gate
+        belongs at the route, which is handed whichever source is available and is
+        the only place a provider without the capability can turn up.
+        """
+        from .bandcamp import _get_fan_info
+
+        if not _is_fetchable(candidate.item_url):
+            # Unreachable for anything the builder produced -- _to_candidates
+            # drops custom-domain albums before they can enter a crate -- but
+            # item_url is remote data read back out of the database, so it gets
+            # the same check the art proxy and preview apply.
+            logger.warning(
+                "discovery: wishlist host not fetchable %s", candidate.item_url
+            )
+            return False
+
+        # Checked, never waited on. Same rule as preview_tracks: this is a click,
+        # and wait_turn would hang it for up to five minutes. Unlike preview it can
+        # refuse outright, because there is no partial answer worth giving.
+        if self._governor.blocked_for(ALBUM_PAGE) > 0:
+            raise RateLimitedError("album pages are cooling down")
+
+        page = self._album_page(candidate)
+        if page is None:
+            return False
+
+        already = parse_is_wishlisted(page)
+        if already is want:
+            # Idempotent by contract, and free: the page we had to fetch anyway
+            # already answered. Bandcamp agrees -- a repeat collect_item_cb returns
+            # ok:true -- so this saves a request rather than changing the outcome.
+            logger.info("discovery: %s already wishlisted=%s", candidate.title, want)
+            return True
+
+        crumbs = parse_crumbs(page)
+        crumb = crumbs.get(crumb_key)
+        if not crumb:
+            # A logged-out page ships data-crumbs="{}". Since capabilities said we
+            # had a session, this means the session is no longer good.
+            logger.warning(
+                "discovery: no %s crumb on %s (session expired?)",
+                crumb_key,
+                candidate.item_url,
+            )
+            return False
+
+        band_id = parse_band_id(page)
+        if not band_id:
+            # Refuse rather than guess. selling_band_id is right there and wrong:
+            # it returns ok:true and silently does nothing, so a fallback would
+            # show a done-state for a record that never moved.
+            logger.warning(
+                "discovery: no band_id on %s — refusing to guess", candidate.item_url
+            )
+            return False
+
+        try:
+            fan_id, _ = _get_fan_info(self._session)
+        except Exception:
+            logger.warning("discovery: could not resolve fan_id for the wishlist write")
+            raise
+
+        form = {
+            "fan_id": fan_id,
+            "item_id": candidate.provider_item_id,
+            # "album", not the discover API's "a" -- the same concept is spelled
+            # differently on the two surfaces and the short form earns a bare 400.
+            "item_type": "album",
+            "band_id": band_id,
+            "crumb": crumb,
+        }
+        ok, fresh = self._post_collect(url, form)
+        if not ok and fresh:
+            # Documented refresh path: a stale crumb comes back as HTTP 403 with a
+            # replacement in the body, and Bandcamp's own Crumb.ajax retries on
+            # exactly this. Once only -- a second failure is not a crumb problem.
+            logger.info("discovery: crumb was stale, retrying with the fresh one")
+            form["crumb"] = fresh
+            ok, _ = self._post_collect(url, form)
+        return ok
+
+    def _album_page(self, candidate: Candidate) -> str | None:
+        """GET the candidate's page, reporting the outcome to the governor."""
+        try:
+            resp = self._session.get(candidate.item_url, timeout=30)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "discovery: wishlist page fetch failed for %s", candidate.item_url
+            )
+            return None
+        if resp.status_code == 429:
+            self._governor.report_429(ALBUM_PAGE)
+            raise RateLimitedError(f"429 from {candidate.item_url}")
+        if resp.status_code != 200:
+            logger.warning(
+                "discovery: wishlist page HTTP %d from %s",
+                resp.status_code,
+                candidate.item_url,
+            )
+            return None
+        self._governor.report_ok(ALBUM_PAGE)
+        return str(resp.text)
+
+    def _post_collect(self, url: str, form: dict[str, Any]) -> tuple[bool, str | None]:
+        """POST one form-encoded mutation. Returns (succeeded, fresh crumb if any).
+
+        Form-encoded, not JSON: the identical call with a JSON body answers HTTP
+        200 carrying an InsistError about a missing crumb.
+
+        Success comes from the parsed body and never from the status, because
+        these endpoints answer 200 on failure. Note this is only trustworthy
+        because band_id came off the album's own page -- with a wrong band_id the
+        body says ok:true and nothing happens (see parse_band_id).
+        """
+        try:
+            resp = self._session.post(
+                url,
+                data=form,
+                # Origin, not Referer. Bandcamp insists on one of the two, and
+                # Chromium blocks a manually-set Referer on net.request outright
+                # (net::ERR_BLOCKED_BY_CLIENT), so a Referer here would work in dev
+                # and fail in every packaged build.
+                headers={
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Origin": "https://bandcamp.com",
+                },
+                timeout=30,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("discovery: wishlist POST to %s failed", url, exc_info=True)
+            return False, None
+
+        if resp.status_code == 429:
+            self._governor.report_429(ALBUM_PAGE)
+            raise RateLimitedError(f"429 from {url}")
+
+        body = str(resp.text)
+        if parse_collect_ok(body):
+            self._governor.report_ok(ALBUM_PAGE)
+            return True, None
+        logger.warning(
+            "discovery: wishlist POST rejected by %s — HTTP %d %.200r",
+            url,
+            resp.status_code,
+            body,
+        )
+        return False, parse_fresh_crumb(body)

--- a/kamp_daemon/wishlist.py
+++ b/kamp_daemon/wishlist.py
@@ -181,12 +181,78 @@ def mark_wishlisted_crate_items(index: "LibraryIndex", ids: set[str]) -> int:
     return marked
 
 
+def write_wishlist(
+    source: Any,
+    item: dict[str, Any],
+    *,
+    add: bool,
+    cache: "WishlistCache | None" = None,
+) -> str:
+    """Add or remove one crate item on the provider's wishlist (KAMP-653).
+
+    Returns ``"ok"``, or a machine reason the API layer maps to a status. Lives
+    here rather than in ``kamp_core.discovery_api`` because it needs
+    :class:`~kamp_daemon.discovery.Candidate` and a provider session, and
+    ``kamp_core`` cannot import ``kamp_daemon`` -- the same boundary that makes
+    the preview player an injected object.
+
+    Reasons, not prose: the daemon does not write brand voice. The renderer turns
+    each of these into the clerk's line.
+    """
+    from .discovery import SAVE_REMOTE, Candidate, UnsupportedCapability
+    from .discovery_sources import RateLimitedError
+
+    if source is None:
+        return "not_connected"
+    # The capability gate, and the first thing in the codebase to read the
+    # property. Without it a provider that cannot write would surface as a
+    # generic failure indistinguishable from the remote service saying no.
+    if SAVE_REMOTE not in getattr(source, "capabilities", frozenset()):
+        return "unsupported"
+
+    candidate = Candidate(
+        provider=str(item.get("provider") or "bandcamp"),
+        provider_item_id=str(item.get("provider_item_id") or ""),
+        item_url=str(item.get("item_url") or ""),
+        artist=str(item.get("artist") or ""),
+        title=str(item.get("title") or ""),
+    )
+    try:
+        ok = source.save_remote(candidate) if add else source.unsave_remote(candidate)
+    except RateLimitedError:
+        return "rate_limited"
+    except UnsupportedCapability:
+        return "unsupported"
+    except Exception as exc:  # noqa: BLE001
+        # NeedsLoginError is raised by _get_fan_info on a 401/403/302. Matched by
+        # name because importing it here would drag kamp_daemon.bandcamp -- and
+        # its module-level requests setup -- into every caller.
+        if type(exc).__name__ == "NeedsLoginError":
+            return "needs_login"
+        logger.warning(
+            "wishlist: write failed for item %s", item.get("id"), exc_info=True
+        )
+        return "rejected"
+
+    if not ok:
+        return "rejected"
+
+    # Keep the exclusion filter honest immediately. Without the discard half, an
+    # album the user just removed stays suppressed from every crate for the rest
+    # of the TTL with nothing to explain why.
+    if cache is not None:
+        if add:
+            cache.add(candidate.provider_item_id)
+        else:
+            cache.discard(candidate.provider_item_id)
+    return "ok"
+
+
 class WishlistCache:
     """The wishlist ids, walked rarely and read often.
 
-    Locked because KAMP-653's ``add`` will arrive on a request thread while a
-    crate build reads on another; builds are serialised today, so this is not
-    yet reachable, but the lock is cheaper than remembering later.
+    Locked because KAMP-653's ``add``/``discard`` arrive on a request thread while
+    a crate build reads on another.
     """
 
     def __init__(
@@ -201,6 +267,11 @@ class WishlistCache:
         self._ids: set[str] = set()
         self._fetched_at: float | None = None
         self._walking = False
+        #: Mutations made *during* a walk, id -> present. A walk takes ~40s and
+        #: runs outside the lock, so it can start before a wishlist click and land
+        #: after it; replacing the id set wholesale would then silently undo what
+        #: the user just did. Applied on top of the walk result when it lands.
+        self._pending: dict[str, bool] = {}
 
     @property
     def ids(self) -> set[str]:
@@ -224,17 +295,31 @@ class WishlistCache:
         """Record a wishlist addition kamp made itself (KAMP-653).
 
         Covers only kamp's own writes. A wishlist change made in a browser is
-        invisible until the next walk, which is why the per-item check on the
-        preview fetch exists.
+        invisible until the next walk.
         """
         with self._lock:
             self._ids.add(str(tralbum_id))
+            if self._walking:
+                self._pending[str(tralbum_id)] = True
+
+    def discard(self, tralbum_id: str) -> None:
+        """Record a wishlist removal kamp made itself (KAMP-653).
+
+        Without this a removed album stays excluded from every crate until the
+        cache expires -- the user takes it off their wishlist and kamp keeps
+        refusing to offer it, for up to an hour, with nothing to explain why.
+        """
+        with self._lock:
+            self._ids.discard(str(tralbum_id))
+            if self._walking:
+                self._pending[str(tralbum_id)] = False
 
     def invalidate(self) -> None:
         """Drop everything — the ids belong to an account that can change."""
         with self._lock:
             self._ids = set()
             self._fetched_at = None
+            self._pending.clear()
 
     def refresh(
         self,
@@ -260,6 +345,7 @@ class WishlistCache:
                 logger.info("wishlist: skipping the walk, endpoint is cooling down")
                 return
             self._walking = True
+            self._pending.clear()
 
         try:
             ids = fetch_wishlist_album_ids(session, fan_id, governor=gov)
@@ -275,6 +361,15 @@ class WishlistCache:
             return
 
         with self._lock:
+            # Re-apply anything the user did while the walk was in flight. The
+            # walk reflects Bandcamp as of ~40s ago; these are newer and were
+            # confirmed by Bandcamp, so they win over whatever the pages said.
+            for tralbum_id, present in self._pending.items():
+                if present:
+                    ids.add(tralbum_id)
+                else:
+                    ids.discard(tralbum_id)
+            self._pending.clear()
             self._ids = ids
             self._fetched_at = self._now()
         logger.info("wishlist: %d albums cached", len(ids))

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -618,6 +618,22 @@ export const dismissCrateItem = (itemId: number): Promise<{ ok: boolean }> =>
 export const crateItemUrlCopied = (itemId: number): Promise<{ ok: boolean }> =>
   post(`/api/v1/discovery/items/${itemId}/url-copied`)
 
+// --- Wishlist write (KAMP-653) ---------------------------------------------
+// postWithDetail, not post: every failure here carries a machine reason the UI
+// turns into the clerk's line, and plain post() would flatten all of them into
+// "502 Bad Gateway — /api/v1/...".
+//
+// The daemon writes to Bandcamp FIRST and records the event only on a confirmed
+// success, so the returned state is never optimistic. The rail's heart comes
+// from the crate snapshot that follows, not from these responses.
+export const wishlistCrateItem = (itemId: number): Promise<{ ok: boolean; wishlisted: boolean }> =>
+  postWithDetail(`/api/v1/discovery/items/${itemId}/wishlist`)
+
+export const unwishlistCrateItem = (
+  itemId: number
+): Promise<{ ok: boolean; wishlisted: boolean }> =>
+  postWithDetail(`/api/v1/discovery/items/${itemId}/unwishlist`)
+
 // --- Preview (KAMP-651) ----------------------------------------------------
 // Preview runs on a second, isolated mpv so it cannot disturb the queue. It is
 // daemon-owned and survives a renderer reload, which is why there is a state

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -196,6 +196,30 @@
   cursor: default;
 }
 
+/* The wishlist done-state. Deliberately not --primary: the primary slot belongs
+   to "Give it a spin", and two accent-filled buttons side by side would read as
+   competing calls to action. This is a quiet confirmation of something already
+   true, so it takes the accent as a tint and an outline rather than a fill. */
+.crate-action--done {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Still clickable when done — pressing it again removes the record — so it must
+   not inherit the flat :disabled treatment. */
+.crate-action--done:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+/* Sits under the action row, beside the button that is also the retry. Matches
+   .crate-preview-error rather than shouting in an error colour: the clerk is
+   explaining, not warning, and Copy link is right there. */
+.crate-action-error {
+  margin: 8px 0 0;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
 .crate-dig-btn {
   border: 1px solid var(--border);
   background: var(--surface);

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -40,6 +40,10 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const commitCrateDismiss = useStore((s) => s.commitCrateDismiss)
   const flushCrateDismissals = useStore((s) => s.flushCrateDismissals)
   const copyCrateItemUrl = useStore((s) => s.copyCrateItemUrl)
+  const toggleCrateWishlist = useStore((s) => s.toggleCrateWishlist)
+  const wishlistPending = useStore((s) => s.crateWishlistPending)
+  const wishlistError = useStore((s) => s.crateWishlistError)
+  const clearCrateWishlistError = useStore((s) => s.clearCrateWishlistError)
   const setActiveView = useStore((s) => s.setActiveView)
   const preview = useStore((s) => s.preview)
   const previewPlay = useStore((s) => s.previewPlay)
@@ -80,6 +84,14 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // the intermediate frame where the focus card would be blank.
   const focusIndex = visible.length === 0 ? 0 : Math.min(focused, visible.length - 1)
   const current = visible[focusIndex] ?? null
+
+  // The done-state is read from item.state, never from a local flag. A confirmed
+  // write re-broadcasts the whole crate, so this arrives from the daemon — which
+  // makes "never show a done-state Bandcamp has not confirmed" structural rather
+  // than something the click handler has to remember. It also survives a remount,
+  // a view switch, and KAMP-652 marking items out of band.
+  const wishlisted = current?.state === 'wishlisted'
+  const wishlistSaving = current ? wishlistPending.includes(current.id) : false
 
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
@@ -152,6 +164,13 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const openOnBandcamp = useCallback((item: CrateItem): void => {
     if (item.item_url) window.api.openExternal(item.item_url)
   }, [])
+
+  // A failure explains the record it happened on. Carrying it to the next one
+  // would have the clerk apologising about something else entirely.
+  const currentId = current?.id ?? null
+  useEffect(() => {
+    clearCrateWishlistError()
+  }, [currentId, clearCrateWishlistError])
 
   const focusSleeve = useCallback((index: number): void => {
     setFocused(index)
@@ -229,10 +248,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       e.stopPropagation()
       if (current) void copyCrateItemUrl(current)
     } else if (e.key === 'w' || e.key === 'W') {
-      // Claimed so it does not fall through to a global shortcut, but wishlist
-      // itself is unavailable until KAMP-653 extends the Electron relay.
       e.preventDefault()
       e.stopPropagation()
+      // `current` is captured here and never read again in the resolution
+      // handler: it is derived during render from a clamped index, and any
+      // snapshot push can change its identity while the request is out.
+      if (current) void toggleCrateWishlist(current)
     } else if (e.key === ' ') {
       // Now that preview exists, Space is the Crate's (KAMP-651). KAMP-650
       // deliberately left it global, because claiming it for a no-op would have
@@ -373,11 +394,16 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   Open on Bandcamp
                 </button>
                 <button
-                  className="crate-action"
-                  disabled
-                  {...tooltip(TOOLTIPS.CRATE_WISHLIST_SOON)}
+                  className={`crate-action${wishlisted ? ' crate-action--done' : ''}`}
+                  onClick={() => void toggleCrateWishlist(current)}
+                  disabled={wishlistSaving}
+                  {...tooltip(wishlisted ? TOOLTIPS.CRATE_UNWISHLIST : TOOLTIPS.CRATE_WISHLIST)}
                 >
-                  Wishlist it
+                  {wishlistSaving
+                    ? 'Setting it aside…'
+                    : wishlisted
+                      ? '♥ In your wishlist'
+                      : 'Wishlist it'}
                 </button>
                 <button
                   className="crate-action"
@@ -394,6 +420,17 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   Pass
                 </button>
               </div>
+
+              {/* The clerk explains a failed wishlist write here rather than in a
+                  toast: the retry is this button, so the message belongs beside
+                  it. Copy link is right there as the fallback every reason ends
+                  at. Not a reserved slot — unlike the preview strip it appears
+                  rarely and pushes nothing the user is mid-interaction with. */}
+              {wishlistError && (
+                <p className="crate-action-error" role="status">
+                  {wishlistError}
+                </p>
+              )}
 
               {/* The preview's own space, always present. Rendering the strip
                   and track list into the normal flow made the whole card grow

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -51,6 +51,11 @@ const GROUPS: Group[] = [
         description: 'Preview / hold',
         note: 'Your queue pauses and comes back'
       },
+      {
+        keys: ['W'],
+        description: 'Wishlist / un-wishlist',
+        note: 'Writes to your Bandcamp account'
+      },
       { keys: ['C'], description: 'Copy link' },
       { keys: ['X'], description: 'Pass', note: 'Undo for 5 seconds' },
       { keys: ['Esc'], description: 'Stop the preview, then leave the crate' }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -241,6 +241,18 @@ type PlayerStore = {
   // the user navigates away, or a pass made in the last few seconds is lost.
   flushCrateDismissals: () => Promise<void>
   copyCrateItemUrl: (item: CrateItem) => Promise<void>
+  // KAMP-653: the wishlist write. Ids currently in flight, so the button can be
+  // disabled per card rather than per view — focus can move with , and . while a
+  // request is out, and a single boolean would disable the wrong card.
+  crateWishlistPending: number[]
+  // The last failure, as a clerk-voice line, or null. Cleared on the next
+  // attempt and when the focused record changes.
+  crateWishlistError: string | null
+  clearCrateWishlistError: () => void
+  // Never optimistic: the daemon writes to Bandcamp first and records the event
+  // only on a confirmed success, so the heart arrives on the crate snapshot that
+  // follows rather than from here.
+  toggleCrateWishlist: (item: CrateItem) => Promise<void>
   // KAMP-651: preview transport. Every action returns the authoritative state,
   // so none of these guess locally.
   loadPreview: () => Promise<void>
@@ -426,6 +438,30 @@ const SEARCH_DEBOUNCE_MS = 250
 let _searchTimer: ReturnType<typeof setTimeout> | null = null
 let _searchAbort: AbortController | null = null
 
+// KAMP-653: the daemon answers a failed wishlist write with a machine reason and
+// no prose — it does not write brand voice. This is where the reason becomes the
+// clerk's line. Every one of them ends somewhere the user can still act, because
+// Copy link is always available beside the button.
+const wishlistErrorLine = (err: unknown, adding: boolean): string => {
+  const reason = err instanceof Error ? err.message : ''
+  switch (reason) {
+    case 'rate_limited':
+      return 'Bandcamp asked us to slow down — try that again shortly.'
+    case 'needs_login':
+      return 'Bandcamp signed us out. Reconnect in Settings and try again.'
+    case 'not_connected':
+      return "We're not connected to Bandcamp right now."
+    case 'unsupported':
+      return "This one can't be wishlisted from here — the link still works."
+    default:
+      // Includes 'rejected' and anything a future provider invents. Deliberately
+      // does not claim to know why: the honest version of "Bandcamp said no".
+      return adding
+        ? "Couldn't reach Bandcamp — here's the link instead."
+        : "Couldn't reach Bandcamp to take that back off."
+  }
+}
+
 // KAMP-571: raw aggregate percent for the global download bar — completed items
 // plus the currently-downloading item's byte-fraction, over the batch total.
 // downloadProgress is keyed by sale_item_id (== provider_item_id for bandcamp);
@@ -581,6 +617,8 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadBatch: null,
   crate: null,
   crateDismissPending: [],
+  crateWishlistPending: [],
+  crateWishlistError: null,
   preview: null,
   flashToast: null,
   flashToastTone: null,
@@ -989,6 +1027,30 @@ export const useStore = create<PlayerStore>((set, get) => ({
       void api.crateItemUrlCopied(item.id).catch(() => {})
     } catch {
       get().showFlashToast('Could not copy the link', 'error')
+    }
+  },
+  clearCrateWishlistError: () => set({ crateWishlistError: null }),
+  toggleCrateWishlist: async (item) => {
+    // Guarded by id, not by a boolean: holding W down repeats the key, and
+    // focus can move to another record with , or . while a request is out.
+    if (get().crateWishlistPending.includes(item.id)) return
+    const adding = item.state !== 'wishlisted'
+    set((s) => ({
+      crateWishlistPending: [...s.crateWishlistPending, item.id],
+      crateWishlistError: null
+    }))
+    try {
+      await (adding ? api.wishlistCrateItem(item.id) : api.unwishlistCrateItem(item.id))
+      // No local state change on success either. The daemon re-broadcasts the
+      // whole crate after a confirmed write, and the heart is drawn from
+      // item.state — so the done-state cannot get ahead of Bandcamp even by
+      // accident, which is the promise rather than a nicety.
+    } catch (err) {
+      set({ crateWishlistError: wishlistErrorLine(err, adding) })
+    } finally {
+      set((s) => ({
+        crateWishlistPending: s.crateWishlistPending.filter((id) => id !== item.id)
+      }))
     }
   },
   // --- Preview (KAMP-651) ---------------------------------------------------

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -50,7 +50,9 @@ export const TOOLTIPS = {
   // Crate (KAMP-650). The clerk card's tooltip is the plain mechanical
   // answer to "why am I seeing this?" — the shelf tag is the short version.
   CRATE_WHY: 'Picked from your own library and listening — nothing leaves this machine',
-  CRATE_WISHLIST_SOON: 'Wishlisting from Kamp is coming — copy the link for now',
+  // Names Bandcamp explicitly: this writes to the account, not to anything local.
+  CRATE_WISHLIST: 'Add to your Bandcamp wishlist (W)',
+  CRATE_UNWISHLIST: 'Remove from your Bandcamp wishlist (W)',
   CRATE_PREVIEW: 'Play a preview (Space) — your queue stays put',
   CRATE_COPY: 'Copy link (C)',
   CRATE_PASS: 'Pass (X)',

--- a/scripts/spike_discovery_recon.py
+++ b/scripts/spike_discovery_recon.py
@@ -38,6 +38,7 @@ import json
 import re
 import sys
 import time
+import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -336,13 +337,7 @@ class DirectTransport:
         timeout: int = 25,
         headers: dict[str, str] | None = None,
     ) -> Fetched:
-        """Form-encoded POST — what the browser actually does for ``*_cb`` endpoints.
-
-        Has no relay equivalent: ``_ProxySession._fetch`` accepts only ``json=``
-        and drops a ``data=`` kwarg into ``**_kwargs``.  Kept here specifically to
-        compare against :meth:`post_json` and settle whether shipped builds can
-        perform this call at all.
-        """
+        """Form-encoded POST — what the browser actually does for ``*_cb`` endpoints."""
         start = time.monotonic()
         resp = self.session.post(url, data=payload, timeout=timeout, headers=headers)
         return Fetched(
@@ -367,11 +362,21 @@ class RelayTransport:
     def __init__(self) -> None:
         self.token = auth_token()
 
-    def _relay(self, method: str, url: str, body: str | None, timeout: int) -> Fetched:
+    def _relay(
+        self,
+        method: str,
+        url: str,
+        body: str | None,
+        timeout: int,
+        content_type: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Fetched:
         start = time.monotonic()
         headers = {"User-Agent": UA}
         if body is not None:
-            headers["Content-Type"] = "application/json"
+            headers["Content-Type"] = content_type or "application/json"
+        if extra_headers:
+            headers.update(extra_headers)
         resp = requests.post(
             PROXY_FETCH_URL,
             json={"url": url, "method": method, "headers": headers, "body": body},
@@ -393,11 +398,44 @@ class RelayTransport:
     def get(self, url: str, timeout: int = 25) -> Fetched:
         return self._relay("GET", url, None, timeout)
 
-    def post_json(self, url: str, payload: Any, timeout: int = 25) -> Fetched:
-        # Note: the relay carries a JSON *string* body.  A form-encoded body has
-        # no representation here at all — see the transport notes in
-        # docs/discovery-recon.md.
-        return self._relay("POST", url, json.dumps(payload), timeout)
+    def post_json(
+        self,
+        url: str,
+        payload: Any,
+        timeout: int = 25,
+        headers: dict[str, str] | None = None,
+    ) -> Fetched:
+        return self._relay(
+            "POST", url, json.dumps(payload), timeout, extra_headers=headers
+        )
+
+    def post_form(
+        self,
+        url: str,
+        payload: Any,
+        timeout: int = 25,
+        headers: dict[str, str] | None = None,
+    ) -> Fetched:
+        """Form-encoded POST through the relay.
+
+        The original spike had no such method, hard-coded a JSON content type in
+        :meth:`_relay`, and gated every form-encoded fallback on
+        ``--transport direct`` — so the relay was never handed a form body, and the
+        resulting "NO-GO on the relay" verdict described this harness rather than
+        the relay.  The wire format is ``{url, method, headers, body}`` with the
+        content type riding in ``headers``, and both the server model
+        (``kamp_core/server.py``) and the Electron handler
+        (``kamp_ui/src/main/index.ts``) forward headers and body verbatim, so a
+        form body has always been expressible.  KAMP-653 tests that claim here.
+        """
+        return self._relay(
+            "POST",
+            url,
+            urllib.parse.urlencode(payload),
+            timeout,
+            content_type="application/x-www-form-urlencoded",
+            extra_headers=headers,
+        )
 
 
 def make_transport(
@@ -436,6 +474,12 @@ def extract_pagedata(html: str) -> dict[str, Any]:
 
 
 def extract_tralbum(html: str) -> dict[str, Any]:
+    """The ``data-tralbum`` blob — an attribute, not a ``data-blob`` element.
+
+    Different shape from :func:`extract_blob`, hence its own function.  Carries
+    ``current.band_id``, which is what ``collect_item_cb`` wants and which nothing
+    else on the page states as plainly.
+    """
     m = re.search(r'data-tralbum="([^"]+)"', html)
     if not m:
         return {}
@@ -1131,9 +1175,18 @@ def cmd_wishlist_roundtrip(args: argparse.Namespace) -> int:
     referer checks, so the only honest verdict for KAMP-653 comes from a real 200.
     Doing it as a round trip means the account ends where it started.
 
-    Also settles the question the relay poses: ``_ProxySession`` can send only
-    JSON bodies, while the site's own ``Crumb.ajax`` defaults to form encoding.
-    Both encodings are tried, and which ones work is the actual finding.
+    Also settles the question the relay poses: the site's own ``Crumb.ajax``
+    defaults to form encoding.  Both encodings are tried **on whichever transport
+    was asked for**, which the original version of this command did not do — its
+    form-encoded fallback was gated on ``--transport direct``, so the relay was
+    only ever handed JSON and the resulting "NO-GO on the relay" verdict was a
+    statement about this script.  KAMP-653 removes that gate.
+
+    ``--band-id`` is optional: omitted, it is read off the album page's own
+    ``data-tralbum`` blob, which is what the shipped implementation must do.  Both
+    ``band_id`` and ``selling_band_id`` are printed, because they differ on
+    label-released albums and only one of them is the one ``collect_item_cb``
+    wants.
     """
     if not args.yes:
         print("Refusing to mutate the account without --yes.")
@@ -1143,7 +1196,19 @@ def cmd_wishlist_roundtrip(args: argparse.Namespace) -> int:
     transport = make_transport(args.transport, data)
     fan_id = fan_id_of(transport)
 
-    print(f"[roundtrip] target item_id={args.item_id} band_id={args.band_id}")
+    page = transport.get(args.album_url)
+    tralbum = extract_tralbum(page.text)
+    current = tralbum.get("current") or {}
+    print(
+        f"  page identity: id={tralbum.get('id')} item_type={tralbum.get('item_type')!r} "
+        f"band_id={current.get('band_id')} selling_band_id={current.get('selling_band_id')}"
+    )
+    band_id = args.band_id or current.get("band_id")
+    if not band_id:
+        print("  ✗ no band_id on the page and none supplied")
+        return 2
+
+    print(f"[roundtrip] target item_id={args.item_id} band_id={band_id}")
     print(f"  transport={transport.name} fan_id={fan_id}")
 
     # Verify via the album page's own fan_tralbum_data rather than by walking the
@@ -1177,25 +1242,37 @@ def cmd_wishlist_roundtrip(args: argparse.Namespace) -> int:
         # "album", not the discover API's "a" — the same concept is spelled
         # differently on the two surfaces, and the wrong one earns a bare 400.
         "item_type": args.item_type,
-        "band_id": int(args.band_id),
+        "band_id": int(band_id),
     }
-    # jQuery's $.ajax sets X-Requested-With, and *_cb endpoints are referer-checked.
+    # Origin, NOT Referer — and that distinction is load-bearing on the relay.
+    #
+    # Bandcamp insists on one of the two: with neither, the call comes back
+    # `InsistError: Failed insist: expected either an origin or a referrer header`.
+    # But Chromium rejects a manually-set Referer on net.request outright — the
+    # relayed call returns HTTP 502 `net::ERR_BLOCKED_BY_CLIENT` before it ever
+    # leaves the machine.  Bisected header by header on the live relay: every case
+    # carrying a Referer is blocked, Origin passes through untouched.
+    #
+    # So the header set the original recon recorded (X-Requested-With + Referer +
+    # Origin) works on the direct transport and can NEVER work on the one every
+    # shipped build uses.  Origin alone satisfies both.
     ajax_headers = {
         "X-Requested-With": "XMLHttpRequest",
-        "Referer": args.album_url,
         "Origin": "https://bandcamp.com",
     }
 
-    # Try JSON first: it is the only encoding the relay can express, so if it
-    # works, shipped builds can wishlist without touching _ProxySession.
-    print("\n  [add] attempt 1: JSON body (the encoding the relay can send)")
+    # JSON first, so the difference between the two encodings is measured on this
+    # transport rather than assumed from the other one.
+    print("\n  [add] attempt 1: JSON body")
     got = transport.post_json(
         COLLECT_URL, {**base, "crumb": crumbs["collect_item_cb"]}, headers=ajax_headers
     )
     print(f"    status={got.status} ok={collect_ok(got)} body={got.text[:160]!r}")
-    json_worked = collect_ok(got)
 
-    if not json_worked and args.transport == "direct":
+    if not collect_ok(got):
+        # No --transport gate: whether a form body survives THIS transport is the
+        # whole question, and gating it on "direct" is what produced a relay
+        # verdict nobody had actually tested.
         print("\n  [add] attempt 2: form-encoded (what the browser sends)")
         form = dict(base)
         form["crumb"] = crumbs["collect_item_cb"]
@@ -1209,6 +1286,16 @@ def cmd_wishlist_roundtrip(args: argparse.Namespace) -> int:
         print("  ✗ add did not land — recording as no-go, nothing to undo")
         return 2
 
+    # Idempotency: what does collect_item_cb say for something already collected?
+    # KAMP-653 treats "already wishlisted" as a silent success, and it matters
+    # whether that is a pre-check we must do ourselves or something the endpoint
+    # reports honestly.
+    print("\n  [add] attempt 3: repeat the same add, now that it is already there")
+    form = dict(base)
+    form["crumb"] = crumbs["collect_item_cb"]
+    got = transport.post_form(COLLECT_URL, form, headers=ajax_headers)
+    print(f"    status={got.status} ok={collect_ok(got)} body={got.text[:160]!r}")
+
     # Undo, so the account ends exactly where it started.
     print("\n  [remove] restoring account state")
     uncrumb = crumbs.get("uncollect_item_cb")
@@ -1219,7 +1306,7 @@ def cmd_wishlist_roundtrip(args: argparse.Namespace) -> int:
     # Gate the fallback on the parsed body, never the status: these endpoints
     # return 200 for a failed call, and trusting the status here is what stranded
     # an album on the account the first time round.
-    if not collect_ok(got) and args.transport == "direct":
+    if not collect_ok(got):
         form = dict(base)
         form["crumb"] = uncrumb or ""
         got = transport.post_form(UNCOLLECT_URL, form, headers=ajax_headers)
@@ -1513,8 +1600,12 @@ def main() -> int:
         "wishlist-roundtrip", help="add then remove one album (net zero); needs --yes"
     )
     p_rt.add_argument("--item-id", required=True)
-    p_rt.add_argument("--band-id", required=True)
-    p_rt.add_argument("--item-type", default="a")
+    p_rt.add_argument(
+        "--band-id", default=None, help="omit to read it off the album page"
+    )
+    # "album", not the discover API's "a" — the *_cb endpoints spell it the long
+    # way and the short one earns a bare HTTP 400.
+    p_rt.add_argument("--item-type", default="album")
     p_rt.add_argument(
         "--album-url", required=True, help="target album page, for verification"
     )

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -2124,6 +2124,73 @@ class TestProxySession:
         assert '"fan_id": 99' in payload["body"]
         assert payload["headers"]["Content-Type"] == "application/json"
 
+    def test_post_sends_form_encoded_body(self) -> None:
+        """A form body reaches the relay urlencoded, with the matching content type.
+
+        Bandcamp's ``collect_item_cb`` accepts only form encoding — the identical
+        call with a JSON body answers HTTP 200 carrying an ``InsistError``. Before
+        KAMP-653 a ``data=`` kwarg fell into ``**_kwargs`` and vanished, so the
+        request went out with an empty body and the wishlist write was dead in
+        every packaged build.
+        """
+        from kamp_daemon.bandcamp import _ProxySession
+
+        sess = _ProxySession()
+        mock_post = self._make_proxy_response(200, '{"ok":true}')
+
+        with patch(
+            "kamp_daemon.bandcamp._requests.post", return_value=mock_post
+        ) as patched:
+            sess.post(
+                "https://bandcamp.com/collect_item_cb",
+                data={"fan_id": 7, "item_id": 42, "crumb": "|collect|1|abc="},
+                timeout=30,
+            )
+
+        payload = patched.call_args[1]["json"]
+        assert payload["method"] == "POST"
+        assert payload["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        # Percent-encoded, not JSON: the pipes and '=' in a crumb must survive.
+        assert payload["body"] == "fan_id=7&item_id=42&crumb=%7Ccollect%7C1%7Cabc%3D"
+
+    def test_form_body_does_not_clobber_a_caller_supplied_content_type(self) -> None:
+        """``headers=`` is applied before the body branch, so the branch must defer.
+
+        Only matters because the same dict is built in one pass; a caller that
+        knows better should keep its own content type.
+        """
+        from kamp_daemon.bandcamp import _ProxySession
+
+        sess = _ProxySession()
+        mock_post = self._make_proxy_response(200, "{}")
+
+        with patch(
+            "kamp_daemon.bandcamp._requests.post", return_value=mock_post
+        ) as patched:
+            sess.post(
+                "https://bandcamp.com/collect_item_cb",
+                data={"a": "b"},
+                headers={"Content-Type": "text/plain"},
+            )
+
+        assert patched.call_args[1]["json"]["headers"]["Content-Type"] == "text/plain"
+
+    def test_json_still_wins_when_both_are_given(self) -> None:
+        """Not a shape any caller should use, but it must not send both bodies."""
+        from kamp_daemon.bandcamp import _ProxySession
+
+        sess = _ProxySession()
+        mock_post = self._make_proxy_response(200, "{}")
+
+        with patch(
+            "kamp_daemon.bandcamp._requests.post", return_value=mock_post
+        ) as patched:
+            sess.post("https://bandcamp.com/x", json={"a": 1}, data={"b": 2})
+
+        payload = patched.call_args[1]["json"]
+        assert payload["headers"]["Content-Type"] == "application/json"
+        assert payload["body"] == '{"a": 1}'
+
     def test_raise_for_status_on_error_response(self) -> None:
         import requests
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from kamp_core.library import LibraryIndex
+from kamp_core.library import _SCHEMA_VERSION, LibraryIndex
 from kamp_daemon.discovery import (
     ALBUM_PAGE,
     DISCOVER_API,
@@ -78,7 +78,7 @@ def _add_collection_row(
 
 
 class TestSchema:
-    def test_fresh_db_is_v61_with_discovery_tables(self, tmp_path: Path) -> None:
+    def test_fresh_db_is_v62_with_discovery_tables(self, tmp_path: Path) -> None:
         LibraryIndex(tmp_path / "library.db").close()
         conn = sqlite3.connect(str(tmp_path / "library.db"))
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
@@ -87,10 +87,111 @@ class TestSchema:
             for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         }
         conn.close()
-        assert version == 61
+        assert version == 62
         assert {"discovery_items", "discovery_events"} <= tables
 
-    def test_v60_db_migrates_to_v61_preserving_data(self, tmp_path: Path) -> None:
+    def test_fresh_db_accepts_a_retraction_without_any_migration(
+        self, tmp_path: Path
+    ) -> None:
+        """_DDL carries the widened CHECK, so a new DB never needs the rebuild."""
+        index = LibraryIndex(tmp_path / "library.db")
+        try:
+            item = index.add_discovery_candidate(
+                provider="bandcamp", provider_item_id="1"
+            )
+            index.record_discovery_event(item, "unwishlisted")
+        finally:
+            index.close()
+
+    def test_v61_db_migrates_to_v62_and_then_accepts_a_retraction(
+        self, tmp_path: Path
+    ) -> None:
+        """The CHECK on discovery_events.kind cannot be ALTERed, so it is rebuilt.
+
+        Before the rebuild an 'unwishlisted' row is an IntegrityError; after it, the
+        same insert is accepted and every pre-existing event is still there with its
+        id intact.
+        """
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted")
+        event_id = index._conn.execute("SELECT id FROM discovery_events").fetchone()[
+            "id"
+        ]
+
+        # Recreate the pre-migration CHECK: _DDL already built the widened one, so
+        # a synthetic v61 DB has to be rebuilt back down to it or the test proves
+        # nothing about the migration.
+        index._conn.executescript(
+            "ALTER TABLE discovery_events RENAME TO discovery_events_old;"
+            "CREATE TABLE discovery_events ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " item_id INTEGER NOT NULL REFERENCES discovery_items(id) ON DELETE RESTRICT,"
+            " provider TEXT NOT NULL DEFAULT 'bandcamp',"
+            " provider_item_id TEXT NOT NULL DEFAULT '',"
+            " kind TEXT NOT NULL,"
+            " at REAL NOT NULL DEFAULT (unixepoch()),"
+            " detail TEXT,"
+            " CHECK (kind IN ('shown', 'previewed', 'wishlisted', 'url_copied',"
+            "                 'dismissed', 'purchased')));"
+            "INSERT INTO discovery_events SELECT * FROM discovery_events_old;"
+            "DROP TABLE discovery_events_old;"
+        )
+        index._conn.execute("UPDATE schema_version SET version = 61")
+        index._conn.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute(
+                "INSERT INTO discovery_events (item_id, kind) VALUES (?, 'unwishlisted')",
+                (item,),
+            )
+        index._conn.rollback()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        try:
+            version = reopened._conn.execute(
+                "SELECT version FROM schema_version"
+            ).fetchone()["version"]
+            surviving = reopened._conn.execute(
+                "SELECT id, kind FROM discovery_events"
+            ).fetchall()
+            # The retraction the old CHECK rejected is now accepted.
+            reopened.record_discovery_event(item, "unwishlisted")
+            state = reopened._conn.execute(
+                "SELECT state FROM discovery_items WHERE id = ?", (item,)
+            ).fetchone()["state"]
+        finally:
+            reopened.close()
+
+        assert version == 62
+        # id copied verbatim -- nothing downstream keys on an event id today, but a
+        # renumbering rebuild would be a silent trap for whatever does first.
+        assert [(r["id"], r["kind"]) for r in surviving] == [(event_id, "wishlisted")]
+        assert state == "fresh"
+
+    def test_v62_rebuild_keeps_the_indexes(self, tmp_path: Path) -> None:
+        """DROP TABLE takes its indexes with it; they must be put back."""
+        db = tmp_path / "library.db"
+        index = LibraryIndex(db)
+        index._conn.execute("UPDATE schema_version SET version = 61")
+        index._conn.commit()
+        index.close()
+
+        reopened = LibraryIndex(db)
+        try:
+            names = {
+                r["name"]
+                for r in reopened._conn.execute(
+                    "SELECT name FROM sqlite_master"
+                    " WHERE type='index' AND tbl_name='discovery_events'"
+                )
+            }
+        finally:
+            reopened.close()
+        assert {"discovery_events_item_idx", "discovery_events_kind_at_idx"} <= names
+
+    def test_v60_db_migrates_forward_preserving_data(self, tmp_path: Path) -> None:
         db = tmp_path / "library.db"
         index = LibraryIndex(db)
         _add_collection_row(index, "sale-1")
@@ -108,7 +209,10 @@ class TestSchema:
             ).fetchone()["c"]
         finally:
             reopened.close()
-        assert version == 61
+        # Against the constant, not a literal: this test is about a v60 DB reaching
+        # the current schema with its rows intact, and pinning the number here means
+        # every later migration has to come back and edit it.
+        assert version == _SCHEMA_VERSION
         assert surviving == 1
 
     def test_crate_slot_is_unique_but_buffered_rows_are_exempt(
@@ -335,6 +439,97 @@ class TestEventLedger:
     def test_unknown_item_raises(self, index: LibraryIndex) -> None:
         with pytest.raises(ValueError):
             index.record_discovery_event(9999, "shown")
+
+    def _state(self, index: LibraryIndex, item: int) -> str:
+        row = index._conn.execute(
+            "SELECT state FROM discovery_items WHERE id = ?", (item,)
+        ).fetchone()
+        return str(row["state"])
+
+    def test_unwishlisting_falls_back_to_what_the_ledger_still_says(
+        self, index: LibraryIndex
+    ) -> None:
+        """Not to 'fresh' — the record was still previewed, and that happened.
+
+        This is the one event that moves state *down*, so it cannot use the
+        highest-rank-wins fast path. It recomputes from the ledger instead, which
+        is what the schema has always claimed state is.
+        """
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "previewed")
+        index.record_discovery_event(item, "wishlisted")
+        assert self._state(index, item) == "wishlisted"
+
+        index.record_discovery_event(item, "unwishlisted")
+        assert self._state(index, item) == "previewed"
+
+    def test_unwishlisting_a_record_never_wishlisted_changes_nothing(
+        self, index: LibraryIndex
+    ) -> None:
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "previewed")
+        index.record_discovery_event(item, "unwishlisted")
+        assert self._state(index, item) == "previewed"
+
+    def test_unwishlisting_does_not_undo_a_purchase(self, index: LibraryIndex) -> None:
+        """Buying it is a different fact from wishlisting it, and outranks both."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "purchased")
+        index.record_discovery_event(item, "unwishlisted")
+        assert self._state(index, item) == "purchased"
+
+    def test_rewishlisting_after_a_retraction_sticks(self, index: LibraryIndex) -> None:
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "unwishlisted")
+        index.record_discovery_event(item, "wishlisted")
+        assert self._state(index, item) == "wishlisted"
+
+    def test_retraction_falls_back_past_a_dismissal_to_the_dismissal(
+        self, index: LibraryIndex
+    ) -> None:
+        """Passing on a record outranks previewing it, and the pass still stands."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "previewed")
+        index.record_discovery_event(item, "dismissed")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "unwishlisted")
+        assert self._state(index, item) == "dismissed"
+
+    def test_a_bare_retraction_on_an_untouched_record_is_fresh(
+        self, index: LibraryIndex
+    ) -> None:
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "unwishlisted")
+        assert self._state(index, item) == "fresh"
+
+    def test_the_retraction_itself_is_recorded(self, index: LibraryIndex) -> None:
+        """The ledger is history: an un-wishlist is a thing the user did."""
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "unwishlisted")
+        kinds = [
+            r["kind"]
+            for r in index._conn.execute(
+                "SELECT kind FROM discovery_events WHERE item_id = ? ORDER BY id",
+                (item,),
+            )
+        ]
+        assert kinds == ["wishlisted", "unwishlisted"]
+
+    def test_retraction_recompute_respects_event_order_not_row_order(
+        self, index: LibraryIndex
+    ) -> None:
+        """Attribution back-dates events, so `at` and insertion order can disagree.
+
+        A wishlist added *after* the retraction in wall-clock terms must survive it,
+        even though its row was inserted first.
+        """
+        item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.record_discovery_event(item, "wishlisted", at=5000.0)
+        index.record_discovery_event(item, "unwishlisted", at=1000.0)
+        assert self._state(index, item) == "wishlisted"
 
     def test_unknown_event_kind_raises(self, index: LibraryIndex) -> None:
         item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -974,8 +974,9 @@ class _FakeSource(DiscoverySource):
 
 class TestDiscoverySource:
     def test_capabilities_are_evaluated_at_call_time(self) -> None:
-        """Not a class constant: Bandcamp's save_remote depends on the transport, and
-        a stale constant would render a wishlist button that silently no-ops."""
+        """Not a class constant: capability depends on runtime state — credentials,
+        the transport, what the remote service will currently accept — and a stale
+        constant would render a control that silently no-ops."""
         source = _FakeSource(can_save=False)
         assert SAVE_REMOTE not in source.capabilities
         source._can_save = True
@@ -1009,6 +1010,8 @@ class TestDiscoverySource:
             source.resolve_preview(candidate)
         with pytest.raises(UnsupportedCapability):
             source.save_remote(candidate)
+        with pytest.raises(UnsupportedCapability):
+            source.unsave_remote(candidate)
 
     def test_gather_respects_the_budget(self) -> None:
         source = _FakeSource()

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -21,6 +21,10 @@ from fastapi.testclient import TestClient
 from kamp_core.discovery_api import CRATE_EVENT, register_discovery_routes
 from kamp_core.library import LibraryIndex
 
+# Sentinel so a test can pass wishlist_write=None (the not-connected case) and
+# have it mean None rather than "use the default".
+_UNSET = object()
+
 
 @pytest.fixture
 def index(tmp_path: Path) -> Iterator[LibraryIndex]:
@@ -36,12 +40,19 @@ class _Harness:
         on_build_start: Any = None,
         art_cache_dir: Path | None = None,
         art_bytes: bytes | None = b"JPEGDATA",
+        wishlist_write: Any = _UNSET,
     ) -> None:
         self.events: list[dict[str, Any]] = []
         self.build_calls = 0
         self.fetched: list[str] = []
         self.art_bytes = art_bytes
+        self.wishlist_calls: list[tuple[dict[str, Any], bool]] = []
+        self.wishlist_reason = "ok"
         self.app = FastAPI()
+
+        def _default_wishlist(item: dict[str, Any], add: bool) -> str:
+            self.wishlist_calls.append((item, add))
+            return self.wishlist_reason
 
         def _default_start() -> None:
             self.build_calls += 1
@@ -59,6 +70,9 @@ class _Harness:
             ),
             art_cache_dir=art_cache_dir,
             fetch_bytes=_fetch,
+            wishlist_write=(
+                _default_wishlist if wishlist_write is _UNSET else wishlist_write
+            ),
         )
         self.client = TestClient(self.app)
 
@@ -278,6 +292,141 @@ class TestItemEvents:
             harness.client.post("/api/v1/discovery/items/999/dismiss").status_code
             == 404
         )
+
+
+# ---------------------------------------------------------------------------
+# Wishlist write (KAMP-653)
+# ---------------------------------------------------------------------------
+
+
+class TestWishlistRoutes:
+    def _item(self, index: LibraryIndex) -> int:
+        item = index.add_discovery_candidate(
+            provider="bandcamp",
+            provider_item_id="555",
+            title="X",
+            item_url="https://a.bandcamp.com/album/x",
+        )
+        index.place_in_crate(item, 1, 0)
+        return item
+
+    def test_a_confirmed_add_records_the_event_and_moves_state(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        item = self._item(index)
+        resp = harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "wishlisted": True}
+        assert index.crate_items(1)[0]["state"] == "wishlisted"
+
+    def test_a_confirmed_removal_walks_the_state_back(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        item = self._item(index)
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        resp = harness.client.post(f"/api/v1/discovery/items/{item}/unwishlist")
+        assert resp.json() == {"ok": True, "wishlisted": False}
+        assert index.crate_items(1)[0]["state"] == "fresh"
+
+    def test_the_provider_is_handed_the_whole_item(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """It needs item_url to fetch the crumb page and provider_item_id for the
+        POST; passing an id alone would make it re-read the row."""
+        item = self._item(index)
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        sent, add = harness.wishlist_calls[0]
+        assert add is True
+        assert sent["provider_item_id"] == "555"
+        assert sent["item_url"] == "https://a.bandcamp.com/album/x"
+
+    def test_nothing_is_written_locally_unless_the_provider_confirms(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The whole promise of the feature: the heart means it really is on your
+        Bandcamp wishlist. An optimistic write would be the feature lying."""
+        item = self._item(index)
+        harness.wishlist_reason = "rejected"
+        assert (
+            harness.client.post(f"/api/v1/discovery/items/{item}/wishlist").status_code
+            == 502
+        )
+        assert index.crate_items(1)[0]["state"] == "fresh"
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events WHERE kind = 'wishlisted'"
+            ).fetchone()["c"]
+            == 0
+        )
+
+    @pytest.mark.parametrize(
+        "reason,status",
+        [
+            ("not_connected", 503),
+            ("unsupported", 501),
+            ("needs_login", 401),
+            ("rate_limited", 429),
+            ("rejected", 502),
+        ],
+    )
+    def test_each_failure_gets_its_own_status_and_reason(
+        self, index: LibraryIndex, harness: _Harness, reason: str, status: int
+    ) -> None:
+        """A blanket 502 would flatten "Bandcamp asked us to slow down" and "you
+        have been logged out" into the same shrug."""
+        item = self._item(index)
+        harness.wishlist_reason = reason
+        resp = harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert resp.status_code == status
+        assert resp.json()["detail"] == reason
+
+    def test_an_unknown_reason_is_still_a_failure(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """A provider inventing a new reason must not read as success."""
+        item = self._item(index)
+        harness.wishlist_reason = "something_new"
+        assert (
+            harness.client.post(f"/api/v1/discovery/items/{item}/wishlist").status_code
+            == 502
+        )
+
+    def test_no_writer_at_all_is_not_connected(self, index: LibraryIndex) -> None:
+        """A server-only context — or a daemon with no Bandcamp session — must
+        503 rather than 500 on a missing callable."""
+        harness = _Harness(index, wishlist_write=None)
+        item = self._item(index)
+        resp = harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "not_connected"
+
+    def test_an_unknown_item_never_reaches_the_provider(
+        self, harness: _Harness
+    ) -> None:
+        assert (
+            harness.client.post("/api/v1/discovery/items/999/wishlist").status_code
+            == 404
+        )
+        assert harness.wishlist_calls == []
+
+    def test_a_confirmed_write_pushes_a_fresh_snapshot(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The rail draws its heart off item.state, so the write has to reach
+        every client rather than just the tab that clicked."""
+        item = self._item(index)
+        harness.events.clear()
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert harness.events[-1]["items"][0]["state"] == "wishlisted"
+
+    def test_a_failed_write_pushes_nothing(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        item = self._item(index)
+        harness.wishlist_reason = "rate_limited"
+        harness.events.clear()
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert harness.events == []
 
 
 # ---------------------------------------------------------------------------
@@ -756,3 +905,36 @@ class TestServerWiring:
         assert client.get("/api/v1/discovery/crate").status_code == 401
         ok = client.get("/api/v1/discovery/crate", headers={"X-Kamp-Token": "secret"})
         assert ok.status_code == 200
+
+    def test_the_wishlist_writer_reaches_the_route(self, index: LibraryIndex) -> None:
+        """create_app takes it and register_discovery_routes must receive it —
+        the KAMP-436 failure shape: a callable set on a wrapper that the thing
+        doing the work never sees."""
+        calls: list[tuple[dict[str, Any], bool]] = []
+
+        def _write(item: dict[str, Any], add: bool) -> str:
+            calls.append((item, add))
+            return "ok"
+
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", item_url="https://a.b.com/x"
+        )
+        index.place_in_crate(item, 1, 0)
+        client = TestClient(self._app(index, wishlist_write=_write))
+
+        assert (
+            client.post(f"/api/v1/discovery/items/{item}/wishlist").status_code == 200
+        )
+        assert calls and calls[0][1] is True
+
+    def test_a_server_without_a_writer_503s_rather_than_500s(
+        self, index: LibraryIndex
+    ) -> None:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", item_url="https://a.b.com/x"
+        )
+        index.place_in_crate(item, 1, 0)
+        client = TestClient(self._app(index))
+        assert (
+            client.post(f"/api/v1/discovery/items/{item}/wishlist").status_code == 503
+        )

--- a/tests/test_discovery_parsers.py
+++ b/tests/test_discovery_parsers.py
@@ -18,9 +18,14 @@ from kamp_daemon.discovery_bandcamp_parsers import (
     art_url_from_image,
     normalise_item_id,
     parse_also_like,
+    parse_band_id,
+    parse_collect_ok,
+    parse_crumbs,
     parse_discography,
     parse_discover_facets,
     parse_discover_results,
+    parse_fresh_crumb,
+    parse_is_wishlisted,
     release_year,
     strip_tracking,
     tag_slug,
@@ -467,3 +472,146 @@ class TestNormalisation:
     )
     def test_release_year(self, value, expected) -> None:
         assert release_year(value) == expected
+
+
+class TestCrumbs:
+    """The CSRF tokens the wishlist write needs (KAMP-653)."""
+
+    def test_crumbs_are_parsed_and_html_unescaped(self) -> None:
+        html = (
+            '<meta id="js-crumbs-data" data-crumbs="{&quot;collect_item_cb&quot;:'
+            "&quot;|collect_item_cb|1754|abc=&quot;,&quot;uncollect_item_cb&quot;:"
+            '&quot;|uncollect_item_cb|1754|def=&quot;}">'
+        )
+        assert parse_crumbs(html) == {
+            "collect_item_cb": "|collect_item_cb|1754|abc=",
+            "uncollect_item_cb": "|uncollect_item_cb|1754|def=",
+        }
+
+    def test_an_anonymous_page_has_an_empty_crumb_map(self) -> None:
+        """Logged-out pages ship `data-crumbs="{}"` — present but empty.
+
+        Distinct from a missing tag, and the reason "is the tag there" is not a
+        usable logged-in check. The captured fixture is anonymous, so this is the
+        shape the fixture itself has.
+        """
+        assert parse_crumbs('<meta id="js-crumbs-data" data-crumbs="{}">') == {}
+
+    def test_a_missing_or_malformed_tag_yields_nothing_rather_than_raising(
+        self,
+    ) -> None:
+        assert parse_crumbs("<html><body>nothing here</body></html>") == {}
+        assert parse_crumbs('<meta id="js-crumbs-data" data-crumbs="{oops">') == {}
+
+    def test_the_real_fixture_is_anonymous_and_therefore_crumbless(
+        self, album_page: str
+    ) -> None:
+        """Guards the privacy rule as much as the parser: a captured page that
+        started carrying live crumbs would fail here as well as in
+        tests/test_discovery_fixtures.py."""
+        assert parse_crumbs(album_page) == {}
+
+
+class TestWriteIdentity:
+    """band_id and is_wishlisted, both read off the album page (KAMP-653)."""
+
+    def test_band_id_comes_from_current_not_selling_band_id(self) -> None:
+        """They diverge on label-released albums, and only one of them works.
+
+        Sending selling_band_id returns HTTP 200 with {"ok":true} and silently
+        does nothing — verified live against a real account. So this must never
+        fall back to it: a fallback would report success and change nothing.
+        """
+        html = (
+            '<script data-tralbum="{&quot;id&quot;:1,&quot;current&quot;:'
+            '{&quot;band_id&quot;:692277828,&quot;selling_band_id&quot;:237579501}}">'
+        )
+        assert parse_band_id(html) == "692277828"
+
+    def test_band_id_is_none_when_absent(self) -> None:
+        assert parse_band_id('<script data-tralbum="{&quot;id&quot;:1}">') is None
+        assert parse_band_id("<html></html>") is None
+
+    def test_selling_band_id_is_never_used_as_a_fallback(self) -> None:
+        """The dangerous shape: band_id absent, selling_band_id right there.
+
+        Falling back would send a value the endpoint accepts with {"ok":true}
+        while doing nothing, so the caller must be told it has no band_id rather
+        than handed one that fails silently.
+        """
+        html = (
+            '<script data-tralbum="{&quot;current&quot;:'
+            '{&quot;selling_band_id&quot;:237579501}}">'
+        )
+        assert parse_band_id(html) is None
+
+    def test_the_real_album_fixture_yields_a_band_id(self, album_page: str) -> None:
+        assert parse_band_id(album_page) == "2009518365"
+
+    @pytest.mark.parametrize("flag,expected", [(True, True), (False, False)])
+    def test_is_wishlisted_is_read_from_fan_tralbum_data(self, flag, expected) -> None:
+        blob = "true" if flag else "false"
+        html = (
+            '<div id="pagedata" data-blob="{&quot;fan_tralbum_data&quot;:'
+            "{&quot;is_wishlisted&quot;:" + blob + '}}"></div>'
+        )
+        assert parse_is_wishlisted(html) is expected
+
+    def test_is_wishlisted_is_none_when_the_page_cannot_say(self) -> None:
+        """None is not False. An anonymous page carries fan_tralbum_data: null,
+        and treating that as "not wishlisted" would turn a logged-out response
+        into a confident negative."""
+        assert parse_is_wishlisted("<html></html>") is None
+        assert (
+            parse_is_wishlisted(
+                '<div id="pagedata" data-blob="{&quot;fan_tralbum_data&quot;:null}">'
+            )
+            is None
+        )
+
+    def test_the_real_album_fixture_cannot_say(self, album_page: str) -> None:
+        """Captured anonymously, so fan_tralbum_data is null — exactly the case
+        that must not be mistaken for False."""
+        assert parse_is_wishlisted(album_page) is None
+
+
+class TestCollectResponse:
+    """Reading a `*_cb` reply. The status is not the answer (KAMP-653)."""
+
+    def test_only_ok_true_without_an_error_counts_as_success(self) -> None:
+        assert parse_collect_ok('{"ok":true}') is True
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # The exact shape a JSON-encoded request comes back with, at HTTP 200.
+            '{"error":true,"ok":false,"exception":"InsistError: old or no crumb"}',
+            '{"ok":false}',
+            '{"ok":true,"error":true}',  # both set: an error is still an error
+            '{"error":"invalid_crumb","crumb":"|c|1|z="}',
+            "not json at all",
+            "[]",
+            "",
+        ],
+    )
+    def test_everything_else_is_a_failure(self, body: str) -> None:
+        assert parse_collect_ok(body) is False
+
+    def test_a_stale_crumb_yields_the_replacement(self) -> None:
+        assert (
+            parse_fresh_crumb('{"error":"invalid_crumb","crumb":"|collect|9|zz="}')
+            == "|collect|9|zz="
+        )
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"error":true,"ok":false}',  # a different error: not retryable
+            '{"error":"invalid_crumb"}',  # says stale but offers nothing to retry with
+            '{"error":"invalid_crumb","crumb":""}',
+            '{"ok":true}',
+            "garbage",
+        ],
+    )
+    def test_no_replacement_crumb_offered(self, body: str) -> None:
+        assert parse_fresh_crumb(body) is None

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -63,13 +63,29 @@ class FakeResponse:
 
 
 class FakeSession:
-    """Records requests and replays canned bodies."""
+    """Records requests and replays canned bodies.
 
-    def __init__(self, get_body: str = "", post_body: str = "") -> None:
+    ``post_bodies`` replays a *sequence* where the crumb-retry path needs the
+    second answer to differ from the first; ``post_body`` is the single-answer
+    shorthand. Same for ``get_bodies`` / ``get_body``.
+    """
+
+    def __init__(
+        self,
+        get_body: str = "",
+        post_body: str = "",
+        *,
+        post_bodies: list[str] | None = None,
+        post_statuses: list[int] | None = None,
+    ) -> None:
         self.get_body = get_body
         self.post_body = post_body
+        self.post_bodies = post_bodies
+        self.post_statuses = post_statuses
         self.gets: list[str] = []
         self.posts: list[tuple[str, Any]] = []
+        self.post_forms: list[dict[str, Any]] = []
+        self.post_headers: list[dict[str, str]] = []
         self.get_status = 200
         self.post_status = 200
 
@@ -77,9 +93,30 @@ class FakeSession:
         self.gets.append(url)
         return FakeResponse(self.get_body, self.get_status)
 
-    def post(self, url: str, json: Any = None, timeout: int = 30) -> FakeResponse:
-        self.posts.append((url, json))
-        return FakeResponse(self.post_body, self.post_status)
+    def post(
+        self,
+        url: str,
+        json: Any = None,
+        data: Any = None,
+        headers: dict[str, str] | None = None,
+        timeout: int = 30,
+    ) -> FakeResponse:
+        n = len(self.posts)
+        self.posts.append((url, json if json is not None else data))
+        if data is not None:
+            self.post_forms.append(dict(data))
+        self.post_headers.append(dict(headers or {}))
+        body = (
+            self.post_bodies[min(n, len(self.post_bodies) - 1)]
+            if self.post_bodies
+            else self.post_body
+        )
+        status = (
+            self.post_statuses[min(n, len(self.post_statuses) - 1)]
+            if self.post_statuses
+            else self.post_status
+        )
+        return FakeResponse(body, status)
 
 
 def _source(session: FakeSession) -> BandcampDiscoverySource:
@@ -439,12 +476,13 @@ class TestFetchPolicy:
 
 
 class TestCapabilities:
-    def test_preview_is_offered_and_wishlist_is_not(self) -> None:
-        """save_remote needs a form-encoded POST the relay cannot send, so
-        declaring it would render a button that silently does nothing."""
+    def test_preview_and_the_wishlist_write_are_both_offered(self) -> None:
+        """SAVE_REMOTE was withheld until KAMP-653 on the belief that the relay
+        could not send a form body. It can; the earlier verdict was measured
+        against a spike helper that had no form path."""
         caps = _source(FakeSession()).capabilities
         assert PREVIEW in caps
-        assert SAVE_REMOTE not in caps
+        assert SAVE_REMOTE in caps
 
     def test_preview_resolves_an_mp3_from_the_album_page(self) -> None:
         import html as html_lib
@@ -620,3 +658,237 @@ class TestPreviewNeverWaitsOnTheGovernor:
             source.preview_tracks(_candidate())
         governor.report_429.assert_called_once_with("album_page")
         governor.wait_turn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Wishlist write (KAMP-653)
+# ---------------------------------------------------------------------------
+
+
+def _write_page(
+    *,
+    band_id: str | int | None = "692277828",
+    selling_band_id: str | int | None = "237579501",
+    is_wishlisted: bool | None = False,
+    crumbs: dict[str, str] | None = None,
+) -> str:
+    """An album page carrying the three things the POST needs.
+
+    Hand-built rather than captured: a real logged-in page embeds live CSRF
+    crumbs and a fan_id, and this repository is public.
+    """
+    import html as html_lib
+
+    current: dict[str, Any] = {}
+    if band_id is not None:
+        current["band_id"] = band_id
+    if selling_band_id is not None:
+        current["selling_band_id"] = selling_band_id
+    tralbum = html_lib.escape(json.dumps({"id": 1, "current": current}), quote=True)
+
+    fan_data = None if is_wishlisted is None else {"is_wishlisted": is_wishlisted}
+    pagedata = html_lib.escape(json.dumps({"fan_tralbum_data": fan_data}), quote=True)
+
+    if crumbs is None:
+        crumbs = {
+            "collect_item_cb": "|collect_item_cb|1754|abc=",
+            "uncollect_item_cb": "|uncollect_item_cb|1754|def=",
+        }
+    crumb_attr = html_lib.escape(json.dumps(crumbs), quote=True)
+
+    return (
+        f'<meta id="js-crumbs-data" data-crumbs="{crumb_attr}">'
+        f'<div id="pagedata" data-blob="{pagedata}"></div>'
+        f'<script data-tralbum="{tralbum}"></script>'
+    )
+
+
+@pytest.fixture
+def fan_id(monkeypatch: pytest.MonkeyPatch) -> int:
+    """_get_fan_info is one authenticated GET; stub it. It is not what is under
+    test here and has its own coverage in tests/test_bandcamp.py."""
+    import kamp_daemon.bandcamp as bc
+
+    monkeypatch.setattr(bc, "_get_fan_info", lambda session: (4346318, "fan"))
+    return 4346318
+
+
+class TestWishlistWrite:
+    def test_add_posts_a_form_and_confirms_from_the_body(self, fan_id: int) -> None:
+        session = FakeSession(get_body=_write_page(), post_body='{"ok":true}')
+        assert _source(session).save_remote(_candidate()) is True
+
+        url, _ = session.posts[0]
+        assert url == "https://bandcamp.com/collect_item_cb"
+        # data=, not json=: the identical call with a JSON body answers HTTP 200
+        # carrying an InsistError about a missing crumb.
+        assert session.post_forms[0] == {
+            "fan_id": fan_id,
+            "item_id": "1",
+            # "album", not the discover API's "a"; the short form earns a bare 400.
+            "item_type": "album",
+            "band_id": "692277828",
+            "crumb": "|collect_item_cb|1754|abc=",
+        }
+
+    def test_remove_uses_the_uncollect_endpoint_and_its_own_crumb(
+        self, fan_id: int
+    ) -> None:
+        session = FakeSession(
+            get_body=_write_page(is_wishlisted=True), post_body='{"ok":true}'
+        )
+        assert _source(session).unsave_remote(_candidate()) is True
+        assert session.posts[0][0] == "https://bandcamp.com/uncollect_item_cb"
+        assert session.post_forms[0]["crumb"] == "|uncollect_item_cb|1754|def="
+
+    def test_origin_is_sent_and_referer_is_not(self, fan_id: int) -> None:
+        """Bandcamp insists on an origin OR a referrer, but Chromium blocks a
+        manually-set Referer on net.request (net::ERR_BLOCKED_BY_CLIENT). A
+        Referer here would work in dev and fail in every packaged build."""
+        session = FakeSession(get_body=_write_page(), post_body='{"ok":true}')
+        _source(session).save_remote(_candidate())
+        headers = session.post_headers[0]
+        assert headers["Origin"] == "https://bandcamp.com"
+        assert headers["X-Requested-With"] == "XMLHttpRequest"
+        assert "Referer" not in headers
+
+    def test_band_id_is_current_band_id_never_selling_band_id(
+        self, fan_id: int
+    ) -> None:
+        """Sending selling_band_id returns HTTP 200 with {"ok":true} and does
+        nothing — verified live. The wrong field is not a failure we would even
+        notice at runtime, so it has to be got right here."""
+        session = FakeSession(get_body=_write_page(), post_body='{"ok":true}')
+        _source(session).save_remote(_candidate())
+        assert session.post_forms[0]["band_id"] == "692277828"
+
+    def test_a_page_without_a_band_id_refuses_rather_than_guessing(
+        self, fan_id: int, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """selling_band_id is right there and wrong. Falling back to it would
+        report success for a record that never moved."""
+        session = FakeSession(
+            get_body=_write_page(band_id=None), post_body='{"ok":true}'
+        )
+        assert _source(session).save_remote(_candidate()) is False
+        assert session.posts == []
+        assert "refusing to guess" in caplog.text
+
+    def test_a_200_carrying_an_error_body_is_a_failure(self, fan_id: int) -> None:
+        """The trap that stranded an album on a real account: these endpoints
+        answer 200 on failure, so the status is never the answer."""
+        session = FakeSession(
+            get_body=_write_page(),
+            post_body='{"error":true,"ok":false,"exception":"InsistError: no crumb"}',
+        )
+        session.post_status = 200
+        assert _source(session).save_remote(_candidate()) is False
+
+    def test_a_stale_crumb_is_retried_once_with_the_fresh_one(
+        self, fan_id: int
+    ) -> None:
+        session = FakeSession(
+            get_body=_write_page(),
+            post_bodies=[
+                '{"error":"invalid_crumb","crumb":"|collect_item_cb|9999|new="}',
+                '{"ok":true}',
+            ],
+            post_statuses=[403, 200],
+        )
+        assert _source(session).save_remote(_candidate()) is True
+        assert len(session.posts) == 2
+        assert session.post_forms[0]["crumb"] == "|collect_item_cb|1754|abc="
+        assert session.post_forms[1]["crumb"] == "|collect_item_cb|9999|new="
+        # The page is fetched once: the fresh crumb rides in on the error body.
+        assert len(session.gets) == 1
+
+    def test_the_crumb_retry_happens_at_most_once(self, fan_id: int) -> None:
+        """A second invalid_crumb is not a crumb problem, and retrying forever
+        would hammer the endpoint class closest to its rate limit."""
+        session = FakeSession(
+            get_body=_write_page(),
+            post_bodies=['{"error":"invalid_crumb","crumb":"|c|9|new="}'],
+            post_statuses=[403],
+        )
+        assert _source(session).save_remote(_candidate()) is False
+        assert len(session.posts) == 2
+
+    def test_a_non_crumb_failure_is_not_retried(self, fan_id: int) -> None:
+        session = FakeSession(
+            get_body=_write_page(), post_body='{"error":true,"ok":false}'
+        )
+        assert _source(session).save_remote(_candidate()) is False
+        assert len(session.posts) == 1
+
+    def test_already_wishlisted_is_a_silent_success_costing_no_post(
+        self, fan_id: int
+    ) -> None:
+        """The page we had to fetch anyway already answered. Bandcamp agrees — a
+        repeat collect_item_cb returns ok:true — so this saves a request rather
+        than changing the outcome."""
+        session = FakeSession(get_body=_write_page(is_wishlisted=True))
+        assert _source(session).save_remote(_candidate()) is True
+        assert session.posts == []
+
+    def test_removing_something_already_absent_is_a_silent_success(
+        self, fan_id: int
+    ) -> None:
+        session = FakeSession(get_body=_write_page(is_wishlisted=False))
+        assert _source(session).unsave_remote(_candidate()) is True
+        assert session.posts == []
+
+    def test_an_unknown_wishlist_state_still_attempts_the_write(
+        self, fan_id: int
+    ) -> None:
+        """None is not False. A page that cannot say must not short-circuit
+        either direction — it means we could not tell, so do the work."""
+        session = FakeSession(
+            get_body=_write_page(is_wishlisted=None), post_body='{"ok":true}'
+        )
+        assert _source(session).save_remote(_candidate()) is True
+        assert len(session.posts) == 1
+
+    def test_a_crumbless_page_fails_without_posting(
+        self, fan_id: int, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A logged-out page ships data-crumbs="{}" — the session has expired."""
+        session = FakeSession(get_body=_write_page(crumbs={}))
+        assert _source(session).save_remote(_candidate()) is False
+        assert session.posts == []
+        assert "session expired" in caplog.text
+
+    def test_a_cooldown_refuses_immediately_without_any_request(
+        self, fan_id: int
+    ) -> None:
+        """Checked, never waited on. wait_turn would hang a click for up to five
+        minutes; unlike preview there is no partial answer worth giving, so this
+        refuses and lets the UI say why."""
+        governor = MagicMock()
+        governor.blocked_for.return_value = 300.0
+        session = FakeSession(get_body=_write_page(), post_body='{"ok":true}')
+        source = BandcampDiscoverySource(session, governor=governor)
+
+        with pytest.raises(RateLimitedError):
+            source.save_remote(_candidate())
+        assert session.gets == []
+        assert session.posts == []
+        governor.wait_turn.assert_not_called()
+
+    def test_a_429_on_the_post_is_reported_and_raised(self, fan_id: int) -> None:
+        governor = MagicMock()
+        governor.blocked_for.return_value = 0.0
+        session = FakeSession(get_body=_write_page())
+        session.post_status = 429
+        source = BandcampDiscoverySource(session, governor=governor)
+
+        with pytest.raises(RateLimitedError):
+            source.save_remote(_candidate())
+        governor.report_429.assert_called_with(ALBUM_PAGE)
+
+    def test_an_unfetchable_host_fails_without_a_request(self, fan_id: int) -> None:
+        """Unreachable for a built crate — _to_candidates drops custom domains —
+        but item_url is remote data read back out of the database."""
+        session = FakeSession(get_body=_write_page())
+        candidate = _candidate("https://music.example.com/album/x")
+        assert _source(session).save_remote(candidate) is False
+        assert session.gets == []

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -15,6 +15,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from kamp_core.library import (
+    _SCHEMA_VERSION,
     AlbumInfo,
     ArtistInfo,
     Condition,
@@ -239,7 +240,7 @@ class TestLibraryIndex:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
 
     def test_track_sources_and_stats_tables_created(self, tmp_path: Path) -> None:
         """The canonical-track child tables exist and are empty on a fresh DB (KAMP-535)."""
@@ -346,7 +347,7 @@ class TestLibraryIndex:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert {"track_sources", "track_stats"} <= tables
 
     def test_v45_backfill_populates_children(self, tmp_path: Path) -> None:
@@ -442,7 +443,7 @@ class TestLibraryIndex:
         ]
         n_src = index._conn.execute("SELECT COUNT(*) FROM track_sources").fetchone()[0]
         index.close()
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert n_src == 0
 
     def test_stats_write_to_track_stats_only(self, tmp_path: Path) -> None:
@@ -1037,7 +1038,7 @@ class TestLibraryIndex:
         t = reopened.get_track_by_id(tid)
         ver = rc.execute("SELECT version FROM schema_version").fetchone()[0]
         reopened.close()
-        assert ver == 61
+        assert ver == _SCHEMA_VERSION
         assert not (dropped & cols)  # all 11 columns gone from tracks
         # KAMP-552 (v51, which also runs on this reopen) drops file_path/sale_item_id.
         assert not ({"file_path", "sale_item_id"} & cols)
@@ -1059,7 +1060,7 @@ class TestLibraryIndex:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 61
+        assert ver == _SCHEMA_VERSION
         assert "favorite" not in cols
 
     def test_v49_rolls_back_and_keeps_version_when_a_drop_fails(
@@ -1156,7 +1157,7 @@ class TestLibraryIndex:
         assert len(album_artist_ids) == 1 and None not in album_artist_ids
         assert album_casings == {"Sunn O)))"}  # both albums normalized
         assert track_casings == {"Sunn O)))"}  # tracks normalized too
-        assert ver == 61
+        assert ver == _SCHEMA_VERSION
         assert has_index is not None  # NOCASE uniqueness now enforced
 
     def test_v50_folds_play_time_and_removes_orphan_variant(
@@ -1280,7 +1281,7 @@ class TestLibraryIndex:
         reopened.close()
         backups = list(tmp_path.glob("library.db.bak-*"))
 
-        assert ver == 61
+        assert ver == _SCHEMA_VERSION
         assert has_index is not None
         assert backups == []  # no work -> no backup
 
@@ -3414,7 +3415,7 @@ class TestSearch:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert len(results) == 1
         assert results[0].title == "Title"
 
@@ -3471,7 +3472,7 @@ class TestSearch:
         ).fetchone()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row is not None
         # date_added will be NULL since the file path is fake; that is expected.
         assert row[0] is None
@@ -4464,7 +4465,7 @@ class TestPreorderResurface:
         ).fetchone()[0]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "last_track_added_at" in cols
         assert backfilled == 1234.0
 
@@ -4507,7 +4508,7 @@ class TestPreorderResurface:
         ).fetchall()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "sale_item_id" not in cols
         assert {
             "provider",
@@ -4574,7 +4575,7 @@ class TestPreorderResurface:
         ).fetchone()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "redownload_url" in cols
         # Existing row survived; the new column is NULL for pre-existing data.
         assert row["provider_item_id"] == "keep"
@@ -4600,7 +4601,7 @@ class TestPreorderResurface:
         cols = {r[1] for r in index._conn.execute("PRAGMA table_info(download_queue)")}
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "redownload_url" in cols
 
     def test_count_available_remote_tracks(self, tmp_path: Path) -> None:
@@ -4954,7 +4955,7 @@ class TestRecordPlayed:
         ).fetchone()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row is not None
         assert row[0] == 0
 
@@ -5419,7 +5420,7 @@ class TestFavorite:
         ).fetchone()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row is not None
         assert row[0] == 0  # existing tracks default to not-favorited
 
@@ -5532,7 +5533,7 @@ class TestAlbumFavorite:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -5716,7 +5717,7 @@ class TestMtimeReindex:
         ).fetchone()
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row is not None
         # file_mtime is intentionally left NULL on migration so the next scan
         # treats all existing tracks as changed and re-reads their tags.
@@ -5811,7 +5812,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 61
+        assert version == _SCHEMA_VERSION
 
     def test_schema_version_9_after_migration(self, tmp_path: Path) -> None:
         index = self._make_index(tmp_path)
@@ -5819,7 +5820,7 @@ class TestSessionManagement:
             0
         ]
         index.close()
-        assert version == 61
+        assert version == _SCHEMA_VERSION
 
     def test_migration_v8_to_v9_nulls_flac_ogg_mtimes(self, tmp_path: Path) -> None:
         """v8→v9 resets file_mtime for FLAC/OGG rows so they are re-scanned.
@@ -6746,7 +6747,7 @@ class TestMigrationV11ToV12:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 61
+        assert version == _SCHEMA_VERSION
 
         index.close()
 
@@ -7477,7 +7478,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         index.close()
 
     def test_migration_existing_rows_get_empty_defaults(self, tmp_path: Path) -> None:
@@ -7512,7 +7513,7 @@ class TestMigrationV16ToV17:
         version = index._conn.execute("SELECT version FROM schema_version").fetchone()[
             0
         ]
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         index.close()
 
 
@@ -8053,7 +8054,7 @@ class TestBandcampCollection:
         reopened.close()
 
         assert row["sale_item_id"] == "bf-1"
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row2["sale_item_id"] == "bf-1"
 
     def test_reset_collection_sync_state(self, tmp_path: Path) -> None:
@@ -8186,7 +8187,7 @@ class TestBandcampCollection:
         index.close()
 
         assert state == {}
-        assert version == 61
+        assert version == _SCHEMA_VERSION
 
 
 class TestRemoteTrackSchema:
@@ -8602,7 +8603,7 @@ class TestRemoteTrackSchema:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "source" in cols
         assert "stream_url" in cols
         assert "stream_url_expires_at" in cols
@@ -8663,7 +8664,7 @@ class TestRemoteTrackSchema:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         sources = {r["file_path"]: r["source"] for r in rows}
         assert sources["bandcamp://123/1"] == "bandcamp"
         assert sources["/local/track.mp3"] == "local"
@@ -9485,7 +9486,7 @@ class TestMigrationV22:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert (
             rows.get("bandcamp://999/1") == "OldForm"
         ), "single-slash row was not normalised to double-slash"
@@ -10449,7 +10450,7 @@ class TestMigrationV23:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "download_queue" in tables
         assert "albums" in tables
         assert "album_favorites" not in tables
@@ -10527,7 +10528,7 @@ class TestMigrationV24:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "albums" in tables
         assert "album_favorites" not in tables
 
@@ -10736,7 +10737,7 @@ class TestMigrationV25:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "is_available" in cols
 
     def test_migration_defaults_existing_rows_to_available(
@@ -10976,7 +10977,7 @@ class TestMigrationV26:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "num_streamable_tracks" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -11076,7 +11077,7 @@ class TestMigrationV27:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "duration" in cols
 
     def test_migration_defaults_existing_rows_to_zero(self, tmp_path: Path) -> None:
@@ -11192,7 +11193,7 @@ class TestMigrationV28:
         ]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert rows["local/a.mp3"] is None  # zero-duration local: mtime nulled
         assert rows["local/b.mp3"] == 2000.0  # already has duration: untouched
         assert rows["bandcamp://1/1"] == 3000.0  # bandcamp: untouched
@@ -11697,7 +11698,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "playlists" in tables
         assert "playlist_tracks" in tables
 
@@ -11812,7 +11813,7 @@ class TestPlaylists:
         ).fetchone()[0]
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "track_id" in columns
         assert "file_path" not in columns
         assert len(rows) == 1
@@ -11910,7 +11911,7 @@ class TestPlaylists:
         }
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "last_played_at" in columns
 
     # ------------------------------------------------------------------
@@ -12010,7 +12011,7 @@ class TestPlaylists:
         results = index.search_playlists("Existing Playlist")
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert len(results) == 1
         assert results[0]["title"] == "Existing Playlist"
 
@@ -12638,7 +12639,7 @@ class TestMagicPlaylists:
         fetched = index.get_magic_playlist_criteria(playlist_id)
         index.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert fetched == criteria
 
     # ------------------------------------------------------------------
@@ -13522,7 +13523,7 @@ class TestMigrationV38:
         version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
         conn.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert "release_date" in cols
         assert "year" not in cols
 
@@ -15305,7 +15306,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert row["album_id"] == stream_album
         assert row["track_number"] == 1
         # The heal took a backup snapshot before mutating.
@@ -15325,7 +15326,7 @@ class TestLooseSingleAttach:
             0
         ]
         index.close()
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert not list(tmp_path.glob("library.db.bak-*"))
 
     def test_v43_migration_restamps_attached_but_unstamped_single(
@@ -15368,7 +15369,7 @@ class TestLooseSingleAttach:
         cards = [a for a in reopened.albums() if a.album == "Celebrity"]
         reopened.close()
 
-        assert version == 61
+        assert version == _SCHEMA_VERSION
         assert stamped == "Celebrity"
         # No duplicate loose card, and the album now reads as owned.
         assert len(cards) == 1
@@ -15647,7 +15648,7 @@ class TestKamp552DropColumns:
         ver = reopened._conn.execute("SELECT version FROM schema_version").fetchone()[0]
         cols = {r[1] for r in reopened._conn.execute("PRAGMA table_info(tracks)")}
         reopened.close()
-        assert ver == 61
+        assert ver == _SCHEMA_VERSION
         assert "file_path" not in cols
         assert album_id is None  # dangling FK nulled
         assert fk == []

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -15,11 +15,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from kamp_core.library import LibraryIndex
-from kamp_daemon.discovery import FANCOLLECTION
+from kamp_daemon.discovery import FANCOLLECTION, PREVIEW, SAVE_REMOTE
 from kamp_daemon.wishlist import (
     PAGE_SIZE,
     WishlistCache,
     fetch_wishlist_album_ids,
+    write_wishlist,
 )
 
 
@@ -271,6 +272,52 @@ class TestCache:
         cache.add("77")
         assert "77" in cache.ids
 
+    def test_discard_records_kamps_own_removal(self) -> None:
+        """Without it, an album the user just un-wishlisted stays excluded from
+        every crate for the rest of the TTL, with nothing to explain why."""
+        cache = WishlistCache()
+        cache.refresh(
+            FakeSession([_page([_row(1), _row(2)], last_token="")]), 42, governor=_gov()
+        )
+        cache.discard("1")
+        assert cache.ids == {"2"}
+
+    def test_an_add_during_a_walk_survives_the_walk_landing(self) -> None:
+        """A walk takes ~40s and runs outside the lock, so it can start before a
+        wishlist click and finish after it. Replacing the id set wholesale would
+        silently undo what the user just did — and Bandcamp confirmed it."""
+        cache = WishlistCache()
+        clicked: list[str] = []
+
+        class ClickMidWalk(FakeSession):
+            def post(self, url, json=None, timeout=30, headers=None):  # type: ignore[no-untyped-def]
+                # Mid-flight, exactly as a request thread would.
+                if not clicked:
+                    clicked.append("77")
+                    cache.add("77")
+                    cache.discard("1")
+                return super().post(url, json=json, timeout=timeout, headers=headers)
+
+        # The walk's own view is stale: it still has 1 and has never seen 77.
+        cache.refresh(
+            ClickMidWalk([_page([_row(1), _row(2)], last_token="")]),
+            42,
+            governor=_gov(),
+        )
+        assert cache.ids == {"2", "77"}
+
+    def test_mutations_outside_a_walk_do_not_leak_into_the_next_one(self) -> None:
+        """Only in-flight mutations are re-applied. One made before a walk is
+        already reflected in what that walk read, and replaying it would pin a
+        stale id past a genuine change made in a browser."""
+        t = [1000.0]
+        cache = self._cache(t)
+        cache.add("99")
+        cache.refresh(
+            FakeSession([_page([_row(1)], last_token="")]), 42, governor=_gov()
+        )
+        assert cache.ids == {"1"}
+
     def test_invalidate_drops_everything(self) -> None:
         """The ids belong to an account that can change."""
         cache = WishlistCache()
@@ -286,3 +333,99 @@ class TestCache:
         cache.add("1")
         cache.ids.add("2")
         assert cache.ids == {"1"}
+
+
+class _FakeSource:
+    """Stands in for BandcampDiscoverySource at the write boundary."""
+
+    def __init__(
+        self,
+        *,
+        result: Any = True,
+        caps: frozenset[str] = frozenset({PREVIEW, SAVE_REMOTE}),
+    ) -> None:
+        self.result = result
+        self.capabilities = caps
+        self.saved: list[Any] = []
+        self.unsaved: list[Any] = []
+
+    def _answer(self, candidate: Any) -> bool:
+        if isinstance(self.result, Exception):
+            raise self.result
+        return bool(self.result)
+
+    def save_remote(self, candidate: Any) -> bool:
+        self.saved.append(candidate)
+        return self._answer(candidate)
+
+    def unsave_remote(self, candidate: Any) -> bool:
+        self.unsaved.append(candidate)
+        return self._answer(candidate)
+
+
+_ITEM = {
+    "id": 1,
+    "provider": "bandcamp",
+    "provider_item_id": "555",
+    "item_url": "https://a.bandcamp.com/album/x",
+    "artist": "Artist",
+    "title": "Title",
+}
+
+
+class TestWriteWishlist:
+    def test_a_confirmed_add_reports_ok_and_updates_the_cache(self) -> None:
+        cache = WishlistCache()
+        source = _FakeSource()
+        assert write_wishlist(source, _ITEM, add=True, cache=cache) == "ok"
+        assert cache.ids == {"555"}
+        assert source.saved[0].item_url == "https://a.bandcamp.com/album/x"
+
+    def test_a_confirmed_removal_drops_it_from_the_cache(self) -> None:
+        """Otherwise the album the user just removed stays excluded from every
+        crate for the rest of the TTL, with nothing to explain why."""
+        cache = WishlistCache()
+        cache.add("555")
+        assert write_wishlist(_FakeSource(), _ITEM, add=False, cache=cache) == "ok"
+        assert cache.ids == set()
+
+    def test_the_cache_is_untouched_when_the_write_fails(self) -> None:
+        cache = WishlistCache()
+        source = _FakeSource(result=False)
+        assert write_wishlist(source, _ITEM, add=True, cache=cache) == "rejected"
+        assert cache.ids == set()
+
+    def test_no_source_is_not_connected(self) -> None:
+        assert write_wishlist(None, _ITEM, add=True) == "not_connected"
+
+    def test_a_source_without_the_capability_is_unsupported_not_rejected(self) -> None:
+        """The capability gate, and the first thing in the codebase to read the
+        property. Without it, a provider that cannot write is indistinguishable
+        from Bandcamp saying no — and the UI would blame Bandcamp."""
+        source = _FakeSource(caps=frozenset({PREVIEW}))
+        assert write_wishlist(source, _ITEM, add=True) == "unsupported"
+        assert source.saved == []
+
+    def test_a_rate_limit_is_reported_as_such(self) -> None:
+        from kamp_daemon.discovery_sources import RateLimitedError
+
+        source = _FakeSource(result=RateLimitedError("cooling down"))
+        assert write_wishlist(source, _ITEM, add=True) == "rate_limited"
+
+    def test_an_expired_session_asks_for_a_login(self) -> None:
+        from kamp_daemon.bandcamp import NeedsLoginError
+
+        source = _FakeSource(result=NeedsLoginError("session rejected"))
+        assert write_wishlist(source, _ITEM, add=True) == "needs_login"
+
+    def test_an_unexpected_error_is_rejected_rather_than_raised(self) -> None:
+        """A failed nicety must not 500 the endpoint."""
+        source = _FakeSource(result=RuntimeError("boom"))
+        assert write_wishlist(source, _ITEM, add=True) == "rejected"
+
+    def test_the_candidate_carries_the_identity_the_post_needs(self) -> None:
+        source = _FakeSource()
+        write_wishlist(source, _ITEM, add=True)
+        candidate = source.saved[0]
+        assert candidate.provider_item_id == "555"
+        assert candidate.provider == "bandcamp"


### PR DESCRIPTION
## Summary

`W` on a crate record puts it in your Bandcamp wishlist, and `W` again takes it back off. The heart appears only once Bandcamp has confirmed it.

This is the first authenticated POST **mutation** kamp has ever made to Bandcamp. Everything shipped before this reads.

| Commit | What |
| --- | --- |
| C0 | Prove the write on the relay, not just on direct — and correct the recon |
| C1 | `_ProxySession._fetch` accepts a form-encoded body |
| C2 | Schema v62 + ledger recompute, so a wishlist can be taken back |
| C3 | `save_remote` / `unsave_remote` on the Bandcamp source |
| C4 | The two routes, with a real error taxonomy |
| C5 | The UI toggle |

Filed as an LP; taken as a **Box Set** with @tterry's agreement. The ticket was priced against a premise that turned out to be false, and the one-way-in-v1 constraint was relaxed to a toggle — see both below.

## The blocker wasn't real

KAMP-644 recorded **"wishlist add/remove: go on direct, NO-GO on the relay, proven on: both"**, and named three files that would need extending. Since every shipped build routes through the relay, that verdict is why `SAVE_REMOTE` was withheld and why the button has sat disabled since KAMP-650.

**The relay half was never run.** `RelayTransport` in the spike had no `post_form` method at all, hard-coded `Content-Type: application/json`, and its `post_json` didn't even accept a `headers=` kwarg — so `wishlist-roundtrip --transport relay` would have raised `TypeError` before reaching Bandcamp. Every form-encoded fallback was additionally gated on `--transport direct`. The verdict described the harness, not the relay.

What's actually true: the wire format is `{url, method, headers, body}` with the content type riding in `headers`, and `server.py`, `kampAPI.ts` and `index.ts` forward both verbatim. **Only `_ProxySession._fetch` needed a `data=` branch** — one Python function, not three layers.

I've recorded this in `docs/discovery-recon.md` as a correction rather than a quiet amendment, because the failure is the interesting part: the doc's own thesis is that a verdict is only as good as the transport it was proven on, and "proven on: both" was itself the unproven claim.

## Three things C0 found that would have shipped broken

I re-ran the round trip live on **both** transports before writing any of it. Each of these cost one round trip to learn and none were guessable:

**`Referer` cannot be sent through the relay.** Chromium answers `net::ERR_BLOCKED_BY_CLIENT` and the request never leaves the machine. But Bandcamp insists on *"either an origin or a referrer"*. So the header set the recon recorded (`X-Requested-With` + `Referer` + `Origin`) works in dev and **can never work in a packaged build**. `Origin` alone satisfies both. Bisected header by header against the live relay.

**The success body lies.** Sending `current.selling_band_id` instead of `current.band_id` — they diverge on label-released albums — returns HTTP 200 **and `{"ok":true}`**, and the album is not wishlisted. Verified by sending the wrong one deliberately. So there is **no fallback** to `selling_band_id`: a fallback would report success and change nothing, which is worse than failing, and a page with no `band_id` refuses rather than guesses.

**`collect_item_cb` is idempotent.** A repeat add answers `ok:true`, so "already wishlisted" is a genuine silent success rather than something we fake.

The account was left exactly as found after every run.

## Un-wishlisting breaks an invariant, so it recomputes

`discovery_items.state` has been strictly monotonic since KAMP-645 — highest-rank-wins, stated as an invariant in the schema comment. A retraction cannot be expressed as a rank comparison at all.

Rather than bolt a downward special case onto highest-rank-wins, the retraction path **recomputes from `discovery_events`** — which is what that column has always been documented as being a cache of. The append-only kinds keep the cheap comparison; only the rare event pays for a re-read. Falling back to the ledger is also what makes the interesting cases come out right without enumerating them: a previewed record returns to `previewed`, a purchase outranks the question entirely, re-wishlisting sticks, and a record both passed on and wishlisted falls back to `dismissed` because that is what the ledger honestly says.

**Schema v61 → v62** widens the CHECK on `discovery_events.kind`. SQLite can't ALTER a CHECK so the table is rebuilt — but far more simply than the KAMP-552 recipe, because `discovery_events` is a **leaf**: it references `discovery_items` and nothing references it, so `DROP TABLE` cascades to nothing and the `foreign_keys=OFF` dance is unnecessary.

## Never optimistic, structurally

The done-state is derived from `item.state`, which arrives on the crate snapshot the daemon re-broadcasts after a confirmed write. So "never show a done-state Bandcamp hasn't confirmed" is enforced by where the data comes from rather than by the click handler remembering. It also survives a remount, a view switch, and KAMP-652 marking items out of band.

Failures get **five statuses**, not a blanket 502 — a single code would flatten "Bandcamp asked us to slow down" and "you've been signed out" into the same shrug. The daemon sends a machine reason and no prose; the renderer owns the clerk's voice.

This is also the **first consumer of `DiscoverySource.capabilities`**. The property has existed since KAMP-645 with no non-test reader, so `SAVE_REMOTE` would have been decoration without a gate that maps it to its own status.

## Test plan

- [x] `poetry run pytest` — **3130 passed, 9 skipped, 3 deselected**, coverage **93.75%**
- [x] `black`, `mypy`, `npm run typecheck`, `npm run lint` clean
- [x] **Live on both transports**: add → verify → repeat-add → remove → verify, net zero each time
- [x] Falsified six ways — trusting the HTTP status, sending a `Referer`, adding a `selling_band_id` fallback, dropping the capability gate, dropping the in-flight mutation overlay, and ordering the ledger by row instead of by time each fail the test that claims to cover them
- [x] v62 validated on a **copy** of the real 84-event library, rolled back to a genuine v61 first: same rows, same event ids, same states, clean `foreign_key_check`

## One thing you should know

**Your live database is already at v62.** The dev daemon you had running picked up the new `_SCHEMA_VERSION` and migrated `~/.local/share/kamp/library.db` in place. Checked afterwards: 70 discovery items, 84 events, `integrity_check` ok, `foreign_key_check` clean. Nothing lost — but it also meant my first migration check was worthless (it compared v62 to v62), which is why the real one rolls a copy back to v61 first.

## Deliberately not done

**A README section for the Crate.** The feature list mentions nothing about discovery at all — that is an epic-level gap rather than drift introduced here, and writing a partial section mid-epic would need rewriting by KAMP-656. Nothing the README currently says has become untrue.

**Re-reading the album page to confirm the write landed.** `ok:true` is trustworthy given a `band_id` read off the album's own page, which is the only value we ever send; the failure above required deliberately sending a different band. A third request per click on the endpoint class measured closest to its rate limit isn't worth it, and the next crate build reconciles anything that did diverge.

## Manual test plan

- Dig a crate, press `W` on a record. The heart should appear **only after** Bandcamp confirms — then check bandcamp.com in a browser and see it there.
- Press `W` again. It should leave the wishlist on Bandcamp too. Dig a fresh crate afterwards: the removed record is eligible again, the added one is not.
- Hold `W` down so it key-repeats. Exactly one request should go out.
- Press `W`, then immediately `.` to move on. The result must land on the record you pressed it on, not the one now in focus.
- Wishlist something from a browser, then press `W` on that same record in kamp: silent success with the heart, no error.
- Pull your network connection and press `W`: a clerk-voice line under the buttons, the button reverts and is retryable, Copy link still works.
- Dig several crates quickly to earn a cooldown, then press `W`: it should say so immediately rather than hanging.
- **Windows / packaged build**: repeat the first two steps. That is the path the relay fix exists for, and the one no dev-machine test covers.

Closes KAMP-653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
