### PR TITLE
KAMP-670: don't hand someone a record they cannot hear

### DIFF
--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -412,6 +412,29 @@ class DiscoverySource(ABC):
         """The first playable track of *candidate*, or None if there is none."""
         return next(iter(self.preview_tracks(candidate)), None)
 
+    def confirm_playable(
+        self, candidate: Candidate, budget: RequestBudget
+    ) -> bool | None:
+        """Whether *candidate* really has audio, for a pick about to be placed.
+
+        The last-resort half of KAMP-670. Most candidates are settled for free at
+        gather time, from a signal the surface already returned — but not all
+        surfaces carry one, and a provider knows which of its own do. This is
+        where it may spend a request to close that gap.
+
+        Called ONLY for candidates the builder is about to put in a crate, never
+        for the whole gathered pool: an implementation that fetched per candidate
+        would spend tens of requests on records nobody will see. Three answers:
+        True and False are findings, and **None means "not worth a request"** —
+        already known from the gather, budget exhausted, or simply not something
+        this provider can check. None is the safe default and the ABC's behaviour.
+
+        It is BUDGETED, unlike :meth:`preview_tracks`, and that difference is the
+        point: this runs on a background build where refusing is free, while a
+        preview runs under a click where refusing would be a hang.
+        """
+        return None
+
     def save_remote(self, candidate: Candidate) -> bool:
         """Save *candidate* to the provider's own list (Bandcamp: the wishlist).
 

--- a/kamp_daemon/discovery_bandcamp_parsers.py
+++ b/kamp_daemon/discovery_bandcamp_parsers.py
@@ -167,16 +167,46 @@ def _audio_url(raw: str) -> str | None:
     not a bare URL -- reading it as a string yields something unplayable that
     would only fail at the point of pressing play.
     """
+    files = _audio_formats(raw)
+    if files is None:
+        return None
+    url = files.get("mp3-128") or files.get("mp3-v0")
+    return url if isinstance(url, str) and url else None
+
+
+def _audio_formats(raw: str) -> dict[str, Any] | None:
+    """The parsed ``data-audiourl`` object, or None if we could not read it.
+
+    Split out from ``_audio_url`` because the two questions it was answering at
+    once are different questions (KAMP-670). "No playable URL" had four causes --
+    the attribute was absent, the JSON did not parse, it parsed to something other
+    than an object, or it was an object with no format we can play -- and only the
+    LAST of those is Bandcamp telling us anything. The first three are our own
+    blind spots, and a record dropped on our parse failure is a record we removed
+    for no reason.
+    """
     if not raw:
         return None
     try:
         files = json.loads(raw)
     except (ValueError, TypeError):
         return None
-    if not isinstance(files, dict):
+    return files if isinstance(files, dict) else None
+
+
+def _has_preview(raw: str) -> bool | None:
+    """Whether the surface says this recommendation is playable (KAMP-670).
+
+    True and False are claims; None is silence, and silence is the common case
+    for anything that is not simply a well-formed object we understood. Only a
+    format map we read successfully and found nothing playable in is a definite
+    "no" -- everything else leaves the record alone for the preview to settle.
+    """
+    files = _audio_formats(raw)
+    if files is None:
         return None
     url = files.get("mp3-128") or files.get("mp3-v0")
-    return url if isinstance(url, str) and url else None
+    return bool(isinstance(url, str) and url)
 
 
 def parse_also_like(html: str) -> ParseResult:
@@ -210,6 +240,11 @@ def parse_also_like(html: str) -> ParseResult:
                 # spawn plus an album-page fetch; the full track list still needs
                 # the page, but the listener does not wait for it.
                 "audio_url": _audio_url(_attr(body, "data-audiourl")),
+                # The same attribute read as a verdict rather than a URL
+                # (KAMP-670). Kept separate because the URL is signed and expires
+                # within hours, so it is useless by the time a crate is read,
+                # while "was there one" stays true.
+                "has_preview": _has_preview(_attr(body, "data-audiourl")),
                 "supporters": _clean_text(supporters.group(1)) if supporters else "",
                 "fan_comment": _clean_text(comment.group(1)) if comment else "",
             }
@@ -252,6 +287,22 @@ def parse_discover_facets(html: str) -> dict[str, list[dict[str, Any]]]:
         return {}
     state = (blob.get("appData") or {}).get("initialState") or {}
     return {family: state.get(family) or [] for family in FACET_FAMILIES}
+
+
+def _featured_track_plays(featured: Any) -> bool | None:
+    """Whether a discover row's ``featured_track`` carries a stream (KAMP-670).
+
+    The discover surface's equivalent of ``data-audiourl``, and read to the same
+    rule: an object we understood with no ``stream_url`` is a definite no, and
+    anything else -- the key absent, null, or some shape we did not expect -- is
+    silence rather than a verdict. Absence has never been observed (the captured
+    fixture carries one on all twenty rows), so calling it "unplayable" would be
+    inventing a claim from a case nobody has seen.
+    """
+    if not isinstance(featured, dict):
+        return None
+    url = featured.get("stream_url")
+    return bool(isinstance(url, str) and url)
 
 
 def parse_discover_results(payload: str | dict[str, Any]) -> ParseResult:
@@ -301,6 +352,10 @@ def parse_discover_results(payload: str | dict[str, Any]) -> ParseResult:
                 "is_owned": bool(row.get("is_owned")),
                 "is_wishlisted": bool(row.get("is_wishlisted")),
                 "band_id": str(row.get("band_id") or ""),
