### PR TITLE
KAMP-683: fewer cards that only know your genre, more that name a record

### DIFF
--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -344,6 +344,24 @@ class DiscoverySource(ABC):
         """
         return {}
 
+    @property
+    def criterion_weights(self) -> dict[str, int]:
+        """How many turns a criterion takes per round of the deal (KAMP-683).
+
+        The sibling of ``criterion_caps`` and the mirror of it: caps say "no more
+        than", this says "more often than the rest". Same bargain, for the same
+        reason — the builder deals round-robin precisely so it never has to know
+        what a label means, so the *provider*, which does know, names the ones
+        worth more of a crate and the builder treats the number as opaque.
+
+        A weight is a preference too. It buys extra chances in the round, not
+        reserved slots: a criterion with nothing left to give simply does not take
+        them, and the crate fills from elsewhere rather than coming up short.
+
+        Default 1 for anything unnamed, which is what every criterion gets today.
+        """
+        return {}
+
     @abstractmethod
     def gather(
         self,

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -192,6 +192,7 @@ def build_crate(
         candidates,
         index=index,
         caps=source.criterion_caps,
+        weights=source.criterion_weights,
         size=size,
         rng=rng,
         wishlist_ids=wishlist_ids,
@@ -390,6 +391,7 @@ def select_crate(
     *,
     index: "LibraryIndex",
     caps: dict[str, int] | None = None,
+    weights: dict[str, int] | None = None,
     size: int = CRATE_SIZE,
     rng: random.Random | None = None,
     wishlist_ids: set[str] | None = None,
@@ -403,6 +405,7 @@ def select_crate(
     """
     rng = rng or random.Random()
     caps = caps or {}
+    weights = weights or {}
     wishlist_ids = wishlist_ids or set()
 
     picks: list[Candidate] = []
@@ -418,6 +421,13 @@ def select_crate(
         # a feature whose entire affordance is dealing another one.
         order = list(groups)
         rng.shuffle(order)
+        # Weighted AFTER the shuffle, and appended rather than inserted beside the
+        # original (KAMP-683). Both matter: shuffling a list that already held the
+        # duplicates would let a weighted criterion land slot 0 more often than the
+        # rest, and inserting beside would hand it two adjacent cards at the front
+        # of the crate instead of two spread through it. The shuffle still decides
+        # who opens the crate, which is the property it exists for.
+        order = _weighted(order, weights)
 
         picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP)
         if len(picks) < size:
