### PR TITLE
KAMP-654: purchase attribution — link new collection items to crate picks

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5007,6 +5007,33 @@ class LibraryIndex:
         (KAMP-527: on a pooled thread-local connection an uncommitted partial write is
         otherwise flushed by the next unrelated commit on the same thread).
         """
+        try:
+            self._record_event(item_id, kind, detail, at)
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def _record_event(
+        self,
+        item_id: int,
+        kind: str,
+        detail: str | None = None,
+        at: float | None = None,
+    ) -> None:
+        """Append the event and reconcile state. Does NOT commit.
+
+        Split out for the same reason ``_append_event`` was (KAMP-654): a caller
+        that must write something else in the *same* transaction -- purchase
+        attribution writes purchased_sale_item_id and purchased_at alongside --
+        would otherwise have to choose an ordering, and both orderings are unsafe.
+        Event first and a crash appends a duplicate on the retry, double-counting
+        the ledger. Columns first and a crash leaves the item attributed but
+        invisible to the ledger.
+
+        Still the only place state is written; the public method is this plus a
+        commit.
+        """
         row = self._conn.execute(
             "SELECT provider, provider_item_id, state FROM discovery_items"
             " WHERE id = ?",
@@ -5020,29 +5047,24 @@ class LibraryIndex:
         if target is None and not retracts:
             raise ValueError(f"unknown discovery event kind {kind!r}")
 
-        try:
-            self._append_event(item_id, row, kind, at, detail)
-            if retracts:
-                # Recomputed AFTER the append, so the retraction is part of the
-                # ledger it is derived from.
-                new_state = self._state_from_ledger(item_id)
-            else:
-                rank = self._DISCOVERY_STATE_RANK
-                assert target is not None  # narrowed by the guard above
-                new_state = (
-                    target
-                    if rank[target] > rank.get(row["state"], 0)
-                    else str(row["state"])
-                )
-            if new_state != row["state"]:
-                self._conn.execute(
-                    "UPDATE discovery_items SET state = ? WHERE id = ?",
-                    (new_state, item_id),
-                )
-            self._conn.commit()
-        except Exception:
-            self._conn.rollback()
-            raise
+        self._append_event(item_id, row, kind, at, detail)
+        if retracts:
+            # Recomputed AFTER the append, so the retraction is part of the
+            # ledger it is derived from.
+            new_state = self._state_from_ledger(item_id)
+        else:
+            rank = self._DISCOVERY_STATE_RANK
+            assert target is not None  # narrowed by the guard above
+            new_state = (
+                target
+                if rank[target] > rank.get(row["state"], 0)
+                else str(row["state"])
+            )
+        if new_state != row["state"]:
+            self._conn.execute(
+                "UPDATE discovery_items SET state = ? WHERE id = ?",
+                (new_state, item_id),
+            )
 
     def _state_from_ledger(self, item_id: int) -> str:
         """Derive state from the whole event history. Does NOT commit.
@@ -5072,6 +5094,128 @@ class LibraryIndex:
         if not live:
             return "fresh"
         return max(live, key=lambda s: self._DISCOVERY_STATE_RANK.get(s, 0))
