### PR TITLE
KAMP-686: seeking the deck moves playback but the bar reports the previous position

### DIFF
--- a/kamp_core/playback.py
+++ b/kamp_core/playback.py
@@ -1518,6 +1518,10 @@ class MpvPlaybackEngine:
         # lock held between the playlist-remove 1 send and the seek send.
         # file-loaded resets state.position to 0 immediately, so the
         # misdirected seek is visible for at most one frame.
+        #
+        # _lock is NOT reentrant, and the file-loaded handler calls this method
+        # on the reader thread. That branch must stay lock-free — see the note
+        # there before wrapping its reset.
         with self._lock:
             # Only remove the lookahead when the seek target lands within the
             # gapless danger window.  Seeking to an early/middle position carries
@@ -1532,6 +1536,37 @@ class MpvPlaybackEngine:
                 self._lookahead_url = None
                 self._lookahead_id = None
                 self._send_command("playlist-remove", 1)
+
+            # Record where we are going rather than waiting to be told (KAMP-686).
+            #
+            # state.position is otherwise written only by the reader thread on a
+            # time-pos event, so for a full IPC round trip after a seek every
+            # consumer reads where playback USED to be. The 4 Hz main snapshot
+            # papers over that within one frame; the Crate deck does not, because
+            # the preview publishes on transitions only and nothing follows to
+            # correct the anchor it interpolates from.
+            #
+            # This is the norm, not a special case: play(), load_paused() and the
+            # file-loaded handler all write position eagerly for the same reason
+            # — play()'s comment spells it out. seek() was the one that didn't.
+            #
+            # Inside the lock, and after the removal above, so the two land
+            # together: preload_next gates on position against the same guard
+            # window, and a call slipping between them would read the PRE-seek
+            # position, judge the seek safe, and re-arm the lookahead into the
+            # window the removal just cleared.
+            #
+            # Clamped to what mpv will actually do, since the value outlives the
+            # moment: __main__ persists state.position every few seconds and the
+            # restore path feeds it back as a pending seek. duration is 0.0
+            # during load, and clamping to that would record a 0 for every seek.
+            recorded = max(0.0, position)
+            if self.state.duration > 0:
+                recorded = min(recorded, self.state.duration)
+            self.state.position = recorded
+            self.state.position_updated_at = time.time()
+        # Raw, not clamped: mpv's own bounds are authoritative, and second-
+        # guessing them here would mean trusting our duration over its.
         self._send_command("seek", position, "absolute")
 
     def stop(self) -> None:
@@ -1708,6 +1743,15 @@ class MpvPlaybackEngine:
             # Reset stale values from the previous track so preload_next's guard
             # (duration > 0 and position > duration - _GAPLESS_GUARD_SECS) does
             # not fire on the new file-loaded event and block the lookahead re-arm.
+            #
+            # It is the DURATION reset that disarms that guard (KAMP-686). The
+            # position reset no longer survives the pending seek below, which now
+            # records its own target — so a restored session near the end of a
+            # track still re-arms its lookahead, on duration alone.
+            #
+            # Must stay lock-free: seek() takes _lock, which is a plain Lock, so
+            # wrapping this block to make the reset atomic would deadlock the
+            # reader thread on the very first restored session.
             self.state.position = 0.0
             self.state.duration = 0.0
             self.state.position_updated_at = time.time()

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -139,13 +139,17 @@ class PreviewPlayer:
     # State
     # ------------------------------------------------------------------
 
-    def snapshot(self) -> dict[str, Any]:
-        """The current preview state. Lock-free by design — see the module docstring."""
+    def snapshot(self, pull_position: bool = True) -> dict[str, Any]:
+        """The current preview state. Lock-free by design — see the module docstring.
+
+        *pull_position* is False when the caller already knows where playback is
+        — see :meth:`_publish`.
+        """
         snap = dict(self._state)
         engine = self._engine
         # Position is pulled rather than pushed: the engine has no position
         # callback, and the UI interpolates between snapshots.
