### PR TITLE
KAMP-673: a stale preview re-signs itself instead of going quiet

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1131,6 +1131,11 @@ class MpvPlaybackEngine:
         # Stored here rather than in on_file_loaded so it doesn't clobber the
         # external callback chain wired up after engine creation.
         self._pending_seek: float | None = None
+        # Why mpv ended the last file: "eof", "error", "network", "redirect",
+        # "stop", or "" before anything has ended (KAMP-673). Set in _handle_event
+        # just before on_track_end fires, so a callback that needs to tell a clean
+        # finish from a failed open can ask. Read via `last_end_reason`.
+        self._last_end_reason: str = ""
         # Path of the track pre-appended to mpv's playlist as a gapless lookahead.
         # None means mpv's playlist has only the current track (slot 0).
         self._lookahead_path: Path | None = None
@@ -1536,6 +1541,17 @@ class MpvPlaybackEngine:
         # The seek is issued by the Lua kamp-stop handler after the fade completes.
         self._send_command("script-message", "kamp-stop")
 
+    @property
+    def last_end_reason(self) -> str:
+        """Why mpv ended the most recent file (KAMP-673).
+
+        ``"eof"`` is a clean finish; ``"error"``, ``"network"`` and ``"redirect"``
+        are a file that would not open or buffer — a dead CDN URL, a 403, a 410.
+        Both arrive at ``on_track_end``, so a callback that must tell them apart
+        reads this.
+        """
+        return self._last_end_reason
+
     def unload(self) -> None:
         # Fully unload the current file from mpv using mpv's "stop" command.
         # Used before deleting a file that is loaded but not actively playing;
@@ -1702,6 +1718,20 @@ class MpvPlaybackEngine:
                 self.on_file_loaded()
 
         elif name == "end-file":
+            # Recorded BEFORE dispatch, so a callback can ask why the file ended
+            # (KAMP-673). mpv distinguishes a clean finish from a failed open, and
+            # the two branches below then hand both to the same on_track_end — so
+            # a preview whose signed URL expired mid-listen is indistinguishable
+            # from a record that simply ended, and gets silently skipped.
+            #
+            # An attribute rather than a second callback, deliberately. The main
+            # player CHAINS on_track_end by capture-and-reassign at four sites
+            # (queue advance, scrobble, notify, deferred drain): a new callback
+            # fired *instead* would stall its queue forever on a dead CDN URL --
+            # the exact bug the error branch below was added to fix -- and one
+            # fired *as well* would have the main queue advance while a preview
+            # retried. This leaves the shared contract untouched.
+            self._last_end_reason = str(event.get("reason") or "")
             if event.get("reason") == "eof":
                 # Hold _lock across the read+send+clear so a concurrent seek()
                 # cannot send playlist-remove 1 while we are sending

