### PR TITLE
KAMP-658: four more ways to dig

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5591,6 +5591,30 @@ class LibraryIndex:
                 )
         return out
 
+    def albums_purchased_between(
+        self, earliest: float, latest: float, limit: int = 25
+    ) -> list["SeedAlbum"]:
+        """Fetchable owned albums bought inside a window, newest purchase first.
+
+        ``bandcamp_collection.added_at`` is Bandcamp's own ``purchased`` field
+        rather than the time kamp synced, so a window around this date last year
+        is a real anniversary (KAMP-658). Note the caller supplies the window: the
+        clock stays out of here so the query is a pure range read.
+
+        An album bought but never downloaded has no ``albums`` row and so is not
+        returned — the same limitation every seed accessor has, since a seed the
+        user does not own locally is still fetchable but is not a shelf fact.
+        """
+        rows = self._conn.execute(
+            self._SEED_ALBUM_SELECT + """
+            WHERE bc.added_at BETWEEN ? AND ?
+            ORDER BY bc.added_at DESC
+            LIMIT ?
+            """,
+            (earliest, latest, limit),
+        ).fetchall()
+        return self._seed_album_rows(rows)
+
     def played_artists_with_pages(self, limit: int = 25) -> list["SeedArtist"]:
         """Artists the user actually plays, most-played first, with a page (KAMP-658).
 

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -895,6 +895,10 @@ class SeedArtist:
     name: str
     artist_page: str
     owned_count: int = 0
+    #: Accumulated playback seconds from ``artists.play_time`` (KAMP-658). Zero
+    #: for accessors that do not rank by it, so a criterion must not read this as
+    #: "never played" without knowing which accessor built the row.
+    play_time: float = 0.0
 
 
 def _artist_page_from_album_url(album_url: str) -> str:
@@ -5583,6 +5587,54 @@ class LibraryIndex:
                         name=r["name"],
                         artist_page=page,
                         owned_count=int(r["owned_count"]),
+                    )
+                )
+        return out
+
+    def played_artists_with_pages(self, limit: int = 25) -> list["SeedArtist"]:
+        """Artists the user actually plays, most-played first, with a page (KAMP-658).
+
+        The counterpart to :meth:`favorite_artists_with_pages`, which ranks by how
+        many albums were *starred*. This ranks by ``artists.play_time`` — the
+        accumulated seconds the user has spent on them — so it reaches an artist
+        they play constantly and never got round to favouriting.
+
+        ``owned_count`` here is the number of albums by them **in the Bandcamp
+        collection**, not in the library as a whole, which is the same definition
+        favorite_artists_with_pages uses. A criterion keying on "you only have the
+        one" must word its clerk line to match that: a record bought elsewhere
+        does not count.
+
+        Joined through ``albums.artist_id`` rather than by name — the column is
+        FK'd to ``artists.id`` and backfilled at index time, so it is the
+        authoritative link and avoids a second COLLATE NOCASE name match.
+        """
+        rows = self._conn.execute(
+            """
+            SELECT ar.name       AS name,
+                   ar.play_time  AS play_time,
+                   MIN(bc.album_url) AS album_url,
+                   COUNT(*)      AS owned_count
+            FROM albums a
+            JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id
+            JOIN artists ar ON ar.id = a.artist_id
+            WHERE bc.album_url != '' AND ar.play_time > 0
+            GROUP BY ar.id
+            ORDER BY ar.play_time DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        out: list[SeedArtist] = []
+        for r in rows:
+            page = _artist_page_from_album_url(r["album_url"])
+            if page:
+                out.append(
+                    SeedArtist(
+                        name=r["name"],
+                        artist_page=page,
+                        owned_count=int(r["owned_count"]),
+                        play_time=float(r["play_time"]),
                     )
                 )
         return out

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -877,6 +877,11 @@ class SeedAlbum:
     album: str
     album_url: str
     tralbum_id: str = ""
+    #: When the album was last started, or None if it never has been (KAMP-658).
+    #: Lets a criterion tell "you have not put this on in months" apart from
+    #: "you have never put this on", which are different clerk lines. Same
+    #: caveat as recently_played_albums: written at track START.
+    last_played_at: float | None = None
 
 
 @dataclass(frozen=True)
