### PR TITLE
KAMP-655: digging history — user-visible engagement stats

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -215,6 +215,17 @@ def register_discovery_routes(
             # be the previous crate's.
             snap["filled"] = len(items)
             snap["short"] = bool(items) and len(items) < CRATE_SIZE
+        # The digging history rides along rather than being fetched separately
+        # (KAMP-655). Five COUNTs over two small indexed tables, against a
+        # snapshot that already reads every row of the crate -- so the numbers
+        # are live with no second request and no staleness, and the end-of-crate
+        # tally cannot drift from the lifetime line.
+        snap["stats"] = index.discovery_stats()
+        # Scoped to the crate on screen, which is always the LATEST one -- see
+        # crate_no above. If crate browsing ever arrives this has to follow it.
+        snap["crate_stats"] = (
+            index.discovery_stats(crate_no=crate_no) if crate_no is not None else None
+        )
         return snap
 
     def _publish(fields: dict[str, Any]) -> None:
@@ -269,6 +280,41 @@ def register_discovery_routes(
             logger.exception("discovery: could not start a crate build")
             raise HTTPException(status_code=500, detail="could not start the build")
         return {"started": True}
+
+    # ------------------------------------------------------------------
+    # Digging history (KAMP-655)
+    # ------------------------------------------------------------------
+
+    @app.get("/api/v1/discovery/stats")
+    def get_discovery_stats() -> dict[str, Any]:
+        """The digging history on its own.
+
+        The crate snapshot already carries these, so the UI does not need this —
+        it is the reconnect path and the answer to "what does kamp know about my
+        digging", which deserves an address of its own rather than being buried
+        in a crate payload. Same function either way, so they cannot disagree.
+        """
+        return {"stats": index.discovery_stats()}
+
+    @app.delete("/api/v1/discovery/history")
+    def clear_discovery_history(forget_seen: bool = False) -> dict[str, Any]:
+        """Erase the digging history. The user's data is theirs to wipe.
+
+        ``forget_seen`` is a materially different act, not a stronger version of
+        the same one: it drops the seen ledger, so records already shown start
+        coming round again. The UI must say that rather than a generic warning.
+        """
+        try:
+            index.clear_discovery_history(forget_seen=forget_seen)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("discovery: could not clear the digging history")
+            raise HTTPException(
+                status_code=500, detail="could not clear the history"
+            ) from exc
+        # Republish: the numbers are on the snapshot, and forget_seen has just
+        # emptied the crate the client is looking at.
+        _publish({})
+        return {"ok": True}
 
     # ------------------------------------------------------------------
     # Per-item engagement

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5159,6 +5159,108 @@ class LibraryIndex:
          GROUP BY d.id
     """
 
+    def discovery_stats(self, crate_no: int | None = None) -> dict[str, int]:
+        """The user's digging history: what they dug, heard, kept and bought.
+
+        Computed on read from ``discovery_events``, the ``get_stats()`` model --
+        there are no counters to drift, and the ledger is the ground truth the
+        schema already promises it is.
+
+        Pass *crate_no* for one crate's tally. Same five counts over a narrower
+        scope, deliberately one function: the end-of-crate summary and the
+        lifetime line cannot disagree if neither has its own query.
+
+        **The counts are not mutually exclusive.** A record previewed, wishlisted
+        and bought appears in all three, because that is the honest account of a
+        dig rather than a bucket it has to be sorted into.
+
+        **Boundary, and it is a product constraint rather than a note.** These
+        may inform how well the criteria mix is working. They must never drive
+        engagement mechanics -- no nudges, no streaks, no notifications, nothing
+        that turns a record shop into a slot machine. The measures that matter
+        are purchases-per-crate and wishlist quality; crates-per-week and session
+        time are explicitly not goals, and a stat added to serve one of those
+        would be the feature turning into the thing it was defined against.
+        """
+        scope = "" if crate_no is None else " AND d.crate_no = :crate_no"
+        args = {"crate_no": crate_no}
+
+        def _count(sql: str) -> int:
+            row = self._conn.execute(sql, args).fetchone()
+            return int(row["c"] if row["c"] is not None else 0)
+
+        # Shown, not merely gathered: "has the user seen this?" is crate_no IS NOT
+        # NULL, so a buffered candidate (KAMP-657) is nobody's history yet.
+        dug = f"FROM discovery_items d WHERE d.crate_no IS NOT NULL{scope}"
+
+        def _with_event(kind: str) -> int:
+            return _count(
+                f"SELECT COUNT(*) AS c {dug} AND EXISTS ("
+                "  SELECT 1 FROM discovery_events e"
+                f"  WHERE e.item_id = d.id AND e.kind = '{kind}')"
+            )
+
+        return {
+            "crates": _count(f"SELECT COUNT(DISTINCT d.crate_no) AS c {dug}"),
+            "records": _count(f"SELECT COUNT(*) AS c {dug}"),
+            # Records previewed, not previews played.
+            "previewed": _with_event("previewed"),
+            # Currently wishlisted: the newest 'wishlisted' is newer than the
+            # newest 'unwishlisted'. NOT a count of 'wishlisted' events, which
+            # would score 3 for one record toggled on/off/on (KAMP-653), and NOT
+            # state = 'wishlisted', because 'purchased' outranks and masks it --
+            # dropping exactly the picks this feature most wants to show.
+            "wishlisted": _count(
+                f"SELECT COUNT(*) AS c {dug} AND ("
+                "  SELECT MAX(e.at) FROM discovery_events e"
+                "   WHERE e.item_id = d.id AND e.kind = 'wishlisted'"
+                ") > COALESCE(("
+                "  SELECT MAX(u.at) FROM discovery_events u"
+                "   WHERE u.item_id = d.id AND u.kind = 'unwishlisted'"
+                "), -1)"
+            ),
+            "purchased": _with_event("purchased"),
+        }
+
+    def clear_discovery_history(self, *, forget_seen: bool = False) -> None:
+        """Erase the digging history. The user's data is theirs to wipe.
+
+        Always clears ``discovery_events`` and everything derived from it.
+        *forget_seen* additionally drops ``discovery_items``, which is a
+        materially different thing and must be presented as one: that table is
+        the **seen ledger**, so dropping it means previously-shown picks start
+        coming round again.
+
+        Order is load-bearing. ``discovery_events.item_id`` is ON DELETE RESTRICT,
+        so the events must go first -- deleting the items first raises. The
+        RESTRICT itself is deliberate (KAMP-645): CASCADE would silently shrink
+        the purchase stats every time KAMP-657's buffer sweep pruned a row, and
+        that sweep relies on RESTRICT to only ever delete event-free rows. For
+        the same reason there are deliberately no append-only triggers here,
+        unlike extension_audit_log -- they would abort the sweep.
+        """
+        try:
+            self._conn.execute("DELETE FROM discovery_events")
+            if forget_seen:
+                self._conn.execute("DELETE FROM discovery_items")
+            else:
+                # Everything derived from the ledger goes with it. state is a
+                # cache of these events, so leaving it set would leave cards
+                # wearing hearts with nothing behind them; and a purchase link
+                # with no event behind it reads to attribute_crate_purchases() as
+                # "attributed but unrecorded", which appends a fresh event on the
+                # next sync.
+                self._conn.execute(
+                    "UPDATE discovery_items"
+                    "   SET state = 'fresh',"
+                    "       purchased_at = NULL,"
+                    "       purchased_sale_item_id = NULL"
+                )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
     def attribute_crate_purchases(self) -> list[dict[str, Any]]:
         """Link newly purchased albums back to the crate picks that offered them.
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -603,9 +603,36 @@ export type CrateSnapshot = {
   hints: string[] // the user's top genres, for the digging status lines
   thin: boolean // a library with no listening history yet — chart picks only
   items: CrateItem[]
+  // KAMP-655: the digging history, computed on read and carried here so the
+  // numbers are live without a second request. `crate_stats` is the same five
+  // counts scoped to this crate — null when there is no crate to tally, which is
+  // different from a crate of zero.
+  stats: DiggingStats
+  crate_stats: DiggingStats | null
+}
+
+// Deliberately not mutually exclusive: a record you previewed, wishlisted and
+// bought counts in all three, because that is the honest account of a dig.
+export type DiggingStats = {
+  crates: number
+  records: number
+  previewed: number
+  wishlisted: number
+  purchased: number
 }
 
 export const getCrate = (): Promise<CrateSnapshot> => get('/api/v1/discovery/crate')
+
+// KAMP-655: the digging history. Also on every crate snapshot, so the UI rarely
+// needs this — it exists as the reconnect path and so "what does kamp know about
+// my digging" has an address of its own.
+export const getDiggingHistory = (): Promise<{ stats: DiggingStats }> =>
+  get('/api/v1/discovery/stats')
+
+// forgetSeen is a materially different act, not a stronger version of the same
+// one: it drops the seen ledger, so records already shown come round again.
+export const clearDiggingHistory = (forgetSeen: boolean): Promise<{ ok: boolean }> =>
+  del(`/api/v1/discovery/history?forget_seen=${forgetSeen ? 'true' : 'false'}`)
 
 // 409 while a crate is already building — postWithDetail keeps the server's
 // message ("a crate is already building") instead of a bare status line.

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -220,6 +220,24 @@
   font-size: 12px;
 }
 
+/* Digging history (KAMP-655). Quiet on purpose: a record of what you have dug,
+   not a scoreboard. Sits under the dig button in the footer. */
+.crate-history {
+  margin: 10px 0 0;
+  color: var(--text-dim);
+  font-size: 12px;
+  text-align: center;
+}
+
+/* The closing beat when you reach the last record. One step less dim than the
+   lifetime line, because it is about what just happened. */
+.crate-tally {
+  margin: 10px 0 0;
+  color: var(--text);
+  font-size: 13px;
+  text-align: center;
+}
+
 .crate-dig-btn {
   border: 1px solid var(--border);
   background: var(--surface);

--- a/kamp_ui/src/renderer/src/components/ClearDiggingHistoryModal.tsx
+++ b/kamp_ui/src/renderer/src/components/ClearDiggingHistoryModal.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+
+type Props = {
+  onConfirm: (forgetSeen: boolean) => void
+  onCancel: () => void
+}
+
+// Confirmation before erasing the digging history (KAMP-655).
+//
+// The checkbox is not a "stronger version" of the same wipe — it is a different
+// act, and the copy has to say which. Clearing the history zeroes the numbers.
+// Forgetting what you have been shown drops the seen ledger, so records already
+// offered start coming round again in future crates. A generic "this cannot be
+// undone" would hide the only consequence the user cannot predict.
+export function ClearDiggingHistoryModal({ onConfirm, onCancel }: Props): React.JSX.Element {
+  const [forgetSeen, setForgetSeen] = useState(false)
+
+  // Esc = implicit Cancel, matching every other modal.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  return (
+    // Click-away backdrop = implicit Cancel.
+    <div className="modal-backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="modal collision-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="clear-digging-history-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="clear-digging-history-title" className="modal-title">
+          Clear digging history
+        </h2>
+        <p className="modal-body">
+          Erase the record of what you&rsquo;ve dug through, previewed, set aside and brought home?
+          The counts go back to zero. This can&rsquo;t be undone.
+        </p>
+        <label className="modal-body" style={{ display: 'flex', gap: 8, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={forgetSeen}
+            onChange={(e) => setForgetSeen(e.target.checked)}
+          />
+          <span>
+            Also forget which records you&rsquo;ve been shown — ones you&rsquo;ve already passed on
+            will come round again.
+          </span>
+        </label>
+        <div className="modal-actions">
+          <button
+            className="modal-btn modal-btn--destructive"
+            onClick={() => onConfirm(forgetSeen)}
+          >
+            Clear
+          </button>
+          <button className="modal-btn modal-btn--primary" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -12,7 +12,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { crateArtUrl } from '../api/client'
-import type { CrateItem } from '../api/client'
+import type { CrateItem, DiggingStats } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
 import { CratePreviewStrip } from './CratePreviewStrip'
 import { formatClock } from '../utils/formatClock'
@@ -29,6 +29,30 @@ function formatPause(seconds: number): string {
   const mins = Math.floor(total / 60)
   const secs = total % 60
   return mins > 0 ? `${mins}:${String(secs).padStart(2, '0')}` : `${secs}s`
+}
+
+const plural = (n: number, word: string): string => `${n} ${word}${n === 1 ? '' : 's'}`
+
+// The lifetime line. Everything the user has dug, in the clerk's register:
+// concrete counts, no percentages, nothing that reads as a score to beat.
+function describeHistory(s: DiggingStats): string {
+  const parts = [plural(s.crates, 'crate') + ' dug', plural(s.records, 'record')]
+  if (s.previewed > 0) parts.push(`${s.previewed} previewed`)
+  if (s.wishlisted > 0) parts.push(`${s.wishlisted} set aside`)
+  if (s.purchased > 0) parts.push(`${s.purchased} brought home`)
+  return parts.join(' · ')
+}
+
+// One crate's tally. Omits the zeroes: "0 brought home" at the end of a crate
+// reads as a reprimand, which is the opposite of what this is for.
+function describeTally(s: DiggingStats): string {
+  const parts: string[] = []
+  if (s.previewed > 0) parts.push(`${s.previewed} previewed`)
+  if (s.wishlisted > 0) parts.push(`${s.wishlisted} set aside`)
+  if (s.purchased > 0) parts.push(`${s.purchased} brought home`)
+  return parts.length > 0
+    ? `${plural(s.records, 'record')} — ${parts.join(', ')}.`
+    : `${plural(s.records, 'record')}.`
 }
 
 export function CrateView({ active = false }: { active?: boolean }): React.JSX.Element {
@@ -101,6 +125,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // is owned sidesteps the masking entirely, and is the better answer anyway:
   // you do not wishlist something you already have.
   const purchased = current?.state === 'purchased'
+
+  // KAMP-655. Both ride the crate snapshot, so they are live without a fetch and
+  // the tally cannot drift from the lifetime line.
+  const history = crate?.stats ?? null
+  const crateTally = crate?.crate_stats ?? null
+  const atLastRecord = visible.length > 1 && focusIndex === visible.length - 1
 
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
@@ -350,6 +380,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             </>
           )}
           {digButton}
+          {/* Also here: the empty state is its own early return, and a first-run
+              user with nothing dug yet should not see a row of zeroes. */}
+          {history && history.records > 0 && (
+            <p className="crate-history">{describeHistory(history)}</p>
+          )}
         </div>
       </div>
     )
@@ -530,7 +565,18 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           ))}
         </ul>
 
