### PR TITLE
KAMP-678: always show the deck's transport, and keep the record on it

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -56,6 +56,9 @@ _IDLE_PREVIEW: dict[str, Any] = {
     "buffering": False,
     "tracks": [],
     "error": None,
+    # The record cued on the deck with nothing playing (KAMP-678).
+    "parked_item_id": None,
+    "parked_track_num": None,
 }
 
 #: Records in a full crate. Mirrors discovery_builder.CRATE_SIZE, duplicated

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -69,6 +69,16 @@ _IDLE_STATE: dict[str, Any] = {
     "buffering": False,
     "tracks": [],
     "error": None,
+    # The record still ON the deck with nothing playing (KAMP-678): the main
+    # transport took the floor, but that is not a statement about the record the
+    # user was listening to, so it stays cued rather than going back to the
+    # crate. Metadata on IDLE rather than a state of its own on purpose -- every
+    # guard in this class reads `state` to decide whether the ENGINE is busy, and
+    # a cued record's honest answer is no. A fifth state would make _idle_kill
+    # refuse to reap the engine, pinning an mpv process and the audio device open
+    # for the rest of the session.
+    "parked_item_id": None,
+    "parked_track_num": None,
 }
 
 
@@ -259,6 +269,12 @@ class PreviewPlayer:
                 buffering=True,
                 position=0.0,
                 duration=0.0,
+                # This record is live now, so it is no longer merely cued. Cleared
+                # here rather than on success: the error returns below all publish
+                # IDLE, and a stale cued id would leave the PREVIOUS record on the
+                # deck as though the failed one had never been asked for.
+                parked_item_id=None,
+                parked_track_num=None,
             )
 
             try:
@@ -302,6 +318,15 @@ class PreviewPlayer:
 
     def resume(self) -> dict[str, Any]:
         with self._lock:
+            # A cued record has nothing loaded to resume: release_for_main
+            # unloaded it, and the idle timer may since have reaped the process
+            # outright. Replaying is the honest equivalent, and branching here
+            # rather than at the call sites means Space, the deck's play button
+            # and the API's resume route all get it without special-casing
+            # (KAMP-678). The lock is an RLock, so re-entering play() is safe.
+            parked = self._state["parked_item_id"]
+            if parked is not None and self._state["state"] == IDLE:
+                return self.play(int(parked), self._state["parked_track_num"])
             if self._engine is None or self._state["state"] != PAUSED:
                 return self.snapshot()
             self._take_over_from_main()
@@ -333,6 +358,10 @@ class PreviewPlayer:
                 buffering=False,
                 tracks=[],
                 error=None,
+                # Stop is the deliberate "take it off the deck" gesture, unlike
+                # release_for_main which only cues it (KAMP-678).
+                parked_item_id=None,
+                parked_track_num=None,
             )
 
     def seek(self, position: float) -> dict[str, Any]:
@@ -381,14 +410,24 @@ class PreviewPlayer:
             self._main.resume()
 
     def release_for_main(self) -> None:
-        """Stop the preview because the main transport was used.
+        """Cue the record and hand the floor to the main transport.
 
         The main transport always wins. Called from the player endpoints, so it
         must not resume main afterwards -- main is about to do whatever the user
         just asked for.
