### PR TITLE
KAMP-657: keep the surplus, fill a thin crate from it

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -614,10 +614,17 @@ CREATE INDEX IF NOT EXISTS discovery_items_crate_idx ON discovery_items(crate_no
 -- extension_audit_log. Two reasons this differs from that precedent: RAISE(ABORT)
 -- triggers would make KAMP-657's buffer TTL sweep abort on any item that ever had an
 -- event, and ON DELETE CASCADE would silently shrink the purchase stats every time a
--- row was pruned. RESTRICT means the sweep can only delete event-free rows, which is
--- exactly the buffered ones. Note the edge it gets right: a buffered candidate the
--- user buys independently gains a 'purchased' event and thereby becomes unsweepable,
--- which is what we want -- the attribution outlives the candidate.
+-- row was pruned. RESTRICT lets a buffered candidate the user buys independently
+-- gain a 'purchased' event and thereby become unsweepable, which is what we want --
+-- the attribution outlives the candidate.
+--
+-- Being buffered and being event-free are NOT the same set, and the sweep must not
+-- assume they are: attribute_purchases records that event ignoring crate_no on
+-- purpose, so buffered rows with events exist. RESTRICT is the backstop, not the
+-- filter -- a DELETE that leans on it raises IntegrityError, and because SQLite
+-- rolls the whole statement back, ONE purchased buffered row would kill the sweep
+-- for good (it never ages out). sweep_discovery_buffer therefore excludes
+-- event-bearing rows in its WHERE clause.
 --
 -- provider/provider_item_id are denormalized so aggregate stats stay answerable
 -- without joining a row that may since have been pruned.
@@ -5037,6 +5044,68 @@ class LibraryIndex:
             item["seed"] = seed if isinstance(seed, dict) else {}
             out.append(item)
         return out
+
+    #: Buffered candidates older than this are swept (KAMP-657). Measured from
+    #: first_seen_at, which is gather time -- promotion never restamps it.
+    BUFFER_TTL_SECS = 30 * 86400
+    #: And the pool is capped regardless of age, so it cannot grow into a stale
+    #: swamp on a machine that digs constantly. Oldest evicted first.
+    BUFFER_CAP = 150
+
+    def sweep_discovery_buffer(
+        self, ttl_secs: float | None = None, cap: int | None = None
+    ) -> int:
+        """Drop aged and surplus buffered candidates. Returns rows removed.
+
+        Two passes: anything unshown and older than the TTL, then anything past
+        the cap, oldest first. Shown rows (``crate_no IS NOT NULL``) are never
+        touched -- they are the seen-ledger, and deleting one would re-offer a
+        record the user has already been shown.
+
+        **Event-bearing rows are excluded in the WHERE clause rather than left to
+        the RESTRICT foreign key.** Being buffered does not imply being
+        event-free: ``attribute_purchases`` records a 'purchased' event ignoring
+        ``crate_no`` on purpose, so a buffered candidate the user bought
+        independently carries one. Leaning on RESTRICT would raise IntegrityError,
+        and since SQLite rolls the whole statement back, a single such row would
+        kill every future sweep -- silently, and permanently, because that row
+        never ages out.
+        """
+        ttl = self.BUFFER_TTL_SECS if ttl_secs is None else ttl_secs
+        limit = self.BUFFER_CAP if cap is None else cap
+        # Sweepable at all: buffered, and carrying no history worth keeping.
+        sweepable = (
+            " FROM discovery_items d"
+            " WHERE d.crate_no IS NULL"
+            "   AND NOT EXISTS ("
+            "       SELECT 1 FROM discovery_events e WHERE e.item_id = d.id)"
+        )
+        aged = [
+            r["id"]
+            for r in self._conn.execute(
+                "SELECT d.id" + sweepable + " AND d.first_seen_at < ?",
+                (_time.time() - ttl,),
+            ).fetchall()
+        ]
+        # Re-read rather than subtracting in Python: the aged delete has not been
+        # applied yet, and the cap is about what SURVIVES it.
+        surplus = [
+            r["id"]
+            for r in self._conn.execute(
+                "SELECT d.id" + sweepable + " AND d.first_seen_at >= ?"
+                " ORDER BY d.first_seen_at DESC, d.id DESC LIMIT -1 OFFSET ?",
+                (_time.time() - ttl, limit),
+            ).fetchall()
+        ]
+        doomed = aged + surplus
+        if not doomed:
+            return 0
+        placeholders = ",".join("?" * len(doomed))
+        self._conn.execute(
+            f"DELETE FROM discovery_items WHERE id IN ({placeholders})", doomed
+        )
+        self._conn.commit()
+        return len(doomed)
 
     def seen_before(self, provider: str, provider_item_id: str) -> bool:
         """True only if this candidate has actually been SHOWN to the user.

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4961,6 +4961,83 @@ class LibraryIndex:
         self._conn.commit()
         return int(cur.lastrowid or 0)
 
+    def buffer_candidates(self, rows: "Sequence[dict[str, Any]]") -> int:
+        """Bulk-insert surplus candidates as buffered rows. Returns rows written.
+
+        The bulk counterpart to :meth:`add_discovery_candidate`, and separate from
+        it on purpose (KAMP-657). That one is a read-then-insert committing per
+        row, which is right for the ten picks a build promotes but wrong for the
+        fifty it has left over: the library is WAL with the default
+        ``synchronous=FULL``, so every commit is an fsync, and fifty fsyncs in a
+        burst is an order of magnitude past the rate KAMP-684 treated as a defect
+        worth fixing. One ``executemany``, one commit.
+
+        ``ON CONFLICT DO NOTHING`` on the existing ``UNIQUE (provider,
+        provider_item_id)`` replaces the Python-side existence check, which also
+        closes the read-then-insert race that check leaves open.
+
+        Surplus is never promoted in the same build, so no row ids are returned.
+        """
+        if not rows:
+            return 0
+        now = _time.time()
+        cur = self._conn.executemany(
+            "INSERT INTO discovery_items"
+            " (provider, provider_item_id, item_url, artist, title, art_url,"
+            "  label, release_date, criterion, why, seed_json, first_seen_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT (provider, provider_item_id) DO NOTHING",
+            [
+                (
+                    r.get("provider", "bandcamp"),
+                    str(r["provider_item_id"]),
+                    r.get("item_url", ""),
+                    r.get("artist", ""),
+                    r.get("title", ""),
+                    r.get("art_url"),
+                    r.get("label", ""),
+                    r.get("release_date", ""),
+                    r.get("criterion", ""),
+                    r.get("why", ""),
+                    r.get("seed_json", "{}"),
+                    r.get("first_seen_at") or now,
+                )
+                for r in rows
+            ],
+        )
+        self._conn.commit()
+        return int(cur.rowcount or 0)
+
+    def buffered_candidates(self, limit: int = 200) -> list[dict[str, Any]]:
+        """Surplus candidates never shown to anyone, oldest gather first.
+
+        Oldest-first so the tail drains before it ages out; newest-first would
+        leave everything below the waterline write-only, aging out unread.
+
+        Same seed_json handling as :meth:`crate_items` — a malformed blob costs
+        that candidate its structured provenance rather than the whole read, and
+        ``why`` is stored separately so the card still reads correctly.
+        """
+        rows = self._conn.execute(
+            "SELECT id, provider, provider_item_id, item_url, artist, title,"
+            "       art_url, label, release_date, criterion, why, seed_json,"
+            "       first_seen_at"
+            " FROM discovery_items WHERE crate_no IS NULL"
+            " ORDER BY first_seen_at, id LIMIT ?",
+            (limit,),
+        ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            item = dict(row)
+            raw = item.pop("seed_json", None)
+            try:
+                seed = json.loads(raw) if raw else {}
+            except (ValueError, TypeError):
+                seed = {}
+            item["seed"] = seed if isinstance(seed, dict) else {}
+            out.append(item)
+        return out
+
     def seen_before(self, provider: str, provider_item_id: str) -> bool:
         """True only if this candidate has actually been SHOWN to the user.
 

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -159,6 +159,34 @@ def build_crate(
         # exactly the waste this exists to stop.
         _save_rotation(index, rotation)
 
+    # Swept before it is read, not at daemon start: sweep_orphan_pending_ingest is
+    # the naming precedent but runs once at launch, and this daemon can run for
+    # weeks. Sweeping first is safe — the read below simply sees what survived, and
+    # a row past its TTL is one we would not want to offer anyway.
+    try:
+        index.sweep_discovery_buffer()
+    except Exception:  # noqa: BLE001 - housekeeping must not cost a crate
+        logger.warning("discovery: buffer sweep failed", exc_info=True)
+
+    # Stock from previous builds, offered only if this gather cannot fill the
+    # crate on its own (KAMP-657). Fallback rather than blend: the gather spends
+    # the same requests either way, so mixing leftovers into a healthy build buys
+    # nothing and costs freshness. What the buffer is actually for is the build
+    # that came back thin — a 429, an exhausted budget, pages picked over — where
+    # today the user just gets a short crate.
+    #
+    # Fresh wins any duplicate: its `why` was computed against the current
+    # profile, and `_deal` dedupes on id() rather than on identity, so two objects
+    # for the same album would both be dealable and the second place_in_crate would
+    # MOVE the row rather than add one — leaving a hole in a crate reporting itself
+    # full.
+    fresh_ids = {(c.provider, c.provider_item_id) for c in candidates}
+    stock = [
+        c
+        for c in _rehydrate(index.buffered_candidates())
+        if (c.provider, c.provider_item_id) not in fresh_ids
+    ]
+
     picks = select_crate(
         candidates,
         index=index,
@@ -166,13 +194,22 @@ def build_crate(
         size=size,
         rng=rng,
         wishlist_ids=wishlist_ids,
+        extra=stock,
     )
     # Attributed BEFORE anything is written, and that ordering is the whole
     # correctness of the flag: place first and this crate's own ten records are
     # `seen_before` by the time we ask, so every short crate would report the well
     # dry — including a three-record crate where nothing had been seen at all.
+    #
+    # Counted against the FRESH picks only. `candidates` is the gather, so letting
+    # buffered picks into `picked` compares two different sets and makes the
+    # inequality trivially easier — a crate topped up from stock would report the
+    # racks picked over when the buffer was simply drained by `in_library`.
+    fresh_picked = sum(
+        1 for p in picks if (p.provider, p.provider_item_id) in fresh_ids
+    )
     dry = len(picks) < size and _short_because_seen(
-        candidates, index=index, picked=len(picks)
+        candidates, index=index, picked=fresh_picked
     )
 
     if not picks:
@@ -221,6 +258,15 @@ def build_crate(
         logger.warning("discovery: crate %d persisted nothing", crate_no)
         return _publish(publish, state="empty", crate_no=None)
 
+    # Keep what this gather found and could not use (KAMP-657). After the guard
+    # above on purpose: that branch means writes are failing, and firing fifty
+    # more at a database that just rejected ten is the wrong move.
+    #
+    # Deliberately not filtered by `_excluded` — exclusion is re-checked at
+    # assembly because a candidate can be bought or wishlisted while it sits, so
+    # filtering now would only bake in a verdict that has to be re-taken anyway.
+    _buffer_surplus(index, candidates, picks)
+
     short = placed < size
     # `dry` was measured against the picks; `short` is measured against what
     # actually landed. Both have to hold: a crate short only because rows failed
@@ -244,6 +290,67 @@ def build_crate(
     )
 
 
+def _rehydrate(rows: "Sequence[dict[str, Any]]") -> list[Candidate]:
+    """Turn stored buffer rows back into Candidates (KAMP-657).
+
+    `seed` arrives already parsed by the accessor, which is also where a
+    malformed blob is absorbed — so a candidate whose provenance did not survive
+    the round trip still carries its `why` and is still showable.
+    """
+    return [
+        Candidate(
+            provider=row["provider"],
+            provider_item_id=row["provider_item_id"],
+            item_url=row["item_url"],
+            artist=row["artist"],
+            title=row["title"],
+            art_url=row["art_url"],
+            label=row["label"],
+            release_date=row["release_date"],
+            criterion=row["criterion"],
+            why=row["why"],
+            seed=row.get("seed") or {},
+        )
+        for row in rows
+    ]
+
+
+def _buffer_surplus(
+    index: "LibraryIndex",
+    candidates: "Sequence[Candidate]",
+    picks: "Sequence[Candidate]",
+) -> int:
+    """Persist what this gather found and did not place. Returns rows written."""
+    placed_keys = {(p.provider, p.provider_item_id) for p in picks}
+    surplus = [
+        c for c in candidates if (c.provider, c.provider_item_id) not in placed_keys
+    ]
+    if not surplus:
+        return 0
+    try:
+        return index.buffer_candidates(
+            [
+                {
+                    "provider": c.provider,
+                    "provider_item_id": c.provider_item_id,
+                    "item_url": c.item_url,
+                    "artist": c.artist,
+                    "title": c.title,
+                    "art_url": c.art_url,
+                    "label": c.label,
+                    "release_date": c.release_date,
+                    "criterion": c.criterion,
+                    "why": c.why,
+                    "seed_json": c.seed_json(),
+                }
+                for c in surplus
+            ]
+        )
+    except Exception:  # noqa: BLE001 - a cache write must not fail a built crate
+        logger.warning("discovery: could not buffer surplus", exc_info=True)
+        return 0
+
+
 def select_crate(
     candidates: Sequence[Candidate],
     *,
@@ -252,6 +359,7 @@ def select_crate(
     size: int = CRATE_SIZE,
     rng: random.Random | None = None,
     wishlist_ids: set[str] | None = None,
+    extra: Sequence[Candidate] | None = None,
 ) -> list[Candidate]:
     """Pick up to *size* candidates, excluded and varied. Pure apart from reads.
 
@@ -263,33 +371,51 @@ def select_crate(
     caps = caps or {}
     wishlist_ids = wishlist_ids or set()
 
+    picks: list[Candidate] = []
     groups = _group_by_criterion(
         c
         for c in candidates
         if not _excluded(c, index=index, wishlist_ids=wishlist_ids)
     )
-    if not groups:
-        return []
+    if groups:
+        # Shuffle the group order per crate. criteria_for() preserves REGISTRY
+        # order and gather() iterates it, so without this slot 0 is the same
+        # criterion in every crate for the life of the install -- a poor look for
+        # a feature whose entire affordance is dealing another one.
+        order = list(groups)
+        rng.shuffle(order)
 
-    # Shuffle the group order per crate. criteria_for() preserves REGISTRY order
-    # and gather() iterates it, so without this slot 0 is the same criterion in
-    # every crate for the life of the install -- a poor look for a feature whose
-    # entire affordance is dealing another one.
-    order = list(groups)
-    rng.shuffle(order)
+        picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP)
+        if len(picks) < size:
+            # A cap is a preference, not a ceiling: honouring one to the point of
+            # shrinking the crate is how a brand-new library (whose only criterion
+            # is the chart) would get a one-item crate. Backfill from what the caps
+            # held back, uncapped criteria having already been exhausted by _deal.
+            #
+            # The seed cap is dropped here for the same reason as the criterion
+            # caps (KAMP-665): a thin profile can yield one seed's worth of
+            # candidates and nothing else, and a two-record crate is a worse answer
+            # than a crate that leans on one album page.
+            picks.extend(_deal(groups, order, size - len(picks), caps={}, skip=picks))
 
-    picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP)
-    if len(picks) < size:
-        # A cap is a preference, not a ceiling: honouring one to the point of
-        # shrinking the crate is how a brand-new library (whose only criterion is
-        # the chart) would get a one-item crate. Backfill from what the caps held
-        # back, uncapped criteria having already been exhausted by _deal.
-        #
-        # The seed cap is dropped here for the same reason as the criterion caps
-        # (KAMP-665): a thin profile can yield one seed's worth of candidates and
-        # nothing else, and a two-record crate is a worse answer than a crate that
-        # leans on one album page.
-        picks.extend(_deal(groups, order, size - len(picks), caps={}, skip=picks))
+    # Stock, and only once the fresh pool has had every chance (KAMP-657). This is
+    # the whole reason the buffer exists: a gather cut short by a 429, an
+    # exhausted budget or picked-over pages still fills its crate. On a healthy
+    # build this branch never runs, so leftovers cannot dilute a crate that did
+    # not need them.
+    #
+    # `skip=picks` carries the seed-cap accounting across, so stock cannot pile a
+    # third record onto a seed the fresh pass already used twice.
+    if extra and len(picks) < size:
+        stock = _group_by_criterion(
+            c for c in extra if not _excluded(c, index=index, wishlist_ids=wishlist_ids)
+        )
+        if stock:
+            stock_order = list(stock)
+            rng.shuffle(stock_order)
+            picks.extend(
+                _deal(stock, stock_order, size - len(picks), caps={}, skip=picks)
+            )
     return picks
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1095,6 +1095,66 @@ class TestCandidateBuffer:
     def test_an_empty_write_touches_nothing(self, index: LibraryIndex) -> None:
         assert index.buffer_candidates([]) == 0
 
+    # -- the sweep --
+
+    def test_aged_buffered_rows_are_swept(self, index: LibraryIndex) -> None:
+        old = time.time() - 40 * 86400
+        index.buffer_candidates(
+            [
+                {"provider_item_id": "stale", "first_seen_at": old},
+                {"provider_item_id": "fresh"},
+            ]
+        )
+        assert index.sweep_discovery_buffer() == 1
+        assert [c["provider_item_id"] for c in index.buffered_candidates()] == ["fresh"]
+
+    def test_the_sweep_never_touches_a_shown_row(self, index: LibraryIndex) -> None:
+        """Shown rows are the seen-ledger. Deleting one would re-offer a record
+        the user has already been shown."""
+        shown = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", first_seen_at=time.time() - 999e5
+        )
+        index.place_in_crate(shown, 1, 0)
+
+        assert index.sweep_discovery_buffer() == 0
+        assert index.seen_before("bandcamp", "1") is True
+
+    def test_a_purchased_buffered_row_does_not_kill_the_sweep(
+        self, index: LibraryIndex
+    ) -> None:
+        """The trap the RESTRICT FK sets. attribute_purchases records a
+        'purchased' event ignoring crate_no, so buffered rows with events exist.
+        A DELETE that leaned on RESTRICT would raise, SQLite would roll the whole
+        statement back, and this one row -- which never ages out -- would kill
+        every future sweep. It must be skipped, and its neighbours still swept."""
+        old = time.time() - 40 * 86400
+        bought = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="bought", first_seen_at=old
+        )
+        index.record_discovery_event(bought, "purchased", at=old)
+        index.buffer_candidates(
+            [{"provider_item_id": "ordinary", "first_seen_at": old}]
+        )
+
+        assert index.sweep_discovery_buffer() == 1
+        left = [c["provider_item_id"] for c in index.buffered_candidates()]
+        assert left == ["bought"]
+
+    def test_the_cap_evicts_oldest_first(self, index: LibraryIndex) -> None:
+        now = time.time()
+        index.buffer_candidates(
+            [{"provider_item_id": str(i), "first_seen_at": now - i} for i in range(5)]
+        )
+        assert index.sweep_discovery_buffer(cap=2) == 3
+        # first_seen_at descends with i, so 0 and 1 are the newest two.
+        assert {c["provider_item_id"] for c in index.buffered_candidates()} == {
+            "0",
+            "1",
+        }
+
+    def test_an_empty_buffer_sweeps_cleanly(self, index: LibraryIndex) -> None:
+        assert index.sweep_discovery_buffer() == 0
+
 
 # ---------------------------------------------------------------------------
 # Crate assembly accessors (KAMP-648)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1022,6 +1022,81 @@ class TestEventLedger:
 
 
 # ---------------------------------------------------------------------------
+# The candidate buffer (KAMP-657)
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateBuffer:
+    def _rows(self, *ids: str, **kw: Any) -> list[dict[str, Any]]:
+        return [{"provider_item_id": i, "artist": f"Artist {i}", **kw} for i in ids]
+
+    def test_surplus_is_written_and_read_back(self, index: LibraryIndex) -> None:
+        assert index.buffer_candidates(self._rows("1", "2", "3")) == 3
+        got = index.buffered_candidates()
+        assert [c["provider_item_id"] for c in got] == ["1", "2", "3"]
+        assert all(c["provider"] == "bandcamp" for c in got)
+
+    def test_writing_the_same_album_twice_is_a_no_op(self, index: LibraryIndex) -> None:
+        """The gather re-returns roughly 15% of its recommendations across seeds,
+        so a conflicting write is the normal case, not an error."""
+        index.buffer_candidates(self._rows("1"))
+        index.buffer_candidates(self._rows("1", "2"))
+        assert [c["provider_item_id"] for c in index.buffered_candidates()] == [
+            "1",
+            "2",
+        ]
+
+    def test_buffering_never_resurrects_a_shown_candidate(
+        self, index: LibraryIndex
+    ) -> None:
+        """A record already in a crate must not be re-offered by the buffer, and
+        the ON CONFLICT must not drag it back to crate_no NULL."""
+        shown = index.add_discovery_candidate(provider="bandcamp", provider_item_id="1")
+        index.place_in_crate(shown, 1, 0)
+
+        index.buffer_candidates(self._rows("1"))
+        assert index.buffered_candidates() == []
+        assert index.seen_before("bandcamp", "1") is True
+
+    def test_buffered_rows_are_read_oldest_first(self, index: LibraryIndex) -> None:
+        """So the tail drains before it ages out rather than going write-only."""
+        index.buffer_candidates(
+            [
+                {"provider_item_id": "new", "first_seen_at": 2000.0},
+                {"provider_item_id": "old", "first_seen_at": 1000.0},
+            ]
+        )
+        got = [c["provider_item_id"] for c in index.buffered_candidates()]
+        assert got == ["old", "new"]
+
+    def test_a_malformed_seed_costs_that_row_its_provenance_only(
+        self, index: LibraryIndex
+    ) -> None:
+        """Matches crate_items: `why` is stored separately and still reads."""
+        index.buffer_candidates(
+            [
+                {
+                    "provider_item_id": "1",
+                    "why": "Filed next to something.",
+                    "seed_json": "{not json",
+                }
+            ]
+        )
+        (item,) = index.buffered_candidates()
+        assert item["seed"] == {}
+        assert item["why"] == "Filed next to something."
+
+    def test_a_seed_that_is_not_an_object_reads_as_empty(
+        self, index: LibraryIndex
+    ) -> None:
+        index.buffer_candidates([{"provider_item_id": "1", "seed_json": '"a string"'}])
+        assert index.buffered_candidates()[0]["seed"] == {}
+
+    def test_an_empty_write_touches_nothing(self, index: LibraryIndex) -> None:
+        assert index.buffer_candidates([]) == 0
+
+
+# ---------------------------------------------------------------------------
 # Crate assembly accessors (KAMP-648)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import random
 import sqlite3
+import time as _time
 from collections import Counter
 from pathlib import Path
 from typing import Any, Iterator
@@ -510,6 +511,89 @@ class TestExclusions:
         index.add_discovery_candidate(provider="fake", provider_item_id="1")
         _build(index, _FakeSource(_spread({"a": 12})))
         assert "1" in {r["provider_item_id"] for r in index.crate_items(1)}
+
+
+class TestCandidateBuffer:
+    """KAMP-657 — the surplus a build cannot use is kept for the next one."""
+
+    @staticmethod
+    def _batch(prefix: str, count: int, criterion: str) -> list[Candidate]:
+        """A gather with its own id space.
+
+        `_spread` restarts numbering on every call, so two of them share ids and
+        the second build is really re-offering the first's records. That is the
+        right fixture for the seen-ledger tests above and the wrong one here.
+        """
+        return [_candidate(f"{prefix}{i}", criterion) for i in range(count)]
+
+    def test_the_surplus_is_kept(self, index: LibraryIndex) -> None:
+        _build(index, _FakeSource(_spread({"a": 25})))
+        buffered = {c["provider_item_id"] for c in index.buffered_candidates()}
+        placed = {r["provider_item_id"] for r in index.crate_items(1)}
+        assert len(placed) == CRATE_SIZE
+        assert len(buffered) == 15
+        assert not (buffered & placed), "a placed record must not also be buffered"
+
+    def test_a_thin_gather_is_filled_from_stock(self, index: LibraryIndex) -> None:
+        """The whole point of the buffer. A build cut short by a 429 or an
+        exhausted budget still produces a full crate."""
+        _build(index, _FakeSource(self._batch("a", 25, "a")))  # stocks 15
+        thin = self._batch("b", 1, "b")
+        assert _build(index, _FakeSource(thin))["state"] == "ready"
+
+        second = index.crate_items(2)
+        assert len(second) == CRATE_SIZE
+        # Nine came out of stock, so the crate is not all one criterion.
+        assert {r["criterion"] for r in second} == {"a", "b"}
+
+    def test_stock_is_not_used_when_the_gather_can_fill_the_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        """Fallback, not blend: leftovers must not dilute a healthy build."""
+        _build(index, _FakeSource(self._batch("a", 25, "a")))
+        _build(index, _FakeSource(self._batch("b", 30, "b")))
+        assert {r["criterion"] for r in index.crate_items(2)} == {"b"}
+
+    def test_a_record_in_both_the_gather_and_the_buffer_lands_once(
+        self, index: LibraryIndex
+    ) -> None:
+        """_deal dedupes on id(), so a rehydrated buffer row and a freshly
+        gathered one for the same album are two dealable objects. Left alone, both
+        get picked, the second place_in_crate MOVES the row rather than adding
+        one, and the crate reports ten while holding nine with a hole in it."""
+        overlap = self._batch("a", 25, "a")
+        _build(index, _FakeSource(overlap))  # buffers 15 of these
+
+        _build(index, _FakeSource(overlap))
+        second = index.crate_items(2)
+        assert len(second) == CRATE_SIZE
+        assert [r["position"] for r in second] == list(range(CRATE_SIZE))
+        ids = [r["provider_item_id"] for r in second]
+        assert len(set(ids)) == CRATE_SIZE
+
+    def test_a_short_crate_from_stock_does_not_claim_the_well_is_dry(
+        self, index: LibraryIndex
+    ) -> None:
+        """`exhausted` is attributed against the FRESH gather. Counting stock
+        picks in it would make the inequality trivially easier and tell the user
+        they had seen everything when the buffer was simply too small."""
+        _build(index, _FakeSource(self._batch("a", 12, "a")))  # buffers 2
+        out = _build(index, _FakeSource(self._batch("b", 3, "b")))
+        assert out["short"] is True
+        assert out["exhausted"] is False
+
+    def test_aged_stock_is_swept_before_it_is_offered(
+        self, index: LibraryIndex
+    ) -> None:
+        _build(index, _FakeSource(self._batch("a", 25, "a")))
+        index._conn.execute(
+            "UPDATE discovery_items SET first_seen_at = ? WHERE crate_no IS NULL",
+            (_time.time() - 40 * 86400,),
+        )
+        index._conn.commit()
+
+        _build(index, _FakeSource(self._batch("b", 2, "b")))
+        assert len(index.crate_items(2)) == 2, "swept stock must not be offered"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes KAMP-657. A crate build gathers ~60 candidates and places 10; the other 50 were discarded in memory. Now they're kept, and a build that comes back thin fills its crate from them.

## This was an addition, not a redesign

The storage was built for it and is already pinned by tests — `crate_no IS NULL` as the buffered/shown discriminator, `seen_before` filtering `AND crate_no IS NOT NULL` so a buffered row stays eligible, a *partial* slot-uniqueness index exempting buffered rows, and `discovery_events` as `ON DELETE RESTRICT` rather than CASCADE specifically so this sweep could run. Nine or ten docstrings across four files already described the buffer in the present tense. Nothing wrote a buffered row.

## Two decisions worth stating

**No per-criterion seed re-validation** (your call). The ticket specified a switch that re-checks each buffered candidate's seed against a fresh profile and drops it if the claim went stale. The universal TTL is the freshness mechanism instead. That's the right trade: two of the seven criteria emit *byte-identical* `seed_data` (`favorite_artist` and `lone_album_artist` are both `{kind: artist, artist: name}` — only the `criterion` column tells them apart), so the switch would have needed a parallel hierarchy that the next criterion added would silently forget.

*The honest cost, recorded rather than argued:* `also_like` encodes two time-sensitive claims — `recent` ("which you played recently") and `dormant` ("you have not put it on in a while"). A 30-day TTL means either can be up to a month stale. `dormant`'s threshold is six months so a month is noise; `recent`'s window is 30 days, so a buffered `recent` card can say "recently" about something played two months ago. If that reads badly, shorten the TTL rather than reintroduce the switch.

**Fallback, not blend.** The buffer is consulted only once the fresh pool has had every chance, including its own uncapped backfill. On a healthy build the branch never runs — the gather spends the same requests whether or not stock exists, so mixing leftovers into a crate that didn't need them buys nothing and costs freshness. What the buffer is *for* is the build cut short by a 429, an exhausted budget or picked-over pages. It also satisfies the ticket's "blend, don't drain" in its strongest form: a crate can never be built primarily from leftovers.

## The bug this would have shipped with

The schema comment claimed `RESTRICT` means "the sweep can only delete event-free rows, **which is exactly the buffered ones**" — and then, two lines later, described a buffered row gaining a purchased event. Both can't be true. `attribute_purchases` records that event *ignoring `crate_no` on purpose*, so buffered rows with events exist in any collection the user has bought from.

A `DELETE` leaning on RESTRICT therefore raises `IntegrityError`, and since SQLite rolls back the whole statement, **one purchased buffered row would kill every future sweep** — permanently, because that row never ages out, and silently, because nothing logs it. The pool would grow past its cap unbounded.

Event-bearing rows are now excluded in the `WHERE` clause and RESTRICT is left as the backstop it should have been. The comment is corrected. The test has teeth: with a naive delete the *neighbouring* aged row survives too, because the rollback takes the whole statement.

## Also worth knowing

- **The write is bulk, not per-row.** `add_discovery_candidate` commits per candidate and the library is WAL with `synchronous=FULL`, so each commit is an fsync — KAMP-684 treated *two per five seconds* as a defect. Fifty in a burst is an order of magnitude worse. `buffer_candidates` does one `executemany` with `ON CONFLICT DO NOTHING` and one commit, which also closes the read-then-insert race the single-row path leaves open.
- **Stock is deduped against the gather on `(provider, provider_item_id)`, fresh winning.** `_deal` dedupes on `id()`, so a rehydrated buffer row and a freshly gathered one for the same album are two dealable objects; the second `place_in_crate` would then *move* the row rather than add one, leaving a hole in a crate reporting itself full. `gather` already dedupes on `provider_item_id`, which is exactly why `id()` was safe until now.
- **`exhausted` stays anchored to the fresh gather.** Counting stock picks in it would compare two different sets and tell the user the racks were picked over when the buffer had simply been drained by `in_library`.
- **Surplus is written after the `placed == 0` guard** — that branch means writes are failing, and firing fifty more at a database that just rejected ten is wrong.

Two things left alone deliberately: `add_discovery_candidate` never updates an existing row, so a record buffered under one criterion keeps it if a later gather finds it under another (the stored criterion and `why` agree with each other, which is what the card needs); and `_spread` in the builder tests restarts its id numbering per call, which is right for the seen-ledger tests and wrong for these, hence a local `_batch` helper rather than changing the shared one.

## Verification

3260 passed, 9 skipped, coverage **93.84%**. mypy and black clean. No UI files touched. No README drift.

Thirteen new tests, including the ones the existing suite structurally could not fail: a full crate where the gather re-returns something already buffered (asserting ten items, contiguous positions, no duplicate ids); a thin gather filled from stock; stock *not* used when the gather can fill the crate; a short crate from stock not claiming the well is dry; and the purchased-row sweep case above.

## Manual test plan

- [ ] Dig several crates back to back on a healthy connection. They should feel exactly as before — the buffer must be invisible when it isn't needed
- [ ] Then force the short path (dig repeatedly until rate-limited, or disconnect mid-session) and confirm a crate still fills rather than coming back with three records
- [ ] Check the crate spine and clerk lines on a stock-filled crate read normally — the copy is whatever was true when the record was gathered
- [ ] Watch for a line claiming you played something "recently" that you haven't touched in months. That's the known cost of dropping re-validation and the signal to shorten the TTL
- [ ] Confirm digging doesn't feel slower: the sweep is one indexed delete per build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