--- a/kamp_daemon/__main__.py
+++ b/kamp_daemon/__main__.py
@@ -1179,12 +1179,19 @@ def _cmd_daemon(
     # NOTE the name: _state_saver and create_app both close over `engine`, so
     # this must never be bound to that name or the preview would become the
     # main player as far as the rest of the daemon is concerned.
+    # The same HEAD the main player uses before handing mpv a remote track
+    # (KAMP-673). Goes to the bcbits CDN, not the bot-managed host, so it costs
+    # nothing against the endpoint that rate-limits. Imported here rather than at
+    # the module top to match how the other bandcamp helpers are pulled in below.
+    from kamp_daemon.bandcamp import check_stream_url as _preview_check_url
+
     preview_player = PreviewPlayer(
         index,
         main_engine=engine,
         engine_factory=_preview_engine,
         source_factory=_discovery_source,
         notify=_preview_notify,
+        check_url=_preview_check_url,
     )
 
     # KAMP-652: wishlist ids for crate exclusion. Walked in the background and

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -334,6 +334,23 @@ class PreviewPlayer:
                 return self.play(int(parked), self._state["parked_track_num"])
             if self._engine is None or self._state["state"] != PAUSED:
                 return self.snapshot()
+            # A pause held overnight is the reported bug (KAMP-673). Nothing reaps
+            # a paused preview -- the idle timer only fires from stop() -- so mpv
+            # sits on the socket for as long as the app runs, and by morning the
+            # signed URL behind it is dead. Every other route back into playback
+            # goes through play() and therefore through _resolve, which re-signs;
+            # this one told mpv to carry on with a link that had expired.
+            #
+            # Replay rather than resume-at-position. Re-signing then seeking back
+            # is not implementable: mpv silently drops a seek issued before
+            # file-loaded, which is why load_paused defers one, and a start=
+            # parameter would be an engine change for a crate bug. Replaying from
+            # the top is already this module's idiom -- see the cued-record branch
+            # just above, and release_for_main's note that the deck's play button
+            # replays.
+            item_id = self._state["item_id"]
+            if item_id is not None and self._is_stale(int(item_id)):
+                return self.play(int(item_id), self._state["track_num"])
             self._take_over_from_main()
             self._engine.resume()
             self._playing_since = self._now()
@@ -536,9 +553,23 @@ class PreviewPlayer:
     # Internals
     # ------------------------------------------------------------------
 
+    def _is_stale(self, item_id: int) -> bool:
+        """Whether this item's cached URLs are past their signature (KAMP-673).
+
+        Split out of `_resolve` so `resume` can ask the same question without
+        fetching: `_resolve`'s answer is "here are usable tracks", which is the
+        wrong shape for a caller that only wants to know whether to replay.
+
+        No cached list reads as stale rather than fresh. It means the tracks were
+        dropped after a failure, or were never resolved -- either way the URL mpv
+        is holding is not one this player can vouch for.
+        """
+        cached = self._tracks.get(item_id)
+        return not cached or any(t.is_expired for t in cached)
+
     def _resolve(self, item_id: int, item: dict[str, Any]) -> list[PreviewStream]:
         cached = self._tracks.get(item_id)
-        if cached and not any(t.is_expired for t in cached):
+        if not self._is_stale(item_id) and cached:
             return cached
 
         source = self._source_factory()

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -95,6 +95,7 @@ class PreviewPlayer:
         notify: Callable[[dict[str, Any]], None] | None = None,
         idle_timeout: float = IDLE_TIMEOUT_SECS,
         now: Callable[[], float] = _time.time,
+        check_url: Callable[[str], int] | None = None,
     ) -> None:
         self._index = index
         self._main = main_engine
@@ -103,6 +104,10 @@ class PreviewPlayer:
         self._notify = notify
         self._idle_timeout = idle_timeout
         self._now = now
+        # HEAD the URL before mpv sees it (KAMP-673). Injected so tests need no
+        # network, and None simply skips the check — the retry path still catches
+        # a dead link, this only stops it getting that far.
+        self._check_url = check_url
 
         self._lock = threading.RLock()
         self._engine: "MpvPlaybackEngine | None" = None
@@ -292,6 +297,10 @@ class PreviewPlayer:
             track = self._pick(tracks, track_num)
             if track is None:
                 return self._publish(state=IDLE, buffering=False, error="unavailable")
+
+            track = self._validated(item_id, item, track, track_num)
+            if track is None:
+                return self._publish(state=IDLE, buffering=False, error="expired")
 
             self._take_over_from_main()
             engine = self._ensure_engine()
