### PR TITLE
KAMP-668: the record goes on the deck — permanent mini-player, and the flight to it

### DIFF
--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -290,9 +290,30 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  transform-style: preserve-3d;
   display: flex;
   justify-content: center;
+  /* transform-style is deliberately left FLAT (the default). This is the fix for
+     records passing through each other, and it is the opposite of what the
+     obvious reading suggests.
+   *
+   * preserve-3d makes siblings share one 3D space, so the browser depth-sorts
+   * them by real geometry and they genuinely INTERSECT — and z-index is ignored
+   * entirely, which is what made it look like a red herring. Depth alone cannot
+   * separate them either: with the pile behind the focused record the arriving
+   * record sweeps backwards through the one advancing to meet it, and with the
+   * pile in front it sweeps forwards through the pile, whose members sit ~1.6px
+   * apart. It has to travel from one group to the other, so some crossing is
+   * unavoidable while they share a space.
+   *
+   * Flat costs nothing that matters. `perspective` on .crate-bin still applies
+   * to each sleeve's OWN rotateX/translateZ, so every record is still
+   * foreshortened and scaled by its depth — the bin looks the same. What changes
+   * is that siblings composite as flat layers in z-index order and cannot
+   * intersect at any angle, at any speed.
+   *
+   * Which makes the z-index in CrateBin authoritative rather than a fallback:
+   * standing records paint back-to-front, and the whole pile paints above all of
+   * them. */
 }
 
 .crate-bin-records:focus {

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -275,15 +275,31 @@
   width: 100%;
   max-width: var(--crate-width);
   margin-inline: auto;
-  /* Deep enough to read as a room rather than a fisheye. Under ~700px the
-     lean starts to look like a funhouse mirror. */
-  perspective: 900px;
-  perspective-origin: 50% 30%;
   padding: 28px 0 12px;
 }
 
 .crate-bin-records {
   position: relative;
+  /* Perspective lives HERE, on the sleeves' immediate parent, and that placement
+     is the whole reason the pile still reads as a trapezoid.
+   *
+   * `perspective` applies to an element's DIRECT children only. It used to sit
+     on .crate-bin, one level up, and reached the sleeves solely because this
+     element was preserve-3d and propagated the 3D context down. Flattening this
+     element to stop the sleeves intersecting therefore also cut them off from
+     the perspective: a record rotated -96deg with no perspective is not a
+     receding trapezoid, it is an orthographic squash — a flat strip, which is
+     exactly what the pile turned into.
+   *
+   * On the immediate parent it applies to each sleeve directly, so every record
+     is foreshortened correctly, while transform-style stays flat so siblings
+     still composite as layers and cannot intersect. Both properties are needed
+     and they are not in tension — they just have to be on the same element.
+   *
+   * 900px is deep enough to read as a room rather than a fisheye; under ~700px
+     the lean starts to look like a funhouse mirror. */
+  perspective: 900px;
+  perspective-origin: 50% 30%;
   /* The sleeve is square, plus room for the lean behind it and the pile in
      front. A fixed height here is what clipped the top of a larger sleeve. */
   height: calc(var(--bin-sleeve) * 1.3);
@@ -305,11 +321,11 @@
    * apart. It has to travel from one group to the other, so some crossing is
    * unavoidable while they share a space.
    *
-   * Flat costs nothing that matters. `perspective` on .crate-bin still applies
-   * to each sleeve's OWN rotateX/translateZ, so every record is still
-   * foreshortened and scaled by its depth — the bin looks the same. What changes
-   * is that siblings composite as flat layers in z-index order and cannot
-   * intersect at any angle, at any speed.
+   * Flat costs nothing that matters PROVIDED the perspective moves down to this
+   * element with it — see the note above. Each sleeve is then still foreshortened
+   * and scaled by its own depth, so the bin looks the same; what changes is that
+   * siblings composite as flat layers in z-index order and cannot intersect at
+   * any angle, at any speed.
    *
    * Which makes the z-index in CrateBin authoritative rather than a fallback:
    * standing records paint back-to-front, and the whole pile paints above all of
@@ -522,7 +538,10 @@
    transitions themselves only exist inside the no-preference wrapper below, so
    this only has to flatten the geometry. */
 @media (prefers-reduced-motion: reduce) {
-  .crate-bin {
+  /* Matches where the perspective actually lives — on the records container, not
+     on .crate-bin. Targeting the wrong element here would have left the reduced
+     path still rendering in perspective. */
+  .crate-bin-records {
     perspective: none;
   }
 

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -753,27 +753,72 @@
    pushed the rail down the page the moment a preview started. Sized for the
    strip plus a scrolling track list, so a 3-track single and a 20-track album
    occupy exactly the same room. */
-/* Below the bin since KAMP-656, and centred with it rather than hugging the
-   left edge of the stage — it reads as the deck under the crate, not as a
-   caption on the card.
-
-   The top margin is clearance, not taste: the flipped pile sits forward of
-   everything at the crate lip and is translated up, so it hangs below the bin's
-   own box and would otherwise land on the player. */
-.crate-preview-slot {
+/* --- The deck (KAMP-668) ---------------------------------------------------
+ *
+ * Always present, with or without a record on it. It used to be a reserved slot
+ * that showed a hint line until something played, which held the space without
+ * ever reading as an object — and a record cannot be put ON something that only
+ * exists once it is playing.
+ *
+ * The top margin is clearance rather than taste: the flipped pile sits forward
+ * at the crate lip and is translated up, so it hangs below the bin's own box and
+ * would otherwise land here.
+ */
+.crate-deck {
   min-height: 236px;
-  max-width: 52ch;
+  max-width: 60ch;
   margin: 44px auto 0;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+}
+
+/* Where a record lands. Sized in ch-independent px so the flight has a stable
+   target, and empty-but-obvious when nothing is on it — a turntable with no
+   record still looks like a turntable. */
+.crate-deck-platter {
+  flex: 0 0 auto;
+  width: 96px;
+  aspect-ratio: 1;
+  border-radius: 3px;
+  border: 1px dashed var(--border);
+  background: var(--bg);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Loaded: a real edge instead of the dashed outline of an empty platter. */
+.crate-deck-platter.is-loaded {
+  border-style: solid;
+}
+
+.crate-deck-art {
+  width: 100%;
+  height: 100%;
+  /* contain, not cover: this is the artwork at its largest on this screen and
+     kamp does not crop covers. */
+  object-fit: contain;
+  background: var(--bg);
+}
+
+.crate-deck-body {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
-.crate-preview-placeholder {
+.crate-deck-empty {
   margin: auto 0;
   color: var(--text-dim);
   font-size: 12px;
-  opacity: 0.7;
-  text-align: center;
+  line-height: 1.5;
 }
 
 /* Its own strip rather than the TransportBar: the whole promise is that the
@@ -966,17 +1011,19 @@
      an animation restarts from the top. At 2-3 flips/sec an animation would
      stutter and queue; this just redirects.
 
-     The curve overshoots ~3% and comes back, which at the flip's 22deg swing is
-     the 2-3deg overshoot and ~90ms spring the ticket asks for. */
+     QUIETENED in KAMP-668, deliberately. Flipping is BROWSING — it happens
+     constantly — and the moment that earns motion is putting a record on the
+     deck. The settle is kept rather than removed so cardboard still has weight,
+     but the overshoot drops from ~3% to ~1 and the duration from 260ms to 180,
+     so a landing reads as a landing instead of a performance and never competes
+     with the flight to the deck. */
   .bin-sleeve {
-    transition: transform 260ms cubic-bezier(0.22, 1.42, 0.36, 1);
+    transition: transform 180ms cubic-bezier(0.25, 1.12, 0.4, 1);
   }
 
-  /* The receiving pile compresses by a pixel or two as a record lands on it,
-     then recovers. Same overshoot logic, slightly slower so it reads as weight
-     rather than as a bounce. */
+  /* The receiving pile still compresses a touch as a record lands, just less. */
   .bin-sleeve--flipped {
-    transition: transform 300ms cubic-bezier(0.18, 1.3, 0.4, 1);
+    transition: transform 200ms cubic-bezier(0.22, 1.1, 0.42, 1);
   }
 
   /* Stock-in: a new crate is filed back-to-front, the way you would put records

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -821,6 +821,43 @@
   line-height: 1.5;
 }
 
+/* The record in transit (KAMP-668).
+ *
+ * position: fixed because the rects it is built from are viewport-relative and
+ * the crate view scrolls — anchoring to a scrolling ancestor would make the
+ * traveller drift away from both ends of its own journey.
+ *
+ * transform-origin: top left so the translate and scale in RecordFlight compose
+ * from the same corner; with the default centre origin they disagree and the
+ * record lands offset by half the size difference.
+ *
+ * Inert: it is a picture, never a control. The real record keeps its place in
+ * the listbox the whole time. */
+.crate-flight {
+  position: fixed;
+  z-index: 950;
+  pointer-events: none;
+  transform-origin: top left;
+  border-radius: 3px;
+  overflow: hidden;
+  box-shadow: 0 10px 26px rgb(0 0 0 / 45%);
+}
+
+.crate-flight-art {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: var(--bg);
+}
+
+/* The gap in the crate. `visibility` rather than `display` or unmounting: the
+   element keeps its box and its place in the listbox, so roving tabindex,
+   aria-posinset and the focus recovery all carry on working while the record is
+   away — only the picture of it leaves. */
+.bin-sleeve--away {
+  visibility: hidden;
+}
+
 /* Its own strip rather than the TransportBar: the whole promise is that the
    main transport keeps showing the user's own queue, so two players on screen
    is the point. */
@@ -1024,6 +1061,17 @@
   /* The receiving pile still compresses a touch as a record lands, just less. */
   .bin-sleeve--flipped {
     transition: transform 200ms cubic-bezier(0.22, 1.1, 0.42, 1);
+  }
+
+  /* The flight to the deck — the one moment in this view that earns real motion,
+     which is the whole reason the flip above was quietened.
+
+     Longer and more weighted than a flip: this is a record being lifted out and
+     set down, not a page turn. A transition rather than a keyframe so a second
+     preview mid-flight redirects instead of restarting, and easing that settles
+     rather than bounces — the record is being placed, not dropped. */
+  .crate-flight {
+    transition: transform 420ms cubic-bezier(0.32, 0.72, 0.2, 1);
   }
 
   /* Stock-in: a new crate is filed back-to-front, the way you would put records

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -43,6 +43,7 @@ function BinSleeve({
   focusIndex,
   focused,
   flipped,
+  away,
   passed,
   onFocus
 }: {
@@ -53,6 +54,8 @@ function BinSleeve({
   focused: boolean
   // Already flipped past: lying on the pile at the crate lip.
   flipped: boolean
+  // Out of the crate and on the deck.
+  away: boolean
   passed: boolean
   onFocus: (index: number) => void
 }): React.JSX.Element {
@@ -62,6 +65,11 @@ function BinSleeve({
   const classes = ['bin-sleeve']
   if (focused) classes.push('bin-sleeve--focused')
   if (flipped) classes.push('bin-sleeve--flipped')
+  // On the deck: the record is genuinely out of the crate, so you see into the
+  // gap where it was. Hidden rather than unmounted — the element keeps its place
+  // in the listbox, so roving tabindex, aria-posinset and the focus recovery all
+  // carry on working while the record is away (KAMP-668).
+  if (away) classes.push('bin-sleeve--away')
   if (passed || item.state === 'dismissed') classes.push('bin-sleeve--passed')
   if (item.state === 'wishlisted') classes.push('bin-sleeve--wishlisted')
   if (item.state === 'purchased') classes.push('bin-sleeve--purchased')
@@ -81,6 +89,10 @@ function BinSleeve({
   return (
     <li
       className={classes.join(' ')}
+      // How the flight finds its start and end rects. An attribute rather than a
+      // ref per sleeve: the view needs to measure exactly one of these, once, at
+      // the moment a flight begins.
+      data-bin-item={item.id}
       role="option"
       aria-selected={focused}
       aria-setsize={total}
@@ -159,6 +171,7 @@ export function CrateBin({
   crateNo,
   focusIndex,
   pendingDismissals,
+  awayItemId,
   spineName,
   railRef,
   onFocus
@@ -167,6 +180,8 @@ export function CrateBin({
   crateNo: number | null
   focusIndex: number
   pendingDismissals: number[]
+  // The record currently out of the crate and on the deck, if any.
+  awayItemId: number | null
   spineName: string
   railRef: React.RefObject<HTMLUListElement | null>
   onFocus: (index: number) => void
@@ -219,6 +234,7 @@ export function CrateBin({
             focusIndex={focusIndex}
             focused={index === focusIndex}
             flipped={index < focusIndex}
+            away={item.id === awayItemId}
             passed={pendingDismissals.includes(item.id)}
             onFocus={onFocus}
           />

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -96,9 +96,13 @@ function BinSleeve({
         {
           '--bin-rel': rel,
           '--bin-order': order,
-          // A fallback only. Inside preserve-3d the browser sorts by actual 3D
-          // position and ignores this, which is exactly why the pile order has
-          // to be right in the transform rather than here.
+          // Authoritative, not a fallback. The records container is deliberately
+          // FLAT rather than preserve-3d (see crate.css), so siblings composite
+          // as layers in this order and can never intersect — which is what
+          // stopped a record in motion showing through the one it moves toward.
+          //
+          // Standing records paint back-to-front (nearer index on top), and the
+          // entire pile paints above all of them, newest landing highest.
           zIndex: flipped ? total + index : total - index
         } as React.CSSProperties
       }

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -140,6 +140,20 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // reads nothing from the clock, so a crate keeps its name.
   const spineName = useMemo(() => crateSpineName(items, crate?.hints ?? []), [items, crate?.hints])
 
+  // What is actually ON the deck, which is deliberately NOT `current`: the
+  // engine plays one item at a time and you can keep flipping while it plays, so
+  // the deck must follow the preview rather than the focus. Looked up in the
+  // crate because the preview state carries an id, not the row (KAMP-668).
+  const deckItem = useMemo(() => {
+    const id = preview?.item_id
+    if (id == null || preview?.state === 'idle') return null
+    return items.find((item) => item.id === id) ?? null
+  }, [items, preview?.item_id, preview?.state])
+
+  // Where a record flies TO. Measured at the moment a flight starts rather than
+  // held as state — the view scrolls, so a rect captured earlier is stale.
+  const deckArtRef = useRef<HTMLDivElement | null>(null)
+
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
   const previewingThis = Boolean(
@@ -558,20 +572,31 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           />
         )}
 
-        {/* The preview's own space, always present, and BELOW the bin (KAMP-656).
-            It sat inside the focus card until the bin got its proper sizing, at
-            which point the sleeves — absolutely positioned and leaning out of
-            their container — drew straight over the mini-player and the hint
-            text. Ordering it after the bin fixes that by construction rather
-            than by fighting the overflow, and there is plenty of vertical room.
+        {/* The deck (KAMP-668). Always here, whether or not a record is on it —
+            it is the thing a record gets put ON, so it has to exist before one
+            does. It used to be a reserved-but-empty slot showing a hint line,
+            which reserved the room without ever reading as an object.
 
-            Still a reserved slot: rendering the strip and track list into the
-            normal flow made the whole thing grow when a preview started, and the
-            track list is unbounded, so a long record shoved everything below it
-            down the page. The slot holds the room; the list scrolls inside it. */}
-        {current && (
-          <div className="crate-preview-slot">
-            {previewingThis && preview ? (
+            Below the bin because the sleeves are absolutely positioned and lean
+            out of their container: ordering it after them keeps them off it by
+            construction rather than by fighting overflow.
+
+            The platter shows whatever is PLAYING, which is not necessarily the
+            focused record — you can keep flipping while something plays, and the
+            deck should not change under you when you do. */}
+        <div className="crate-deck" role="group" aria-label="Preview deck">
+          <div
+            className={`crate-deck-platter${deckItem ? ' is-loaded' : ''}`}
+            ref={deckArtRef}
+            aria-hidden="true"
+          >
+            {deckItem?.art_url && (
+              <img className="crate-deck-art" src={crateArtUrl(deckItem.id)} alt="" />
+            )}
+          </div>
+
+          <div className="crate-deck-body">
+            {deckItem && preview ? (
               <>
                 <CratePreviewStrip
                   preview={preview}
@@ -588,7 +613,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                           className={`crate-track${
                             track.track_num === preview.track_num ? ' crate-track--current' : ''
                           }`}
-                          onClick={() => void previewPlay(current.id, track.track_num)}
+                          onClick={() => void previewPlay(deckItem.id, track.track_num)}
                         >
                           <span className="crate-track-num">{track.track_num}</span>
                           <span className="crate-track-title">
@@ -610,12 +635,13 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 )}
               </>
             ) : (
-              <p className="crate-preview-placeholder">
-                Space to hear it — your queue stays where it is.
+              <p className="crate-deck-empty">
+                Nothing on the deck. Space puts the record you&rsquo;re looking at on — your queue
+                stays where it is.
               </p>
             )}
           </div>
-        )}
+        </div>
 
         <div className="crate-footer">
           {digButton}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -17,6 +17,8 @@ import { CrateSleeve, CrateSlot } from './CrateSleeve'
 import { CrateBin } from './CrateBin'
 import { crateSpineName } from './crateSpine'
 import { CratePreviewStrip } from './CratePreviewStrip'
+import { RecordFlight } from './RecordFlight'
+import type { FlightRect } from './RecordFlight'
 import { formatClock } from '../utils/formatClock'
 import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
@@ -34,6 +36,11 @@ function formatPause(seconds: number): string {
 }
 
 const plural = (n: number, word: string): string => `${n} ${word}${n === 1 ? '' : 's'}`
+
+// A record in transit between its slot in the crate and the deck (KAMP-668).
+// `dir` is where it is heading, which decides both which end hides its copy and
+// which end the rects came from.
+type Flight = { id: number; dir: 'deck' | 'home'; from: FlightRect; to: FlightRect }
 
 // The lifetime line. Everything the user has dug, in the clerk's register:
 // concrete counts, no percentages, nothing that reads as a score to beat.
@@ -153,6 +160,53 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // Where a record flies TO. Measured at the moment a flight starts rather than
   // held as state — the view scrolls, so a rect captured earlier is stale.
   const deckArtRef = useRef<HTMLDivElement | null>(null)
+  const [flight, setFlight] = useState<Flight | null>(null)
+  const lastDeckId = useRef<number | null>(null)
+  const seededDeck = useRef(false)
+
+  // A record leaves the crate when it goes on the deck and comes back when it
+  // comes off. The flight is an enhancement on that STATE CHANGE, never the
+  // thing that puts it there: preview is daemon-owned and survives a renderer
+  // reload (KAMP-651), so arriving with something already playing must show an
+  // occupied deck and no flight at all. Hence seeding the first value silently.
+  useEffect(() => {
+    const nextId = deckItem?.id ?? null
+    const prevId = lastDeckId.current
+    lastDeckId.current = nextId
+    if (!seededDeck.current) {
+      seededDeck.current = true
+      return
+    }
+    if (nextId === prevId) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    const platter = deckArtRef.current?.getBoundingClientRect()
+    if (!platter) return
+    const sleeveOf = (id: number): DOMRect | undefined =>
+      railRef.current
+        ?.querySelector<HTMLElement>(`[data-bin-item="${id}"]`)
+        ?.getBoundingClientRect()
+
+    if (nextId !== null) {
+      // Out of the crate and onto the deck.
+      const sleeve = sleeveOf(nextId)
+      if (sleeve) setFlight({ id: nextId, dir: 'deck', from: sleeve, to: platter })
+    } else if (prevId !== null) {
+      // Off the deck and home. Covers stopping, and covers a preview that
+      // failed to play — otherwise a record that never started would leave the
+      // crate a gap forever.
+      const sleeve = sleeveOf(prevId)
+      if (sleeve) setFlight({ id: prevId, dir: 'home', from: platter, to: sleeve })
+    }
+  }, [deckItem?.id, railRef])
+
+  // Which sleeve is invisible in the bin: the one on the deck, or the one still
+  // flying home. Without the second case the sleeve reappears the instant the
+  // preview stops and you see the record in two places at once.
+  const awayItemId = deckItem?.id ?? (flight?.dir === 'home' ? flight.id : null)
+  // Same idea at the other end: the platter stays empty until the outbound
+  // flight lands on it, or the art is in two places for the length of the trip.
+  const platterItem = flight?.dir === 'deck' ? null : deckItem
 
   // Preview state for the record on screen. The engine plays one item at a
   // time, so a preview belonging to another card must not light this one up.
@@ -566,6 +620,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             crateNo={crate?.crate_no ?? null}
             focusIndex={focusIndex}
             pendingDismissals={pendingDismissals}
+            awayItemId={awayItemId}
             spineName={spineName}
             railRef={railRef}
             onFocus={focusSleeve}
@@ -586,12 +641,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             deck should not change under you when you do. */}
         <div className="crate-deck" role="group" aria-label="Preview deck">
           <div
-            className={`crate-deck-platter${deckItem ? ' is-loaded' : ''}`}
+            className={`crate-deck-platter${platterItem ? ' is-loaded' : ''}`}
             ref={deckArtRef}
             aria-hidden="true"
           >
-            {deckItem?.art_url && (
-              <img className="crate-deck-art" src={crateArtUrl(deckItem.id)} alt="" />
+            {platterItem?.art_url && (
+              <img className="crate-deck-art" src={crateArtUrl(platterItem.id)} alt="" />
             )}
           </div>
 
@@ -664,6 +719,19 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           {current ? `Record ${focusIndex + 1} of ${visible.length}. ${current.why}` : ''}
         </div>
       </div>
+
+      {/* Keyed on the record AND the direction, so previewing a second record
+          before the first has landed mounts a fresh traveller for it rather than
+          the old one snapping to a new destination mid-flight. */}
+      {flight && (
+        <RecordFlight
+          key={`${flight.id}-${flight.dir}`}
+          from={flight.from}
+          to={flight.to}
+          artUrl={crateArtUrl(flight.id)}
+          onDone={() => setFlight((f) => (f === flight ? null : f))}
+        />
+      )}
 
       {undoItem && (
         <div className="crate-undo-toast" role="status">

--- a/kamp_ui/src/renderer/src/components/RecordFlight.tsx
+++ b/kamp_ui/src/renderer/src/components/RecordFlight.tsx
@@ -1,0 +1,82 @@
+// The record travelling between the crate and the deck (KAMP-668).
+//
+// This is the one genuinely cross-container motion in the whole feature. The
+// sleeve lives inside the bin's stacking context and the deck is elsewhere in
+// the tree, so nothing that transforms the sleeve in place can reach across —
+// hence a single travelling element, positioned over the page, that neither
+// container owns.
+//
+// It is a FLIP: the element is laid out at its DESTINATION, then given an
+// inverting transform that maps it back onto the source rect, then that
+// transform is removed so it animates to where it already is. Doing it this way
+// keeps the whole animation on `transform` — no width/height/top/left tweening,
+// which is the project rule and also the only way this stays cheap.
+//
+// It is inert by construction: aria-hidden, pointer-events: none, never focused,
+// never part of the listbox. The record it represents keeps its place in the bin
+// the entire time; only the picture of it moves.
+import React, { useEffect, useState } from 'react'
+
+export type FlightRect = { left: number; top: number; width: number; height: number }
+
+export function RecordFlight({
+  from,
+  to,
+  artUrl,
+  onDone
+}: {
+  from: FlightRect
+  to: FlightRect
+  artUrl: string | null
+  onDone: () => void
+}): React.JSX.Element {
+  const [settled, setSettled] = useState(false)
+
+  useEffect(() => {
+    // Two frames, not one. The browser has to paint the inverted transform
+    // before it is removed, or it coalesces both into a single style change and
+    // there is no transition at all — the record simply appears at the deck.
+    let second = 0
+    const first = requestAnimationFrame(() => {
+      second = requestAnimationFrame(() => setSettled(true))
+    })
+    return () => {
+      cancelAnimationFrame(first)
+      cancelAnimationFrame(second)
+    }
+  }, [])
+
+  useEffect(() => {
+    // transitionend is the normal path, but it never fires if the two rects
+    // happen to match (nothing to animate) — and a traveller stuck on screen
+    // would leave the crate looking permanently short a record. A timeout longer
+    // than the transition guarantees cleanup either way.
+    const bail = window.setTimeout(onDone, 900)
+    return () => window.clearTimeout(bail)
+  }, [onDone])
+
+  // transform-origin is top left so the translate and the scale compose from the
+  // same corner; with the default centre origin the two disagree and the record
+  // arrives offset by half the size difference.
+  const dx = from.left - to.left
+  const dy = from.top - to.top
+  const sx = to.width > 0 ? from.width / to.width : 1
+  const sy = to.height > 0 ? from.height / to.height : 1
+
+  return (
+    <div
+      className="crate-flight"
+      aria-hidden="true"
+      style={{
+        left: `${to.left}px`,
+        top: `${to.top}px`,
+        width: `${to.width}px`,
+        height: `${to.height}px`,
+        transform: settled ? 'none' : `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`
+      }}
+      onTransitionEnd={onDone}
+    >
+      {artUrl && <img className="crate-flight-art" src={artUrl} alt="" />}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Previewing now takes the record out of the crate and puts it on the deck. Stopping puts it back.

**This PR contains KAMP-667 as well** — it's branched off `kamp-667-no-interpenetration` (PR #759), which is a stated dependency and not merged yet. Review or merge that one first and I'll rebase.

## The re-frame

KAMP-668 was "pull-out: the focused record comes out of the crate to be read". That premise was wrong about which moment deserves motion.

Flipping through a bin is **browsing** — it happens constantly and should be quiet. The moment that earns animation is **previewing**, because it's the only action that's a commitment: you've picked a record and put it on. The old framing also had the two competing — a performance on every flip, and a preview that just started playing somewhere else on the page.

So the flip settle is turned down (overshoot ~3° → ~1°, 260ms → 180ms — kept rather than removed, so cardboard still has weight), and the flight gets the room that frees up.

## The deck is now a thing that exists

It was a reserved slot showing a hint line until something played. It held the space without ever reading as an object — and a record can't be put *on* something that only exists once it's already playing. It's now a platter with a dashed empty state, present either way.

The platter shows what's **playing**, not what's focused. Those diverge the moment you keep flipping while something plays, and the deck changing under you as you flip past would be wrong.

## The flight

This is the only genuinely cross-container motion in the feature: the sleeve lives inside the bin's stacking context and the deck is elsewhere in the tree, so nothing that transforms the sleeve in place can reach across. Hence one travelling element that neither container owns.

It's a FLIP, so it stays transform-only — laid out at its destination, given an inverting transform back onto the source rect, then that transform removed so it animates to where it already is. A few things that each had to be got right:

- **Two animation frames, not one.** The browser has to paint the inverted transform before it's removed, or both collapse into one style change and the record simply appears at the deck.
- **`position: fixed`.** The rects are viewport-relative and this view scrolls; anchoring to a scrolling ancestor would make the traveller drift away from both ends of its own journey.
- **`transform-origin: top left`.** The translate and the scale have to compose from the same corner — with the default centre origin they disagree and the record lands offset by half the size difference.
- **The gap is `visibility: hidden`**, not an unmount. The element keeps its box and its place in the listbox, so roving tabindex, `aria-posinset` and the KAMP-598 focus recovery all keep working while the record is away. Only the picture of it leaves.

## Three cases that would each have looked like a bug

- **A second preview mid-flight** — the traveller is keyed on record *and* direction, so a new one mounts rather than the old one snapping to a new destination.
- **A preview that fails** (`not_found` / `unavailable` / `rate_limited`) — the return flight is driven by the deck emptying, so a record that never played still comes home instead of leaving the crate permanently short. Worth testing, since KAMP-670 means unplayable records are still reaching crates.
- **A renderer reload mid-preview** — preview state is daemon-owned (KAMP-651), so the deck can be occupied with no flight ever having happened. The first deck value is seeded silently; only a change animates.

## Test plan

- [x] `npm run typecheck`, `npm run lint` clean
- [x] `poetry run pytest` — **3177 passed**, unchanged; no Python touched

No test runner in `kamp_ui`, so this needs your eyes.

## What to check

- Flip around with nothing playing — it should feel calmer than before, and the deck should sit there empty and obvious.
- Space: the record should leave the crate and land on the deck, with a visible gap behind it. Space again: home.
- Preview one, then immediately preview another mid-flight. Nothing should snap.
- Preview something with no streamable tracks — it must come home.
- Reload with a preview playing: occupied deck, no flight.
- Keyboard only throughout: `,`/`.`, arrows in the bin, `W`/`X`/`C`, Space. The traveller must never take focus.
- Reduce Motion on: no flight, everything still works.

`npm start` rather than `npm run dev`, given the framerate difference.

Closes KAMP-668. Contains KAMP-667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