+                # Passed through as a verdict, the way is_owned/is_wishlisted are
+                # passed through as flags: the parser reads the surface, the
+                # source decides policy (KAMP-670).
+                "has_preview": _featured_track_plays(row.get("featured_track")),
             }
         )
     return result

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -149,8 +149,14 @@ def build_crate(
     # pool would look exhausted again each time, which is the same bug on a
     # longer fuse.
     rotation = _load_rotation(index)
+    # ONE budget for the whole build, resolved once. The gather and the KAMP-670
+    # confirmation both draw on it, and that is the property that makes confirming
+    # affordable: it spends the gather's leftovers rather than a fresh allowance,
+    # so a build can never exceed what crate_budget() funds. Resolving it inline
+    # at each call site would hand the second one a full, untouched allowance.
+    budget = budget or crate_budget()
     try:
-        candidates = source.gather(profile, budget or crate_budget(), rotation)
+        candidates = source.gather(profile, budget, rotation)
     except Exception:  # noqa: BLE001 - a provider must not take the daemon with it
         logger.exception("discovery: gather failed")
         return _publish(publish, state="error")
@@ -188,6 +194,22 @@ def build_crate(
         if (c.provider, c.provider_item_id) not in fresh_ids
     ]
 
+    # Records the provider proved unplayable while the crate was being dealt
+    # (KAMP-670). Kept so they are not written back to the buffer: nothing on disk
+    # remembers the verdict, so a buffered dead record would be re-fetched and
+    # re-proved dead on every future build.
+    unplayable: set[tuple[str, str]] = set()
+
+    def _confirm(candidate: Candidate) -> bool | None:
+        verdict = source.confirm_playable(candidate, budget)
+        if verdict is False:
+            unplayable.add((candidate.provider, candidate.provider_item_id))
+            logger.info(
+                "discovery: %s has nothing playable, taking the next one instead",
+                candidate.item_url,
+            )
+        return verdict
+
     picks = select_crate(
         candidates,
         index=index,
@@ -197,6 +219,7 @@ def build_crate(
         rng=rng,
         wishlist_ids=wishlist_ids,
         extra=stock,
+        confirm=_confirm,
     )
     # Attributed BEFORE anything is written, and that ordering is the whole
     # correctness of the flag: place first and this crate's own ten records are
@@ -269,7 +292,7 @@ def build_crate(
     # Deliberately not filtered by `_excluded` — exclusion is re-checked at
     # assembly because a candidate can be bought or wishlisted while it sits, so
     # filtering now would only bake in a verdict that has to be re-taken anyway.
-    _buffer_surplus(index, candidates, picks)
+    _buffer_surplus(index, candidates, picks, unplayable)
 
     short = placed < size
     # `dry` was measured against the picks; `short` is measured against what
@@ -354,9 +377,17 @@ def _buffer_surplus(
     index: "LibraryIndex",
     candidates: "Sequence[Candidate]",
     picks: "Sequence[Candidate]",
+    unplayable: "set[tuple[str, str]] | None" = None,
 ) -> int:
-    """Persist what this gather found and did not place. Returns rows written."""
+    """Persist what this gather found and did not place. Returns rows written.
+
+    *unplayable* is what the provider proved dead while dealing (KAMP-670), and
+    it is excluded. Nothing on disk remembers that verdict, so a buffered dead
+    record would be re-fetched and re-proved dead on every future build — paying
+    the same request forever to reach the same answer.
+    """
     placed_keys = {(p.provider, p.provider_item_id) for p in picks}
+    placed_keys |= unplayable or set()
     surplus = [
         c for c in candidates if (c.provider, c.provider_item_id) not in placed_keys
     ]
@@ -396,12 +427,19 @@ def select_crate(
     rng: random.Random | None = None,
     wishlist_ids: set[str] | None = None,
     extra: Sequence[Candidate] | None = None,
+    confirm: "Callable[[Candidate], bool | None] | None" = None,
 ) -> list[Candidate]:
-    """Pick up to *size* candidates, excluded and varied. Pure apart from reads.
+    """Pick up to *size* candidates, excluded and varied.
 
     Exclusion runs here, at assembly, rather than at capture: a candidate may
     have been bought or wishlisted since it was gathered, and a buffered one
     (KAMP-657) may have been sitting for weeks.
+
+    Pure apart from reads, EXCEPT for *confirm* (KAMP-670), which may perform I/O
+    — it is the provider's last chance to check a pick whose surface never said
+    whether it was playable. It is injected rather than reached for so this stays
+    testable without a network, and it is called only on a candidate about to be
+    placed, never on the pool.
     """
     rng = rng or random.Random()
     caps = caps or {}
@@ -429,7 +467,7 @@ def select_crate(
         # who opens the crate, which is the property it exists for.
         order = _weighted(order, weights)
 
-        picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP)
+        picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP, confirm=confirm)
         if len(picks) < size:
             # A cap is a preference, not a ceiling: honouring one to the point of
             # shrinking the crate is how a brand-new library (whose only criterion
@@ -440,7 +478,16 @@ def select_crate(
             # caps (KAMP-665): a thin profile can yield one seed's worth of
             # candidates and nothing else, and a two-record crate is a worse answer
             # than a crate that leans on one album page.
-            picks.extend(_deal(groups, order, size - len(picks), caps={}, skip=picks))
+            picks.extend(
+                _deal(
+                    groups,
+                    order,
+                    size - len(picks),
+                    caps={},
+                    skip=picks,
+                    confirm=confirm,
+                )
+            )
 
     # Stock, and only once the fresh pool has had every chance (KAMP-657). This is
     # the whole reason the buffer exists: a gather cut short by a 429, an
@@ -458,7 +505,14 @@ def select_crate(
             stock_order = list(stock)
             rng.shuffle(stock_order)
             picks.extend(
-                _deal(stock, stock_order, size - len(picks), caps={}, skip=picks)
+                _deal(
+                    stock,
+                    stock_order,
+                    size - len(picks),
+                    caps={},
+                    skip=picks,
+                    confirm=confirm,
+                )
             )
     return picks
 
@@ -499,6 +553,7 @@ def _deal(
     caps: dict[str, int],
     skip: list[Candidate] | None = None,
     seed_cap: int | None = None,
+    confirm: "Callable[[Candidate], bool | None] | None" = None,
 ) -> list[Candidate]:
     """Round-robin one card per criterion until *size* or nothing is left.
 
@@ -564,6 +619,15 @@ def _deal(
                     and key is not None
                     and seed_counts.get(key, 0) >= seed_cap
                 ):
+                    continue
+                # Asked only of a card about to be PLACED, which is the whole
+                # reason it is affordable (KAMP-670). Rejecting one here simply
+                # moves to the next candidate in the same group, so a confirmed
+                # dead record costs the crate nothing rather than leaving a hole.
+                # `taken` is marked either way: a record we just proved unplayable
+                # must not be reconsidered by the backfill a moment later.
+                if confirm is not None and confirm(candidate) is False:
+                    taken.add(id(candidate))
                     continue
                 taken.add(id(candidate))
                 counts[criterion] = counts.get(criterion, 0) + 1

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -411,12 +411,26 @@ class BandcampDiscoverySource(DiscoverySource):
                 continue
 
             consumed = step + 1
-            got = self._run_seed(criterion, seed, budget, owned or set(), state)
+            got, dropped = self._run_seed(
+                criterion, seed, budget, owned or set(), state
+            )
             if got:
                 found.extend(got)
-                productive += 1
                 if dimension is not None:
                     used.add(dimension)
+            # A seed filtered down to nothing is NOT an unproductive seed
+            # (KAMP-670). `productive` decides whether to walk on and spend
+            # another request, so without the `or dropped` the playability filter
+            # would buy extra fetches on the class that rate-limits hardest, and
+            # starve purchase_anniversary, which shares ALBUM_PAGE and runs last.
+            # That would break this ticket's own "no increase in requests" rule.
+            #
+            # Deliberately narrow: the owned and unfetchable drops still make a
+            # seed look unproductive, exactly as before. Walking on when
+            # everything was owned is a real chance of finding something and is
+            # not this change's business.
+            if got or dropped:
+                productive += 1
 
         # Advance past every seed TRIED, not just a productive one. Advancing only
         # on success looks right and is the trap: a seed at the head of the list
@@ -434,20 +448,25 @@ class BandcampDiscoverySource(DiscoverySource):
         budget: RequestBudget,
         owned: set[str],
         state: "MutableMapping[str, Any] | None" = None,
-    ) -> list[Candidate]:
+    ) -> tuple[list[Candidate], int]:
+        """One seed's candidates, and how many it dropped for having no audio.
+
+        The second half rides all the way up to ``_run_criterion`` so a seed whose
+        yield was filtered is not mistaken for a seed that found nothing.
+        """
         if criterion.surface == SURFACE_DISCOVER:
             return self._discover(criterion, seed, budget, owned, state)
         if criterion.surface == SURFACE_ALBUM_RECS:
             body = self._fetch(criterion.endpoint_class, str(seed.target), budget)
             if body is None:
-                return []
+                return [], 0
             result = parse_also_like(body)
             result.warn_if_drifted(criterion.surface, str(seed.target))
             return self._to_candidates(criterion, seed, result, owned)
         if criterion.surface == SURFACE_DISCOGRAPHY:
             body = self._fetch(criterion.endpoint_class, str(seed.target), budget)
             if body is None:
-                return []
+                return [], 0
             result = parse_discography(body, base_url=str(seed.target))
             result.warn_if_drifted(criterion.surface, str(seed.target))
             # The grid carries no artist name — every entry is the page's artist,
@@ -457,7 +476,7 @@ class BandcampDiscoverySource(DiscoverySource):
                 item.setdefault("artist", artist)
             return self._to_candidates(criterion, seed, result, owned)
         logger.warning("discovery: unknown surface %r", criterion.surface)
-        return []
+        return [], 0
 
     def _discover(
         self,
@@ -466,7 +485,7 @@ class BandcampDiscoverySource(DiscoverySource):
         budget: RequestBudget,
         owned: set[str],
         state: "MutableMapping[str, Any] | None" = None,
-    ) -> list[Candidate]:
+    ) -> tuple[list[Candidate], int]:
         params: dict[str, Any] = dict(seed.target)
         # Normalise here rather than in the criterion: the seed carries the display
         # genre so the clerk card can say "you've been deep in Indie Rock lately",
