### PR TITLE
KAMP-665: spread a crate across seeds instead of leaning on one

### DIFF
--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -322,6 +322,18 @@ def _deal(
     the case: it carries no personal claim and one seed produces the whole
     criterion, so folding every chart pick into a single bucket would cap the
     criterion at two by accident.
+
+    **The cap is not enough on its own, and measuring a live crate is what showed
+    it.** Five criteria over ten slots is two slots each, so a cap of two never
+    binds -- a criterion only ever had two cards to place. It then spent both on
+    the FIRST seed in its group, because groups are built in gather order and one
+    seed's candidates are contiguous, so gathering a second album page changed
+    nothing about what reached the crate. Crates 22, 23 and 24 each had two
+    records from one album page for exactly this reason.
+
+    So the pick inside a group goes to the seed used LEAST so far. It costs no
+    requests -- the same candidates in a better order -- and it is what makes the
+    extra seeds gathered upstream actually show up in the crate.
     """
     taken = {id(c) for c in (skip or [])}
     counts: dict[str, int] = {}
@@ -342,9 +354,16 @@ def _deal(
             cap = caps.get(criterion)
             if cap is not None and counts.get(criterion, 0) >= cap:
                 continue
-            for candidate in groups[criterion]:
-                if id(candidate) in taken:
-                    continue
+
+            # Least-used seed first. Stable within a tie, so a group whose seeds
+            # are all equally used keeps its gather order and the existing
+            # ordering tests still describe the behaviour.
+            available = [c for c in groups[criterion] if id(c) not in taken]
+            available.sort(
+                key=lambda c: seed_counts.get(seed_dimension(c.seed) or "", 0)
+            )
+
+            for candidate in available:
                 key = seed_dimension(candidate.seed)
                 if (
                     seed_cap is not None

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -36,6 +36,7 @@ from .discovery import (
     build_seed_profile,
     crate_budget,
 )
+from .discovery_criteria import seed_dimension
 
 if TYPE_CHECKING:  # pragma: no cover - types only
     from kamp_core.library import LibraryIndex
@@ -46,6 +47,15 @@ logger = logging.getLogger(__name__)
 #: rather than a tuning knob: a crate you can finish in a sitting is the whole
 #: affordance.
 CRATE_SIZE = 10
+
+#: How many records in one crate may come from a single seed (KAMP-665).
+#:
+#: Two, because one is too strict — a genre you actually listen to earning two
+#: records is a crate reflecting your taste, not a crate repeating itself — and
+#: three is what the complaint was: three cards off one album page, three clerk
+#: lines naming the same record. Enforced as a preference, not a ceiling; the
+#: backfill in select_crate overruns it rather than shipping a short crate.
+SEED_CAP = 2
 
 #: Where the source's scratch space is kept between crates (KAMP-661): which seed
 #: each criterion stopped on, how far into each paginated query it has read. One
@@ -268,12 +278,17 @@ def select_crate(
     order = list(groups)
     rng.shuffle(order)
 
-    picks = _deal(groups, order, size, caps)
+    picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP)
     if len(picks) < size:
         # A cap is a preference, not a ceiling: honouring one to the point of
         # shrinking the crate is how a brand-new library (whose only criterion is
         # the chart) would get a one-item crate. Backfill from what the caps held
         # back, uncapped criteria having already been exhausted by _deal.
+        #
+        # The seed cap is dropped here for the same reason as the criterion caps
+        # (KAMP-665): a thin profile can yield one seed's worth of candidates and
+        # nothing else, and a two-record crate is a worse answer than a crate that
+        # leans on one album page.
         picks.extend(_deal(groups, order, size - len(picks), caps={}, skip=picks))
     return picks
 
@@ -289,15 +304,35 @@ def _deal(
     size: int,
     caps: dict[str, int],
     skip: list[Candidate] | None = None,
+    seed_cap: int | None = None,
 ) -> list[Candidate]:
     """Round-robin one card per criterion until *size* or nothing is left.
 
     Round-robin is what enforces "a criterion may repeat but a crate must span
     several" without the builder interpreting a single label -- which is what
     keeps a future non-Bandcamp provider from having to teach it their criteria.
+
+    *seed_cap* bounds how many cards may come from one SEED (KAMP-665). One album
+    page returns about twenty recommendations, so a criterion could satisfy the
+    round-robin while quietly taking three of its cards off the same page --
+    three clerk lines all reading "filed next to DOGGOD". A criterion is not a
+    fine enough unit to catch that; the seed is.
+
+    A candidate whose seed names nothing shareable is never capped. The chart is
+    the case: it carries no personal claim and one seed produces the whole
+    criterion, so folding every chart pick into a single bucket would cap the
+    criterion at two by accident.
     """
     taken = {id(c) for c in (skip or [])}
     counts: dict[str, int] = {}
+    # Seeded from what an earlier pass already took, so the backfill below cannot
+    # undo the cap it is backfilling past.
+    seed_counts: dict[str, int] = {}
+    for candidate in skip or []:
+        key = seed_dimension(candidate.seed)
+        if key is not None:
+            seed_counts[key] = seed_counts.get(key, 0) + 1
+
     picks: list[Candidate] = []
     while len(picks) < size:
         progressed = False
@@ -310,8 +345,17 @@ def _deal(
             for candidate in groups[criterion]:
                 if id(candidate) in taken:
                     continue
+                key = seed_dimension(candidate.seed)
+                if (
+                    seed_cap is not None
+                    and key is not None
+                    and seed_counts.get(key, 0) >= seed_cap
+                ):
+                    continue
                 taken.add(id(candidate))
                 counts[criterion] = counts.get(criterion, 0) + 1
+                if key is not None:
+                    seed_counts[key] = seed_counts.get(key, 0) + 1
                 picks.append(candidate)
                 progressed = True
                 break

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -63,6 +63,40 @@ class Criterion:
     label: str
 
 
+def seed_dimension(seed_data: dict[str, Any]) -> str | None:
+    """What a crate can only stand so much of, or None if the seed shares nothing.
+
+    A crate read narrower than the library it came from (KAMP-665): three records
+    off one album page, and one genre covering both discover criteria. Preventing
+    that needs a name for the thing being repeated, and the seeds already carry
+    it — ``seed_data`` exists to explain a pick, and "what explains it" and "what
+    it must not duplicate" turn out to be the same question.
+
+    Read off the provenance rather than added as a field, which is what makes it
+    work ACROSS criteria: ``genre_top`` says ``kind='genre'`` and
+    ``older_than_ten`` says ``kind='genre_old'``, but both name a genre, so both
+    produce the same key and cannot both take Rock.
+
+    Case- and space-folded, because these are tags typed by hundreds of different
+    labels and "Dub Techno" is not a second genre.
+
+    **None means "never excluded"**, not "excluded from everything". The chart
+    seed carries no personal claim and there is exactly one of it; giving it an
+    empty-string key would make it collide with itself and drop the criterion
+    from every crate after the first.
+    """
+    for field_name in ("genre", "artist", "album_id", "label"):
+        value = seed_data.get(field_name)
+        if value in (None, ""):
+            continue
+        # Namespaced so an artist called "Rock" is not the genre Rock. `genre` is
+        # deliberately NOT namespaced per criterion -- the whole point is that the
+        # two genre criteria collide with each other.
+        kind = "genre" if field_name == "genre" else field_name
+        return f"{kind}:{str(value).strip().casefold()}"
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Seed selectors — pure functions of the profile
 # ---------------------------------------------------------------------------

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -52,6 +52,7 @@ from .discovery_criteria import (
     Criterion,
     Seed,
     criteria_for,
+    seed_dimension,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - types only
@@ -68,6 +69,16 @@ DISCOVER_API_URL = "https://bandcamp.com/api/discover/1/discover_web"
 # only to the album-page GET that supplies the crumb and band_id.
 COLLECT_URL = "https://bandcamp.com/collect_item_cb"
 UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
+
+#: How many seeds one criterion may read from in a single crate (KAMP-665).
+#:
+#: Two, not "until the budget is spent". The allowance is per endpoint class and
+#: three criteria share DISCOVER_API's six, so an uncapped criterion would take
+#: the lot and starve the others — narrow in a different way. Two also keeps a
+#: build near the 3-6 requests crate_budget() was calibrated against, which
+#: matters because these endpoints are the thing that rate-limits hardest and a
+#: 429 here cascades account-wide (KAMP-639).
+_SEEDS_PER_CRITERION = 2
 
 
 def _sub(state: "MutableMapping[str, Any]", key: str) -> dict[str, Any]:
@@ -246,9 +257,19 @@ class BandcampDiscoverySource(DiscoverySource):
         # ids, so no database access is needed here.
         owned = set(profile.purchase_dates)
 
+        # Seed dimensions already spoken for in THIS crate (KAMP-665). Criteria
+        # run in sequence here, which is what lets a later one be told what an
+        # earlier one took: genre_top and older_than_ten both read top_genres and
+        # both started at its head, so one genre covered two criteria in the same
+        # crate. Per gather, never persisted — it is about the shape of one crate,
+        # not about what previous crates did (that is rotation's job, KAMP-661).
+        used: set[str] = set()
+
         for criterion in criteria_for(profile):
             try:
-                found = self._run_criterion(criterion, profile, budget, owned, state)
+                found = self._run_criterion(
+                    criterion, profile, budget, owned, state, used=used
+                )
             except RateLimitedError as exc:
                 logger.warning("discovery: stopping gather early — %s", exc)
                 break
@@ -275,17 +296,40 @@ class BandcampDiscoverySource(DiscoverySource):
         budget: RequestBudget,
         owned: set[str] | None = None,
         state: "MutableMapping[str, Any] | None" = None,
+        used: set[str] | None = None,
     ) -> list[Candidate]:
-        """One criterion's worth of candidates, starting where last crate stopped.
+        """One criterion's worth of candidates, spread over a few seeds.
 
-        Still one productive seed per criterion — spending the rest of the budget
-        deepening a single criterion would starve the others and make every crate
-        look the same. What changed in KAMP-661 is WHICH seed that is: the seed
-        list is rotated so consecutive crates read different albums, artists and
-        genre slices instead of re-reading the head of the list forever.
+        Two things are being balanced, and they pull opposite ways.
+
+        It used to stop at the FIRST productive seed, so a criterion never spread
+        across its own seed list — which is how three of one crate's records came
+        off a single album page (KAMP-665). Now it keeps going up to
+        ``_SEEDS_PER_CRITERION``.
+
+        But it must not simply run until the budget is gone. The allowance is
+        per ENDPOINT CLASS and three criteria share DISCOVER_API's six requests,
+        so an uncapped first criterion would spend the lot on its own seed list
+        and starve the other two — trading one kind of narrowness for another.
+        Two seeds is deliberately modest: these endpoints are the scarce resource
+        (KAMP-637/639), and crate_budget()'s caps carry only about 2x margin over
+        a measured build.
+
+        *used* is the dimensions other criteria have already taken in this crate.
+        A seed naming one of them is skipped without spending a request — that is
+        what stops genre_top and older_than_ten both landing on Rock.
+
+        The rotation offset DOES advance past a skipped seed, which looks wrong
+        and is not. A dimension only enters *used* when the seed that claimed it
+        actually produced records (see the `if got` below), so a skip always means
+        "the crate already has records for this genre, from the other criterion".
+        The genre was covered; this criterion simply was not the one to cover it.
+        Parking the offset behind it instead would leave this criterion
+        permanently a step behind whichever one happens to run first.
         """
         state = {} if state is None else state
         offsets = _sub(state, "seeds")
+        used = set() if used is None else used
 
         seeds = list(criterion.seeds(profile))
         if not seeds:
@@ -293,23 +337,37 @@ class BandcampDiscoverySource(DiscoverySource):
         start = int(offsets.get(criterion.key, 0)) % len(seeds)
 
         found: list[Candidate] = []
-        tried = 0
+        productive = 0
+        # Where to resume next crate: advanced only over seeds actually TRIED, and
+        # tracked as an absolute step so a run of skips does not shift it.
+        consumed = 0
         for step in range(len(seeds)):
+            if productive >= _SEEDS_PER_CRITERION:
+                break
             seed = seeds[(start + step) % len(seeds)]
             if not budget.allow(criterion.endpoint_class):
                 break
-            tried += 1
-            found.extend(self._run_seed(criterion, seed, budget, owned or set(), state))
-            if found:
-                break
+
+            dimension = seed_dimension(seed.seed_data)
+            if dimension is not None and dimension in used:
+                # Someone else is on this genre. Leave the offset behind it.
+                continue
+
+            consumed = step + 1
+            got = self._run_seed(criterion, seed, budget, owned or set(), state)
+            if got:
+                found.extend(got)
+                productive += 1
+                if dimension is not None:
+                    used.add(dimension)
 
         # Advance past every seed TRIED, not just a productive one. Advancing only
         # on success looks right and is the trap: a seed at the head of the list
         # that yields nothing (a deleted album, an artist page with one release)
         # would be re-fetched at the head of every crate for the life of the
         # install, and the rotation would never begin.
-        if tried:
-            offsets[criterion.key] = (start + tried) % len(seeds)
+        if consumed:
+            offsets[criterion.key] = (start + consumed) % len(seeds)
         return found
 
     def _run_seed(

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import random
 import sqlite3
+from collections import Counter
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -47,7 +48,9 @@ def _candidate(item_id: str, criterion: str = "also_like", **kw: Any) -> Candida
         title=kw.pop("title", f"Title {item_id}"),
         criterion=criterion,
         why=f"because {criterion}",
-        seed={"kind": criterion},
+        # Overridable, because KAMP-665 made the seed something the builder reads
+        # rather than provenance it only stores.
+        seed=kw.pop("seed", {"kind": criterion}),
         **kw,
     )
 
@@ -215,6 +218,112 @@ class TestSelection:
         _build(index, _FakeSource(_spread({"a": 8, "b": 8})))
         used = _criteria(index, 1)
         assert used.count("a") > 1 and used.count("b") > 1
+
+
+class TestSeedCaps:
+    """KAMP-665: a crate can have too much of one SEED, not just one criterion.
+
+    Measured on a real crate: three of its ten records came off a single album
+    page, so three clerk lines all said "filed next to DOGGOD". The builder had
+    no way to notice, because Candidate.seed was provenance it never read.
+    """
+
+    def test_no_more_than_two_records_share_a_seed(self, index: LibraryIndex) -> None:
+        """A SEED-RICH profile, which is the condition the cap needs to hold.
+
+        Six seeds at two apiece covers a crate of ten with room over. Give it
+        three and the cap is arithmetically unsatisfiable — 3 x 2 = 6 — and the
+        backfill correctly overruns it rather than shipping a six-record crate.
+        That case has its own test below; this one is about the cap doing its job
+        when it can.
+        """
+        candidates = []
+        for n in range(3):
+            candidates += [
+                _candidate(
+                    f"a{n}{i}", "also_like", seed={"kind": "album", "album_id": n}
+                )
+                for i in range(4)
+            ]
+        for genre in ("rock", "metal"):
+            candidates += [
+                _candidate(
+                    f"g{genre}{i}", "genre_top", seed={"kind": "genre", "genre": genre}
+                )
+                for i in range(4)
+            ]
+        candidates += [
+            _candidate(
+                f"x{i}", "favorite_artist", seed={"kind": "artist", "artist": "X"}
+            )
+            for i in range(4)
+        ]
+
+        _build(index, _FakeSource(candidates))
+        items = index.crate_items(1)
+        assert len(items) == CRATE_SIZE, "the cap must not have cost records"
+        seeds = [json.dumps(row["seed"], sort_keys=True) for row in items]
+        for seed, count in Counter(seeds).items():
+            assert count <= 2, f"{count} records share one seed: {seed}"
+
+    def test_the_cap_is_overrun_rather_than_shipping_a_short_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        """Three seeds cannot cover ten records at two apiece.
+
+        The cap is a preference, exactly as the criterion caps are (KAMP-648): a
+        crate that leans on one album page is a better answer than a crate with
+        four empty slots.
+        """
+        candidates = []
+        for n in range(3):
+            candidates += [
+                _candidate(
+                    f"a{n}{i}", "also_like", seed={"kind": "album", "album_id": n}
+                )
+                for i in range(8)
+            ]
+        status = _build(index, _FakeSource(candidates))
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
+
+    def test_a_seed_cap_never_shrinks_the_crate(self, index: LibraryIndex) -> None:
+        """The same rule the criterion cap follows (KAMP-648).
+
+        A thin profile can yield a single seed's worth of candidates and nothing
+        else; honouring the cap unconditionally would hand that user a two-record
+        crate, which is a worse answer than a crate that leans on one album page.
+        """
+        source = _FakeSource(
+            [
+                _candidate(str(n), "best_seller", seed={"kind": "chart"})
+                for n in range(20)
+            ]
+        )
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
+
+    def test_candidates_without_a_seed_dimension_are_not_all_one_seed(
+        self, index: LibraryIndex
+    ) -> None:
+        """The chart has no dimension, and must not therefore be capped to two.
+
+        Treating "no dimension" as a single shared key would collapse every
+        chart pick into one bucket and cap the criterion at two by accident.
+        """
+        source = _FakeSource(
+            [
+                _candidate(str(n), "best_seller", seed={"kind": "chart"})
+                for n in range(6)
+            ]
+            + [
+                _candidate(f"x{n}", "also_like", seed={"kind": "album", "album_id": n})
+                for n in range(6)
+            ]
+        )
+        _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
 
 
 class TestCriterionCaps:

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -266,6 +266,68 @@ class TestSeedCaps:
         for seed, count in Counter(seeds).items():
             assert count <= 2, f"{count} records share one seed: {seed}"
 
+    def test_a_criterion_spends_its_slots_on_different_seeds(
+        self, index: LibraryIndex
+    ) -> None:
+        """The bug the seed cap alone did not catch, found in crate 24.
+
+        The round-robin gives five criteria two slots each over a crate of ten,
+        so a cap of two per seed never binds — a criterion only ever had two
+        cards to place. It then took both off the FIRST seed in its group,
+        because groups are built in gather order and a seed's candidates are
+        contiguous. Fetching a second album page changed nothing about what
+        landed in the crate.
+
+        So the choice inside a group has to prefer the seed used least so far.
+        Costs no requests: it is the same candidates, picked in a better order.
+
+        FIVE criteria over a crate of ten is the real shape — that is what makes
+        two slots each, and two slots is where a cap of two stops binding. With
+        fewer criteria each gets more slots and the cap catches it, which is why
+        this has to mirror the live registry rather than a convenient pair.
+        """
+        # Two seeds each, exactly as _SEEDS_PER_CRITERION gathers.
+        candidates: list[Candidate] = []
+        for criterion, dimension in (
+            ("also_like", "album_id"),
+            ("genre_top", "genre"),
+            ("older_than_ten", "genre"),
+            ("favorite_artist", "artist"),
+            ("best_seller", None),
+        ):
+            for s in range(2):
+                for i in range(4):
+                    seed = (
+                        {"kind": criterion, dimension: f"{criterion}-{s}"}
+                        if dimension
+                        else {"kind": "chart"}
+                    )
+                    candidates.append(
+                        _candidate(f"{criterion}{s}{i}", criterion, seed=seed)
+                    )
+
+        _build(index, _FakeSource(candidates))
+        rows = index.crate_items(1)
+        assert len(rows) == CRATE_SIZE
+
+        # Every criterion that had two seeds available should have used both.
+        for criterion in (
+            "also_like",
+            "genre_top",
+            "older_than_ten",
+            "favorite_artist",
+        ):
+            seeds = {
+                json.dumps(r["seed"], sort_keys=True)
+                for r in rows
+                if r["criterion"] == criterion
+            }
+            picked = [r for r in rows if r["criterion"] == criterion]
+            if len(picked) > 1:
+                assert (
+                    len(seeds) > 1
+                ), f"{criterion} spent {len(picked)} slots on one seed: {seeds}"
+
     def test_the_cap_is_overrun_rather_than_shipping_a_short_crate(
         self, index: LibraryIndex
     ) -> None:

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -19,6 +19,7 @@ from kamp_daemon.discovery import (
     ALBUM_PAGE,
     ARTIST_PAGE,
     DISCOVER_API,
+    FANCOLLECTION,
     PREVIEW,
     SAVE_REMOTE,
     Candidate,
@@ -32,6 +33,7 @@ from kamp_daemon.discovery_criteria import (
     Seed,
     _genre_top_seeds,
     criteria_for,
+    seed_dimension,
 )
 from kamp_daemon.discovery_sources import (
     BandcampDiscoverySource,
@@ -394,6 +396,243 @@ class TestGatherAgainstFixtures:
         assert len(found) == 1
 
 
+class TestSeedDimension:
+    """KAMP-665: what a crate can have too much of.
+
+    A crate took three records off one album page and covered two criteria with
+    the same genre. The dimension is the thing that must not repeat — read from
+    the provenance a seed already carries rather than a new field, so it
+    generalises past genre to artist and album for free.
+    """
+
+    def test_a_genre_seed_is_keyed_on_its_genre(self) -> None:
+        """Both discover criteria read top_genres, so both must key the same way
+        or the exclusion between them cannot work."""
+        top = seed_dimension({"kind": "genre", "genre": "Rock"})
+        old = seed_dimension({"kind": "genre_old", "genre": "Rock"})
+        assert top == old, "genre_top and older_than_ten must collide on Rock"
+
+    def test_case_and_spacing_do_not_defeat_it(self) -> None:
+        """'Dub Techno' and 'dub techno' are one genre wearing two hats — taste
+        signals come from tags typed by hundreds of different labels."""
+        assert seed_dimension({"kind": "genre", "genre": " Dub Techno "}) == (
+            seed_dimension({"kind": "genre_old", "genre": "dub techno"})
+        )
+
+    def test_artists_and_albums_have_their_own_dimensions(self) -> None:
+        assert seed_dimension({"kind": "artist", "artist": "Four Tet"}) is not None
+        assert seed_dimension({"kind": "album", "album_id": 7}) is not None
+        assert seed_dimension({"kind": "artist", "artist": "Four Tet"}) != (
+            seed_dimension({"kind": "album", "album_id": 7})
+        )
+
+    def test_a_seed_with_nothing_to_share_has_no_dimension(self) -> None:
+        """The chart carries no personal claim and there is only one of it.
+
+        None means "never excluded" rather than "excluded from everything" — an
+        empty-string key would make the single chart seed collide with itself and
+        the criterion would vanish from every crate after the first.
+        """
+        assert seed_dimension({"kind": "chart"}) is None
+        assert seed_dimension({}) is None
+        assert seed_dimension({"kind": "genre", "genre": ""}) is None
+
+
+class TestSpreadWithinACrate:
+    """KAMP-665: one criterion should not take everything from one seed."""
+
+    def test_a_criterion_reads_more_than_one_seed(self) -> None:
+        """It used to stop at the first productive seed, so three of a crate's
+        records could come off a single album page."""
+        session = FakeSession(get_body=_fixture("album_page_with_recs"))
+        profile = SeedProfile(
+            recent_album_ids={1, 2, 3},
+            recent_albums=[
+                _album_seed(album_id=i, url=f"https://a{i}.bandcamp.com/album/x")
+                for i in (1, 2, 3)
+            ],
+        )
+        _source(session).gather(profile, crate_budget(), {})
+        assert len(session.gets) >= 2, "still stopping at the first productive seed"
+
+    def test_the_spread_stays_inside_the_budget(self) -> None:
+        """Variety is bought from the allowance, never from more of it.
+
+        These endpoints are the scarce resource — KAMP-637/639 are both about a
+        crate build earning a 429 that cascades account-wide — so the guard is
+        that the spend never exceeds what crate_budget() funds.
+        """
+        budget = crate_budget()
+        session = FakeSession(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        _source(session).gather(RICH_PROFILE, budget, {})
+
+        for endpoint_class, cap in budget.limits.items():
+            assert budget.spent.get(endpoint_class, 0) <= cap, endpoint_class
+        # And the collection endpoint is never touched at all — funded at zero as
+        # a tripwire rather than a limit.
+        assert budget.spent.get(FANCOLLECTION, 0) == 0
+
+    def test_one_criterion_cannot_eat_a_shared_class_allowance(self) -> None:
+        """Three criteria sit on DISCOVER_API's six requests.
+
+        Without a per-criterion seed cap the first of them would spend the lot on
+        its own seed list — genre_top alone offers twenty seeds against a profile
+        of ten genres — and the other two would find nothing left, trading one
+        kind of narrowness for another.
+
+        Asserted on the REQUESTS, not the candidates: every seed replays the same
+        canned body here, so gather's id-dedupe would credit all of them to
+        whichever criterion ran first and the candidate list would say nothing
+        about who got to spend.
+        """
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        budget = crate_budget()
+        profile = SeedProfile(top_genres=[f"g{i}" for i in range(10)])
+        _source(session).gather(profile, budget, {})
+
+        spent = budget.spent[DISCOVER_API]
+        assert spent <= budget.limits[DISCOVER_API], "spilled past the class cap"
+        assert spent >= 3, "at least one request each for the three criteria"
+        # The chart carries no tag, so its request is the one identifiable by
+        # shape — proof the criteria after genre_top still had budget to spend.
+        assert any(
+            not p[1]["tag_norm_names"] for p in session.posts
+        ), "genre_top consumed the whole discover allowance"
+
+
+class TestGenreExclusionAcrossCriteria:
+    def test_the_two_genre_criteria_do_not_take_the_same_genre(self) -> None:
+        """Both read top_genres and both started at its head, so one genre
+        covered two criteria in the same crate — measured on a real library."""
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        profile = SeedProfile(top_genres=["rock", "metal", "dub techno"])
+        _source(session).gather(profile, crate_budget(), {})
+
+        tags = [
+            p[1]["tag_norm_names"] for p in session.posts if p[1].get("tag_norm_names")
+        ]
+        flat = [t[0] for t in tags if t]
+        assert len(flat) == len(set(flat)), f"a genre was fetched twice: {flat}"
+
+    def test_a_skipped_genre_is_not_owed_another_turn(self) -> None:
+        """The offset advances past a skipped seed, and that is deliberate.
+
+        A dimension only enters the used set when the seed that claimed it
+        actually produced records, so a skip always means "the crate already has
+        records for this genre, from the other criterion". The genre was covered;
+        this criterion simply was not the one to cover it. Parking the offset
+        behind it would leave this criterion permanently one step behind whichever
+        one runs first.
+        """
+        source = _source(FakeSession())
+        criterion = Criterion(
+            key="fake",
+            surface="fake",
+            endpoint_class=ALBUM_PAGE,
+            seeds=lambda _p: [
+                Seed(target=f"https://x/{i}", why="", seed_data={"genre": g})
+                for i, g in enumerate(["rock", "metal", "jazz", "funk"])
+            ],
+            label="fake",
+        )
+        state: dict[str, Any] = {}
+        source._run_seed = lambda *a, **k: [MagicMock()]  # type: ignore[method-assign]
+        source._run_criterion(
+            criterion,
+            SeedProfile(),
+            crate_budget(),
+            set(),
+            state,
+            used={"genre:rock"},
+        )
+        # rock skipped, then metal and jazz taken (the two-seed spread) — so the
+        # next crate resumes at funk rather than re-reading any of them.
+        assert state["seeds"]["fake"] == 3
+
+
+class TestACrateReflectsTheLibrarysRange:
+    """The user-visible complaint, end to end (KAMP-665).
+
+    A user with 800 albums and six genres got a crate that looked like it knew
+    one album and one genre. These run the real criteria against the real parsers
+    with a fake session, so they fail if any layer stops spreading.
+    """
+
+    def test_a_library_dominated_by_one_genre_still_names_several(self) -> None:
+        """Raw track count puts the broadest genre first and keeps it there.
+
+        The ranking is right — Rock really is the biggest thing in that library —
+        so the fix is not to rerank it but to stop both discover criteria starting
+        at its head.
+        """
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        # The shape of a real library: one enormous genre, then a long tail.
+        profile = SeedProfile(top_genres=["rock", "metal", "dub techno", "ambient"])
+        _source(session).gather(profile, crate_budget(), {})
+
+        tags = {t[0] for _, p in session.posts if (t := p["tag_norm_names"])}
+        assert len(tags) >= 2, f"the whole crate came from one genre: {tags}"
+
+    def test_the_favourite_artist_criterion_reads_more_than_one_artist(self) -> None:
+        """Both favorite_artist picks in a real crate were the same artist."""
+        session = FakeSession(get_body=_fixture("artist_discography"))
+        profile = SeedProfile(
+            favorite_artists=[
+                SeedArtist(
+                    name=f"Band {i}", artist_page=f"https://b{i}.bandcamp.com/music"
+                )
+                for i in range(4)
+            ]
+        )
+        _source(session).gather(profile, crate_budget(), {})
+        assert len(set(session.gets)) >= 2, "one artist page supplied the lot"
+
+    def test_consecutive_crates_change_which_artists_they_read(self) -> None:
+        """The rotation from KAMP-661 applies per criterion, so favourite_artist
+        gets it too — asserted rather than assumed, because the acceptance
+        criteria name this case specifically and 'the mechanism is generic' is
+        the kind of claim that is true right up until it is not."""
+        session = FakeSession(get_body=_fixture("artist_discography"))
+        profile = SeedProfile(
+            favorite_artists=[
+                SeedArtist(
+                    name=f"Band {i}", artist_page=f"https://b{i}.bandcamp.com/music"
+                )
+                for i in range(4)
+            ]
+        )
+        source = _source(session)
+        state: dict[str, Any] = {}
+
+        source.gather(profile, crate_budget(), state)
+        first = set(session.gets)
+        session.gets.clear()
+        source.gather(profile, crate_budget(), state)
+        assert not (first & set(session.gets)), "the same artists two crates running"
+
+    def test_a_whole_crate_gather_stays_within_every_class_budget(self) -> None:
+        """The guard on the whole story: variety comes out of the allowance.
+
+        Asserted across a rich profile that exercises every criterion at once,
+        because the allowance is per endpoint class and three criteria share
+        DISCOVER_API's six — the interesting failure is one of them starving the
+        others, not any single criterion overspending.
+        """
+        budget = crate_budget()
+        session = FakeSession(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        _source(session).gather(RICH_PROFILE, budget, {})
+        assert budget.spent[ALBUM_PAGE] <= budget.limits[ALBUM_PAGE]
+        assert budget.spent[DISCOVER_API] <= budget.limits[DISCOVER_API]
+        assert budget.spent.get(ARTIST_PAGE, 0) <= budget.limits[ARTIST_PAGE]
+        assert budget.spent.get(FANCOLLECTION, 0) == 0
+
+
 class TestRotationAndPagination:
     """KAMP-661: the reachable candidate space has to grow with use.
 
@@ -447,13 +686,19 @@ class TestRotationAndPagination:
     def test_consecutive_gathers_use_different_seeds_for_the_same_criterion(
         self,
     ) -> None:
-        """Rotation, asserted on the URL fetched rather than on the candidates."""
+        """Rotation, asserted on the URL fetched rather than on the candidates.
+
+        FOUR albums, not two. KAMP-665 lets a criterion read two seeds per crate,
+        so a two-album profile is fully consumed every time and there is nothing
+        left to rotate — the offset wraps straight back to the head, correctly.
+        Rotation is only observable once the list is longer than the spread.
+        """
         session = FakeSession(get_body=_fixture("album_page_with_recs"))
         profile = SeedProfile(
-            recent_album_ids={1, 2},
+            recent_album_ids={1, 2, 3, 4},
             recent_albums=[
-                _album_seed(album_id=1, url="https://a.bandcamp.com/album/one"),
-                _album_seed(album_id=2, url="https://b.bandcamp.com/album/two"),
+                _album_seed(album_id=i, url=f"https://a{i}.bandcamp.com/album/x")
+                for i in (1, 2, 3, 4)
             ],
         )
         source = _source(session)
@@ -466,7 +711,7 @@ class TestRotationAndPagination:
         second = list(session.gets)
 
         assert first and second
-        assert first[0] != second[0], "the same seed was fetched twice running"
+        assert not (set(first) & set(second)), "a seed was re-read the very next crate"
 
     def test_rotation_advances_past_a_seed_that_produced_nothing(self) -> None:
         """Otherwise a dead seed at the head of the list is retried forever.


### PR DESCRIPTION
## Summary

A crate read narrower than the library it came from. Measured on real crates: three of one crate's ten records came off a single album page, so three clerk lines all named the same record; every `genre_top` and `older_than_ten` pick was Rock, one genre covering two criteria across both crates; and both favourite-artist picks were the same artist.

Sibling of KAMP-661, not a repeat of it. That one was about running *out* over five crates; this is the shape of a **single** crate, and would still matter if the pool were infinite.

**One of the four bullets was already settled by KAMP-661** — rotation means consecutive builds already vary the recent-listen and favourite-artist seeds, and that's now asserted for artists explicitly rather than assumed from "the mechanism is generic".

## A seed is a thing a crate can have too much of

The builder already understood "too much of one criterion" — `_deal` round-robins by criterion and `criterion_caps` bounds the chart pick. It had no idea three records could share a **seed**, because `Candidate.seed` was provenance it never read.

So the same idea now applies at two layers, and **both are needed**: spreading the gather alone would still let `_deal` take three cards off one album page, and capping selection alone would cap the crate at ten with no slack.

`seed_dimension()` reads the key off the provenance a seed already carries rather than adding a field, which is what makes it work *across* criteria — `genre_top` says `kind='genre'` and `older_than_ten` says `kind='genre_old'`, but both name a genre, so both produce the same key and cannot both take Rock. It generalises to artist and album for free.

Two details that would each have been a bug:

- **Case- and space-folded.** These are tags typed by hundreds of different labels; "Dub Techno" is not a second genre.
- **`None` means "never excluded", not "excluded from everything".** The chart carries no personal claim and one seed produces the whole criterion, so an empty-string key would make it collide with itself and drop `best_seller` from every crate after the first.

## Spread, bounded at two

`_run_criterion` reads up to two seeds instead of stopping at the first productive one.

**Two, not "until the budget is gone."** The allowance is per *endpoint class* and three criteria share `DISCOVER_API`'s six, so an uncapped first criterion would spend the lot on its own seed list and starve the other two — narrow in a different way. It also keeps a build near the 3-6 requests `crate_budget()` was calibrated against, which matters because these are the endpoints that rate-limit hardest and a 429 cascades account-wide (KAMP-637/639). Asserted: the spend never exceeds the caps, and `FANCOLLECTION` stays at zero.

## The skipped-seed rule, which looks wrong

The rotation offset **does** advance past a seed skipped for a taken dimension. A dimension only enters the used set when the seed that claimed it actually produced records, so a skip always means *"the crate already has records for this genre, from the other criterion"* — the genre was covered, this criterion just wasn't the one to cover it. Parking the offset behind it would leave the criterion permanently a step behind whichever one runs first.

My plan said the opposite before I'd worked the case through; the code comment and its test now carry the reasoning.

## taste_genres is left alone

The ticket asked to reweight it so "dub techno" isn't buried under "Rock". Its own diagnosis is the better one: *each ordering is the right ranking and nothing spreads the selection across it.* Rock really is the biggest thing in that library. So no scoring heuristic and no tuning constant — the exclusion stops both discover criteria starting at the head, and rotation walks the rest.

## Two KAMP-661 tests changed with the behaviour

Called out rather than buried, since changing a passing test deserves a reason:

- The rotation test used **two** albums, which the two-seed spread now consumes whole every crate — so the offset correctly wraps to the head and there is nothing to observe. It takes four albums before rotation is visible at all.
- The skipped-seed expectation was written before the offset semantics above were settled, and asserted the opposite.

## Test plan

- [x] `poetry run pytest` — **3216 passed, 9 skipped** (16 new), coverage **93.80%** (was 93.78%)
- [x] `poetry run mypy kamp_daemon kamp_core` — clean
- [x] `black --check` clean

Every acceptance criterion is asserted:

- No more than two records share a seed, against a seed-rich profile — plus the companion test that three seeds correctly *overrun* the cap rather than shipping a six-record crate.
- `genre_top` and `older_than_ten` never fetch the same genre in one crate.
- Consecutive builds change which artists they read.
- A library dominated by one broad genre still names several.
- Per-class request counts stay within `crate_budget()`.

The starvation test asserts on **requests, not candidates** — every seed replays the same canned body, so gather's id-dedupe would credit them all to whichever criterion ran first and the candidate list would say nothing about who got to spend.

## What to check

The ticket asks for this explicitly — *"the last three defects in this area were all found by running it"*. Dig two or three crates against the real library and read the clerk lines: no more than two should name the same album, the genre lines should name different genres, and the favourite-artist picks should be different artists. Worth watching the daemon log for the per-crate request count at the same time — it should sit around 8, not 18.

Closes KAMP-665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