@@ -552,6 +561,47 @@ class PreviewPlayer:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _validated(
+        self,
+        item_id: int,
+        item: dict[str, Any],
+        track: PreviewStream,
+        track_num: int | None,
+    ) -> PreviewStream | None:
+        """*track*, or a re-signed replacement, or None if it cannot be played.
+
+        ``expires_at`` is a guess and the library path already learned that the
+        guess is not enough — ``resolve_playback_uri``'s HEAD step exists because
+        "a 4xx from the CDN means the signed token was invalidated (e.g. 410 Gone
+        when Bandcamp's session key rotates)". A URL can be dead while
+        ``is_expired`` is False, and no amount of clock arithmetic catches that.
+
+        Cheap, which is what makes it worth doing on the play path: the HEAD goes
+        to the bcbits CDN, and per the KAMP-636 lesson the CDN is plain nginx
+        rather than the bot-managed host — it is not the resource that
+        rate-limits. `check_stream_url` returns 0 on a network failure and only a
+        4xx is treated as a verdict, so a blocked or slow check leaves the record
+        alone rather than dropping it.
+        """
+        check = self._check_url
+        if check is None or not track.url.startswith("https://"):
+            return track
+        status = check(track.url)
+        if not 400 <= status < 500:
+            return track
+        logger.info(
+            "preview: HEAD %d for item %s track %s — re-signing before playback",
+            status,
+            item_id,
+            track.track_num,
+        )
+        # Drop the whole album's list, not just this track: they were signed
+        # together on one page fetch, so one dead link means the rest are dead too
+        # and re-fetching per track would pay for the same page repeatedly.
+        self._tracks.pop(item_id, None)
+        tracks = self._resolve(item_id, item)
+        return self._pick(tracks, track_num) if tracks else None
 
     def _is_stale(self, item_id: int) -> bool:
         """Whether this item's cached URLs are past their signature (KAMP-673).

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -115,6 +115,11 @@ class PreviewPlayer:
         # per button press, so the list is kept for as long as its URLs live.
         self._tracks: dict[int, list[PreviewStream]] = {}
 
+        # The (item, track) whose re-signed URL is currently being tried, or None
+        # (KAMP-673). One retry per track: set before the attempt, and returned in
+        # _on_file_loaded, which is the only evidence a load actually succeeded.
+        self._retry_key: tuple[int, int] | None = None
+
         # Captured BEFORE main is paused and never read back: pause() is a
         # ~0.4s fade (a script-message the Lua schedules), so main.state.playing
         # is still True immediately after the call and would lie.
@@ -457,14 +462,75 @@ class PreviewPlayer:
     # ------------------------------------------------------------------
 
     def _on_file_loaded(self) -> None:
+        # mpv opened the file, which is the only proof a retry actually worked --
+        # so this is where the retry budget is returned (KAMP-673). Spending it
+        # once per attempt rather than once per session is what stops a single
+        # bad afternoon disabling retries for every record after it.
+        self._retry_key = None
         self._publish(buffering=False)
 
     def _on_track_end(self, _had_lookahead: bool) -> None:
-        # Advance within the album; stepping past the last track stops.
+        """A file stopped. Whether that is an ending or a failure decides
+        everything, and until KAMP-673 this could not tell (see `last_end_reason`
+        on the engine: mpv distinguishes them and then hands both here).
+
+        A stale signed URL therefore read as "the record finished" and the deck
+        moved on, which is the reported bug -- silently skipping a track the user
+        had asked to hear, or on the last track emptying the deck with no message.
+        """
         try:
+            engine = self._engine
+            reason = getattr(engine, "last_end_reason", "") if engine else ""
+            if reason and reason != "eof":
+                self._on_playback_failed(reason)
+                return
+            # Advance within the album; stepping past the last track stops.
             self.step(1)
         except Exception:  # noqa: BLE001 - a callback must never kill the reader thread
             logger.warning("preview: advance failed", exc_info=True)
+
+    def _on_playback_failed(self, reason: str) -> None:
+        """mpv could not open or buffer the stream. Re-sign it and try again once.
+
+        The URL is almost always the cause: Bandcamp signs them with a ``ts`` and
+        they die after about a day, so a record that sat on the deck overnight has
+        a whole album of dead links. Dropping the cached list forces `_resolve` to
+        fetch the album page again and hand back freshly signed ones.
+
+        **Bounded to one attempt per track.** An unbounded retry's only natural
+        terminator is a 429 on album pages, which CLAUDE.md records as
+        account-wide -- it would cascade into the download queue and the stream
+        sync, turning one dead track into a poisoned session.
+        """
+        with self._lock:
+            item_id = self._state["item_id"]
+            track_num = self._state["track_num"]
+            if item_id is None or track_num is None:
+                return
+            key = (int(item_id), int(track_num))
+            spent = self._retry_key == key
+            if not spent:
+                self._retry_key = key
+                self._tracks.pop(int(item_id), None)
+        if spent:
+            logger.warning(
+                "preview: item %s track %s still would not play after re-signing"
+                " (reason=%s)",
+                key[0],
+                key[1],
+                reason,
+            )
+            # Published directly, NOT via stop(), which clears `error` in the same
+            # call -- that erasure is why the failure has always been silent.
+            self._publish(
+                state=IDLE,
+                buffering=False,
+                position=0.0,
+                error="expired",
+            )
+            return
+        logger.info("preview: %s ended with reason=%s, re-signing", item_id, reason)
+        self.play(key[0], key[1])
 
     # ------------------------------------------------------------------
     # Internals

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -686,8 +686,10 @@ export type PreviewState = {
   duration: number
   buffering: boolean
   tracks: PreviewTrack[]
-  // 'not_found' | 'unavailable' | 'rate_limited' — a rate limit and an album
-  // with nothing streamable want different words on screen.
+  // 'not_found' | 'unavailable' | 'rate_limited' | 'expired' — each wants
+  // different words on screen. 'expired' is the one that is not the record's
+  // fault: Bandcamp signs stream URLs for about a day, so a record left on the
+  // deck overnight has a dead link and a working album behind it (KAMP-673).
   error: string | null
   // The record still ON the deck with nothing playing, because the main
   // transport took the floor (KAMP-678). Set only while `state` is 'idle': it is

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -955,7 +955,14 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                   <p className="crate-preview-error" role="status">
                     {preview.error === 'rate_limited'
                       ? 'Bandcamp asked us to slow down — try again shortly.'
-                      : 'No preview for this one.'}
+                      : preview.error === 'expired'
+                        ? // Distinct from the line below, because the record is
+                          // fine and only the link went stale — Bandcamp signs
+                          // them for about a day (KAMP-673). Saying "no preview
+                          // for this one" would send the user away from a record
+                          // that plays perfectly well on a second press.
+                          'That link went stale — press play again.'
+                        : 'No preview for this one.'}
                   </p>
                 )}
 

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -633,6 +633,30 @@ class TestAStaleStream:
         h.engine.fail()
         assert h.player.snapshot()["error"] == "expired"
 
+    def test_resuming_a_stale_pause_replays_it(self, index: LibraryIndex) -> None:
+        """The reported repro. Nothing reaps a paused preview — the idle timer
+        only fires from stop() — so mpv holds the socket all night and the signed
+        URL behind it dies. Every other route back into playback goes through
+        play() and re-signs; this one told mpv to carry on regardless."""
+        h = Harness(index, source=FakeSource([_stream(1, expires_at=1.0)]))
+        h.player.play(_item(index))
+        h.player.pause()
+        h.engine.settle()
+        assert h.player.resume()["state"] == PLAYING
+        assert h.source.calls == 2, "resumed a dead socket instead of re-signing"
+        assert h.engine.calls.count("play") == 2, "resumed rather than replayed"
+
+    def test_resuming_a_live_pause_just_resumes(self, index: LibraryIndex) -> None:
+        """The common case must not pay for the rare one: a pause of a few
+        seconds resumes where it was, with no album-page fetch and no restart."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.pause()
+        h.engine.settle()
+        assert h.player.resume()["state"] == PLAYING
+        assert h.source.calls == 1
+        assert "resume" in h.engine.calls
+
     def test_a_recovered_track_may_fail_again_later(self, index: LibraryIndex) -> None:
         """The retry budget is per attempt, not per session. Clearing it on a
         confirmed load is what stops one bad afternoon disabling the retry for

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -181,6 +181,7 @@ class Harness:
         index: LibraryIndex,
         source: FakeSource | None = None,
         main_playing: bool = False,
+        check_url: Any = None,
     ) -> None:
         self.index = index
         self.main = FakeEngine()
@@ -210,6 +211,9 @@ class Harness:
             notify=self.events.append,
             idle_timeout=0.05,
             now=self.clock,
+            # Default None, so every pre-existing test keeps its exact behaviour
+            # and no test reaches the network (KAMP-673).
+            check_url=check_url,
         )
 
     @property
@@ -632,6 +636,39 @@ class TestAStaleStream:
         h.engine.fail()
         h.engine.fail()
         assert h.player.snapshot()["error"] == "expired"
+
+    def test_a_dead_link_is_caught_before_mpv_sees_it(
+        self, index: LibraryIndex
+    ) -> None:
+        """expires_at is a guess, and the library path already learned it is not
+        enough — a signed token can be invalidated early when Bandcamp rotates a
+        session key, so a URL is dead while is_expired still says fine."""
+        seen: list[str] = []
+
+        def check(url: str) -> int:
+            seen.append(url)
+            return 410 if len(seen) == 1 else 200
+
+        h = Harness(index, check_url=check)
+        h.player.play(_item(index))
+        assert h.source.calls == 2, "trusted the clock over the CDN"
+        assert h.engine.played, "gave up instead of re-signing"
+
+    def test_a_live_link_is_played_without_a_refetch(self, index: LibraryIndex) -> None:
+        """The check must not cost a fetch when it passes."""
+        h = Harness(index, check_url=lambda _url: 200)
+        h.player.play(_item(index))
+        assert h.source.calls == 1
+
+    def test_an_unreachable_check_leaves_the_record_alone(
+        self, index: LibraryIndex
+    ) -> None:
+        """check_stream_url returns 0 on a network failure, and only a 4xx is a
+        verdict. A blocked or slow check must not drop a playable record."""
+        h = Harness(index, check_url=lambda _url: 0)
+        h.player.play(_item(index))
+        assert h.source.calls == 1
+        assert h.engine.played
 
     def test_resuming_a_stale_pause_replays_it(self, index: LibraryIndex) -> None:
         """The reported repro. Nothing reaps a paused preview — the idle timer

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -48,11 +48,36 @@ class FakeEngine:
         self.played: list[str] = []
         self.calls: list[str] = []
         self.shutdown_count = 0
