### PR TITLE
KAMP-679: double-click, drag or Enter to put a record on the deck

### DIFF
--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -872,6 +872,38 @@
   gap: 8px;
 }
 
+/* Dragging a record to the deck (KAMP-679).
+ *
+ * The ghost must not be hit-testable: the drop is resolved with
+ * elementFromPoint, and a ghost under the cursor would answer every query with
+ * itself. */
+.crate-drag-ghost {
+  position: fixed;
+  top: -100px;
+  left: -100px;
+  z-index: 9999;
+  pointer-events: none;
+  max-width: 220px;
+  overflow: hidden;
+  padding: 4px 10px;
+  border-radius: 3px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Lit only while a drag is actually over the deck. The strip's own "Cueing it
+ * up…" covers the beat between the drop and the audio, so this does not need to
+ * stay lit past the release. */
+.crate-deck--drop-target {
+  outline: 2px dashed var(--accent);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
 .crate-deck-empty {
   margin: auto 0;
   color: var(--text-dim);

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -46,7 +46,8 @@ function BinSleeve({
   focused,
   flipped,
   away,
-  onFocus
+  onFocus,
+  onPlay
 }: {
   item: CrateItem
   index: number
@@ -58,6 +59,12 @@ function BinSleeve({
   // Out of the crate and on the deck.
   away: boolean
   onFocus: (index: number) => void
+  // Put this record on (KAMP-679). Offered on the FOCUSED sleeve only: the
+  // others are stacked in the same place behind a 7% depth step and a 15° lean,
+  // so a back sleeve shows a ~12px crescent — small enough that aiming a
+  // double-click at one is a coin flip with the sleeve in front of it. Clicking
+  // a back sleeve focuses it, and then it is the front one.
+  onPlay: (item: CrateItem) => void
 }): React.JSX.Element {
   const [artFailed, setArtFailed] = useState(false)
   const showArt = Boolean(item.art_url) && !artFailed
@@ -116,6 +123,9 @@ function BinSleeve({
       // handling to its own container instead of listening on document.
       tabIndex={focused ? 0 : -1}
       onClick={() => onFocus(index)}
+      // `away` is the record already on the deck — putting it on again would
+      // restart the album from track 1 for no reason the user asked for.
+      onDoubleClick={focused && !away ? () => onPlay(item) : undefined}
       style={
         {
           '--bin-rel': rel,
@@ -180,7 +190,8 @@ export function CrateBin({
   awayItemId,
   spineName,
   railRef,
-  onFocus
+  onFocus,
+  onPlay
 }: {
   items: CrateItem[]
   crateNo: number | null
@@ -190,6 +201,7 @@ export function CrateBin({
   spineName: string
   railRef: React.RefObject<HTMLUListElement | null>
   onFocus: (index: number) => void
+  onPlay: (item: CrateItem) => void
 }): React.JSX.Element {
   // Stock-in runs on a DELIVERY, not on every render that happens to have
   // records in it. Arriving at a crate that already exists — switching to the
@@ -237,6 +249,7 @@ export function CrateBin({
             flipped={index < focusIndex}
             away={item.id === awayItemId}
             onFocus={onFocus}
+            onPlay={onPlay}
           />
         ))}
       </ul>

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -47,7 +47,8 @@ function BinSleeve({
   flipped,
   away,
   onFocus,
-  onPlay
+  onPlay,
+  onDragStart
 }: {
   item: CrateItem
   index: number
@@ -65,6 +66,9 @@ function BinSleeve({
   // double-click at one is a coin flip with the sleeve in front of it. Clicking
   // a back sleeve focuses it, and then it is the front one.
   onPlay: (item: CrateItem) => void
+  // Begin a pointer drag toward the deck. Offered on the same sleeve as onPlay
+  // and for the same reason.
+  onDragStart: (item: CrateItem, startX: number, startY: number) => void
 }): React.JSX.Element {
   const [artFailed, setArtFailed] = useState(false)
   const showArt = Boolean(item.art_url) && !artFailed
@@ -123,9 +127,18 @@ function BinSleeve({
       // handling to its own container instead of listening on document.
       tabIndex={focused ? 0 : -1}
       onClick={() => onFocus(index)}
-      // `away` is the record already on the deck — putting it on again would
-      // restart the album from track 1 for no reason the user asked for.
-      onDoubleClick={focused && !away ? () => onPlay(item) : undefined}
+      // Double-click is an explicit "put this on", so it is allowed even for the
+      // record already on the deck — that restarts it, which is what was asked
+      // for. Dragging it back onto the deck is not: that is a misdrop, and the
+      // cost of honouring it is an album restarting from track 1.
+      onDoubleClick={focused ? () => onPlay(item) : undefined}
+      onPointerDown={
+        focused && !away
+          ? (e) => {
+              if (e.button === 0) onDragStart(item, e.clientX, e.clientY)
+            }
+          : undefined
+      }
       style={
         {
           '--bin-rel': rel,
@@ -148,6 +161,11 @@ function BinSleeve({
             src={crateArtUrl(item.id)}
             alt=""
             loading="lazy"
+            // The sleeve is a pointer drag source and nothing in that path calls
+            // preventDefault (KAMP-679), so without this the browser's own image
+            // drag starts on top of it — an uncancellable OS session, which is
+            // the exact thing KAMP-456 established must not happen here.
+            draggable={false}
             onError={() => setArtFailed(true)}
           />
         )}
@@ -191,7 +209,8 @@ export function CrateBin({
   spineName,
   railRef,
   onFocus,
-  onPlay
+  onPlay,
+  onDragStart
 }: {
   items: CrateItem[]
   crateNo: number | null
@@ -202,6 +221,7 @@ export function CrateBin({
   railRef: React.RefObject<HTMLUListElement | null>
   onFocus: (index: number) => void
   onPlay: (item: CrateItem) => void
+  onDragStart: (item: CrateItem, startX: number, startY: number) => void
 }): React.JSX.Element {
   // Stock-in runs on a DELIVERY, not on every render that happens to have
   // records in it. Arriving at a crate that already exists — switching to the
@@ -250,6 +270,7 @@ export function CrateBin({
             away={item.id === awayItemId}
             onFocus={onFocus}
             onPlay={onPlay}
+            onDragStart={onDragStart}
           />
         ))}
       </ul>

--- a/kamp_ui/src/renderer/src/components/CrateTitles.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateTitles.tsx
@@ -21,12 +21,15 @@ export function CrateTitles({
   focusIndex,
   wishlistPending,
   onFocus,
+  onPlay,
   onToggleWishlist
 }: {
   items: CrateItem[]
   focusIndex: number
   wishlistPending: number[]
   onFocus: (index: number) => void
+  // Put this record on, replacing whatever is on the deck (KAMP-679).
+  onPlay: (item: CrateItem) => void
   onToggleWishlist: (item: CrateItem) => void
 }): React.JSX.Element {
   const tooltip = useTooltip()
@@ -57,6 +60,14 @@ export function CrateTitles({
               <button
                 className="crate-title-btn"
                 onClick={() => onFocus(index)}
+                // Click flips the bin to this record; double-click puts it on.
+                // Deliberately a plain onDoubleClick rather than the hand-rolled
+                // tap detector QueuePanel uses — that only exists there because
+                // its pointerdown calls preventDefault, which suppresses the
+                // compat mousedown and with it DOM focus, click and dblclick.
+                // These rows are real buttons whose focus matters, so nothing
+                // here preventDefaults and the native events are left alone.
+                onDoubleClick={() => onPlay(item)}
                 // Marks the row the bin is showing without claiming this is a
                 // selection widget in its own right.
                 aria-current={index === focusIndex ? 'true' : undefined}

--- a/kamp_ui/src/renderer/src/components/CrateTitles.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateTitles.tsx
@@ -19,17 +19,26 @@ import { TOOLTIPS } from '../tooltipStrings'
 export function CrateTitles({
   items,
   focusIndex,
+  awayItemId,
   wishlistPending,
   onFocus,
   onPlay,
+  onDragStart,
   onToggleWishlist
 }: {
   items: CrateItem[]
   focusIndex: number
+  // The record already on the deck. Not draggable — dropping it back on the deck
+  // is a misdrop, and honouring it restarts the album from track 1. Double-click
+  // is still allowed, because that one is explicit.
+  awayItemId: number | null
   wishlistPending: number[]
   onFocus: (index: number) => void
   // Put this record on, replacing whatever is on the deck (KAMP-679).
   onPlay: (item: CrateItem) => void
+  // Begin a pointer drag toward the deck. Never preventDefaults, so the row's
+  // own click, double-click and focus all still happen.
+  onDragStart: (item: CrateItem, startX: number, startY: number) => void
   onToggleWishlist: (item: CrateItem) => void
 }): React.JSX.Element {
   const tooltip = useTooltip()
@@ -68,6 +77,13 @@ export function CrateTitles({
                 // These rows are real buttons whose focus matters, so nothing
                 // here preventDefaults and the native events are left alone.
                 onDoubleClick={() => onPlay(item)}
+                onPointerDown={
+                  item.id === awayItemId
+                    ? undefined
+                    : (e) => {
+                        if (e.button === 0) onDragStart(item, e.clientX, e.clientY)
+                      }
+                }
                 // Marks the row the bin is showing without claiming this is a
                 // selection widget in its own right.
                 aria-current={index === focusIndex ? 'true' : undefined}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -177,6 +177,8 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   const [flight, setFlight] = useState<Flight | null>(null)
   const lastDeckId = useRef<number | null>(null)
   const seededDeck = useRef(false)
+  // The one arrival a drag has already animated by hand — see the flight effect.
+  const suppressFlightRef = useRef<number | null>(null)
 
   // A record leaves the crate when it goes on the deck and comes back when it
   // comes off. The flight is an enhancement on that STATE CHANGE, never the
@@ -192,6 +194,21 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       return
     }
     if (nextId === prevId) return
+
+    // A record dragged onto the deck has already made the trip by hand, and the
+    // flight would not even start until the previewPlay POST returns — so it
+    // would fly out of the bin a beat late, from a sleeve the cursor left long
+    // ago. Suppress that one arrival (KAMP-679). Held in a ref rather than state
+    // because the effect runs on a daemon snapshot an arbitrary number of
+    // renders later, and cleared on any OTHER change so a drop that failed to
+    // play (every failure publishes state: idle) cannot leave it armed against a
+    // later Space press.
+    if (suppressFlightRef.current !== null) {
+      const suppressed = suppressFlightRef.current
+      suppressFlightRef.current = null
+      if (suppressed === nextId) return
+    }
+
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
 
     const platter = deckArtRef.current?.getBoundingClientRect()
@@ -260,6 +277,98 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // flip and press it, so there is one rule rather than two.
   const playFromCrate = (item: CrateItem): void => {
     void previewPlay(item.id)
+  }
+
+  // Dragging a record onto the deck (KAMP-679).
+  //
+  // Pointer events rather than HTML5 drag, per the KAMP-456/458 lesson: the
+  // Crate has an Escape contract and an HTML5 drag's OS session cannot be
+  // cancelled from JS. Adapted from QueuePanel/DownloadsView, with one
+  // deliberate difference — nothing here calls preventDefault, because that
+  // suppresses the compat mousedown and with it DOM focus, click and dblclick.
+  // Those matter here (real buttons, roving tabindex) and did not there.
+  const justDraggedRef = useRef(false)
+  const [dragOverDeck, setDragOverDeck] = useState(false)
+
+  const startCrateDrag = (item: CrateItem, startX: number, startY: number): void => {
+    let dragStarted = false
+    let ghost: HTMLDivElement | null = null
+
+    const overDeck = (x: number, y: number): boolean =>
+      Boolean(document.elementFromPoint(x, y)?.closest('.crate-deck'))
+
+    const onMove = (ev: PointerEvent): void => {
+      if (!dragStarted) {
+        // Same 4px threshold as the two existing drags, so a press that drifts
+        // is still a click.
+        if (Math.abs(ev.clientX - startX) < 4 && Math.abs(ev.clientY - startY) < 4) return
+        dragStarted = true
+        ghost = document.createElement('div')
+        ghost.className = 'crate-drag-ghost'
+        ghost.textContent = item.title
+        document.body.appendChild(ghost)
+      }
+      if (ghost) {
+        ghost.style.left = `${ev.clientX + 12}px`
+        ghost.style.top = `${ev.clientY - 12}px`
+      }
+      setDragOverDeck(overDeck(ev.clientX, ev.clientY))
+    }
+
+    const cleanup = (): void => {
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onUp)
+      document.removeEventListener('pointercancel', cleanup)
+      document.removeEventListener('keydown', onEscape)
+      window.removeEventListener('blur', cleanup)
+      if (ghost) {
+        document.body.removeChild(ghost)
+        ghost = null
+      }
+      setDragOverDeck(false)
+    }
+
+    const onUp = (ev: PointerEvent): void => {
+      const wasDrag = dragStarted
+      const dropped = wasDrag && overDeck(ev.clientX, ev.clientY)
+      cleanup()
+      if (!wasDrag) return
+      // A press that wandered past 4px can still be inside the platform's
+      // double-click DISTANCE, which is far larger — so a shaky double-click
+      // produces a completed drag AND a native dblclick. Without this gate that
+      // is two previewPlay calls and a restarted album. Cleared on the next task
+      // so the click and dblclick this same press generates are the ones caught.
+      justDraggedRef.current = true
+      window.setTimeout(() => {
+        justDraggedRef.current = false
+      }, 0)
+      if (dropped) {
+        suppressFlightRef.current = item.id
+        playFromCrate(item)
+      }
+    }
+
+    const onEscape = (ev: KeyboardEvent): void => {
+      if (ev.key !== 'Escape') return
+      // Cancel the drag and NOTHING else. CrateView's own Escape listener is on
+      // window (deliberately, so document-level modals win), so a document
+      // listener runs first and stopping propagation here keeps a drag-cancel
+      // from also stopping the preview or leaving the view. Bubble phase is
+      // enough; this is the DownloadsView KAMP-585 shape.
+      ev.stopPropagation()
+      cleanup()
+    }
+
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onUp)
+    // Chromium fires pointercancel — on a native drag, a system gesture, a
+    // window blur — and then sends NO pointerup, so without this the ghost
+    // survives on screen and the document listeners leak. Both existing drags in
+    // this codebase are missing it; the drag surface here is almost entirely an
+    // <img>, which is exactly where it bites.
+    document.addEventListener('pointercancel', cleanup)
+    document.addEventListener('keydown', onEscape)
+    window.addEventListener('blur', cleanup)
   }
 
   // Leaving the view stops the preview: audio with no visible controls is the
@@ -337,6 +446,17 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     },
     [crateNo]
   )
+
+  // The cards' click handlers go through these so a completed drag does not also
+  // fire the click and dblclick that the same press still generates (KAMP-679).
+  const focusUnlessDragged = (index: number): void => {
+    if (justDraggedRef.current) return
+    focusSleeve(index)
+  }
+  const playUnlessDragged = (item: CrateItem): void => {
+    if (justDraggedRef.current) return
+    playFromCrate(item)
+  }
 
   // Escape leaves the view. Deliberately a window listener, matching
   // DownloadsView: modals listen on document, which runs first, so Escape closes
@@ -633,9 +753,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             <CrateTitles
               items={items}
               focusIndex={focusIndex}
+              awayItemId={awayItemId}
               wishlistPending={wishlistPending}
-              onFocus={focusSleeve}
-              onPlay={playFromCrate}
+              onFocus={focusUnlessDragged}
+              onPlay={playUnlessDragged}
+              onDragStart={startCrateDrag}
               onToggleWishlist={(item) => void toggleCrateWishlist(item)}
             />
           </div>
@@ -671,8 +793,9 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               awayItemId={awayItemId}
               spineName={spineName}
               railRef={railRef}
-              onFocus={focusSleeve}
-              onPlay={playFromCrate}
+              onFocus={focusUnlessDragged}
+              onPlay={playUnlessDragged}
+              onDragStart={startCrateDrag}
             />
           </div>
         )}
@@ -688,7 +811,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             that depends on what is on it. */}
         {!building && (
           <div className="crate-deck-col">
-            <div className="crate-deck" role="group" aria-label="Preview deck">
+            <div
+              className={`crate-deck${dragOverDeck ? ' crate-deck--drop-target' : ''}`}
+              role="group"
+              aria-label="Preview deck"
+            >
               <div
                 className={`crate-deck-platter${platterItem ? ' is-loaded' : ''}`}
                 ref={deckArtRef}

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -12,7 +12,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../store'
 import { crateArtUrl, IDLE_PREVIEW } from '../api/client'
-import type { DiggingStats } from '../api/client'
+import type { CrateItem, DiggingStats } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
 import { CrateBin } from './CrateBin'
 import { CrateTitles } from './CrateTitles'
@@ -249,6 +249,19 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     else togglePreview()
   }
 
+  // Put a NAMED record on, whatever is on the deck already (KAMP-679).
+  //
+  // The routes above are both scoped to something implicit — Space to what you
+  // are looking at, the deck's button to what is on the deck — and between them
+  // they leave a hole: once the deck holds anything, a mouse has no way to play
+  // a DIFFERENT record. You have to press Escape or Stop first, which is a
+  // keyboard key, and not finding the keyboard route is the whole complaint.
+  // Replacing whatever is on the deck matches what Space already does when you
+  // flip and press it, so there is one rule rather than two.
+  const playFromCrate = (item: CrateItem): void => {
+    void previewPlay(item.id)
+  }
+
   // Leaving the view stops the preview: audio with no visible controls is the
   // one outcome worse than no preview at all.
   useEffect(() => {
@@ -396,6 +409,16 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       e.preventDefault()
       e.stopPropagation()
       if (items.length > 0) focusSleeve(Math.max(focusIndex - 1, 0))
+    } else if (e.key === 'Enter') {
+      // The keyboard's answer to double-click (KAMP-679). Both of the routes
+      // this story adds are mouse-only, and Enter was a dead key here: on a
+      // titles row it fired the button's onClick, which re-focuses the row it
+      // is already on, and on a sleeve it did nothing at all. Handled in the
+      // container alongside the other crate keys rather than per component, so
+      // it works from wherever focus happens to be in the view.
+      e.preventDefault()
+      e.stopPropagation()
+      if (current) playFromCrate(current)
     } else if (e.key === 'c' || e.key === 'C') {
       e.preventDefault()
       e.stopPropagation()
@@ -612,6 +635,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               focusIndex={focusIndex}
               wishlistPending={wishlistPending}
               onFocus={focusSleeve}
+              onPlay={playFromCrate}
               onToggleWishlist={(item) => void toggleCrateWishlist(item)}
             />
           </div>
@@ -648,6 +672,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               spineName={spineName}
               railRef={railRef}
               onFocus={focusSleeve}
+              onPlay={playFromCrate}
             />
           </div>
         )}
@@ -724,11 +749,15 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 )}
 
                 {/* The strip's meta line already says "Nothing on the deck"; this
-                    keeps the part no icon conveys — which key, and that using it
-                    does not disturb the user's own queue. */}
+                    keeps the part no icon conveys — how to put one on, and that
+                    doing so does not disturb the user's own queue. It named only
+                    Space until KAMP-679, which is a keyboard instruction shown to
+                    people who could not find the keyboard route: the mouse one
+                    goes first now. */}
                 {!deckItem && (
                   <p className="crate-deck-empty">
-                    Space puts the record you&rsquo;re looking at on — your queue stays where it is.
+                    Double-click a record to put it on, or press Space — your queue stays where it
+                    is.
                   </p>
                 )}
               </div>

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -57,6 +57,11 @@ const GROUPS: Group[] = [
         note: 'Replaces whatever is on the deck'
       },
       {
+        keys: ['drag', 'to deck'],
+        description: 'Put this record on',
+        note: 'From the record you are looking at, or any row in the list'
+      },
+      {
         keys: ['←', '→'],
         description: 'Previous / next track',
         note: 'The preview while one is playing, otherwise your own queue'

--- a/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
+++ b/kamp_ui/src/renderer/src/components/KeyboardShortcutsOverlay.tsx
@@ -52,6 +52,11 @@ const GROUPS: Group[] = [
         note: 'Your queue pauses and comes back'
       },
       {
+        keys: ['Enter', 'double-click'],
+        description: 'Put this record on',
+        note: 'Replaces whatever is on the deck'
+      },
+      {
         keys: ['←', '→'],
         description: 'Previous / next track',
         note: 'The preview while one is playing, otherwise your own queue'


### PR DESCRIPTION
Closes KAMP-679. Three new routes to put a record on the deck: double-click, drag, and Enter.

## The hole was sharper than the ticket says, and KAMP-678 made it

Beta testers couldn't work out how to play a record from the Crate. That reads as "Space is undiscoverable", but `toggleDeck` acts on the record **on the deck** — correct for a play button, and my change in KAMP-678 — which means:

- **empty deck** → play puts the record you're looking at on. Fine.
- **deck playing, paused, or merely cued** → play acts on *that* record, and **there is no mouse route at all to play a different one.** You have to press Escape or Stop first — a keyboard key, which is exactly what the testers couldn't find.

So a mouse user was stuck from the second record onward, in a feature whose whole premise is digging through ten. The empty-deck hint made it worse: it named only Space, and it renders only while the deck is empty, so the instruction disappeared at the moment it started being needed.

`playFromCrate` names a record explicitly and replaces whatever is on the deck, matching what Space already does when you flip and press it. The hint now leads with the mouse route.

## What's here

**Double-click and Enter** (commit 1, ships alone and closes the hole): on the titles rows and the focused bin sleeve, plus Enter in the container key handler. Enter was a dead key in the crate — on a titles row it fired the button's `onClick`, re-focusing the row it was already on — and both new mouse routes are unreachable from a keyboard, so it's the parity route.

**Drag to the deck** (commit 2): from the focused sleeve or any titles row.

## Three deliberate departures from the existing drag pattern

Pointer events rather than HTML5, per CLAUDE.md's KAMP-456/458 lesson — the Crate has an Escape contract and an HTML5 drag's OS session can't be cancelled from JS. But QueuePanel's implementation isn't transferable wholesale:

- **Nothing calls `preventDefault`.** QueuePanel's pointerdown does, which suppresses the compat mousedown and with it DOM focus, click and dblclick — that is precisely why it needs a hand-rolled 300ms tap detector. It gets away with it because its card is a bare `<li>` with no tabIndex. Both sources here are focusable (the titles rows are real buttons; the sleeve carries the roving tabindex `focusSleeve` and `onBlurCapture` depend on), so the native events are left alone and `draggable={false}` on the sleeve art stops the browser's own image drag starting on top of the pointer one.
- **`pointercancel` is handled**, which neither existing drag does. Chromium fires it on a native drag, a system gesture or a window blur and then sends **no `pointerup`** — so without it the ghost survives on screen and the document listeners leak. The drag surface here is almost entirely an `<img>`, which is where that bites.
- **A completed drag gates the click and dblclick the same press still generates.** A press that wanders past the 4px threshold can still sit inside the platform's double-click *distance*, which is far larger — so a shaky double-click produces a drag **and** a native dblclick, i.e. two `previewPlay` calls and a restarted album.

## Two more things worth knowing

**The arrival flight is suppressed for a dropped record.** It wouldn't start until the `previewPlay` POST returned, so the record flew out of the bin a beat late, from a sleeve the cursor had already left. Held in a ref (the flight effect runs on a daemon snapshot an arbitrary number of renders later) and cleared on any other change, so a drop that failed to play can't leave it armed against a later Space press.

**Escape cancels the drag and nothing else** — a document listener with `stopPropagation`, which runs before CrateView's own window listener and so doesn't also stop the preview or leave the view. That's the DownloadsView KAMP-585 shape.

**Scope note:** the bin is draggable from the focused sleeve only (your call). The others stack in the same place behind a 7% depth step and a 15° lean, so a back sleeve shows a ~12px crescent and a 4px-threshold drag off one is a coin flip with the sleeve in front. Clicking a back sleeve focuses it, and then it's the front one. Neither source offers a drag for the record already on the deck — dropping it back is a misdrop whose cost is an album restarting from track 1. Double-click still does, because that gesture is explicit.

## Verification

`npm run typecheck` and `npm run lint` clean (one pre-existing prettier warning in `main/index.ts`, untouched). Full pytest: 3226 passed, coverage 93.83% — unchanged, nothing Python was touched. No README drift.

`kamp_ui` has no test runner, so **all of this is manual**. Every claim above about click-target resolution, double-click distance and `pointercancel` is hand-verifiable only.

## Manual test plan

**Double-click and Enter**
- [ ] Double-click a titles row while another record plays: it replaces it and starts
- [ ] Double-click the focused sleeve: same
- [ ] Double-click a *non-focused* sleeve: focuses only, does not play (deliberate)
- [ ] Enter with a record focused plays it; Space still behaves as before
- [ ] Single click still just moves focus, everywhere

**Drag**
- [ ] Drag the focused sleeve onto the deck: it plays, and the record does **not** fly out of the bin a beat late
- [ ] Drag a titles row onto the deck: same
- [ ] Drag onto a deck that is already playing: replaces it
- [ ] The record already on the deck is not draggable (from either source); double-clicking it still restarts it
- [ ] Drop somewhere that is not the deck: nothing happens, ghost disappears
- [ ] Drag and return to the same sleeve: no spurious play
- [ ] **A shaky double-click must not both drag and play** — two `previewPlay` calls is the failure
- [ ] Escape mid-drag cancels the drag only: the preview keeps playing and the view does not close
- [ ] Start a drag then Cmd-Tab away: the ghost must not survive
- [ ] Drag while a crate is still building: no crash (the deck is not mounted then)

**Unchanged**
- [ ] Roving tabindex still works: Tab reaches the focused sleeve, `,`/`.` still flip
- [ ] Titles rows still activate from the keyboard; the heart buttons still work and don't start a drag
- [ ] Wishlist, copy-link and the deck's own transport are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
