### PR TITLE
KAMP-663: end-of-crate ceremony — the closing beat, and a way out

### DIFF
--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -685,6 +685,35 @@
   cursor: default;
 }
 
+/* Dig and the way out, side by side at the end of a crate (KAMP-663). A row
+   rather than two rows in the footer column: the closing beat lands when the
+   flipped pile is at its full extent and nearest the footer, and .crate-bin-
+   records has a FIXED height inside a view that never scrolls, so a footer that
+   grew by a whole button there would clip the bin. One row is the same height
+   holding one button or two. */
+.crate-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+/* Quieter than the dig button, and deliberately not a button-looking thing:
+   stopping is offered, not urged. It carries no border or fill, so the primary
+   action stays the only object in the row that reads as one. */
+.crate-quit-btn {
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  padding: 8px 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.crate-quit-btn:hover {
+  color: var(--text);
+}
+
 /* --- The rail ------------------------------------------------------------- */
 
 /* The build-time rail. Takes the bin's grid slot, which .crate-stage--building

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -498,6 +498,14 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     playFromCrate(item)
   }
 
+  // Where the Crate hands you back to. Shared by Escape and by the footer's
+  // "That's enough for today" (KAMP-663) so the two destinations cannot drift —
+  // they differ in what they do to a running preview, and in nothing else.
+  const leaveCrate = useCallback((): void => {
+    const prev = useStore.getState().previousView
+    void setActiveView(prev && prev !== 'crate' ? prev : 'library')
+  }, [setActiveView])
+
   // Escape leaves the view. Deliberately a window listener, matching
   // DownloadsView: modals listen on document, which runs first, so Escape closes
   // an open dialog rather than dropping the user out of the Crate underneath it.
@@ -515,12 +523,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         void previewAction('stop')
         return
       }
-      const prev = useStore.getState().previousView
-      void setActiveView(prev && prev !== 'crate' ? prev : 'library')
+      leaveCrate()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [active, setActiveView, previewAction])
+  }, [active, leaveCrate, previewAction])
 
   // The crate's own keys live on the view container, NOT on document. App's
   // global handler is a window listener and the React root sits below document
@@ -707,6 +714,31 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
       disabled={building || pauseRemaining > 0}
     >
       {hasCrate ? 'Dig up another crate' : 'Dig up a crate'}
+    </button>
+  )
+
+  // The way out, offered next to the way on (KAMP-663). "Never infinite" is one
+  // of the epic's hard principles, and a shop that only ever offers you another
+  // crate is not honouring it — so at the end of a crate, stopping is a visible
+  // choice rather than something you have to know a keystroke for.
+  //
+  // It earns its place by doing what no single press does today: Escape is
+  // deliberately two-stage, so with a preview running it stops the preview and
+  // leaves you standing in the Crate. This ends the sitting outright. A control
+  // that merely left would duplicate Escape and the sidebar, and would be
+  // decoration.
+  //
+  // Never disabled. The dig button goes dead during a rate-limit cooldown, and a
+  // cooldown is precisely when leaving is the thing you want.
+  const enoughButton = (
+    <button
+      className="crate-quit-btn"
+      onClick={() => {
+        if (useStore.getState().preview?.state !== 'idle') void previewAction('stop')
+        leaveCrate()
+      }}
+    >
+      That&rsquo;s enough for today
     </button>
   )
 
@@ -944,8 +976,14 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           </div>
         )}
 
+        {/* Statement, then offer, then the quiet register (KAMP-663). The tally
+            used to sit UNDER the button, which read as a footnote to the next
+            dig rather than as the close of this one. Order only — the row keeps
+            the footer exactly as tall either way, which matters because the beat
+            lands when nine records are on the flipped pile at its full extent
+            and the bin row has a fixed height inside a view that never
+            scrolls. */}
         <div className="crate-footer">
-          {digButton}
           {/* The closing beat, at the moment the user has actually just done the
               digging rather than as a running score. A one-record crate gets one
               too (KAMP-663) — reaching the end of a short crate is still
@@ -956,6 +994,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
               That&rsquo;s the crate. {describeTally(crateTally)}
             </p>
           )}
+          {/* One row whether it holds one button or two, so offering the way out
+              costs no height at the moment there is none to spare. */}
+          <div className="crate-actions">
+            {digButton}
+            {atCrateEnd && enoughButton}
+          </div>
           {history && <p className="crate-history">{describeHistory(history)}</p>}
         </div>
 

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -147,7 +147,47 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // the tally cannot drift from the lifetime line.
   const history = crate?.stats ?? null
   const crateTally = crate?.crate_stats ?? null
