### PR TITLE
KAMP-689: one record per artist, and one per seed

### DIFF
--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -154,6 +154,17 @@ class Candidate:
     release_date: str = ""
     criterion: str = ""
     why: str = ""
+    #: The provider's own id for whoever made this record (KAMP-689). All three
+    #: Bandcamp surfaces already carry one and used to discard it; it is the key
+    #: the builder caps on, because the artist STRING differs between them -- the
+    #: discography surface fills it in from the seed, which is kamp's spelling,
+    #: while the album page carries Bandcamp's.
+    #:
+    #: Deliberately NOT persisted, and that is only safe because the cap runs on
+    #: the fresh pool alone. A candidate rehydrated from the KAMP-657 buffer
+    #: arrives with this empty and falls back to the name, which costs nothing
+    #: because the pass that deals stock does not cap at all.
+    band_id: str = ""
     seed: dict[str, Any] = field(default_factory=dict)
 
     def seed_json(self) -> str:

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -49,14 +49,23 @@ logger = logging.getLogger(__name__)
 #: affordance.
 CRATE_SIZE = 10
 
-#: How many records in one crate may come from a single seed (KAMP-665).
+#: How many records in one crate may come from a single seed (KAMP-665/689).
 #:
-#: Two, because one is too strict — a genre you actually listen to earning two
-#: records is a crate reflecting your taste, not a crate repeating itself — and
-#: three is what the complaint was: three cards off one album page, three clerk
-#: lines naming the same record. Enforced as a preference, not a ceiling; the
-#: backfill in select_crate overruns it rather than shipping a short crate.
-SEED_CAP = 2
+#: One. Two was the original call — "a genre you actually listen to earning two
+#: records is a crate reflecting your taste, not a crate repeating itself" — and
+#: measurement disagreed: 12 of 15 crates put two cards from one seed on screen,
+#: and the reader does not experience that as taste. They see one album page's
+#: recommendations twice, under two clerk lines naming the same record.
+#:
+#: KAMP-683 made it worse arithmetically rather than causing it. A weight of 4 on
+#: also_like times a cap of 2 is four cards off exactly two album pages, every
+#: crate. also_like now reads FOUR seeds instead of two (see
+#: _SEEDS_PER_CRITERION), so the same four cards come from four different
+#: records — the variety the weight was supposed to buy in the first place.
+#:
+#: Still a preference, not a ceiling: the backfill in select_crate drops it rather
+#: than shipping a short crate.
+SEED_CAP = 1
 
 #: How many records by one artist may share a crate (KAMP-689).
 #:

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -58,6 +58,23 @@ CRATE_SIZE = 10
 #: backfill in select_crate overruns it rather than shipping a short crate.
 SEED_CAP = 2
 
+#: How many records by one artist may share a crate (KAMP-689).
+#:
+#: One. Measured, 8 of 15 crates offered a band twice, and every instance was two
+#: cards from a single seed -- so SEED_CAP, which exists to prevent narrowness, was
+#: the direct cause of the narrowest thing a crate did. Two of the seven criteria
+#: make it structural rather than unlucky: they seed on an ARTIST and read that
+#: artist's own discography, so both their cards are necessarily by the same band.
+#:
+#: Two would not have been enough. It only catches a third card, which nothing
+#: observed produced -- and the copy argues harder than the counting does, since
+#: `lone_album_artist` says "you've just got the one. Try another." twice, in two
+#: different phrasings (KAMP-664), as if the clerk forgot he had already offered.
+#:
+#: A preference like every other cap here: enforced on the first deal only, so a
+#: gather that came back as one artist's grid still ships ten.
+ARTIST_CAP = 1
+
 #: Where the source's scratch space is kept between crates (KAMP-661): which seed
 #: each criterion stopped on, how far into each paginated query it has read. One
 #: settings row rather than a table, because the shape is the source's own and the