+
+    # The join that attributes a purchase to the crate pick that caused it.
+    #
+    # Driven from discovery_items, not from the collection: there is no index on
+    # bandcamp_collection.tralbum_id, and the unattributed discovery set is small
+    # and shrinks while the collection only grows.
+    #
+    # Every clause in the WHERE is a guard against a *silent wrong answer* rather
+    # than a crash, so none of them is optional:
+    #
+    #   provider_item_id != '' / tralbum_id != ''
+    #     Both columns are NOT NULL DEFAULT '' and tralbum_id is lazily backfilled
+    #     (schema note, KAMP-382). One empty-id discovery row would otherwise
+    #     attribute every un-backfilled collection row to it.
+    #
+    #   added_at > 0
+    #     mark_collection_synced writes added_at=0 for "you already owned this at
+    #     first run", and upsert_collection_item merges with MIN(), so once 0 it
+    #     can never become non-zero. An exact marker for pre-owned, not a guess.
+    #
+    #   added_at >= first_seen_at
+    #     The gather-time ownership exclusion is NOT airtight -- it reads
+    #     collection_purchase_dates(), which itself drops blank tralbum_ids -- so an
+    #     already-owned album can reach a crate. Buying it before we showed it is
+    #     proof we did not sell it.
+    #
+    #   NOT EXISTS(a purchased event)
+    #     The idempotency key, deliberately NOT purchased_at as the ticket
+    #     specified: clear_bandcamp_collection() nulls purchased_sale_item_id and
+    #     leaves purchased_at set, so keying on the column would orphan the FK
+    #     permanently. The ledger is ground truth and cannot be nulled by a reset,
+    #     which lets the columns re-heal on the next walk without a second event.
+    #
+    # MIN(added_at) because tralbum_id is not unique -- a gift or a re-purchase
+    # yields two rows -- and an unaggregated join would pick nondeterministically.
+    _ATTRIBUTABLE_SQL = """
+        SELECT d.id            AS id,
+               d.artist        AS artist,
+               d.title         AS title,
+               d.crate_no      AS crate_no,
+               b.sale_item_id  AS sale_item_id,
+               b.added_at      AS added_at,
+               NOT EXISTS (
+                   SELECT 1 FROM discovery_events e
+                    WHERE e.item_id = d.id AND e.kind = 'purchased'
+               )               AS is_new
+          FROM discovery_items d
+          JOIN bandcamp_collection b
+            ON b.tralbum_id = d.provider_item_id
+           AND b.added_at = (
+                   SELECT MIN(b2.added_at) FROM bandcamp_collection b2
+                    WHERE b2.tralbum_id = d.provider_item_id
+               )
+         WHERE d.provider = 'bandcamp'
+           AND d.provider_item_id != ''
+           AND b.tralbum_id != ''
+           AND b.added_at > 0
+           AND b.added_at >= d.first_seen_at
+           AND (d.purchased_sale_item_id IS NULL OR NOT EXISTS (
+                   SELECT 1 FROM discovery_events e
+                    WHERE e.item_id = d.id AND e.kind = 'purchased'
+               ))
+         GROUP BY d.id
+    """
+
+    def attribute_crate_purchases(self) -> list[dict[str, Any]]:
+        """Link newly purchased albums back to the crate picks that offered them.
+
+        Returns the picks attributed *for the first time* by this call, each with
+        ``shown`` saying whether it was ever actually in a crate -- so a caller can
+        celebrate the ones the user really was offered and stay quiet about the
+        rest. Re-healing a link broken by an account reset returns nothing: it is
+        not a new purchase.
+
+        Idempotent by construction, which matters because a full collection walk
+        runs at every app start and this re-fires on every one of them.
+
+        Attribution deliberately ignores ``crate_no``. A buffered candidate the
+        user buys independently must still gain its 'purchased' event -- that is
+        what makes the row unsweepable by KAMP-657's TTL sweep, so the attribution
+        outlives the candidate (see the discovery_events schema note).
+        """
+        rows = self._conn.execute(self._ATTRIBUTABLE_SQL).fetchall()
+        attributed: list[dict[str, Any]] = []
+        for row in rows:
+            is_new = bool(row["is_new"])
+            try:
+                self._conn.execute(
+                    "UPDATE discovery_items"
+                    "   SET purchased_sale_item_id = ?, purchased_at = ?"
+                    " WHERE id = ?",
+                    (row["sale_item_id"], float(row["added_at"]), row["id"]),
+                )
+                if is_new:
+                    # Back-dated to the sale, not to this sync. _state_from_ledger
+                    # orders by `at`, and KAMP-655 wants the gap between digging
+                    # and buying.
+                    self._record_event(
+                        int(row["id"]), "purchased", at=float(row["added_at"])
+                    )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                logger.warning(
+                    "discovery: could not attribute purchase for item %s",
+                    row["id"],
+                    exc_info=True,
+                )
+                continue
+            if is_new:
+                attributed.append(
+                    {
+                        "id": int(row["id"]),
+                        "artist": str(row["artist"]),
+                        "title": str(row["title"]),
+                        "sale_item_id": str(row["sale_item_id"]),
+                        "shown": row["crate_no"] is not None,
+                    }
+                )
+        if attributed:
+            logger.info("discovery: attributed %d purchased pick(s)", len(attributed))
+        return attributed
 
     def _append_event(
         self,

--- a/kamp_core/server.py
+++ b/kamp_core/server.py
@@ -1370,6 +1370,34 @@ def create_app(
 
     app.state.notify_deferred_op_completed = _notify_deferred_op_completed
 
+    def _notify_crate_purchase(items: list[dict[str, Any]]) -> None:
+        """Tell the UI a crate pick came home (KAMP-654).
+
+        Sent as a batch, not one event per item: attribution runs once per sync
+        and a user who bought three picks since last launch would otherwise get
+        three toasts into a single-slot 5s display, where each new one clears the
+        previous early and two are lost outright.
+
+        Carries artist and title because the crate snapshot cannot supply them —
+        it only ever rebuilds the *latest* crate, so a pick bought out of crate 2
+        while the user is looking at crate 7 has no card to read from.
+        """
+        _broadcast(
+            {
+                "type": "discovery.purchased",
+                "items": [
+                    {
+                        "id": item["id"],
+                        "artist": item["artist"],
+                        "title": item["title"],
+                    }
+                    for item in items
+                ],
+            }
+        )
+
+    app.state.notify_crate_purchase = _notify_crate_purchase
+
     # Wired by the daemon after create_app() to suppress watcher events and
     # trigger a direct scan following a tag-edit file move.
     app.state.on_track_file_moved = None

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1697,6 +1697,38 @@ def _cmd_daemon(
         threading.Thread(target=_run, daemon=True, name="stream-genre-enrich").start()
 
     core.syncer.on_stream_albums_added = _on_stream_albums_added
+
+    def _on_collection_synced() -> None:
+        """Attribute any crate picks the user has since bought (KAMP-654).
+
+        Runs in the parent, where the index and the broadcaster both live. Pure
+        DB work over a collection that was just written, so it is cheap and needs
+        no network -- the same shape as mark_wishlisted_crate_items.
+        """
+        try:
+            attributed = index.attribute_crate_purchases()
+        except Exception:
+            _logger.warning("purchase attribution failed", exc_info=True)
+            return
+        if not attributed:
+            return
+        # The card's own state moved, so refresh whoever is looking at the crate.
+        # Only ever rebuilds the LATEST crate, which is why the toast below has to
+        # carry its own copy of the album -- a pick bought out of an older crate
+        # has no card on screen to update.
+        publish = getattr(app.state, "discovery_publish", None)
+        if publish is not None:
+            publish({})
+        # Congratulate only on records actually offered. A buffered candidate is
+        # still attributed (it must be, or KAMP-657's sweep would prune the
+        # attribution away) but was never shown, and "good ear" about something
+        # the user found themselves is nonsense.
+        shown = [item for item in attributed if item["shown"]]
+        notify = getattr(app.state, "notify_crate_purchase", None)
+        if shown and notify is not None:
+            notify(shown)
+
+    core.syncer.on_collection_synced = _on_collection_synced
     core.watcher.stage_callback = app.state.notify_pipeline_stage
 
     # After each album finishes processing, run a library rescan directly on a

--- a/kamp_daemon/ext/builtin/bandcamp.py
+++ b/kamp_daemon/ext/builtin/bandcamp.py
@@ -198,6 +198,20 @@ class KampBandcampSyncer(BaseSyncer):
         self._inner.on_stream_albums_added = cb
 
     @property
+    def on_collection_synced(self) -> Callable[[], None] | None:
+        """Callback fired once after any successful collection walk (KAMP-654)."""
+        if self._inner is None:
+            return None
+        return self._inner.on_collection_synced
+
+    @on_collection_synced.setter
+    def on_collection_synced(self, cb: Callable[[], None] | None) -> None:
+        assert (
+            self._inner is not None
+        ), "call _configure() before setting on_collection_synced"
+        self._inner.on_collection_synced = cb
+
+    @property
     def progress_callback(self) -> Callable[[str, int, int], None] | None:
         """Per-album byte-progress callback (sale_item_id, downloaded_bytes,
         total_bytes) (KAMP-436/566)."""

--- a/kamp_daemon/syncer.py
+++ b/kamp_daemon/syncer.py
@@ -332,6 +332,15 @@ class Syncer:
         self.on_stream_albums_added: Callable[[list[tuple[str, str]]], None] | None = (
             None
         )
+        # KAMP-654: fired once after any successful collection walk, in the parent
+        # process. Named for what happened rather than "after a sync", because the
+        # thing a listener cares about is that bandcamp_collection changed --
+        # purchase attribution is a pure-DB join over it.
+        #
+        # The parent, not the subprocess: the child cannot broadcast, its index is
+        # closed in a finally, and marshalling a toast payload back through
+        # result_q to do the same work is strictly worse.
+        self.on_collection_synced: Callable[[], None] | None = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -538,6 +547,21 @@ class Syncer:
         # and manual syncs — an empty string signals "no active sync").
         if self.status_callback is not None:
             self.status_callback("")
+
+        # The ONE place this fires, deliberately. Both result branches converge
+        # here, and the other two entry points route through this method:
+        # sync_all_purchases() delegates to sync_once() in both modes, and
+        # mark_synced() is invoked from *inside* sync_once()'s first-run branch
+        # above. Firing at those sites too would double-fire, and firing in
+        # mark_synced() would fire before the sync that produces the purchases.
+        #
+        # A listener that raises must not fail the sync -- the collection is
+        # already written and this is bookkeeping on top of it.
+        if self.on_collection_synced is not None:
+            try:
+                self.on_collection_synced()
+            except Exception:  # noqa: BLE001
+                logger.warning("on_collection_synced failed", exc_info=True)
 
     def sync_all_purchases(self) -> None:
         """Re-sync or re-download the entire Bandcamp collection.

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -370,6 +370,10 @@ export default function App(): React.JSX.Element {
         // carries whatever is already playing rather than starting from idle.
         (state) => {
           useStore.getState().setPreview(state)
+        },
+        // KAMP-654: crate picks the user bought, found by a collection sync.
+        (items) => {
+          useStore.getState().celebrateCratePurchases(items)
         }
       )
     }

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -1174,6 +1174,17 @@ export type DiscoveryCrateMessage = { type: 'discovery.crate' } & CrateSnapshot
 // see PreviewState.position.
 export type DiscoveryPreviewMessage = { type: 'discovery.preview' } & PreviewState
 
+// KAMP-654: crate picks the user has since bought, found by a collection sync.
+// Batched — attribution runs once per sync and can turn up several at once.
+export type PurchasedPick = { id: number; artist: string; title: string }
+// Carries artist/title rather than just ids on purpose: the crate snapshot only
+// ever rebuilds the LATEST crate, so a pick bought out of an older one has no
+// card on screen to read them from.
+export type DiscoveryPurchasedMessage = {
+  type: 'discovery.purchased'
+  items: PurchasedPick[]
+}
+
 export type ServerMessage =
   | StateMessage
   | TrackChangedMessage
@@ -1187,6 +1198,7 @@ export type ServerMessage =
   | DownloadQueueMessage
   | DiscoveryCrateMessage
   | DiscoveryPreviewMessage
+  | DiscoveryPurchasedMessage
 
 export async function getDeferredOps(): Promise<{ op_id: number; track_id: number }[]> {
   const res = await fetch(`${BASE_URL}/api/v1/deferred-ops`, {
@@ -1220,7 +1232,10 @@ export function connectStateStream(
   // KAMP-650: full crate snapshot for the Crate view. Appended last, same reason.
   onDiscoveryCrate?: (snapshot: CrateSnapshot) => void,
   // KAMP-651: preview transport state. Appended last, same reason.
-  onDiscoveryPreview?: (state: PreviewState) => void
+  onDiscoveryPreview?: (state: PreviewState) => void,
+  // KAMP-654: crate picks the user has bought, batched per sync. Appended last,
+  // same reason.
+  onDiscoveryPurchased?: (items: PurchasedPick[]) => void
 ): () => void {
   const ws = new WebSocket(`${WS_BASE}/api/v1/ws`)
 
@@ -1247,6 +1262,7 @@ export function connectStateStream(
       // callback as-is; the discriminator rides along inertly.
       else if (msg.type === 'discovery.crate') onDiscoveryCrate?.(msg)
       else if (msg.type === 'discovery.preview') onDiscoveryPreview?.(msg)
+      else if (msg.type === 'discovery.purchased') onDiscoveryPurchased?.(msg.items)
     } catch {
       // malformed message — ignore
     }

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -309,6 +309,13 @@
   opacity: 0.35;
 }
 
+/* Brought home. Reads as the strongest of the "dug" states because it is the
+   one that means the record left the shop. */
+.crate-sleeve--purchased .crate-sleeve-art {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .crate-sleeve--wishlisted .crate-sleeve-art {
   border-color: var(--accent);
 }

--- a/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
@@ -40,6 +40,7 @@ export function CrateSleeve({
   if (focused) classes.push('crate-sleeve--focused')
   if (passed || item.state === 'dismissed') classes.push('crate-sleeve--passed')
   if (item.state === 'wishlisted') classes.push('crate-sleeve--wishlisted')
+  if (item.state === 'purchased') classes.push('crate-sleeve--purchased')
   if (item.state !== 'fresh' && item.state !== 'dismissed') classes.push('crate-sleeve--dug')
 
   return (
@@ -77,6 +78,15 @@ export function CrateSleeve({
       {item.state === 'wishlisted' && (
         <span className="crate-sleeve-badge" aria-hidden="true">
           ♥
+        </span>
+      )}
+      {/* Outranks the heart rather than sitting beside it: `state` is a
+          single-slot rank cache, so a purchased pick reports only 'purchased'
+          even if it was wishlisted first. Showing the record you own is the
+          truer of the two anyway. */}
+      {item.state === 'purchased' && (
+        <span className="crate-sleeve-badge" aria-hidden="true">
+          ◆
         </span>
       )}
     </li>

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -92,6 +92,15 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // a view switch, and KAMP-652 marking items out of band.
   const wishlisted = current?.state === 'wishlisted'
   const wishlistSaving = current ? wishlistPending.includes(current.id) : false
+  // A bought record is not offered a wishlist toggle at all (KAMP-654).
+  //
+  // Not cosmetic: `state` is a single-slot rank cache and 'purchased' (rank 4)
+  // MASKS 'wishlisted' (rank 3), so after attribution `wishlisted` above goes
+  // false for a record that really is on the user's Bandcamp wishlist — and the
+  // next W press would POST an *add* for it. Retiring the toggle once the record
+  // is owned sidesteps the masking entirely, and is the better answer anyway:
+  // you do not wishlist something you already have.
+  const purchased = current?.state === 'purchased'
 
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
@@ -253,7 +262,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       // `current` is captured here and never read again in the resolution
       // handler: it is derived during render from a clamped index, and any
       // snapshot push can change its identity while the request is out.
-      if (current) void toggleCrateWishlist(current)
+      //
+      // Guarded on `purchased` for the same reason the button is disabled — the
+      // key would otherwise walk straight past it and re-add an owned record to
+      // the wishlist (see the `purchased` note above).
+      if (current && !purchased) void toggleCrateWishlist(current)
     } else if (e.key === ' ') {
       // Now that preview exists, Space is the Crate's (KAMP-651). KAMP-650
       // deliberately left it global, because claiming it for a no-op would have
@@ -394,16 +407,24 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   Open on Bandcamp
                 </button>
                 <button
-                  className={`crate-action${wishlisted ? ' crate-action--done' : ''}`}
+                  className={`crate-action${wishlisted || purchased ? ' crate-action--done' : ''}`}
                   onClick={() => void toggleCrateWishlist(current)}
-                  disabled={wishlistSaving}
-                  {...tooltip(wishlisted ? TOOLTIPS.CRATE_UNWISHLIST : TOOLTIPS.CRATE_WISHLIST)}
+                  disabled={wishlistSaving || purchased}
+                  {...tooltip(
+                    purchased
+                      ? TOOLTIPS.CRATE_PURCHASED
+                      : wishlisted
+                        ? TOOLTIPS.CRATE_UNWISHLIST
+                        : TOOLTIPS.CRATE_WISHLIST
+                  )}
                 >
-                  {wishlistSaving
-                    ? 'Setting it aside…'
-                    : wishlisted
-                      ? '♥ In your wishlist'
-                      : 'Wishlist it'}
+                  {purchased
+                    ? '◆ In your collection'
+                    : wishlistSaving
+                      ? 'Setting it aside…'
+                      : wishlisted
+                        ? '♥ In your wishlist'
+                        : 'Wishlist it'}
                 </button>
                 <button
                   className="crate-action"

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -17,6 +17,7 @@ import type {
   CrateItem,
   CrateSnapshot,
   PreviewState,
+  PurchasedPick,
   CriteriaDoc,
   DownloadItem,
   PlayerState,
@@ -253,6 +254,9 @@ type PlayerStore = {
   // only on a confirmed success, so the heart arrives on the crate snapshot that
   // follows rather than from here.
   toggleCrateWishlist: (item: CrateItem) => Promise<void>
+  // KAMP-654: a sync found crate picks the user has bought. Batched, because
+  // attribution runs once per sync and can turn up several at once.
+  celebrateCratePurchases: (items: PurchasedPick[]) => void
   // KAMP-651: preview transport. Every action returns the authoritative state,
   // so none of these guess locally.
   loadPreview: () => Promise<void>
@@ -1028,6 +1032,18 @@ export const useStore = create<PlayerStore>((set, get) => ({
     } catch {
       get().showFlashToast('Could not copy the link', 'error')
     }
+  },
+  celebrateCratePurchases: (items) => {
+    if (items.length === 0) return
+    // One toast, never one per item: showFlashToast is a single slot with its
+    // own 5s timer, so three would show one and silently discard two — and each
+    // new timer would clear the previous message early. Naming the album is the
+    // whole charm of this, so a single purchase still gets named.
+    const msg =
+      items.length === 1
+        ? `Good ear. You took home a crate pick — ${items[0].title}.`
+        : `Good ear. ${items.length} crate picks came home.`
+    get().showFlashToast(msg)
   },
   clearCrateWishlistError: () => set({ crateWishlistError: null }),
   toggleCrateWishlist: async (item) => {

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -53,6 +53,7 @@ export const TOOLTIPS = {
   // Names Bandcamp explicitly: this writes to the account, not to anything local.
   CRATE_WISHLIST: 'Add to your Bandcamp wishlist (W)',
   CRATE_UNWISHLIST: 'Remove from your Bandcamp wishlist (W)',
+  CRATE_PURCHASED: 'You brought this one home',
   CRATE_PREVIEW: 'Play a preview (Space) — your queue stays put',
   CRATE_COPY: 'Copy link (C)',
   CRATE_PASS: 'Pass (X)',

--- a/tests/test_builtin_bandcamp.py
+++ b/tests/test_builtin_bandcamp.py
@@ -261,6 +261,56 @@ class TestKampBandcampSyncer:
         syncer = KampBandcampSyncer(_ctx())
         assert syncer.on_stream_albums_added is None
 
+    def test_on_collection_synced_getter_delegates(self) -> None:
+        """on_collection_synced getter returns the inner syncer's value (KAMP-654)."""
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer._inner.on_collection_synced = cb
+        assert syncer.on_collection_synced is cb
+
+    def test_on_collection_synced_setter_delegates(self) -> None:
+        """on_collection_synced setter writes THROUGH to the inner syncer.
+
+        The KAMP-436 lesson again: without the setter, the daemon's assignment
+        lands on the wrapper, the inner Syncer never fires it, and purchase
+        attribution never runs — silently, and only in the running daemon.
+        """
+        syncer = _make_syncer()
+        cb = MagicMock()
+        syncer.on_collection_synced = cb
+        assert syncer._inner.on_collection_synced is cb
+
+    def test_on_collection_synced_none_before_configure(self) -> None:
+        syncer = KampBandcampSyncer(_ctx())
+        assert syncer.on_collection_synced is None
+
+    def test_every_inner_syncer_callback_has_a_wrapper(self) -> None:
+        """No Syncer callback may exist without a delegating property here.
+
+        KAMP-436 shipped a feature that worked at every layer and did nothing in
+        the daemon, because a new Syncer callback had no wrapper setter and the
+        assignment landed on a dead attribute. Enumerating the pair rather than
+        remembering to add one is what stops that recurring — a new callback on
+        Syncer fails this test rather than failing silently in production.
+        """
+        from kamp_daemon.syncer import Syncer
+
+        # __init__ only stores the config; nothing reads it until start().
+        probe = Syncer(MagicMock())
+        callbacks = {
+            name
+            for name, value in vars(probe).items()
+            if not name.startswith("_")
+            and (value is None or callable(value))
+            and ("callback" in name or name.startswith("on_"))
+        }
+        missing = {
+            name
+            for name in callbacks
+            if not isinstance(getattr(KampBandcampSyncer, name, None), property)
+        }
+        assert not missing, f"Syncer callbacks with no wrapper property: {missing}"
+
     def test_methods_assert_before_configure(self) -> None:
         """Calling lifecycle methods before _configure() raises AssertionError."""
         syncer = KampBandcampSyncer(_ctx())

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -313,6 +314,237 @@ class TestAccountResetWithPurchasedPick:
             ).fetchone()["c"]
             == 1
         )
+
+
+# ---------------------------------------------------------------------------
+# Purchase attribution (KAMP-654)
+# ---------------------------------------------------------------------------
+
+
+class TestPurchaseAttribution:
+    """Linking a new bandcamp_collection row back to the crate pick it came from.
+
+    Most of these guard a *silent wrong answer* rather than a crash: attribution
+    that fires for an album owned since before kamp existed reads, to the user,
+    as the app congratulating itself for their own record collection.
+    """
+
+    def _pick(
+        self,
+        index: LibraryIndex,
+        provider_item_id: str = "777",
+        *,
+        first_seen_at: float = 1000.0,
+        crate_no: int | None = 1,
+    ) -> int:
+        item = index.add_discovery_candidate(
+            provider="bandcamp",
+            provider_item_id=provider_item_id,
+            artist="Artist",
+            title="Album",
+        )
+        index._conn.execute(
+            "UPDATE discovery_items SET first_seen_at = ? WHERE id = ?",
+            (first_seen_at, item),
+        )
+        index._conn.commit()
+        if crate_no is not None:
+            index.place_in_crate(item, crate_no, 0)
+        return item
+
+    def _row(self, index: LibraryIndex, item: int) -> Any:
+        return index._conn.execute(
+            "SELECT purchased_sale_item_id, purchased_at, state"
+            " FROM discovery_items WHERE id = ?",
+            (item,),
+        ).fetchone()
+
+    def _events(self, index: LibraryIndex, kind: str = "purchased") -> list[Any]:
+        return index._conn.execute(
+            "SELECT item_id, at FROM discovery_events WHERE kind = ? ORDER BY id",
+            (kind,),
+        ).fetchall()
+
+    # -- the happy path --------------------------------------------------
+
+    def test_a_bought_pick_is_attributed(self, index: LibraryIndex) -> None:
+        item = self._pick(index)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+
+        attributed = index.attribute_crate_purchases()
+
+        assert [a["id"] for a in attributed] == [item]
+        row = self._row(index, item)
+        assert row["purchased_sale_item_id"] == "sale-1"
+        assert row["state"] == "purchased"
+
+    def test_the_event_is_back_dated_to_the_sale(self, index: LibraryIndex) -> None:
+        """Not the sync time. _state_from_ledger orders by `at`, and KAMP-655 needs
+        it to answer how long passed between digging and buying."""
+        item = self._pick(index)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        index.attribute_crate_purchases()
+        assert self._events(index)[0]["at"] == 2000.0
+
+    def test_a_purchase_outranks_a_wishlist(self, index: LibraryIndex) -> None:
+        """The ticket's own AC: wishlisted elsewhere, then bought."""
+        item = self._pick(index)
+        index.record_discovery_event(item, "wishlisted")
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        index.attribute_crate_purchases()
+        assert self._row(index, item)["state"] == "purchased"
+
+    # -- idempotency -----------------------------------------------------
+
+    def test_a_second_walk_attributes_nothing(self, index: LibraryIndex) -> None:
+        """A full collection walk runs at every app start, so the join re-fires
+        constantly and must be a no-op once attributed."""
+        self._pick(index)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        assert len(index.attribute_crate_purchases()) == 1
+        assert index.attribute_crate_purchases() == []
+        assert len(self._events(index)) == 1
+
+    def test_a_crash_before_the_event_cannot_double_count(
+        self, index: LibraryIndex
+    ) -> None:
+        """The ledger is the idempotency key, not purchased_at.
+
+        If the columns were written and the process died before the event, keying
+        on purchased_at would either block the item forever or, on the other
+        ordering, append a second event and double-count the KAMP-655 stat the
+        ledger is supposed to be ground truth for.
+        """
+        item = self._pick(index)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        # Simulate the half-write: columns set, no event.
+        index._conn.execute(
+            "UPDATE discovery_items SET purchased_sale_item_id = ?, purchased_at = ?"
+            " WHERE id = ?",
+            ("sale-1", 2000.0, item),
+        )
+        index._conn.commit()
+
+        index.attribute_crate_purchases()
+        assert len(self._events(index)) == 1
+
+    def test_an_account_reset_re_heals_the_link_without_a_second_event(
+        self, index: LibraryIndex
+    ) -> None:
+        """clear_bandcamp_collection() nulls purchased_sale_item_id and leaves
+        purchased_at set. Keying idempotency on purchased_at alone would orphan
+        the FK permanently; keying it on the ledger lets the column re-heal."""
+        item = self._pick(index)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        index.attribute_crate_purchases()
+
+        index.clear_bandcamp_collection()
+        assert self._row(index, item)["purchased_sale_item_id"] is None
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+
+        again = index.attribute_crate_purchases()
+        assert self._row(index, item)["purchased_sale_item_id"] == "sale-1"
+        # Healing a column is not a new purchase.
+        assert len(self._events(index)) == 1
+        assert again == [], "a re-heal must not be reported as a fresh purchase"
+
+    # -- the guards that stop a false congratulation ---------------------
+
+    def test_an_album_marked_synced_at_first_run_is_never_attributed(
+        self, index: LibraryIndex
+    ) -> None:
+        """added_at == 0 is mark_collection_synced's permanent marker for "you
+        already owned this". upsert_collection_item merges added_at with MIN(),
+        so once 0 it can never become non-zero -- the test is exact, not a
+        heuristic.
+
+        Without this guard, upgrading and syncing would retroactively congratulate
+        the user on records they have owned for years, the moment a lazily
+        backfilled tralbum_id happened to match.
+
+        first_seen_at is pinned to 0 here **so that this guard is the only thing
+        that can reject the row**. In production the added_at >= first_seen_at
+        comparison would also catch it, since first_seen_at defaults to
+        unixepoch(); with a realistic fixture this test passed even with the guard
+        deleted, which is exactly the vacuous test falsification exists to find.
+        The guard stays as defence in depth: it protects against congratulating
+        someone on their own collection, and that is worth not having depend on a
+        second clause continuing to be written the way it is today.
+        """
+        self._pick(index, first_seen_at=0.0)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=0.0)
+        assert index.attribute_crate_purchases() == []
+
+    def test_an_album_bought_before_the_pick_was_seen_is_never_attributed(
+        self, index: LibraryIndex
+    ) -> None:
+        """The ownership exclusion at gather time is not airtight -- it reads
+        collection_purchase_dates(), which itself filters out blank tralbum_ids --
+        so an already-owned album can reach a crate. Buying it earlier than we
+        showed it is proof we did not sell it."""
+        self._pick(index, first_seen_at=5000.0)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=4000.0)
+        assert index.attribute_crate_purchases() == []
+
+    def test_a_purchase_at_the_same_instant_still_counts(
+        self, index: LibraryIndex
+    ) -> None:
+        """Boundary: >= rather than >, so a same-timestamp row is not lost."""
+        self._pick(index, first_seen_at=2000.0)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        assert len(index.attribute_crate_purchases()) == 1
+
+    def test_an_empty_tralbum_id_matches_nothing(self, index: LibraryIndex) -> None:
+        """tralbum_id is NOT NULL DEFAULT '' and is lazily backfilled, and
+        normalise_item_id returns '' for falsy input. One empty-id discovery row
+        would otherwise attribute every un-backfilled collection row to it."""
+        self._pick(index, provider_item_id="")
+        _add_collection_row(index, "sale-1", tralbum_id="", added_at=2000.0)
+        _add_collection_row(index, "sale-2", tralbum_id="", added_at=3000.0)
+        assert index.attribute_crate_purchases() == []
+
+    def test_a_different_album_is_not_attributed(self, index: LibraryIndex) -> None:
+        self._pick(index, provider_item_id="777")
+        _add_collection_row(index, "sale-1", tralbum_id="888", added_at=2000.0)
+        assert index.attribute_crate_purchases() == []
+
+    def test_a_non_bandcamp_provider_is_not_attributed(
+        self, index: LibraryIndex
+    ) -> None:
+        item = index.add_discovery_candidate(provider="other", provider_item_id="777")
+        index.place_in_crate(item, 1, 0)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+        assert index.attribute_crate_purchases() == []
+
+    # -- determinism and the buffered case --------------------------------
+
+    def test_two_collection_rows_sharing_an_id_pick_deterministically(
+        self, index: LibraryIndex
+    ) -> None:
+        """tralbum_id is not unique -- a gift or a re-purchase yields two rows --
+        so an unaggregated join would attribute a nondeterministic sale_item_id."""
+        item = self._pick(index)
+        _add_collection_row(index, "sale-late", tralbum_id="777", added_at=3000.0)
+        _add_collection_row(index, "sale-early", tralbum_id="777", added_at=2000.0)
+        index.attribute_crate_purchases()
+        assert self._row(index, item)["purchased_sale_item_id"] == "sale-early"
+
+    def test_a_buffered_candidate_is_attributed_but_not_celebrated(
+        self, index: LibraryIndex
+    ) -> None:
+        """The schema depends on this: a buffered candidate that gains a purchased
+        event becomes unsweepable by KAMP-657's TTL sweep, so the attribution
+        outlives the candidate. But congratulating someone on a record we never
+        showed them is nonsense, so it is not offered for a toast.
+        """
+        item = self._pick(index, crate_no=None)
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=2000.0)
+
+        attributed = index.attribute_crate_purchases()
+
+        assert self._row(index, item)["state"] == "purchased"
+        assert len(self._events(index)) == 1
+        assert [a["id"] for a in attributed if a["shown"]] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -927,6 +927,44 @@ class TestServerWiring:
         )
         assert calls and calls[0][1] is True
 
