### PR TITLE
KAMP-685: no focus ring from the mouse, by construction rather than by blur

### DIFF
--- a/kamp_ui/src/renderer/src/App.tsx
+++ b/kamp_ui/src/renderer/src/App.tsx
@@ -32,14 +32,27 @@ import { useExtensionState } from './hooks/useExtensionState'
 import type { UnifiedPanel } from './hooks/usePanelLayout'
 import type { ExtensionInfo } from '../../shared/kampAPI'
 
-// KAMP-598: track whether focus was last established by the mouse (a click) vs
-// the keyboard (Tab). A mouse click leaves DOM focus on the clicked element
-// without a ring; the global transport shortcuts blur it so no phantom
-// :focus-visible ring appears on the next keypress. We track modality ourselves
-// rather than reading :focus-visible at keydown time — Chromium promotes the
-// element to :focus-visible while processing the keydown, *before* our handler
-// runs, so that check reads true and is unreliable here.
-let _focusFromMouse = false
+// How focus was last established: by a click, or by Tab (KAMP-598/685).
+//
+// Published on the document root so CSS can decide whether a ring paints, rather
+// than JavaScript trying to prevent one. That is the whole fix: the previous
+// mechanism blurred the focused element inside App's global keydown handler, and
+// a keydown handler is reachable — CrateView stops propagation on all seven keys
+// it owns, so the blur never ran and the ring appeared. ANY view that claims its
+// own keys opted itself out. An attribute cannot be opted out of.
+//
+// Tracked rather than read off :focus-visible at keydown time, which stays true:
+// Chromium promotes the element to :focus-visible while processing the keydown,
+// *before* any handler runs, so reading it there always says yes.
+//
+// Only Tab returns it to 'key', and that is deliberate rather than an omission.
+// It is what makes "click a record, then press ," show no ring while "Tab to it"
+// does — the question is how focus GOT here, not which device is being used now.
+type FocusModality = 'mouse' | 'key'
+
+function setFocusModality(modality: FocusModality): void {
+  document.documentElement.dataset.focusModality = modality
+}
 
 // ---------------------------------------------------------------------------
 // Register built-in panels before the component mounts.
@@ -400,14 +413,30 @@ export default function App(): React.JSX.Element {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // KAMP-598: any pointer press means the focus it establishes is mouse-driven,
-  // so the transport shortcuts should blur it rather than let it grow a ring.
+  // Modality tracking, and BOTH listeners are capture-phase on window for the
+  // same reason (KAMP-685): capture on window is the outermost point in the
+  // propagation path, so nothing downstream can stopPropagation its way out of
+  // being tracked. The old Tab reset was bubble-phase and sat inside the
+  // shortcut handler, which is exactly how the Crate escaped it.
+  //
+  // Capture also fixes a second bug for free. KeyboardShortcutsOverlay is a
+  // capture-phase *document* listener that swallows every key including Tab, so
+  // modality could not reset while it was open: open the overlay after clicking
+  // anything, Tab to its close button, and there was no ring to follow.
   useEffect(() => {
-    const onPointerDown = (): void => {
-      _focusFromMouse = true
+    const onPointerDown = (): void => setFocusModality('mouse')
+    const onKeyDownCapture = (e: KeyboardEvent): void => {
+      // Tab is the only key that MOVES focus, so it is the only one that makes
+      // the focus it lands on keyboard-driven. Every other key is operating
+      // whatever the mouse already chose.
+      if (e.key === 'Tab') setFocusModality('key')
     }
     window.addEventListener('pointerdown', onPointerDown, true)
-    return () => window.removeEventListener('pointerdown', onPointerDown, true)
+    window.addEventListener('keydown', onKeyDownCapture, true)
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true)
+      window.removeEventListener('keydown', onKeyDownCapture, true)
+    }
   }, [])
 
   // Global keyboard shortcuts
@@ -432,25 +461,23 @@ export default function App(): React.JSX.Element {
         return
       }
 
-      // Tab moves focus via the keyboard — from here on, focus is keyboard-driven
-      // and its ring should stay (KAMP-598).
-      if (e.key === 'Tab') {
-        _focusFromMouse = false
-        return
-      }
+      // Tab is handled by the capture listener above, which tracks modality.
+      // Nothing to do here but stay out of its way.
+      if (e.key === 'Tab') return
 