+        # The reason mpv gave for the last file ending, exactly as the real engine
+        # records it. Without this the fake could not tell a track that finished
+        # from one that failed — which is why nothing caught KAMP-673: the two are
+        # the same callback and the fake never fired it at all.
+        self.last_end_reason: str | None = None
 
     def play(self, path: str) -> None:
         self.played.append(str(path))
         self.calls.append("play")
         self.state.playing = True
+
+    def finish(self) -> None:
+        """The file played to its end — mpv's `end-file reason=eof`."""
+        self._end("eof")
+
+    def fail(self) -> None:
+        """The file would not open or buffer — a dead CDN URL, a 403, a 410.
+
+        mpv reports this as `end-file reason=error`, and the engine funnels it
+        into the SAME on_track_end callback as a clean finish (playback.py). That
+        conflation is the bug: a preview whose signed URL expired mid-listen looks
+        exactly like a record that ended.
+        """
+        self._end("error")
+
+    def _end(self, reason: str) -> None:
+        self.state.playing = False
+        self.last_end_reason = reason
+        if self.on_track_end is not None:
+            self.on_track_end(False)
 
     def pause(self) -> None:
         self.calls.append("pause")
@@ -557,6 +582,69 @@ class TestTransport:
         h.player.play(item)
         h.player.play(item)
         assert h.source.calls == 1