-        <div className="crate-footer">{digButton}</div>
+        <div className="crate-footer">
+          {digButton}
+          {/* The closing beat, at the moment the user has actually just done the
+              digging rather than as a running score. Only worth showing for a
+              crate with more than one record in it. */}
+          {atLastRecord && crateTally && (
+            <p className="crate-tally" role="status">
+              That&rsquo;s the crate. {describeTally(crateTally)}
+            </p>
+          )}
+          {history && <p className="crate-history">{describeHistory(history)}</p>}
+        </div>
 
         {/* The clerk card lives on the focus card, so arrowing the rail would
             otherwise never announce it: the option's own aria-label and

--- a/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
+++ b/kamp_ui/src/renderer/src/components/PreferencesDialog.tsx
@@ -4,7 +4,13 @@ import type { PrefsTab } from '../store'
 import type { ExtensionInfo, ExtensionSettingSchema } from '../../../shared/kampAPI'
 import type { ExtensionStateHook } from '../hooks/useExtensionState'
 import { useExtensionInstall } from '../hooks/useExtensionInstall'
-import { connectLastfm, disconnectLastfm, disconnectBandcamp } from '../api/client'
+import {
+  connectLastfm,
+  disconnectLastfm,
+  disconnectBandcamp,
+  clearDiggingHistory
+} from '../api/client'
+import { ClearDiggingHistoryModal } from './ClearDiggingHistoryModal'
 import { DiscordIcon } from './TransportIcons'
 import { GenreManagementSection } from './GenreManagementSection'
 
@@ -682,6 +688,8 @@ function BandcampSection({
 }): React.JSX.Element {
   const [busy, setBusy] = useState(false)
   const [syncAllBusy, setSyncAllBusy] = useState(false)
+  const [clearingHistory, setClearingHistory] = useState(false)
+  const [clearBusy, setClearBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const handleConnect = async (): Promise<void> => {
@@ -711,6 +719,21 @@ function BandcampSection({
       setError(e instanceof Error ? e.message : 'Disconnect failed.')
     } finally {
       setBusy(false)
+    }
+  }
+
+  const handleClearHistory = async (forgetSeen: boolean): Promise<void> => {
+    setClearingHistory(false)
+    setClearBusy(true)
+    setError(null)
+    try {
+      await clearDiggingHistory(forgetSeen)
+      // No local state to update: the daemon republishes the crate snapshot,
+      // which is where the numbers live.
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not clear the digging history.')
+    } finally {
+      setClearBusy(false)
     }
   }
 
@@ -794,6 +817,34 @@ function BandcampSection({
             </span>
           </div>
         </div>
+      )}
+      {/* Digging history (KAMP-655). Here rather than in the Crate view because
+          this is where the user is already asking who has their data — and it is
+          where the privacy line belongs, stated once, next to the thing that
+          proves it. */}
+      <div className="prefs-row">
+        <div className="prefs-row-header">
+          <span className="prefs-label">Digging history</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <button
+            className="prefs-choose-btn"
+            onClick={() => setClearingHistory(true)}
+            disabled={clearBusy}
+          >
+            {clearBusy ? 'Clearing…' : 'Clear digging history'}
+          </button>
+          <span className="prefs-hint">
+            Your digging history lives in your library database on this machine. It&rsquo;s never
+            sent anywhere.
+          </span>
+        </div>
+      </div>
+      {clearingHistory && (
+        <ClearDiggingHistoryModal
+          onConfirm={(forgetSeen) => void handleClearHistory(forgetSeen)}
+          onCancel={() => setClearingHistory(false)}
+        />
       )}
     </>
   )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -548,6 +548,236 @@ class TestPurchaseAttribution:
 
 
 # ---------------------------------------------------------------------------