-        if engine is not None and snap["state"] in (PLAYING, PAUSED):
+        if pull_position and engine is not None and snap["state"] in (PLAYING, PAUSED):
             snap["position"] = float(engine.state.position)
             snap["position_updated_at"] = self._now()
         return snap
@@ -155,8 +159,26 @@ class PreviewPlayer:
         :meth:`snapshot` can read without a lock."""
         state = dict(self._state)
         state.update(fields)
+        # A caller that supplies a position IS the authority on it, and the pull
+        # in snapshot() would overwrite it with a value the engine has not caught
+        # up to yet (KAMP-686). That is how the deck's bar came to sit one seek
+        # behind: seek() published its target and snapshot() immediately replaced
+        # it with where playback had been before the seek was even sent.
+        #
+        # The engine now records a seek target itself, which alone would be a
+        # race rather than a fix — a time-pos event already in the socket can
+        # land between the engine's write and snapshot's read. Here it cannot: a
+        # supplied position is simply never second-guessed. Local, no flag, no
+        # lifetime, and every caller with nothing to say still pulls.
+        supplied = "position" in fields
+        # The anchor travels with the position it anchors, or the UI adds the age
+        # of the LAST publish to the new value — a seek would read as the target
+        # plus however long the record had been playing. Skipped when the caller
+        # names its own stamp: release_for_main zeroes both on purpose.
+        if supplied and "position_updated_at" not in fields:
+            state["position_updated_at"] = self._now()
         self._state = state
-        snap = self.snapshot()
+        snap = self.snapshot(pull_position=not supplied)
         if self._notify is not None:
             self._notify(snap)
         return snap

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -102,6 +102,15 @@ class FakeEngine:
         self.state.playing = False
 
     def seek(self, position: float) -> None:
+        # Deliberately does NOT move state.position, and neither does play()
+        # above. mpv reports position asynchronously on the IPC reader thread, so
+        # a real engine is stale for a full round trip after either call.
+        #
+        # Keeping the fake hostile is what gives the tests below their teeth
+        # (KAMP-686). A fake that helpfully wrote the target would make them pass
+        # against a daemon that still re-pulled the stale value — they would be
+        # asserting the fake, not the product. This is the same shape as the fake
+        # that never fired on_track_end and so could not see KAMP-673.
         self.calls.append(f"seek:{position}")
 
     def shutdown(self) -> None:
@@ -586,6 +595,89 @@ class TestTransport:
         h.player.play(item)
         h.player.play(item)
         assert h.source.calls == 1
+
+
+class TestThePublishedPosition:
+    """KAMP-686: the deck's bar was always one seek behind.
+
+    snapshot() re-pulls position from the engine, which reports asynchronously —
+    so every publish carried the value from BEFORE whatever just happened. The
+    main player hides this by rebuilding on a 4 Hz ping; the preview publishes on
+    transitions only and the strip interpolates from the anchor it was given, so
+    a wrong anchor is permanent.
+
+    Every test here holds the engine at a stale position on purpose. That is the
+    real engine's behaviour, not a contrivance.
+    """
+
+    def test_seeking_publishes_the_target_not_the_engines_stale_position(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.engine.state.position = 5.0
+        assert h.player.seek(90.0)["position"] == 90.0
+
+    def test_seeking_a_paused_preview_publishes_the_target_and_stays_paused(
+        self, index: LibraryIndex
+    ) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.pause()
+        h.engine.settle()
+        h.engine.state.position = 5.0
+        state = h.player.seek(90.0)
+        assert state["position"] == 90.0
+        assert state["state"] == PAUSED
+
+    def test_a_published_seek_carries_a_fresh_anchor(self, index: LibraryIndex) -> None:
+        """The strip extrapolates `now - position_updated_at` from the last
+        sample, so the anchor has to travel with the position it anchors. Left
+        at the previous publish's stamp, a seek would read as the target PLUS
+        however long the record had been playing."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.clock.t += 45  # plays on, publishing nothing — transitions only
+        assert h.player.seek(90.0)["position_updated_at"] == h.clock.t
+
+    def test_a_negative_seek_publishes_the_start(self, index: LibraryIndex) -> None:
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.engine.state.position = 5.0
+        assert h.player.seek(-10.0)["position"] == 0.0
+
+    def test_starting_a_track_publishes_zero_not_the_last_position(
+        self, index: LibraryIndex
+    ) -> None:
+        """The same bug at the other end of the record. Stepping to the next
+        track published the position the previous one had reached, so the bar
+        opened part-way through and interpolated on from there."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.engine.state.position = 60.0
+        assert h.player.step(1)["position"] == 0.0
+
+    def test_pausing_still_reports_the_engines_position(
+        self, index: LibraryIndex
+    ) -> None:
+        """The rule is narrow on purpose: only a caller that SUPPLIES a position
+        overrides the pull. pause names no position, so the engine stays the
+        authority — as it must, since nothing else knows how far the record got.
+        """
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.engine.state.position = 42.0
+        assert h.player.pause()["position"] == 42.0
+
+    def test_the_plain_snapshot_still_reports_the_engines_position(
+        self, index: LibraryIndex
+    ) -> None:
+        """The GET route reads through snapshot() with no publish in sight; it
+        must keep pulling, or a reconnecting client would be told 0:00."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.engine.state.position = 42.0
+        assert h.player.snapshot()["position"] == 42.0
 
 
 class TestAStaleStream:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1519,6 +1519,77 @@ class TestMpvPlaybackEngine:
         send.assert_called_once_with("seek", 235.0, "absolute")
         assert engine._lookahead_path is not None
 
