### PR TITLE
KAMP-690: give the thin criteria something to rotate through

### DIFF
--- a/kamp_core/library.py
+++ b/kamp_core/library.py
@@ -5785,7 +5785,9 @@ class LibraryIndex:
         ).fetchall()
         return self._seed_album_rows(rows)
 
-    def played_artists_with_pages(self, limit: int = 25) -> list["SeedArtist"]:
+    def played_artists_with_pages(
+        self, limit: int = 25, owned_count: int | None = None
+    ) -> list["SeedArtist"]:
         """Artists the user actually plays, most-played first, with a page (KAMP-658).
 
         The counterpart to :meth:`favorite_artists_with_pages`, which ranks by how
@@ -5799,12 +5801,20 @@ class LibraryIndex:
         one" must word its clerk line to match that: a record bought elsewhere
         does not count.
 
+        Pass *owned_count* to filter on it **inside the query**, and that is not a
+        convenience (KAMP-690). Filtering the returned list instead applies the
+        LIMIT first, so "the twenty artists you play most who you own one album
+        by" silently became "however many of your twenty most-played artists
+        happen to own-count one" — four, on a library holding 235 of them. The
+        LIMIT then means what it says.
+
         Joined through ``albums.artist_id`` rather than by name — the column is
         FK'd to ``artists.id`` and backfilled at index time, so it is the
         authoritative link and avoids a second COLLATE NOCASE name match.
         """