+    def test_purchase_notification_broadcasts_the_album_not_just_an_id(
+        self, index: LibraryIndex
+    ) -> None:
+        """The crate snapshot only ever rebuilds the LATEST crate, so a pick
+        bought out of an older one has no card to read artist/title from. The
+        toast has to be self-contained (KAMP-654)."""
+        engine = MagicMock()
+        # The WS accept frame reads real numbers off the engine; a bare MagicMock
+        # makes the position extrapolation compare a mock with an int.
+        engine.state.playing = False
+        engine.state.duration = 0.0
+        engine.state.position = 0.0
+        engine.state.position_updated_at = 0.0
+        queue = MagicMock()
+        queue.current.return_value = None
+        queue.peek_next.return_value = None
+
+        from kamp_core.server import create_app
+
+        app = create_app(index=index, engine=engine, queue=queue)
+        sent: list[dict[str, Any]] = []
+        # Captured through a real WS client rather than by reaching into internals.
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/ws") as ws:
+                ws.receive_json()  # accept frame
+                app.state.notify_crate_purchase(
+                    [{"id": 7, "artist": "abracadabra", "title": "peel away"}]
+                )
+                for _ in range(20):
+                    msg = ws.receive_json()
+                    if msg.get("type") == "discovery.purchased":
+                        sent.append(msg)
+                        break
+        assert sent, "no discovery.purchased frame was broadcast"
+        assert sent[0]["items"] == [
+            {"id": 7, "artist": "abracadabra", "title": "peel away"}
+        ]
+
     def test_a_server_without_a_writer_503s_rather_than_500s(
         self, index: LibraryIndex
     ) -> None:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -641,6 +641,98 @@ class TestMarkSynced:
         mock_mark.assert_called_once()
 
 