+# Digging history (KAMP-655)
+# ---------------------------------------------------------------------------
+
+
+class TestDiggingHistory:
+    """The collector's journal: what the user has dug, and erasing it.
+
+    The counts are deliberately NOT mutually exclusive. A record you previewed,
+    wishlisted and bought counts in all three, because that is the honest story
+    of your digging rather than a bucket it has to be sorted into.
+    """
+
+    def _dig(
+        self,
+        index: LibraryIndex,
+        crate_no: int,
+        position: int,
+        provider_item_id: str,
+    ) -> int:
+        item = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id=provider_item_id
+        )
+        index.place_in_crate(item, crate_no, position)
+        return item
+
+    def test_an_untouched_library_is_all_zeroes_not_an_error(
+        self, index: LibraryIndex
+    ) -> None:
+        stats = index.discovery_stats()
+        assert stats == {
+            "crates": 0,
+            "records": 0,
+            "previewed": 0,
+            "wishlisted": 0,
+            "purchased": 0,
+        }
+
+    def test_counts_crates_and_records_dug_through(self, index: LibraryIndex) -> None:
+        self._dig(index, 1, 0, "a")
+        self._dig(index, 1, 1, "b")
+        self._dig(index, 2, 0, "c")
+        stats = index.discovery_stats()
+        assert stats["crates"] == 2
+        assert stats["records"] == 3
+
+    def test_a_buffered_candidate_counts_in_neither(self, index: LibraryIndex) -> None:
+        """ "Has the user seen this" is crate_no IS NOT NULL, not row existence.
+        A gathered-but-never-shown candidate is not part of anyone's history."""
+        self._dig(index, 1, 0, "a")
+        index.add_discovery_candidate(provider="bandcamp", provider_item_id="buffered")
+        stats = index.discovery_stats()
+        assert stats["crates"] == 1
+        assert stats["records"] == 1
+
+    def test_previewing_the_same_record_twice_counts_once(
+        self, index: LibraryIndex
+    ) -> None:
+        """Records previewed, not previews played."""
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "previewed")
+        index.record_discovery_event(item, "previewed")
+        assert index.discovery_stats()["previewed"] == 1
+
+    def test_wishlisting_and_un_wishlisting_nets_out(self, index: LibraryIndex) -> None:
+        """The count is what is on your wishlist NOW.
+
+        Counting 'wishlisted' events would score 3 for one record toggled on, off
+        and on again — KAMP-653 made that reachable and this story predates it.
+        """
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "unwishlisted")
+        assert index.discovery_stats()["wishlisted"] == 0
+
+        index.record_discovery_event(item, "wishlisted")
+        assert index.discovery_stats()["wishlisted"] == 1
+
+    def test_a_wishlisted_record_that_was_bought_still_counts_as_both(
+        self, index: LibraryIndex
+    ) -> None:
+        """The masked-cache case, and why these are ledger-derived.
+
+        discovery_items.state is a single-slot rank cache: 'purchased' (rank 4)
+        masks 'wishlisted' (rank 3). Counting state would silently drop every
+        pick the user wishlisted and then bought out of the wishlist number —
+        exactly the records the feature most wants to show.
+        """
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "wishlisted")
+        index.record_discovery_event(item, "purchased")
+        state = index._conn.execute(
+            "SELECT state FROM discovery_items WHERE id = ?", (item,)
+        ).fetchone()["state"]
+        assert state == "purchased", "guards the premise of this test"
+
+        stats = index.discovery_stats()
+        assert stats["wishlisted"] == 1
+        assert stats["purchased"] == 1
+
+    def test_dismissing_does_not_reduce_what_you_dug_through(
+        self, index: LibraryIndex
+    ) -> None:
+        """Passing on a record is still digging through it."""
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "dismissed")
+        assert index.discovery_stats()["records"] == 1
+
+    def test_scoping_to_one_crate(self, index: LibraryIndex) -> None:
+        """The end-of-crate tally is the same query over a narrower scope, which
+        is what makes it impossible for the two to disagree."""
+        first = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(first, "previewed")
+        second = self._dig(index, 2, 0, "b")
+        index.record_discovery_event(second, "wishlisted")
+
+        tally = index.discovery_stats(crate_no=2)
+        assert tally["crates"] == 1
+        assert tally["records"] == 1
+        assert tally["previewed"] == 0
+        assert tally["wishlisted"] == 1
+
+    def test_lifetime_and_per_crate_agree_for_a_single_crate_library(
+        self, index: LibraryIndex
+    ) -> None:
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "previewed")
+        assert index.discovery_stats() == index.discovery_stats(crate_no=1)
+
+    # -- erasing it ------------------------------------------------------
+
+    def test_clearing_stats_zeroes_the_numbers_but_keeps_the_records(
+        self, index: LibraryIndex
+    ) -> None:
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "previewed")
+        index.record_discovery_event(item, "wishlisted")
+
+        index.clear_discovery_history(forget_seen=False)
+
+        assert index.discovery_stats() == {
+            "crates": 1,
+            "records": 1,
+            "previewed": 0,
+            "wishlisted": 0,
+            "purchased": 0,
+        }
+        assert index.seen_before("bandcamp", "a") is True
+
+    def test_clearing_stats_resets_the_state_cache(self, index: LibraryIndex) -> None:
+        """state is a cache of discovery_events. Leaving it set after wiping the
+        ledger leaves cards wearing hearts with nothing behind them."""
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "wishlisted")
+        index.clear_discovery_history(forget_seen=False)
+        assert index.crate_items(1)[0]["state"] == "fresh"
+
+    def test_clearing_stats_also_clears_the_purchase_link(
+        self, index: LibraryIndex
+    ) -> None:
+        """Left set with no event behind it, KAMP-654's guard reads "attributed
+        but unrecorded" and appends a fresh event on the next sync."""
+        item = self._dig(index, 1, 0, "777")
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=9e9)
+        index.attribute_crate_purchases()
+
+        index.clear_discovery_history(forget_seen=False)
+
+        row = index._conn.execute(
+            "SELECT purchased_sale_item_id, purchased_at FROM discovery_items"
+            " WHERE id = ?",
+            (item,),
+        ).fetchone()
+        assert row["purchased_sale_item_id"] is None
+        assert row["purchased_at"] is None
+
+    def test_a_stats_wipe_lets_the_purchase_be_re_derived(
+        self, index: LibraryIndex
+    ) -> None:
+        """Pinned as intended behaviour, not a bug.
+
+        The purchase really did happen and the ledger is ground truth, so after
+        erasing the ledger kamp re-learns what it still can from the collection.
+        Suppressing it would mean keeping a shadow copy of the history the user
+        just asked to erase, which is the opposite of the point.
+        """
+        self._dig(index, 1, 0, "777")
+        _add_collection_row(index, "sale-1", tralbum_id="777", added_at=9e9)
+        index.attribute_crate_purchases()
+        index.clear_discovery_history(forget_seen=False)
+
+        again = index.attribute_crate_purchases()
+        assert len(again) == 1
+        assert index.discovery_stats()["purchased"] == 1
+
+    def test_clearing_everything_makes_old_picks_eligible_again(
+        self, index: LibraryIndex
+    ) -> None:
+        self._dig(index, 1, 0, "a")
+        index.clear_discovery_history(forget_seen=True)
+        assert index.discovery_stats()["records"] == 0
+        assert index.seen_before("bandcamp", "a") is False
+
+    def test_clearing_everything_removes_the_events_first(
+        self, index: LibraryIndex
+    ) -> None:
+        """discovery_events.item_id is ON DELETE RESTRICT, so deleting the items
+        first raises. The order is load-bearing, not incidental."""
+        item = self._dig(index, 1, 0, "a")
+        index.record_discovery_event(item, "previewed")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            index._conn.execute("DELETE FROM discovery_items")
+        index._conn.rollback()
+
+        index.clear_discovery_history(forget_seen=True)
+        assert (
+            index._conn.execute(
+                "SELECT COUNT(*) AS c FROM discovery_events"
+            ).fetchone()["c"]
+            == 0
+        )
+
+    def test_clearing_an_empty_history_is_not_an_error(
+        self, index: LibraryIndex
+    ) -> None:
+        index.clear_discovery_history(forget_seen=True)
+        index.clear_discovery_history(forget_seen=False)
+
+
+# ---------------------------------------------------------------------------
 # seen_before / in_library
 # ---------------------------------------------------------------------------
 

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -295,6 +295,79 @@ class TestItemEvents:
 
 
 # ---------------------------------------------------------------------------