+
+        The record stays ON the deck (KAMP-678) rather than flying back to the
+        crate: pressing play on your own queue says nothing about the record you
+        were listening to. `title` and `tracks` ride along so the deck can keep
+        naming it.
         """
         with self._lock:
-            if self._state["state"] == IDLE and self._engine is None:
+            item_id = self._state["item_id"]
+            if item_id is None:
+                # Nothing live to release -- never previewed, already stopped, or
+                # already cued. Without this the middleware fires on EVERY
+                # subsequent transport press, each one re-publishing and
+                # clobbering the cued record with None.
                 return
             if self._engine is not None:
                 try:
@@ -402,11 +441,14 @@ class PreviewPlayer:
                 state=IDLE,
                 item_id=None,
                 track_num=None,
-                title="",
+                parked_item_id=item_id,
+                parked_track_num=self._state["track_num"],
+                # Zeroed deliberately: the engine is unloaded and the deck's play
+                # button replays from the top, so a retained position would paint
+                # a playhead partway through a track that is about to restart.
                 position=0.0,
-                duration=0.0,
+                position_updated_at=0.0,
                 buffering=False,
-                tracks=[],
                 error=None,
             )
 

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -689,6 +689,13 @@ export type PreviewState = {
   // 'not_found' | 'unavailable' | 'rate_limited' — a rate limit and an album
   // with nothing streamable want different words on screen.
   error: string | null
+  // The record still ON the deck with nothing playing, because the main
+  // transport took the floor (KAMP-678). Set only while `state` is 'idle': it is
+  // metadata about the deck, not a state of the engine, which is why the deck is
+  // the one thing that reads it and every "is a preview live" check still just
+  // reads `state`.
+  parked_item_id: number | null
+  parked_track_num: number | null
 }
 
 // An empty deck, as a value (KAMP-678). The deck's strip renders unconditionally
@@ -708,7 +715,9 @@ export const IDLE_PREVIEW: PreviewState = {
   duration: 0,
   buffering: false,
   tracks: [],
-  error: null
+  error: null,
+  parked_item_id: null,
+  parked_track_num: null
 }
 
 export const getPreviewState = (): Promise<PreviewState> => get('/api/v1/discovery/preview/state')

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -691,6 +691,26 @@ export type PreviewState = {
   error: string | null
 }
 
+// An empty deck, as a value (KAMP-678). The deck's strip renders unconditionally
+// so its transport is a visible affordance before anything is on — and so the
+// error line has somewhere to live, since every failure publishes state=idle.
+// A constant rather than a nullable prop: guarding ~150 lines of strip would put
+// a future divergence at every `?.`, and a second component would drift from
+// this one the first time the seek bar's CSS changed. Mirrors the daemon's
+// _IDLE_STATE, which is also what `preview` is before loadPreview resolves.
+export const IDLE_PREVIEW: PreviewState = {
+  state: 'idle',
+  item_id: null,
+  track_num: null,
+  title: '',
+  position: 0,
+  position_updated_at: 0,
+  duration: 0,
+  buffering: false,
+  tracks: [],
+  error: null
+}
+
 export const getPreviewState = (): Promise<PreviewState> => get('/api/v1/discovery/preview/state')
 
 export const previewPlay = (itemId: number, trackNum?: number): Promise<PreviewState> =>

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -1016,6 +1016,20 @@
   cursor: default;
 }
 
+/* Nothing on the deck (KAMP-678). The strip renders anyway — its transport is
+ * what tells you the deck is there — so the controls that need a record are
+ * dimmed rather than hidden. Play deliberately keeps full strength: it stays
+ * live, and means "put the record you're looking at on". */
+.crate-preview-seek:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.crate-preview-title--empty {
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
 /* ONE progress bar, and it is still a real control.
  *
  * The spec asks for the thin bar without a handle; there used to be both a

--- a/kamp_ui/src/renderer/src/components/CratePreviewStrip.tsx
+++ b/kamp_ui/src/renderer/src/components/CratePreviewStrip.tsx
@@ -57,15 +57,27 @@ export function CratePreviewStrip({
   const playing = preview.state === 'playing'
   const preparing = preview.state === 'preparing' || preview.buffering
 
+  // Nothing on the deck (KAMP-678). The strip still renders — its transport is
+  // the affordance that says the deck is there — but the controls that need a
+  // record are disabled rather than merely inert. Play stays live: it means
+  // "put the record you're looking at on", which is the whole point of showing
+  // the strip early.
+  const empty = item === null
+
   const wishlisted = item?.state === 'wishlisted'
   const purchased = item?.state === 'purchased'
 
   return (
-    <div className="crate-preview" role="group" aria-label="Preview">
+    <div
+      className={`crate-preview${empty ? ' crate-preview--empty' : ''}`}
+      role="group"
+      aria-label="Preview"
+    >
       <div className="crate-preview-controls">
         <button
           className="crate-preview-btn"
           onClick={() => onStep(-1)}
+          disabled={empty}
           aria-label="Previous track"
         >
           <PrevIcon size={16} />
@@ -77,7 +89,12 @@ export function CratePreviewStrip({
         >
           {playing ? <PauseIcon size={20} /> : <PlayIcon size={20} />}
         </button>
-        <button className="crate-preview-btn" onClick={() => onStep(1)} aria-label="Next track">
+        <button
+          className="crate-preview-btn"
+          onClick={() => onStep(1)}
+          disabled={empty}
+          aria-label="Next track"
+        >
           <NextIcon size={16} />
         </button>
 
@@ -89,6 +106,10 @@ export function CratePreviewStrip({
         <div className="crate-preview-meta">
           {preparing ? (
             <span className="crate-preview-title">Cueing it up…</span>
+          ) : empty ? (
+            <span className="crate-preview-title crate-preview-title--empty">
+              Nothing on the deck
+            </span>
           ) : (
             <>
               <span className="crate-preview-artist">{item?.artist ?? ''}</span>
@@ -136,6 +157,7 @@ export function CratePreviewStrip({
         max={Math.max(1, Math.floor(preview.duration))}
         value={Math.floor(position)}
         onChange={(e) => onSeek(Number(e.target.value))}
+        disabled={empty}
         style={{ '--pct': `${pct}%` } as React.CSSProperties}
         aria-label="Seek preview"
       />

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -11,7 +11,7 @@
 // and is rendered verbatim — it is the promise that every pick explains itself.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../store'
-import { crateArtUrl } from '../api/client'
+import { crateArtUrl, IDLE_PREVIEW } from '../api/client'
 import type { DiggingStats } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
 import { CrateBin } from './CrateBin'
@@ -231,6 +231,16 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     if (!current) return
     if (previewingThis) void previewAction('toggle')
     else void previewPlay(current.id)
+  }
+
+  // The deck's own play button acts on what is ON the deck; Space acts on what
+  // you are LOOKING AT. The two coincide until you flip while something plays —
+  // at which point the deck button used to swap the deck to the focused record,
+  // which is not what a play button on an occupied deck means (KAMP-678). With
+  // an empty deck it falls through to Space's meaning: put this one on.
+  const toggleDeck = (): void => {
+    if (deckItem) void previewAction('toggle')
+    else togglePreview()
   }
 
   // Leaving the view stops the preview: audio with no visible controls is the
@@ -671,53 +681,60 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               </div>
 
               <div className="crate-deck-body">
-                {deckItem && preview ? (
-                  <>
-                    <CratePreviewStrip
-                      preview={preview}
-                      item={deckItem}
-                      wishlistSaving={wishlistPending.includes(deckItem.id)}
-                      onToggle={togglePreview}
-                      onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
-                      onSeek={(position) => void previewSeek(position)}
-                      onToggleWishlist={(item) => void toggleCrateWishlist(item)}
-                    />
+                {/* The strip renders whether or not anything is on: its transport
+                    is what tells you the deck is there and ready (KAMP-678). It
+                    also gives the error line below a home — every failure path
+                    publishes state=idle, which used to unmount this whole block
+                    and take the message with it. */}
+                <CratePreviewStrip
+                  preview={preview ?? IDLE_PREVIEW}
+                  item={deckItem}
+                  wishlistSaving={deckItem !== null && wishlistPending.includes(deckItem.id)}
+                  onToggle={toggleDeck}
+                  onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
+                  onSeek={(position) => void previewSeek(position)}
+                  onToggleWishlist={(item) => void toggleCrateWishlist(item)}
+                />
 
-                    {preview.tracks.length > 0 && (
-                      <ol className="crate-tracklist">
-                        {preview.tracks.map((track) => (
-                          <li key={track.track_num}>
-                            <button
-                              className={`crate-track${
-                                track.track_num === preview.track_num ? ' crate-track--current' : ''
-                              }`}
-                              onClick={() => void previewPlay(deckItem.id, track.track_num)}
-                            >
-                              <span className="crate-track-num">{track.track_num}</span>
-                              <span className="crate-track-title">
-                                {track.title || `Track ${track.track_num}`}
-                              </span>
-                              <span className="crate-track-time">
-                                {formatClock(track.duration)}
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ol>
-                    )}
+                {deckItem && preview && preview.tracks.length > 0 && (
+                  <ol className="crate-tracklist">
+                    {preview.tracks.map((track) => (
+                      <li key={track.track_num}>
+                        <button
+                          className={`crate-track${
+                            track.track_num === preview.track_num ? ' crate-track--current' : ''
+                          }`}
+                          onClick={() => void previewPlay(deckItem.id, track.track_num)}
+                        >
+                          <span className="crate-track-num">{track.track_num}</span>
+                          <span className="crate-track-title">
+                            {track.title || `Track ${track.track_num}`}
+                          </span>
+                          <span className="crate-track-time">{formatClock(track.duration)}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ol>
+                )}
 
-                    {preview.error && (
-                      <p className="crate-preview-error" role="status">
-                        {preview.error === 'rate_limited'
-                          ? 'Bandcamp asked us to slow down — try again shortly.'
-                          : 'No preview for this one.'}
-                      </p>
-                    )}
-                  </>
-                ) : (
+                {/* Deliberately OUTSIDE the deckItem gate: every failure path
+                    publishes state=idle, which empties the deck — so gating this
+                    on an occupied deck is precisely why it has never once been
+                    seen on screen. */}
+                {preview?.error && (
+                  <p className="crate-preview-error" role="status">
+                    {preview.error === 'rate_limited'
+                      ? 'Bandcamp asked us to slow down — try again shortly.'
+                      : 'No preview for this one.'}
+                  </p>
+                )}
+
+                {/* The strip's meta line already says "Nothing on the deck"; this
+                    keeps the part no icon conveys — which key, and that using it
+                    does not disturb the user's own queue. */}
+                {!deckItem && (
                   <p className="crate-deck-empty">
-                    Nothing on the deck. Space puts the record you&rsquo;re looking at on — your
-                    queue stays where it is.
+                    Space puts the record you&rsquo;re looking at on — your queue stays where it is.
                   </p>
                 )}
               </div>

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -159,11 +159,17 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // engine plays one item at a time and you can keep flipping while it plays, so
   // the deck must follow the preview rather than the focus. Looked up in the
   // crate because the preview state carries an id, not the row (KAMP-668).
+  //
+  // "Occupied" and "live" are different questions, and `state !== 'idle'` was
+  // answering both. A record the main transport took over from is cued on the
+  // deck without being live (KAMP-678) — it rides on the idle state as
+  // `parked_item_id`, so every predicate that genuinely means "live" keeps
+  // reading `state` and only this one falls back.
   const deckItem = useMemo(() => {
-    const id = preview?.item_id
-    if (id == null || preview?.state === 'idle') return null
+    const id = preview?.state === 'idle' ? preview?.parked_item_id : preview?.item_id
+    if (id == null) return null
     return items.find((item) => item.id === id) ?? null
-  }, [items, preview?.item_id, preview?.state])
+  }, [items, preview?.item_id, preview?.parked_item_id, preview?.state])
 
   // Where a record flies TO. Measured at the moment a flight starts rather than
   // held as state — the view scrolls, so a rect captured earlier is stale.
@@ -268,33 +274,22 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // precisely because claiming the arrows for a whole view would strand a
   // listener mid-album; a claim that lasts exactly as long as the thing it
   // controls is the case that objection does not cover.
-  // One transport session: the record on the deck, for as long as it is live.
-  // null when nothing is playing, and a different value for the next record.
-  const session =
-    preview && preview.state !== 'idle' && preview.item_id != null ? String(preview.item_id) : null
-
-  // Yielding is recorded AGAINST THE SESSION it applies to rather than as a bare
-  // flag. A flag would have to be cleared when the next preview starts, which is
-  // a setState in an effect — and an effect that resets state leaves one render
-  // where the stale value is live. Comparing against the current session means a
-  // new record simply is not the one that was yielded, so it owns the transport
-  // again with no reset step at all.
-  const [yieldedSession, setYieldedSession] = useState<string | null>(null)
-  const ownsTransport = session !== null && yieldedSession !== session
-
-  // Clicking the global transport hands the keys straight back — the user has
-  // just said, with a pointer, which of the two players they mean. Capture phase,
-  // and pointerdown rather than click, so it lands before the button's own
-  // handler and before any focus change. Mirrors App's KAMP-598 listener.
-  useEffect(() => {
-    if (!active || session === null) return
-    const onPointerDown = (e: PointerEvent): void => {
-      const el = e.target as HTMLElement | null
-      if (el?.closest('.transport-bar')) setYieldedSession(session)
-    }
-    window.addEventListener('pointerdown', onPointerDown, true)
-    return () => window.removeEventListener('pointerdown', onPointerDown, true)
-  }, [active, session])
+  // The deck owns the transport keys for exactly as long as a preview is LIVE.
+  //
+  // This used to be a session id plus a `yieldedSession` set by a capture-phase
+  // pointerdown on `.transport-bar`, on the theory that clicking the global
+  // transport said which of the two players the user meant. The daemon already
+  // records that, and more reliably: the only way to claim the floor is a POST
+  // under /api/v1/player/, and every one of those parks the preview (server.py's
+  // _preview_yields_to_transport), which ends the live state by itself.
+  //
+  // Deriving it removes two bugs the local flag carried (KAMP-678). Volume and
+  // mute are deliberately exempt from that middleware — they are not a demand
+  // for the floor — yet a pointerdown anywhere in the transport bar handed the
+  // arrows away while the preview kept playing. And because the flag was keyed
+  // on the item id, replaying a record that had been parked produced a session
+  // string identical to the yielded one, so the deck never got its keys back.
+  const ownsTransport = preview != null && preview.state !== 'idle'
 
   // NOTE: there is no longer any way to open the record's own Bandcamp page from
   // the Crate. Its only affordance was the header icon row, which this story
@@ -416,17 +411,16 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       // key would otherwise walk straight past it and re-add an owned record to
       // the wishlist (see the `purchased` note above).
       if (current && !purchased) void toggleCrateWishlist(current)
-    } else if (e.key === ' ' && (session === null || ownsTransport)) {
-      // Space is the Crate's (KAMP-651) — with one exception, and it is the same
-      // ownership rule the arrows follow (KAMP-672): once the user has clicked
-      // the global transport during a live preview, they have said which player
-      // they mean, and Space goes with the arrows. Falling through rather than
-      // handling it is the whole implementation — App's global play/pause picks
-      // it up because nothing stopped it.
-      //
-      // With nothing playing Space is unconditionally ours, because starting a
-      // preview is the primary action of the view and there is no session to
-      // have yielded yet.
+    } else if (e.key === ' ') {
+      // Space is the Crate's while the Crate is up (KAMP-651). It used to carry
+      // an exception mirroring the arrows' ownership rule (KAMP-672) — fall
+      // through to App's global play/pause once the user had clicked the global
+      // transport during a live preview. That exception was unreachable in the
+      // case it described: a real transport press parks the preview before the
+      // keypress can land, so the fall-through only ever fired for volume and
+      // mute, which are exactly the two the daemon exempts as "not a demand for
+      // the floor" (KAMP-678). Starting a preview is the primary action of this
+      // view, so Space belongs to it unconditionally.
       e.preventDefault()
       e.stopPropagation()
       togglePreview()

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -58,8 +58,8 @@ const GROUPS: Group[] = [
       },
       {
         keys: ['click', 'transport'],
-        description: 'Hand the keys back',
-        note: 'Space and the arrows return to your queue until the next preview'
+        description: 'Your queue takes over',
+        note: 'The record stays on the deck — press play there to pick it back up'
       },
       {
         keys: ['W'],

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -974,6 +974,18 @@ class TestMainTransportWins:
         assert preview.calls == []
 
 
+class TestIdlePreviewParity:
+    def test_the_idle_shape_matches_the_daemons(self) -> None:
+        """kamp_core cannot import kamp_daemon, so _IDLE_PREVIEW is a hand-copy
+        of _IDLE_STATE — and nothing has ever kept the two in step. A field added
+        to one and not the other means the no-preview path answers /preview/state
+        with a snapshot missing a key the UI's type says is always there."""
+        from kamp_core.discovery_api import _IDLE_PREVIEW
+        from kamp_daemon.discovery_preview import _IDLE_STATE
+
+        assert _IDLE_PREVIEW == _IDLE_STATE
+
+
 class TestArtHostAllowlist:
     def test_art_hosts_are_a_subset_of_the_proxy_allowlist(self) -> None:
         """Two lists that must not drift apart: anything the art proxy will fetch

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -294,6 +294,110 @@ class TestHandoff:
 
 
 # ---------------------------------------------------------------------------
+# Parking (KAMP-678)
+# ---------------------------------------------------------------------------
+
+
+class TestParking:
+    """Pressing play on your own queue cues the crate record rather than
+    shelving it. Carried as metadata on IDLE rather than as a fifth state, so
+    every guard that reads `state` to ask "is the engine busy" keeps working."""
+
+    def test_the_cued_record_stays_readable(self, index: LibraryIndex) -> None:
+        h = Harness(index, main_playing=True)
+        item = _item(index)
+        h.player.play(item)
+
+        h.player.release_for_main()
+        snap = h.player.snapshot()
+        # Idle to every engine guard...
+        assert snap["state"] == IDLE
+        assert snap["item_id"] is None
+        # ...but the deck can still name what is on it.
+        assert snap["parked_item_id"] == item
+
+    def test_the_engine_is_still_reaped_while_a_record_is_cued(
+        self, index: LibraryIndex
+    ) -> None:
+        """The whole reason parking is metadata and not a state. _idle_kill
+        returns on any non-IDLE state AND clears its timer without re-arming, so
+        a fifth state would pin an mpv process and the audio device open for the
+        rest of the session — and the existing teardown test drives stop(), so
+        it would not have noticed."""
+        h = Harness(index)
+        h.player.play(_item(index))
+
+        h.player.release_for_main()
+        assert _wait_for(lambda: h.engines[0].shutdown_count == 1), "engine not reaped"
+        # And the record is still on the deck after the process is gone.
+        assert h.player.snapshot()["parked_item_id"] is not None
+
+    def test_a_second_transport_press_does_not_clobber_the_cued_record(
+        self, index: LibraryIndex
+    ) -> None:
+        """The middleware fires on every non-volume player POST, so this runs
+        once per button press for as long as the record stays cued."""
+        h = Harness(index, main_playing=True)
+        item = _item(index)
+        h.player.play(item)
+
+        h.player.release_for_main()
+        h.player.release_for_main()
+        assert h.player.snapshot()["parked_item_id"] == item
+
+    def test_resume_replays_a_cued_record_and_retakes_the_floor(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index, main_playing=True)
+        item = _item(index)
+        h.player.play(item)
+        h.player.release_for_main()
+        # The user's queue has the floor now.
+        h.main.settle()
+        h.main.state.playing = True
+        h.main.calls.clear()
+
+        snap = h.player.resume()
+        assert snap["state"] == PLAYING
+        assert snap["item_id"] == item
+        assert snap["parked_item_id"] is None
+        assert "pause" in h.main.calls
+
+    def test_stop_takes_the_record_off_the_deck(self, index: LibraryIndex) -> None:
+        """Stop is the deliberate take-it-off gesture; parking is not."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.release_for_main()
+
+        h.player.stop()
+        assert h.player.snapshot()["parked_item_id"] is None
+
+    def test_a_failed_play_does_not_strand_the_cued_record(
+        self, index: LibraryIndex
+    ) -> None:
+        """Every failure below the PREPARING publish returns IDLE. Without
+        clearing the cued id up front, the PREVIOUS record would sit on the deck
+        as though the one that just failed had never been asked for."""
+        h = Harness(index, main_playing=True)
+        h.player.play(_item(index, "1"))
+        h.player.release_for_main()
+        assert h.player.snapshot()["parked_item_id"] is not None
+
+        h.source.tracks = []
+        snap = h.player.play(_item(index, "2"))
+        assert snap["error"] == "unavailable"
+        assert snap["parked_item_id"] is None
+
+    def test_releasing_with_nothing_live_does_nothing(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        h.player.release_for_main()
+        assert h.player.snapshot()["parked_item_id"] is None
+        assert h.events == []
+
+
+# ---------------------------------------------------------------------------
 # Audio settings
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes KAMP-678. Two halves: the deck's transport is always on screen, and a record the main transport takes over from stays cued on the deck instead of flying back to the crate.

## Half 1 — the deck's transport is always there

The mini-player only rendered once a record was on it; before that the body was a line of hint text, so nothing said the deck existed or how to use it. The strip now renders unconditionally against a shared `IDLE_PREVIEW` constant.

A constant rather than a nullable prop: guarding ~150 lines of strip would leave a future divergence at every `?.`, and a second empty-state component would drift from this one the first time the seek bar's CSS changed. The strip already renders correctly against an all-zero state — `duration: 0` gives `pct = 0` and `max = 1`, the position tick effect returns early, `item` is already nullable and the wishlist button already conditional.

Prev, next and seek are disabled while the deck is empty. **Play stays live** and means "put the record you're looking at on" — your call during planning, and it takes a bite out of KAMP-679's discoverability complaint at no extra cost.

## Half 2 — the record stays cued

`release_for_main` wiped `item_id`, `track_num`, `title` and `tracks`, so pressing play on your own queue sent the crate record home. Pressing play on your queue says nothing about the record you were listening to, so it now stays on the deck.

**Carried as metadata on the IDLE state, not as a fifth state.** The estimate proposed a `parked` state and that turned out to be the wrong axis. The enum in `discovery_preview.py` is an *engine* state machine — every guard reads it to answer "is the engine loaded and busy", and a cued record's honest answer is no. Concretely, `_idle_kill` returns on any non-IDLE state **and** clears its timer without re-arming, so a fifth value would have pinned an mpv process and the audio device open for the rest of the session. The existing teardown test drives `stop()` rather than `release_for_main()`, so nothing would have caught it. `seek()`, `pause()`, `resume()` and `release_for_main`'s own guard all key on the same axis.

Two signals that the field design is the right one: `test_the_main_transport_wins_and_is_not_resumed` and the whole `TestMainTransportWins` class pass **unchanged**, and the leave-the-view and Escape predicates needed no edit — because a cued record genuinely *is* idle.

## Bugs fixed along the way

- **`preview.error` has never been reachable.** It was rendered inside the occupied-deck gate, while every failure path publishes `state=idle`, which empties the deck and unmounts the block. "No preview for this one." and the rate-limit line have never once been on screen; the only other signal is an HTTP-error toast that doesn't fire, because these are 200 responses. Rendering the strip unconditionally gives them a home.
- **Volume and mute stole the Crate's arrow keys.** A capture-phase `pointerdown` anywhere in `.transport-bar` handed the keys back, but `/player/volume` and `/player/mute` are deliberately exempt from the yield middleware as "not a demand for the floor" — so adjusting volume took the arrows away while the preview kept playing. Ownership is now derived from whether a preview is live, which the daemon already records reliably. That also fixes the bug this PR would otherwise have introduced: the old flag was keyed on item id, so replaying a record that had been cued produced a session string identical to the yielded one and the deck never got its keys back.
- **The deck's play button acted on the wrong record.** It was bound to `togglePreview`, which acts on the *focused* record — so flipping to another record while one played and pressing it swapped the deck rather than pausing.
- **`_IDLE_PREVIEW` and `_IDLE_STATE` had no parity check.** `kamp_core` can't import `kamp_daemon`, so one is a hand-copy of the other and nothing kept them in step. This change added two fields to both, which is what surfaced it; there's now a test.

## Verification

`npm run typecheck` and `npm run lint` clean (one pre-existing prettier warning in `main/index.ts`, untouched). Full pytest: **3226 passed**, 9 skipped, coverage **93.83%** — up from 93.80% on main. Eight new tests. README documents none of this, so no drift.

`kamp_ui` has no test runner, so the renderer half is manual.

## Manual test plan

**The ready deck**
- [x] Dig a crate: the transport is visible, play enabled, prev/next/seek visibly disabled, hint text still present
- [x] Press the deck's play with nothing on: the record you are looking at goes on and plays
- [ ] Flip to another record while one plays, then press the deck's play: it toggles the record **on the deck**, not the focused one
- [x] Force a failure (a record with nothing streamable): "No preview for this one." is now actually visible — it never has been

**Cueing**
- [x] Preview a record, then click the global transport: the record stays on the deck, no homeward flight, the bin sleeve stays ghosted and the record does not appear in two places
- [x] Your queue takes over and plays
- [x] Press the deck's play: the record restarts from the top of that track and your queue pauses
- [x] Adjust volume or mute while previewing: the Crate keeps the arrow keys (this is the bug fix)
- [x] Escape once with a record cued leaves the Crate — it must not take two presses
- [ ] Leave the Crate and come back: the cued record is still on the deck
- [ ] Cue a record, wait 5+ minutes, then press play: it still works (the engine is torn down and respawns)
- [ ] Pause a preview, then leave the view: the preview stops and your queue resumes, exactly as before
- [ ] Stop a preview with Escape: the record *does* fly home — stop is still the take-it-off gesture

**Worth a look because the ownership rule changed**
- [ ] Arrows step preview tracks while a preview plays, and control your own queue otherwise
- [ ] Space starts/toggles a preview while the Crate is up
- [ ] The shortcuts overlay's Crate section reads correctly against the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