@@ -495,7 +514,7 @@ class BandcampDiscoverySource(DiscoverySource):
             criterion.endpoint_class, DISCOVER_API_URL, budget, payload=payload
         )
         if body is None:
-            return []
+            return [], 0
         result = parse_discover_results(body)
         result.warn_if_drifted(criterion.surface, DISCOVER_API_URL)
 
@@ -533,8 +552,35 @@ class BandcampDiscoverySource(DiscoverySource):
         seed: Seed,
         result: ParseResult,
         owned: set[str],
-    ) -> list[Candidate]:
+    ) -> tuple[list[Candidate], int]:
+        """Usable candidates, and how many were dropped for having no audio.
+
+        The count is returned rather than logged and forgotten because
+        ``_run_criterion`` has to know: a seed judged unproductive walks to the
+        next one and spends another request, so without this the new filter would
+        quietly buy extra fetches on the endpoint class that rate-limits hardest
+        (KAMP-670). It is also the number that answers "does this filter ever
+        actually fire", which no sample so far has been able to.
+        """
         out: list[Candidate] = []
+        # A page where EVERY record reads as unplayable is drift, not twenty dead
+        # records (KAMP-670). Measured, a definite negative is vanishingly rare --
+        # 7/7, 20/20 and 48/48 across every sample ever taken -- so all of them at
+        # once means we stopped understanding the format, and the honest response
+        # is the one this module already uses for that: say so and keep the
+        # records. Dropping them instead would empty the x4-weighted flagship
+        # criterion silently, which is the exact failure ParseResult.drifted was
+        # invented to prevent.
+        verdicts = [item.get("has_preview") for item in result.items]
+        blanket = bool(verdicts) and all(v is False for v in verdicts)
+        if blanket:
+            logger.warning(
+                "discovery: every record on %s reads as unplayable — treating as"
+                " parser drift and keeping them (%d records)",
+                seed.target,
+                len(verdicts),
+            )
+        dropped = 0
         for item in result.items:
             if item["provider_item_id"] in owned:
                 # Recommending someone a record they already own is the clerk who
@@ -545,6 +591,14 @@ class BandcampDiscoverySource(DiscoverySource):
             if not _is_fetchable(url):
                 # Same reasoning as the fetch-side skip: a candidate we could
                 # never fetch art or a preview for is not a usable card.
+                continue
+            if not blanket and item.get("has_preview") is False:
+                # The surface said there is nothing to hear. `is False` and not a
+                # falsy check: None means the surface said nothing, which is every
+                # discography record and anything we failed to parse, and those
+                # keep their place — the preview-time message stays the honest
+                # answer for a record we genuinely do not know about.
+                dropped += 1
                 continue
             out.append(
                 Candidate(
@@ -560,7 +614,15 @@ class BandcampDiscoverySource(DiscoverySource):
                     seed=dict(seed.seed_data),
                 )
             )
-        return out
+        if dropped:
+            logger.info(
+                "discovery: dropped %d unplayable of %d from %s (%s)",
+                dropped,
+                len(result.items),
+                seed.target,
+                criterion.key,
+            )
+        return out, dropped
 
     # ------------------------------------------------------------------
     # Preview

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -123,6 +123,23 @@ def _is_fetchable(url: str) -> bool:
     return host_allowed(url, FETCHABLE_HOSTS)
 
 