@@ -5486,7 +5491,8 @@ class LibraryIndex:
     # it. A seed with no album_url is useless to a fetcher, so these filter them
     # out at the source rather than making every caller remember to.
     _SEED_ALBUM_SELECT = """
-            SELECT a.id, a.album_artist, a.album, bc.album_url, bc.tralbum_id
+            SELECT a.id, a.album_artist, a.album, bc.album_url, bc.tralbum_id,
+                   a.last_played_at
             FROM albums a
             JOIN bandcamp_collection bc ON bc.sale_item_id = a.sale_item_id"""
 
@@ -5499,6 +5505,11 @@ class LibraryIndex:
                 album=r["album"],
                 album_url=r["album_url"],
                 tralbum_id=r["tralbum_id"] or "",
+                last_played_at=(
+                    float(r["last_played_at"])
+                    if r["last_played_at"] is not None
+                    else None
+                ),
             )
             for r in rows
             if r["album_url"]

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -209,6 +209,11 @@ class SeedProfile:
     favorite_album_ids: set[int] = field(default_factory=set)
     favorite_albums: list["SeedAlbum"] = field(default_factory=list)
     favorite_artists: list["SeedArtist"] = field(default_factory=list)
+    #: Artists ranked by accumulated play time rather than by what was starred
+    #: (KAMP-658), each carrying `owned_count` and a fetchable page. Distinct from
+    #: `top_artists`, which is names only — a criterion that wants to say "you
+    #: only have the one by them" needs the count and the address, not a name.
+    played_artists: list["SeedArtist"] = field(default_factory=list)
     top_artists: list[str] = field(default_factory=list)
     top_genres: list[str] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