-  const atLastRecord = items.length > 1 && focusIndex === items.length - 1
+
+  // Reaching the end of a crate is an EVENT, not a position (KAMP-663).
+  //
+  // This used to read the cursor live — `items.length > 1 && focusIndex ===
+  // items.length - 1` — so the closing line vanished the instant you flipped
+  // back a record and announced itself again on your way forward. The ticket
+  // asks for it once per crate; the shipped code gave it once per visit to the
+  // last sleeve. Recording the crate you have reached the end of fixes both,
+  // and self-invalidates the way `focus` does: a crate that is not the one
+  // recorded simply has no beat yet.
+  //
+  // A click straight to the last title COUNTS. Requiring the user to have
+  // stepped there was considered and rejected: jumping to the end of the crate
+  // is still going to the end of the crate, and the line reports what is in the
+  // crate — records, and ledger-derived counts — rather than narrating how
+  // diligently they arrived.
+  // Adjusted during render rather than in an effect. This is React's documented
+  // shape for "derive from what just changed" and the one the compiler's
+  // set-state-in-effect rule pushes you to: the re-render happens before
+  // anything commits, so there is no frame where the user is standing at the end
+  // of the crate with no line under it.
+  const [endedCrate, setEndedCrate] = useState<number | null>(null)
+  // `building` is load-bearing, not defensive. A build streams one record at a
+  // time, and with the first one placed `items.length - 1` is 0 — which is
+  // exactly where a new crate's focus sits, so without this the beat fires on
+  // record one of ten and then sits there for the rest of the dig.
+  if (
+    !building &&
+    crateNo !== null &&
+    items.length > 0 &&
+    focusIndex === items.length - 1 &&
+    endedCrate !== crateNo
+  ) {
+    setEndedCrate(crateNo)
+  }
+
+  // Not `endedCrate === crateNo` alone: newCrate() empties the items but leaves
+  // crate_no alone until the daemon says otherwise (store.ts), so the line has
+  // to go the moment the stage does. A 409 leaves the items in place and this
+  // stays true, which is right — that crate is still on screen and still ended.
+  const atCrateEnd = endedCrate !== null && endedCrate === crateNo && hasCrate && !building
 
   // The name on the crate's divider card (KAMP-656). Derived from the snapshot
   // the view already has, because this story is skin only — no API changes. It