@@ -456,6 +466,30 @@ def select_crate(
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+
+
+def _weighted(order: list[str], weights: dict[str, int]) -> list[str]:
+    """*order* with weighted criteria repeated, so they get extra turns per round.
+
+    The whole weighting mechanism (KAMP-683), and it needs no change to ``_deal``:
+    that function iterates ``for criterion in order``, so a key present twice is
+    simply asked twice a round. ``taken`` stops it dealing the same card, and
+    ``counts``, ``caps`` and ``seed_cap`` all accumulate across both turns, so a
+    weighted criterion is still capped and still seed-spread exactly as before.
+
+    Two things this gets for free that a reserved-slots pass would not. It carries
+    into the BACKFILL, which is handed this same list -- and the backfill is where
+    the skew actually comes from, because the deepest surviving pool wins the
+    tiebreak and the impersonal criteria have far more buffered stock. And it
+    cannot pin the front of the crate, because the caller shuffles first.
+
+    Only keys already in *order* are repeated. ``_deal`` indexes ``groups``
+    unguarded, so inventing a key here would raise straight out of
+    ``select_crate`` -- which ``build_crate`` does not wrap -- and surface as a
+    crate that failed for no stated reason.
+    """
+    extra = [key for key in order for _ in range(max(1, weights.get(key, 1)) - 1)]
+    return order + extra
 
 
 def _deal(

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -92,6 +92,11 @@ CRITERION_CAPS: dict[str, int] = {
     "older_than_ten": 1,
 }
 
+#: Turns per round of the deal, for criteria worth more of a crate (KAMP-683).
+#: Module-level for the same reason as the caps: the builder suite's fake source
+#: inherits the ABC default, so a test has to read the real thing.
+CRITERION_WEIGHTS: dict[str, int] = {"also_like": 4}
+
 
 def _sub(state: "MutableMapping[str, Any]", key: str) -> dict[str, Any]:
     """The ``key`` sub-dict of the rotation state, created and attached if absent.
@@ -178,6 +183,32 @@ class BandcampDiscoverySource(DiscoverySource):
         # Copied, because the builder hands this to _deal and a shared mutable
         # default is the kind of thing that only bites once, in production.
         return dict(CRITERION_CAPS)
+
+    @property
+    def criterion_weights(self) -> dict[str, int]:
+        """A double turn for the criterion that can actually name your record.
+
+        ``also_like`` reads the recommendation block of an album the user played
+        or favourited, so its clerk line is the most specific one the shop can
+        write: "Filed next to DOGGOD, which you played recently." It was also the
+        thinnest, at 1.3 cards a crate — round-robin over seven groups gives
+        everyone the same one or two regardless of what they can claim.
+
+        Four is measured, not picked. Averaged over sixty crates, the caps alone
+        take it to 1.7 and the weights land it at 2.4, 3.2 and 4.0 — so four turns
+        is what reaches four cards, which is the agreed target.
+
+        Four is also its ceiling, and deliberately so rather than by luck:
+        _SEEDS_PER_CRITERION x SEED_CAP = 2 x 2 = 4. A bigger weight buys nothing,
+        because the KAMP-665 seed cap refuses the fifth card — which is the guard
+        that matters, since the bug that ticket was filed about is three records
+        off ONE album page, and no weight here can produce that.
+
+        The cost of running at the ceiling is that the share stops varying: every
+        healthy crate is two records from each of two album pages. Worth watching
+        when reading real crates; a drop to 3 buys the variation back at 3.2.
+        """
+        return dict(CRITERION_WEIGHTS)
 
     # ------------------------------------------------------------------
     # The only place that touches the network

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -80,6 +80,18 @@ UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
 #: 429 here cascades account-wide (KAMP-639).
 _SEEDS_PER_CRITERION = 2
 
+#: How many cards one criterion may contribute to a crate (KAMP-683).
+#:
+#: Module-level rather than inline in the property so a test can assert the crate
+#: SHAPE against what the source really declares. Every builder test uses a fake
+#: whose caps are the ABC's empty default, so without this the suite cannot see
+#: this policy at all. See `criterion_caps` for what the numbers mean.
+CRITERION_CAPS: dict[str, int] = {
+    "best_seller": 1,
+    "genre_top": 1,
+    "older_than_ten": 1,
+}
+
 
 def _sub(state: "MutableMapping[str, Any]", key: str) -> dict[str, Any]:
     """The ``key`` sub-dict of the rotation state, created and attached if absent.
@@ -144,14 +156,28 @@ class BandcampDiscoverySource(DiscoverySource):
 
     @property
     def criterion_caps(self) -> dict[str, int]:
-        """One chart pick per crate.
+        """One apiece from the criteria that know only a tag about you (KAMP-683).
 
-        ``best_seller`` is the only criterion carrying no personal claim, and the
-        brand guardrails forbid letting un-personalised content dominate a crate
-        that presents itself as dug for you. Every other criterion may repeat as
-        the round-robin allows.
+        ``best_seller`` carries no personal claim at all, and the brand guardrails
+        forbid letting un-personalised content dominate a crate that presents
+        itself as dug for you. ``genre_top`` and ``older_than_ten`` make a weaker
+        version of the same claim: their seed is a genre, so the clerk line can
+        say what is on your shelves but never which record sent us here.
+
+        Measured, that half was winning. Over ten crates on a real library the
+        three of them averaged 4.4 cards of ten, and the ticket's own complaint --
+        too many "random" records -- is exactly that ratio. They are also the
+        criteria a reader cannot tell apart: "Pulled at random from the
+        Alternative racks" and "A hidden Alternative gem?" are the same card.
+
+        A cap, deliberately, not a ban. The backfill overruns these rather than
+        shipping a short crate (KAMP-661), so a thin gather still fills -- and
+        ``older_than_ten`` keeps its place as the occasional oddity, which is the
+        job it is actually good at.
         """
-        return {"best_seller": 1}
+        # Copied, because the builder hands this to _deal and a shared mutable
+        # default is the kind of thing that only bites once, in production.
+        return dict(CRITERION_CAPS)
 
     # ------------------------------------------------------------------
     # The only place that touches the network

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -31,7 +31,7 @@ from kamp_daemon.discovery import (
     SeedProfile,
 )
 from kamp_daemon.discovery_builder import CRATE_SIZE, build_crate
-from kamp_daemon.discovery_sources import CRITERION_CAPS
+from kamp_daemon.discovery_sources import CRITERION_CAPS, CRITERION_WEIGHTS
 
 
 @pytest.fixture
@@ -78,15 +78,21 @@ class _FakeSource(DiscoverySource):
         candidates: list[Candidate],
         caps: dict[str, int] | None = None,
         error: Exception | None = None,
+        weights: dict[str, int] | None = None,
     ) -> None:
         self._candidates = candidates
         self._caps = caps or {}
+        self._weights = weights or {}
         self._error = error
         self.gather_calls = 0
 
     @property
     def criterion_caps(self) -> dict[str, int]:
         return self._caps
+
+    @property
+    def criterion_weights(self) -> dict[str, int]:
+        return self._weights
 
     def gather(
         self,
@@ -453,6 +459,72 @@ class TestCrateShape:
         used = Counter(_criteria(index, 1))
         for criterion in self.GENRE_ONLY:
             assert used[criterion] <= 1, f"{criterion} took {used[criterion]}: {used}"
+
+    def test_the_crate_leans_on_the_criterion_that_names_your_record(
+        self, index: LibraryIndex
+    ) -> None:
+        """also_like was the thinnest criterion at 1.3 cards a crate, despite
+        writing the most specific line the shop can write. Caps and weight
+        together are meant to make it the one a crate leans on."""
+        source = _FakeSource(
+            self._realistic(), caps=CRITERION_CAPS, weights=CRITERION_WEIGHTS
+        )
+        _build(index, source)
+        used = Counter(_criteria(index, 1))
+        assert used["also_like"] >= 3, f"also_like got {used['also_like']}: {used}"
+
+    def test_a_weight_does_not_beat_the_seed_cap(self, index: LibraryIndex) -> None:
+        """The KAMP-665 guard has to survive the thing pushing against it.
+
+        Extra turns are extra CHANCES, taken from whatever the criterion has
+        left — so a weighted criterion with one seed still cannot pile a crate
+        onto one album page. If this ever fails, the weight is too big.
+        """
+        candidates = [
+            _candidate(f"a{i}", "also_like", seed={"kind": "album", "album_id": 1})
+            for i in range(20)
+        ] + _spread({"genre_top": 8, "favorite_artist": 8})
+        _build(
+            index,
+            _FakeSource(candidates, caps=CRITERION_CAPS, weights=CRITERION_WEIGHTS),
+        )
+        seeds = Counter(
+            json.dumps(r["seed"], sort_keys=True) for r in index.crate_items(1)
+        )
+        one_album = seeds[json.dumps({"album_id": 1, "kind": "album"}, sort_keys=True)]
+        assert one_album <= 2, f"{one_album} records off one album page"
+
+    def test_a_weight_cannot_pin_the_front_of_the_crate(self, tmp_path: Path) -> None:
+        """Weighting is applied AFTER the shuffle for this reason. Repeating a key
+        in a list that was then shuffled would make the weighted criterion the
+        likeliest to open every crate — which is the property
+        test_group_order_varies_between_crates exists to protect, and it cannot
+        see this because it uses unweighted synthetic criteria."""
+        firsts = set()
+        for seed in range(12):
+            idx = LibraryIndex(tmp_path / f"crate-{seed}.db")
+            try:
+                _build(
+                    idx,
+                    _FakeSource(self._realistic(), weights=CRITERION_WEIGHTS),
+                    rng=random.Random(seed),
+                )
+                firsts.add(_criteria(idx, 1)[0])
+            finally:
+                idx.close()
+        assert len(firsts) > 1, f"every crate opened with {firsts}"
+
+    def test_a_weight_never_shrinks_a_crate(self, index: LibraryIndex) -> None:
+        """A weight is a preference like a cap. A criterion with nothing left to
+        give simply does not take its extra turns."""
+        source = _FakeSource(
+            _spread({"also_like": 1, "genre_top": 20}),
+            caps=CRITERION_CAPS,
+            weights=CRITERION_WEIGHTS,
+        )
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
 
     def test_the_caps_still_yield_to_a_thin_gather(self, index: LibraryIndex) -> None:
         """Three caps rather than one is three more chances to shrink a crate.

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -31,6 +31,7 @@ from kamp_daemon.discovery import (
     SeedProfile,
 )
 from kamp_daemon.discovery_builder import CRATE_SIZE, build_crate
+from kamp_daemon.discovery_sources import CRITERION_CAPS
 
 
 @pytest.fixture
@@ -389,6 +390,84 @@ class TestSeedCaps:
         )
         _build(index, source)
         assert len(index.crate_items(1)) == CRATE_SIZE
+
+
+class TestCrateShape:
+    """What a crate READS like, against the real registry (KAMP-683).
+
+    Every other test in this file uses synthetic criteria and `_FakeSource`,
+    which inherits the ABC's empty `criterion_caps` -- so the whole suite is blind
+    to what the Bandcamp source actually declares, and none of it would notice
+    the real crate skewing. These use the real seven keys and the real caps.
+    """
+
+    #: Criteria whose seed is a genre or nothing, so the clerk line can never say
+    #: which of YOUR records sent us here. The complaint behind KAMP-683 was that
+    #: half of every crate was these; measured, it was 4-5 of ten.
+    GENRE_ONLY = ("genre_top", "older_than_ten", "best_seller")
+
+    @staticmethod
+    def _realistic() -> list[Candidate]:
+        """A rich gather: every registry criterion, two seeds each, plenty spare.
+
+        Deliberately generous. The question is what the builder CHOOSES when it
+        can have anything, which is the condition a healthy library produces and
+        the one the measured crates were built under.
+        """
+        out: list[Candidate] = []
+        for criterion, dimension in (
+            ("also_like", "album_id"),
+            ("purchase_anniversary", "album_id"),
+            ("favorite_artist", "artist"),
+            ("lone_album_artist", "artist"),
+            ("genre_top", "genre"),
+            ("older_than_ten", "genre"),
+            ("best_seller", None),
+        ):
+            for s in range(2):
+                for i in range(5):
+                    seed = (
+                        {"kind": criterion, dimension: f"{criterion}-{s}"}
+                        if dimension
+                        else {"kind": "chart"}
+                    )
+                    out.append(_candidate(f"{criterion}{s}{i}", criterion, seed=seed))
+        return out
+
+    def test_most_of_a_crate_names_a_record_you_own(self, index: LibraryIndex) -> None:
+        """The acceptance criterion, and it is about the crate rather than the
+        plumbing: a crate that presents itself as dug for you may not be half
+        made of picks that know nothing about you but a tag."""
+        source = _FakeSource(self._realistic(), caps=CRITERION_CAPS)
+        _build(index, source)
+        used = _criteria(index, 1)
+        genre_only = sum(1 for c in used if c in self.GENRE_ONLY)
+        assert len(used) == CRATE_SIZE
+        assert genre_only <= 3, f"{genre_only} of ten know only a genre: {used}"
+
+    def test_no_single_impersonal_criterion_repeats(self, index: LibraryIndex) -> None:
+        """Each of the three is held to one. Measured before the cap, genre_top
+        alone averaged 1.9 a crate and older_than_ten 1.5."""
+        source = _FakeSource(self._realistic(), caps=CRITERION_CAPS)
+        _build(index, source)
+        used = Counter(_criteria(index, 1))
+        for criterion in self.GENRE_ONLY:
+            assert used[criterion] <= 1, f"{criterion} took {used[criterion]}: {used}"
+
+    def test_the_caps_still_yield_to_a_thin_gather(self, index: LibraryIndex) -> None:
+        """Three caps rather than one is three more chances to shrink a crate.
+
+        The contract is unchanged (KAMP-661): a cap is a preference and the
+        backfill overruns it. A gather that found only genre picks must still
+        hand over ten records, not three.
+        """
+        source = _FakeSource(
+            _spread({"genre_top": 8, "older_than_ten": 8, "best_seller": 8}),
+            caps=CRITERION_CAPS,
+        )
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
 
 
 class TestCriterionCaps:


### PR DESCRIPTION
The complaint: crates carry too many "random" records and not enough "filed next to something you played".

Ticket said LP and prescribed resting `older_than_ten` to every 3-5 crates. **Measured against the production library first, that prescription was aimed at the wrong criterion**, and the resulting change is a Side.

## The diagnosis was stale

`older_than_ten` is not over-represented, and has not been since around crate 20. Averages over the last ten crates:

| criterion | avg/crate |
| --- | --- |
| genre_top | 1.90 |
| purchase_anniversary | 1.50 |
| **older_than_ten** | **1.50** |
| favorite_artist | 1.40 |
| lone_album_artist | 1.40 |
| also_like | 1.30 |
| best_seller | 1.00 |

Everything sits at 1-2 because round-robin over seven criteria does exactly that. `genre_top`, not `older_than_ten`, was the leader.

The lifetime totals that motivated the ticket (172 `older_than_ten` vs 75 `also_like`) are archaeology: crates 12-18 ran 8-9 and **zero** respectively, and that collapsed when KAMP-661/665/657 landed. **The bug the ticket describes was real and was already fixed.**

Resting `older_than_ten` now would drop it to ~0.4/crate — below every other criterion — and the backfill would hand most of those slots to `genre_top`, whose "Pulled at random from the Alternative racks" reads identically to "A hidden Alternative gem?". Near-zero visible change.

## What the complaint actually is

Splitting the criteria by what their clerk line can honestly claim:

```
crate 43:  5 name a record of yours, 5 know only a genre
crate 44:  6 / 4      crate 45:  6 / 4
crate 46:  6 / 4      crate 47:  6 / 4
crate 48:  5 name a record of yours, 5 know only a genre
```

Four to five of every ten cards know nothing about you but a tag. That is the axis worth moving, and `older_than_ten` is a third of it.

## Result

| | before | after |
| --- | --- | --- |
| cards that only know a genre | 4.40 / 10 | **3.00** |
| also_like | 1.30 / 10 | **4.00** |

## Commit 1 — cap the criteria that only know a tag about you

`best_seller` was already held to one, with the reason written down: the guardrails forbid letting un-personalised content dominate a crate that presents itself as dug for you. `genre_top` and `older_than_ten` make a weaker version of the same claim — their seed is a genre, so the line can say what is on your shelves but never which record sent us here. They join it.

A cap, deliberately, **not** a ban. The backfill overruns these rather than shipping a short crate (KAMP-661), so a thin gather still fills — and `older_than_ten` keeps its place as the occasional oddity, which is the job it is good at and which resting it would have taken away.

The caps move to a module constant so a test can read them. That is not tidying: every builder test drives a fake source inheriting the ABC's empty `criterion_caps`, so **the whole suite was structurally blind** to what the real source declares and would not have noticed the crate skewing in either direction.

`TestCrateShape` asserts the crate a user actually reads, against the real seven registry keys rather than synthetic `a`/`b`/`c`. Verified red before the cap — and the failure reproduced the production mix almost exactly (`genre_top` 2, `also_like` 1), which is good evidence the synthetic setup measures the real thing.

## Commit 2 — extra turns for the criterion that can name your record

`criterion_weights` is the mirror of `criterion_caps` and takes the same bargain: caps say "no more than", weights say "more often than the rest", and the builder treats both as opaque provider data so it still never learns what a label means.

**`_deal` is untouched.** It already iterates `for criterion in order`, so a key present twice is simply asked twice a round — `taken` stops it dealing the same card, and `counts`, `caps` and `seed_cap` all accumulate across the turns. The entire mechanism is one list-expansion helper.

Two things this shape gets that a reserved-slots pass would not:

- **It carries into the backfill**, which is handed the same `order` list — and the backfill is where the skew was actually generated, because pass one comes up short and the deepest surviving pool wins on availability. `genre_top` has 73 buffered rows to `also_like`'s 17.
- **It cannot pin the front of the crate.** Weighting is applied *after* the shuffle and appended rather than inserted. Shuffling a list that already held the duplicates would have quietly broken the property `test_group_order_varies_between_crates` exists to protect — and that test could not have caught it, because it uses unweighted synthetic criteria. There is now one that can.

**Four is measured, not picked.** Averaged over sixty crates: caps alone 1.72, then 2.40 / 3.23 / 4.00 as the weight climbs, with genre-only cards flat at 3.00 throughout.

**The planned third `also_like` seed is not here**, because the measurement says it does nothing — 3.23 with two seeds, 3.23 with three. The constraint is turns in the round, not seed supply, so it would have cost an ALBUM_PAGE request on every crate for no benefit at all.

## The KAMP-665 boundary

Weighting also-like up pushes directly against KAMP-665, whose point was a crate reading narrower than the library. Two things hold the line:

- `SEED_CAP` still refuses a third card off one album page, and its tests pass **unchanged**. A test pins this directly by handing a weighted criterion twenty candidates off a single seed and asserting it still takes two.
- Four is also `also_like`'s ceiling by construction (`_SEEDS_PER_CRITERION` × `SEED_CAP` = 2 × 2), so a larger weight buys nothing — the seed cap refuses the fifth card.

**One tradeoff worth your eye.** Running at the ceiling means the share stops varying: every healthy crate becomes two records from each of two album pages. The bug KAMP-665 was filed about (three off one page) cannot recur, but if crates start reading mechanical, dropping the weight to 3 buys the variation back at 3.23. That is recorded in the code comment rather than left to be rediscovered.

## CI, run locally

- `pytest`: 3292 passed, 9 skipped. Coverage 93.85%, in line with main's 93.84% (below the 94% practice target, which is main's pre-existing state, not a regression here).
- `black` and `mypy` clean. No renderer changes.
- README: no drift — it does not mention the Crate at all.

## Manual test plan

1. **Dig several crates back to back and read the clerk lines end to end.** The question is whether a crate now reads as mostly about records you own, with a couple of genre picks alongside — rather than half and half.
2. Confirm `older_than_ten` still turns up — about one a crate. It should feel like an occasional oddity, not absent.
3. Watch whether four also-like cards per crate reads as rich or as repetitive, given they come from two album pages. This is the one judgement call the numbers cannot make.
4. Dig with a thin or picked-over library (or right after a rate-limit pause) and confirm crates still come back full — the caps must yield rather than shorten.