+def _preview_unavailable(reason: str, url: str) -> None:
+    """Record why a preview could not be produced, in one greppable shape.
+
+    "No preview for this one." has five distinct causes and they used to be five
+    differently-worded lines at three different levels — the one that matters
+    most, an album whose page carries no stream at all, was the quietest of them
+    at INFO. So when a user reported the failure there was no way to tell which
+    had happened, and there still would not be next time (KAMP-670).
+
+    One prefix to grep for, one reason word to tell them apart, and all of them
+    at WARNING, because every one of them is a card the user cannot play. The
+    reasons are: ``host_blocked``, ``fetch_failed``, ``http_<status>``,
+    ``no_tralbum``, ``no_streams``.
+    """
+    logger.warning("discovery: preview unavailable (%s) for %s", reason, url)
+
+
 class RateLimitedError(RuntimeError):
     """Raised internally when the origin rate-limits us mid-gather."""
 
@@ -648,13 +665,13 @@ class BandcampDiscoverySource(DiscoverySource):
         # the same host check the art proxy applies (KAMP-649). A Bandcamp Pro
         # custom domain also lands here, and is unfetchable in packaged builds.
         if not _is_fetchable(candidate.item_url):
-            logger.debug("discovery: preview host not fetchable %s", candidate.item_url)
+            _preview_unavailable("host_blocked", candidate.item_url)
             return []
 
         try:
             resp = self._session.get(candidate.item_url, timeout=30)
         except Exception:  # noqa: BLE001 - a failed preview is not an error state
-            logger.warning("discovery: preview fetch failed for %s", candidate.item_url)
+            _preview_unavailable("fetch_failed", candidate.item_url)
             return []
 
         status = resp.status_code
@@ -662,15 +679,13 @@ class BandcampDiscoverySource(DiscoverySource):
             self._governor.report_429("album_page")
             raise RateLimitedError(f"429 from {candidate.item_url}")
         if status != 200:
-            logger.warning(
-                "discovery: preview HTTP %d from %s", status, candidate.item_url
-            )
+            _preview_unavailable(f"http_{status}", candidate.item_url)
             return []
         self._governor.report_ok("album_page")
 
         tralbum = parse_tralbum(resp.text)
         if not tralbum:
-            logger.warning("discovery: no tralbum on %s", candidate.item_url)
+            _preview_unavailable("no_tralbum", candidate.item_url)
             return []
 
         # A standalone single-track page exposes its lone track with
@@ -692,7 +707,11 @@ class BandcampDiscoverySource(DiscoverySource):
                 )
             )
         if not out:
-            logger.info("discovery: nothing streamable on %s", candidate.item_url)
+            # The cause KAMP-670's gather-time filter is meant to pre-empt. If
+            # this still appears after that shipped, the surface did not tell us
+            # -- a discography pick, or a page whose recommendation block we could
+            # not read -- and THAT is the interesting case.
+            _preview_unavailable("no_streams", candidate.item_url)
         return out
 
     # ------------------------------------------------------------------

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -46,6 +46,7 @@ from .discovery_bandcamp_parsers import (
 )
 from .discovery_criteria import (
     OLD_ALBUM_YEARS,
+    REGISTRY,
     SURFACE_ALBUM_RECS,
     SURFACE_DISCOGRAPHY,
     SURFACE_DISCOVER,
@@ -96,6 +97,12 @@ CRITERION_CAPS: dict[str, int] = {
 #: Module-level for the same reason as the caps: the builder suite's fake source
 #: inherits the ABC default, so a test has to read the real thing.
 CRITERION_WEIGHTS: dict[str, int] = {"also_like": 4}
+
+#: Which surface each criterion reads, so `confirm_playable` can tell the ones
+#: whose gather already settled playability from the ones it could not (KAMP-670).
+#: Derived from the registry rather than restated, so a new criterion cannot
+#: quietly default to "already checked".
+_CRITERION_SURFACE: dict[str, str] = {c.key: c.surface for c in REGISTRY}
 
 
 def _sub(state: "MutableMapping[str, Any]", key: str) -> dict[str, Any]:
@@ -640,6 +647,60 @@ class BandcampDiscoverySource(DiscoverySource):
                 criterion.key,
             )
         return out, dropped
+
+    def confirm_playable(
+        self, candidate: Candidate, budget: RequestBudget
+    ) -> bool | None:
+        """Check a discography pick's album page, because nothing else can.
+
+        Two of the seven criteria come off an artist's ``/music`` grid, and that
+        grid says nothing about audio — not in ``data-audiourl``, which it does
+        not carry, nor in ``data-client-items``, which holds only art_id, band_id,
+        id, page_url, title and type. So the gather-time filter is blind to about
+        2.8 records of every ten, and the first no_streams failure seen in the
+        wild was one of them.
+
+        Every other criterion returns None immediately and costs nothing: they
+        were settled from the surface's own signal during the gather, and asking
+        again would be paying twice for the same answer.
+
+        **Only picks reach here.** The ticket forbids "an album-page fetch per
+        candidate" and it is right — a gather holds tens of discography
+        candidates. It holds about three that get placed, which is a different
+        number, and the one this spends.
+
+        Budget-bounded rather than best-effort-unbounded: `allow` says no and this
+        returns None, so a crate degrades to today's behaviour instead of
+        overrunning the class that rate-limits hardest. ALBUM_PAGE is funded at 8
+        and a gather spends about 4.
+        """
+        if _CRITERION_SURFACE.get(candidate.criterion) != SURFACE_DISCOGRAPHY:
+            return None
+        if not budget.allow(ALBUM_PAGE):
+            logger.info(
+                "discovery: no budget left to confirm %s, placing it unchecked",
+                candidate.item_url,
+            )
+            return None
+        budget.consume(ALBUM_PAGE)
+        try:
+            # preview_tracks is the same question asked at play time, so there is
+            # one definition of "playable" rather than two that can disagree. It
+            # is unbudgeted by design; the allowance is spent above, by the caller
+            # that can afford to be refused.
+            return bool(self.preview_tracks(candidate))
+        except RateLimitedError:
+            # Never fail a pick on a rate limit. It says nothing about the record,
+            # and dropping one here would quietly shrink the crate for a reason
+            # the user would see as a short crate with no explanation.
+            raise
+        except Exception:  # noqa: BLE001 - a check that breaks must not lose a card
+            logger.warning(
+                "discovery: could not confirm %s, placing it unchecked",
+                candidate.item_url,
+                exc_info=True,
+            )
+            return None
 
     # ------------------------------------------------------------------
     # Preview

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -398,6 +398,73 @@ class TestSeedCaps:
         assert len(index.crate_items(1)) == CRATE_SIZE
 
 
+class TestConfirmingAPick:
+    """KAMP-670: the last chance to check a pick no surface vouched for.
+
+    Two of seven criteria come off the discography grid, which carries no audio
+    signal at all — so the gather-time filter is blind to roughly 2.8 records of
+    every ten, and the first no_streams failure seen in the wild was one of them.
+    """
+
+    @staticmethod
+    def _source(dead: set[str], **kw: Any) -> _FakeSource:
+        source = _FakeSource(_spread({"a": 8, "b": 8, "c": 8}), **kw)
+        asked: list[str] = []
+
+        def confirm(candidate: Candidate, budget: Any) -> bool | None:
+            asked.append(candidate.provider_item_id)
+            if candidate.provider_item_id in dead:
+                return False
+            return None
+
+        source.confirm_playable = confirm  # type: ignore[method-assign]
+        source.asked = asked  # type: ignore[attr-defined]
+        return source
+
+    def test_a_confirmed_dead_record_never_reaches_the_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        source = self._source(dead={"1", "2", "3"})
+        _build(index, source)
+        placed = {row["provider_item_id"] for row in index.crate_items(1)}
+        assert not (placed & {"1", "2", "3"})
+
+    def test_the_crate_is_still_full(self, index: LibraryIndex) -> None:
+        """The point of confirming during the deal rather than after it: a
+        rejected pick moves to the next candidate in the same group, so a dead
+        record costs the crate nothing instead of leaving a hole."""
+        _build(index, self._source(dead={"1", "2", "3", "4"}))
+        assert len(index.crate_items(1)) == CRATE_SIZE
+
+    def test_only_records_about_to_be_placed_are_checked(
+        self, index: LibraryIndex
+    ) -> None:
+        """The affordability argument, made checkable. A gather holds tens of
+        candidates and a crate holds ten; confirming the pool would spend tens of
+        album-page requests on records nobody will ever see."""
+        source = self._source(dead=set())
+        _build(index, source)
+        assert len(source.asked) <= CRATE_SIZE, f"asked {len(source.asked)} times"
+
+    def test_a_dead_record_is_not_buffered_for_next_time(
+        self, index: LibraryIndex
+    ) -> None:
+        """Nothing on disk remembers the verdict, so a buffered dead record would
+        be re-fetched and re-proved dead on every future build — paying the same
+        request forever to reach the same answer."""
+        _build(index, self._source(dead={"1"}))
+        buffered = {row["provider_item_id"] for row in index.buffered_candidates()}
+        assert "1" not in buffered
+
+    def test_an_unknown_verdict_places_the_record(self, index: LibraryIndex) -> None:
+        """None means "not worth a request" — already settled at gather time, or
+        the budget is gone. It must never read as a rejection, or a provider that
+        cannot check anything would be unable to fill a crate."""
+        source = _FakeSource(_spread({"a": 8, "b": 8, "c": 8}))
+        _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+
+
 class TestCrateShape:
     """What a crate READS like, against the real registry (KAMP-683).
 

--- a/tests/test_discovery_parsers.py
+++ b/tests/test_discovery_parsers.py
@@ -102,6 +102,41 @@ class TestAlsoLike:
 
         assert _audio_url(raw) is None
 
+    @pytest.mark.parametrize(
+        "raw", ["{}", '{"flac": "https://x/y.flac"}', '{"mp3-128": ""}']
+    )
+    def test_a_format_map_with_nothing_playable_is_a_definite_no(
+        self, raw: str
+    ) -> None:
+        """KAMP-670. These three are Bandcamp answering the question: we read the
+        object it gave us and there is no format we can play. That is the ONLY
+        case a record may be dropped for."""
+        from kamp_daemon.discovery_bandcamp_parsers import _has_preview
+
+        assert _has_preview(raw) is False
+
+    @pytest.mark.parametrize("raw", ["", "not json", "[]", '"https://x/y.mp3"'])
+    def test_an_unreadable_audio_attribute_says_nothing(self, raw: str) -> None:
+        """The other half of the split that `test_unusable_audio_url_is_none`
+        conflates: absent, unparseable, or a shape we did not expect are OUR
+        blind spots, not a verdict. Dropping a record on our own parse failure
+        would remove it for no reason -- and if Bandcamp ever renames the
+        attribute, this is what stops the whole criterion silently emptying."""
+        from kamp_daemon.discovery_bandcamp_parsers import _has_preview
+
+        assert _has_preview(raw) is None
+
+    def test_every_recommendation_on_the_fixture_reads_as_playable(
+        self, album_page: str
+    ) -> None:
+        """The base rate the drop rule rests on. Measured 7/7 here and 48/48 in
+        the KAMP-644 recon, so a definite negative has never actually been seen
+        -- which is worth pinning, because it means this filter should almost
+        never fire and a sudden change of heart is a signal, not a success."""
+        items = parse_also_like(album_page).items
+        assert items
+        assert all(item["has_preview"] is True for item in items)
+
     def test_tracking_parameter_is_stripped(self, album_page: str) -> None:
         """Bandcamp appends ?from=<seed>, so the same album reached from two seeds
         would otherwise look like two albums and defeat cross-seed dedupe."""
@@ -190,6 +225,47 @@ class TestDiscoverResults:
         items = parse_discover_results(payload).items
         assert [i["is_owned"] for i in items] == [True, False]
         assert [i["is_wishlisted"] for i in items] == [False, True]
+
+    def test_featured_track_is_read_as_a_playability_verdict(self) -> None:
+        """KAMP-670. Same rule as the album page's data-audiourl: an object we
+        understood with no stream_url is a definite no; the key absent or null is
+        silence. Synthetic because the fixture carries a stream on all twenty
+        rows and is checksum-locked, so there is no negative case to draw on."""
+        payload = {
+            "results": [
+                {
+                    "item_id": 1,
+                    "item_url": "https://a.bandcamp.com/album/plays",
+                    "featured_track": {"stream_url": "https://t4.bcbits.com/x"},
+                },
+                {
+                    "item_id": 2,
+                    "item_url": "https://b.bandcamp.com/album/silent",
+                    "featured_track": {"title": "Track", "stream_url": ""},
+                },
+                {
+                    "item_id": 3,
+                    "item_url": "https://c.bandcamp.com/album/nulled",
+                    "featured_track": None,
+                },
+                {
+                    "item_id": 4,
+                    "item_url": "https://d.bandcamp.com/album/absent",
+                },
+            ]
+        }
+        items = parse_discover_results(payload).items
+        assert [i["has_preview"] for i in items] == [True, False, None, None]
+
+    def test_every_discover_row_on_the_fixture_reads_as_playable(
+        self, discover_results: str
+    ) -> None:
+        """The discover half of the base rate, 20/20. Pinned for the same reason
+        as the album page's: the drop rule is designed around definite negatives
+        being rare, and if a re-capture ever changes that we want to know."""
+        items = parse_discover_results(discover_results).items
+        assert len(items) == 20
+        assert all(item["has_preview"] is True for item in items)
 
     def test_carries_the_cursor_for_the_next_page(self, discover_results: str) -> None:
         """The whole of KAMP-661 hangs off this value being kept.

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -685,6 +685,58 @@ class TestUnplayableRecords:
         # seed list until the budget stopped it.
         assert len(session.gets) == 2, f"spent {len(session.gets)} requests"
 
+    @staticmethod
+    def _pick(criterion: str) -> Candidate:
+        return Candidate(
+            provider="bandcamp",
+            provider_item_id="1",
+            item_url="https://a.bandcamp.com/album/x",
+            criterion=criterion,
+        )
+
+    @pytest.mark.parametrize(
+        "criterion",
+        ["also_like", "purchase_anniversary", "genre_top", "best_seller"],
+    )
+    def test_a_vouched_criterion_costs_no_request_to_confirm(
+        self, criterion: str
+    ) -> None:
+        """Every criterion whose surface carries the signal was already settled
+        during the gather. Asking again would pay twice for the same answer."""
+        session = FakeSession()
+        budget = crate_budget()
+        assert _source(session).confirm_playable(self._pick(criterion), budget) is None
+        assert session.gets == []
+        assert budget.spent.get(ALBUM_PAGE, 0) == 0
+
+    @pytest.mark.parametrize("criterion", ["favorite_artist", "lone_album_artist"])
+    def test_a_discography_pick_is_checked_against_its_album_page(
+        self, criterion: str
+    ) -> None:
+        """The gap this closes: the /music grid says nothing about audio, so the
+        only way to know is the album page — and only for a pick."""
+        session = FakeSession(
+            get_body='<script data-tralbum="'
+            + html.escape('{"trackinfo": [{"title": "A", "file": {}}]}', quote=True)
+            + '"></script>'
+        )
+        budget = crate_budget()
+        assert _source(session).confirm_playable(self._pick(criterion), budget) is False
+        assert len(session.gets) == 1
+        assert budget.spent[ALBUM_PAGE] == 1
+
+    def test_an_exhausted_budget_places_the_record_unchecked(self) -> None:
+        """Bounded by the gather's own allowance rather than a fresh one, so a
+        build degrades to the old behaviour instead of overrunning the endpoint
+        class that rate-limits hardest."""
+        session = FakeSession()
+        budget = SimpleBudget(limits={ALBUM_PAGE: 0})
+        assert (
+            _source(session).confirm_playable(self._pick("favorite_artist"), budget)
+            is None
+        )
+        assert session.gets == [], "spent a request it could not afford"
+
     @pytest.mark.parametrize(
         ("body", "status", "reason"),
         [

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -7,6 +7,7 @@ supply the markup, so these exercise the actual parsers rather than mocks of the
 from __future__ import annotations
 
 import gzip
+import html
 import json
 from dataclasses import replace
 from pathlib import Path
@@ -584,6 +585,122 @@ class TestSeedDimension:
         assert seed_dimension({"kind": "genre", "genre": ""}) is None
 
 
+def _rec_page(*audio: str) -> str:
+    """An album page whose recommendation block is exactly *audio*.
+
+    Synthetic because the captured fixture is checksum-locked AND 7/7 positive --
+    it holds no unplayable record to test against, and one cannot be added to it.
+    Each argument is the raw `data-audiourl` attribute for one recommendation.
+    """
+    # Attributes are double-quoted with the JSON entity-escaped inside, which is
+    # how Bandcamp really ships them — `_attr` only matches double quotes, so a
+    # single-quoted attribute would silently read as absent and the record would
+    # look unknown rather than unplayable.
+    recs = "".join(
+        f'<li class="recommended-album" data-albumid="{n}" data-artist="Artist {n}"'
+        f' data-albumtitle="Title {n}" data-audiourl="{html.escape(raw, quote=True)}">'
+        f'<a class="album-link" href="https://b{n}.bandcamp.com/album/x"></a></li>'
+        for n, raw in enumerate(audio)
+    )
+    return f'<div id="detail_recommendations">{recs}</div>'
+
+
+class TestUnplayableRecords:
+    """KAMP-670: a record the surface says has no audio never reaches a crate."""
+
+    PLAYS = '{"mp3-128": "https://t4.bcbits.com/stream/x"}'
+    SILENT = '{"flac": "https://x/y.flac"}'
+    UNREADABLE = "not json"
+
+    @staticmethod
+    def _seed() -> Seed:
+        return Seed(
+            target="https://a.bandcamp.com/album/x",
+            why="because",
+            seed_data={"kind": "album", "album_id": 1},
+        )
+
+    def _gather_one_seed(self, page: str) -> tuple[list[Any], FakeSession]:
+        session = FakeSession(get_body=page)
+        source = _source(session)
+        criterion = next(c for c in REGISTRY if c.key == "also_like")
+        got, _dropped = source._run_seed(
+            criterion, self._seed(), crate_budget(), set(), {}
+        )
+        return got, session
+
+    def test_a_record_with_no_playable_format_is_dropped(self) -> None:
+        got, _ = self._gather_one_seed(_rec_page(self.PLAYS, self.SILENT))
+        assert [c.provider_item_id for c in got] == ["0"]
+
+    def test_a_record_we_could_not_read_is_kept(self) -> None:
+        """The distinction the whole design rests on. An attribute we failed to
+        parse is our blind spot, not Bandcamp saying no -- and the preview-time
+        message is the honest answer for a record we do not know about."""
+        got, _ = self._gather_one_seed(_rec_page(self.PLAYS, self.UNREADABLE))
+        assert [c.provider_item_id for c in got] == ["0", "1"]
+
+    def test_a_page_where_everything_is_unplayable_is_treated_as_drift(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The failure this module is architected against: a format change that
+        empties a criterion while every test still passes.
+
+        A definite negative has never been observed -- 7/7, 20/20, 48/48 across
+        every sample ever taken -- so ALL of them at once means we stopped
+        understanding the format, not that Bandcamp shipped a page of silent
+        records. Say so and keep them.
+        """
+        with caplog.at_level("WARNING", logger="kamp_daemon.discovery_sources"):
+            got, _ = self._gather_one_seed(_rec_page(self.SILENT, self.SILENT))
+        assert len(got) == 2, "a format change must not empty the criterion"
+        assert "parser drift" in caplog.text
+
+    def test_dropping_a_seed_dry_does_not_buy_another_request(self) -> None:
+        """The acceptance criterion "no increase in requests per crate", made
+        checkable -- and the one the fixtures cannot test, being all-positive.
+
+        `productive` decides whether to walk to the next seed, and it used to be
+        judged on the post-filter list. So a seed filtered down to nothing read as
+        a seed that FOUND nothing, and the loop spent another fetch on the
+        endpoint class that rate-limits hardest.
+        """
+        # One playable record the user already owns, and one with no audio. The
+        # mix matters: a page that is ENTIRELY unplayable is treated as drift and
+        # kept, so the only way a seed empties via this filter is alongside one of
+        # the older drops.
+        session = FakeSession(get_body=_rec_page(self.PLAYS, self.SILENT))
+        source = _source(session)
+        criterion = next(c for c in REGISTRY if c.key == "also_like")
+        profile = SeedProfile(
+            recent_album_ids={1, 2, 3, 4},
+            recent_albums=[
+                _album_seed(album_id=i, url=f"https://a{i}.bandcamp.com/album/x")
+                for i in (1, 2, 3, 4)
+            ],
+        )
+        source._run_criterion(criterion, profile, crate_budget(), {"0"}, {})
+        # Two seeds tried, exactly as _SEEDS_PER_CRITERION allows for a criterion
+        # whose seeds all produce records. Before the fix this walked the whole
+        # seed list until the budget stopped it.
+        assert len(session.gets) == 2, f"spent {len(session.gets)} requests"
+
+    def test_a_discography_record_is_never_dropped(self) -> None:
+        """Two of seven criteria sit on a surface with no audio signal at all. A
+        rule that dropped them would zero those criteria on a guess."""
+        session = FakeSession(get_body=_fixture("artist_discography"))
+        source = _source(session)
+        criterion = next(c for c in REGISTRY if c.key == "favorite_artist")
+        seed = Seed(
+            target="https://fourtet.bandcamp.com/music",
+            why="because",
+            seed_data={"kind": "artist", "artist": "Four Tet"},
+        )
+        got, dropped = source._run_seed(criterion, seed, crate_budget(), set(), {})
+        assert got, "the discography surface must still yield candidates"
+        assert dropped == 0
+
+
 class TestSpreadWithinACrate:
     """KAMP-665: one criterion should not take everything from one seed."""
 
@@ -685,7 +802,7 @@ class TestGenreExclusionAcrossCriteria:
             label="fake",
         )
         state: dict[str, Any] = {}
-        source._run_seed = lambda *a, **k: [MagicMock()]  # type: ignore[method-assign]
+        source._run_seed = lambda *a, **k: ([MagicMock()], 0)  # type: ignore[method-assign]
         source._run_criterion(
             criterion,
             SeedProfile(),
@@ -908,7 +1025,9 @@ class TestRotationAndPagination:
         def fake_run_seed(criterion, seed, budget, owned, state=None):  # noqa: ANN001
             tried.append(seed.target)
             # Barren, barren, then a hit — so it stops on the third of three.
-            return [MagicMock()] if len(tried) == 3 else []
+            # The second value is the KAMP-670 unplayable-drop count; zero here,
+            # because these seeds find nothing rather than finding it unplayable.
+            return ([MagicMock()], 0) if len(tried) == 3 else ([], 0)
 
         source._run_seed = fake_run_seed  # type: ignore[method-assign]
         criterion = Criterion(
@@ -988,7 +1107,7 @@ class TestRotationAndPagination:
             # Spends the budget the way a real fetch would, and finds nothing —
             # so the loop keeps going until the budget, not the results, stops it.
             b.consume(ALBUM_PAGE)
-            return []
+            return [], 0
 
         source._run_seed = barren  # type: ignore[method-assign]
         state: dict[str, Any] = {}

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -685,6 +685,48 @@ class TestUnplayableRecords:
         # seed list until the budget stopped it.
         assert len(session.gets) == 2, f"spent {len(session.gets)} requests"
 
+    @pytest.mark.parametrize(
+        ("body", "status", "reason"),
+        [
+            ("", 404, "http_404"),
+            ("<html>nothing here</html>", 200, "no_tralbum"),
+            # Double-quoted with the JSON entity-escaped inside, the way
+            # parse_tralbum actually matches it.
+            (
+                '<script data-tralbum="'
+                + html.escape('{"trackinfo": [{"title": "A", "file": {}}]}', quote=True)
+                + '"></script>',
+                200,
+                "no_streams",
+            ),
+        ],
+    )
+    def test_every_preview_failure_names_its_cause(
+        self,
+        body: str,
+        status: int,
+        reason: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """KAMP-670. "No preview for this one." has five causes, and they used to
+        be five differently-worded lines at three levels -- with the one that
+        matters most, an album carrying no stream at all, the quietest of them at
+        INFO. A user reporting the failure left nothing behind to say WHICH.
+
+        One prefix to grep, one reason word to tell them apart.
+        """
+        session = FakeSession()
+        session.get_body = body
+        session.get_status = status
+        candidate = Candidate(
+            provider="bandcamp",
+            provider_item_id="1",
+            item_url="https://a.bandcamp.com/album/x",
+        )
+        with caplog.at_level("WARNING", logger="kamp_daemon.discovery_sources"):
+            assert _source(session).preview_tracks(candidate) == []
+        assert f"preview unavailable ({reason})" in caplog.text
+
     def test_a_discography_record_is_never_dropped(self) -> None:
         """Two of seven criteria sit on a surface with no audio signal at all. A
         rule that dropped them would zero those criteria on a guess."""


### PR DESCRIPTION
The clerk should not hand you a record and then tell you that you cannot play it. Where a surface told us a release has no audio, it no longer reaches a crate.

Ticket said LP; it is a **Side**. The `preview_hint` field, the schema migration and the `_deal` ordering all proved unnecessary.

## The signal was already parsed and already thrown away

`parse_also_like` has extracted `audio_url` from `data-audiourl` since KAMP-647 and **nothing consumes it** — repo-wide it appears exactly twice, at the definition and the assignment. It dies at the `Candidate(...)` literal. The discover surface never looked at `featured_track` at all, though every fixture row carries a real signed `stream_url`.

## Two acceptance criteria were corrected before implementing

**"Preorders are excluded" — dropped.** Its rationale is "a preorder frequently has nothing released yet". Both `is_album_preorder` rows in the captured fixture carry a full playable `stream_url` with a real duration (296s of a 3640s album, 329s of a 2082s album) — classic advance tracks. A Bandcamp preorder is also purchasable, and purchases-per-crate is the feature's metric, so excluding them would drop playable, buyable records to prevent a problem the only evidence we have says does not occur. `track_count` was considered and rejected too: 1–30 on every row, no zeros. Recorded on the ticket.

**The diagnosis is weaker than the description implies.** A definite negative has never been observed anywhere: `docs/discovery-recon.md:240` measured `mp3-128 preview embedded | 48/48` live, and the fixtures are 7/7 and 20/20. So **this filter may rarely fire**, and the crate that prompted the report may have failed for one of the other two causes. Hence the third commit.

## Commit 1 — let the two surfaces that know say whether a record plays

Both signal-bearing parsers now emit a tri-state `has_preview`. The URL itself stays where it was: it is signed and expires within hours, so it is useless by the time a crate is read, while "was there one" stays true.

**`_audio_url` could not express the distinction the drop rule needs.** It returned `None` for four different reasons — the attribute was absent, the JSON did not parse, it parsed to a non-object, or it was an object with no playable format — and **only the last is Bandcamp telling us anything**. The other three are our own blind spots, and a record dropped on our parse failure is a record removed for no reason. Worse, the conflation is how a rename empties a criterion: if `data-audiourl` is ever spelled differently, every recommendation reads as unplayable at once.

Both base rates are now pinned by tests, deliberately: this filter should almost never fire, and if a re-capture changes that it is a signal, not a success.

## Commit 2 — drop a record the surface says has nothing to hear

One uniform line in `_to_candidates`, beside the two drops already there: `if item.get("has_preview") is False`. **`is False`, not a falsy check** — `None` means the surface said nothing, which covers every discography record and anything we failed to parse, and those keep their place. The preview-time message stays the honest answer for a record we genuinely do not know about, exactly as the ticket asks.

Dropping *here* rather than at assembly is what keeps this small: the record never reaches `select_crate` and never reaches `_buffer_surplus`, so no `Candidate` field, no schema migration, and no change to `_rehydrate`, `buffer_candidates` or the deal. (`_rehydrate` is a **fourth** `Candidate` construction site that arrived with KAMP-657, after the estimation was written.)

**A page where every record reads as unplayable is treated as drift, not as twenty dead records.** All of them at once means we stopped understanding the format, and dropping them would empty the ×4-weighted flagship criterion silently — precisely the failure `ParseResult.drifted` exists to prevent. Warn and keep.

**The productivity accounting had to move with it, or the filter buys extra requests.** `productive` decides whether to walk to the next seed and spend another fetch, and it was judged on the *post-filter* list — so a seed filtered down to nothing read as a seed that *found* nothing. Measured: **four requests where two were due**, on ALBUM_PAGE, the class that rate-limits hardest, starving `purchase_anniversary` which shares it and runs last. That is a straight violation of this ticket's own "no increase in requests per crate", and there is now a test asserting the request count that fails without the fix.

Deliberately narrow: owned and unfetchable still make a seed look unproductive, exactly as before.

## Commit 3 — make a failed preview say which of its five causes it was

**This ticket could not be diagnosed.** "No preview for this one." has five causes; they were five differently-worded lines at three levels, with the one that matters most — an album carrying no stream at all — the quietest of them at INFO. After the gather-time filter there still would not have been a way to tell next time.

One prefix to grep, one reason word to tell them apart, all at WARNING: `host_blocked`, `fetch_failed`, `http_<status>`, `no_tralbum`, `no_streams`. The gather-side drop count stays at INFO, and the split is the point — a dropped record is normal operation, a failed preview is a failure. Previously it was the other way round for the case that mattered. INFO is the daemon's default level, so the drop line is visible without asking for it.

## Tests

All synthetic, because the fixtures are checksum-locked **and** 100% positive — they contain no unplayable record and one cannot be added.

Two are worth calling out. The **request-count test** is the acceptance criterion made checkable, and it needs a page mixing a playable record with a silent one — a wholly unplayable page is kept as drift, so the only way a seed empties through this filter is alongside one of the older drops. The **drift test** asserts an all-negative page warns and keeps its records rather than emptying the criterion.

Three existing tests that monkeypatch `_run_seed` were updated for its new return shape.

## CI, run locally

- `pytest`: 3310 passed, 9 skipped. Coverage **93.90%**, up from main's 93.85%.
- `black` and `mypy` clean. No renderer changes.
- README: no drift — it does not mention the Crate at all.

## Follow-up filed — KAMP-691

Even a perfect gather-time filter leaves the message reachable, and **nothing retires the dead card or moves on**. Signed URLs expire within a day, albums get pulled, and two of seven criteria have no signal at all. KAMP-691 also notes that the new logging is what will settle how much it is worth: after a few weeks, the balance of `no_streams` against `http_404` and `fetch_failed` says whether the case this PR fixes is the one that actually bites.

## Manual test plan

1. Dig several crates and confirm they still come back full, and still lean on also-like as KAMP-683 left them.
2. **Watch the daemon output for `discovery: dropped N unplayable`.** If it never appears, that is the answer to the diagnosis question — the filter is not firing and the original report had a different cause.
3. Press Space on a record that fails, and check the log names the reason. `no_streams` means the surface did not tell us at gather time (a discography pick, or a page we could not read); anything else means the record went bad after selection, which is KAMP-691.
4. Preview several records normally and confirm nothing that used to play has stopped.
5. The ~246 existing buffered candidates predate this filter and are left to decay on their 30-day TTL, so a thin build may still surface one.
