### PR TITLE
KAMP-664: clerk note copy pass — variation, and claims the library can support

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -126,6 +126,16 @@ _INITIAL_STATUS: dict[str, Any] = {
     "thin": False,
 }
 
+#: Criteria that need nothing from the library. A crate made only of these was
+#: built with nothing to go on, which is what `thin` reports (KAMP-664).
+#:
+#: Named here rather than imported, because this module deliberately does not
+#: depend on :mod:`kamp_daemon`. `test_the_unpersonalised_criteria_constant_is
+#: _current` holds the two in agreement from the daemon side, where both are
+#: importable -- so adding a criterion that works from an empty profile fails a
+#: test rather than quietly making the banner wrong.
+UNPERSONALISED_CRITERIA = frozenset({"best_seller"})
+
 
 def sized_art_url(art_url: str, size: int) -> str:
     """Swap the bcbits rendition code in *art_url*, or return it untouched.
@@ -224,6 +234,20 @@ def register_discovery_routes(
             # be the previous crate's.
             snap["filled"] = len(items)
             snap["short"] = bool(items) and len(items) < CRATE_SIZE
+            # `thin` IS re-derived, unlike `exhausted` below, because the rows do
+            # record it: a crate built from an empty profile can only have come
+            # from criteria that need nothing to go on, so an all-chart crate IS
+            # the thin case. Left at its in-memory default it stayed False after a
+            # restart, and the first-run user -- the only one who ever sees this
+            # banner -- lost the explanation permanently by relaunching.
+            #
+            # It is also the truer statement of the two. The banner describes the
+            # crate on screen, and this reads the crate on screen; the profile
+            # flag describes the moment the build started, which may be several
+            # syncs ago by the time anyone reads it.
+            snap["thin"] = bool(items) and all(
+                item.get("criterion") in UNPERSONALISED_CRITERIA for item in items
+            )
             # `exhausted` is deliberately NOT re-derived alongside these. Nothing
             # on disk records why a build stopped, so it could only be guessed at
             # here -- and guessing "you have seen everything" about a restored

--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -4935,15 +4935,39 @@ class LibraryIndex:
         seed_json: str = "{}",
         first_seen_at: float | None = None,
     ) -> int:
-        """Insert a *buffered* candidate (crate_no NULL) and return its row id.
+        """Insert or refresh a *buffered* candidate (crate_no NULL); returns its id.
 
         Idempotent on (provider, provider_item_id): re-gathering an album we have
         already seen or buffered returns the existing row rather than raising, and
         never resurrects it into a new crate. Promotion into a crate is a separate,
         explicit step (KAMP-648).
+
+        Idempotent on identity, NOT on provenance (KAMP-664): an existing row has
+        its `criterion`, `why` and `seed_json` refreshed, because those describe
+        why we are offering it *now* and the stored ones may be weeks old. `art_url`
+        is the deliberate exception — see the UPDATE below.
         """
         existing = self.discovery_item_id(provider, provider_item_id)
         if existing is not None:
+            # Refresh the provenance, do not just hand the id back (KAMP-664).
+            #
+            # A record the gather re-finds may already be sitting in the KAMP-657
+            # buffer from weeks ago, and the row's stored `why` was written then --
+            # naming an album that is no longer recent, or an artist no longer
+            # favourited. Returning early made the crate show that stale sentence
+            # and silently discard the one computed against the current profile,
+            # which is the exact failure the clerk note exists not to have.
+            #
+            # `art_url` is deliberately NOT refreshed: discovery_api grants the art
+            # proxy `immutable` cache-control precisely because this column never
+            # changes, and updating it would make a year-long cache header a lie.
+            self._conn.execute(
+                "UPDATE discovery_items"
+                "   SET criterion = ?, why = ?, seed_json = ?"
+                " WHERE id = ?",
+                (criterion, why, seed_json, existing),
+            )
+            self._conn.commit()
             return existing
         cur = self._conn.execute(
             "INSERT INTO discovery_items"

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -134,9 +134,14 @@ class Candidate:
 
     ``why`` is the human sentence the clerk card shows, and ``seed`` is the structured
     attribution behind it. Both are required for a pick to be shown: the feature's
-    promise is that every recommendation explains itself, and KAMP-657 re-validates
-    ``seed`` before showing a buffered candidate so the explanation is still true at
-    the moment it is read.
+    promise is that every recommendation explains itself.
+
+    A buffered candidate's ``seed`` is NOT re-validated against the current profile
+    before it is dealt. That was considered for KAMP-657 and deliberately dropped:
+    the seed says what was true when the record was found, which is a fact about
+    provenance and does not expire, and re-checking it would mean discarding stock
+    for having been gathered on a Tuesday. ``why`` can be restated at build time
+    (KAMP-664), which is a separate thing — a rephrasing, not a re-derivation.
     """
 
     provider: str
@@ -201,10 +206,13 @@ class SeedProfile:
     implementation detail.
 
     The qualifying sets are deliberately exposed as plain data rather than being
-    consumed internally and discarded. KAMP-657 re-validates a buffered candidate's
-    seed before showing it (taste drifts; "because you've been on a dub techno kick
-    lately" stops being true), and that check must be a membership lookup rather than
-    a re-derivation of the whole profile.
+    consumed internally and discarded: the selectors read them directly, several of
+    them more than once, and a membership test is what most of them actually want.
+
+    They are NOT a re-validation hook for buffered stock. That reading was written
+    into this docstring and was never true — nothing re-checks a buffered
+    candidate's seed before dealing it, by design (see ``Candidate``). The
+    predicates that existed only to serve the claim are gone with it (KAMP-664).
     """
 
     recent_album_ids: set[int] = field(default_factory=set)
@@ -243,15 +251,6 @@ class SeedProfile:
             or self.top_artists
             or self.top_genres
         )