+class TestCollectionSyncedCallback:
+    """KAMP-654: the hook purchase attribution hangs off."""
+
+    def test_fires_after_a_sync(self, tmp_path: Path) -> None:
+        _seed_collection_db(tmp_path)
+        fired: list[int] = []
+        with patch("kamp_daemon.syncer._spawn_worker", side_effect=_noop_worker):
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+                syncer.on_collection_synced = lambda: fired.append(1)
+                syncer.sync_once()
+        assert fired == [1]
+
+    def test_fires_exactly_once_for_sync_all_purchases(self, tmp_path: Path) -> None:
+        """sync_all_purchases() delegates to sync_once() in both modes, so a
+        second fire site there would double-fire — and double-attribute."""
+        _seed_collection_db(tmp_path)
+        fired: list[int] = []
+        with patch("kamp_daemon.syncer._spawn_worker", side_effect=_noop_worker):
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+                syncer.on_collection_synced = lambda: fired.append(1)
+                syncer.sync_all_purchases()
+        assert fired == [1]
+
+    def test_does_not_fire_before_the_sync_that_produces_purchases(
+        self, tmp_path: Path
+    ) -> None:
+        """mark_synced() is called from INSIDE sync_once()'s first-run branch.
+
+        Firing there would run attribution against a collection that has just been
+        wholesale marked as already-owned, before the sync that would actually
+        bring in a new purchase — so the one fire must come after both.
+        """
+        fired_at: list[str] = []
+
+        def _recording_worker(
+            target: Any, args: tuple[Any, ...]
+        ) -> tuple[Any, Any, Any, Any]:
+            fired_at.append(f"worker:{target.__name__}")
+            status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q.put(("ok", []))
+            return _FakeProc(), status_q, log_q, result_q
+
+        # No collection rows => sync_once() takes the first-run auto-mark branch.
+        with patch("kamp_daemon.syncer._spawn_worker", side_effect=_recording_worker):
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+                syncer.on_collection_synced = lambda: fired_at.append("callback")
+                syncer.sync_once()
+
+        assert fired_at.count("callback") == 1
+        assert fired_at[-1] == "callback", "must fire after every worker has run"
+
+    def test_a_raising_listener_does_not_fail_the_sync(self, tmp_path: Path) -> None:
+        """The collection is already written; this is bookkeeping on top of it."""
+        _seed_collection_db(tmp_path)
+        with patch("kamp_daemon.syncer._spawn_worker", side_effect=_noop_worker):
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+
+                def _boom() -> None:
+                    raise RuntimeError("no")
+
+                syncer.on_collection_synced = _boom
+                syncer.sync_once()  # must not raise
+
+    def test_does_not_fire_when_the_sync_failed(self, tmp_path: Path) -> None:
+        """Nothing was written, so there is nothing to attribute."""
+        _seed_collection_db(tmp_path)
+        fired: list[int] = []
+
+        def _failing_worker(
+            target: Any, args: tuple[Any, ...]
+        ) -> tuple[Any, Any, Any, Any]:
+            status_q: _queue_module.Queue[str] = _queue_module.Queue()
+            log_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q: _queue_module.Queue[Any] = _queue_module.Queue()
+            result_q.put(("error", "boom"))
+            return _FakeProc(), status_q, log_q, result_q
+
+        with patch("kamp_daemon.syncer._spawn_worker", side_effect=_failing_worker):
+            with patch("kamp_daemon.syncer._state_dir", return_value=tmp_path):
+                syncer = Syncer(_make_config(tmp_path))
+                syncer.on_collection_synced = lambda: fired.append(1)
+                with pytest.raises(RuntimeError):
+                    syncer.sync_once()
+        assert fired == []
+
+
 class TestSyncAllPurchases:
     def test_resets_collection_sync_state_before_sync(self, tmp_path: Path) -> None:
         """sync_all_purchases() nulls synced_at for all rows and runs sync with skip_auto_mark."""


