### PR TITLE
KAMP-674: remove 'pass' from the Crate

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -328,10 +328,14 @@ def register_discovery_routes(
         _publish({})  # state unchanged; the item's cached state moved
         return {"ok": True}
 
-    @app.post("/api/v1/discovery/items/{item_id}/dismiss")
-    def dismiss_item(item_id: int) -> dict[str, Any]:
-        """Pass on a record. Recorded, never deleted — the ledger is history."""
-        return _record(item_id, "dismissed")
+    # There is deliberately no 'dismiss' endpoint (KAMP-674). Passing on a record
+    # changed nothing a user could observe: `_excluded` bans anything ever placed
+    # in a crate via `seen_before`, so a passed record and an ignored one produce
+    # identical future crates, and no stat counted the difference.
+    #
+    # The 'dismissed' event kind is still honoured by the ledger — real rows exist
+    # on disk and `_state_from_ledger` must keep resolving them — it simply has no
+    # writer anymore.
 
     @app.post("/api/v1/discovery/items/{item_id}/url-copied")
     def url_copied(item_id: int) -> dict[str, Any]:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -585,6 +585,9 @@ export type CrateItem = {
   seed: Record<string, unknown> // parsed seed_json; {} when the blob was malformed
   crate_no: number | null
   position: number | null
+  // 'dismissed' is legacy-only (KAMP-674 removed pass): nothing writes it any
+  // more, but rows on disk from before the removal still report it and must
+  // render as ordinary records rather than crash a narrowed union.
   state: 'fresh' | 'previewed' | 'wishlisted' | 'dismissed' | 'purchased'
   first_seen_at: number
 }
@@ -638,9 +641,6 @@ export const clearDiggingHistory = (forgetSeen: boolean): Promise<{ ok: boolean 
 // message ("a crate is already building") instead of a bare status line.
 export const newCrate = (): Promise<{ started: boolean }> =>
   postWithDetail('/api/v1/discovery/crate/new')
-
-export const dismissCrateItem = (itemId: number): Promise<{ ok: boolean }> =>
-  post(`/api/v1/discovery/items/${itemId}/dismiss`)
 
 export const crateItemUrlCopied = (itemId: number): Promise<{ ok: boolean }> =>
   post(`/api/v1/discovery/items/${itemId}/url-copied`)

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -437,10 +437,6 @@
 /* Same rule as the flat rail: state is opacity, border weight and a glyph —
    never hue. There is one --accent token and it swings from indigo to magenta
    to green across the eight palettes. */
-.bin-sleeve--passed {
-  opacity: 0.35;
-}
-
 .bin-sleeve--wishlisted .bin-sleeve-art,
 .bin-sleeve--purchased .bin-sleeve-art {
   outline: 2px solid var(--accent);
@@ -652,10 +648,6 @@
   border-color: var(--text-dim);
 }
 
-.crate-sleeve--passed {
-  opacity: 0.35;
-}
-
 /* Brought home. Reads as the strongest of the "dug" states because it is the
    one that means the record left the shop. */
 .crate-sleeve--purchased .crate-sleeve-art {
@@ -703,56 +695,6 @@
   padding-top: 20px;
 }
 
-/* --- Undo toast ----------------------------------------------------------- */
-
-.crate-undo-toast {
-  position: fixed;
-  right: 16px;
-  bottom: calc(var(--transport-h) + 16px);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--surface);
-  color: var(--text);
-  font-size: 13px;
-  z-index: 900;
-  overflow: hidden;
-}
-
-.crate-undo-text {
-  color: var(--text-dim);
-}
-
-.crate-undo-btn {
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--accent);
-  border-radius: 3px;
-  padding: 3px 10px;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.crate-undo-bar {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  height: 2px;
-  width: 100%;
-  background: var(--accent);
-  transform-origin: left center;
-}
-
-/* --- Preview mini-player (KAMP-651) --------------------------------------- */
-
-/* The preview's reserved space. Held open whether or not anything is playing,
-   because rendering the strip into the normal flow grew the whole card and
-   pushed the rail down the page the moment a preview started. Sized for the
-   strip plus a scrolling track list, so a 3-track single and a 20-track album
-   occupy exactly the same room. */
 /* --- The deck (KAMP-668) ---------------------------------------------------
  *
  * Always present, with or without a record on it. It used to be a reserved slot
@@ -1018,25 +960,12 @@
     animation: crateArtIn 200ms ease both;
   }
 
-  .crate-undo-bar {
-    animation: crateUndoBar linear forwards;
-  }
-
   @keyframes crateArtIn {
     from {
       opacity: 0;
     }
     to {
       opacity: 1;
-    }
-  }
-
-  @keyframes crateUndoBar {
-    from {
-      transform: scaleX(1);
-    }
-    to {
-      transform: scaleX(0);
     }
   }
 

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -44,7 +44,6 @@ function BinSleeve({
   focused,
   flipped,
   away,
-  passed,
   onFocus
 }: {
   item: CrateItem
@@ -56,7 +55,6 @@ function BinSleeve({
   flipped: boolean
   // Out of the crate and on the deck.
   away: boolean
-  passed: boolean
   onFocus: (index: number) => void
 }): React.JSX.Element {
   const [artFailed, setArtFailed] = useState(false)
@@ -70,7 +68,9 @@ function BinSleeve({
   // in the listbox, so roving tabindex, aria-posinset and the focus recovery all
   // carry on working while the record is away (KAMP-668).
   if (away) classes.push('bin-sleeve--away')
-  if (passed || item.state === 'dismissed') classes.push('bin-sleeve--passed')
+  // No 'dismissed' branch: pass is gone (KAMP-674). A legacy dismissed row from
+  // before the removal is an ordinary record now, which is the honest rendering
+  // — nothing in the product acts on that state any more.
   if (item.state === 'wishlisted') classes.push('bin-sleeve--wishlisted')
   if (item.state === 'purchased') classes.push('bin-sleeve--purchased')
 
@@ -130,11 +130,6 @@ function BinSleeve({
           />
         )}
       </div>
-      {(passed || item.state === 'dismissed') && (
-        <span className="bin-sleeve-badge" aria-hidden="true">
-          ✕
-        </span>
-      )}
       {item.state === 'wishlisted' && (
         <span className="bin-sleeve-badge" aria-hidden="true">
           ♥
@@ -170,7 +165,6 @@ export function CrateBin({
   items,
   crateNo,
   focusIndex,
-  pendingDismissals,
   awayItemId,
   spineName,
   railRef,
@@ -179,7 +173,6 @@ export function CrateBin({
   items: CrateItem[]
   crateNo: number | null
   focusIndex: number
-  pendingDismissals: number[]
   // The record currently out of the crate and on the deck, if any.
   awayItemId: number | null
   spineName: string
@@ -235,7 +228,6 @@ export function CrateBin({
             focused={index === focusIndex}
             flipped={index < focusIndex}
             away={item.id === awayItemId}
-            passed={pendingDismissals.includes(item.id)}
             onFocus={onFocus}
           />
         ))}

--- a/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
@@ -22,15 +22,12 @@ export function CrateSleeve({
   index,
   total,
   focused,
-  passed,
   onFocus
 }: {
   item: CrateItem
   index: number
   total: number
   focused: boolean
-  // Passed locally but not yet committed — the 5s Undo window.
-  passed: boolean
   onFocus: (index: number) => void
 }): React.JSX.Element {
   const [artFailed, setArtFailed] = useState(false)
@@ -38,10 +35,11 @@ export function CrateSleeve({
 
   const classes = ['crate-sleeve']
   if (focused) classes.push('crate-sleeve--focused')
-  if (passed || item.state === 'dismissed') classes.push('crate-sleeve--passed')
   if (item.state === 'wishlisted') classes.push('crate-sleeve--wishlisted')
   if (item.state === 'purchased') classes.push('crate-sleeve--purchased')
-  if (item.state !== 'fresh' && item.state !== 'dismissed') classes.push('crate-sleeve--dug')
+  // 'dismissed' is a legacy state with no writer (KAMP-674), so it no longer
+  // gets an exemption here — a record carrying it counts as dug like any other.
+  if (item.state !== 'fresh') classes.push('crate-sleeve--dug')
 
   return (
     <li
@@ -70,11 +68,6 @@ export function CrateSleeve({
           />
         )}
       </div>
-      {(passed || item.state === 'dismissed') && (
-        <span className="crate-sleeve-badge" aria-hidden="true">
-          ✕
-        </span>
-      )}
       {item.state === 'wishlisted' && (
         <span className="crate-sleeve-badge" aria-hidden="true">
           ♥

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -24,9 +24,6 @@ import { useTooltip } from '../hooks/useTooltip'
 import { TOOLTIPS } from '../tooltipStrings'
 
 const CRATE_SIZE = 10
-// How long a passed record can be brought back. The dismiss POST is held for
-// this long rather than sent and reversed: 'dismissed' is terminal server-side.
-const UNDO_MS = 5000
 
 function formatPause(seconds: number): string {
   const total = Math.ceil(seconds)
@@ -66,12 +63,7 @@ function describeTally(s: DiggingStats): string {
 
 export function CrateView({ active = false }: { active?: boolean }): React.JSX.Element {
   const crate = useStore((s) => s.crate)
-  const pendingDismissals = useStore((s) => s.crateDismissPending)
   const newCrate = useStore((s) => s.newCrate)
-  const deferCrateDismiss = useStore((s) => s.deferCrateDismiss)
-  const undoCrateDismiss = useStore((s) => s.undoCrateDismiss)
-  const commitCrateDismiss = useStore((s) => s.commitCrateDismiss)
-  const flushCrateDismissals = useStore((s) => s.flushCrateDismissals)
   const copyCrateItemUrl = useStore((s) => s.copyCrateItemUrl)
   const toggleCrateWishlist = useStore((s) => s.toggleCrateWishlist)
   const wishlistPending = useStore((s) => s.crateWishlistPending)
@@ -85,8 +77,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const tooltip = useTooltip()
 
   const [focused, setFocused] = useState(0)
-  const [undoItem, setUndoItem] = useState<CrateItem | null>(null)
-  const undoTimerRef = useRef<number | null>(null)
   const railRef = useRef<HTMLUListElement | null>(null)
   const [pauseRemaining, setPauseRemaining] = useState(0)
 
@@ -96,7 +86,10 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // Never derived from `filled` outside a live build: the daemon's status is
   // in-memory, so a restored crate reports the builder's last count. The
   // snapshot derives both from the stored rows when idle (KAMP-650).
-  const visible = items.filter((item) => !pendingDismissals.includes(item.id))
+  //
+  // The crate is exactly what the daemon sent. There used to be a `visible`
+  // subset filtering out locally-passed records; pass is gone (KAMP-674), so
+  // every record in the snapshot is on screen for the life of the crate.
   const hasCrate = items.length > 0
 
   // Rate-limit countdown, ticked locally so the daemon publishes the deadline
@@ -112,11 +105,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   }, [pausedUntil])
 
   // Clamped during render rather than corrected in an effect: the crate grows
-  // while a build streams and shrinks as records are passed, so the stored index
-  // can briefly point past the end. Deriving avoids a re-render round trip and
-  // the intermediate frame where the focus card would be blank.
-  const focusIndex = visible.length === 0 ? 0 : Math.min(focused, visible.length - 1)
-  const current = visible[focusIndex] ?? null
+  // while a build streams, so the stored index can briefly point past the end.
+  // Deriving avoids a re-render round trip and the intermediate frame where the
+  // focus card would be blank.
+  const focusIndex = items.length === 0 ? 0 : Math.min(focused, items.length - 1)
+  const current = items[focusIndex] ?? null
 
   // The done-state is read from item.state, never from a local flag. A confirmed
   // write re-broadcasts the whole crate, so this arrives from the daemon — which
@@ -139,7 +132,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // the tally cannot drift from the lifetime line.
   const history = crate?.stats ?? null
   const crateTally = crate?.crate_stats ?? null
-  const atLastRecord = visible.length > 1 && focusIndex === visible.length - 1
+  const atLastRecord = items.length > 1 && focusIndex === items.length - 1
 
   // The name on the crate's divider card (KAMP-656). Derived from the snapshot
   // the view already has, because this story is skin only — no API changes. It
@@ -231,49 +224,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     if (useStore.getState().preview?.state !== 'idle') void previewAction('stop')
   }, [active, previewAction])
 
-  // Any held dismiss must be sent before this view stops being able to send it.
-  // Without this, passing a record and immediately switching views loses it.
-  useEffect(() => {
-    if (active) return
-    void flushCrateDismissals()
-  }, [active, flushCrateDismissals])
-  useEffect(() => {
-    return () => {
-      void useStore.getState().flushCrateDismissals()
-    }
-  }, [])
-
-  const clearUndoTimer = useCallback((): void => {
-    if (undoTimerRef.current !== null) {
-      window.clearTimeout(undoTimerRef.current)
-      undoTimerRef.current = null
-    }
-  }, [])
-
-  const pass = useCallback(
-    (item: CrateItem): void => {
-      // Commit whatever was already waiting — only one Undo is offered at a time,
-      // and the previous one's window is over the moment a new pass happens.
-      if (undoItem && undoItem.id !== item.id) void commitCrateDismiss(undoItem.id)
-      clearUndoTimer()
-      deferCrateDismiss(item.id)
-      setUndoItem(item)
-      undoTimerRef.current = window.setTimeout(() => {
-        undoTimerRef.current = null
-        setUndoItem(null)
-        void commitCrateDismiss(item.id)
-      }, UNDO_MS)
-    },
-    [clearUndoTimer, commitCrateDismiss, deferCrateDismiss, undoItem]
-  )
-
-  const undo = useCallback((): void => {
-    if (!undoItem) return
-    clearUndoTimer()
-    undoCrateDismiss(undoItem.id)
-    setUndoItem(null)
-  }, [clearUndoTimer, undoCrateDismiss, undoItem])
-
   // The album's own page, for buying it or reading the notes — preview now
   // handles listening (KAMP-651).
   const openOnBandcamp = useCallback((item: CrateItem): void => {
@@ -349,15 +299,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     if (isNext) {
       e.preventDefault()
       e.stopPropagation()
-      if (visible.length > 0) focusSleeve(Math.min(focusIndex + 1, visible.length - 1))
+      if (items.length > 0) focusSleeve(Math.min(focusIndex + 1, items.length - 1))
     } else if (isPrev) {
       e.preventDefault()
       e.stopPropagation()
-      if (visible.length > 0) focusSleeve(Math.max(focusIndex - 1, 0))
-    } else if (e.key === 'x' || e.key === 'X') {
-      e.preventDefault()
-      e.stopPropagation()
-      if (current) pass(current)
+      if (items.length > 0) focusSleeve(Math.max(focusIndex - 1, 0))
     } else if (e.key === 'c' || e.key === 'C') {
       e.preventDefault()
       e.stopPropagation()
@@ -407,7 +353,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // and a plain focus() scrolls the record into view, yanking the card off the
   // top of the screen the moment you arrive.
   useEffect(() => {
-    if (!active || visible.length === 0) return
+    if (!active || items.length === 0) return
     const rail = railRef.current
     if (!rail) return
     // Never steal focus from something already in use inside the view — a
@@ -415,7 +361,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     if (rail.contains(document.activeElement)) return
     const option = rail.querySelectorAll<HTMLElement>('[role="option"]')[focusIndex]
     option?.focus({ preventScroll: true })
-  }, [active, visible.length, focusIndex])
+  }, [active, items.length, focusIndex])
 
   // ---------------------------------------------------------------------------
   // Compositions
@@ -487,7 +433,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     )
   }
 
-  const slots = building ? Math.max(CRATE_SIZE - visible.length, 0) : 0
+  const slots = building ? Math.max(CRATE_SIZE - items.length, 0) : 0
 
   return (
     <div className="crate-view" onKeyDown={onKeyDown} onBlurCapture={onBlurCapture}>
@@ -515,7 +461,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 </p>
               )}
               <p className="crate-focus-position">
-                Record {focusIndex + 1} of {visible.length}
+                Record {focusIndex + 1} of {items.length}
                 {current.release_date ? ` · ${current.release_date.slice(0, 4)}` : ''}
               </p>
               <div className="crate-actions">
@@ -565,13 +511,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 >
                   Copy link
                 </button>
-                <button
-                  className="crate-action"
-                  onClick={() => pass(current)}
-                  {...tooltip(TOOLTIPS.CRATE_PASS)}
-                >
-                  Pass
-                </button>
               </div>
 
               {/* The clerk explains a failed wishlist write here rather than in a
@@ -599,27 +538,25 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             a half-full bin has no pile to show yet. */}
         {building ? (
           <ul className="crate-rail" role="listbox" aria-label="Crate" ref={railRef} tabIndex={-1}>
-            {visible.map((item, index) => (
+            {items.map((item, index) => (
               <CrateSleeve
                 key={item.id}
                 item={item}
                 index={index}
-                total={visible.length}
+                total={items.length}
                 focused={index === focusIndex}
-                passed={pendingDismissals.includes(item.id)}
                 onFocus={focusSleeve}
               />
             ))}
             {Array.from({ length: slots }, (_unused, i) => (
-              <CrateSlot key={`slot-${i}`} index={visible.length + i} />
+              <CrateSlot key={`slot-${i}`} index={items.length + i} />
             ))}
           </ul>
         ) : (
           <CrateBin
-            items={visible}
+            items={items}
             crateNo={crate?.crate_no ?? null}
             focusIndex={focusIndex}
-            pendingDismissals={pendingDismissals}
             awayItemId={awayItemId}
             spineName={spineName}
             railRef={railRef}
@@ -716,7 +653,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             aria-posinset already carry identity and position. Announcing only
             the reason keeps this from double-reading every record. */}
         <div className="sr-only" role="status" aria-live="polite">
-          {current ? `Record ${focusIndex + 1} of ${visible.length}. ${current.why}` : ''}
+          {current ? `Record ${focusIndex + 1} of ${items.length}. ${current.why}` : ''}
         </div>
       </div>
 
@@ -731,16 +668,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           artUrl={crateArtUrl(flight.id)}
           onDone={() => setFlight((f) => (f === flight ? null : f))}
         />
-      )}
-
-      {undoItem && (
-        <div className="crate-undo-toast" role="status">
-          <span className="crate-undo-text">Passed on {undoItem.title}.</span>
-          <button className="crate-undo-btn" onClick={undo}>
-            Undo
-          </button>
-          <div className="crate-undo-bar" style={{ animationDuration: `${UNDO_MS}ms` }} />
-        </div>
       )}
     </div>
   )

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -57,7 +57,6 @@ const GROUPS: Group[] = [
         note: 'Writes to your Bandcamp account'
       },
       { keys: ['C'], description: 'Copy link' },
-      { keys: ['X'], description: 'Pass', note: 'Undo for 5 seconds' },
       { keys: ['Esc'], description: 'Stop the preview, then leave the crate' }
     ]
   },

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -177,11 +177,6 @@ type PlayerStore = {
   // first snapshot arrives, which the view renders as "not dug yet" rather than
   // as an error.
   crate: CrateSnapshot | null
-  // Items passed locally but whose dismiss POST has not been sent yet. Pass is
-  // deferred rather than optimistic because 'dismissed' is terminal server-side
-  // (discovery_events has no un-dismiss kind and the state rank is monotonic),
-  // so an Undo has to happen before the request, not after it.
-  crateDismissPending: number[]
   // KAMP-651: preview transport state. Daemon-owned — it survives a renderer
   // reload, so this is seeded from GET .../preview/state on every WS connect
   // and kept live by the `discovery.preview` event, never invented locally.
@@ -233,14 +228,6 @@ type PlayerStore = {
   loadCrate: () => Promise<void>
   setCrate: (snapshot: CrateSnapshot) => void
   newCrate: () => Promise<void>
-  // Marks an item passed locally and holds the POST. Call commitCrateDismiss to
-  // send it or undoCrateDismiss to cancel — see crateDismissPending.
-  deferCrateDismiss: (itemId: number) => void
-  undoCrateDismiss: (itemId: number) => void
-  commitCrateDismiss: (itemId: number) => Promise<void>
-  // Sends every held dismiss at once. Must be called when the view unmounts or
-  // the user navigates away, or a pass made in the last few seconds is lost.
-  flushCrateDismissals: () => Promise<void>
   copyCrateItemUrl: (item: CrateItem) => Promise<void>
   // KAMP-653: the wishlist write. Ids currently in flight, so the button can be
   // disabled per card rather than per view — focus can move with , and . while a
@@ -620,7 +607,6 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadPausedUntil: 0,
   downloadBatch: null,
   crate: null,
-  crateDismissPending: [],
   crateWishlistPending: [],
   crateWishlistError: null,
   preview: null,
@@ -988,40 +974,6 @@ export const useStore = create<PlayerStore>((set, get) => ({
       const msg = err instanceof Error ? err.message : 'Could not dig a crate'
       get().showFlashToast(msg)
     }
-  },
-  deferCrateDismiss: (itemId) =>
-    set((s) => ({
-      crateDismissPending: s.crateDismissPending.includes(itemId)
-        ? s.crateDismissPending
-        : [...s.crateDismissPending, itemId]
-    })),
-  undoCrateDismiss: (itemId) =>
-    set((s) => ({ crateDismissPending: s.crateDismissPending.filter((id) => id !== itemId) })),
-  commitCrateDismiss: async (itemId) => {
-    // Already undone while the timer was running.
-    if (!get().crateDismissPending.includes(itemId)) return
-    set((s) => ({ crateDismissPending: s.crateDismissPending.filter((id) => id !== itemId) }))
-    try {
-      await api.dismissCrateItem(itemId)
-      // The daemon re-broadcasts the whole snapshot after a dismiss, so the
-      // authoritative state arrives on its own.
-    } catch {
-      // The pass is lost rather than wrongly shown as kept — reload so the UI
-      // matches the server instead of quietly disagreeing with it.
-      void get().loadCrate()
-    }
-  },
-  flushCrateDismissals: async () => {
-    const pending = get().crateDismissPending
-    if (pending.length === 0) return
-    set({ crateDismissPending: [] })
-    await Promise.all(
-      pending.map((id) =>
-        api.dismissCrateItem(id).catch(() => {
-          // Best-effort on the way out; loadCrate() on the next mount reconciles.
-        })
-      )
-    )
   },
   copyCrateItemUrl: async (item) => {
     try {

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -56,7 +56,6 @@ export const TOOLTIPS = {
   CRATE_PURCHASED: 'You brought this one home',
   CRATE_PREVIEW: 'Play a preview (Space) — your queue stays put',
   CRATE_COPY: 'Copy link (C)',
-  CRATE_PASS: 'Pass (X)',
 
   // Track / album favorites
   ALBUM_FAVORITE_ADD: 'Add to favorites',

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -647,10 +647,15 @@ class TestDiggingHistory:
         assert stats["wishlisted"] == 1
         assert stats["purchased"] == 1
 
-    def test_dismissing_does_not_reduce_what_you_dug_through(
+    def test_a_legacy_dismissal_does_not_reduce_what_you_dug_through(
         self, index: LibraryIndex
     ) -> None:
-        """Passing on a record is still digging through it."""
+        """A record passed on before KAMP-674 is still a record you dug through.
+
+        'dismissed' has no writer now, but the counts are computed on read from
+        the whole ledger, so a pre-removal row must not quietly shrink anyone's
+        history the first time they open the Crate after upgrading.
+        """
         item = self._dig(index, 1, 0, "a")
         index.record_discovery_event(item, "dismissed")
         assert index.discovery_stats()["records"] == 1
@@ -951,7 +956,14 @@ class TestEventLedger:
     def test_retraction_falls_back_past_a_dismissal_to_the_dismissal(
         self, index: LibraryIndex
     ) -> None:
-        """Passing on a record outranks previewing it, and the pass still stands."""
+        """A retraction falls back through a LEGACY dismissal, not past it.
+
+        Pass was removed in KAMP-674 and nothing writes 'dismissed' any more, but
+        rows written before the removal are real history on real disks. The
+        vocabulary therefore stays in the ledger maps: drop it and this record
+        would resolve to 'previewed' after the retraction, silently rewriting
+        what the user did.
+        """
         item = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
         index.record_discovery_event(item, "previewed")
         index.record_discovery_event(item, "dismissed")

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -254,15 +254,21 @@ class TestItemEvents:
         index.place_in_crate(item, 1, 0)
         return item
 
-    def test_dismiss_records_and_moves_state(
+    def test_there_is_no_way_to_pass_on_a_record(
         self, index: LibraryIndex, harness: _Harness
     ) -> None:
+        """The dismiss endpoint is gone (KAMP-674).
+
+        Not merely unused by the UI: passing changed nothing a user could
+        observe, so leaving the writer reachable would keep minting 'dismissed'
+        rows that nothing reads. 405 rather than 404 because FastAPI still has a
+        route for the {item_id} prefix.
+        """
         item = self._item(index)
-        assert (
-            harness.client.post(f"/api/v1/discovery/items/{item}/dismiss").status_code
-            == 200
-        )
-        assert index.crate_items(1)[0]["state"] == "dismissed"
+        assert harness.client.post(
+            f"/api/v1/discovery/items/{item}/dismiss"
+        ).status_code in (404, 405)
+        assert index.crate_items(1)[0]["state"] == "fresh"
 
     def test_copying_a_link_is_not_passing_on_it(
         self, index: LibraryIndex, harness: _Harness
@@ -284,12 +290,13 @@ class TestItemEvents:
     ) -> None:
         item = self._item(index)
         harness.events.clear()
-        harness.client.post(f"/api/v1/discovery/items/{item}/dismiss")
-        assert harness.events[-1]["items"][0]["state"] == "dismissed"
+        harness.client.post(f"/api/v1/discovery/items/{item}/url-copied")
+        assert len(harness.events) == 1
+        assert [i["id"] for i in harness.events[-1]["items"]] == [item]
 
     def test_unknown_item_is_a_404(self, harness: _Harness) -> None:
         assert (
-            harness.client.post("/api/v1/discovery/items/999/dismiss").status_code
+            harness.client.post("/api/v1/discovery/items/999/url-copied").status_code
             == 404
         )
 


### PR DESCRIPTION
## Summary

Removes pass from the Crate. It cost a keystroke, a button, a five-second undo toast, four store actions, an endpoint and a `visible` subset — to do nothing a user could observe.

## The finding

`_excluded` in `discovery_builder.py` decides what may appear in a future crate:

```python
if candidate.provider_item_id in wishlist_ids: return True
if index.seen_before(candidate.provider, candidate.provider_item_id): return True
return index.in_library(...)
```

and `seen_before` is *"has this ever been placed in a crate"*, keyed on `crate_no IS NOT NULL` (`library.py:4955`). **Every record shown in a crate is excluded from every future crate regardless of what the user does with it.** The string `dismissed` appears nowhere in the builder.

So passing did exactly two things: hid the card from the crate on screen, and wrote a `dismissed` event that drove a dim sleeve and a ✕ badge. It is not in `discovery_stats` — the counts are crates, records, previewed, wishlisted, purchased — so no number ever told the user it had happened. Passing a record and ignoring one produce identical future crates.

That is the worst pairing available: a gesture that felt consequential enough to need an undo timer, attached to no consequence.

## Why not give it teeth instead

It cannot act on the record — already banned forever by `seen_before` — so a pass that mattered would have to narrow the racks by artist, label or genre. That is the Crate becoming a recommender, which the epic defines itself against, and "I passed on this release" is a poor signal about an artist regardless. Digging is *supposed* to involve rejecting nine records to find one; letting rejection narrow the racks would make the tenth crate worse than the first.

The redesign also removes pass's last job: KAMP-671 puts every record in a permanent list and KAMP-672 keeps a ghost in the bin, so there is nothing left for it to hide.

## What is deliberately NOT removed

**The ledger vocabulary, and there is no migration.** Real users have real `dismissed` rows on disk and they are genuine history. `_state_from_ledger` walks the whole ledger, so a wishlist retraction over a previously-passed record must still resolve to `dismissed` — drop the vocabulary and it silently falls back to `previewed`, rewriting what the user did. `dismissed` keeps its place in both CHECK constraints and in the rank and state maps; it simply has no writer any more.

Dropping it would have meant a table rebuild to narrow a CHECK, purely to delete history. All risk, no gain.

The two ledger tests that exercise `dismissed` are retitled to say that this is now their job.

Rendering follows the same rule: a legacy dismissed row is an ordinary record — no dim, no ✕, and it counts as dug like any other, because nothing acts on that state now.

## implementation note

`POST /api/v1/discovery/items/{id}/dismiss` is removed. Local-only API whose sole consumer is the bundled UI, so it goes rather than becoming a shim. Pinned by a test that the route is gone and the item's state is untouched — non-vacuous, since it returned 200 and moved state to `dismissed` before this change.

## Test plan

- [x] `poetry run pytest` — **3177 passed, 9 skipped**, coverage **93.74%** (gate 93%)
- [x] `npm run typecheck`, `npm run lint` clean (one pre-existing `main/index.ts` prettier warning, untouched)

No test runner in `kamp_ui`, so the UI side needs your eyes.

## What to check

- The Pass button is gone from the focus card and `X` does nothing.
- `?` shortcuts overlay no longer lists `X`.
- `,`/`.`, arrows in the bin, `W`, `C`, Space and Escape all still work — the key handler lost a branch, so it is worth a pass over the rest.
- "Record N of M" counts every record in the crate and never changes as you flip.
- If you have passed on anything in a previous crate, that record should now look completely ordinary — no dim, no ✕ — and your digging-history numbers should be unchanged.

`npm start` rather than `npm run dev`, given the framerate difference.

Closes KAMP-674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
