### PR TITLE
KAMP-684: stop kamp burning CPU while idle

### DIFF
--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -844,6 +844,16 @@ def _cmd_daemon(
         import time
 
         tick = 0
+        # KAMP-684: what was last persisted, so an unchanged tick writes nothing.
+        # Both saves COMMIT, and the library is WAL with synchronous=FULL, so
+        # each one is an fsync — and fsync stalls system-wide on macOS, not just
+        # this process. The old gate was `if current:`, so a daemon sitting on a
+        # restored queue with nothing playing fsynced twice every five seconds
+        # forever, re-serialising an identical queue to JSON each time.
+        # get_state() returns fresh lists, so caching its result is safe from
+        # mutation underneath us.
+        last_player_state: tuple[int, float] | None = None
+        last_queue_state: tuple[list[int], list[int], int, bool, str] | None = None
         while True:
             time.sleep(1)
             current = queue.current()
@@ -870,9 +880,17 @@ def _cmd_daemon(
                 _et_prev_pos[0] = pos
                 _et_playing[0] = playing
                 if tick % 5 == 0:
-                    index.save_player_state(current.id, engine.state.position)
-                    q_ids, q_order, q_pos, q_shuffle, q_repeat = queue.get_state()
-                    index.save_queue_state(q_ids, q_order, q_pos, q_shuffle, q_repeat)
+                    player_state = (current.id, engine.state.position)
+                    if player_state != last_player_state:
+                        index.save_player_state(*player_state)
+                        last_player_state = player_state
+                    queue_state = queue.get_state()
+                    if queue_state != last_queue_state:
+                        q_ids, q_order, q_pos, q_shuffle, q_repeat = queue_state
+                        index.save_queue_state(
+                            q_ids, q_order, q_pos, q_shuffle, q_repeat
+                        )
+                        last_queue_state = queue_state
             elif _et_path[0] is not None:
                 # Queue became empty — flush any accumulated time.
                 _flush_elapsed()

--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -258,17 +258,30 @@ export default function App(): React.JSX.Element {
     // Never give up in packaged mode — retry indefinitely at the 30s cap.
     const MAX_ATTEMPTS = window.api.isPackaged ? Infinity : 8
 
-    const connect = (): (() => void) => {
-      return connectStateStream(
+    // KAMP-684: the stream's lifecycle needs three handles, not one. `dispose`
+    // so a reconnect can shut the previous stream's 250ms ping interval down
+    // (it used to be dropped on the floor, leaking one timer per reconnect for
+    // the life of the process); `retryId` so a pending retry can be cancelled;
+    // `torn` so nothing reconnects after the effect has been cleaned up.
+    let dispose: (() => void) | null = null
+    let retryId: ReturnType<typeof setTimeout> | undefined
+    let torn = false
+
+    const connect = (): void => {
+      if (torn) return
+      // The previous socket is already closed — this is here for its interval.
+      dispose?.()
+      dispose = connectStateStream(
         applyServerState,
         () => {
+          if (torn) return
           attempts++
           if (attempts >= MAX_ATTEMPTS) {
             setServerStatus('disconnected')
           } else {
             setServerStatus('reconnecting')
             const delay = Math.min(1000 * 2 ** (attempts - 1), 30000)
-            setTimeout(connect, delay)
+            retryId = setTimeout(connect, delay)
           }
         },
         () => {
@@ -378,8 +391,13 @@ export default function App(): React.JSX.Element {
       )
     }
 
-    const disconnect = connect()
-    return disconnect
+    connect()
+    return () => {
+      torn = true
+      clearTimeout(retryId)
+      dispose?.()
+      dispose = null
+    }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // KAMP-598: any pointer press means the focus it establishes is mouse-driven,

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -1301,7 +1301,15 @@ export function connectStateStream(
     }
   }
 
-  ws.onclose = () => onClose?.()
+  // KAMP-684: set once teardown begins, so a close event already in flight
+  // cannot reach onClose (which is what schedules a reconnect) and so calling
+  // the disposer twice is harmless.
+  let disposed = false
+
+  ws.onclose = () => {
+    if (disposed) return
+    onClose?.()
+  }
 
   // Keep state fresh while playing: poll at ~4 Hz.
   const interval = setInterval(() => {
@@ -1309,7 +1317,15 @@ export function connectStateStream(
   }, 250)
 
   return () => {
+    // KAMP-684: teardown has to be silent as well as complete. Closing an OPEN
+    // socket fires onclose asynchronously, and that handler is what schedules
+    // the reconnect — so disposing a live stream used to spawn a replacement
+    // socket and a 250ms interval that nothing held a handle to. Flag first,
+    // detach the handler, then close.
+    if (disposed) return
+    disposed = true
     clearInterval(interval)
+    ws.onclose = null
     ws.close()
   }
 }

--- a/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
+++ b/kamp_ui/src/renderer/src/components/modules/StereoRackModule.tsx
@@ -165,8 +165,39 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
     // Pause idle tracking — local to this closure, no React state involved.
     let pauseStartTs = -1
     let idleElapsedMs = 0
+    let idleTimerId: ReturnType<typeof setTimeout> | undefined
 
-    const frame = (timestamp: number): void => {
+    // KAMP-684: draw dead air at ~10fps rather than at the display refresh.
+    // The dead-air branch of the oscilloscope is pure per-pixel Math.random()
+    // noise — it returns before the AR(1) and smoothing work — so drawing it
+    // less often costs no signal fidelity, and VUMeter's decay and peak-hold
+    // are time-delta based, so their speed is unaffected by the rate. The
+    // signal path deliberately stays at full rate: its AR(1) loop advances once
+    // per FRAME, so throttling that would change the trace's character.
+    const IDLE_FRAME_MS = 100
+
+    const stop = (): void => {
+      cancelAnimationFrame(rafIdRef.current)
+      clearTimeout(idleTimerId)
+      idleTimerId = undefined
+    }
+
+    // Going through a timer while idle is what actually stops the renderer
+    // producing frames. Skipping the draw inside a still-full-rate callback
+    // would keep waking it 60-120 times a second to decide to do nothing.
+    const schedule = (): void => {
+      if (deadAirRef.current) {
+        idleTimerId = setTimeout(() => {
+          rafIdRef.current = requestAnimationFrame(frame)
+        }, IDLE_FRAME_MS)
+      } else {
+        rafIdRef.current = requestAnimationFrame(frame)
+      }
+    }
+
+    // Hoisted declaration rather than an arrow: frame and schedule call each
+    // other, so one of the two has to be reachable before its own definition.
+    function frame(timestamp: number): void {
       // Stamp the real start timestamp on the first frame after arming.
       if (coldBootRef.current.startTs === -1) {
         coldBootRef.current = { startTs: timestamp }
@@ -211,23 +242,23 @@ export function StereoRackModule({ displayStyle: _ds }: ModuleProps): React.JSX.
       }
 
       drawsRef.current.forEach((draw) => draw(level, peak, timestamp))
-      rafIdRef.current = requestAnimationFrame(frame)
+      schedule()
     }
 
-    rafIdRef.current = requestAnimationFrame(frame)
+    schedule()
 
     const onVisibilityChange = (): void => {
-      if (document.hidden) {
-        cancelAnimationFrame(rafIdRef.current)
-      } else {
-        rafIdRef.current = requestAnimationFrame(frame)
-      }
+      // Stop unconditionally first. The old shape scheduled a second chain here
+      // without cancelling the live one, and because both wrote the same ref the
+      // orphan could never be cancelled again — not even by the cleanup below.
+      stop()
+      if (!document.hidden) schedule()
     }
 
     document.addEventListener('visibilitychange', onVisibilityChange)
 
     return () => {
-      cancelAnimationFrame(rafIdRef.current)
+      stop()
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }, [])

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -34,6 +34,7 @@ import type { DisplayStyle } from './components/modules/registry'
 import { applyTheme } from '../../shared/theme'
 import type { ThemeName } from '../../shared/theme'
 import type { MagicPlaylistContents, MagicPlaylistSort } from './api/client'
+import { jsonEqual } from './utils/jsonEqual'
 
 export type TrackDisplaySize = 'teeny' | 'less-teeny' | 'large-print'
 
@@ -1232,11 +1233,41 @@ export const useStore = create<PlayerStore>((set, get) => ({
   },
 
   applyServerState: (state) => {
-    const prevTrack = get().player.current_track
-    set({ player: state })
+    const prev = get().player
+    // KAMP-684: this snapshot arrives ~4x/sec whether or not anything moved —
+    // client.ts pings on a fixed interval and the server answers
+    // unconditionally — and JSON.parse mints fresh objects every time.
+    // Installing them verbatim re-rendered every `s.player` and
+    // `s.player.current_track` subscriber at 4 Hz forever, which is O(albums):
+    // AlbumGrid is unvirtualized and LibraryView stays mounted behind
+    // `display: none`. Reusing the previous objects wherever the incoming ones
+    // are field-equal makes Object.is do that work once, here, instead of a
+    // dozen components each having to select defensively.
+    const next: PlayerState = {
+      ...state,
+      current_track: jsonEqual(prev.current_track, state.current_track)
+        ? prev.current_track
+        : state.current_track,
+      next_track: jsonEqual(prev.next_track, state.next_track) ? prev.next_track : state.next_track
+    }
+    // Hold the whole snapshot too, not just the tracks. At idle the scalars are
+    // static as well, so keeping `prev` wholesale is what also stops the three
+    // components that subscribe to the entire slice (TransportBar,
+    // NowPlayingView, StereoRackModule). While playing, `position` moves every
+    // tick and they update exactly as before.
+    const moved =
+      next.current_track !== prev.current_track ||
+      next.next_track !== prev.next_track ||
+      next.playing !== prev.playing ||
+      next.position !== prev.position ||
+      next.duration !== prev.duration ||
+      next.volume !== prev.volume ||
+      next.muted !== prev.muted ||
+      next.buffering !== prev.buffering
+    if (moved) set({ player: next })
     // When the track changes (e.g. auto-advance at end-of-track), the queue
     // position has moved server-side — reload so the panel stays in sync.
-    if (state.current_track?.id !== prevTrack?.id) {
+    if (state.current_track?.id !== prev.current_track?.id) {
       void get().loadQueue()
     }
   },

--- a/kamp_ui/src/renderer/src/utils/jsonEqual.ts
+++ b/kamp_ui/src/renderer/src/utils/jsonEqual.ts
@@ -1,0 +1,34 @@
+// Structural equality for values that came out of JSON.parse (KAMP-684).
+//
+// Exists so the store can hand back the PREVIOUS object when a server payload
+// is field-equal to it. Every parse mints fresh objects, so without this any
+// component subscribing to a slice of that payload re-renders on every message
+// even when nothing moved. Comparing once here lets Object.is short-circuit
+// every subscriber, rather than each of them selecting defensively.
+//
+// Deliberately not a general deep-equal: the inputs are parsed JSON, so there
+// are no Dates, Maps, Sets, functions or cycles to handle and pretending
+// otherwise would be untestable dead code. It compares by key rather than
+// against a hand-written field list so a field added to a payload is covered
+// automatically instead of silently going stale.
+export function jsonEqual(a: unknown, b: unknown): boolean {
+  // Covers primitives, identical references, and null === null.
+  if (a === b) return true
+  if (a === null || b === null) return false
+  if (typeof a !== 'object' || typeof b !== 'object') return false
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false
+    if (a.length !== b.length) return false
+    return a.every((item, i) => jsonEqual(item, b[i]))
+  }
+
+  const aRecord = a as Record<string, unknown>
+  const bRecord = b as Record<string, unknown>
+  const aKeys = Object.keys(aRecord)
+  if (aKeys.length !== Object.keys(bRecord).length) return false
+  return aKeys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(bRecord, key) && jsonEqual(aRecord[key], bRecord[key])
+  )
+}


### PR DESCRIPTION
Closes KAMP-684. Split out of KAMP-681 — see the bottom for what this does and does not settle there.

## Measured result

Isolated cleanly: both runs are `npm start` on the same machine with the same library, five-minute windows, kamp idle with nothing playing and the window behind another app. The only variable is the four commits on this branch. Cumulative CPU **time**, not sampled percentages.

| | 1.27.0 unfixed | this branch | change |
|---|---|---|---|
| Renderer | 59.9% of a core | **8.7–9.2%** | **−85%** (6.6×) |
| GPU helper | 18.1% | 12.1–13.0% | −30% |
| Daemon | 1.8% | 1.7–1.8% | unchanged |
| **Total** | **80.4%** | **23.0–24.3%** | **−71%** (3.4×) |

The daemon row should not be read as "the fsync change did nothing" — fsync is I/O wait rather than CPU time, so this probe cannot see it in either direction.

Also confirmed while measuring: **backgrounding the window changes nothing.** 1.26.1 went 107.7% → 107.0% and the fixed build 23.0% → 24.3%, both within noise. macOS is not marking the window occluded, `document.hidden` never becomes true, and nothing throttles on app switch — so the Stereo Rack loop really was running at full rate, and the throttle in commit 3 applies.

## What this fixes

Four defects that all run in exactly the state KAMP-681 describes: idle, nothing playing, window behind another app. Each is readable in the source rather than inferred.

**1. The whole app re-rendered 4x/sec at idle** — `store.ts`, new `utils/jsonEqual.ts`

The player snapshot arrives ~4x/sec whether or not anything moved (the client pings on a fixed 250ms interval; the server answers unconditionally), and `JSON.parse` mints fresh objects each time. Installing them verbatim re-rendered every component subscribing to `s.player` or `s.player.current_track`. That is O(albums), not a constant — `AlbumGrid` is unvirtualized and `LibraryView` stays mounted behind `display: none`, so a large library re-rendered every card four times a second while the user was in another app.

`applyServerState` now reuses the previous track objects when the incoming ones are field-equal, and holds the whole snapshot when nothing moved at all. `Object.is` then short-circuits all twelve subscribers at once — which no per-component selector change could do, and which the next component to reach for `s.player` cannot undo. While playing, `position` moves every tick and the three whole-slice subscribers update exactly as before.

**2. The Stereo Rack drew at display refresh forever** — `StereoRackModule.tsx`

The rack is in the default module layout and its loop had no playback gate, so a kamp that had never played anything still drew ~240 random points and ran the VU decay at 60–120Hz indefinitely. Its only brake was `document.hidden`, which stays false for a window merely behind another app.

Dead air is now drawn at ~10fps. That branch of the oscilloscope returns before the AR(1) and smoothing work, so it is pure per-pixel noise and drawing it less often costs no fidelity; `VUMeter`'s decay and peak-hold are time-delta based, so their speed is unchanged. **The signal path deliberately stays at full rate** — its AR(1) loop advances once per *frame*, so throttling it would alter the trace's character. Scheduling goes through a timer while idle rather than early-returning inside a full-rate callback, so the renderer actually stops producing frames instead of waking 60–120 times a second to decide to do nothing.

**3. An uncancellable rAF chain** — `StereoRackModule.tsx`

The `visibilitychange` handler scheduled a second chain without cancelling the live one, and because both wrote the same ref the orphan could never be cancelled again — not even by the effect's own cleanup. Extracting `schedule()`/`stop()` fixes this as a consequence.

**4. A leaked socket and timer per reconnect** — `App.tsx`, `api/client.ts`

Two separate leaks. The reconnect path discarded the disposer, so each reconnect left the previous stream's 250ms interval running for the life of the process. Worse, the effect cleanup called that disposer on an *open* socket, whose `onclose` then fired after unmount and scheduled a replacement socket plus another interval that nothing held a handle to.

The disposer is now silent and idempotent (`disposed` flag, `ws.onclose` detached before `close()`), and `App` holds three handles instead of one: the current disposer, the pending retry id, and a `torn` flag. The reconnect path cannot storm as a result — by the time `connect()` runs the old socket is already closed, and `close()` on a closed socket is a spec no-op that fires no event.

**5. Two fsyncs every five seconds at idle** — `kamp_daemon/__main__.py`

`_state_saver` persisted player and queue state every fifth tick gated on `if current:` rather than on anything having changed. Both saves COMMIT, and the library is WAL with `synchronous=FULL`, so each is an fsync — which stalls system-wide on macOS, not just in this process. It now remembers what was last written and skips the write when it matches. `get_state()` builds fresh lists rather than returning internal references, so the cache cannot go stale through mutation underneath us — that would have silently stopped the queue persisting.

## Verification

`npm run typecheck` and `npm run lint` clean (one pre-existing prettier warning in `main/index.ts`, untouched). Full pytest: 3218 passed, 9 skipped, coverage 93.80% — unchanged, since the only Python change is in `kamp_daemon/__main__.py`, which is omitted from coverage by design. README has no drift (it documents none of this).

`kamp_ui` has no test runner, so the renderer changes are verified manually.

## Manual test plan

**Measurement — cumulative CPU *time*, not Activity Monitor percentages.** Percentages are decaying point samples and the effect is 1–10% of one core; they cannot resolve it. Start at least 5 minutes after launch so the startup stream sync is finished, then with kamp idle and behind another app:

- `ps -o pid,time,comm -p <renderer,gpu,daemon,WindowServer>` at t=0 and t+300s; the delta is a true integral
- a 30s DevTools Performance profile of the renderer — exact frame count plus scripting/rendering/painting ms
- `sudo powermetrics --samplers cpu_power,gpu_power -i 5000 -n 24` for GPU residency

A/B/A rather than A/B. Log alongside: whether kamp is partially visible or fully covered, whether a track is loaded, and the active view.

**Behaviour that must not change**

- [x] While playing: oscilloscope trace character, VU decay speed, peak-hold timing
- [x] Pause mid-track: VU decays smoothly; the slow pause drift on the trace reads as before
- [x] Dead air after the idle timeout: trace still moves, just calmer — confirm it reads as intentional, not stuck
- [x] Cold boot: the VU sin-arc sweep at launch is unchanged (clear `stereo-rack:coldBootSeen` in localStorage to re-arm it)
- [x] `trippy` and `plasma` trace styles still render correctly
- [x] Now Playing art, transport state and the playing-album highlight update promptly on track change
- [x] The playing indicator lands on the right album card, including a single-track/missing album
- [x] Queue position and player state survive an app restart — this is what the `_state_saver` change could break

**WebSocket lifecycle — the riskiest change**

- [ ] Kill the daemon mid-session; the UI shows reconnecting, then reconnects cleanly when it returns
- [ ] Repeat three times, then confirm the app is not progressively slower and state still updates at the normal rate
- [ ] After a reconnect, switch views and play a track to confirm the stream is genuinely live rather than silently dead
- [ ] Leave the app running 10+ minutes after several reconnects; no drift in responsiveness

## On KAMP-681: there is no regression

The A/B has now been run. Packaged 1.26.1 measured **107.7% / 107.0%** of a core at idle with nothing playing — renderer alone at 68–69%. Unfixed 1.27.0 measured **80.4%**. Packaging differs between those two (packaged app vs `npm start`, PyInstaller daemon vs poetry), so it is not a perfect comparison, but the gap runs the wrong way for a regression: **1.26.1 is the worse of the two.**

So none of these five defects is new in 1.27.0, and neither is the symptom. kamp has burned roughly a full core at idle for at least a version, and this branch is what actually reduces it.

Two hypotheses were killed during this work rather than fixed:

- The **new-arrival highlight CSS** (~5–7 infinite animations per recent album, one animating a 44px-blur box-shadow on the main thread) looked like the strongest suspect and would have explained the version difference without any code change, since it scales with recent sync volume. Ruled out: the reporter has no new arrivals and still sees the symptom.
- The **Crate** is not in the 4Hz reconciliation path at all — `CrateView` renders ~8 DOM nodes when no crate has been dug and never subscribes to the `player` slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
