### PR TITLE
KAMP-656 (prototype): the bin — flip, settle, and a crate spine name

### DIFF
--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -312,10 +312,18 @@
      Any other origin makes the flip look like a card turning over. */
   transform-origin: 50% 100%;
   /* Standing in the bin: stepped back from the record you are looking at, and
-     leaning. Relative to focus, so the stack advances as you flip instead of the
-     focused record pulling away from a bin that never moves. */
+     leaning BACK. Relative to focus, so the stack advances as you flip instead
+     of the focused record pulling away from a bin that never moves.
+
+     The lean is POSITIVE, and the sign is the whole point. CSS's +Y axis points
+     DOWN, so rotateX(positive) takes the bottom toward the viewer and the top
+     away — a record leaning back into the crate. A negative lean does the
+     opposite: every record behind tips its top toward you and crosses in front
+     of the one you are looking at, which is exactly the band of someone else's
+     art that appeared across the top of the focused sleeve once the sleeves got
+     big enough to notice. */
   transform: translateZ(calc(var(--bin-rel) * var(--bin-depth-step) * -1))
-    translateY(calc(var(--bin-rel) * -2px)) rotateX(calc(var(--bin-lean) * -1));
+    translateY(calc(var(--bin-rel) * -2px)) rotateX(var(--bin-lean));
   will-change: transform;
 }
 
@@ -341,9 +349,12 @@
     translateY(calc(var(--bin-order) * -1px - 4px)) rotateX(-96deg);
 }
 
-/* The one you are looking at: upright and forward of the rest. */
+/* The one you are looking at: upright and forward of the rest. A touch of the
+   same backward lean rather than a forward one, so it never tips into the record
+   behind it — being pulled forward is carried by translateZ, not by tilting at
+   the viewer. */
 .bin-sleeve--focused {
-  transform: translateZ(18px) translateY(-6px) rotateX(-4deg);
+  transform: translateZ(18px) translateY(-6px) rotateX(3deg);
 }
 
 .bin-sleeve-art {
@@ -925,7 +936,7 @@
       /* Dropped in from above and slightly behind, so it arrives into its slot
          rather than sliding across the front of the ones already filed. */
       transform: translateZ(calc(var(--bin-rel) * var(--bin-depth-step) * -1))
-        translateY(calc(var(--bin-rel) * -2px - 40px)) rotateX(calc(var(--bin-lean) * -1));
+        translateY(calc(var(--bin-rel) * -2px - 40px)) rotateX(var(--bin-lean));
     }
     to {
       opacity: 1;

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -435,22 +435,26 @@
    handwritten-adjacent face is allowed, small and once — the typeface is a
    seasoning, not a theme. */
 .crate-bin-spine {
-  margin: 10px auto 0;
+  /* Above the records, because the card stands at the BACK of the bin — you
+     read it over their tops. The tab is therefore clipped on its top corners
+     and open at the bottom, where the card continues down behind the sleeves. */
+  margin: 0 auto 8px;
   width: fit-content;
   max-width: 90%;
-  padding: 4px 14px 5px;
+  padding: 4px 14px 6px;
   text-align: center;
   font-size: 11px;
   letter-spacing: 0.1em;
   color: var(--text-dim);
-  /* Kraft: a warm wash over the theme surface, plus the tab notch that makes it
-     read as a divider rather than a caption. */
+  /* Kraft: a warm wash over the theme surface rather than a hardcoded tan,
+     which would be wrong in seven of the eight palettes. */
   background:
-    linear-gradient(0deg, rgb(0 0 0 / 8%), rgb(0 0 0 / 0%)), var(--surface-hover);
+    linear-gradient(180deg, rgb(255 255 255 / 6%), rgb(0 0 0 / 10%)),
+    var(--surface-hover);
   border: 1px solid var(--border);
   border-bottom: none;
   border-radius: 3px 3px 0 0;
-  /* The tab: clipped top corners, the way a divider card is cut. */
+  /* The cut of a divider card's tab. */
   clip-path: polygon(0 8px, 8px 0, calc(100% - 8px) 0, 100% 8px, 100% 100%, 0 100%);
 }
 
@@ -648,10 +652,15 @@
   opacity: 0.5;
 }
 
+/* Dig button and the digging-history line, centred in the space between the
+   preview slot above and the app's transport bar below. */
 .crate-footer {
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  padding-top: 4px;
+  gap: 4px;
+  padding-top: 20px;
 }
 
 /* --- Undo toast ----------------------------------------------------------- */
@@ -704,9 +713,17 @@
    pushed the rail down the page the moment a preview started. Sized for the
    strip plus a scrolling track list, so a 3-track single and a 20-track album
    occupy exactly the same room. */
+/* Below the bin since KAMP-656, and centred with it rather than hugging the
+   left edge of the stage — it reads as the deck under the crate, not as a
+   caption on the card.
+
+   The top margin is clearance, not taste: the flipped pile sits forward of
+   everything at the crate lip and is translated up, so it hangs below the bin's
+   own box and would otherwise land on the player. */
 .crate-preview-slot {
   min-height: 236px;
   max-width: 52ch;
+  margin: 44px auto 0;
   display: flex;
   flex-direction: column;
 }
@@ -716,6 +733,7 @@
   color: var(--text-dim);
   font-size: 12px;
   opacity: 0.7;