+    def test_seek_records_the_target_position_immediately(self) -> None:
+        """state.position must report the seek target without waiting for mpv.
+
+        It is only ever written by the IPC reader thread on a time-pos event, so
+        for a full round trip after a seek it reports where playback USED to be.
+        Every consumer that samples in that window gets the old number — the
+        Crate deck's bar keeps it permanently, because the preview publishes on
+        transitions only and nothing follows to correct it (KAMP-686).
+        """
+        engine, _ = _make_engine()
+        engine.state.position = 5.0
+        engine.state.duration = 240.0
+        engine.seek(42.5)
+        assert engine.state.position == 42.5
+
+    def test_seek_stamps_position_updated_at(self) -> None:
+        """The timestamp is not optional. _state_snapshot extrapolates
+        position + (now - position_updated_at) once the gap exceeds 0.3s, so
+        recording the position against a stale stamp would report a value
+        INFLATED past the target — worse than the staleness being fixed."""
+        engine, _ = _make_engine()
+        engine.state.position_updated_at = time.time() - 30.0
+        engine.seek(42.5)
+        assert time.time() - engine.state.position_updated_at < 1.0
+
+    def test_seek_floors_the_recorded_position_at_zero(self) -> None:
+        """mpv clamps a negative seek to the start; the record must agree."""
+        engine, _ = _make_engine()
+        engine.state.duration = 240.0
+        engine.seek(-5.0)
+        assert engine.state.position == 0.0
+
+    def test_seek_clamps_the_recorded_position_to_duration(self) -> None:
+        """Past the end, mpv's own clamp is authoritative and the record follows.
+
+        Not cosmetic: __main__ persists state.position every few seconds and the
+        restore path feeds it back as a pending seek, so an unclamped value
+        outlives the session and restores to an instant EOF.
+        """
+        engine, send = _make_engine()
+        engine.state.duration = 240.0
+        engine.seek(1e9)
+        assert engine.state.position == 240.0
+        # The value SENT stays raw — mpv does the real clamping, and second-
+        # guessing it here would mean trusting our own duration over its.
+        send.assert_called_once_with("seek", 1e9, "absolute")
+
+    def test_seek_with_unknown_duration_records_the_raw_target(self) -> None:
+        """duration is 0.0 during load, and clamping to it would report 0."""
+        engine, _ = _make_engine()
+        engine.state.duration = 0.0
+        engine.seek(42.5)
+        assert engine.state.position == 42.5
+
+    def test_seek_into_guard_window_records_position_with_the_removal(self) -> None:
+        """The recorded position and the lookahead removal must land under one
+        lock acquisition.
+
+        preload_next gates on position > duration - _GAPLESS_GUARD_SECS. A
+        concurrent call landing between the removal and the record would read
+        the PRE-seek position, judge the seek safe, and re-arm the lookahead
+        into the danger window the removal exists to clear.
+        """
+        engine, send = _make_engine()
+        engine.state.duration = 240.0
+        engine.preload_next(_track(2))
+        send.reset_mock()
+        engine.seek(235.0)
+        assert engine._lookahead_path is None
+        assert engine.state.position == 235.0
+
     def test_set_volume_sends_set_property(self) -> None:
         engine, send = _make_engine()
         engine.volume = 75