+        having = "" if owned_count is None else "HAVING owned_count = :owned"
         rows = self._conn.execute(
-            """
+            f"""
             SELECT ar.name       AS name,
                    ar.play_time  AS play_time,
                    MIN(bc.album_url) AS album_url,
@@ -5814,10 +5824,11 @@ class LibraryIndex:
             JOIN artists ar ON ar.id = a.artist_id
             WHERE bc.album_url != '' AND ar.play_time > 0
             GROUP BY ar.id
+            {having}
             ORDER BY ar.play_time DESC
-            LIMIT ?
+            LIMIT :limit
             """,
-            (limit,),
+            {"limit": limit, "owned": owned_count},
         ).fetchall()
         out: list[SeedArtist] = []
         for r in rows:

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -239,6 +239,15 @@ class SeedProfile:
     #: `top_artists`, which is names only — a criterion that wants to say "you
     #: only have the one by them" needs the count and the address, not a name.
     played_artists: list["SeedArtist"] = field(default_factory=list)
+    #: The same ranking, filtered to artists with exactly one album in the
+    #: collection, and filtered IN THE QUERY (KAMP-690).
+    #:
+    #: Its own field rather than a slice of `played_artists`, because the two want
+    #: different depths for different reasons. `_favorite_artist_seeds` yields
+    #: starred artists first and played ones second, so lengthening the shared
+    #: list to reach more single-album artists would dilute the starred branch's
+    #: share of the rotation and push that criterion toward its weaker claim.
+    lone_album_artists: list["SeedArtist"] = field(default_factory=list)
     #: Albums bought around this date a year ago (KAMP-658). The window is
     #: applied by the profile builder rather than the selector, so the selector
     #: stays a pure function of the profile and carries no clock.
@@ -271,6 +280,10 @@ def build_seed_profile(
     genre_limit: int = 25,
     artist_limit: int = 25,
     label_limit: int = 25,
+    # Its own knob, deliberately NOT artist_limit — that one is shared with
+    # favorite_artists_with_pages and top_artists, so raising it to widen one
+    # criterion's pool would quietly resize two others (KAMP-690).
+    lone_artist_limit: int = 20,
 ) -> SeedProfile:
     """Assemble a :class:`SeedProfile` from local library signals.
 
@@ -291,6 +304,9 @@ def build_seed_profile(
         favorite_albums=favorites,
         favorite_artists=index.favorite_artists_with_pages(artist_limit),
         played_artists=index.played_artists_with_pages(artist_limit),
+        lone_album_artists=index.played_artists_with_pages(
+            lone_artist_limit, owned_count=1
+        ),
         anniversary_albums=index.albums_purchased_between(
             year_ago - ANNIVERSARY_WINDOW_SECS, year_ago + ANNIVERSARY_WINDOW_SECS
         ),

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -234,8 +234,21 @@ def _old_album_seeds(profile: SeedProfile) -> Iterable[Seed]:
     when it was released (KAMP-644). ``slice=top`` skews overwhelmingly to the
     current year, so only the random slice reaches back. The age filter is
     applied client-side on ``release_date``.
+
+    Every genre, not the top three (KAMP-690). The old slice arrived whole in
+    KAMP-647 with nothing defending the number, and it was the entire pool — read
+    two a crate, so the criterion cycled the same three genres forever. Measured,
+    ten consecutive crates read Electronic, Alternative, Rock, Electronic,
+    Alternative, Rock. `genre_top` walks the whole list and always has.
+
+    Costs nothing in cards: KAMP-683 caps this criterion at one a crate, so a
+    wider pool changes WHICH genre turns up, never how many. It does make the
+    KAMP-665 dimension collision with `genre_top` more frequent rather than less
+    — the two are near-disjoint today only because they read different parts of
+    the same list — and that is the accepted trade, since a collision means the
+    crate already has that genre covered.
     """
-    for rank, genre in enumerate(profile.top_genres[:3]):
+    for rank, genre in enumerate(profile.top_genres):
         yield Seed(
             target={"tag": genre, "slice": "rand", "size": 60},
             why=f"A hidden {genre} gem? Who knows, could be good.",
@@ -310,8 +323,16 @@ def _lone_album_artist_seeds(profile: SeedProfile) -> Iterable[Seed]:
     `owned_count` counts albums in the Bandcamp collection, so the copy says
     "here" rather than claiming to know the user's whole shelf — a record bought
     somewhere else would make a flat "you only own one" false.
+
+    Reads its own profile field, filtered in the query (KAMP-690). Filtering
+    `played_artists` here meant the LIMIT was applied first, so a library holding
+    235 qualifying artists surfaced the four that happened to rank inside the 25
+    most-played OVERALL — and the criterion cycled the same seeds every second
+    crate. The guard below stays anyway: the query now enforces it, but the guard
+    is what a test asserts the honesty rule against, and an unasserted rule is one
+    that quietly stops being true.
     """
-    for artist in profile.played_artists:
+    for artist in profile.lone_album_artists:
         if artist.owned_count != 1:
             continue
         yield Seed(

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -41,6 +41,7 @@ from kamp_daemon.discovery_criteria import (
 from kamp_daemon.discovery_sources import (
     BandcampDiscoverySource,
     RateLimitedError,
+    _seeds_allowed,
 )
 from kamp_core.discovery_api import UNPERSONALISED_CRITERIA
 from kamp_core.library import SeedAlbum, SeedArtist
@@ -244,10 +245,17 @@ class TestCriteriaRegistry:
         keys = [c.key for c in criteria_for(SeedProfile())]
         assert keys == ["best_seller"]
 
-    def test_rich_profile_runs_several_criteria(self) -> None:
-        # Raised with the registry (KAMP-658). Left at 4 it would stay green while
-        # half the criteria produced nothing, which is the opposite of its job.
-        assert len(criteria_for(RICH_PROFILE)) >= 6
+    def test_a_rich_profile_runs_every_criterion(self) -> None:
+        """Set equality, not a floor (KAMP-690).
+
+        It was `>= 6` against seven criteria — raised from 4 with the registry in
+        KAMP-658 — and a floor cannot tell "all seven ran" from "six ran and one
+        is dead". That is not hypothetical: a criterion that starts reading a NEW
+        SeedProfile field silently produces nothing until RICH_PROFILE populates
+        it, and this test would have stayed green through it. Naming the set is
+        what makes a missing criterion fail loudly.
+        """
+        assert {c.key for c in criteria_for(RICH_PROFILE)} == {c.key for c in REGISTRY}
 
     def test_no_genre_line_claims_listening_or_recency(self) -> None:
         """KAMP-664. taste_genres counts tag rows and Bandcamp keywords — it has
@@ -1019,6 +1027,69 @@ class TestACrateReflectsTheLibrarysRange:
         wanted = {c.key for c in criteria_for(profile)}
         ran = set(state.get("seeds", {}))
         assert wanted <= ran, f"never got a request: {sorted(wanted - ran)}"
+
+
+class TestSeedPoolsAreDeepEnoughToRotate:
+    """KAMP-690: rotation only varies a crate if there is something to rotate.
+
+    Rotation advances `_seeds_allowed(criterion)` per crate and wraps modulo the
+    pool, so a pool barely larger than one crate's spread cycles straight back to
+    the head. Measured on a real library, `lone_album_artist` held 4 seeds and
+    `older_than_ten` 3 — repeating every two crates and every one and a half, and
+    the user saw one artist "in many many crates".
+
+    Driven from a profile through the real selectors rather than from a hand-built
+    seed list, so these track what a criterion actually reaches rather than what a
+    fixture says it does.
+    """
+
+    #: Crates a seed must survive before it may come round again. Ten is what the
+    #: measured complaint needs: at two seeds a crate it means a pool of twenty,
+    #: which takes the reported artist from every other crate to one in ten.
+    MIN_CYCLE = 10
+
+    @staticmethod
+    def _rich() -> SeedProfile:
+        """A profile with plenty of everything the two thin criteria read."""
+        return replace(
+            RICH_PROFILE,
+            top_genres=[f"genre-{i}" for i in range(25)],
+            lone_album_artists=[
+                SeedArtist(
+                    name=f"Solo {i}",
+                    artist_page=f"https://solo{i}.bandcamp.com/music",
+                    owned_count=1,
+                    play_time=float(9000 - i * 100),
+                )
+                for i in range(20)
+            ],
+        )
+
+    @pytest.mark.parametrize("key", ["lone_album_artist", "older_than_ten"])
+    def test_a_seed_does_not_come_round_within_ten_crates(self, key: str) -> None:
+        criterion = next(c for c in REGISTRY if c.key == key)
+        seeds = list(criterion.seeds(self._rich()))
+        cycle = len(seeds) / _seeds_allowed(criterion)
+        assert cycle >= self.MIN_CYCLE, (
+            f"{key} holds {len(seeds)} seeds and reads "
+            f"{_seeds_allowed(criterion)} a crate — repeats every {cycle:.1f}"
+        )
+
+    def test_the_lone_album_pool_is_not_truncated_by_the_shared_limit(self) -> None:
+        """The actual defect. played_artists_with_pages applied its LIMIT and the
+        criterion then filtered owned_count == 1, so a library with 235 qualifying
+        artists surfaced four — the ones that happened to rank inside the 25
+        most-played artists OVERALL."""
+        criterion = next(c for c in REGISTRY if c.key == "lone_album_artist")
+        seeds = list(criterion.seeds(self._rich()))
+        assert len(seeds) == 20, f"the pool was truncated to {len(seeds)}"
+
+    def test_the_older_record_criterion_reads_every_genre(self) -> None:
+        """It sliced top_genres[:3] while genre_top walked all of them, which is
+        why the same three genres cycled forever."""
+        criterion = next(c for c in REGISTRY if c.key == "older_than_ten")
+        genres = {s.seed_data.get("genre") for s in criterion.seeds(self._rich())}
+        assert len(genres) == 25, f"only reached {len(genres)} genres"
 
 
 class TestRotationAndPagination:

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -186,6 +186,17 @@ RICH_PROFILE = SeedProfile(
             play_time=8000.0,
         ),
     ],
+    # Its own field since KAMP-690, filtered in the query rather than out of
+    # `played_artists` here. Four Tet is deliberately absent — the criterion's
+    # claim is "you have just the one", and a test below pins that.
+    lone_album_artists=[
+        SeedArtist(
+            name="Loraine James",
+            artist_page="https://lorainejames.bandcamp.com/music",
+            owned_count=1,
+            play_time=9000.0,
+        ),
+    ],
     anniversary_albums=[_album_seed(9, "https://c.bandcamp.com/album/z")],
     top_artists=["Four Tet"],
     top_genres=["ambient", "dub techno"],


### PR DESCRIPTION
"I have one Star Moles record and I have seen 'you like Star Moles, why not more Star Moles' in many many crates."

Rotation works and always has. What it had nothing to rotate through was two seed pools barely larger than one crate's spread.

## Measured, re-derived after KAMP-689 changed the arithmetic

| criterion | seeds | per crate | cycles every |
| --- | --- | --- | --- |
| also_like | 95 | 4 | 23.8 crates |
| genre_top | 50 | 2 | 25.0 |
| favorite_artist | 41 | 2 | 20.5 |
| purchase_anniversary | 22 | 2 | 11.0 |
| **lone_album_artist** | **4** | 2 | **2.0** |
| **older_than_ten** | **3** | 2 | **1.5** |

**The ticket names `also_like` and it is not involved** — 95 seeds, offset 74, absent from the reuse table entirely. Two small pools are the whole bug, with two different causes.

And **`older_than_ten` is the worse of the two by volume**, which the title does not suggest: its last ten crates are a perfect three-cycle — Electronic, Alternative, Rock, Electronic, Alternative, Rock — firing in nearly every crate, where `lone_album_artist` fires in about a third.

## Result

| | before | after |
| --- | --- | --- |
| lone_album_artist | 4 seeds, repeats every 2 crates | **20 seeds, every 10** |
| older_than_ten | 3 seeds, repeats every 1.5 crates | **25 seeds, every 12.5** |

## Commit 1 — the tests, including one that earned its keep immediately

Pool sizes are asserted through the **real selectors** driven from a profile, not from a hand-built seed list, so they track what a criterion actually reaches.

`test_rich_profile_runs_several_criteria` is tightened from `>= 6` to set equality in the same commit, and that is not tidying. A floor cannot tell "all seven ran" from "six ran and one is dead" — and commit 2 makes a criterion read a **new** `SeedProfile` field, which produces nothing until the fixture populates it. **It caught exactly that**: `RICH_PROFILE` didn't populate `lone_album_artists`, the criterion went dark, and the old floor stayed green through it.

## Commit 2 — the two widenings

**`lone_album_artist` saw 4 seeds because the LIMIT was applied before the filter.** `played_artists_with_pages(limit=25)` took the 25 most-played artists and the criterion then kept those with `owned_count == 1`, leaving four — on a library holding **235** qualifying artists. The filter goes into the query so the LIMIT means what it says.

**Its own profile field, not a slice of `played_artists`.** `_favorite_artist_seeds` yields starred artists first and played ones second, so lengthening the shared list would dilute the starred branch's share of the rotation and push that criterion toward its weaker claim. Its own limit too — `artist_limit` is shared with `favorite_artists_with_pages` and `top_artists`, so raising it would quietly resize two other criteria.

**Depth 20, chosen against the measured curve.** Play time among single-album artists is flat: 3.0h at rank 1, 1.5h at rank 20, 1.1h at rank 50. Worth being exact about what this is — it **removes an artificial truncation rather than lowering a bar**. Every artist it admits was always qualified and was being discarded for ranking below 25 *overall*, and the query still orders by play time.

The `owned_count` guard stays in the selector even though the query now enforces it: a test asserts the honesty rule through that guard, and removing it would leave the test asserting nothing.

**`older_than_ten` reads every genre** instead of `top_genres[:3]`. That slice was its entire pool and arrived whole in KAMP-647 with nothing defending the number; `genre_top` has always walked the full list. It costs nothing in cards, since KAMP-683 caps the criterion at one per crate — a wider pool changes *which* genre turns up, never how many.

## Two consequences accepted deliberately

**This makes the KAMP-665 genre collision MORE frequent, not less.** I initially told the user the opposite and it was wrong. The two genre criteria are near-disjoint today only because they read different parts of the same list — `genre_top` sits around rank 15 while `older_than_ten` was pinned at 0-2. Accepted, because a collision means the crate already has that genre covered from the other criterion.

**`top_genres` is not purely genres.** It unions Bandcamp keywords, and ranks 16 and 18 on this library are **"New York"** and **"Los Angeles"** — so the wider pool will sometimes offer "a hidden New York gem". Read as a scene rather than an error, decided with the user. Filed as **KAMP-696**, because the shape of `taste_genres` is its own problem and any future consumer of `top_genres` inherits it.

## Also filed — KAMP-697

The KAMP-657 **stock** deal passes `caps={}` with neither `seed_cap` nor `artist_cap`. Dropping them on the *backfill* is deliberate (KAMP-661), but the stock pass inherited it by proximity rather than by argument — and the buffer usually holds plenty to choose from. Measured, it is not firing: 59 crates all shipped ten. Latent, not active.

## CI, run locally

- `pytest`: 3344 passed, 9 skipped. Coverage **93.89%**, level with main.
- `black` and `mypy` clean. No renderer changes.
- README: no drift — it does not mention the Crate.

## Manual test plan

1. **Dig several crates in a row and read the clerk lines.** Star Moles should appear at most once in ten crates rather than every other one.
2. The older-record pick should stop cycling Rock / Alternative / Electronic and start reaching further down your genres.
3. Confirm `lone_album_artist` still appears at all — it now reaches artists you play somewhat less, so check the line still reads true.
4. Watch for a genre pick naming a city. That is KAMP-696 and is expected; the question is only whether it reads acceptably.
5. Crates should still come back full — nothing here changes cap or budget behaviour.