### PR DESCRIPTION
## Summary

When you buy an album the Crate recommended, kamp now notices — links the collection row back to the pick, records it in the ledger, and says so once.

This is the epic's third engagement metric, and the one the brand principles name as the *only* success measure worth having. It unblocks KAMP-655, whose headline "brought home" number would otherwise read 0 forever.

| Commit | What |
| --- | --- |
| C1 | The attribution join, and the guards that stop it lying |
| C2 | Where it runs — one fire point, in the parent |
| C3 | The toast, and a state-masking bug the ticket walks into |

Filed as a Side; taken as an **LP**. The Side assumed the schema had done the work — it had done about half, and the ticket's own acceptance criterion walks straight into a UI bug.

## The join is easy. Every guard on it is a defect I found by reading.

Each of these is a *silent wrong answer* rather than a crash, which is why none is optional.

**The ownership exclusion is not airtight.** `bandcamp_collection.tralbum_id` is lazily backfilled, and the gather-time owned set reads `collection_purchase_dates()` — which itself filters out blank `tralbum_id`s. So an album owned since before the migration, with a blank id and any edition difference in its title, passes both that filter *and* `in_library`'s NOCASE fallback, gets dug, and is then congratulated the moment a later sync backfills its id. The fix — `added_at >= first_seen_at` — is exact: buying it before we showed it is proof we didn't sell it.