@@ -467,7 +484,15 @@ def select_crate(
         # who opens the crate, which is the property it exists for.
         order = _weighted(order, weights)
 
-        picks = _deal(groups, order, size, caps, seed_cap=SEED_CAP, confirm=confirm)
+        picks = _deal(
+            groups,
+            order,
+            size,
+            caps,
+            seed_cap=SEED_CAP,
+            artist_cap=ARTIST_CAP,
+            confirm=confirm,
+        )
         if len(picks) < size:
             # A cap is a preference, not a ceiling: honouring one to the point of
             # shrinking the crate is how a brand-new library (whose only criterion
@@ -522,6 +547,30 @@ def select_crate(
 # ---------------------------------------------------------------------------
 
 
+def _artist_key(candidate: Candidate) -> str | None:
+    """Who made this record, or None when the surface did not say (KAMP-689).
+
+    The provider's band id first, because the artist STRING is not comparable
+    across surfaces: a discography candidate carries kamp's own spelling (the
+    source fills it in from the seed) while an album-page recommendation carries
+    Bandcamp's, so "Godspeed You! Black Emperor" and "Godspeed You Black Emperor"
+    are one band and two strings.
+
+    Falling back to the name, case- and space-folded exactly as `seed_dimension`
+    folds a genre and for the same reason — these strings pass through three
+    different parsers.
+
+    **None means never capped**, matching `seed_dimension`'s rule. A candidate
+    with neither an id nor a name is a parser that has stopped yielding identity,
+    and quietly emptying a crate over it would be a worse failure than the
+    duplicate this prevents.
+    """
+    if candidate.band_id:
+        return f"band:{candidate.band_id}"
+    name = (candidate.artist or "").strip().casefold()
+    return f"name:{name}" if name else None
+
+
 def _weighted(order: list[str], weights: dict[str, int]) -> list[str]:
     """*order* with weighted criteria repeated, so they get extra turns per round.
 
@@ -553,6 +602,7 @@ def _deal(
     caps: dict[str, int],
     skip: list[Candidate] | None = None,
     seed_cap: int | None = None,
+    artist_cap: int | None = None,
     confirm: "Callable[[Candidate], bool | None] | None" = None,
 ) -> list[Candidate]:
     """Round-robin one card per criterion until *size* or nothing is left.
@@ -594,6 +644,11 @@ def _deal(
         if key is not None:
             seed_counts[key] = seed_counts.get(key, 0) + 1
 
+    # NOT seeded from `skip`, unlike seed_counts, and that asymmetry is the point:
+    # the artist cap is enforced on the first deal only, so the passes that would
+    # consume a carried-over count do not cap at all (KAMP-689).
+    artist_counts: dict[str, int] = {}
+
     picks: list[Candidate] = []
     while len(picks) < size:
         progressed = False
@@ -620,6 +675,24 @@ def _deal(
                     and seed_counts.get(key, 0) >= seed_cap
                 ):
                     continue
+                # Before `confirm`, and that ordering is a cost decision rather
+                # than a style one (KAMP-689): confirm_playable does a network
+                # fetch, and it is free for every criterion EXCEPT the two that
+                # read a discography — which are exactly the ones this cap binds
+                # hardest. Checking after it would spend an album-page request to
+                # validate a record we were about to refuse.
+                #
+                # A bare `continue`, deliberately NOT marking the candidate taken:
+                # mirroring seed_cap is what lets the uncapped backfill reconsider
+                # it, and what sends it to _buffer_surplus to come back as its own
+                # card in a later crate rather than being thrown away.
+                who = _artist_key(candidate)
+                if (
+                    artist_cap is not None
+                    and who is not None
+                    and artist_counts.get(who, 0) >= artist_cap
+                ):
+                    continue
                 # Asked only of a card about to be PLACED, which is the whole
                 # reason it is affordable (KAMP-670). Rejecting one here simply
                 # moves to the next candidate in the same group, so a confirmed
@@ -633,6 +706,8 @@ def _deal(
                 counts[criterion] = counts.get(criterion, 0) + 1
                 if key is not None:
                     seed_counts[key] = seed_counts.get(key, 0) + 1
+                if who is not None:
+                    artist_counts[who] = artist_counts.get(who, 0) + 1
                 picks.append(candidate)
                 progressed = True
                 break

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -71,7 +71,8 @@ DISCOVER_API_URL = "https://bandcamp.com/api/discover/1/discover_web"
 COLLECT_URL = "https://bandcamp.com/collect_item_cb"
 UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
 
-#: How many seeds one criterion may read from in a single crate (KAMP-665).
+#: How many seeds a criterion may read from in a single crate, by default
+#: (KAMP-665). `_SEEDS_FOR` below overrides it per criterion.
 #:
 #: Two, not "until the budget is spent". The allowance is per endpoint class and
 #: three criteria share DISCOVER_API's six, so an uncapped criterion would take
@@ -80,6 +81,25 @@ UNCOLLECT_URL = "https://bandcamp.com/uncollect_item_cb"
 #: matters because these endpoints are the thing that rate-limits hardest and a
 #: 429 here cascades account-wide (KAMP-639).
 _SEEDS_PER_CRITERION = 2
+
+#: Criteria allowed more than the default, and why (KAMP-689).
+#:
+#: `also_like` reads four album pages rather than two. SEED_CAP is now 1, so a
+#: criterion's card count IS its seed count — and KAMP-683's agreed target of four
+#: also-like records a crate therefore needs four seeds. The cards come from four
+#: different albums instead of two, which is what the weight was meant to buy.
+#:
+#: It costs two more ALBUM_PAGE requests, and the class is funded at 8: four here
+#: plus two for purchase_anniversary plus about two for KAMP-670's playability
+#: checks is exactly eight. No headroom, deliberately spent — the check degrades
+#: to unverified when the budget runs out rather than overrunning it.
+_SEEDS_FOR: dict[str, int] = {"also_like": 4}
+
+
+def _seeds_allowed(criterion: Criterion) -> int:
+    """How many seeds *criterion* may read in one crate."""
+    return _SEEDS_FOR.get(criterion.key, _SEEDS_PER_CRITERION)
+
 
 #: How many cards one criterion may contribute to a crate (KAMP-683).
 #:
@@ -426,7 +446,7 @@ class BandcampDiscoverySource(DiscoverySource):
         # tracked as an absolute step so a run of skips does not shift it.
         consumed = 0
         for step in range(len(seeds)):
-            if productive >= _SEEDS_PER_CRITERION:
+            if productive >= _seeds_allowed(criterion):
                 break
             seed = seeds[(start + step) % len(seeds)]
             if not budget.allow(criterion.endpoint_class):

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -228,9 +228,12 @@ class BandcampDiscoverySource(DiscoverySource):
         that matters, since the bug that ticket was filed about is three records
         off ONE album page, and no weight here can produce that.
 
-        The cost of running at the ceiling is that the share stops varying: every
-        healthy crate is two records from each of two album pages. Worth watching
-        when reading real crates; a drop to 3 buys the variation back at 3.2.
+        KAMP-689 lowered that ceiling to min(4, distinct artists across the two
+        pages): one record per artist per crate, so a page whose recommendations
+        cluster on one band gives fewer than two. A seven-rec block essentially
+        always carries two or more, so four still lands in practice — but a
+        label-curated or back-catalogue block genuinely can come up short, and
+        that is the honest reason a crate sometimes shows three.
         """
         return dict(CRITERION_WEIGHTS)
 
@@ -633,6 +636,10 @@ class BandcampDiscoverySource(DiscoverySource):
                     title=item.get("title", ""),
                     art_url=item.get("art_url"),
                     release_date=item.get("release_date", ""),
+                    # Two spellings, one key: the album page calls it artist_id
+                    # and the other two call it band_id, and all three were being
+                    # dropped on the floor here (KAMP-689).
+                    band_id=str(item.get("band_id") or item.get("artist_id") or ""),
                     criterion=criterion.key,
                     why=seed.why,
                     seed=dict(seed.seed_data),

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -360,8 +360,10 @@ class TestOnePerArtist:
         """Guards KAMP-683. The weight of 4 survives the cap as long as a
         recommendation page carries more than one band, which a 7-rec block
         essentially always does."""
+        # FOUR seeds, because SEED_CAP is 1 since KAMP-689 — also_like's card count
+        # is now its seed count, which is why it gathers four album pages.
         candidates: list[Candidate] = []
-        for s in range(2):
+        for s in range(4):
             for i in range(4):
                 candidates.append(
                     _candidate(
@@ -387,17 +389,18 @@ class TestSeedCaps:
     no way to notice, because Candidate.seed was provenance it never read.
     """
 
-    def test_no_more_than_two_records_share_a_seed(self, index: LibraryIndex) -> None:
+    def test_no_two_records_share_a_seed(self, index: LibraryIndex) -> None:
         """A SEED-RICH profile, which is the condition the cap needs to hold.
 
-        Six seeds at two apiece covers a crate of ten with room over. Give it
-        three and the cap is arithmetically unsatisfiable — 3 x 2 = 6 — and the
-        backfill correctly overruns it rather than shipping a six-record crate.
-        That case has its own test below; this one is about the cap doing its job
-        when it can.
+        The cap was two until KAMP-689 measured what two produced: 12 of 15 crates
+        put two cards from one seed on screen, which the reader experiences as one
+        album page's recommendations shown twice rather than as taste. Ten seeds
+        for ten slots, so a cap of one is satisfiable; give it fewer and the
+        backfill correctly overruns rather than shipping a short crate, which has
+        its own test below.
         """
         candidates = []
-        for n in range(3):
+        for n in range(10):
             candidates += [
                 _candidate(
                     f"a{n}{i}", "also_like", seed={"kind": "album", "album_id": n}
@@ -423,7 +426,7 @@ class TestSeedCaps:
         assert len(items) == CRATE_SIZE, "the cap must not have cost records"
         seeds = [json.dumps(row["seed"], sort_keys=True) for row in items]
         for seed, count in Counter(seeds).items():
-            assert count <= 2, f"{count} records share one seed: {seed}"
+            assert count == 1, f"{count} records share one seed: {seed}"
 
     def test_a_criterion_spends_its_slots_on_different_seeds(
         self, index: LibraryIndex
@@ -630,11 +633,15 @@ class TestCrateShape:
 
     @staticmethod
     def _realistic() -> list[Candidate]:
-        """A rich gather: every registry criterion, two seeds each, plenty spare.
+        """A rich gather: every registry criterion, several seeds each, plenty spare.
 
         Deliberately generous. The question is what the builder CHOOSES when it
         can have anything, which is the condition a healthy library produces and
         the one the measured crates were built under.
+
+        also_like gets FOUR seeds because that is what the source now gathers for
+        it: SEED_CAP is 1 since KAMP-689, so a criterion's card count is its seed
+        count, and four seeds is what keeps KAMP-683's four-of-ten target.
         """
         out: list[Candidate] = []
         for criterion, dimension in (
@@ -646,7 +653,7 @@ class TestCrateShape:
             ("older_than_ten", "genre"),
             ("best_seller", None),
         ):
-            for s in range(2):
+            for s in range(4 if criterion == "also_like" else 2):
                 for i in range(5):
                     seed = (
                         {"kind": criterion, dimension: f"{criterion}-{s}"}

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -230,6 +230,155 @@ class TestSelection:
         assert used.count("a") > 1 and used.count("b") > 1
 
 
+class TestOnePerArtist:
+    """KAMP-689: a crate must not offer two records by the same band.
+
+    Every candidate elsewhere in this file gets a UNIQUE artist from `_candidate`'s
+    default, so the suite was structurally unable to see this — nothing here broke
+    when the cap landed, including the four "never shrinks the crate" tests that
+    guard the invariant it could most easily have violated. Each test below sets a
+    shared artist on purpose.
+    """
+
+    @staticmethod
+    def _by(artist: str, criterion: str, n: int, **kw: Any) -> list[Candidate]:
+        """*n* candidates all by *artist* — the shape one discography seed returns."""
+        return [
+            _candidate(f"{artist}-{criterion}-{i}", criterion, artist=artist, **kw)
+            for i in range(n)
+        ]
+
+    def test_one_seed_cannot_offer_a_band_twice(self, index: LibraryIndex) -> None:
+        """The structural case. `lone_album_artist` seeds on an ARTIST and fetches
+        that artist's own /music grid, so every card it returns is by them — two
+        slots meant two cards by one band, every time the criterion ran."""
+        candidates = self._by(
+            "Star Moles", "lone_album_artist", 4, seed={"kind": "artist"}
+        ) + _spread({"genre_top": 8, "best_seller": 8})
+        _build(index, _FakeSource(candidates))
+        artists = [r["artist"] for r in index.crate_items(1)]
+        assert artists.count("Star Moles") == 1, artists
+
+    def test_the_key_is_who_made_the_record_not_the_seed(
+        self, index: LibraryIndex
+    ) -> None:
+        """An also_like recommendation BY a band, plus a favorite_artist seed ON
+        that band, are two different seeds and two different criteria — and still
+        one artist on screen."""
+        candidates = (
+            self._by(
+                "Blackbraid", "also_like", 1, seed={"kind": "album", "album_id": 1}
+            )
+            + self._by("Blackbraid", "favorite_artist", 1, seed={"kind": "artist"})
+            + _spread({"genre_top": 8, "best_seller": 8})
+        )
+        _build(index, _FakeSource(candidates))
+        artists = [r["artist"] for r in index.crate_items(1)]
+        assert artists.count("Blackbraid") == 1, artists
+
+    def test_a_one_artist_gather_still_fills_the_crate(
+        self, index: LibraryIndex
+    ) -> None:
+        """THE test. A cap enforced in the backfill would re-impose, harder, the
+        constraint the backfill exists to drop — and a gather that came back as one
+        artist's grid would ship a crate of ONE.
+
+        Reachable: `blocked_for` is per endpoint class, so DISCOVER_API and
+        ALBUM_PAGE can be cooling down while ARTIST_PAGE is not. The cap is a
+        preference like every other one here (KAMP-661).
+        """
+        source = _FakeSource(self._by("Star Moles", "lone_album_artist", 20))
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
+
+    def test_a_blocked_record_costs_no_request_to_reject(
+        self, index: LibraryIndex
+    ) -> None:
+        """The cap runs BEFORE KAMP-670's confirm, which does network I/O.
+
+        confirm_playable is free for every criterion except the two discography
+        ones — exactly where this cap binds hardest — so checking after it would
+        spend an ALBUM_PAGE request to validate a record we were about to refuse.
+        """
+        asked: list[str] = []
+
+        source = _FakeSource(
+            self._by("Star Moles", "lone_album_artist", 4)
+            + _spread({"genre_top": 8, "best_seller": 8})
+        )
+
+        def confirm(candidate: Candidate, _budget: Any) -> bool | None:
+            asked.append(candidate.provider_item_id)
+            return None
+
+        source.confirm_playable = confirm  # type: ignore[method-assign]
+        _build(index, source)
+        placed = {r["provider_item_id"] for r in index.crate_items(1)}
+        blocked = [i for i in asked if i.startswith("Star Moles") and i not in placed]
+        assert not blocked, f"paid to confirm records the cap then refused: {blocked}"
+
+    def test_a_record_with_no_artist_is_never_capped(self, index: LibraryIndex) -> None:
+        """Fail open. A parser that stops yielding an identity must not silently
+        empty a crate — the same call the KAMP-670 blanket-drift rule makes."""
+        source = _FakeSource(
+            [_candidate(str(i), "also_like", artist="") for i in range(20)]
+        )
+        status = _build(index, source)
+        assert len(index.crate_items(1)) == CRATE_SIZE
+        assert status["short"] is False
+
+    def test_spelling_and_case_do_not_defeat_the_cap(self, index: LibraryIndex) -> None:
+        """Normalised the way `seed_dimension` already normalises a genre, and for
+        the same reason: these strings come from three different parsers."""
+        candidates = [
+            _candidate("a", "also_like", artist="Star Moles"),
+            _candidate("b", "also_like", artist="  star moles "),
+        ] + _spread({"genre_top": 8, "best_seller": 8})
+        _build(index, _FakeSource(candidates))
+        artists = [r["artist"].strip().casefold() for r in index.crate_items(1)]
+        assert artists.count("star moles") == 1, artists
+
+    def test_a_band_id_beats_two_spellings(self, index: LibraryIndex) -> None:
+        """The reason the id is carried at all. The discography surface fills the
+        artist in from the SEED — kamp's own spelling — while also_like carries
+        Bandcamp's, so a band whose name differs between them slips a string
+        comparison. All three parsers already extract an id."""
+        candidates = [
+            _candidate(
+                "a", "also_like", artist="Godspeed You! Black Emperor", band_id="7"
+            ),
+            _candidate(
+                "b", "favorite_artist", artist="Godspeed You Black Emperor", band_id="7"
+            ),
+        ] + _spread({"genre_top": 8, "best_seller": 8})
+        _build(index, _FakeSource(candidates))
+        ids = [r["provider_item_id"] for r in index.crate_items(1)]
+        assert not ("a" in ids and "b" in ids), "two spellings of one band both placed"
+
+    def test_also_like_still_reaches_four(self, index: LibraryIndex) -> None:
+        """Guards KAMP-683. The weight of 4 survives the cap as long as a
+        recommendation page carries more than one band, which a 7-rec block
+        essentially always does."""
+        candidates: list[Candidate] = []
+        for s in range(2):
+            for i in range(4):
+                candidates.append(
+                    _candidate(
+                        f"al{s}{i}",
+                        "also_like",
+                        artist=f"Band {s}{i}",
+                        seed={"kind": "album", "album_id": s},
+                    )
+                )
+        candidates += _spread({"genre_top": 8, "best_seller": 8, "favorite_artist": 8})
+        _build(
+            index,
+            _FakeSource(candidates, caps=CRITERION_CAPS, weights=CRITERION_WEIGHTS),
+        )
+        assert _criteria(index, 1).count("also_like") == 4
+
+
 class TestSeedCaps:
     """KAMP-665: a crate can have too much of one SEED, not just one criterion.
 

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -680,10 +680,10 @@ class TestUnplayableRecords:
             ],
         )
         source._run_criterion(criterion, profile, crate_budget(), {"0"}, {})
-        # Two seeds tried, exactly as _SEEDS_PER_CRITERION allows for a criterion
-        # whose seeds all produce records. Before the fix this walked the whole
-        # seed list until the budget stopped it.
-        assert len(session.gets) == 2, f"spent {len(session.gets)} requests"
+        # Four seeds tried, exactly what also_like is allowed since KAMP-689 gave
+        # it four (SEED_CAP is 1, so its card count IS its seed count). Before the
+        # KAMP-670 fix this walked the whole seed list until the budget stopped it.
+        assert len(session.gets) == 4, f"spent {len(session.gets)} requests"
 
     @staticmethod
     def _pick(criterion: str) -> Candidate:
@@ -1076,17 +1076,18 @@ class TestRotationAndPagination:
     ) -> None:
         """Rotation, asserted on the URL fetched rather than on the candidates.
 
-        FOUR albums, not two. KAMP-665 lets a criterion read two seeds per crate,
-        so a two-album profile is fully consumed every time and there is nothing
-        left to rotate — the offset wraps straight back to the head, correctly.
-        Rotation is only observable once the list is longer than the spread.
+        EIGHT albums, because rotation is only observable once the list is longer
+        than one crate's spread — a pool fully consumed every time wraps straight
+        back to the head, correctly, and shows nothing. It was four while
+        also_like read two seeds a crate; KAMP-689 takes it to four seeds, so the
+        pool has to double to keep the assertion meaningful.
         """
         session = FakeSession(get_body=_fixture("album_page_with_recs"))
         profile = SeedProfile(
-            recent_album_ids={1, 2, 3, 4},
+            recent_album_ids=set(range(1, 9)),
             recent_albums=[
                 _album_seed(album_id=i, url=f"https://a{i}.bandcamp.com/album/x")
-                for i in (1, 2, 3, 4)
+                for i in range(1, 9)
             ],
         )
         source = _source(session)


### PR DESCRIPTION
A crate offers two records by the same band. Measured against a copy of the real library, **8 of the last 15 crates do it.**

## One mechanism, not several

Every observed instance is *two cards from a single seed*, both permitted by `SEED_CAP = 2`:

```
crate 42  lone_album_artist  seed='Star Moles'        two Star Moles records
crate 50  also_like          seed='Habibi Funk 027'   two Analog Africa comps
crate 52  also_like          seed='Bleak Days Ahead'  Blackbraid I and Blackbraid II
crate 53  favorite_artist    seed='Hurray for the...' two of theirs
```

Two of the seven criteria make it **structural rather than unlucky**: `lone_album_artist` and `favorite_artist` seed on an *artist* and read that artist's own discography, so both their cards are necessarily by the same band. The rest is `also_like` landing on a page whose recommendations cluster.

So `SEED_CAP`, added by KAMP-665 to prevent narrowness, had become the direct cause of the narrowest thing a crate did. `_deal` capped the criterion and the seed and nothing on the **artist being offered** — `seed_dimension` is `album_id:<n>` for also_like and `artist:<seed>` for the discography criteria, and neither says who made the record being handed over.

Two recent changes sharpened it. KAMP-683 gave also_like a weight of 4, so it takes exactly 2 from each of 2 seeds — precisely the cap. And KAMP-664's phrasing variation made it read *worse*: `lone_album_artist` says "you've just got the one. Try another." twice in two different sentences, as though the clerk forgot he had already offered.

## Result

Over 60 crates on the shapes the real ones had:

| | before | after |
| --- | --- | --- |
| crates repeating an artist | 8 of 15 | **0 of 60** |
| crate size | 10 | 10 |
| a gather that is only one artist's grid | 10 | **10** |

## Commit 1 — tests the suite could not previously express

`_candidate` gives every test candidate a **unique** artist, so nothing in this file could produce a duplicate even deliberately, and **nothing broke** when the cap landed — including the four "never shrinks the crate" tests guarding the invariant a careless implementation would most easily violate. Zero breakage is an alarm, not a green light; it is the KAMP-436 shape, where a feature passes its unit test and is wired to nothing. Every test here sets a shared artist on purpose.

Two of the eight decide whether the implementation is right:

- **A gather that is only one artist's grid must still ship ten.** A cap enforced in the backfill would re-impose, harder, the constraint the backfill exists to drop, and that crate would ship **one**. Reachable, because `blocked_for` is per endpoint class — DISCOVER_API and ALBUM_PAGE can be cooling down while ARTIST_PAGE is open.
- **A record the cap refuses must cost no request.** The cap has to run before KAMP-670's `confirm`.

## Commit 2 — the cap

**Enforced on the first deal only**, and that is the safety argument rather than an optimisation. For a discography criterion the seed dimension and the offered artist are the *same string*, so a cap in the backfill would undo exactly what the backfill is for. Capping only where `seed_cap` is enforced also means `artist_counts` needs no seeding from `skip` — the passes that would read it do not cap.

**Keyed on the provider's band id**, falling back to the folded name. All three parsers already extracted one — `artist_id` on the album page, `band_id` on the other two — and `_to_candidates` dropped all three on the floor. The string alone is not comparable across surfaces: the discography surface fills the artist in from the seed (kamp's spelling) while the album page carries Bandcamp's, so one band can arrive as two names.

**No migration**, and only because the cap is first-pass-only: the id never has to survive the buffer, since rehydrated stock is dealt by the uncapped third pass. The field is deliberately not persisted and the asymmetry is stated where it lives.

**Placed before `confirm`** — a cost decision, not a style one. `confirm_playable` does a network fetch and is free for every criterion *except* the two that read a discography, which are exactly the ones this binds hardest. There is a test asserting it, because request cost is not observable any other way.

**A bare `continue`, not marking the candidate taken.** Mirroring `seed_cap` is what lets the uncapped backfill reconsider it, and what sends a blocked record to `_buffer_surplus` to come back as its own card in a later crate. Blackbraid II is deferred, not discarded.

Also corrects the `criterion_weights` docstring I wrote in KAMP-683, which claimed four was also_like's ceiling "deliberately rather than by luck". It is now `min(4, distinct artists across the two pages)`, and leaving it would have been a lie a future reader acted on.

## Follow-up filed — KAMP-695

Found while working in the same loop, **not caused by this change**: `_deal` rebuilds `taken` from `skip`, which holds only *placed* candidates, so a record `confirm` proved dead in the main pass is a fresh candidate again in the backfill. It gets re-confirmed at the cost of a second request — and once the ALBUM_PAGE budget is spent, `confirm` returns `None` and the backfill **places a record already proved unplayable**. `build_crate._confirm` already tracks these in `unplayable`; memoising there is about two lines. Deliberately not folded in.

## CI, run locally

- `pytest`: 3340 passed, 9 skipped. Coverage **93.90%**, level with main.
- `black` and `mypy` clean. No renderer changes.
- README: no drift — it does not mention the Crate.

## Manual test plan

1. **Dig several crates and read the titles list end to end — no band should appear twice.**
2. Confirm `lone_album_artist` and `favorite_artist` still appear at all. They are the criteria this constrains hardest, contributing one card per seed artist instead of two.
3. Check also-like still reaches roughly four cards, as KAMP-683 left it. A page whose recommendations cluster on one band will now yield fewer, which is the intended trade.
4. Dig with a thin or picked-over library, or right after a rate-limit pause, and confirm crates still come back full — the cap yields rather than shortening, and a duplicate is acceptable there.