+      // SELECT joins INPUT and TEXTAREA (KAMP-685). A focused <select> type-aheads
+      // on a printable key, so `q` and `c` would jump its options AND fire the
+      // shortcut — neither of which is preventDefaulted below. The blur that used
+      // to sit here masked that for mouse users by dropping focus first; it never
+      // covered a keyboard user who tabbed to the select, and it is gone now.
       const tag = (e.target as HTMLElement).tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
 
-      // KAMP-598: these are global shortcuts, not input for the focused control.
-      // If the focused element was focused by a mouse click (not Tab), drop that
-      // leftover focus so the keypress can't promote it to a :focus-visible ring.
-      // Genuine keyboard focus (_focusFromMouse === false) is left alone.
-      if (_focusFromMouse) {
-        const active = document.activeElement as HTMLElement | null
-        if (active && active !== document.body) active.blur()
-      }
-
+      // No blur here any more (KAMP-685). It was the KAMP-598 ring suppression,
+      // and it had two faults: any view stopping propagation never reached it, and
+      // it dumped focus to document.body on every shortcut — which loses a screen
+      // reader user's place in the document. Modality is published on the root
+      // element instead and the ring is decided in CSS, so focus can stay put.
       switch (e.key) {
         case '?':
           setShowShortcuts((prev) => !prev)

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -505,6 +505,15 @@
   border-width: 2px;
 }
 
+/* No ring on a sleeve, from any modality (KAMP-685). The bin uses a roving
+   tabindex, so the only sleeve Tab can reach IS the focused one — and it already
+   says so three ways: pulled forward out of the bin, a 2px accent border on its
+   art, and aria-current for anyone listening. A ring would stack a second accent
+   outline on that border, inside a clipped perspective box that would crop it. */
+.bin-sleeve:focus-visible {
+  outline: none;
+}
+
 /* Same rule as the flat rail: state is opacity, border weight and a glyph —
    never hue. There is one --accent token and it swings from indigo to magenta
    to green across the eight palettes. */

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -739,7 +739,13 @@ html[data-platform='win32'] .view-tabs {
 .search-clear:focus-visible,
 .track-title:focus-visible,
 .track-artist:focus-visible,
-.track-album:focus-visible {
+.track-album:focus-visible,
+/* KAMP-685: the opposite call to .bin-sleeve, for the opposite reason. Every
+   titles row is tabbable while only one is --current, so Tab position and bin
+   selection genuinely diverge here and the ring is the only thing saying where
+   Tab is. It was getting Chromium's yellow UA ring. Inset because the list
+   scrolls, so an outward outline would be clipped at the column edge. */
+.crate-title-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }

--- a/kamp_ui/src/renderer/src/assets/layout.css
+++ b/kamp_ui/src/renderer/src/assets/layout.css
@@ -744,6 +744,49 @@ html[data-platform='win32'] .view-tabs {
   outline-offset: -2px;
 }
 
+/* KAMP-685: no focus ring when focus arrived by mouse.
+
+   This is the enforcement point for a requirement that applies to every UI in
+   kamp. It used to live in App's global keydown handler, which BLURRED the
+   focused element — and a keydown handler is reachable, so any view that
+   stopPropagation'd its own keys (CrateView, seven of them) opted itself out
+   silently. App now publishes how focus was established on the root element and
+   the decision is made here, where nothing can intercept it.
+
+   `!important` is load-bearing, not laziness. Without it this computes to
+   (0,2,1) and merely TIES `.breadcrumb button:focus-visible` in track-list.css,
+   which main.css imports AFTER layout.css — so the breadcrumb ring would survive
+   and nothing would say why. Six selectors tie, several in this same file, which
+   would make rule ORDER the thing holding the requirement up. A modality-scoped
+   global override is the textbook case for !important.
+
+   Text inputs are excluded because they match :focus-visible even on a click and
+   their caret already shows focus; range inputs because `.crate-preview-seek`
+   has an opacity:0 thumb, so the ring is the ONLY thing marking the focused
+   control — and arrowing a slider is real keyboard use that "only Tab sets
+   keyboard modality" cannot see. Excluding the element is simpler and safer than
+   trying to detect that. */
+html[data-focus-modality='mouse'] :focus-visible:not(input, textarea) {
+  outline: none !important;
+}
+
+/* The sibling-subject case, which the rule above cannot reach at any
+   specificity: the real checkbox is opacity:0 and the outline is drawn on its
+   sibling track, so the subject never matches :focus-visible itself. Without
+   naming it, every mouse-clicked preferences toggle keeps its ring. */
+html[data-focus-modality='mouse'] .prefs-toggle input:focus-visible + .prefs-toggle-track {
+  outline: none !important;
+}
+
+/* High-contrast mode draws its own focus indicator and users there depend on it.
+   Never strip a ring in forced colors, whatever the modality. */
+@media (forced-colors: active) {
+  html[data-focus-modality='mouse'] :focus-visible:not(input, textarea),
+  html[data-focus-modality='mouse'] .prefs-toggle input:focus-visible + .prefs-toggle-track {
+    outline: revert !important;
+  }
+}
+
 /* Active / press feedback ------------------------------------------------- */
 
 .transport-btn:active,

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -617,12 +617,17 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
     }
   }
 