**`added_at == 0` is a permanent pre-owned marker.** `mark_collection_synced` writes it, and `upsert_collection_item` merges with `MIN()`, so once 0 it can never become non-zero. Exact, not heuristic.

**The join can match on empty string.** Both id columns are `NOT NULL DEFAULT ''` and `normalise_item_id` returns `""` for falsy input, so one empty-id discovery row would attribute *every* un-backfilled collection row to it. Your real library has 2 such rows — this is live, not theoretical.

**`tralbum_id` is not unique** (gift, re-purchase), so `MIN(added_at)` picks deterministically.

## Two deliberate deviations from the ticket

**The idempotency key is the ledger, not `purchased_at`.** `clear_bandcamp_collection()` nulls `purchased_sale_item_id` and leaves `purchased_at` set — asserted in an existing test — so keying on the column would orphan the FK permanently after an account reset. Keying on the event lets the column re-heal on the next walk without appending a second event, and a re-heal isn't reported as a new purchase, because it isn't one.

**Attribution ignores `crate_no`; only the *toast* is gated on it.** The schema comment is explicit that a buffered candidate bought independently must still gain its event — that's what makes the row unsweepable by KAMP-657's TTL sweep. But congratulating someone on a record we never showed them is nonsense, so the two concerns are split rather than one being picked.