@@ -1638,6 +1709,25 @@ class TestMpvPlaybackEngine:
         engine._handle_event({"event": "file-loaded"})
         send.assert_any_call("seek", 42.5, "absolute")
         assert engine._pending_seek is None  # one-shot: cleared after firing
+
+    def test_pending_seek_records_its_position_and_leaves_the_lookahead_free(
+        self,
+    ) -> None:
+        """Session restore lands on its saved position immediately, and a seek
+        near the end of the track does not block the lookahead.
+
+        The reset above it writes position 0.0 AND duration 0.0, and it is the
+        duration that disarms preload_next's guard — position no longer holds
+        still long enough to matter. Pinning both here so a future reorder of
+        those two lines cannot silently break restored-session gapless.
+        """
+        engine, send = _make_engine()
+        engine.load_paused(Path("/music/track.mp3"), 235.0)
+        engine._handle_event({"event": "file-loaded"})
+        assert engine.state.position == 235.0
+        send.reset_mock()
+        engine.preload_next(_track(2))
+        assert engine._lookahead_path is not None
 
     def test_pending_seek_fires_before_on_file_loaded_callback(self) -> None:
         """Seek must happen before the user callback so position is set first."""


### PR DESCRIPTION
## What

Click along the Crate deck's timeline and playback jumps, but the indicator doesn't. Clicking again *appears* to work, which is what makes it look like a first-click problem. It isn't — **the bar was always one seek behind.** The second click showed where the first seek landed, the third showed the second. Only the first had no previous seek to display, so only that one looked frozen rather than merely wrong.

`PreviewPlayer.seek` did the right thing and then threw it away. `_publish` wrote the seek target into `_state` correctly, then called `snapshot()`, which **re-pulls** position from the engine. `engine.state.position` is only ever written by the mpv IPC reader thread on a `time-pos` event, and `MpvPlaybackEngine.seek` just sent the command and returned — so the payload carried the pre-seek position. The daemon's own state was right throughout; only the published value was stale.

The main transport runs the same pull-on-snapshot pattern but rebuilds on every 4 Hz client ping, so a stale value corrects within 250 ms and has never been seen. The preview publishes **on transitions only** — deliberately, so the daemon doesn't broadcast several times a second — and the strip interpolates locally between snapshots. Nothing followed to correct it, so the deck kept interpolating forward from a wrong anchor.

## How

**The engine records where a seek is going** ([playback.py](kamp_core/playback.py)). This is the norm rather than a new trick: `play()`, `load_paused()` and the `file-loaded` handler all write position eagerly already, and `play()`'s own comment spells out the same reasoning — a notification fired right after would otherwise carry the finishing track's stale position. `seek()` was the one entry point that changed playback without saying so.

Three details are each load-bearing:

- **`position_updated_at` goes with it.** `_state_snapshot` extrapolates `position + (now - position_updated_at)` once the gap passes 0.3 s, so recording the position against a stale stamp would report a value inflated *past* the target — worse than the staleness being fixed.
- **The write sits inside the existing lock, after the lookahead removal.** `preload_next` gates on position against the same guard window; a call slipping between them would read the pre-seek position, judge the seek safe, and re-arm the lookahead into the window the removal had just cleared. That window exists today and closes here as a side effect.
- **The *recorded* value is clamped to `[0, duration]`; the value sent to mpv stays raw,** because mpv's bounds are authoritative. Clamping matters because the value outlives the moment: `__main__` persists `state.position` every few seconds and the restore path feeds it back as a pending seek, so an unclamped number survives the session and restores to an instant EOF.

**The daemon stops re-pulling a position it was given** ([discovery_preview.py](kamp_daemon/discovery_preview.py)). The engine fix alone would be a race rather than a fix — a `time-pos` event already in the socket can land between the engine's write and `snapshot()`'s read, and for the preview that clobber is *permanent* rather than one invisible frame. So `_publish` no longer second-guesses a supplied position. It's local: no in-flight flag, no lifetime, and every caller with nothing to say still pulls (the GET route, `pause`, `resume`, `_on_file_loaded`), as they must — nothing else knows how far the record got.

**Two things surfaced during implementation that weren't in the plan:**

The **anchor had to travel with the position**. Skipping the pull also skips `snapshot()`'s `position_updated_at` stamp, and the strip extrapolates `now - position_updated_at` — so a seek would have published the target *plus* however long the record had been playing. Now stamped whenever a position arrives without one; `release_for_main` names its own zero on purpose and keeps it.

The bug had a **second face nobody reported**: starting a track published the position the *previous* one had reached, so the bar opened part-way through and interpolated on from there. Same publish-then-clobber shape at the other end of the record. It only ever misfired on the daemon side, because the real `play()` resets eagerly — which is exactly why no test caught it.

**The fake engine stays deliberately hostile.** `seek()` and `play()` both leave `state.position` alone, as a real engine does until mpv answers. A helpful fake would have made every daemon test here pass against the *unfixed* daemon — asserting the fake rather than the product. It's the same shape as the fake that never fired `on_track_end` and so couldn't see KAMP-673, and it's why four of those seven tests were red on the code they now guard.

## Testing

- `poetry run pytest` — 3358 passed, 9 skipped, coverage **93.93%** (up from 93.89%). 14 new tests, 10 of them red before the fix.
- `poetry run black` / `poetry run mypy` — clean.
- README has nothing about the deck or seeking, so no drift.

No UI change. `CratePreviewStrip`'s range input is fully controlled from the published snapshot, so pointer and arrow-key seek are both fixed by the daemon.

### Manual test plan

1. Put a record on the deck, let it play, click once anywhere on the timeline — playback and the indicator move together on the **first** click.
2. Seek, then watch for ten seconds — the bar tracks from the new point rather than drifting from an old anchor.
3. Click near the start, then near the end, then the middle — each click lands where clicked, no one-behind lag.
4. Arrow-key the bar (it is a real range control) — same behaviour.
5. Pause the preview, seek, confirm the indicator moves and it stays paused; resume and confirm it continues from there.
6. Skip to the next track mid-record — the bar starts at 0:00, not at the previous track's position.
7. Seek the **main** player's transport too: scrub, and check the bar doesn't jump ahead of the audio in the first fraction of a second.
8. Let a record play to its natural end with a next track queued — gapless still works (the lookahead guard is the riskiest thing this touches).

## Follow-up

KAMP-700 — the same family, split out by decision rather than folded in. Pause and resume also publish positions mpv hasn't caught up to (it plays through the ~0.15 s pause fade and doesn't resume until that fade plus the audio-buffer lead), so the deck's clock creeps forward a little per cycle. Unlike this fix it can't be made deterministic without modelling the fade, and per the KAMP-508 lesson it can only be verified on a real audio device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