+
+
+class TestAStaleStream:
+    """KAMP-673: a signed URL that died while the record sat on the deck.
+
+    Nothing here could be written before FakeEngine could end a file — it never
+    fired on_track_end at all, which is why a playback failure being read as a
+    clean finish went unnoticed through six tickets in this module.
+    """
+
+    def test_a_track_that_finishes_moves_on(self, index: LibraryIndex) -> None:
+        """The behaviour that must NOT change. An album plays through."""
+        h = Harness(index)
+        h.player.play(_item(index), track_num=1)
+        h.engine.finish()
+        assert h.player.snapshot()["track_num"] == 2
+
+    def test_a_track_that_fails_is_retried_not_skipped(
+        self, index: LibraryIndex
+    ) -> None:
+        """The bug. A dead URL mid-album looked exactly like a record ending, so
+        the deck silently jumped a track the user had asked to hear."""
+        h = Harness(index)
+        h.player.play(_item(index), track_num=1)
+        h.engine.fail()
+        assert h.player.snapshot()["track_num"] == 1, "skipped instead of retrying"
+        assert h.source.calls == 2, "retried without re-signing the URL"
+
+    def test_a_failure_that_repeats_gives_up_and_says_so(
+        self, index: LibraryIndex
+    ) -> None:
+        """Bounded, because an unbounded retry's natural terminator is a 429 on
+        album pages — which is account-wide and cascades into the download queue.
+        One retry, then an honest answer."""
+        h = Harness(index)
+        h.player.play(_item(index), track_num=1)
+        h.engine.fail()
+        h.engine.fail()
+        assert h.player.snapshot()["error"] == "expired"
+        assert h.source.calls == 2, "kept refetching after giving up"
+
+    def test_the_error_survives_the_last_track(self, index: LibraryIndex) -> None:
+        """stop() publishes error=None, so a failure that routed through it would
+        have its own message wiped in the same call that set it — which is the
+        silent vanish the report describes."""
+        h = Harness(index, source=FakeSource([_stream(1)]))
+        h.player.play(_item(index), track_num=1)
+        h.engine.fail()
+        h.engine.fail()
+        assert h.player.snapshot()["error"] == "expired"
+
+    def test_a_recovered_track_may_fail_again_later(self, index: LibraryIndex) -> None:
+        """The retry budget is per attempt, not per session. Clearing it on a
+        confirmed load is what stops one bad afternoon disabling the retry for
+        every record after it."""
+        h = Harness(index)
+        item = _item(index)
+        h.player.play(item, track_num=1)
+        h.engine.fail()
+        h.engine.on_file_loaded()  # mpv confirms the retry actually opened
+        h.engine.fail()
+        assert h.player.snapshot()["track_num"] == 1
+        assert h.player.snapshot()["error"] is None
 
 
 class TestFailures:


### PR DESCRIPTION
Preview an album from the crate, listen, wait a day, press play — nothing happens.

Bandcamp signs stream URLs with a `ts` and they die after about a day. `PreviewPlayer._tracks` is an in-memory cache that is **never cleared** — not by `stop()`, `_idle_kill()` or `shutdown()` — so an app left running overnight holds a list of dead links.

## Both the ticket title and the estimation are wrong about where it breaks

`_resolve` already refuses an expired cache and refetches, and `play()`, `step()`, `_on_track_end` and resume-from-cued all funnel through it. **All four self-heal.** "URIs aren't refreshed" is not the defect.

What actually failed, and all three are fixed here:

| | |
| --- | --- |
| **`resume()` from paused** | The one route back into playback that never re-resolved. It told mpv to continue a socket that died overnight. **This is the reported repro.** |
| **`expires_at` is a guess** | `stream_url_expiry`'s own docstring calls it a hint. A signed token can be invalidated early when Bandcamp rotates a session key, so a URL is dead while `is_expired` says fine. No guard band reaches that. |
| **A failure looked like an ending** | mpv *does* separate `reason=eof` from `error`/`network`/`redirect` — and then funnels both into the same `on_track_end`. So an expired URL mid-album silently skipped a track; on the last track it emptied the deck with no message at all. |

## Commit 1 — teach the fake engine to end a file, and fail one

**Nothing in this module's tests had ever exercised the track-end path.** `FakeEngine.play()` recorded a call and stopped; it never fired `on_track_end`. So the callback deciding what happens when a track stops was covered by nothing, through six tickets that touched the file. That is why this shipped, and it is why the first commit is the harness and four deliberately-red tests.

## Commit 2 — tell a record that ended from one that would not play

The engine records the end reason just before dispatching; the preview player reads it.

**An attribute rather than a second callback, and that is the load-bearing choice.** The main player chains `on_track_end` by capture-and-reassign at four sites — queue advance, scrobble, notify, deferred drain. A new callback fired *instead* would stall the main queue forever on a dead CDN URL, which is exactly the bug that error branch was added to fix; fired *as well*, the main queue would advance while a preview retried. Neither is acceptable for a crate bug.

On failure the cached list is dropped and the **same** track replayed, sending `_resolve` back for freshly signed URLs.