## One fire point, not three

There appear to be three collection-walking entry points. `sync_all_purchases()` delegates to `sync_once()` in both modes, and `mark_synced()` is invoked from *inside* `sync_once()`'s first-run branch — so hooking all three would double-fire, and hooking `mark_synced` would fire *before* the sync that produces the purchases, against a collection just wholesale marked as already-owned. The single site where both result branches converge covers all three. Tests pin it: one fire for `sync_all_purchases`, and the callback lands last of all.

It runs in the **parent** — the child can't broadcast, its index is closed in a `finally`, and marshalling a payload back through `result_q` to do the same pure-DB work in the parent anyway is strictly worse.

## The bug the acceptance criteria walk into

The AC says *"wishlisted-elsewhere-then-purchased still attributes"* and stops there. But `state` is a single-slot rank cache and `purchased` (rank 4) **masks** `wishlisted` (rank 3) — so the moment a wishlisted pick is attributed, the heart un-fills and the next `W` press POSTs an **add** for a record already on your Bandcamp wishlist.

Rather than add a second ledger-derived field to see around the masking, a purchased pick simply stops being offered the toggle: the action reads "In your collection" and both the button and the key are inert. That sidesteps it entirely and is the better answer anyway. The key needed its own guard — disabling the button alone would leave `W` walking past it.