-
-    def has_genre(self, name: str) -> bool:
-        return name.casefold() in {g.casefold() for g in self.top_genres}
-
-    def has_artist(self, name: str) -> bool:
-        return name.casefold() in {a.casefold() for a in self.top_artists}
-
-    def has_label(self, name: str) -> bool:
-        return name.casefold() in {label.casefold() for label in self.labels}
 
 
 def build_seed_profile(

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -23,6 +23,7 @@ import json
 import logging
 import random
 import time
+from collections import Counter
 from typing import TYPE_CHECKING, Any, Callable, Protocol, Sequence
 
 from .discovery import (
@@ -36,7 +37,7 @@ from .discovery import (
     build_seed_profile,
     crate_budget,
 )
-from .discovery_criteria import seed_dimension
+from .discovery_criteria import phrasings, seed_dimension
 
 if TYPE_CHECKING:  # pragma: no cover - types only
     from kamp_core.library import LibraryIndex
@@ -212,6 +213,8 @@ def build_crate(
         candidates, index=index, picked=fresh_picked
     )
 
+    _vary_notes(picks)
+
     if not picks:
         # Do not burn a crate number on nothing. An empty crate is a distinct
         # state from a short one -- the UI offers a retry rather than a tally.
@@ -288,6 +291,37 @@ def build_crate(
         short=short,
         exhausted=exhausted,
     )
+
+
+def _vary_notes(picks: "Sequence[Candidate]") -> None:
+    """Give repeated clerk notes an alternative phrasing, in place (KAMP-664).
+
+    One seed's sentence rides every candidate that seed produced, and the seed cap
+    is a preference rather than a ceiling, so a crate can arrive with the same
+    line ten times over. Walking the picks and restating the repeats is the only
+    place this can happen: the sentence is chosen per seed, and whether it repeats
+    is a fact about the crate, which nothing upstream can see.
+
+    **A note is never blanked.** Where the alternatives run out the line repeats,
+    because every pick explaining itself is the promise the feature rests on and a
+    silent card breaks it far worse than a dull one does.
+
+    Runs before persistence so the stored sentence is the one shown. Surplus keeps
+    its original — a variant is a fact about one crate's composition and means
+    nothing to a row sitting in the buffer.
+
+    One consequence worth naming: after this, `why` and `seed_json` no longer
+    determine each other, so anything that re-renders from the seed will not
+    reproduce the stored sentence.
+    """
+    used: Counter[str] = Counter()
+    for candidate in picks:
+        # Least-used wins rather than first-unused: with ten cards off one seed,
+        # first-unused spends each alternative once and then falls back to the
+        # original for the rest, which is barely better than not varying at all.
+        options = [candidate.why, *phrasings(candidate.criterion, candidate.seed)]
+        candidate.why = min(options, key=lambda text: (used[text], options.index(text)))
+        used[candidate.why] += 1
 
 
 def _rehydrate(rows: "Sequence[dict[str, Any]]") -> list[Candidate]:

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -140,11 +140,11 @@ def _also_like_seeds(profile: SeedProfile) -> Iterable[Seed]:
             and now - seed_album.last_played_at >= _DORMANT_SECS
         )
         if recent:
-            why = f"Filed next to {seed_album.album}, which you played recently."
+            why = f"You played {seed_album.album} recently, try this one."
         elif dormant:
-            why = f"You have not put {seed_album.album} on in a while — this sits beside it."
+            why = f"You listened to {seed_album.album} a while ago — give this one a shot."
         else:
-            why = f"You favourited {seed_album.album} — this sits beside it."
+            why = f"You favourited {seed_album.album} — you might like this too."
         yield Seed(
             target=seed_album.album_url,
             why=why,
@@ -238,7 +238,7 @@ def _old_album_seeds(profile: SeedProfile) -> Iterable[Seed]:
     for rank, genre in enumerate(profile.top_genres[:3]):
         yield Seed(
             target={"tag": genre, "slice": "rand", "size": 60},
-            why=f"An older {genre} record — the kind that turns up at the back.",
+            why=f"A hidden {genre} gem? Who knows, could be good.",
             seed_data={"kind": "genre_old", "genre": genre, "rank": rank},
         )
 
@@ -289,7 +289,7 @@ def _purchase_anniversary_seeds(profile: SeedProfile) -> Iterable[Seed]:
     for seed_album in profile.anniversary_albums:
         yield Seed(
             target=seed_album.album_url,
-            why=f"You bought {seed_album.album} about a year ago.",
+            why=f"You bought {seed_album.album} about a year ago. This one's pretty similar.",
             seed_data={
                 "kind": "album",
                 "album_id": seed_album.album_id,
@@ -316,7 +316,7 @@ def _lone_album_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
             continue
         yield Seed(
             target=artist.artist_page,
-            why=f"You play {artist.name} a lot and have just the one here.",
+            why=f"You play {artist.name} a lot, but you've just got the one. Try another.",
             seed_data={"kind": "artist", "artist": artist.name},
         )
 
@@ -386,7 +386,7 @@ def _genre_shelf(seed: dict[str, Any]) -> str:
 
 _VARIANTS: dict[str, list[Callable[[dict[str, Any]], str]]] = {
     "also_like": [
-        lambda s: f"Also in the racks beside {_album_of(s)}.",
+        lambda s: f"If you liked {_album_of(s)}, you'll probably like this too.",
         lambda s: f"{_album_of(s)} led here.",
         lambda s: f"One more from the same corner as {_album_of(s)}.",
     ],
@@ -397,8 +397,8 @@ _VARIANTS: dict[str, list[Callable[[dict[str, Any]], str]]] = {
         lambda s: "One of the week's best sellers.",
     ],
     "older_than_ten": [
-        lambda s: f"An older {_genre_of(s)} record from the back of the rack.",
-        lambda s: f"Been in the {_genre_of(s)} racks a good while.",
+        lambda s: f"Here's an odd {_genre_of(s)} record from the back of the rack.",
+        lambda s: f"Give this older {_genre_of(s)} record a shot.",
     ],
     "favorite_artist": [
         lambda s: f"Another from {_artist_of(s)}.",
@@ -409,8 +409,8 @@ _VARIANTS: dict[str, list[Callable[[dict[str, Any]], str]]] = {
         lambda s: f"You have just the one {_artist_of(s)} here — this would be two.",
     ],
     "purchase_anniversary": [
-        lambda s: f"Around a year since you picked up {_album_of(s)}.",
-        lambda s: f"Filed near {_album_of(s)}, bought about this time last year.",
+        lambda s: f"Around a year since you picked up {_album_of(s)}. Try this one too.",
+        lambda s: f"Similar to {_album_of(s)}, bought about this time last year.",
     ],
 }
 

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -321,6 +321,110 @@ def _lone_album_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
         )
 
 
+# ---------------------------------------------------------------------------
+# Alternate phrasings (KAMP-664)
+# ---------------------------------------------------------------------------
+#
+# One seed's sentence is copied onto every candidate that seed produces, and the
+# seed cap is a preference rather than a ceiling — the two backfill deals drop it
+# so a thin gather still returns ten records. Measured, that means a first-run
+# crate is ten cards reading "Selling fast on Bandcamp right now." and a crate
+# built off one album page is nine identical lines.
+#
+# These give the builder somewhere else to go. They are a polish item, not a
+# guarantee: where the alternatives run out the line simply repeats, because a
+# card with NO rationale breaks the promise the whole feature rests on, and a
+# strained ninth phrasing of "selling fast" would be a worse failure than an
+# honest repeat.
+#
+# Kept beside the selectors so a criterion's copy lives in one place. Each takes
+# the stored seed rather than the profile, so a candidate promoted out of the
+# KAMP-657 buffer can be restated from what was written down with it — and every
+# reader tolerates a missing key, because older buffered rows predate them.
+
+
+def _album_of(seed: dict[str, Any]) -> str:
+    return str(seed.get("album") or "it")
+
+
+def _artist_of(seed: dict[str, Any]) -> str:
+    return str(seed.get("artist") or "them")
+
+
+def _genre_of(seed: dict[str, Any]) -> str:
+    return str(seed.get("genre") or "that")
+
+
+def _genre_pile(seed: dict[str, Any]) -> str:
+    """A genre pick's alternative, which has to respect the slice it came from.
+
+    ``genre_top`` seeds two branches per genre: ``top`` is Bandcamp's sales
+    ordering for the tag, ``rand`` is an arbitrary reach into the same catalogue.
+    A restated line that claimed sales rank for a ``rand`` pick would be an
+    invented claim of exactly the kind this ticket removes, so the slice picks the
+    sentence. Seeds written before KAMP-664 carry no ``slice``; they take the
+    neutral line, which is true either way.
+    """
+    genre = _genre_of(seed)
+    if seed.get("slice") == "top":
+        return f"Near the top of the {genre} pile."
+    return f"Another one out of the {genre} racks."
+
+
+def _genre_shelf(seed: dict[str, Any]) -> str:
+    """A second genre alternative, sized down to the claim any rank can carry.
+
+    "which you keep some of" is the weakest thing ``_shelf_standing`` says, and it
+    is true of every tag in ``top_genres`` — so it needs no rank and stays honest
+    for the twenty-fifth genre as well as the first.
+    """
+    genre = _genre_of(seed)
+    if seed.get("slice") == "top":
+        return f"Selling well under {genre}, which you keep some of."
+    return f"Filed under {genre}, which you keep some of."
+
+
+_VARIANTS: dict[str, list[Callable[[dict[str, Any]], str]]] = {
+    "also_like": [
+        lambda s: f"Also in the racks beside {_album_of(s)}.",
+        lambda s: f"{_album_of(s)} led here.",
+        lambda s: f"One more from the same corner as {_album_of(s)}.",
+    ],
+    "genre_top": [_genre_pile, _genre_shelf],
+    "best_seller": [
+        lambda s: "Near the top of Bandcamp's sellers.",
+        lambda s: "Moving quickly on Bandcamp today.",
+        lambda s: "One of the week's best sellers.",
+    ],
+    "older_than_ten": [
+        lambda s: f"An older {_genre_of(s)} record from the back of the rack.",
+        lambda s: f"Been in the {_genre_of(s)} racks a good while.",
+    ],
+    "favorite_artist": [
+        lambda s: f"Another from {_artist_of(s)}.",
+        lambda s: f"More of {_artist_of(s)}, since you have them already.",
+    ],
+    "lone_album_artist": [
+        lambda s: f"A second one from {_artist_of(s)}.",
+        lambda s: f"You have just the one {_artist_of(s)} here — this would be two.",
+    ],
+    "purchase_anniversary": [
+        lambda s: f"Around a year since you picked up {_album_of(s)}.",
+        lambda s: f"Filed near {_album_of(s)}, bought about this time last year.",
+    ],
+}
+
+
+def phrasings(criterion: str, seed: dict[str, Any]) -> list[str]:
+    """Alternative sentences for *criterion*, rendered from a stored seed.
+
+    Alternatives only — the seed's own sentence is not in here, because the
+    caller already has it and it is the one that reads best. An unknown criterion
+    returns nothing, which simply means its line repeats rather than varying.
+    """
+    return [render(seed) for render in _VARIANTS.get(criterion, ())]
+
+
 REGISTRY: tuple[Criterion, ...] = (
     Criterion(
         key="also_like",

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -173,17 +173,43 @@ def _genre_top_seeds(profile: SeedProfile) -> Iterable[Seed]:
     cycles them for free: no slice-picking logic anywhere, and the copy stays
     honest because each variant carries its own ``why``.
     """
-    for genre in profile.top_genres:
+    for rank, genre in enumerate(profile.top_genres):
+        shelf = _shelf_standing(genre, rank)
         yield Seed(
             target={"tag": genre, "slice": "top"},
-            why=f"You've been deep in {genre} lately; this is near the top of the pile.",
-            seed_data={"kind": "genre", "genre": genre},
+            why=f"{shelf} This one is near the top of the {genre} pile.",
+            # `slice` and `rank` are recorded so a stored seed can say which of
+            # these two sentences produced it and how strong a claim it may make
+            # (KAMP-664). Without them the two branches are indistinguishable
+            # after the fact, exactly as `recent`/`dormant` prevent for albums.
+            seed_data={"kind": "genre", "genre": genre, "slice": "top", "rank": rank},
         )
         yield Seed(
             target={"tag": genre, "slice": "rand"},
             why=f"Pulled at random from the {genre} racks.",
-            seed_data={"kind": "genre", "genre": genre},
+            seed_data={"kind": "genre", "genre": genre, "slice": "rand", "rank": rank},
         )
+
+
+def _shelf_standing(genre: str, rank: int) -> str:
+    """How firmly the library lets us claim this genre, given its rank.
+
+    A claim about the SHELF, never about listening (KAMP-664). ``taste_genres``
+    counts tag rows and Bandcamp keywords — it has no play signal at all and no
+    time filter of any kind — so "you've been deep in X lately" was two invented
+    claims in one sentence: the recency and the listening. What the data actually
+    supports is how much of the collection carries the tag, and rank is a free,
+    honest proxy for that.
+
+    Rank is the profile's own ordering rather than a share, which would need a
+    denominator ``taste_genres`` cannot give: its count mixes per-track tag rows
+    with per-album keyword hits, so there is no population to divide by.
+    """
+    if rank == 0:
+        return f"{genre.capitalize()} takes up more of your shelves than anything else."
+    if rank < 5:
+        return f"You have a good stack of {genre} already."
+    return f"There is some {genre} on your shelves."
 
 
 def _best_seller_seeds(profile: SeedProfile) -> Iterable[Seed]:
@@ -209,11 +235,11 @@ def _old_album_seeds(profile: SeedProfile) -> Iterable[Seed]:
     current year, so only the random slice reaches back. The age filter is
     applied client-side on ``release_date``.
     """
-    for genre in profile.top_genres[:3]:
+    for rank, genre in enumerate(profile.top_genres[:3]):
         yield Seed(
             target={"tag": genre, "slice": "rand", "size": 60},
             why=f"An older {genre} record — the kind that turns up at the back.",
-            seed_data={"kind": "genre_old", "genre": genre},
+            seed_data={"kind": "genre_old", "genre": genre, "rank": rank},
         )
 
 
@@ -236,7 +262,11 @@ def _favorite_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
         yield Seed(
             target=artist.artist_page,
             why=f"Another one from {artist.name}, who you already know you like.",
-            seed_data={"kind": "artist", "artist": artist.name},
+            # `starred` distinguishes the two branches after the fact (KAMP-664).
+            # Both emitted {kind, artist} and differed only in prose, so a stored
+            # seed could not say which claim it had made — and the two claims are
+            # different acts: starring a record and playing it are not the same.
+            seed_data={"kind": "artist", "artist": artist.name, "starred": True},
         )
     for artist in profile.played_artists:
         if artist.name.casefold() in seen:
@@ -245,7 +275,7 @@ def _favorite_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
         yield Seed(
             target=artist.artist_page,
             why=f"You keep going back to {artist.name}. Here is another of theirs.",
-            seed_data={"kind": "artist", "artist": artist.name},
+            seed_data={"kind": "artist", "artist": artist.name, "starred": False},
         )
 
 

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -627,6 +627,24 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
          only some of the time. A real rate limit has its own banner above, with
          a countdown. */
     }
+    {
+      /* Thin outranks both of the lines below (KAMP-664). A first crate is
+         routinely thin AND short, and it used to say only "Short crate today",
+         which describes the symptom and hides the cause; the user is left
+         thinking the shop is broken rather than that we have nothing to go on
+         yet. It outranks "everything in these racks" for the same reason — the
+         racks are not empty for a new user, our knowledge of them is.
+
+         All three now gate on `ready` alike. The thin line used to render on any
+         state with rows on screen, so it also sat over a crate that was already
+         rebuilding from a profile that had since filled out. */
+    }
+    if (state === 'ready' && crate?.thin && hasCrate)
+      return (
+        <div className="crate-banner" role="status">
+          Nothing on your shelves to go on yet, so this one is what&rsquo;s selling.
+        </div>
+      )
     if (state === 'ready' && crate?.exhausted)
       return (
         <div className="crate-banner" role="status">
@@ -637,12 +655,6 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       return (
         <div className="crate-banner" role="status">
           Short crate today — we couldn&rsquo;t fill it.
-        </div>
-      )
-    if (crate?.thin && hasCrate)
-      return (
-        <div className="crate-banner" role="status">
-          Nothing on your shelves to go on yet, so this one is what&rsquo;s selling.
         </div>
       )
     return null

--- a/kamp_ui/src/renderer/src/tooltipStrings.ts
+++ b/kamp_ui/src/renderer/src/tooltipStrings.ts
@@ -49,7 +49,11 @@ export const TOOLTIPS = {
 
   // Crate (KAMP-650). The clerk card's tooltip is the plain mechanical
   // answer to "why am I seeing this?" — the shelf tag is the short version.
-  CRATE_WHY: 'Picked from your own library and listening — nothing leaves this machine',
+  // "and listening" was wrong for a genre pick (taste_genres has no play signal
+  // at all) and wrong twice over for a chart pick, which reads nothing about you.
+  // "Chosen here" is the claim that holds for every card: the picking happens on
+  // this machine whatever it was based on, which is the part worth promising.
+  CRATE_WHY: 'Chosen here from what is on your shelves — nothing leaves this machine',
   // Names Bandcamp explicitly: this writes to the account, not to anything local.
   CRATE_WISHLIST: 'Add to your Bandcamp wishlist (W)',
   CRATE_UNWISHLIST: 'Remove from your Bandcamp wishlist (W)',

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1095,6 +1095,59 @@ class TestCandidateBuffer:
     def test_an_empty_write_touches_nothing(self, index: LibraryIndex) -> None:
         assert index.buffer_candidates([]) == 0
 
+    def test_re_finding_a_buffered_record_refreshes_its_reason(
+        self, index: LibraryIndex
+    ) -> None:
+        """KAMP-664. A record can sit in the buffer for weeks, and the sentence
+        stored with it named the profile as it was THEN. When a later gather finds
+        it again the fresh reason must win, or the card explains itself with a
+        claim that is no longer true."""
+        index.buffer_candidates(
+            [
+                {
+                    "provider_item_id": "1",
+                    "criterion": "also_like",
+                    "why": "Filed next to DOGGOD, which you played recently.",
+                    "seed_json": '{"kind": "album", "album_id": 7}',
+                    "art_url": "https://f4.bcbits.com/img/old_16.jpg",
+                }
+            ]
+        )
+
+        index.add_discovery_candidate(
+            provider="bandcamp",
+            provider_item_id="1",
+            criterion="genre_top",
+            why="Near the top of the ambient pile.",
+            seed_json='{"kind": "genre", "genre": "ambient"}',
+            art_url="https://f4.bcbits.com/img/new_16.jpg",
+        )
+
+        (row,) = index.buffered_candidates()
+        assert row["why"] == "Near the top of the ambient pile."
+        assert row["criterion"] == "genre_top"
+        assert row["seed"] == {"kind": "genre", "genre": "ambient"}
+        # Not refreshed on purpose: the art proxy serves this immutable, so a
+        # changing URL would make a year-long cache header a lie.
+        assert row["art_url"] == "https://f4.bcbits.com/img/old_16.jpg"
+
+    def test_refreshing_provenance_does_not_resurrect_a_shown_record(
+        self, index: LibraryIndex
+    ) -> None:
+        """The refresh must not touch crate_no — a record already shown stays
+        shown, and stays out of the buffer."""
+        shown = index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", why="first"
+        )
+        index.place_in_crate(shown, 1, 0)
+
+        index.add_discovery_candidate(
+            provider="bandcamp", provider_item_id="1", why="second"
+        )
+        assert index.buffered_candidates() == []
+        assert index.seen_before("bandcamp", "1") is True
+        assert index.crate_items(1)[0]["why"] == "second"
+
     # -- the sweep --
 
     def test_aged_buffered_rows_are_swept(self, index: LibraryIndex) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1636,7 +1636,7 @@ class TestSeedProfile:
         profile = build_seed_profile(index)
         assert recent_id in profile.recent_album_ids
         assert fav_id in profile.favorite_album_ids
-        assert profile.has_genre("Shoegaze") is True
+        assert "shoegaze" in profile.top_genres
         assert profile.purchase_dates["900"] == pytest.approx(now)
         assert profile.is_thin is False
 
@@ -1681,16 +1681,6 @@ class TestSeedProfile:
             album_url="https://music.example.com/album/record",
         )
         assert index.favorite_artists_with_pages() == []
-
-    def test_membership_helpers_are_case_insensitive(self) -> None:
-        """KAMP-657 re-validates seeds through these, so casing must not matter."""
-        profile = SeedProfile(
-            top_genres=["Dub Techno"], top_artists=["Four Tet"], labels=["Ghostly"]
-        )
-        assert profile.has_genre("dub techno") is True
-        assert profile.has_artist("FOUR TET") is True
-        assert profile.has_label("ghostly") is True
-        assert profile.has_genre("noise") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -91,14 +91,19 @@ def art_dir(tmp_path: Path) -> Path:
     return tmp_path / "art_cache"
 
 
-def _stock(index: LibraryIndex, crate_no: int, count: int = 3) -> None:
+def _stock(
+    index: LibraryIndex,
+    crate_no: int,
+    count: int = 3,
+    criterion: str = "also_like",
+) -> None:
     for position in range(count):
         item = index.add_discovery_candidate(
             provider="bandcamp",
             provider_item_id=f"{crate_no}-{position}",
             artist=f"Artist {position}",
             title=f"Title {position}",
-            criterion="also_like",
+            criterion=criterion,
             why="because",
             seed_json='{"kind": "album"}',
         )
@@ -189,6 +194,44 @@ class TestCrateSnapshot:
         body = harness.client.get("/api/v1/discovery/crate").json()
         assert body["short"] is True
         assert body["exhausted"] is False
+
+    def test_a_restored_first_run_crate_still_says_it_was_unpersonalised(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """KAMP-664. `thin` lived only in memory, so the one user who ever sees
+        that banner -- someone whose library we know nothing about -- lost the
+        explanation the first time they relaunched, and the crate then read as
+        just a short one with no reason given."""
+        _stock(index, 1, count=10, criterion="best_seller")
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["state"] == "idle"
+        assert body["thin"] is True
+
+    def test_a_restored_ordinary_crate_is_not_called_thin(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The derivation has to be able to say no. One chart pick in a crate of
+        library-driven ones is normal padding, not a first run."""
+        _stock(index, 1, count=9)
+        item = index.add_discovery_candidate(
+            provider="bandcamp",
+            provider_item_id="1-chart",
+            artist="Artist",
+            title="Title",
+            criterion="best_seller",
+            why="because",
+            seed_json='{"kind": "chart"}',
+        )
+        index.place_in_crate(item, 1, 9)
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["thin"] is False
+
+    def test_an_empty_crate_is_not_thin(self, harness: _Harness) -> None:
+        """`all()` over nothing is True, which would have put the first-run banner
+        on the empty state before a user had ever dug a crate."""
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["items"] == []
+        assert body["thin"] is False
 
     def test_a_live_build_keeps_its_own_progress(
         self, index: LibraryIndex, harness: _Harness

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -48,7 +48,9 @@ def _candidate(item_id: str, criterion: str = "also_like", **kw: Any) -> Candida
         artist=kw.pop("artist", f"Artist {item_id}"),
         title=kw.pop("title", f"Title {item_id}"),
         criterion=criterion,
-        why=f"because {criterion}",
+        # Overridable so a test can hand every candidate the *same* sentence and
+        # watch what KAMP-664 does with it.
+        why=kw.pop("why", f"because {criterion}"),
         # Overridable, because KAMP-665 made the seed something the builder reads
         # rather than provenance it only stores.
         seed=kw.pop("seed", {"kind": criterion}),
@@ -511,6 +513,65 @@ class TestExclusions:
         index.add_discovery_candidate(provider="fake", provider_item_id="1")
         _build(index, _FakeSource(_spread({"a": 12})))
         assert "1" in {r["provider_item_id"] for r in index.crate_items(1)}
+
+
+class TestClerkNotes:
+    """KAMP-664 — every card explains itself, and a crate does not read as one
+    sentence ten times over."""
+
+    @staticmethod
+    def _one_seed(criterion: str, why: str, seed: dict[str, Any], n: int = 25):
+        return [
+            _candidate(f"{criterion}{i}", criterion, why=why, seed=seed)
+            for i in range(n)
+        ]
+
+    def test_every_card_keeps_a_note(self, index: LibraryIndex) -> None:
+        """The assertion that matters. A repeated line is dull; a blank one breaks
+        the promise the whole feature rests on, so variation must never be bought
+        by dropping the note."""
+        _build(index, _FakeSource(_spread({"a": 8, "b": 8, "c": 8})))
+        assert all(r["why"].strip() for r in index.crate_items(1))
+
+    def test_a_crate_off_one_seed_does_not_read_as_one_sentence(
+        self, index: LibraryIndex
+    ) -> None:
+        """Measured before the fix: nine of ten cards identical. The seed cap is a
+        preference, not a ceiling — both backfill deals drop it so a thin gather
+        still returns ten records — so one seed really can supply almost a crate."""
+        cands = self._one_seed(
+            "also_like",
+            "Filed next to DOGGOD, which you played recently.",
+            {"kind": "album", "album_id": 7, "album": "DOGGOD"},
+        )
+        _build(index, _FakeSource(cands))
+        whys = [r["why"] for r in index.crate_items(1)]
+
+        assert all(w.strip() for w in whys)
+        assert max(Counter(whys).values()) < 9, Counter(whys)
+        assert len(set(whys)) > 1
+
+    def test_a_first_run_crate_does_not_read_as_one_sentence(
+        self, index: LibraryIndex
+    ) -> None:
+        """The thin case, and the worst one measured: ten of ten identical, on the
+        very first crate a new user sees."""
+        cands = self._one_seed(
+            "best_seller", "Selling fast on Bandcamp right now.", {"kind": "chart"}
+        )
+        _build(index, _FakeSource(cands), profile=SeedProfile())
+        whys = [r["why"] for r in index.crate_items(1)]
+
+        assert all(w.strip() for w in whys)
+        assert max(Counter(whys).values()) < 10, Counter(whys)
+
+    def test_a_varied_crate_is_left_alone(self, index: LibraryIndex) -> None:
+        """Nothing to restate, so nothing is restated — the seed's own sentence is
+        the one that reads best and stays first choice."""
+        cands = _spread({"a": 4, "b": 4, "c": 4})
+        _build(index, _FakeSource(cands))
+        whys = {r["why"] for r in index.crate_items(1)}
+        assert whys <= {c.why for c in cands}
 
 
 class TestCandidateBuffer:

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -222,6 +222,31 @@ class TestCriteriaRegistry:
         # half the criteria produced nothing, which is the opposite of its job.
         assert len(criteria_for(RICH_PROFILE)) >= 6
 
+    def test_no_genre_line_claims_listening_or_recency(self) -> None:
+        """KAMP-664. taste_genres counts tag rows and Bandcamp keywords — it has
+        no play signal and no time filter — so a genre line may talk about the
+        shelf and nothing else. "You've been deep in Rock lately" was two
+        invented claims in one sentence."""
+        banned = ("lately", "recently", "you listen", "you've been", "you have been")
+        for key in ("genre_top", "older_than_ten"):
+            criterion = next(c for c in REGISTRY if c.key == key)
+            for seed in criterion.seeds(RICH_PROFILE):
+                low = seed.why.casefold()
+                for phrase in banned:
+                    assert phrase not in low, f"{key} claims '{phrase}': {seed.why}"
+
+    def test_the_top_genre_makes_a_stronger_claim_than_the_tail(self) -> None:
+        """Rank is the honest stand-in for dominance: a share would need a
+        denominator taste_genres cannot give, since its count mixes per-track tag
+        rows with per-album keyword hits."""
+        profile = replace(
+            RICH_PROFILE, top_genres=["ambient"] + [f"g{i}" for i in range(9)]
+        )
+        genre_top = next(c for c in REGISTRY if c.key == "genre_top")
+        by_rank = {s.seed_data["rank"]: s for s in genre_top.seeds(profile)}
+        assert by_rank[0].seed_data["genre"] == "ambient"
+        assert by_rank[0].why != by_rank[9].why
+
     def test_the_lone_album_criterion_skips_artists_you_own_several_by(self) -> None:
         """The claim is about a gap on the shelf, so an artist with four albums
         in the collection must not produce "you have just the one here"."""
@@ -230,13 +255,18 @@ class TestCriteriaRegistry:
         assert names == {"Loraine James"}
 
     def test_the_artist_criterion_falls_through_to_what_you_play(self) -> None:
-        """Favourites first, then artists merely played a lot — and the two say
-        different things, because starring and playing are different acts."""
+        """Favourites first, then artists merely played a lot — and the two make
+        different claims, because starring and playing are different acts.
+
+        Asserted on the `starred` discriminator and the distinctness of the two
+        sentences, not on their wording (KAMP-664). Pinning prose here made every
+        copy pass a test change, and the thing that must hold is that the claims
+        stay distinguishable, not that they use particular words."""
         fav = next(c for c in REGISTRY if c.key == "favorite_artist")
-        seeds = list(fav.seeds(RICH_PROFILE))
-        whys = {s.seed_data["artist"]: s.why for s in seeds}
-        assert "already know you like" in whys["Four Tet"]
-        assert "keep going back to" in whys["Loraine James"]
+        seeds = {s.seed_data["artist"]: s for s in fav.seeds(RICH_PROFILE)}
+        assert seeds["Four Tet"].seed_data["starred"] is True
+        assert seeds["Loraine James"].seed_data["starred"] is False
+        assert seeds["Four Tet"].why != seeds["Loraine James"].why
 
     def test_a_favourite_is_not_offered_twice_by_the_fall_through(self) -> None:
         """Four Tet is in both lists; the artist page must be seeded once."""
@@ -258,8 +288,11 @@ class TestCriteriaRegistry:
         """The clerk card must not claim you played something you only starred."""
         recent = SeedProfile(recent_album_ids={1}, recent_albums=[_album_seed(1)])
         fav = SeedProfile(favorite_albums=[_album_seed(2)])
-        assert "recently" in list(REGISTRY[0].seeds(recent))[0].why
-        assert "favourited" in list(REGISTRY[0].seeds(fav))[0].why
+        recent_seed = list(REGISTRY[0].seeds(recent))[0]
+        fav_seed = list(REGISTRY[0].seeds(fav))[0]
+        assert recent_seed.seed_data["recent"] is True
+        assert fav_seed.seed_data["recent"] is False
+        assert recent_seed.why != fav_seed.why
 
     def test_a_favourite_gone_quiet_gets_its_own_line(self) -> None:
         """KAMP-658's "clerk remembers". Folded into also_like rather than made a
@@ -269,22 +302,22 @@ class TestCriteriaRegistry:
 
         stale = _album_seed(3, last_played_at=_t.time() - 200 * 86400)
         seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[stale])))
-        assert "not put" in seeds[0].why
         assert seeds[0].seed_data["dormant"] is True
+        # Distinct from the plain-favourite line, without pinning either wording.
+        plain = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[_album_seed(3)])))
+        assert seeds[0].why != plain[0].why
 
     def test_a_favourite_played_last_month_is_not_called_dormant(self) -> None:
         import time as _t
 
         warm = _album_seed(4, last_played_at=_t.time() - 30 * 86400)
         seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[warm])))
