### PR TITLE
KAMP-661: let the crate's reachable pool grow with use

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -112,6 +112,12 @@ _INITIAL_STATUS: dict[str, Any] = {
     "crate_no": None,
     "filled": 0,
     "short": False,
+    # Why the last crate came up short: everything else had already been shown,
+    # as opposed to a budget stop or a 429 (KAMP-661). Deliberately NOT derived
+    # from the stored rows the way `short` is below — nothing on disk records why
+    # a build ended, and the claim is about the build that just happened, so it
+    # resets to False on a restart rather than being restated from stale data.
+    "exhausted": False,
     "paused_until": 0.0,
     "hints": [],
     "thin": False,
@@ -215,6 +221,11 @@ def register_discovery_routes(
             # be the previous crate's.
             snap["filled"] = len(items)
             snap["short"] = bool(items) and len(items) < CRATE_SIZE
+            # `exhausted` is deliberately NOT re-derived alongside these. Nothing
+            # on disk records why a build stopped, so it could only be guessed at
+            # here -- and guessing "you have seen everything" about a restored
+            # crate is exactly the kind of invented explanation the clerk does not
+            # give. It rides the live build's publish and resets on a restart.
         # The digging history rides along rather than being fetched separately
         # (KAMP-655). Five COUNTs over two small indexed tables, against a
         # snapshot that already reads every row of the crate -- so the numbers

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -32,6 +32,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard, types only
+    from collections.abc import MutableMapping
+
     from kamp_core.library import LibraryIndex, SeedAlbum, SeedArtist
 
 logger = logging.getLogger(__name__)
@@ -321,7 +323,12 @@ class DiscoverySource(ABC):
         return {}
 
     @abstractmethod
-    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+    def gather(
+        self,
+        profile: SeedProfile,
+        budget: RequestBudget,
+        state: "MutableMapping[str, Any] | None" = None,
+    ) -> list[Candidate]:
         """Return candidates for *profile*, spending no more than *budget* allows.
 
         Criteria are provider-internal: the source decides what to look for and
@@ -332,6 +339,14 @@ class DiscoverySource(ABC):
         have logged a WARNING naming the surface and URL.** Every discovery surface is
         an unofficial endpoint that will eventually drift, and silent emptiness is how
         that arrives as "discovery is broken" with nothing in the log to explain it.
+
+        *state* is scratch space the source may carry between crates: which seed it
+        stopped on, how far into a paginated query it has read (KAMP-661). Its shape
+        is the source's own business — the caller only persists it and hands it back,
+        which is what keeps rotation out of the builder and out of the schema. Mutate
+        it in place; it must stay JSON-serialisable. Optional, and a source that
+        needs no memory may ignore it, but one that ignores it can only ever reach
+        the first page of whatever it queries.
         """
 
     def preview_tracks(self, candidate: Candidate) -> list[PreviewStream]:

--- a/kamp_daemon/discovery_bandcamp_parsers.py
+++ b/kamp_daemon/discovery_bandcamp_parsers.py
@@ -49,6 +49,11 @@ class ParseResult:
     #: from "marker present and empty" got the JSON case backwards and warned on
     #: every genuinely empty query.
     drifted: bool = False
+    #: Opaque continuation token for surfaces that page (KAMP-661). Only the
+    #: discover API sets it; None means "this surface does not page" or "there is
+    #: nothing after this", and the caller may not tell those apart — it stores
+    #: whatever it gets and stops paging when it gets None.
+    cursor: str | None = None
 
     def __bool__(self) -> bool:
         return bool(self.items)
@@ -270,8 +275,16 @@ def parse_discover_results(payload: str | dict[str, Any]) -> ParseResult:
     # returns exactly that for a tag outside its vocabulary, which is a normal
     # query outcome and must not be reported as drift. Drift on this surface means
     # the response parsed as JSON but no longer has a results key at all.
+    # The cursor is the whole of KAMP-661: it was parsed and dropped, so every
+    # crate re-asked for page one of the same query and the candidate pool looked
+    # exhausted after about five digs. The captured fixture reports 815,356
+    # results behind it. Coerced to str|None because an absent key, an explicit
+    # null and an empty string all mean the same thing to the caller.
+    cursor = body.get("cursor")
     result = ParseResult(
-        marker_present=isinstance(rows, list), drifted="results" not in body
+        marker_present=isinstance(rows, list),
+        drifted="results" not in body,
+        cursor=str(cursor) if cursor else None,
     )
     for row in rows or []:
         item_id = normalise_item_id(row.get("item_id"))

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -19,6 +19,7 @@ into a UI that never updates.
 
 from __future__ import annotations
 
+import json
 import logging
 import random
 import time
@@ -45,6 +46,12 @@ logger = logging.getLogger(__name__)
 #: rather than a tuning knob: a crate you can finish in a sitting is the whole
 #: affordance.
 CRATE_SIZE = 10
+
+#: Where the source's scratch space is kept between crates (KAMP-661): which seed
+#: each criterion stopped on, how far into each paginated query it has read. One
+#: settings row rather than a table, because the shape is the source's own and the
+#: builder only round-trips it — nothing here or in the schema knows what is in it.
+_ROTATION_KEY = "discovery.rotation"
 
 #: The endpoint classes discovery spends. Each carries its own cooldown, so a
 #: single "am I rate limited" answer has to consider all of them.
@@ -111,6 +118,10 @@ def build_crate(
         filled=0,
         crate_no=None,
         short=False,
+        # Stated rather than left, and that is load-bearing: _publish MERGES, so a
+        # flag omitted here would carry over from the previous build and a full
+        # crate would inherit the last one's "you have seen everything" (KAMP-661).
+        exhausted=False,
         # Genres come from the local profile, not the provider: it lets the UI
         # name what is being dug through without the builder knowing any
         # provider's criteria.
@@ -121,11 +132,22 @@ def build_crate(
         thin=profile.is_thin,
     )
 
+    # The source's memory of previous crates (KAMP-661). Loaded before the gather
+    # and saved after it, so seed rotation and discover pagination survive a
+    # daemon restart — held in memory they would reset on every launch and the
+    # pool would look exhausted again each time, which is the same bug on a
+    # longer fuse.
+    rotation = _load_rotation(index)
     try:
-        candidates = source.gather(profile, budget or crate_budget())
+        candidates = source.gather(profile, budget or crate_budget(), rotation)
     except Exception:  # noqa: BLE001 - a provider must not take the daemon with it
         logger.exception("discovery: gather failed")
         return _publish(publish, state="error")
+    finally:
+        # Saved even when the gather raised: whatever it managed to advance before
+        # failing is still progress, and re-reading those same pages next time is
+        # exactly the waste this exists to stop.
+        _save_rotation(index, rotation)
 
     picks = select_crate(
         candidates,
@@ -135,6 +157,14 @@ def build_crate(
         rng=rng,
         wishlist_ids=wishlist_ids,
     )
+    # Attributed BEFORE anything is written, and that ordering is the whole
+    # correctness of the flag: place first and this crate's own ten records are
+    # `seen_before` by the time we ask, so every short crate would report the well
+    # dry — including a three-record crate where nothing had been seen at all.
+    dry = len(picks) < size and _short_because_seen(
+        candidates, index=index, picked=len(picks)
+    )
+
     if not picks:
         # Do not burn a crate number on nothing. An empty crate is a distinct
         # state from a short one -- the UI offers a retry rather than a tally.
@@ -182,9 +212,26 @@ def build_crate(
         return _publish(publish, state="empty", crate_no=None)
 
     short = placed < size
+    # `dry` was measured against the picks; `short` is measured against what
+    # actually landed. Both have to hold: a crate short only because rows failed
+    # to persist is a write problem, not a picked-over rack, and must not be
+    # explained to the user as one.
+    exhausted = short and dry
     if short:
-        logger.info("discovery: short crate %d (%d/%d)", crate_no, placed, size)
-    return _publish(publish, state="ready", crate_no=crate_no, short=short)
+        logger.info(
+            "discovery: short crate %d (%d/%d)%s",
+            crate_no,
+            placed,
+            size,
+            " — everything else was already shown" if exhausted else "",
+        )
+    return _publish(
+        publish,
+        state="ready",
+        crate_no=crate_no,
+        short=short,
+        exhausted=exhausted,
+    )
 
 
 def select_crate(
@@ -281,6 +328,62 @@ def _group_by_criterion(
     for candidate in candidates:
         groups.setdefault(candidate.criterion, []).append(candidate)
     return groups
+
+
+def _load_rotation(index: "LibraryIndex") -> dict[str, Any]:
+    """The source's scratch space from the settings row, or a blank slate.
+
+    Never raises. The blob is a hint about where to resume, so a value that fails
+    to parse — hand-edited, or written by a build that shaped it differently —
+    costs exactly one crate's worth of variety. Letting it reach the build thread
+    would cost the crate, which is a far worse trade for a cache.
+    """
+    raw = index.get_setting(_ROTATION_KEY)
+    if not raw:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except ValueError:
+        logger.warning("discovery: rotation state unreadable, starting over")
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _save_rotation(index: "LibraryIndex", rotation: dict[str, Any]) -> None:
+    """Persist the scratch space. Never raises, for the same reason as above."""
+    if not rotation:
+        # Nothing learned — a source that ignores the state, or a gather that
+        # never got as far as a request. Writing "{}" would be noise.
+        return
+    try:
+        index.set_setting(_ROTATION_KEY, json.dumps(rotation))
+    except Exception:  # noqa: BLE001 - a cache write must not fail a built crate
+        logger.warning("discovery: could not save rotation state", exc_info=True)
+
+
+def _short_because_seen(
+    candidates: "Sequence[Candidate]", *, index: "LibraryIndex", picked: int
+) -> bool:
+    """True when the shortfall is the well being dry rather than a thin gather.
+
+    The distinction is the whole point of the flag. A crate can come up short
+    because the budget stopped us, because a 429 cut the gather off, or because
+    everything found had already been shown — and only the last of those is a
+    sentence the user should be told, because only it means the racks are
+    genuinely picked over rather than something having gone wrong.
+
+    Attributed by re-running the one exclusion that means "you have already seen
+    this". `seen_before` is an indexed lookup and the candidate list is tens of
+    rows, so re-checking is cheaper than threading a counter out of select_crate
+    and through a signature every existing caller and test depends on.
+    """
+    if not candidates:
+        return False
+    seen = sum(
+        1 for c in candidates if index.seen_before(c.provider, c.provider_item_id)
+    )
+    # Every candidate that did not make the crate had already been shown.
+    return seen > 0 and picked + seen >= len(candidates)
 
 
 def _excluded(

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -100,11 +100,28 @@ def _also_like_seeds(profile: SeedProfile) -> Iterable[Seed]:
 
 
 def _genre_top_seeds(profile: SeedProfile) -> Iterable[Seed]:
-    """Best-selling right now within a genre the user actually listens to."""
+    """Selling well right now within a genre the user actually listens to.
+
+    Two seeds per genre, not one (KAMP-661). ``slice=top`` for the same tag
+    returns the same twenty albums next week, so a criterion that only ever asks
+    for it contributes the same records to every crate forever. ``rand`` reaches a
+    different part of the same catalogue at identical request cost — the trick
+    ``_old_album_seeds`` already relies on to get past the current year's
+    releases.
+
+    Emitting both as ordinary seeds means the rotation in ``_run_criterion``
+    cycles them for free: no slice-picking logic anywhere, and the copy stays
+    honest because each variant carries its own ``why``.
+    """
     for genre in profile.top_genres:
         yield Seed(
             target={"tag": genre, "slice": "top"},
             why=f"You've been deep in {genre} lately; this is near the top of the pile.",
+            seed_data={"kind": "genre", "genre": genre},
+        )
+        yield Seed(
+            target={"tag": genre, "slice": "rand"},
+            why=f"Pulled at random from the {genre} racks.",
             seed_data={"kind": "genre", "genre": genre},
         )
 

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -55,6 +55,8 @@ from .discovery_criteria import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - types only
+    from collections.abc import MutableMapping
+
     from .bandcamp import _AnySession
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,21 @@ DISCOVER_API_URL = "https://bandcamp.com/api/discover/1/discover_web"
 # only to the album-page GET that supplies the crumb and band_id.
 COLLECT_URL = "https://bandcamp.com/collect_item_cb"
 UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
+
+
+def _sub(state: "MutableMapping[str, Any]", key: str) -> dict[str, Any]:
+    """The ``key`` sub-dict of the rotation state, created and attached if absent.
+
+    The blob is round-tripped through JSON in the settings row, so a value that
+    arrives as the wrong type (hand-edited, or written by an older build) is
+    replaced rather than raising — rotation state is a hint, and losing it costs
+    one crate's variety, while a crash here costs the crate.
+    """
+    value = state.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        state[key] = value
+    return value
 
 
 def _is_fetchable(url: str) -> bool:
@@ -193,16 +210,33 @@ class BandcampDiscoverySource(DiscoverySource):
     # Gather
     # ------------------------------------------------------------------
 
-    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+    def gather(
+        self,
+        profile: SeedProfile,
+        budget: RequestBudget,
+        state: "MutableMapping[str, Any] | None" = None,
+    ) -> list[Candidate]:
         """Collect candidates across the criteria that suit *profile*.
 
         Mirrors ``genre_sources.fetch_all_genres``: each criterion is best-effort
         and a broken one costs a card rather than the crate. Unlike that helper,
         this stops early on a 429 — letting the remaining criteria each rediscover
         the limit would turn one rate limit into several and log it repeatedly.
+
+        *state* carries what this source learned last time: which seed each
+        criterion stopped on, and how far into each discover query it has read
+        (KAMP-661). It is mutated in place and the caller persists it. Passed in
+        rather than read from a database because this class is provider code
+        behind a provider-neutral ABC and has no business holding a LibraryIndex;
+        a plain dict also makes rotation and pagination assertable in a test with
+        no network and no storage.
         """
         out: list[Candidate] = []
         seen: set[str] = set()
+        if state is None:
+            # A caller that does not care about rotation gets one throwaway round,
+            # which is exactly the old behaviour.
+            state = {}
 
         # Albums the user already owns. The discover surface reports is_owned
         # itself, but album-page recommendations and the discography grid do not,
@@ -214,7 +248,7 @@ class BandcampDiscoverySource(DiscoverySource):
 
         for criterion in criteria_for(profile):
             try:
-                found = self._run_criterion(criterion, profile, budget, owned)
+                found = self._run_criterion(criterion, profile, budget, owned, state)
             except RateLimitedError as exc:
                 logger.warning("discovery: stopping gather early — %s", exc)
                 break
@@ -240,17 +274,42 @@ class BandcampDiscoverySource(DiscoverySource):
         profile: SeedProfile,
         budget: RequestBudget,
         owned: set[str] | None = None,
+        state: "MutableMapping[str, Any] | None" = None,
     ) -> list[Candidate]:
+        """One criterion's worth of candidates, starting where last crate stopped.
+
+        Still one productive seed per criterion — spending the rest of the budget
+        deepening a single criterion would starve the others and make every crate
+        look the same. What changed in KAMP-661 is WHICH seed that is: the seed
+        list is rotated so consecutive crates read different albums, artists and
+        genre slices instead of re-reading the head of the list forever.
+        """
+        state = {} if state is None else state
+        offsets = _sub(state, "seeds")
+
+        seeds = list(criterion.seeds(profile))
+        if not seeds:
+            return []
+        start = int(offsets.get(criterion.key, 0)) % len(seeds)
+
         found: list[Candidate] = []
-        for seed in criterion.seeds(profile):
+        tried = 0
+        for step in range(len(seeds)):
+            seed = seeds[(start + step) % len(seeds)]
             if not budget.allow(criterion.endpoint_class):
                 break
-            found.extend(self._run_seed(criterion, seed, budget, owned or set()))
+            tried += 1
+            found.extend(self._run_seed(criterion, seed, budget, owned or set(), state))
             if found:
-                # One good seed per criterion is enough for a crate; spending the
-                # rest of the budget deepening a single criterion would starve the
-                # others and make every crate look the same.
                 break
+
+        # Advance past every seed TRIED, not just a productive one. Advancing only
+        # on success looks right and is the trap: a seed at the head of the list
+        # that yields nothing (a deleted album, an artist page with one release)
+        # would be re-fetched at the head of every crate for the life of the
+        # install, and the rotation would never begin.
+        if tried:
+            offsets[criterion.key] = (start + tried) % len(seeds)
         return found
 
     def _run_seed(
@@ -259,9 +318,10 @@ class BandcampDiscoverySource(DiscoverySource):
         seed: Seed,
         budget: RequestBudget,
         owned: set[str],
+        state: "MutableMapping[str, Any] | None" = None,
     ) -> list[Candidate]:
         if criterion.surface == SURFACE_DISCOVER:
-            return self._discover(criterion, seed, budget, owned)
+            return self._discover(criterion, seed, budget, owned, state)
         if criterion.surface == SURFACE_ALBUM_RECS:
             body = self._fetch(criterion.endpoint_class, str(seed.target), budget)
             if body is None:
@@ -290,19 +350,28 @@ class BandcampDiscoverySource(DiscoverySource):
         seed: Seed,
         budget: RequestBudget,
         owned: set[str],
+        state: "MutableMapping[str, Any] | None" = None,
     ) -> list[Candidate]:
         params: dict[str, Any] = dict(seed.target)
         # Normalise here rather than in the criterion: the seed carries the display
         # genre so the clerk card can say "you've been deep in Indie Rock lately",
         # while the API needs "indie-rock".
         tag = tag_slug(params.get("tag") or "")
+        slice_ = params.get("slice", "top")
+
+        # Where this query got to last time (KAMP-661). Keyed on the query rather
+        # than on the criterion, because two criteria can ask about the same tag
+        # with different slices and each has its own place in the results.
+        cursors = _sub({} if state is None else state, "cursors")
+        cursor_key = f"{criterion.key}:{tag}:{slice_}"
+
         payload = {
             "category_id": 0,
             "tag_norm_names": [tag] if tag else [],
             "geoname_id": 0,
-            "slice": params.get("slice", "top"),
+            "slice": slice_,
             "time_facet_id": None,
-            "cursor": None,
+            "cursor": cursors.get(cursor_key),
             "size": params.get("size", 20),
             "include_result_types": ["a"],
             "followed_bands": False,
@@ -314,6 +383,17 @@ class BandcampDiscoverySource(DiscoverySource):
             return []
         result = parse_discover_results(body)
         result.warn_if_drifted(criterion.surface, DISCOVER_API_URL)
+
+        # Advance, or start the query over.
+        #
+        # The reset on an empty page is the important half. A cursor that has
+        # walked off the end — or gone stale, since it is opaque and Bandcamp owes
+        # us nothing about its lifetime — would otherwise pin this query on an
+        # empty page for the rest of the install, silently. That is a worse
+        # version of the bug this story exists to fix, so an empty page always
+        # returns the query to the beginning rather than storing whatever came
+        # back with it.
+        cursors[cursor_key] = result.cursor if result.items else None
 
         # Bandcamp reports ownership on this surface, so let it do the exclusion.
         result.items = [

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -602,6 +602,12 @@ export type CrateSnapshot = {
   crate_no: number | null
   filled: number
   short: boolean
+  // KAMP-661: WHY the crate is short — everything else had already been shown,
+  // rather than a budget stop or a rate limit. Unlike `short` this is not
+  // re-derived from the stored rows, because nothing on disk records why a build
+  // ended; it resets to false on a daemon restart, which is honest rather than
+  // restating a guess.
+  exhausted: boolean
   paused_until: number // Unix seconds; 0 when running
   hints: string[] // the user's top genres, for the digging status lines
   thin: boolean // a library with no listening history yet — chart picks only

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -468,10 +468,28 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           The distributor&rsquo;s on the phone — back in {formatPause(pauseRemaining)}.
         </div>
       )
+    {
+      /* Two reasons a crate can be short, and the clerk gives the one that is
+         true (KAMP-661). The dry-well case used to fall through to the line
+         below and blame a rate limit that had not happened — an invented
+         explanation, which is the one thing this feature cannot do.
+
+         The other line no longer claims a cause either. Short can also mean the
+         request budget ran out or a surface drifted, and the daemon does not
+         tell the UI which; asserting "Bandcamp asked us to slow down" was right
+         only some of the time. A real rate limit has its own banner above, with
+         a countdown. */
+    }
+    if (state === 'ready' && crate?.exhausted)
+      return (
+        <div className="crate-banner" role="status">
+          That&rsquo;s everything in these racks for now — more turns up as you listen.
+        </div>
+      )
     if (state === 'ready' && crate?.short)
       return (
         <div className="crate-banner" role="status">
-          Short crate today — Bandcamp asked us to slow down.
+          Short crate today — we couldn&rsquo;t fill it.
         </div>
       )
     if (crate?.thin && hasCrate)

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -166,6 +166,30 @@ class TestCrateSnapshot:
         assert body["filled"] == 4
         assert body["short"] is True
 
+    def test_the_dry_well_reaches_the_client(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """`exhausted` is what lets the UI say WHY a crate is short (KAMP-661)."""
+        _stock(index, 1, count=4)
+        harness.publish({"state": "ready", "crate_no": 1, "exhausted": True})
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["short"] is True
+        assert body["exhausted"] is True
+
+    def test_a_restored_short_crate_does_not_claim_the_well_is_dry(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """`short` IS re-derived from the rows after a restart; `exhausted` is not.
+
+        Nothing on disk records why a build stopped, so restating it would be a
+        guess — and "you have seen everything" is precisely the kind of invented
+        explanation this feature is defined against. False on a fresh daemon.
+        """
+        _stock(index, 1, count=4)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["short"] is True
+        assert body["exhausted"] is False
+
     def test_a_live_build_keeps_its_own_progress(
         self, index: LibraryIndex, harness: _Harness
     ) -> None:

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -10,6 +10,7 @@ rate limit that presents as a hang.
 
 from __future__ import annotations
 
+import json
 import random
 import sqlite3
 from pathlib import Path
@@ -80,11 +81,54 @@ class _FakeSource(DiscoverySource):
     def criterion_caps(self) -> dict[str, int]:
         return self._caps
 
-    def gather(self, profile: SeedProfile, budget: RequestBudget) -> list[Candidate]:
+    def gather(
+        self,
+        profile: SeedProfile,
+        budget: RequestBudget,
+        state: Any = None,
+    ) -> list[Candidate]:
         self.gather_calls += 1
+        self.last_state = state
         if self._error is not None:
             raise self._error
         return list(self._candidates)
+
+
+class _PaginatingSource(DiscoverySource):
+    """A source with a deep well, reachable only by carrying the cursor.
+
+    Stands in for the discover API: it holds far more candidates than one crate
+    needs and hands out the next page each time, remembering where it got to in
+    the *state* the builder passes back. A source that ignored the state would
+    return page one forever, which is the bug KAMP-661 is about.
+    """
+
+    provider_id = "fake"
+
+    def __init__(self, pool: int = 200, page: int = 20) -> None:
+        self._pool = pool
+        self._page = page
+        self.states: list[dict[str, Any]] = []
+
+    def gather(
+        self,
+        profile: SeedProfile,
+        budget: RequestBudget,
+        state: Any = None,
+    ) -> list[Candidate]:
+        state = {} if state is None else state
+        self.states.append(dict(state))
+        offset = int(state.get("offset", 0))
+        # Its own id namespace. _spread() numbers from 1, so a bare str(n) here
+        # would collide with candidates another fake source had already put in a
+        # crate — and `seen_before` would then reject them for the right reason
+        # under a test asserting the wrong thing.
+        rows = [
+            _candidate(f"page-{n}", "genre_top")
+            for n in range(offset, min(offset + self._page, self._pool))
+        ]
+        state["offset"] = offset + len(rows)
+        return rows
 
 
 class _FakeGovernor:
@@ -300,6 +344,133 @@ class TestExclusions:
 # ---------------------------------------------------------------------------
 # Degradation — short crates and rate limits are normal, not errors
 # ---------------------------------------------------------------------------
+
+
+class TestVarietyAcrossSessions:
+    """KAMP-661 — the reachable pool has to grow with use, not stay fixed."""
+
+    def test_ten_consecutive_crates_are_full_and_share_no_records(
+        self, index: LibraryIndex
+    ) -> None:
+        """The acceptance criterion the whole story is built around.
+
+        Before this, roughly five crates exhausted the reachable candidates and
+        every crate after that was silently short — the pool was one page of one
+        query per criterion, re-fetched forever, against a `seen_before` that
+        (correctly) excludes anything already shown.
+        """
+        source = _PaginatingSource()
+        seen: set[str] = set()
+        for crate_no in range(1, 11):
+            status = _build(index, source)
+            assert status["state"] == "ready", f"crate {crate_no} did not build"
+            assert status["short"] is False, f"crate {crate_no} came up short"
+            titles = _titles(index, crate_no)
+            assert len(titles) == 10
+            assert not (seen & set(titles)), f"crate {crate_no} repeated a record"
+            seen.update(titles)
+        assert len(seen) == 100
+
+    def test_the_rotation_state_survives_between_builds(
+        self, index: LibraryIndex
+    ) -> None:
+        """Persisted in one settings row, so it outlives the daemon.
+
+        Held in memory it would reset on every restart, and the pool would look
+        exhausted again after each launch — the same bug on a longer fuse.
+        """
+        source = _PaginatingSource()
+        _build(index, source)
+        _build(index, source)
+        assert source.states[0] == {}, "the first build starts with a blank slate"
+        assert source.states[1].get("offset") == 20, "state did not come back"
+
+        # Round-tripped through the settings row rather than the source object.
+        stored = json.loads(index.get_setting("discovery.rotation") or "{}")
+        assert stored["offset"] == 40
+
+    def test_a_source_that_never_ran_leaves_no_setting(
+        self, index: LibraryIndex
+    ) -> None:
+        """A cooldown refuses before the gather, so there is nothing to remember."""
+        _build(index, _FakeSource(_spread({"a": 12})), governor=_FakeGovernor(42.0))
+        assert index.get_setting("discovery.rotation") is None
+
+    def test_corrupt_rotation_state_costs_variety_not_the_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        """It is a hint, and a hint that fails to parse is worth exactly one crate
+        of variety — never an exception on the build thread."""
+        index.set_setting("discovery.rotation", "{not json")
+        status = _build(index, _PaginatingSource())
+        assert status["state"] == "ready"
+
+    def test_a_rotation_state_of_the_wrong_type_is_discarded(
+        self, index: LibraryIndex
+    ) -> None:
+        """Valid JSON, wrong shape — a list where a dict belongs."""
+        index.set_setting("discovery.rotation", "[1, 2, 3]")
+        assert _build(index, _PaginatingSource())["state"] == "ready"
+
+    def test_a_failed_state_write_does_not_lose_the_crate(
+        self, index: LibraryIndex, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The crate is the product; the rotation state is a cache of where to
+        resume. Letting a failed cache write take a built crate with it would be
+        exactly the wrong trade."""
+        monkeypatch.setattr(
+            index,
+            "set_setting",
+            lambda *a, **k: (_ for _ in ()).throw(sqlite3.OperationalError("disk")),
+        )
+        status = _build(index, _PaginatingSource())
+        assert status["state"] == "ready"
+        assert len(index.crate_items(1)) == 10
+
+
+class TestTheWellRunningDry:
+    def test_a_crate_short_because_everything_was_seen_says_so(
+        self, index: LibraryIndex
+    ) -> None:
+        """Distinct from a budget stop: the user is owed the difference.
+
+        A half-empty crate with no explanation reads as "discovery is broken";
+        "we have shown you everything in these racks lately" is a true sentence
+        about a working feature.
+        """
+        source = _FakeSource(_spread({"a": 12}))
+        _build(index, source)  # first crate takes ten of the twelve
+        status = _build(index, source)  # only two are left, and both are new
+        assert status["short"] is True
+        assert status["exhausted"] is True
+
+    def test_a_full_crate_is_never_exhausted(self, index: LibraryIndex) -> None:
+        status = _build(index, _PaginatingSource())
+        assert status["short"] is False
+        assert status["exhausted"] is False
+
+    def test_a_thin_gather_is_short_but_not_exhausted(
+        self, index: LibraryIndex
+    ) -> None:
+        """Nothing was rejected for having been seen — the well is not dry, the
+        source simply found little. Saying "you have seen everything" here would
+        be the clerk inventing a reason."""
+        status = _build(index, _FakeSource(_spread({"a": 3})))
+        assert status["short"] is True
+        assert status["exhausted"] is False
+
+    def test_exhausted_does_not_stick_to_the_next_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        """_publish MERGES, so a flag left unset carries over from the last build.
+
+        Same trap `short` already has to work around: every terminal path must
+        state the flag rather than leaving it.
+        """
+        source = _FakeSource(_spread({"a": 12}))
+        _build(index, source)
+        assert _build(index, source)["exhausted"] is True
+        assert _build(index, _PaginatingSource())["exhausted"] is False
 
 
 class TestDegradation:

--- a/tests/test_discovery_fixtures.py
+++ b/tests/test_discovery_fixtures.py
@@ -139,6 +139,25 @@ def test_discover_api_fixture_shape() -> None:
         assert "release_date" in row
 
 
+def test_discover_api_fixture_carries_a_cursor_and_a_deep_result_count() -> None:
+    """The evidence KAMP-661 rests on: the pool is huge and it is paginated.
+
+    Crates went short after about five digs and the diagnosis on the ticket was a
+    small candidate space. It is the opposite — this single captured response
+    reports six figures of results and hands back a cursor for the next page. We
+    asked for the first 20 and threw the cursor away, forever.
+
+    Pinned as a fixture test because both facts are contract, not trivia: lose the
+    cursor key and pagination silently stops advancing, which looks exactly like
+    the bug this story fixed.
+    """
+    if "discover_web_ambient_top" not in FIXTURE_NAMES:
+        pytest.skip("discover fixture not captured")
+    payload = json.loads(_read("discover_web_ambient_top"))
+    assert payload["cursor"], "no cursor — the discover response is not paginated"
+    assert payload["result_count"] > len(payload["results"]) * 100
+
+
 def test_discover_root_fixture_carries_the_facet_vocabulary() -> None:
     """Genres/locations/times/slices are read from this blob, not hard-coded."""
     if "discover_root" not in FIXTURE_NAMES:

--- a/tests/test_discovery_parsers.py
+++ b/tests/test_discovery_parsers.py
@@ -191,10 +191,25 @@ class TestDiscoverResults:
         assert [i["is_owned"] for i in items] == [True, False]
         assert [i["is_wishlisted"] for i in items] == [False, True]
 
+    def test_carries_the_cursor_for_the_next_page(self, discover_results: str) -> None:
+        """The whole of KAMP-661 hangs off this value being kept.
+
+        It was parsed and dropped, so every crate asked for the first page of the
+        same query — which is why the candidate pool looked exhausted after about
+        five digs when the response itself reports six figures of results.
+        """
+        assert parse_discover_results(discover_results).cursor
+
+    def test_a_response_without_a_cursor_is_the_end_of_the_line(self) -> None:
+        """None rather than '' — the caller stores it and must be able to tell
+        'no more pages' from 'a page I have not asked for yet'."""
+        assert parse_discover_results({"results": []}).cursor is None
+
     def test_malformed_json_is_not_drift(self) -> None:
         result = parse_discover_results("not json")
         assert result.items == []
         assert result.marker_present is False
+        assert result.cursor is None
 
     def test_empty_result_list_is_an_honest_empty_and_does_not_warn(
         self, caplog

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -26,7 +26,13 @@ from kamp_daemon.discovery import (
     SimpleBudget,
     crate_budget,
 )
-from kamp_daemon.discovery_criteria import REGISTRY, Criterion, criteria_for
+from kamp_daemon.discovery_criteria import (
+    REGISTRY,
+    Criterion,
+    Seed,
+    _genre_top_seeds,
+    criteria_for,
+)
 from kamp_daemon.discovery_sources import (
     BandcampDiscoverySource,
     RateLimitedError,
@@ -386,6 +392,192 @@ class TestGatherAgainstFixtures:
         profile = SeedProfile(top_genres=["a", "b"])
         found = _source(session).gather(profile, crate_budget())
         assert len(found) == 1
+
+
+class TestRotationAndPagination:
+    """KAMP-661: the reachable candidate space has to grow with use.
+
+    Everything here asserts on what the source *asked for*, not on what came back
+    — variety is a property of the requests, and a fake that returns the same body
+    every time would make an output-based assertion pass for the wrong reason.
+    """
+
+    # A THIN profile throughout the pagination tests, deliberately. It yields
+    # seeds for nothing but the chart, so exactly one criterion with exactly one
+    # seed runs and rotation cannot move. Testing pagination against a profile
+    # with genres conflates the two: rotation correctly advances to the `rand`
+    # slice on the second crate, which is a different query with its own place in
+    # the results, so the cursor legitimately starts over and the assertion fails
+    # for a reason that is not a bug.
+    def test_the_discover_cursor_is_carried_into_the_next_gather(self) -> None:
+        """Page two, without a network.
+
+        Before this, `"cursor": None` was hard-coded, so every crate for the life
+        of the install re-asked for the first 20 rows of the same query.
+        """
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        source = _source(session)
+        state: dict[str, Any] = {}
+
+        source.gather(SeedProfile(), crate_budget(), state)
+        first = session.posts[0][1]["cursor"]
+        session.posts.clear()
+        source.gather(SeedProfile(), crate_budget(), state)
+        second = session.posts[0][1]["cursor"]
+
+        assert first is None, "the first ever request has no page to continue from"
+        assert second, "the second gather did not continue where the first stopped"
+
+    def test_an_empty_page_drops_the_cursor_rather_than_pinning_the_seed(self) -> None:
+        """A cursor that has walked off the end must not strand the query there.
+
+        Storing it unconditionally is the worse bug: that query would return
+        nothing for the rest of the install, invisibly, which is a quieter version
+        of the failure this story exists to remove.
+        """
+        state: dict[str, Any] = {}
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        _source(session).gather(SeedProfile(), crate_budget(), state)
+        assert any(v for v in state.get("cursors", {}).values())
+
+        dry = FakeSession(post_body='{"results": [], "cursor": "zzz"}')
+        _source(dry).gather(SeedProfile(), crate_budget(), state)
+        assert not any(v for v in state.get("cursors", {}).values())
+
+    def test_consecutive_gathers_use_different_seeds_for_the_same_criterion(
+        self,
+    ) -> None:
+        """Rotation, asserted on the URL fetched rather than on the candidates."""
+        session = FakeSession(get_body=_fixture("album_page_with_recs"))
+        profile = SeedProfile(
+            recent_album_ids={1, 2},
+            recent_albums=[
+                _album_seed(album_id=1, url="https://a.bandcamp.com/album/one"),
+                _album_seed(album_id=2, url="https://b.bandcamp.com/album/two"),
+            ],
+        )
+        source = _source(session)
+        state: dict[str, Any] = {}
+
+        source.gather(profile, crate_budget(), state)
+        first = list(session.gets)
+        session.gets.clear()
+        source.gather(profile, crate_budget(), state)
+        second = list(session.gets)
+
+        assert first and second
+        assert first[0] != second[0], "the same seed was fetched twice running"
+
+    def test_rotation_advances_past_a_seed_that_produced_nothing(self) -> None:
+        """Otherwise a dead seed at the head of the list is retried forever.
+
+        Advancing only past PRODUCTIVE seeds looks right and is the trap: a seed
+        that yields nothing — a deleted album, an artist page with one release —
+        would sit at the head of every crate's fetch and the rotation would never
+        begin.
+
+        Driven through _run_criterion with a stubbed _run_seed rather than through
+        gather: the point is precisely which seeds were TRIED, and a fake session
+        cannot make the first fetch barren and the second fruitful.
+        """
+        source = _source(FakeSession())
+        tried: list[Any] = []
+
+        def fake_run_seed(criterion, seed, budget, owned, state=None):  # noqa: ANN001
+            tried.append(seed.target)
+            # Barren, barren, then a hit — so it stops on the third of three.
+            return [MagicMock()] if len(tried) == 3 else []
+
+        source._run_seed = fake_run_seed  # type: ignore[method-assign]
+        criterion = Criterion(
+            key="fake",
+            surface="fake",
+            endpoint_class=ALBUM_PAGE,
+            seeds=lambda _p: [
+                Seed(target=f"https://x/{i}", why="", seed_data={}) for i in range(3)
+            ],
+            label="fake",
+        )
+        state: dict[str, Any] = {}
+        source._run_criterion(criterion, SeedProfile(), crate_budget(), set(), state)
+
+        assert len(tried) == 3
+        # Past all three, wrapping — not parked on the first barren one.
+        assert state["seeds"]["fake"] == 0
+
+        tried.clear()
+        source._run_criterion(criterion, SeedProfile(), crate_budget(), set(), state)
+        assert tried[0] == "https://x/0", "wrapped offset should restart the list"
+
+    def test_genre_top_reaches_both_slices_over_successive_crates(self) -> None:
+        """Same tag, same request cost, a different part of the catalogue.
+
+        slice=top skews hard to the current year; alternating with rand is free
+        variety that needs no new mechanism — the seed list carries both and
+        rotation cycles them.
+        """
+        seeds = [
+            s.target for s in _genre_top_seeds(SeedProfile(top_genres=["ambient"]))
+        ]
+        assert {s["slice"] for s in seeds} == {"top", "rand"}
+
+    def test_a_criterion_with_no_seeds_is_not_a_division_by_zero(self) -> None:
+        """`start = offset % len(seeds)` needs the guard above it.
+
+        criteria_for() filters seedless criteria out before gather ever sees
+        them, so this is only reachable directly — which is exactly why it is
+        worth pinning rather than trusting the caller to keep filtering.
+        """
+        criterion = Criterion(
+            key="empty",
+            surface="fake",
+            endpoint_class=ALBUM_PAGE,
+            seeds=lambda _p: [],
+            label="empty",
+        )
+        source = _source(FakeSession())
+        assert (
+            source._run_criterion(criterion, SeedProfile(), crate_budget(), set(), {})
+            == []
+        )
+
+    def test_a_budget_stop_does_not_advance_past_seeds_never_tried(self) -> None:
+        """The offset records where to RESUME, so it may only move over seeds that
+        actually got a request. Advancing on the loop counter instead would skip
+        whatever the budget cut off, and those seeds would never be read.
+
+        Five seeds against a budget for two, so the expected offset is 2 — a
+        number that is neither "none tried" nor "all tried", which is what makes
+        the assertion mean something.
+        """
+        source = _source(FakeSession())
+        budget = SimpleBudget(limits={ALBUM_PAGE: 2})
+        criterion = Criterion(
+            key="fake",
+            surface="fake",
+            endpoint_class=ALBUM_PAGE,
+            seeds=lambda _p: [
+                Seed(target=f"https://x/{i}", why="", seed_data={}) for i in range(5)
+            ],
+            label="fake",
+        )
+
+        def barren(_c, _s, b, _o, _st=None):  # noqa: ANN001, ANN202
+            # Spends the budget the way a real fetch would, and finds nothing —
+            # so the loop keeps going until the budget, not the results, stops it.
+            b.consume(ALBUM_PAGE)
+            return []
+
+        source._run_seed = barren  # type: ignore[method-assign]
+        state: dict[str, Any] = {}
+        source._run_criterion(criterion, SeedProfile(), budget, set(), state)
+        assert state["seeds"]["fake"] == 2
+
+    def test_state_is_optional_so_every_existing_caller_still_works(self) -> None:
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        assert _source(session).gather(
+            SeedProfile(top_genres=["ambient"]), crate_budget()
+        )
 
 
 class TestFetchPolicy:


### PR DESCRIPTION
## Summary

Repeated digging exhausted the candidate space in about five crates, and every crate after that came up short — silently.

**The ticket's diagnosis was a small pool. It is the opposite.** The captured discover fixture reports `result_count: 815356` and hands back a cursor for the next page:

```
'cursor': 'AoMIQcErt3jp6c2XnQMrYTExMzY3NDAzODA='
'result_count': 815356
'batch_result_count': 20
```

We asked for the first 20 rows of the same query forever and threw the cursor away in the parser. This is plumbing, not sourcing — which is why it fits in one sitting.

## The source gets a memory, passed in rather than owned

`gather(profile, budget, state)` takes a mutable mapping the builder loads before and saves after, as one `settings` row (no schema change).

`BandcampDiscoverySource` has no `LibraryIndex` and shouldn't grow one — it's provider code behind a provider-neutral ABC — and the shape of the blob is the source's own business, so nothing in the builder or the schema knows what's in it. It also makes rotation and pagination assertable with a plain `dict`: no network, no storage.

## Seeds rotate

`_run_criterion` still stops at one productive seed per criterion — deepening one would starve the others and make every crate look the same. What changed is *which* seed: it starts where the last crate stopped.

**It advances past every seed tried, not just a productive one.** Advancing only on success looks right and is the trap: a barren seed at the head of the list (a deleted album, an artist page with one release) would be re-fetched first on every crate for the life of the install, and rotation would never begin. It does *not* advance past seeds a spent budget never reached — the offset means "resume here".

## The discover query paginates

`ParseResult` carries the cursor; `_discover` sends the stored one keyed on `(criterion, tag, slice)` and stores what comes back.

**An empty page resets the cursor rather than storing it.** A stale or walked-off-the-end cursor would otherwise pin that query on an empty page for the rest of the install, invisibly — a quieter version of the bug being fixed.

## Slice variety falls out of rotation for free

`_genre_top_seeds` yields both `top` and `rand` per genre instead of hard-coding `top`, so rotation cycles them with no slice-picking logic anywhere and no extra requests. `slice=top` for the same tag returns the same twenty albums next week; `rand` reaches a different part of the same catalogue — the trick `_old_album_seeds` already relies on.

## And the clerk says when the well is dry

A crate can be short because the budget stopped us, because a 429 cut the gather off, or because everything found had already been shown. Only the last is worth telling the user, because only it means the racks are picked over rather than something having gone wrong.

Three details that each would have been a bug:

- **Attributed before anything is written.** Place first and this crate's own ten records are `seen_before` by the time you ask — so *every* short crate would claim the well was dry, including a three-record crate where nothing had been seen at all. (Caught by a test that went red for exactly this.)
- **Published on every terminal path**, because `_publish` merges and a flag left unset carries over from the previous build. Same trap `short` already works around.
- **Not re-derived from the stored rows** the way `short` is. Nothing on disk records why a build stopped, and guessing "you have seen everything" about a restored crate is the kind of invented explanation this feature is defined against. It resets to false on a restart.

The short-crate banner no longer blames a rate limit either — it asserted one as the cause of *every* short crate, which was true only some of the time. A real rate limit already has its own banner, with a countdown.

## Failure policy

The rotation state is a cache of where to resume, so everything around it costs variety rather than the crate: unparseable JSON, the wrong type, and a failed write are all swallowed with a warning. It's saved even when the gather *raised*, because whatever it advanced before failing is still progress and re-reading those pages is the waste this exists to stop.

## Test plan

- [x] `poetry run pytest` — **3200 passed, 9 skipped** (19 new), coverage **93.78%** (was 93.74%)
- [x] `poetry run mypy kamp_daemon kamp_core` — clean
- [x] `npm run typecheck`, `npm run lint` clean (one pre-existing `main/index.ts` warning)

The four acceptance criteria are all asserted, without a network:

- Ten consecutive crates against a paginating fake are full and share no records.
- Consecutive gathers fetch **different** seeds for the same criterion — asserted on the URLs requested, not the candidates returned, since a fake that returns the same body every time would make an output assertion pass for the wrong reason.
- A cursor written by one gather is sent by the next — asserted on the request payload.
- A pool where everything was already seen reports `exhausted`; a thin gather and a budget stop do not.

## What to check

Dig six or more crates in a row. Each should be full, and none should repeat a record from an earlier one — that's the whole story. If the well genuinely runs dry, the banner should say so instead of leaving a half-empty crate unexplained.

Closes KAMP-661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