**Bounded to one attempt per track.** An unbounded retry's only natural terminator is `_resolve` raising on a 429 — and a 429 on album pages is account-wide, cascading into the download queue and the stream sync. The retry would have ended by poisoning the session rather than admitting one dead track. The budget is keyed on `(item, track)`, spent before the attempt, and returned in `_on_file_loaded` — the only proof mpv actually opened the file.

A failed retry publishes `error="expired"` **directly, never through `stop()`**. That is the real fix for the silent vanish: `stop()` sets `error=None` in the same call, so any message routed through it is erased by the thing meant to report it.

## Commit 3 — a pause held overnight replays

**Replay rather than resume-at-position, and that is forced rather than chosen.** Re-signing then seeking back is not implementable: mpv silently drops a seek issued before `file-loaded`, which is why `load_paused` defers one through `_pending_seek`. A `start=` parameter would be a change to shared playback for a crate bug. Replaying is already this module's idiom — the cued-record branch does it, and `release_for_main`'s docstring says the deck's play button replays from the top.

The common case is untouched, with a test saying so: a pause of a few seconds still resumes where it was, no fetch and no restart.

## Commit 4 — ask the CDN, not the clock

The picked track is HEADed before mpv sees it; a 4xx drops the list and re-signs. Same mechanism as `resolve_playback_uri`, same helper.

Cheap enough for the play path: `check_stream_url` is a bare 5s HEAD with no cookies, and it goes to the **bcbits CDN** — per the KAMP-636 lesson, plain nginx rather than the bot-managed host, so it spends nothing against the endpoint that rate-limits. Only a 4xx counts as a verdict; the helper returns 0 on a network failure, so a blocked check leaves a playable record alone.

This also makes commit 2's retry rare rather than routine, which matters: that retry runs on mpv's reader thread, where a refetch is an album-page GET that freezes the playhead and blocks pause and stop. **The hazard is pre-existing** — today's clean-finish path already refetches there when the cache has expired — and moving it to a worker is a bigger change than this ticket. Catching the dead link first is what keeps it from being reached.

## Commit 5 — say the link went stale, not that the record is no good

An expired signature was landing in "No preview for this one.", which sends the user away from a record that plays fine on a second press. Now: **"That link went stale — press play again."** The instruction is true; the retry re-signs.

## Deliberately not done

- **`seek()` re-resolving** — a scrub-bar drag would fire an album-page GET against the host that rate-limits hardest, and it is redundant: a seek into a dead URL raises the same error the retry path handles.
- **A guard band** — it only helps a URL dying inside the connect window. The HEAD covers that *and* the case a guard band cannot.
- **The `expires_at == 0.0` immortality** — a real trap but a production no-op; every branch of `stream_url_expiry` returns a real time, so a special case would be dead code.
- **`pause()` not arming the idle timer** — genuine, and filed as **KAMP-692**. Fixing it here would have made things worse: `_idle_kill` only reaps when IDLE, so arming is inert without relaxing that guard, and relaxing it would have torn the engine down under the very paused preview commit 3 depends on. That ordering now reverses — since commit 3 resume replays through `play()`, which respawns, a reaped engine is no longer a problem.

## CI, run locally

- `pytest`: 3332 passed, 9 skipped. Coverage **93.90%**, up from main's 93.88%.
- `black`, `mypy`, `npm run typecheck` clean; `npm run lint` clean apart from one pre-existing prettier warning in an untouched file.
- README: no drift — it does not mention the Crate.

## Manual test plan

1. **The repro.** Preview a record, pause mid-track, leave kamp running overnight, press play next day — it should start that track from the top rather than doing nothing.
2. A pause of a few seconds must still resume from where it was, instantly and with no refetch.
3. Let a preview run to the end of an album and confirm it still advances track to track normally — the behaviour commit 2 must not have broken.
4. Play a stale record and watch the log for `preview: HEAD 4xx … re-signing before playback`; it should then play without you noticing anything.
5. If a preview ever does fail twice, the deck should read "That link went stale — press play again." rather than emptying silently, and pressing play again should work.