+# Digging history (KAMP-655)
+# ---------------------------------------------------------------------------
+
+
+class TestDiggingHistoryRoutes:
+    def test_the_snapshot_carries_the_history(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """Riding the snapshot is what keeps the numbers live without a second
+        request, and what stops the tally and the lifetime line disagreeing."""
+        _stock(index, 1, count=2)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["stats"]["records"] == 2
+        assert body["crate_stats"]["records"] == 2
+
+    def test_an_empty_library_reports_no_crate_stats(self, harness: _Harness) -> None:
+        """There is no crate to tally, which is different from a crate of zero."""
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["stats"]["records"] == 0
+        assert body["crate_stats"] is None
+
+    def test_the_endpoint_and_the_snapshot_agree(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1, count=3)
+        endpoint = harness.client.get("/api/v1/discovery/stats").json()["stats"]
+        snapshot = harness.client.get("/api/v1/discovery/crate").json()["stats"]
+        assert endpoint == snapshot
+
+    def test_the_numbers_move_with_an_event(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1, count=2)
+        item = index.crate_items(1)[0]["id"]
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+        assert harness.events[-1]["stats"]["wishlisted"] == 1
+
+    def test_clearing_stats_keeps_the_crate(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1, count=2)
+        item = index.crate_items(1)[0]["id"]
+        harness.client.post(f"/api/v1/discovery/items/{item}/wishlist")
+
+        resp = harness.client.delete("/api/v1/discovery/history")
+
+        assert resp.status_code == 200
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["stats"]["wishlisted"] == 0
+        assert body["stats"]["records"] == 2, "the records themselves stay"
+        assert len(body["items"]) == 2
+
+    def test_clearing_everything_empties_the_crate(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        _stock(index, 1, count=2)
+        harness.client.delete("/api/v1/discovery/history?forget_seen=true")
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["items"] == []
+        assert body["stats"]["records"] == 0
+        assert index.seen_before("bandcamp", "1-0") is False
+
+    def test_clearing_republishes_so_open_clients_update(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """Without this the numbers stay on screen until something else moves."""
+        _stock(index, 1, count=2)
+        harness.events.clear()
+        harness.client.delete("/api/v1/discovery/history")
+        assert harness.events[-1]["stats"]["records"] == 2
+
+
+# ---------------------------------------------------------------------------
 # Wishlist write (KAMP-653)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The Crate now shows what you've dug — and Preferences lets you erase it.

On your real library that reads **9 crates dug · 90 records · 13 previewed · 2 set aside · 1 brought home**.

The epic's planning decision was to invert engagement stats from hidden telemetry into a **digging history the user owns**. This reads the `discovery_events` ledger back, which only became complete last commit: `shown`/`previewed` from KAMP-650/651, `wishlisted`/`unwishlisted` from KAMP-653, `purchased` from KAMP-654.

| Commit | What |
| --- | --- |
| C1 | The aggregate queries, and `clear_discovery_history` |
| C2 | Stats on the snapshot, the two routes, and the UI |

Filed as a Side; taken as an **LP** with @tterry's agreement, having chosen to build the end-of-crate tally rather than strike the clause.

## "Wishlisted" was the one real question, and both obvious answers are wrong

The ticket predates the wishlist toggle. Each naive query fails the test the other passes — verified by falsification, not by argument:

- **`COUNT` of `wishlisted` events over-counts.** One record toggled on, off and on again scores 3. KAMP-653 made that reachable.
- **`state = 'wishlisted'` under-counts.** `state` is a single-slot rank cache and `purchased` (rank 4) **masks** `wishlisted` (rank 3) — so every pick you wishlisted *and then bought* silently drops out of the wishlist number. Exactly the records this feature most wants to show.

So it counts records whose newest `wishlisted` is newer than their newest `unwishlisted`: retraction-aware, and reading nothing from the masked cache. **This corrects the recommendation I left on the ticket** before KAMP-654 existed to do the masking — state-based was right until it wasn't.

The counts are also deliberately **not mutually exclusive**. A record you previewed, wishlisted and bought counts in all three, because that's the honest account of a dig rather than a bucket it has to be sorted into.

## Two clauses in the ticket that no longer held

**"Also feeds the end-of-crate tally in KAMP-650"** — there wasn't one. KAMP-650 shipped the empty and error states and no tally, so "consistent with the same queries" had nothing to be consistent with. You chose to build it, so it's here: it appears when the focused record is the last one, and it's the *same function* over a narrower scope, which makes the consistency structural rather than checked.

**Both stats surfaces omit their zeroes.** "0 brought home" at the end of a crate reads as a reprimand, which is the opposite of what this is for.

## The two wipes are different acts, and the copy says which

Clearing the history zeroes the numbers. Forgetting what you've been shown drops `discovery_items` — the **seen ledger**, since "has the user seen this?" is `crate_no IS NOT NULL` rather than row existence — so records you've already passed on start coming round again. A generic "this cannot be undone" would hide the only consequence you can't predict, so the checkbox says it plainly.

**Order is load-bearing.** `discovery_events.item_id` is `ON DELETE RESTRICT`, so events go first and deleting items first raises — pinned by a test. That RESTRICT is deliberate: `CASCADE` would silently shrink the purchase stats whenever KAMP-657's buffer sweep pruned a row, and the sweep depends on RESTRICT to only ever delete event-free rows. For the same reason there are still no append-only triggers here.

**A stats-only wipe resets everything derived from the ledger** — `state` back to `'fresh'`, and the purchase link cleared. Leaving `state` set would leave cards wearing hearts with nothing behind them; leaving the purchase link set reads to KAMP-654's guard as "attributed but unrecorded" and appends a fresh event on the next sync.

Which leaves one interaction **pinned as intended rather than engineered around**: after a stats-only wipe, the next sync re-derives the purchase and toasts again. The purchase really did happen, so kamp re-learns what it still can. Suppressing it would mean keeping a shadow copy of the history you just asked to erase.

## The boundary is in the code, not just the ticket

The query function's docstring carries it: these may inform how well the criteria mix is working; they must **never** drive engagement mechanics — no nudges, no streaks, no notifications. Purchases-per-crate and wishlist quality are the measures. Crates-per-week and session time are explicitly not, and a stat added to serve one of those would be the feature turning into the thing it was defined against.

## Test plan

- [x] `poetry run pytest` — **3177 passed, 9 skipped, 3 deselected**, coverage **93.74%**
- [x] `black`, `mypy`, `npm run typecheck`, `npm run lint` clean
- [x] **Falsified the wishlist count both ways** — the event-count version and the state-based version each fail a different test, so the retraction-aware query is the only one that satisfies both
- [x] **Verified on a copy of your real library**: the numbers above; a stats-only wipe zeroes them, resets all 90 items to `fresh` and keeps them known; forgetting what was seen empties both tables with a clean `foreign_key_check`

## Deliberately not done

**A README section for the Crate.** Still no drift — the feature list has never mentioned discovery. The epic has KAMP-656/657 and several others outstanding, so that section wants writing once, when KAMP-643 actually closes.

## Manual test plan

- Open the Crate. The footer should read your real history — you have 1 brought home already.
- Dig through to the last record: the tally should close the crate out with what you just did.
- Pass one record and wishlist another: the numbers should move without a reload.
- Preferences → Clear digging history, leaving the checkbox **unticked**. Numbers zero, hearts drop off the cards, and the records themselves stay — dig again and you shouldn't see them offered.
- Do it again **with** the checkbox ticked, then dig: previously-seen picks should start coming round.
- Read the privacy line and confirm it's true of everything you just did.

Closes KAMP-655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