@@ -907,9 +947,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         <div className="crate-footer">
           {digButton}
           {/* The closing beat, at the moment the user has actually just done the
-              digging rather than as a running score. Only worth showing for a
-              crate with more than one record in it. */}
-          {atLastRecord && crateTally && (
+              digging rather than as a running score. A one-record crate gets one
+              too (KAMP-663) — reaching the end of a short crate is still
+              reaching the end, and the old `items.length > 1` guard denied a
+              closing line to exactly the crates that came up thin. */}
+          {atCrateEnd && crateTally && (
             <p className="crate-tally" role="status">
               That&rsquo;s the crate. {describeTally(crateTally)}
             </p>


### PR DESCRIPTION
The Crate is meant to end — "never infinite" is one of the epic's hard brand principles. This ticket asked for a beat of ceremony at crate turnover and a quiet way to stop.

Ticket said LP; it is a **Side**. Two of the four scope items had already shipped, one acceptance criterion is unsatisfiable, and the fourth item is split out to KAMP-688.

## What was already done

- **The session tally ships.** `crate_stats` comes from `discovery_stats` (`library.py:5341`), computed from `discovery_events` — exactly the ledger-not-`state` argument the ticket's "Why" section spends its length making. KAMP-655 closed it. `describeTally` already omits zeroes, because "0 brought home" at the end of a crate reads as a reprimand.
- **The divider card ships**, as the crate's spine name (KAMP-656).

## Two acceptance criteria cannot be met as written

**"including a record that was previewed and then passed (counted in both)"** — KAMP-674 removed pass entirely: the endpoint, the keystroke, the store actions. `dismissed` survives in the ledger's CHECK constraint as legacy history with no writer. The case does not exist.

**"Session tally"** — nothing in the codebase has a session. `crate_stats` is per-crate, `stats` is lifetime; the ticket uses "session" and "one crate's" interchangeably. The word implies a time-window aggregate over `discovery_events.at` that nobody has built.

Also worth stating plainly: **"copy passes the banned-vocabulary check" is unfalsifiable.** There is no check. The guardrail is prose in a comment at `CrateView.tsx:8-11` (algorithm, curated, personalized, "made for you", match %, feed, radio, smart) and `kamp_ui` has no test runner at all. The copy here was reviewed against that comment; nothing ran.

## The divider was the wrong object for the beat

The ticket names a "divider-card moment". Three reasons it went elsewhere:

- `crateSpineName` can return `''` (`crateSpine.ts:96-97`), so a crate with no name would have had **no closing beat at all**.
- The divider is a persistent label that stands *behind* the records — its own comment says you read it over the tops of the sleeves. You never reach it. Repurposing a standing label as an event marker gives one object two jobs.
- Under `prefers-reduced-motion: reduce` the bin becomes a wrapped auto-height grid with `perspective: none` (`crate.css:639-667`), where "comes forward" has no meaning.

## The two commits

**1 — reaching the end is an event, not a position.** The closing line read the cursor live (`items.length > 1 && focusIndex === items.length - 1`), so it vanished the instant you flipped back a record and announced itself again on your way forward. The ticket asks for it once per crate; the shipped code gave it once per visit to the last sleeve.

Dropping the `items.length > 1` guard — it denied a closing line to exactly the crates that came up thin — exposed why it was there. A build streams one record at a time, and with the first one placed `items.length - 1` is 0, which is where a new crate's focus sits. So that guard was accidentally suppressing a beat on record one of ten. `building` is now the explicit gate, which is the condition actually meant.

A click straight to the last title **counts**. Requiring the user to have stepped there was considered and rejected: jumping to the end of the crate is still going to the end of it, and the line reports what is *in* the crate rather than narrating how diligently they arrived.

State is adjusted during render, not in an effect — React's documented shape for this, and what the compiler's `set-state-in-effect` rule pushes you to. The re-render lands before anything commits, so there is no frame where the user stands at the end of the crate with no line under it.

**2 — the way out, next to the way on.** "That's enough for today" earns its place by doing what no single press does today: Escape is deliberately two-stage, so with a preview running it stops the preview and leaves you standing in the Crate. This ends the sitting outright. A control that merely left would duplicate Escape and the sidebar and would be decoration — that version was considered and rejected. The destination is extracted so the two paths cannot drift.

Never disabled, unlike the dig button, which goes dead during a rate-limit cooldown — and a cooldown is precisely when leaving is what you want.

**Both buttons share one row, and that is structural.** The beat lands exactly when nine records are on the flipped pile at full extent and nearest the footer; `.crate-bin-records` has a **fixed** height and `.crate-view` never scrolls. `crate.css:148-156` already records that the pile once ran "straight through the footer". One row is the same height holding one button or two, so the offer costs no height at the moment there is none to spare. Footer order is now statement → offer → register; the tally used to sit *under* the button, reading as a footnote to the next dig rather than the close of this one.

## Split out — KAMP-688

The inline confirm needed a number the product deliberately does not record. `focusIndex` is renderer-only React state, and `shown` is written at build time for all ten records at once, so `discovery_stats.records` is the crate's size, not what was looked at. "Six still in the crate" would be invented in the renderer: unverifiable against the ledger, per-machine, lost on every restart while the crate persists, and sitting inches from the tally's server-derived "10 records" contradicting it.

`discovery_stats`' own docstring forbids the mechanic — "no nudges … nothing that turns a record shop into a slot machine" — and a count of what you have not looked at, shown when you try to leave, is a completion nudge. The seen-ledger also means those records are already excluded from every future crate, so the confirm cannot let the user act on the loss it names.

KAMP-688 asks the honest question and is prepared for the answer to be no. It also records the one defensible reason to confirm, which nobody had written down: digging costs a rate-limited round trip.

## CI, run locally

- `npm run typecheck` clean. `npm run lint` clean apart from one pre-existing prettier warning in `src/main/index.ts`, untouched here.
- `pytest`: 3285 passed, 9 skipped, coverage 93.86% — byte-identical to main, since nothing server-side is touched.
- **No automated tests accompany this.** `kamp_ui` has no vitest, no jest, no `test` script. Verification is by reading and by the manual pass below.
- README: no drift — it does not mention the Crate at all.

## Manual test plan

1. Dig a crate and flip to the last record — the closing line appears once.
2. Flip back several records and forward again — it does **not** re-announce, and does not flicker off.
3. Click the last title directly from the titles list on arrival — the line appears. This is deliberate; worth confirming it reads acceptably rather than premature.
4. A one-record crate — the line appears and reads correctly in the singular.
5. Reach the end, then "Dig up another crate" — the line clears immediately and does not flash over the building stage.
6. Reach the end while another crate is already building (409) — the toast appears and the crate stays put with its line intact.
7. **"That's enough for today" with a preview playing** — one press stops the preview and leaves. Compare against Escape, which should still take two.
8. The same button during a rate-limit pause — still works while "Dig up another crate" is disabled.
9. Watch the flipped pile at the last record: the footer must not clip the bin or push the pile through it.
10. Reduced motion, and a couple of non-default palettes.

Note for (1)-(4): the new button will take a focus ring on mouse click. That is KAMP-685, already open against every crate element, not something introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