+  text-align: center;
 }
 
 /* Its own strip rather than the TransportBar: the whole promise is that the

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -281,6 +281,18 @@
   outline: none;
 }
 
+/* TRANSFORM ORDER IS LOAD-BEARING, and getting it wrong is what made the first
+   pile stack upside down.
+ *
+ * `transform: A B C` composes as A×B×C, so the RIGHTMOST function is applied
+ * first, in the element's own space, and everything to its left then operates on
+ * the result. Put translateZ after rotateX(-96deg) and the translation is
+ * rotated too — after a 96 degree tilt it points roughly up and down, not toward
+ * the viewer, so it stops controlling depth at all and the pile stacks by
+ * whatever the browser felt like.
+ *
+ * So: translate first (world space), rotate last. */
+
 .bin-sleeve {
   position: absolute;
   bottom: 0;
@@ -289,22 +301,29 @@
   /* Hinged at the bottom edge, like a record resting on the bottom of a crate.
      Any other origin makes the flip look like a card turning over. */
   transform-origin: 50% 100%;
-  /* Standing in the bin: leaning back, stepped away from the viewer. */
-  transform: rotateX(calc(var(--bin-lean) * -1))
-    translateZ(calc(var(--bin-depth) * var(--bin-depth-step) * -1))
-    translateY(calc(var(--bin-depth) * -2px));
+  /* Standing in the bin: stepped back from the record you are looking at, and
+     leaning. Relative to focus, so the stack advances as you flip instead of the
+     focused record pulling away from a bin that never moves. */
+  transform: translateZ(calc(var(--bin-rel) * var(--bin-depth-step) * -1))
+    translateY(calc(var(--bin-rel) * -2px)) rotateX(calc(var(--bin-lean) * -1));
   will-change: transform;
 }
 
 /* Flipped past: tipped forward past vertical onto the pile at the crate lip.
-   The growing pile IS the progress indicator — there is no separate bar. */
+   The growing pile IS the progress indicator — there is no separate bar.
+ *
+ * Stacked by --bin-order (the absolute index), NOT by position relative to
+ * focus: records land in index order, so record 0 is the bottom of the pile and
+ * every later one lands on top of it. Ordering the pile relative to focus
+ * rebuilds it upside down on every flip, which is exactly what it did. */
 .bin-sleeve--flipped {
-  transform: rotateX(-96deg) translateZ(calc(var(--bin-depth) * 2px)) translateY(-4px);
+  transform: translateZ(calc(var(--bin-order) * 1.6px + 6px))
+    translateY(calc(var(--bin-order) * -1px - 4px)) rotateX(-96deg);
 }
 
 /* The one you are looking at: upright and forward of the rest. */
 .bin-sleeve--focused {
-  transform: rotateX(-4deg) translateZ(18px) translateY(-6px);
+  transform: translateZ(18px) translateY(-6px) rotateX(-4deg);
 }
 
 .bin-sleeve-art {

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -252,8 +252,16 @@
  */
 
 .crate-bin {
+  /* ONE number the rest is derived from. The prototype hardcoded a 132px sleeve
+     and a 180px bin height, which is why the sizing read wrong and why tuning it
+     meant guessing at two unrelated constants. Everything below is a ratio of
+     this, so a crate of four and a crate of ten need no separate treatment and
+     the bin scales with the content column rather than against it. */
+  --bin-sleeve: clamp(160px, 24%, 240px);
   --bin-lean: 15deg;
-  --bin-depth-step: 14px;
+  /* Proportional to the sleeve, so the stagger stays a constant fraction of the
+     art rather than collapsing at large sizes and swamping it at small ones. */
+  --bin-depth-step: calc(var(--bin-sleeve) * 0.07);
 
   position: relative;
   width: 100%;
@@ -268,7 +276,9 @@
 
 .crate-bin-records {
   position: relative;
-  height: 180px;
+  /* The sleeve is square, plus room for the lean behind it and the pile in
+     front. A fixed height here is what clipped the top of a larger sleeve. */
+  height: calc(var(--bin-sleeve) * 1.3);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -296,7 +306,7 @@
 .bin-sleeve {
   position: absolute;
   bottom: 0;
-  width: 132px;
+  width: var(--bin-sleeve);
   cursor: pointer;
   /* Hinged at the bottom edge, like a record resting on the bottom of a crate.
      Any other origin makes the flip look like a card turning over. */
@@ -337,6 +347,7 @@
 }
 
 .bin-sleeve-art {
+  position: relative; /* containing block for the worn top edge */
   aspect-ratio: 1;
   border: 1px solid var(--border);
   border-radius: 2px;
@@ -389,15 +400,77 @@
   text-shadow: 0 1px 2px rgb(0 0 0 / 60%);
 }
 
-/* The divider card standing at the back of the bin. The single place a
-   handwritten-adjacent face is allowed, small and once — per the brand note that
-   the typeface is a seasoning, not a theme. */
+/* --- Paper props ----------------------------------------------------------
+ *
+ * Two materials, and they behave differently: cardboard is the sleeve, paper is
+ * the divider and the sticker. Paper is lighter, so it sits flatter and catches
+ * a little more light.
+ *
+ * No colour is invented here. Kraft is built from the theme's own surface and
+ * text tokens at low alpha rather than a hardcoded brown — there are eight
+ * palettes and a fixed tan would be wrong in most of them. The accent stays
+ * reserved for interactive affordances; none of this is interactive.
+ */
+
+/* The divider card standing at the back of the bin. The one place a
+   handwritten-adjacent face is allowed, small and once — the typeface is a
+   seasoning, not a theme. */
 .crate-bin-spine {
-  margin: 6px 0 0;
+  margin: 10px auto 0;
+  width: fit-content;
+  max-width: 90%;
+  padding: 4px 14px 5px;
   text-align: center;
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--text-dim);
+  /* Kraft: a warm wash over the theme surface, plus the tab notch that makes it
+     read as a divider rather than a caption. */
+  background:
+    linear-gradient(0deg, rgb(0 0 0 / 8%), rgb(0 0 0 / 0%)), var(--surface-hover);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  /* The tab: clipped top corners, the way a divider card is cut. */
+  clip-path: polygon(0 8px, 8px 0, calc(100% - 8px) 0, 100% 8px, 100% 100%, 0 100%);
+}
+
+/* Corner sticker on the focused record: honest metadata only.
+   Year and label, straight from the crate row. Never a price, never a rating,
+   never a fabricated "rare" — a shop that lies on its stickers is the thing this
+   whole feature is defined against. Hidden entirely when the data is absent
+   rather than filled with a placeholder. */
+.bin-sleeve-sticker {
+  position: absolute;
+  left: 6px;
+  bottom: 6px;
+  max-width: calc(100% - 12px);
+  padding: 2px 6px;
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  /* Paper, not cardboard: a lighter shadow, and a slight lie of the hand. */
+  box-shadow: 0 1px 3px rgb(0 0 0 / 30%);
+  transform: rotate(-1.5deg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+
+/* Worn top edge. The edge a crate's records actually wear, from being flipped
+   through by a thousand thumbs — so it belongs on the top, not all round. */
+.bin-sleeve-art::after {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(180deg, rgb(255 255 255 / 14%), rgb(255 255 255 / 0%));
+  pointer-events: none;
 }
 
 /* Reduced motion: keep the bin, lose the depth and the movement. A flipped
@@ -827,5 +900,35 @@
      rather than as a bounce. */
   .bin-sleeve--flipped {
     transition: transform 300ms cubic-bezier(0.18, 1.3, 0.4, 1);
+  }
+
+  /* Stock-in: a new crate is filed back-to-front, the way you would put records
+     into a bin — not all at once, and not front-to-back, which would look like
+     they were being dealt at you.
+
+     The stagger is applied per sleeve from --bin-order, so the last record is
+     the last to land. At 70ms a step, ten records take 630ms of stagger plus one
+     260ms drop: comfortably inside the 1.5s the story asks for.
+
+     opacity and transform only. This is an entrance, so a keyframe animation is
+     right where the flip needed a transition — there is nothing to interrupt,
+     and it must not re-run when the crate merely re-renders, which is what the
+     one-shot `both` fill gives. */
+  .crate-bin--stocking .bin-sleeve {
+    animation: binStockIn 260ms cubic-bezier(0.2, 0.9, 0.3, 1) both;
+    animation-delay: calc(var(--bin-order) * 70ms);
+  }
+
+  @keyframes binStockIn {
+    from {
+      opacity: 0;
+      /* Dropped in from above and slightly behind, so it arrives into its slot
+         rather than sliding across the front of the ones already filed. */
+      transform: translateZ(calc(var(--bin-rel) * var(--bin-depth-step) * -1))
+        translateY(calc(var(--bin-rel) * -2px - 40px)) rotateX(calc(var(--bin-lean) * -1));
+    }
+    to {
+      opacity: 1;
+    }
   }
 }

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -315,9 +315,19 @@
  * Stacked by --bin-order (the absolute index), NOT by position relative to
  * focus: records land in index order, so record 0 is the bottom of the pile and
  * every later one lands on top of it. Ordering the pile relative to focus
- * rebuilds it upside down on every flip, which is exactly what it did. */
+ * rebuilds it upside down on every flip, which is exactly what it did.
+ *
+ * The pile MUST sit in front of the focused record, and that is a correctness
+ * constraint rather than a look. A transition interpolates the transform matrix,
+ * so the two sleeves that move on a flip sweep continuously between their
+ * endpoints; if the outgoing record travels backwards while the incoming one
+ * travels forwards, their planes cross mid-flight and you see one through the
+ * other. With the pile behind focus that crossing was unavoidable — separation
+ * ran 32px to -11px and hit zero about three-quarters through. Ahead of focus,
+ * the outgoing record stays ahead of the incoming one for the whole transition
+ * and nothing intersects. */
 .bin-sleeve--flipped {
-  transform: translateZ(calc(var(--bin-order) * 1.6px + 6px))
+  transform: translateZ(calc(var(--bin-order) * 1.6px + 44px))
     translateY(calc(var(--bin-order) * -1px - 4px)) rotateX(-96deg);
 }
 

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -238,6 +238,170 @@
   text-align: center;
 }
 
+/* --- The bin (KAMP-656, prototype) ---------------------------------------
+ *
+ * A three-quarter crate of records you flip through, rendering exactly the state
+ * the flat rail rendered: everything before focusIndex lies on the pile at the
+ * lip, everything from it back stands leaning in the bin.
+ *
+ * Geometry lives out here rather than inside the prefers-reduced-motion wrapper
+ * on purpose. Reduced motion means "do not animate", not "do not have a shape" —
+ * the bin still looks like a bin, it just stops moving (see the override at the
+ * bottom of this block). Only transform and opacity are ever animated; nothing
+ * here touches height, which is the project rule and Electron is why.
+ */
+
+.crate-bin {
+  --bin-lean: 15deg;
+  --bin-depth-step: 14px;
+
+  position: relative;
+  width: 100%;
+  max-width: var(--crate-width);
+  margin-inline: auto;
+  /* Deep enough to read as a room rather than a fisheye. Under ~700px the
+     lean starts to look like a funhouse mirror. */
+  perspective: 900px;
+  perspective-origin: 50% 30%;
+  padding: 28px 0 12px;
+}
+
+.crate-bin-records {
+  position: relative;
+  height: 180px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  transform-style: preserve-3d;
+  display: flex;
+  justify-content: center;
+}
+
+.crate-bin-records:focus {
+  outline: none;
+}
+
+.bin-sleeve {
+  position: absolute;
+  bottom: 0;
+  width: 132px;
+  cursor: pointer;
+  /* Hinged at the bottom edge, like a record resting on the bottom of a crate.
+     Any other origin makes the flip look like a card turning over. */
+  transform-origin: 50% 100%;
+  /* Standing in the bin: leaning back, stepped away from the viewer. */
+  transform: rotateX(calc(var(--bin-lean) * -1))
+    translateZ(calc(var(--bin-depth) * var(--bin-depth-step) * -1))
+    translateY(calc(var(--bin-depth) * -2px));
+  will-change: transform;
+}
+
+/* Flipped past: tipped forward past vertical onto the pile at the crate lip.
+   The growing pile IS the progress indicator — there is no separate bar. */
+.bin-sleeve--flipped {
+  transform: rotateX(-96deg) translateZ(calc(var(--bin-depth) * 2px)) translateY(-4px);
+}
+
+/* The one you are looking at: upright and forward of the rest. */
+.bin-sleeve--focused {
+  transform: rotateX(-4deg) translateZ(18px) translateY(-6px);
+}
+
+.bin-sleeve-art {
+  aspect-ratio: 1;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: 20px;
+  /* Pre-baked rather than an animated box-shadow: shadow is one of the most
+     expensive things to animate, and the depth cue does not need to move. */
+  box-shadow: 0 6px 14px rgb(0 0 0 / 35%);
+}
+
+.bin-sleeve-art:not(.has-art)::before {
+  content: '♪';
+}
+
+.bin-sleeve-art-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.bin-sleeve--focused .bin-sleeve-art {
+  border-color: var(--accent);
+  border-width: 2px;
+}
+
+/* Same rule as the flat rail: state is opacity, border weight and a glyph —
+   never hue. There is one --accent token and it swings from indigo to magenta
+   to green across the eight palettes. */
+.bin-sleeve--passed {
+  opacity: 0.35;
+}
+
+.bin-sleeve--wishlisted .bin-sleeve-art,
+.bin-sleeve--purchased .bin-sleeve-art {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.bin-sleeve-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 12px;
+  color: var(--text);
+  text-shadow: 0 1px 2px rgb(0 0 0 / 60%);
+}
+
+/* The divider card standing at the back of the bin. The single place a
+   handwritten-adjacent face is allowed, small and once — per the brand note that
+   the typeface is a seasoning, not a theme. */
+.crate-bin-spine {
+  margin: 6px 0 0;
+  text-align: center;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+/* Reduced motion: keep the bin, lose the depth and the movement. A flipped
+   record simply fades rather than tipping, and nothing transitions — the
+   transitions themselves only exist inside the no-preference wrapper below, so
+   this only has to flatten the geometry. */
+@media (prefers-reduced-motion: reduce) {
+  .crate-bin {
+    perspective: none;
+  }
+
+  .bin-sleeve,
+  .bin-sleeve--focused,
+  .bin-sleeve--flipped {
+    transform: none;
+    position: relative;
+  }
+
+  .crate-bin-records {
+    height: auto;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .bin-sleeve--flipped {
+    opacity: 0.4;
+  }
+
+  .bin-sleeve {
+    width: 72px;
+  }
+}
+
 .crate-dig-btn {
   border: 1px solid var(--border);
   background: var(--surface);
@@ -613,5 +777,26 @@
     to {
       transform: scaleX(0);
     }
+  }
+
+  /* The settle — the payload of the whole bin concept (KAMP-656).
+
+     An overshooting cubic-bezier on the transition rather than a @keyframes
+     animation, and that choice is what makes riffling work: a transition
+     retargets from wherever it currently is when the value changes again, while
+     an animation restarts from the top. At 2-3 flips/sec an animation would
+     stutter and queue; this just redirects.
+
+     The curve overshoots ~3% and comes back, which at the flip's 22deg swing is
+     the 2-3deg overshoot and ~90ms spring the ticket asks for. */
+  .bin-sleeve {
+    transition: transform 260ms cubic-bezier(0.22, 1.42, 0.36, 1);
+  }
+
+  /* The receiving pile compresses by a pixel or two as a record lands on it,
+     then recovers. Same overshoot logic, slightly slower so it reads as weight
+     rather than as a bounce. */
+  .bin-sleeve--flipped {
+    transition: transform 300ms cubic-bezier(0.18, 1.3, 0.4, 1);
   }
 }

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -257,7 +257,15 @@
      meant guessing at two unrelated constants. Everything below is a ratio of
      this, so a crate of four and a crate of ten need no separate treatment and
      the bin scales with the content column rather than against it. */
-  --bin-sleeve: clamp(160px, 24%, 240px);
+  /* vw, NOT a percentage, and that is load-bearing rather than a preference.
+     This token is used for `width` AND inside `calc()` for `height` below. A
+     percentage means "of the containing block's width" in one and "of its
+     height" in the other — and the parent's height is auto, so the height calc
+     went indefinite, the records box collapsed to zero, and every sleeve (all
+     absolutely positioned at bottom: 0) hung its full height UPWARD out of a box
+     with no height, straight over the focus card. A viewport unit resolves
+     identically in both contexts. */
+  --bin-sleeve: clamp(150px, 20vw, 230px);
   --bin-lean: 15deg;
   /* Proportional to the sleeve, so the stagger stays a constant fraction of the
      art rather than collapsing at large sizes and swamping it at small ones. */

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -31,6 +31,7 @@ function BinSleeve({
   item,
   index,
   total,
+  focusIndex,
   focused,
   flipped,
   passed,
@@ -39,6 +40,7 @@ function BinSleeve({
   item: CrateItem
   index: number
   total: number
+  focusIndex: number
   focused: boolean
   // Already flipped past: lying on the pile at the crate lip.
   flipped: boolean
@@ -55,10 +57,17 @@ function BinSleeve({
   if (item.state === 'wishlisted') classes.push('bin-sleeve--wishlisted')
   if (item.state === 'purchased') classes.push('bin-sleeve--purchased')
 
-  // Standing records step back into the bin; flipped ones stack forward at the
-  // lip. Both are expressed as one custom property so the transform itself stays
-  // in CSS, where the transition and its overshoot live.
-  const depth = flipped ? index - total : index
+  // Two different numbers, because the pile and the bin are ordered differently.
+  //
+  // `rel` is distance from the record you are looking at, so the standing stack
+  // advances as you flip rather than the focused record pulling away from a
+  // bin that never moves.
+  //
+  // `order` is the absolute index, and it is what stacks the pile: records land
+  // in index order, so record 0 is at the BOTTOM and each later one lands on top
+  // of it. Using `rel` here would rebuild the pile upside down every flip.
+  const rel = index - focusIndex
+  const order = index
 
   return (
     <li
@@ -76,9 +85,11 @@ function BinSleeve({
       onClick={() => onFocus(index)}
       style={
         {
-          '--bin-depth': depth,
-          // Later records paint behind earlier ones; flipped ones stack on top
-          // of the pile in the order they landed.
+          '--bin-rel': rel,
+          '--bin-order': order,
+          // A fallback only. Inside preserve-3d the browser sorts by actual 3D
+          // position and ignores this, which is exactly why the pile order has
+          // to be right in the transform rather than here.
           zIndex: flipped ? total + index : total - index
         } as React.CSSProperties
       }
@@ -148,6 +159,7 @@ export function CrateBin({
             item={item}
             index={index}
             total={items.length}
+            focusIndex={focusIndex}
             focused={index === focusIndex}
             flipped={index < focusIndex}
             passed={pendingDismissals.includes(item.id)}

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -16,7 +16,7 @@
 // shipped — roving tabindex, aria-setsize/aria-posinset, arrows inside the
 // widget — and the perspective sits on top of that contract rather than
 // replacing it.
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { crateArtUrl } from '../api/client'
 import type { CrateItem } from '../api/client'
 
@@ -26,6 +26,16 @@ const DEPTH = 14
 // How far back the standing sleeves lean. The ticket asks for 72-78 degrees off
 // the horizontal, which is 12-18 off vertical.
 const LEAN = 15
+
+// What goes on the corner sticker. Only facts already on the row: the release
+// year and the label. Deliberately no price and no scarcity claim — those would
+// be invented, and an invented sticker is the one thing a record shop cannot do
+// and stay trustworthy. Returns '' when there is nothing honest to print, and
+// the caller renders no sticker at all rather than an empty one.
+function sticker(item: CrateItem): string {
+  const year = item.release_date ? item.release_date.slice(0, 4) : ''
+  return [year, item.label].filter(Boolean).join(' · ')
+}
 
 function BinSleeve({
   item,
@@ -120,12 +130,30 @@ function BinSleeve({
           ◆
         </span>
       )}
+      {/* Corner sticker, on the focused record only — a bin of ten stickers is
+          a spreadsheet. Year and label straight off the row, and nothing else:
+          no price, no rating, no invented "rare". A shop that lies on its
+          stickers is precisely what this feature is defined against, so an
+          absent field means no sticker rather than a placeholder.
+
+          aria-hidden because both values are already in the focus card above;
+          a screen reader should not hear the year twice. */}
+      {focused && sticker(item) && (
+        <span className="bin-sleeve-sticker" aria-hidden="true">
+          {sticker(item)}
+        </span>
+      )}
     </li>
   )
 }
 
+// How long the stock-in cascade needs to finish: the last record's delay plus
+// its own drop, with a little slack. Ten records at 70ms is 630ms + 260ms.
+const STOCK_IN_MS = 1200
+
 export function CrateBin({
   items,
+  crateNo,
   focusIndex,
   pendingDismissals,
   spineName,
@@ -133,15 +161,41 @@ export function CrateBin({
   onFocus
 }: {
   items: CrateItem[]
+  crateNo: number | null
   focusIndex: number
   pendingDismissals: number[]
   spineName: string
   railRef: React.RefObject<HTMLUListElement | null>
   onFocus: (index: number) => void
 }): React.JSX.Element {
+  // Stock-in runs on a DELIVERY, not on every render that happens to have
+  // records in it. Arriving at a crate that already exists — switching to the
+  // tab, reloading the renderer — is not a delivery, and replaying the cascade
+  // there would turn a moment into a tic.
+  //
+  // So the first crate_no this component sees is seeded silently, and only a
+  // change from it counts. That also gets the first-ever crate right: mount
+  // seeds null, the build completes, null -> 1 is a change, and it plays.
+  const seenRef = useRef<number | null>(null)
+  const seededRef = useRef(false)
+  const [stocking, setStocking] = useState(false)
+
+  useEffect(() => {
+    if (!seededRef.current) {
+      seededRef.current = true
+      seenRef.current = crateNo
+      return
+    }
+    if (crateNo === null || crateNo === seenRef.current) return
+    seenRef.current = crateNo
+    setStocking(true)
+    const timer = window.setTimeout(() => setStocking(false), STOCK_IN_MS)
+    return () => window.clearTimeout(timer)
+  }, [crateNo])
+
   return (
     <div
-      className="crate-bin"
+      className={`crate-bin${stocking ? ' crate-bin--stocking' : ''}`}
       style={
         { '--bin-lean': `${LEAN}deg`, '--bin-depth-step': `${DEPTH}px` } as React.CSSProperties
       }

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -1,0 +1,163 @@
+// The bin (KAMP-656) — a three-quarter crate you flip through.
+//
+// PROTOTYPE. This is the checkpoint the ticket mandates: build the flip first,
+// and if it reads as cover-flow pastiche after tuning, fall back to the flat
+// "Counter" treatment. CrateSleeve and its styles are deliberately left intact
+// so that fallback is a one-line switch in CrateView rather than a rewrite.
+//
+// The whole thing is a re-skin of state that already existed. `focusIndex` is
+// KAMP-650's; records before it lie on the flipped pile at the crate lip,
+// records at and after it stand tilted in the bin. So "flip" is just `,`/`.`
+// under a different rendering — no new interaction, no new state, nothing added
+// to the store. That is also why riffling keeps up: a CSS transition on
+// transform retargets mid-flight, where a @keyframes animation would restart.
+//
+// Accessibility is NOT part of the skin. This is still the listbox KAMP-650
+// shipped — roving tabindex, aria-setsize/aria-posinset, arrows inside the
+// widget — and the perspective sits on top of that contract rather than
+// replacing it.
+import React, { useState } from 'react'
+import { crateArtUrl } from '../api/client'
+import type { CrateItem } from '../api/client'
+
+// Depth stagger between standing sleeves, in px. Small: enough for art slivers
+// to tease the next few records, not so much that the bin becomes a fan.
+const DEPTH = 14
+// How far back the standing sleeves lean. The ticket asks for 72-78 degrees off
+// the horizontal, which is 12-18 off vertical.
+const LEAN = 15
+
+function BinSleeve({
+  item,
+  index,
+  total,
+  focused,
+  flipped,
+  passed,
+  onFocus
+}: {
+  item: CrateItem
+  index: number
+  total: number
+  focused: boolean
+  // Already flipped past: lying on the pile at the crate lip.
+  flipped: boolean
+  passed: boolean
+  onFocus: (index: number) => void
+}): React.JSX.Element {
+  const [artFailed, setArtFailed] = useState(false)
+  const showArt = Boolean(item.art_url) && !artFailed
+
+  const classes = ['bin-sleeve']
+  if (focused) classes.push('bin-sleeve--focused')
+  if (flipped) classes.push('bin-sleeve--flipped')
+  if (passed || item.state === 'dismissed') classes.push('bin-sleeve--passed')
+  if (item.state === 'wishlisted') classes.push('bin-sleeve--wishlisted')
+  if (item.state === 'purchased') classes.push('bin-sleeve--purchased')
+
+  // Standing records step back into the bin; flipped ones stack forward at the
+  // lip. Both are expressed as one custom property so the transform itself stays
+  // in CSS, where the transition and its overshoot live.
+  const depth = flipped ? index - total : index
+
+  return (
+    <li
+      className={classes.join(' ')}
+      role="option"
+      aria-selected={focused}
+      aria-setsize={total}
+      aria-posinset={index + 1}
+      aria-label={`${item.title} by ${item.artist}`}
+      // Roving tabindex, exactly as the rail had it: only the focused sleeve is
+      // reachable by Tab, and the arrows move which one that is. Keeping real
+      // DOM focus in the widget is what lets CrateView scope its key handling to
+      // its own container instead of listening on document.
+      tabIndex={focused ? 0 : -1}
+      onClick={() => onFocus(index)}
+      style={
+        {
+          '--bin-depth': depth,
+          // Later records paint behind earlier ones; flipped ones stack on top
+          // of the pile in the order they landed.
+          zIndex: flipped ? total + index : total - index
+        } as React.CSSProperties
+      }
+    >
+      <div className={`bin-sleeve-art${showArt ? ' has-art' : ''}`}>
+        {showArt && (
+          <img
+            className="bin-sleeve-art-img"
+            src={crateArtUrl(item.id)}
+            alt=""
+            loading="lazy"
+            onError={() => setArtFailed(true)}
+          />
+        )}
+      </div>
+      {(passed || item.state === 'dismissed') && (
+        <span className="bin-sleeve-badge" aria-hidden="true">
+          ✕
+        </span>
+      )}
+      {item.state === 'wishlisted' && (
+        <span className="bin-sleeve-badge" aria-hidden="true">
+          ♥
+        </span>
+      )}
+      {item.state === 'purchased' && (
+        <span className="bin-sleeve-badge" aria-hidden="true">
+          ◆
+        </span>
+      )}
+    </li>
+  )
+}
+
+export function CrateBin({
+  items,
+  focusIndex,
+  pendingDismissals,
+  spineName,
+  railRef,
+  onFocus
+}: {
+  items: CrateItem[]
+  focusIndex: number
+  pendingDismissals: number[]
+  spineName: string
+  railRef: React.RefObject<HTMLUListElement | null>
+  onFocus: (index: number) => void
+}): React.JSX.Element {
+  return (
+    <div
+      className="crate-bin"
+      style={
+        { '--bin-lean': `${LEAN}deg`, '--bin-depth-step': `${DEPTH}px` } as React.CSSProperties
+      }
+    >
+      <ul
+        className="crate-bin-records"
+        role="listbox"
+        aria-label="Crate"
+        ref={railRef}
+        tabIndex={-1}
+      >
+        {items.map((item, index) => (
+          <BinSleeve
+            key={item.id}
+            item={item}
+            index={index}
+            total={items.length}
+            focused={index === focusIndex}
+            flipped={index < focusIndex}
+            passed={pendingDismissals.includes(item.id)}
+            onFocus={onFocus}
+          />
+        ))}
+      </ul>
+      {/* The divider card at the back of the bin. Written in marker, so it is
+          the one place a handwritten-adjacent face is allowed — small, and once. */}
+      {spineName && <p className="crate-bin-spine">{spineName}</p>}
+    </div>
+  )
+}

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -194,6 +194,11 @@ export function CrateBin({
 
   return (
     <div className={`crate-bin${stocking ? ' crate-bin--stocking' : ''}`}>
+      {/* The divider card, ABOVE the records — it stands at the back of the bin,
+          so from this angle you read it over the tops of the sleeves rather than
+          under them. Written in marker, and the one place a
+          handwritten-adjacent face is allowed: small, and once. */}
+      {spineName && <p className="crate-bin-spine">{spineName}</p>}
       <ul
         className="crate-bin-records"
         role="listbox"
@@ -215,9 +220,6 @@ export function CrateBin({
           />
         ))}
       </ul>
-      {/* The divider card at the back of the bin. Written in marker, so it is
-          the one place a handwritten-adjacent face is allowed — small, and once. */}
-      {spineName && <p className="crate-bin-spine">{spineName}</p>}
     </div>
   )
 }

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -20,12 +20,11 @@ import React, { useEffect, useRef, useState } from 'react'
 import { crateArtUrl } from '../api/client'
 import type { CrateItem } from '../api/client'
 
-// Depth stagger between standing sleeves, in px. Small: enough for art slivers
-// to tease the next few records, not so much that the bin becomes a fan.
-const DEPTH = 14
-// How far back the standing sleeves lean. The ticket asks for 72-78 degrees off
-// the horizontal, which is 12-18 off vertical.
-const LEAN = 15
+// The bin's geometry — sleeve size, lean and depth stagger — lives entirely in
+// crate.css, derived from a single --bin-sleeve. It used to be set inline from
+// constants here too, which silently won: an inline custom property beats the
+// stylesheet, so the proportional depth step introduced with the sizing pass
+// never actually applied and a hardcoded 14px kept being used. One home for it.
 
 // What goes on the corner sticker. Only facts already on the row: the release
 // year and the label. Deliberately no price and no scarcity claim — those would
@@ -194,12 +193,7 @@ export function CrateBin({
   }, [crateNo])
 
   return (
-    <div
-      className={`crate-bin${stocking ? ' crate-bin--stocking' : ''}`}
-      style={
-        { '--bin-lean': `${LEAN}deg`, '--bin-depth-step': `${DEPTH}px` } as React.CSSProperties
-      }
-    >
+    <div className={`crate-bin${stocking ? ' crate-bin--stocking' : ''}`}>
       <ul
         className="crate-bin-records"
         role="listbox"

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -14,6 +14,8 @@ import { useStore } from '../store'
 import { crateArtUrl } from '../api/client'
 import type { CrateItem, DiggingStats } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
+import { CrateBin } from './CrateBin'
+import { crateSpineName } from './crateSpine'
 import { CratePreviewStrip } from './CratePreviewStrip'
 import { formatClock } from '../utils/formatClock'
 import { useTooltip } from '../hooks/useTooltip'
@@ -131,6 +133,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const history = crate?.stats ?? null
   const crateTally = crate?.crate_stats ?? null
   const atLastRecord = visible.length > 1 && focusIndex === visible.length - 1
+
+  // The name on the crate's divider card (KAMP-656). Derived from the snapshot
+  // the view already has, because this story is skin only — no API changes. It
+  // is memoised on the item identities rather than recomputed per render, and it
+  // reads nothing from the clock, so a crate keeps its name.
+  const spineName = useMemo(() => crateSpineName(items, crate?.hints ?? []), [items, crate?.hints])
 
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
@@ -548,22 +556,38 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           </div>
         )}
 
-        <ul className="crate-rail" role="listbox" aria-label="Crate" ref={railRef} tabIndex={-1}>
-          {visible.map((item, index) => (
-            <CrateSleeve
-              key={item.id}
-              item={item}
-              index={index}
-              total={visible.length}
-              focused={index === focusIndex}
-              passed={pendingDismissals.includes(item.id)}
-              onFocus={focusSleeve}
-            />
-          ))}
-          {Array.from({ length: slots }, (_unused, i) => (
-            <CrateSlot key={`slot-${i}`} index={visible.length + i} />
-          ))}
-        </ul>
+        {/* KAMP-656 prototype: the bin renders the same state the flat rail did.
+            CrateSleeve and .crate-sleeve are left intact so the Counter fallback
+            is a switch back to them here, not a rewrite. While a build streams,
+            the flat rail still runs — the empty slots are the fill indicator and
+            a half-full bin has no pile to show yet. */}
+        {building ? (
+          <ul className="crate-rail" role="listbox" aria-label="Crate" ref={railRef} tabIndex={-1}>
+            {visible.map((item, index) => (
+              <CrateSleeve
+                key={item.id}
+                item={item}
+                index={index}
+                total={visible.length}
+                focused={index === focusIndex}
+                passed={pendingDismissals.includes(item.id)}
+                onFocus={focusSleeve}
+              />
+            ))}
+            {Array.from({ length: slots }, (_unused, i) => (
+              <CrateSlot key={`slot-${i}`} index={visible.length + i} />
+            ))}
+          </ul>
+        ) : (
+          <CrateBin
+            items={visible}
+            focusIndex={focusIndex}
+            pendingDismissals={pendingDismissals}
+            spineName={spineName}
+            railRef={railRef}
+            onFocus={focusSleeve}
+          />
+        )}
 
         <div className="crate-footer">
           {digButton}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -581,6 +581,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         ) : (
           <CrateBin
             items={visible}
+            crateNo={crate?.crate_no ?? null}
             focusIndex={focusIndex}
             pendingDismissals={pendingDismissals}
             spineName={spineName}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -328,6 +328,27 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     option?.focus()
   }
 
+  // Claim focus when the view opens, so , and . work on arrival.
+  //
+  // The recovery above only fires when focus is LOST; nothing ever claimed it in
+  // the first place, so the keys did nothing until you clicked a record. The
+  // handlers live on this container by design — listening on document would
+  // pre-empt every modal's Escape — so the container has to actually hold focus.
+  //
+  // preventScroll matters: the view scrolls, the bin sits below the focus card,
+  // and a plain focus() scrolls the record into view, yanking the card off the
+  // top of the screen the moment you arrive.
+  useEffect(() => {
+    if (!active || visible.length === 0) return
+    const rail = railRef.current
+    if (!rail) return
+    // Never steal focus from something already in use inside the view — a
+    // pressed action button, or a record the user just clicked.
+    if (rail.contains(document.activeElement)) return
+    const option = rail.querySelectorAll<HTMLElement>('[role="option"]')[focusIndex]
+    option?.focus({ preventScroll: true })
+  }, [active, visible.length, focusIndex])
+
   // ---------------------------------------------------------------------------
   // Compositions
   // ---------------------------------------------------------------------------
@@ -495,59 +516,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   {wishlistError}
                 </p>
               )}
-
-              {/* The preview's own space, always present. Rendering the strip
-                  and track list into the normal flow made the whole card grow
-                  when a preview started, shoving the rail down the page — and
-                  the track list is unbounded, so a long record shoved it hard.
-                  The slot reserves the room; the list scrolls inside it. */}
-              <div className="crate-preview-slot">
-                {previewingThis && preview ? (
-                  <>
-                    <CratePreviewStrip
-                      preview={preview}
-                      onToggle={togglePreview}
-                      onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
-                      onSeek={(position) => void previewSeek(position)}
-                    />
-
-                    {preview.tracks.length > 0 && (
-                      <ol className="crate-tracklist">
-                        {preview.tracks.map((track) => (
-                          <li key={track.track_num}>
-                            <button
-                              className={`crate-track${
-                                track.track_num === preview.track_num ? ' crate-track--current' : ''
-                              }`}
-                              onClick={() => void previewPlay(current.id, track.track_num)}
-                            >
-                              <span className="crate-track-num">{track.track_num}</span>
-                              <span className="crate-track-title">
-                                {track.title || `Track ${track.track_num}`}
-                              </span>
-                              <span className="crate-track-time">
-                                {formatClock(track.duration)}
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ol>
-                    )}
-
-                    {preview.error && (
-                      <p className="crate-preview-error" role="status">
-                        {preview.error === 'rate_limited'
-                          ? 'Bandcamp asked us to slow down — try again shortly.'
-                          : 'No preview for this one.'}
-                      </p>
-                    )}
-                  </>
-                ) : (
-                  <p className="crate-preview-placeholder">
-                    Space to hear it — your queue stays where it is.
-                  </p>
-                )}
-              </div>
             </div>
           </article>
         ) : (
@@ -588,6 +556,65 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             railRef={railRef}
             onFocus={focusSleeve}
           />
+        )}
+
+        {/* The preview's own space, always present, and BELOW the bin (KAMP-656).
+            It sat inside the focus card until the bin got its proper sizing, at
+            which point the sleeves — absolutely positioned and leaning out of
+            their container — drew straight over the mini-player and the hint
+            text. Ordering it after the bin fixes that by construction rather
+            than by fighting the overflow, and there is plenty of vertical room.
+
+            Still a reserved slot: rendering the strip and track list into the
+            normal flow made the whole thing grow when a preview started, and the
+            track list is unbounded, so a long record shoved everything below it
+            down the page. The slot holds the room; the list scrolls inside it. */}
+        {current && (
+          <div className="crate-preview-slot">
+            {previewingThis && preview ? (
+              <>
+                <CratePreviewStrip
+                  preview={preview}
+                  onToggle={togglePreview}
+                  onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
+                  onSeek={(position) => void previewSeek(position)}
+                />
+
+                {preview.tracks.length > 0 && (
+                  <ol className="crate-tracklist">
+                    {preview.tracks.map((track) => (
+                      <li key={track.track_num}>
+                        <button
+                          className={`crate-track${
+                            track.track_num === preview.track_num ? ' crate-track--current' : ''
+                          }`}
+                          onClick={() => void previewPlay(current.id, track.track_num)}
+                        >
+                          <span className="crate-track-num">{track.track_num}</span>
+                          <span className="crate-track-title">
+                            {track.title || `Track ${track.track_num}`}
+                          </span>
+                          <span className="crate-track-time">{formatClock(track.duration)}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+
+                {preview.error && (
+                  <p className="crate-preview-error" role="status">
+                    {preview.error === 'rate_limited'
+                      ? 'Bandcamp asked us to slow down — try again shortly.'
+                      : 'No preview for this one.'}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="crate-preview-placeholder">
+                Space to hear it — your queue stays where it is.
+              </p>
+            )}
+          </div>
         )}
 
         <div className="crate-footer">

--- a/kamp_ui/src/renderer/src/components/crateSpine.ts
+++ b/kamp_ui/src/renderer/src/components/crateSpine.ts
@@ -1,0 +1,93 @@
+// The name written on a crate's spine (KAMP-656).
+//
+// Marker on a divider card, not a generated string: it names what is actually in
+// this crate, in the order a person would say it. "AUG '26 — MOSTLY DUB TECHNO,
+// TWO DEEP CUTS, ONE WILDCARD".
+//
+// Pure and deterministic. The story is explicitly skin-only — no API and no
+// store-shape changes — so everything here comes from the crate snapshot the
+// view already has. Nothing is random and nothing reads the clock: the month is
+// the crate's own earliest first_seen_at, so a crate keeps its name forever
+// rather than being relabelled every time you look at it.
+import type { CrateItem } from '../api/client'
+
+const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+
+// Small numbers read as handwriting; large ones read as a database. A crate is
+// ten records, so this never needs to go past that.
+const WORDS = ['NO', 'ONE', 'TWO', 'THREE', 'FOUR', 'FIVE', 'SIX', 'SEVEN', 'EIGHT', 'NINE', 'TEN']
+
+const count = (n: number): string => WORDS[n] ?? String(n)
+
+// How each criterion is described when it is a *minority* of the crate. Keyed on
+// the provider's own criterion strings (kamp_daemon/discovery_criteria.py). An
+// unknown key is skipped rather than guessed at — a future provider inventing a
+// criterion should be silent here, not wrong.
+const PHRASES: Record<string, { one: string; many: string }> = {
+  older_than_ten: { one: 'ONE DEEP CUT', many: 'DEEP CUTS' },
+  best_seller: { one: 'ONE WILDCARD', many: 'WILDCARDS' },
+  favorite_artist: { one: 'ONE OLD FRIEND', many: 'OLD FRIENDS' },
+  also_like: { one: 'ONE FILED NEXT DOOR', many: 'FILED NEXT DOOR' }
+}
+
+function stamp(items: CrateItem[]): string {
+  const earliest = items.reduce(
+    (min, item) => (item.first_seen_at > 0 && item.first_seen_at < min ? item.first_seen_at : min),
+    Number.POSITIVE_INFINITY
+  )
+  if (!Number.isFinite(earliest)) return ''
+  const when = new Date(earliest * 1000)
+  return `${MONTHS[when.getMonth()]} '${String(when.getFullYear()).slice(2)}`
+}
+
+// The genre the crate leans on, from the seed hints the snapshot already carries.
+// Upper-cased because the whole label is marker capitals, not because it is
+// shouting.
+//
+// "MOSTLY" is a claim about the majority, so it has to earn it: the genre picks
+// must be the biggest group in the crate and at least three of them. Run against
+// eleven real crates without that guard, two of them announced "MOSTLY ROCK" off
+// the back of one and two genre picks while the other eight were deep cuts —
+// a label that is simply untrue, on the one surface whose whole job is that
+// every pick explains itself honestly.
+const MIN_LEAD = 3
+
+function leading(tallies: Map<string, number>, hints: string[]): string {
+  const genreLed = tallies.get('genre_top') ?? 0
+  if (genreLed < MIN_LEAD || hints.length === 0) return ''
+  const biggest = Math.max(...tallies.values())
+  if (genreLed < biggest) return ''
+  return `MOSTLY ${hints[0].toUpperCase()}`
+}
+
+export function crateSpineName(items: CrateItem[], hints: string[]): string {
+  if (items.length === 0) return ''
+
+  const tallies = new Map<string, number>()
+  for (const item of items) {
+    if (item.criterion) tallies.set(item.criterion, (tallies.get(item.criterion) ?? 0) + 1)
+  }
+
+  const parts: string[] = []
+  const lead = leading(tallies, hints)
+  if (lead) parts.push(lead)
+
+  // Descending, then by key, so the same crate always reads the same way — a
+  // Map preserves insertion order, which would otherwise make the name depend on
+  // the order the builder happened to fill the crate.
+  const rest = [...tallies.entries()]
+    .filter(([key]) => key in PHRASES)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+
+  for (const [key, n] of rest) {
+    const phrase = PHRASES[key]
+    parts.push(n === 1 ? phrase.one : `${count(n)} ${phrase.many}`)
+    // Three clauses is a divider card. Four is an inventory.
+    if (parts.length >= 3) break
+  }
+
+  const when = stamp(items)
+  const body = parts.join(', ')
+  if (!body) return when
+  return when ? `${when} — ${body}` : body
+}


### PR DESCRIPTION
## Summary

**This is a prototype for you to judge, not a finished feature.** The ticket's acceptance criteria mandate a checkpoint — build the flip first, fall back to a flat "Counter" treatment if it reads as cover-flow pastiche, and record the decision on the issue *before* full build-out. That verdict is yours; I never run the dev server.

So this is deliberately the smallest thing that can be judged, plus the one delight item you kept.

Everything else in KAMP-656 — pull-out, stock-in cascade, hold shelf, paper props, ambient dust — waits for your answer.

## The insight that keeps this small

**The flip is the existing `,`/`.` navigation re-skinned.** `focusIndex` already exists and already moves; the bin just renders that same state differently — records before it lie on the pile at the crate lip, records from it back stand leaning in the bin. No new interaction, no new state, nothing added to the store. Which is also exactly what the ticket meant by "skin + texture, no API or store-shape changes".

**That's why riffling should keep up.** The settle is an overshooting `cubic-bezier` on a transform **transition**, not a `@keyframes` animation. A transition retargets from wherever it currently is when the value changes again; an animation restarts from the top. At 2–3 flips/sec the animation version would queue and stutter — this just redirects. Whether it *feels* right at speed is one of the things I need you to check.

## What's deliberately untouched

`CrateSleeve` and `.crate-sleeve` are exactly as they were. The ticket says the fallback "shares everything but the crate rendering", so Counter has to stay a one-line switch in `CrateView` rather than a rewrite — and the flat rail is still what renders *during* a build, where the empty slots are the fill indicator and a half-full bin has no pile to show yet.

**The listbox contract is not part of the skin.** Roving tabindex, `aria-setsize`/`aria-posinset`, per-option labels and arrow keys inside the widget all carry over intact. The perspective sits on top of a widget with a contract rather than replacing it.

**Geometry lives outside the `prefers-reduced-motion` wrapper on purpose** — reduced motion means "don't animate", not "don't have a shape". The reduce branch flattens the bin back to a wrapped row and drops the perspective entirely.

## The spine name earned a guard by being previewed against real data

Rendering it against your eleven real crates caught something I'd otherwise have shipped: without a threshold, **two crates announced "MOSTLY ROCK" off the back of one and two genre picks**, while the other eight were deep cuts.

"Mostly" is a claim about the majority, so it now has to be the biggest group *and* at least three. On the one surface whose entire job is that every pick explains itself honestly, a label that's merely plausible isn't good enough.

All eleven now read true:

```
crate 1  {also_like 3, older 2, best_seller 1, favorite 2, genre 2}
         AUG '26 — THREE FILED NEXT DOOR, TWO OLD FRIENDS, TWO DEEP CUTS
crate 5  {best_seller 1, older 4, also_like 1, genre 4}
         AUG '26 — MOSTLY ROCK, FOUR DEEP CUTS, ONE FILED NEXT DOOR
crate 9  {genre 1, best_seller 1, older 8}
         AUG '26 — EIGHT DEEP CUTS, ONE WILDCARD
```

It's deterministic and reads nothing from the clock — the month comes from the crate's own earliest `first_seen_at`, so a crate keeps its name rather than being relabelled every time you look at it. It also survives either verdict: on the bin it's the spine, on Counter it's a divider-card header.

## Test plan

- [x] `npm run typecheck`, `npm run lint` clean
- [x] `poetry run pytest` — **3177 passed**, unchanged; no Python moved
- [x] Spine names previewed against all eleven real crates, which is what surfaced the "mostly" bug

`kamp_ui` has no test runner, so everything visual here is eye-verified — by you.

## What I need from you

**The checkpoint question, honestly: does this read as a crate of records, or as cover-flow?** Pastiche is the failure mode, not jerkiness. If it's the latter, say so and I'll switch to Counter — that's a one-line change plus deleting `CrateBin`, and nothing else in the epic is affected.

Specifically worth checking:

- **Riffle**: hold `.` down at 2–3 flips/sec. Does it keep up, or does it lag and queue?
- **A single flip**: is the settle there — the small overshoot, the dip as it lands — or does it just move?
- **Keyboard only**: tab into the bin and drive it. Everything KAMP-650 did must still work.
- **Reduce Motion** (macOS Accessibility): should flatten, sit still, and stay fully usable.
- **Themes**: it should hold up across the palettes — state is opacity, border weight and glyph, never hue.
- **The spine name**: marker on a divider card, or generated string?

Then record the verdict on KAMP-656 and I'll either build out the bin or pivot to Counter.

Refs KAMP-656 — deliberately **not** "Closes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