## KAMP-436, and a test instead of a memory

A new `Syncer` callback needs a matching wrapper property or the daemon's assignment lands on a dead attribute and the feature no-ops silently. Rather than just add the pair, **a test now enumerates every `Syncer` callback and asserts each has one** — the landmine is that the failure is invisible, so "remember to add a wrapper" is a bad control and "fail a test" is a good one. Verified by adding the callback to `Syncer` first and watching the enumeration test fail before the wrapper existed.

## Test plan

- [x] `poetry run pytest` — **3154 passed, 9 skipped, 3 deselected**, coverage **93.77%**
- [x] `black`, `mypy`, `npm run typecheck`, `npm run lint` clean
- [x] **Validated on a copy of your real library** — 836 collection rows against 90 real picks. One attribution, and a true one: *abracadabra — peel away*, shown in crate 2 at 15:16 on 7 Aug, bought **4.1 hours later**, event back-dated to the sale rather than to the sync a day after. Second run attributed nothing.
- [x] Falsified the `added_at > 0` guard, the empty-string guard, and the ticket's `purchased_at` idempotency key — each fails the test that claims to cover it

**Falsification caught a vacuous test of my own.** With a realistic fixture the mark-synced case was being rejected by the *timestamp* guard, so deleting the `added_at > 0` guard changed nothing and the test passed for the wrong reason. It now pins `first_seen_at` to 0 to isolate the guard, and says why in the docstring.

## Deliberately not done

**The lineage surface** ("Pulled from a crate, Aug 2026"). The ticket marks it optional; it's a new AlbumDetail surface for a nicety and the epic has several stories left. The FK it would read is written and correct, so it stays cheap to add later.

**A README section for the Crate.** Still no drift — the feature list has never mentioned discovery. That gap is epic-level and wants writing once, when KAMP-643 closes.

## Manual test plan

- Buy a record from a crate on bandcamp.com, then sync. One "Good ear." toast naming the album; the card shows it brought home.
- Sync again immediately. No second toast, no second event.
- Buy two picks and sync once: a single aggregated toast, both cards updated.
- Wishlist a pick, then buy it, then sync: the card reads as brought home and offers **no** wishlist toggle — pressing `W` on it must do nothing.
- Disconnect and reconnect Bandcamp, then sync: no repeat toast, and the lineage link is restored rather than left null.
- Most important: confirm nothing in your existing 836-album collection is retroactively congratulated. The dry run above says one item attributes and it's a genuine 4-hour-old purchase, but worth seeing on the real thing.

Closes KAMP-654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