@@ -261,6 +266,7 @@ def build_seed_profile(
         favorite_album_ids={s.album_id for s in favorites},
         favorite_albums=favorites,
         favorite_artists=index.favorite_artists_with_pages(artist_limit),
+        played_artists=index.played_artists_with_pages(artist_limit),
         top_artists=[a.name for a in index.top_artists(artist_limit)],
         top_genres=[name for name, _ in index.taste_genres(genre_limit)],
         labels=[name for name, _ in index.taste_labels(limit=label_limit)],

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -52,6 +52,12 @@ DISCOVER_API = "discover_api"
 FANCOLLECTION = "fancollection"
 ARTIST_PAGE = "artist_page"
 
+#: How far either side of "a year ago today" still counts as the anniversary
+#: (KAMP-658). Purchases are lumpy, so an exact-day match would leave the
+#: criterion silent on most days; a fortnight either side found 17 albums in the
+#: reference library.
+ANNIVERSARY_WINDOW_SECS = 14 * 86400
+
 
 class RequestBudget(Protocol):
     """How many requests a gather may spend, per endpoint class.
@@ -214,6 +220,10 @@ class SeedProfile:
     #: `top_artists`, which is names only — a criterion that wants to say "you
     #: only have the one by them" needs the count and the address, not a name.
     played_artists: list["SeedArtist"] = field(default_factory=list)
+    #: Albums bought around this date a year ago (KAMP-658). The window is
+    #: applied by the profile builder rather than the selector, so the selector
+    #: stays a pure function of the profile and carries no clock.
+    anniversary_albums: list["SeedAlbum"] = field(default_factory=list)
     top_artists: list[str] = field(default_factory=list)
     top_genres: list[str] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
@@ -260,6 +270,10 @@ def build_seed_profile(
     """
     recent = index.recently_played_albums(days=days)
     favorites = index.favorite_albums()
+    # "About a year ago" needs a window, not a date: purchases are lumpy and an
+    # exact-day match would leave the criterion silent on most days. A fortnight
+    # either side found 17 albums in the reference library.
+    year_ago = _time.time() - 365 * 86400
     return SeedProfile(
         recent_album_ids={s.album_id for s in recent},
         recent_albums=recent,
@@ -267,6 +281,9 @@ def build_seed_profile(
         favorite_albums=favorites,
         favorite_artists=index.favorite_artists_with_pages(artist_limit),
         played_artists=index.played_artists_with_pages(artist_limit),
+        anniversary_albums=index.albums_purchased_between(
+            year_ago - ANNIVERSARY_WINDOW_SECS, year_ago + ANNIVERSARY_WINDOW_SECS
+        ),
         top_artists=[a.name for a in index.top_artists(artist_limit)],
         top_genres=[name for name, _ in index.taste_genres(genre_limit)],
         labels=[name for name, _ in index.taste_labels(limit=label_limit)],

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -218,11 +218,55 @@ def _old_album_seeds(profile: SeedProfile) -> Iterable[Seed]:
 
 
 def _favorite_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
-    """More from a band the user has already favourited."""
+    """More from a band the user already knows they like.
+
+    Favourites first, then — once those are exhausted — artists they simply play
+    a lot without ever having starred anything (KAMP-658). The fall-through is
+    folded in here rather than made a criterion of its own: both would read the
+    same discography surface and emit the same `artist` seed dimension, so a
+    separate row would only have contended for the four-request artist-page
+    budget with this one while saying nearly the same thing.
+
+    The two `why` lines are deliberately different claims. Starring something and
+    playing it are different acts, and the card must not report one as the other.
+    """
+    seen: set[str] = set()
     for artist in profile.favorite_artists:
+        seen.add(artist.name.casefold())
         yield Seed(
             target=artist.artist_page,
             why=f"Another one from {artist.name}, who you already know you like.",
+            seed_data={"kind": "artist", "artist": artist.name},
+        )
+    for artist in profile.played_artists:
+        if artist.name.casefold() in seen:
+            continue
+        seen.add(artist.name.casefold())
+        yield Seed(
+            target=artist.artist_page,
+            why=f"You keep going back to {artist.name}. Here is another of theirs.",
+            seed_data={"kind": "artist", "artist": artist.name},
+        )
+
+
+def _lone_album_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
+    """The artist you play constantly and own exactly one record by.
+
+    A gap in the shelf rather than a taste match, which is why it earns its own
+    criterion where the play-time fall-through above does not: the claim is about
+    what is MISSING, and that is a different sentence from "another one from a
+    band you like".
+
+    `owned_count` counts albums in the Bandcamp collection, so the copy says
+    "here" rather than claiming to know the user's whole shelf — a record bought
+    somewhere else would make a flat "you only own one" false.
+    """
+    for artist in profile.played_artists:
+        if artist.owned_count != 1:
+            continue
+        yield Seed(
+            target=artist.artist_page,
+            why=f"You play {artist.name} a lot and have just the one here.",
             seed_data={"kind": "artist", "artist": artist.name},
         )
 
@@ -262,6 +306,15 @@ REGISTRY: tuple[Criterion, ...] = (
         endpoint_class=ARTIST_PAGE,
         seeds=_favorite_artist_seeds,
         label="more from a favourite band",
+    ),
+    # Appended, never inserted: tests index REGISTRY[0] positionally, and
+    # criteria_for() preserves this order for gather.
+    Criterion(
+        key="lone_album_artist",
+        surface=SURFACE_DISCOGRAPHY,
+        endpoint_class=ARTIST_PAGE,
+        seeds=_lone_album_artist_seeds,
+        label="you only have the one by them",
     ),
 )
 

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -249,6 +249,26 @@ def _favorite_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
         )
 
 
+def _purchase_anniversary_seeds(profile: SeedProfile) -> Iterable[Seed]:
+    """Album pages of records bought around this time last year.
+
+    A real anniversary, not a proxy: `added_at` is Bandcamp's own `purchased`
+    field rather than when kamp synced or when the files landed on disk. The
+    window is applied by the profile builder, so this stays a pure read.
+    """
+    for seed_album in profile.anniversary_albums:
+        yield Seed(
+            target=seed_album.album_url,
+            why=f"You bought {seed_album.album} about a year ago.",
+            seed_data={
+                "kind": "album",
+                "album_id": seed_album.album_id,
+                "album": seed_album.album,
+                "album_artist": seed_album.album_artist,
+            },
+        )
+
+
 def _lone_album_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
     """The artist you play constantly and own exactly one record by.
 
@@ -315,6 +335,13 @@ REGISTRY: tuple[Criterion, ...] = (
         endpoint_class=ARTIST_PAGE,
         seeds=_lone_album_artist_seeds,
         label="you only have the one by them",
+    ),
+    Criterion(
+        key="purchase_anniversary",
+        surface=SURFACE_ALBUM_RECS,
+        endpoint_class=ALBUM_PAGE,
+        seeds=_purchase_anniversary_seeds,
+        label="a year to the week since you bought it",
     ),
 )
 

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -20,6 +20,7 @@ on data kamp does not have; see the KAMP-647 plan.
 from __future__ import annotations
 
 import logging
+import time as _time
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 
@@ -34,6 +35,11 @@ SURFACE_DISCOGRAPHY = "discography"
 
 # How far back "over ten years old" reaches, in years.
 OLD_ALBUM_YEARS = 10
+
+# How long a favourite has to have gone unplayed before the clerk remarks on it
+# (KAMP-658). Six months: long enough that "you have not put it on in a while" is
+# true rather than pedantic, short enough that a real library has some.
+_DORMANT_SECS = 183 * 86400
 
 
 @dataclass(frozen=True)
@@ -110,25 +116,45 @@ def _also_like_seeds(profile: SeedProfile) -> Iterable[Seed]:
     is already ordered. Deduped by album_id so an album that is both recent and
     favourited is not fetched twice.
     """
+    now = _time.time()
     seen: set[int] = set()
     for seed_album in [*profile.recent_albums, *profile.favorite_albums]:
         if seed_album.album_id in seen:
             continue
         seen.add(seed_album.album_id)
         recent = seed_album.album_id in profile.recent_album_ids
+        # A favourite gone quiet for half a year is a different claim from a
+        # favourite in general, and it is the more interesting one — the clerk
+        # noticing what has slipped off your turntable rather than what is on it
+        # (KAMP-658). Folded in here rather than added as its own criterion: this
+        # selector ALREADY reaches those albums via favorite_albums, so a second
+        # criterion would collide with this one on the album_id seed dimension
+        # and spend an album-page request to relabel a card it would have
+        # produced anyway.
+        #
+        # Never played at all is deliberately NOT this line: "you have not put it
+        # on in a while" is false for a record that has never been on.
+        dormant = (
+            not recent
+            and seed_album.last_played_at is not None
+            and now - seed_album.last_played_at >= _DORMANT_SECS
+        )
+        if recent:
+            why = f"Filed next to {seed_album.album}, which you played recently."
+        elif dormant:
+            why = f"You have not put {seed_album.album} on in a while — this sits beside it."
+        else:
+            why = f"You favourited {seed_album.album} — this sits beside it."
         yield Seed(
             target=seed_album.album_url,
-            why=(
-                f"Filed next to {seed_album.album}, which you played recently."
-                if recent
-                else f"You favourited {seed_album.album} — this sits beside it."
-            ),
+            why=why,
             seed_data={
                 "kind": "album",
                 "album_id": seed_album.album_id,
                 "album": seed_album.album,
                 "album_artist": seed_album.album_artist,
                 "recent": recent,
+                "dormant": dormant,
             },
         )
 

--- a/kamp_ui/src/renderer/src/components/crateSpine.ts
+++ b/kamp_ui/src/renderer/src/components/crateSpine.ts
@@ -27,7 +27,12 @@ const PHRASES: Record<string, { one: string; many: string }> = {
   older_than_ten: { one: 'ONE DEEP CUT', many: 'DEEP CUTS' },
   best_seller: { one: 'ONE WILDCARD', many: 'WILDCARDS' },
   favorite_artist: { one: 'ONE OLD FRIEND', many: 'OLD FRIENDS' },
-  also_like: { one: 'ONE FILED NEXT DOOR', many: 'FILED NEXT DOOR' }
+  also_like: { one: 'ONE FILED NEXT DOOR', many: 'FILED NEXT DOOR' },
+  // KAMP-658. Both are deliberately not "DEEP CUT" or "OLD FRIEND" — those are
+  // already spoken for above by different criteria, and reusing them would make
+  // the divider card describe the wrong pick.
+  lone_album_artist: { one: 'ONE SECOND HELPING', many: 'SECOND HELPINGS' },
+  purchase_anniversary: { one: 'ONE FROM A YEAR BACK', many: 'FROM A YEAR BACK' }
 }
 
 function stamp(items: CrateItem[]): string {

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1290,6 +1290,38 @@ class TestSeedProfile:
         assert by_name["Four Tet"].owned_count == 2
         assert by_name["Loraine James"].artist_page == "https://lj.bandcamp.com/music"
 
+    def test_the_anniversary_window_has_both_edges(self, index: LibraryIndex) -> None:
+        """A fortnight either side of a year ago is in; a month out is not. The
+        window exists because purchases are lumpy — an exact-day match would
+        leave the criterion silent on most days (KAMP-658)."""
+        now = time.time()
+        year = 365 * 86400
+        for name, bought in (
+            ("OnTheDay", now - year),
+            ("JustInside", now - year + 13 * 86400),
+            ("WayBefore", now - year - 60 * 86400),
+            ("WayAfter", now - year + 60 * 86400),
+        ):
+            sale = f"sale-{name}"
+            _add_collection_row(
+                index,
+                sale,
+                band_name=name,
+                item_title=name,
+                album_url=f"https://{name.lower()}.bandcamp.com/album/a",
+                added_at=bought,
+            )
+            index._conn.execute(
+                "INSERT INTO albums (album_artist, album, sale_item_id)"
+                " VALUES (?, ?, ?)",
+                (name, name, sale),
+            )
+        index._conn.commit()
+
+        window = 14 * 86400
+        found = index.albums_purchased_between(now - year - window, now - year + window)
+        assert {a.album for a in found} == {"OnTheDay", "JustInside"}
+
     def test_played_artists_skip_the_never_played(self, index: LibraryIndex) -> None:
         """play_time 0 is the overwhelming majority of a real library's artists —
         returning them would make "you play them a lot" a lie."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1207,12 +1207,18 @@ class TestSeedProfile:
         label: str = "",
         album_url: str | None = None,
         sale_item_id: str | None = None,
+        play_time: float | None = None,
     ) -> int:
         """Insert an album, optionally linked to a collection row.
 
         The link matters: seed accessors only return albums with a fetchable
         Bandcamp URL, so an album created without one is deliberately invisible to
         them (a local-only album has no page to read recommendations from).
+
+        *play_time* creates the `artists` row and wires `albums.artist_id` to it,
+        which production does by name at index time. Accessors that rank by play
+        time join through that FK, so without it they return nothing and a test
+        proves only that the fixture is empty (KAMP-658).
         """
         if album_url is not None:
             sale_item_id = sale_item_id or f"sale-{artist}-{title}"
@@ -1223,14 +1229,78 @@ class TestSeedProfile:
                 item_title=title,
                 album_url=album_url,
             )
+        artist_id: int | None = None
+        if play_time is not None:
+            row = index._conn.execute(
+                "SELECT id FROM artists WHERE name = ? COLLATE NOCASE", (artist,)
+            ).fetchone()
+            if row is None:
+                cur = index._conn.execute(
+                    "INSERT INTO artists (name, play_time) VALUES (?, ?)",
+                    (artist, play_time),
+                )
+                artist_id = int(cur.lastrowid or 0)
+            else:
+                artist_id = int(row["id"])
+                index._conn.execute(
+                    "UPDATE artists SET play_time = ? WHERE id = ?",
+                    (play_time, artist_id),
+                )
         cur = index._conn.execute(
             "INSERT INTO albums"
-            " (album_artist, album, last_played_at, favorite, label, sale_item_id)"
-            " VALUES (?, ?, ?, ?, ?, ?)",
-            (artist, title, last_played_at, favorite, label, sale_item_id),
+            " (album_artist, album, last_played_at, favorite, label, sale_item_id,"
+            "  artist_id)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (artist, title, last_played_at, favorite, label, sale_item_id, artist_id),
         )
         index._conn.commit()
         return int(cur.lastrowid or 0)
+
+    def test_played_artists_rank_by_play_time_and_count_what_you_own(
+        self, index: LibraryIndex
+    ) -> None:
+        """KAMP-658. owned_count is albums in the COLLECTION, which is what the
+        "you have just the one here" copy is allowed to claim."""
+        self._album(
+            index,
+            "Loraine James",
+            "Reflection",
+            album_url="https://lj.bandcamp.com/album/reflection",
+            play_time=9000.0,
+        )
+        self._album(
+            index,
+            "Four Tet",
+            "Rounds",
+            album_url="https://fourtet.bandcamp.com/album/rounds",
+            play_time=8000.0,
+        )
+        self._album(
+            index,
+            "Four Tet",
+            "Pink",
+            album_url="https://fourtet.bandcamp.com/album/pink",
+            play_time=8000.0,
+        )
+
+        artists = index.played_artists_with_pages()
+        by_name = {a.name: a for a in artists}
+        assert [a.name for a in artists] == ["Loraine James", "Four Tet"]
+        assert by_name["Loraine James"].owned_count == 1
+        assert by_name["Four Tet"].owned_count == 2
+        assert by_name["Loraine James"].artist_page == "https://lj.bandcamp.com/music"
+
+    def test_played_artists_skip_the_never_played(self, index: LibraryIndex) -> None:
+        """play_time 0 is the overwhelming majority of a real library's artists —
+        returning them would make "you play them a lot" a lie."""
+        self._album(
+            index,
+            "Silent",
+            "Untouched",
+            album_url="https://silent.bandcamp.com/album/untouched",
+            play_time=0.0,
+        )
+        assert index.played_artists_with_pages() == []
 
     def test_recency_window_boundaries(self, index: LibraryIndex) -> None:
         """29 days ago is recent; 31 is not. The boundary is the whole point."""

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -137,13 +137,18 @@ def _profile(**kw: Any) -> SeedProfile:
     return SeedProfile(**kw)
 
 
-def _album_seed(album_id: int = 1, url: str = "https://a.bandcamp.com/album/x"):
+def _album_seed(
+    album_id: int = 1,
+    url: str = "https://a.bandcamp.com/album/x",
+    last_played_at: float | None = None,
+):
     return SeedAlbum(
         album_id=album_id,
         album_artist="Artist",
         album="Album",
         album_url=url,
         tralbum_id="111",
+        last_played_at=last_played_at,
     )
 
 
@@ -213,6 +218,32 @@ class TestCriteriaRegistry:
         fav = SeedProfile(favorite_albums=[_album_seed(2)])
         assert "recently" in list(REGISTRY[0].seeds(recent))[0].why
         assert "favourited" in list(REGISTRY[0].seeds(fav))[0].why
+
+    def test_a_favourite_gone_quiet_gets_its_own_line(self) -> None:
+        """KAMP-658's "clerk remembers". Folded into also_like rather than made a
+        criterion of its own, because this selector already reaches these albums
+        through favorite_albums."""
+        import time as _t
+
+        stale = _album_seed(3, last_played_at=_t.time() - 200 * 86400)
+        seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[stale])))
+        assert "not put" in seeds[0].why
+        assert seeds[0].seed_data["dormant"] is True
+
+    def test_a_favourite_played_last_month_is_not_called_dormant(self) -> None:
+        import time as _t
+
+        warm = _album_seed(4, last_played_at=_t.time() - 30 * 86400)
+        seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[warm])))
+        assert "favourited" in seeds[0].why
+        assert seeds[0].seed_data["dormant"] is False
+
+    def test_a_favourite_never_played_is_not_called_dormant(self) -> None:
+        """ "You have not put it on in a while" is false for a record that has
+        never been on. Never-played reads as an ordinary favourite."""
+        seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[_album_seed(5)])))
+        assert "favourited" in seeds[0].why
+        assert seeds[0].seed_data["dormant"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import gzip
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -181,6 +182,7 @@ RICH_PROFILE = SeedProfile(
             play_time=8000.0,
         ),
     ],
+    anniversary_albums=[_album_seed(9, "https://c.bandcamp.com/album/z")],
     top_artists=["Four Tet"],
     top_genres=["ambient", "dub techno"],
     labels=["Ghostly"],
@@ -702,6 +704,37 @@ class TestACrateReflectsTheLibrarysRange:
         assert budget.spent[DISCOVER_API] <= budget.limits[DISCOVER_API]
         assert budget.spent.get(ARTIST_PAGE, 0) <= budget.limits[ARTIST_PAGE]
         assert budget.spent.get(FANCOLLECTION, 0) == 0
+
+    def test_no_criterion_is_starved_by_the_budget(self) -> None:
+        """The failure the budget test above cannot see (KAMP-658).
+
+        `gather` iterates criteria in registry order and stops asking once a class
+        is exhausted, so a registry that outgrows its allowance starves whichever
+        criteria come last — silently, and while the <= assertions above stay
+        green. Two criteria per endpoint class times two seeds is exactly the
+        allowance today; a third on either class breaks this, which is the point.
+
+        Given ENOUGH GENRES on purpose. With only two, `older_than_ten` is skipped
+        for a reason that is not starvation: `genre_top` claims both genre
+        dimensions first and the KAMP-665 variety rule deliberately stops the
+        second genre criterion reusing them. That is correct behaviour, and a test
+        that could not tell it apart from budget exhaustion would be worse than no
+        test at all.
+        """
+        budget = crate_budget()
+        session = FakeSession(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        profile = replace(
+            RICH_PROFILE, top_genres=["ambient", "dub techno", "shoegaze", "dub"]
+        )
+        state: dict[str, Any] = {}
+        _source(session).gather(profile, budget, state)
+
+        wanted = {c.key for c in criteria_for(profile)}
+        ran = set(state.get("seeds", {}))
+        assert wanted <= ran, f"never got a request: {sorted(wanted - ran)}"
 
 
 class TestRotationAndPagination:

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -165,6 +165,22 @@ RICH_PROFILE = SeedProfile(
     favorite_artists=[
         SeedArtist(name="Four Tet", artist_page="https://fourtet.bandcamp.com/music")
     ],
+    # owned_count=1 so the lone-album criterion has something; a second artist
+    # with more than one keeps that filter honest rather than vacuous.
+    played_artists=[
+        SeedArtist(
+            name="Loraine James",
+            artist_page="https://lorainejames.bandcamp.com/music",
+            owned_count=1,
+            play_time=9000.0,
+        ),
+        SeedArtist(
+            name="Four Tet",
+            artist_page="https://fourtet.bandcamp.com/music",
+            owned_count=4,
+            play_time=8000.0,
+        ),
+    ],
     top_artists=["Four Tet"],
     top_genres=["ambient", "dub techno"],
     labels=["Ghostly"],
@@ -200,7 +216,31 @@ class TestCriteriaRegistry:
         assert keys == ["best_seller"]
 
     def test_rich_profile_runs_several_criteria(self) -> None:
-        assert len(criteria_for(RICH_PROFILE)) >= 4
+        # Raised with the registry (KAMP-658). Left at 4 it would stay green while
+        # half the criteria produced nothing, which is the opposite of its job.
+        assert len(criteria_for(RICH_PROFILE)) >= 6
+
+    def test_the_lone_album_criterion_skips_artists_you_own_several_by(self) -> None:
+        """The claim is about a gap on the shelf, so an artist with four albums
+        in the collection must not produce "you have just the one here"."""
+        lone = next(c for c in REGISTRY if c.key == "lone_album_artist")
+        names = {s.seed_data["artist"] for s in lone.seeds(RICH_PROFILE)}
+        assert names == {"Loraine James"}
+
+    def test_the_artist_criterion_falls_through_to_what_you_play(self) -> None:
+        """Favourites first, then artists merely played a lot — and the two say
+        different things, because starring and playing are different acts."""
+        fav = next(c for c in REGISTRY if c.key == "favorite_artist")
+        seeds = list(fav.seeds(RICH_PROFILE))
+        whys = {s.seed_data["artist"]: s.why for s in seeds}
+        assert "already know you like" in whys["Four Tet"]
+        assert "keep going back to" in whys["Loraine James"]
+
+    def test_a_favourite_is_not_offered_twice_by_the_fall_through(self) -> None:
+        """Four Tet is in both lists; the artist page must be seeded once."""
+        fav = next(c for c in REGISTRY if c.key == "favorite_artist")
+        names = [s.seed_data["artist"] for s in fav.seeds(RICH_PROFILE)]
+        assert names.count("Four Tet") == 1
 
     def test_also_like_dedupes_an_album_that_is_both_recent_and_favourite(
         self,


### PR DESCRIPTION
Closes KAMP-658. Four of the ticket's five criteria; the fifth is split out as KAMP-687 with the reason recorded there.

## The ticket's premise was half right

"No new fetch surface" holds — all of these ride the three existing surfaces, `_run_seed` dispatches them with no parser work, and `discovery_items.criterion` is plain TEXT so there's no migration. But **"just seed selectors" doesn't**, and following it literally would have made the crate worse in three ways:

**Two of the five were already reachable.** `_also_like_seeds` iterates `[*recent_albums, *favorite_albums]`, so a favourite unplayed for six months — by definition not recent, definitely a favourite — is fetched *today*. As its own criterion it would have emitted the same `album_id` seed dimension, collided with `also_like` in `gather`'s `used` set, and spent an album-page request to relabel a card `also_like` would have produced anyway. One of the two would have contributed nothing. Same story for "New From an Old Friend" against `favorite_artist`. **Both are folded in as seed ordering plus their own clerk lines**, which is why this adds two registry rows rather than four.

**Ten criteria would have broken the crate arithmetic.** `_deal` round-robins one card per criterion over ten slots, so at ten criteria every criterion places exactly one card, `SEED_CAP = 2` can never bind, and the *second* seed `_SEEDS_PER_CRITERION = 2` fetches is always discarded — 9 to 16 requests for the same ten cards, on the endpoint family KAMP-639 showed cascades account-wide. At seven the budgets hold: ALBUM_PAGE 4/8, DISCOVER_API 5/6, ARTIST_PAGE 4/4. No budget or rotation change was needed; that work was an artefact of the larger registry.

**One name would have made shipped copy lie.** The crate spine already uses **DEEP CUTS** for `older_than_ten` and **OLD FRIENDS** for `favorite_artist` — the ticket's names for #7 and #9. Renamed to `lone_album_artist`, and #9 no longer needs a name at all.

## What's in

**The clerk remembers a favourite gone quiet.** Folded into `also_like`: a favourite you haven't put on in six months gets its own line instead of the generic "you favourited this". Never-played deliberately doesn't qualify — "you haven't put it on in a while" is false for a record that has never been on. `SeedAlbum` gains `last_played_at` to support it, one column both existing seed accessors absorb for free.

**Dig by what you play, not only what you starred.** New accessor `played_artists_with_pages` ranks by `artists.play_time` where the existing one ranks by how many albums were starred, joined through `albums.artist_id` (100% populated in the live library, so it's the authoritative link). It feeds two behaviours:

- `lone_album_artist` as a new criterion — the artist you play constantly and own exactly one record by. It earns a row where the fall-through below doesn't, because its claim is about what's *missing* from the shelf, a different sentence from "another one from a band you like". 234 artists qualify in the live library.
- a fall-through in `favorite_artist` for high-play-time artists once favourites are exhausted. The two `why` lines are deliberately different claims: starring something and playing it are different acts.

**A record you bought a year ago.** New criterion `purchase_anniversary`. The anniversary is real, not a proxy — `bandcamp_collection.added_at` is Bandcamp's own `purchased` field, not sync time, and not `albums.date_added` which is file birthtime at first scan. A fortnight either side rather than an exact day, because purchases are lumpy; the window found 17 albums in the reference library.

**"New From an Old Friend" is re-spec'd, not dropped.** Its defining filter — newest release post-dating your last purchase — is not buildable: `parse_discography` returns no `release_date` at all, so there is nothing to compare against. What survives is the play-time fall-through above.

## A test that should have existed

The existing budget test asserts spend `<=` allowance, which stays green while a criterion at the end of the registry never runs at all. `test_no_criterion_is_starved_by_the_budget` asserts every criterion actually issued a request.

It's given four genres deliberately. With two, `older_than_ten` is skipped — but by the KAMP-665 variety rule, because `genre_top` claims both genre dimensions first, not by budget. That's correct behaviour, and a test that couldn't tell it apart from starvation would be worse than none. It caught this on first run, which is the reason for the four.

## Verification

3242 passed, 9 skipped, coverage **93.85%** (up from 93.83%). `npm run typecheck` and `npm run lint` clean (one pre-existing prettier warning in `main/index.ts`, untouched). No README drift. The parametrized registry tests cover provenance, thin-profile safety and endpoint funding for both new rows automatically — `RICH_PROFILE` had to be extended or they'd have failed instantly, and `test_rich_profile_runs_several_criteria` went from `>= 4` to `>= 6` so it keeps guarding something.

## Manual test plan

- [ ] Dig several crates and read the clerk lines. Each must claim only what its seed supports: "you keep going back to X" only for a played artist, "just the one here" only when the collection really has one, "about a year ago" only near the anniversary
- [ ] Confirm the two new lines actually appear over a few crates — they compete with five other criteria for ten slots
- [ ] Check the divider card still names the crate rather than showing a bare date, and that SECOND HELPINGS / FROM A YEAR BACK read right next to the existing phrases
- [ ] Confirm a crate build hasn't got noticeably slower: about 9 to about 13 requests, spaced 1.5s apart on album-page and discover
- [ ] Watch for a repeated artist across the favourite and lone-album criteria — they share the artist seed dimension, so `used` should stop the same page being read twice in one crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