-  // App blurs the focused element on any key it handles when focus came from
-  // the mouse (KAMP-598), which lands focus on document.body — outside this
-  // container, so none of the handlers above would fire again. Click a sleeve,
-  // press a global key, and digging went silently dead. Taking focus back the
-  // moment it falls to nothing fixes that; focus moving into a dialog names
-  // that dialog as relatedTarget, so modals are left alone.
+  // Take focus back whenever it falls to nothing, so digging never goes silently
+  // dead. A null relatedTarget means focus left for no element at all, and this
+  // container holds every key handler above — once focus is on document.body,
+  // none of them fire again. Focus moving into a dialog names that dialog as
+  // relatedTarget, so modals are left alone.
+  //
+  // This was written for App's KAMP-598 blur, which is gone (KAMP-685). It stays
+  // because that was never its only trigger: the focused sleeve UNMOUNTING blurs
+  // with a null relatedTarget too, which is exactly what dropping a record does
+  // (KAMP-670). Removing this on the strength of its old comment would have
+  // broken a flow that shipped three commits ago.
   const onBlurCapture = (e: React.FocusEvent<HTMLDivElement>): void => {
     if (e.relatedTarget !== null || !active) return
     const rail = railRef.current

--- a/kamp_ui/src/renderer/src/main.tsx
+++ b/kamp_ui/src/renderer/src/main.tsx
@@ -22,6 +22,12 @@ window.api.syncThemeChrome(savedTheme)
 // on .view-tabs that clears the Windows titleBarOverlay) can target it.
 document.documentElement.dataset.platform = window.electron.process.platform
 
+// How focus was last established, which decides whether a ring paints (KAMP-685).
+// Seeded here rather than in App so there is no first frame without it, and seeded
+// to 'key' so a keyboard-only user who never touches the mouse gets a ring from
+// their very first Tab. App's capture listeners keep it current from then on.
+document.documentElement.dataset.focusModality = 'key'
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <TooltipProvider>


### PR DESCRIPTION
## What

"No focus highlight from mouse interaction" is a non-functional requirement for every UI in kamp. Click a record in the Crate bin, press `,` or `.` or Space, and a ring appeared — Chromium's default one, not even kamp's accent.

The cause was structural rather than a missed selector. KAMP-598 enforced the requirement by **blurring** the focused element inside App's global keydown handler, which is a bubble-phase window listener. `CrateView.onKeyDown` calls `stopPropagation()` on all seven keys it owns, so the event never arrived and the blur never ran. **Any view that claims its own keys opted itself out of an app-wide requirement**, silently, with nothing anywhere to say so. The Crate is just the only one that claims a broad set of ordinary keys.

The codebase already showed the mechanism was wrong: `CrateView.onBlurCapture` existed *only* to undo App's blur, because that blur landed focus on `document.body` and — in its own words — "digging went silently dead". A mechanism and its antidote, fighting inside one view. Its unwritten cost was worse: it dumped focus to `body` on every global shortcut, losing a screen reader user's place in the document.

Modality is now published on the document root and CSS decides whether a ring paints. An attribute cannot be opted out of.

## How

**Modality tracking (commit 1).** `pointerdown` → `mouse`, `Tab` → `key`, both **capture-phase on `window`** — the outermost point in the propagation path, so nothing downstream can `stopPropagation` its way out of being tracked. Seeded to `key` in `main.tsx` so there is no first frame without it and a keyboard-only user gets a ring from their first Tab.

Capture fixes a second bug for free: `KeyboardShortcutsOverlay` is a capture-phase *document* listener that swallows every key including Tab, so modality could not reset while it was open — open the overlay after clicking anything, Tab to its close button, and there was no ring to follow.

"Only Tab resets to keyboard" is kept deliberately. It is what makes *click a record, then press `,`* show no ring while *Tab to it* does: the question is how focus GOT here, not which device is in your hand now. The semantics were right; only the enforcement was broken.

**The gate (commit 2)**, with three qualifications that are each load-bearing:

- **`!important`.** The naive rule computes to (0,2,1) and merely *ties* `.breadcrumb button:focus-visible` in `track-list.css`, which `main.css` imports after `layout.css` — that ring would have survived, alone, with nothing to explain why. Six selectors tie, several inside `layout.css` itself, which would leave rule *order* quietly holding the requirement up.
- **`:not(input, textarea)`.** Text fields match `:focus-visible` even on a click and their caret already shows focus. `.crate-preview-seek` is the sharper case: its thumb is `opacity: 0`, so the outline is the *only* thing marking the focused control — and arrowing a slider is genuine keyboard use that "only Tab" cannot detect.
- **A companion rule for `.prefs-toggle`,** whose outline is drawn on a *sibling* (the real checkbox is `opacity: 0`), so the subject never matches `:focus-visible` and no rule of that shape reaches it at any specificity.

Plus a `forced-colors: active` revert — high-contrast users depend on the system indicator and it is never ours to strip.

Scoping to modality rather than a blanket `outline: none` matters for the controls with no author focus rule at all (`.search-track-row`, `.theme-swatch`, `.library-tab`, `.genre-admin-input`, `.merge-genre-filter`, `.module-config-field input[type=number]`): Chromium's UA ring is their only focus indicator, and a blanket rule would have silently taken it.

**The two Crate elements get opposite treatment (commit 3),** because they are two problems that look like one. `.bin-sleeve` gets **no ring at all** — the bin uses a roving tabindex, so the only sleeve Tab can reach *is* the focused one, and it already says so three ways (pulled forward, 2px accent border, `aria-current`). `.crate-title-btn` gets the accent ring — every row is tabbable while only one is `--current`, so Tab position and bin selection genuinely diverge and the ring is the only thing saying where Tab is. It was drawing Chromium's yellow UA ring.

**Two things travelled with removing the blur.** `SELECT` joins `INPUT`/`TEXTAREA` in App's early return: a focused `<select>` type-aheads on a printable key, so `q` and `c` would jump its options *and* fire the shortcut — a hole that already existed for keyboard users and that the blur was masking for mouse users. And `onBlurCapture` **stays** with a corrected comment (commit 4): its stated reason is gone, but a focused sleeve *unmounting* also blurs with a null `relatedTarget`, which is exactly what dropping a record does (KAMP-670). Deleting it on the strength of its old comment would have broken a flow that shipped three commits ago.

## Testing

`kamp_ui` has no test runner, so typecheck and lint cover the `App.tsx` refactor and nothing about the CSS — the correctness story here is the manual pass, which is why it names specific cases rather than "check the Crate".

- `npm run typecheck` — clean
- `npm run lint` — clean (one pre-existing prettier warning in `src/main/index.ts`, untouched)
- `poetry run pytest` — 3344 passed, 9 skipped, coverage 93.89% (no Python change)

### Manual test plan

Each is a case that would silently survive a naive fix:

- [ ] Click a bin sleeve, then press `,` `.` Space `w` `c` `q` `?` — no ring, and digging still works after every one
- [ ] Tab from cold — accent ring on the titles rows, no ring on the bin sleeve, no double outline
- [ ] Click a breadcrumb, press Space — the specificity case; without `!important` the ring survives here and nowhere else obvious
- [ ] Click a preferences toggle, press `q` — the sibling-subject case
- [ ] Click the Crate preview seek, then arrow it — the invisible thumb must still be findable
- [ ] Every `<select>` in preferences and the magic-playlist modal: click one, press `c`, press `q` — confirms the type-ahead hole is closed rather than opened
- [ ] Drop a record with a sleeve focused, then press `.` — the KAMP-670 unmount path `onBlurCapture` is kept for
- [ ] Open the shortcuts overlay after clicking something, then Tab to its close button — should now show a ring where it never did

🤖 Generated with [Claude Code](https://claude.com/claude-code)