-        assert "favourited" in seeds[0].why
         assert seeds[0].seed_data["dormant"] is False
 
     def test_a_favourite_never_played_is_not_called_dormant(self) -> None:
         """ "You have not put it on in a while" is false for a record that has
         never been on. Never-played reads as an ordinary favourite."""
         seeds = list(REGISTRY[0].seeds(SeedProfile(favorite_albums=[_album_seed(5)])))
-        assert "favourited" in seeds[0].why
         assert seeds[0].seed_data["dormant"] is False
 
 

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -34,6 +34,7 @@ from kamp_daemon.discovery_criteria import (
     Seed,
     _genre_top_seeds,
     criteria_for,
+    phrasings,
     seed_dimension,
 )
 from kamp_daemon.discovery_sources import (
@@ -202,6 +203,30 @@ class TestCriteriaRegistry:
             assert seed.target
 
     @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_alternative_phrasings_are_usable_and_distinct(
+        self, criterion: Criterion
+    ) -> None:
+        """KAMP-664. A variant that renders blank is worse than the repeat it
+        replaces, and one that renders the sentence it is standing in for buys
+        nothing -- so every criterion's alternatives must be sayable and pairwise
+        different from each other and from the original."""
+        for seed in criterion.seeds(RICH_PROFILE):
+            lines = [seed.why, *phrasings(criterion.key, seed.seed_data)]
+            assert all(line.strip() for line in lines), criterion.key
+            assert len(set(lines)) == len(lines), (criterion.key, lines)
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_phrasings_tolerate_a_seed_from_an_older_build(
+        self, criterion: Criterion
+    ) -> None:
+        """Rows sitting in the KAMP-657 buffer were written before the
+        discriminators existed, and their seeds outlive any one release. A variant
+        that needs a key the stored seed lacks must degrade to a sentence, not to a
+        KeyError on the crate build."""
+        for line in phrasings(criterion.key, {"kind": criterion.key}):
+            assert line.strip()
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
     def test_thin_profile_never_raises(self, criterion: Criterion) -> None:
         """A brand-new library is the common first run, not an edge case."""
         list(criterion.seeds(SeedProfile()))
@@ -231,9 +256,13 @@ class TestCriteriaRegistry:
         for key in ("genre_top", "older_than_ten"):
             criterion = next(c for c in REGISTRY if c.key == key)
             for seed in criterion.seeds(RICH_PROFILE):
-                low = seed.why.casefold()
-                for phrase in banned:
-                    assert phrase not in low, f"{key} claims '{phrase}': {seed.why}"
+                # The alternatives are held to the same rule as the sentence they
+                # stand in for. A variant is still a claim on a card, so exempting
+                # them would just move the invented claim one hop away.
+                for line in (seed.why, *phrasings(key, seed.seed_data)):
+                    low = line.casefold()
+                    for phrase in banned:
+                        assert phrase not in low, f"{key} claims '{phrase}': {line}"
 
     def test_the_top_genre_makes_a_stronger_claim_than_the_tail(self) -> None:
         """Rank is the honest stand-in for dominance: a share would need a

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -41,6 +41,7 @@ from kamp_daemon.discovery_sources import (
     BandcampDiscoverySource,
     RateLimitedError,
 )
+from kamp_core.discovery_api import UNPERSONALISED_CRITERIA
 from kamp_core.library import SeedAlbum, SeedArtist
 
 FIXTURES = Path(__file__).parent / "fixtures" / "discovery"
@@ -263,6 +264,16 @@ class TestCriteriaRegistry:
                     low = line.casefold()
                     for phrase in banned:
                         assert phrase not in low, f"{key} claims '{phrase}': {line}"
+
+    def test_the_unpersonalised_criteria_constant_is_current(self) -> None:
+        """KAMP-664. discovery_api derives the "we had nothing to go on" banner
+        from the stored criteria, and names them in its own constant because it
+        must not import kamp_daemon. This is the seam that keeps the two in step:
+        add a criterion that yields seeds from an empty profile and the banner
+        would silently stop appearing, so fail here instead."""
+        thin = SeedProfile()
+        yields_from_nothing = {c.key for c in REGISTRY if list(c.seeds(thin))}
+        assert yields_from_nothing == set(UNPERSONALISED_CRITERIA)
 
     def test_the_top_genre_makes_a_stronger_claim_than_the_tail(self) -> None:
         """Rank is the honest stand-in for dominance: a share would need a


### PR DESCRIPTION
The clerk note is the feature's whole promise: every pick explains itself, in a voice that sounds like a person. The ticket reported two faults — a crate repeats itself, and "You've been deep in Rock lately" claims something the library cannot support. Both are real, and investigation found each worse than described, plus a write-path bug that blocked any of the copy work from reaching the database.

Ticket said Side; this is an LP.

## What was actually wrong

**The repetition, measured rather than reasoned.** A throwaway probe built crates against three profiles:

| crate | max repeat, before | after |
| --- | --- | --- |
| first run (chart only) | **10 of 10** | 3 |
| built from one album page | **9 of 10** | 3 |
| healthy gather | 1 | 1 |

So the first thing a new user sees was ten cards reading "Selling fast on Bandcamp right now." `SEED_CAP` is passed only to the first deal; both backfill deals drop it so a thin gather still returns ten records — the right trade (a two-record crate is a worse answer than one leaning on a single album page) and not one undone here.

**The genre claim was doubly unsupportable.** `taste_genres` counts `track_genres` association rows unioned with Bandcamp `keywords`. It has **no play signal at all** and **no time filter of any kind** — so "you've been deep in X lately" was two invented claims in one sentence: the recency was false by construction, and the listening was never measured. It is a census of the shelf.

**A write-path bug blocked all of it.** `add_discovery_candidate` returned early on an existing row and never updated it, so a record re-found in the KAMP-657 buffer kept its **old** `why` and `seed_json`. The comment written in KAMP-657 — "Fresh wins any duplicate" — was false. Any restate done at build time would have been discarded for exactly the rows most likely to carry a stale sentence.

## The five commits

**1 — refresh a re-found record's reason.** `add_discovery_candidate` now updates `criterion`, `why` and `seed_json` on conflict. Never `art_url`: the art proxy grants `immutable` cache-control precisely because that column never changes, and updating it would make a year-long cache header a lie.

**2 — genre lines talk about the shelf.** Sized by rank, which is the profile's own ordering and costs nothing; a real share is unavailable because `taste_genres`' count mixes per-track tag rows with per-album keyword hits and so has no denominator. Top genre gets a firm claim, the next few a softer one, the tail the softest — all about what is on the shelves, none about listening, because a hedged line that still implied listening would just be a quieter invented claim.

Also adds the branch discriminators the copy work needs. `_genre_top_seeds` emitted `{kind, genre}` for both its `top` and `rand` slices and `_favorite_artist_seeds` emitted `{kind, artist}` for both its branches, so a stored seed could not say which of two sentences produced it. `slice`, `rank` and `starred` fix that, mirroring `also_like`'s existing `recent`/`dormant`. Every reader tolerates their absence — rows already in the buffer predate them.

**3 — give a repeated note somewhere else to go.** `_vary_notes` walks the picks just before persistence and restates duplicates from a table of alternates kept beside the selectors that produce them. It picks the **least-used** option rather than the first unused one: with ten cards off one seed, first-unused spends each alternative once then falls back to the original for the remaining seven, which is barely better than not varying at all.

**A note is never blanked.** Where the alternates run out the line repeats — a card with no rationale breaks the promise the feature rests on, and a strained ninth phrasing of "selling fast" is a worse failure than an honest repeat. Variation here is polish; the claims being true is the point.

Alternates render from the **stored seed**, not the profile, so a candidate promoted out of the buffer can be restated from what was written down with it. The genre alternates read `slice` — claiming sales rank for a `rand` pick would be the same invented claim this PR removes.

Named rather than left to be discovered: after this, `why` and `seed_json` no longer determine each other.

**4 — the first-run banner outranks the others, and survives a relaunch.** Three defects, all landing on the same user. *Precedence:* a first crate is routinely thin **and** short, and `short` was tested first, so the banner read "Short crate today — we couldn't fill it": the symptom, cause hidden, reading as a broken shop rather than one with nothing to go on. *Gating:* the thin line rendered on any state with rows on screen while the other two waited for `ready`. *Persistence:* `thin` lived only in memory, so a relaunch dropped it to `False` and the explanation was gone for good. It is now derived from the stored rows — a crate built from an empty profile can only be made of criteria needing nothing to go on, so an all-chart crate **is** the thin case. That is also the truer statement: the banner describes the crate on screen and the derivation reads the crate on screen, where the profile flag described the moment the build started.

Tooltip: "Picked from your own library and listening" was wrong for a genre pick and wrong twice over for a chart pick. Now "Chosen here from what is on your shelves — nothing leaves this machine", which holds for every card and keeps the part worth promising.

**5 — retire the re-validation claim and the code that only served it.** Two docstrings said KAMP-657 re-validates a buffered candidate's seed before showing it. It does not, and never did. `has_genre`/`has_artist`/`has_label` existed only to be the lookups that re-validation would have used and had no production caller; their one test asserted case-insensitivity "because KAMP-657 re-validates seeds through these" — a test for a caller that does not exist. Deleted together rather than left as dead surface behind a corrected comment, which is how the claim would have grown back.

## Tests

Pin the rule, not the words. Where prose was previously asserted, the structural flag is asserted instead — pinning wording made every copy pass a test change while guarding nothing.

- The two measured repetition cases are regressions, **verified red** with `_vary_notes` disabled (10/10 and 9/10 reproduced in-suite).
- Every card keeps a non-empty note; a varied crate is left alone.
- The parametrized registry test now requires every criterion's alternates to be sayable, pairwise distinct, and safe against a seed written by an older build.
- The genre ban on "lately" / "recently" / "you listen" now covers the alternates too, so the claim cannot return one hop away.
- `thin` after a restart: derived True for an all-chart crate, False for one chart pick among nine library-driven ones, False for an empty crate (`all()` over nothing is True, which would have put the first-run banner on the empty state).
- `UNPERSONALISED_CRITERIA` is named in `discovery_api` rather than imported, because that module deliberately does not depend on `kamp_daemon`. A test on the daemon side holds the two in step: add a criterion that yields seeds from an empty profile and it fails, rather than the banner quietly ceasing to appear.

## CI, run locally

- `pytest`: 3285 passed, 9 skipped. Coverage **93.86%**, up from **93.84%** on main (measured in a clean worktree). Below the 94% practice target, but that is the pre-existing state of main, not a regression from this branch — touched files are at 97–100%, `discovery.py` and `discovery_criteria.py` at 100%.
- `npm run typecheck` clean; `npm run lint` clean apart from one pre-existing prettier warning in `src/main/index.ts`, untouched here.
- README: no drift — it does not mention the Crate at all.

## Manual test plan

1. **Clear the digging history and dig a first crate** — this is the 10/10 case and the one most worth looking at. Every card must still say something, and the few sentences it cycles should read naturally rather than strained.
2. Dig several normal crates and read the notes end to end. No line should claim listening where only ownership is known, and nothing should say "lately".
3. Confirm a crate that is both thin and short now says it was un-personalised rather than just "short".
4. **Relaunch on that first crate** — the thin banner must still be there.
5. Confirm the divider card and the other banners still read correctly, and check the clerk-card tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
