### PR TITLE
KAMP-693: a better transition state while digging the next crate

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -521,7 +521,13 @@ def register_discovery_routes(
         what keeps it from being an arbitrary method call.
         """
         player = _preview_or_503()
-        if action in ("pause", "resume", "toggle", "stop"):
+        if action == "stop":
+            # A stop can ring the record out instead of cutting it (KAMP-693).
+            # Opt-in, and the caller decides: the crate moving on under a playing
+            # record wants the fade, while Escape and the deck's stop are answers
+            # to "get off" and stay immediate.
+            return cast(dict[str, Any], player.stop(fade=bool((req or {}).get("fade"))))
+        if action in ("pause", "resume", "toggle"):
             return cast(dict[str, Any], getattr(player, action)())
         if action == "next":
             return cast(dict[str, Any], player.step(1))

--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -218,12 +218,34 @@ def register_discovery_routes(
         with _lock:
             snap = dict(_status)
         crate_no = snap.get("crate_no")
-        if crate_no is None:
+        # The fallback is the reconnect path: the status is in-memory and the
+        # crate is not, so a client arriving with nothing published still gets the
+        # last crate dug.
+        #
+        # It must NOT apply mid-dig (KAMP-693). The builder publishes
+        # crate_no=None because the new crate has no number yet — next_crate_no()
+        # is not called until the whole gather is over — and reading that as "use
+        # the latest" handed back the PREVIOUS crate's ten records under a
+        # `building` label. That is the reported bug: a 15-30 second dig spent
+        # showing the crate the user had just asked to replace, with the first new
+        # record eventually arriving among the old ten.
+        #
+        # The client cannot fix this from its end, which is why it is fixed here.
+        # `newCrate` does clear the rows once the POST is accepted, but the POST
+        # returns as soon as the worker thread is spawned and the `building`
+        # publish lands after it — and _warm_wishlist republishes partway through
+        # a build anyway, so the old crate came back regardless of who won.
+        #
+        # Deliberately not extended to the failed states. `empty` and `error` also
+        # publish crate_no=None, and there the previous crate genuinely is what is
+        # still on the counter.
+        building = snap.get("state") == "building"
+        if crate_no is None and not building:
             crate_no = index.latest_crate_no()
             snap["crate_no"] = crate_no
         items = index.crate_items(crate_no) if crate_no is not None else []
         snap["items"] = items
-        if snap.get("state") != "building":
+        if not building:
             # The status is in-memory; the crate is not. After a daemon restart
             # _status is still _INITIAL_STATUS while items holds a full crate, so
             # a restored crate of ten reported filled=0 and a genuinely short one

--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -124,6 +124,11 @@ _INITIAL_STATUS: dict[str, Any] = {
     "paused_until": 0.0,
     "hints": [],
     "thin": False,
+    # What the gather is looking at right now, in the clerk's voice (KAMP-693).
+    # Declared here so the shape always carries it — the builder's own `detail`
+    # field was published for the paused state and never declared or read, which
+    # is exactly how a field becomes untrustworthy. Empty except during a dig.
+    "digging": "",
 }
 
 #: Criteria that need nothing from the library. A crate made only of these was
@@ -294,6 +299,15 @@ def register_discovery_routes(
             _status.update(fields)
             if fields.get("state") in _TERMINAL_STATES:
                 _building[0] = False
+                # The dig is over, so nothing is being dug through (KAMP-693).
+                # Cleared here rather than at each publisher because _status
+                # MERGES: a line left standing would sit under a finished crate
+                # describing a fetch that ended minutes ago, and it would have to
+                # be remembered at every terminal publish — including __main__'s
+                # error paths, which never touch the builder's helper. This is the
+                # carry-over trap `exhausted` was fixed for in KAMP-661, and the
+                # single release point is the one place it cannot be forgotten.
+                _status["digging"] = ""
         broadcast({"type": CRATE_EVENT, **_snapshot()})
 
     app.state.discovery_publish = _publish

--- a/kamp_daemon/discovery.py
+++ b/kamp_daemon/discovery.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard, types only
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
 
     from kamp_core.library import LibraryIndex, SeedAlbum, SeedArtist
 
@@ -395,6 +395,7 @@ class DiscoverySource(ABC):
         profile: SeedProfile,
         budget: RequestBudget,
         state: "MutableMapping[str, Any] | None" = None,
+        on_seed: "Callable[[str, dict[str, Any]], None] | None" = None,
     ) -> list[Candidate]:
         """Return candidates for *profile*, spending no more than *budget* allows.
 
@@ -414,6 +415,15 @@ class DiscoverySource(ABC):
         it in place; it must stay JSON-serialisable. Optional, and a source that
         needs no memory may ignore it, but one that ignores it can only ever reach
         the first page of whatever it queries.
+
+        *on_seed* is an optional progress channel, called with ``(criterion_key,
+        seed_data)`` before each fetch (KAMP-693). A gather takes 15-30 seconds
+        and it is the only thing that knows what those seconds are being spent on;
+        without this the UI can only show a spinner over an empty crate. Ignoring
+        it is allowed and costs nothing but a stiller status line — but a source
+        that calls it must do so BEFORE the work, or the line describes what has
+        already finished. Treat a raising callback as best-effort, exactly like a
+        raising criterion: it is a line of copy and must not cost the crate.
         """
 
     def preview_tracks(self, candidate: Candidate) -> list[PreviewStream]:

--- a/kamp_daemon/discovery_builder.py
+++ b/kamp_daemon/discovery_builder.py
@@ -37,7 +37,7 @@ from .discovery import (
     build_seed_profile,
     crate_budget,
 )
-from .discovery_criteria import phrasings, seed_dimension
+from .discovery_criteria import digging_phrase, phrasings, seed_dimension
 
 if TYPE_CHECKING:  # pragma: no cover - types only
     from kamp_core.library import LibraryIndex
@@ -181,8 +181,21 @@ def build_crate(
     # so a build can never exceed what crate_budget() funds. Resolving it inline
     # at each call site would hand the second one a full, untouched allowance.
     budget = budget or crate_budget()
+
+    # Narrate the gather (KAMP-693). This is the 15-30 seconds of a dig, and
+    # until now the only thing on screen for the whole of it was a static line
+    # over an empty crate. The source announces each seed before fetching it, and
+    # the seeds have always carried their own provenance — every pick has to
+    # explain itself — so saying what is being looked at costs no extra work and
+    # invents nothing.
+    #
+    # Published rather than accumulated: only the current line matters, and a
+    # history of them would be a log, not a status.
+    def _say(criterion: str, seed: dict[str, Any]) -> None:
+        _publish(publish, digging=digging_phrase(criterion, seed))
+
     try:
-        candidates = source.gather(profile, budget, rotation)
+        candidates = source.gather(profile, budget, rotation, on_seed=_say)
     except Exception:  # noqa: BLE001 - a provider must not take the daemon with it
         logger.exception("discovery: gather failed")
         return _publish(publish, state="error")

--- a/kamp_daemon/discovery_criteria.py
+++ b/kamp_daemon/discovery_criteria.py
@@ -436,6 +436,59 @@ _VARIANTS: dict[str, list[Callable[[dict[str, Any]], str]]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# What the clerk is doing right now (KAMP-693)
+# ---------------------------------------------------------------------------
+#
+# A dig takes 15-30 seconds and every one of them used to show a static line over
+# the previous crate's records. What is actually happening in that time is this
+# module's own loop: one seed at a time, each naming a record, a band or a genre
+# it is about to go and read.
+#
+# So the wait is narrated from the seed rather than from a spinner. These are the
+# same seed_data dicts `phrasings` renders, and the same accessors, which is what
+# keeps the two voices consistent -- but the tense is different and that is the
+# whole point. `why` explains a record that is already in the crate; this says
+# what is being looked at before anything has been found.
+#
+# Present participle and a trailing ellipsis throughout: it is a thing in
+# progress, and the ellipsis is what makes a line that sits for two seconds read
+# as work rather than as a result.
+_DIGGING: dict[str, Callable[[dict[str, Any]], str]] = {
+    "also_like": lambda s: f"Seeing what sits next to {_album_of(s)}…",
+    "genre_top": lambda s: (
+        f"Working through the top of the {_genre_of(s)} pile…"
+        if s.get("slice") == "top"
+        else f"Reaching into the {_genre_of(s)} racks…"
+    ),
+    "best_seller": lambda s: "Seeing what's moving today…",
+    "older_than_ten": lambda s: f"Back through the older {_genre_of(s)} records…",
+    "favorite_artist": lambda s: f"Pulling the {_artist_of(s)} shelf…",
+    "lone_album_artist": lambda s: f"Looking for more {_artist_of(s)}…",
+    "purchase_anniversary": lambda s: (
+        f"Back to what {_album_of(s)} sat next to a year ago…"
+    ),
+}
+
+
+def digging_phrase(criterion: str, seed: dict[str, Any]) -> str:
+    """What to say while *seed* is being fetched.
+
+    Degrades rather than raising, for the same reason ``phrasings`` does and with
+    more at stake: this is called from inside the gather, so a KeyError here would
+    cost the crate in order to decorate it. An unknown criterion, or a seed
+    missing the key its line wants, falls back to something true of every dig.
+    """
+    render = _DIGGING.get(criterion)
+    if render is None:
+        return "Going through the racks…"
+    try:
+        return render(seed)
+    except Exception:  # noqa: BLE001 - a line of copy cannot cost a crate
+        logger.warning("discovery: could not phrase %s", criterion, exc_info=True)
+        return "Going through the racks…"
+
+
 def phrasings(criterion: str, seed: dict[str, Any]) -> list[str]:
     """Alternative sentences for *criterion*, rendered from a stored seed.
 

--- a/kamp_daemon/discovery_preview.py
+++ b/kamp_daemon/discovery_preview.py
@@ -53,6 +53,13 @@ IDLE_TIMEOUT_SECS = 300.0
 #: card forever and inflate KAMP-655's engagement stats.
 MIN_PREVIEW_SECS = 10.0
 
+#: How long a fading stop lets the record ring out before unloading (KAMP-693).
+#: Comfortably longer than the engine's own 0.15s ramp: what has to finish is not
+#: the ramp but the already-buffered audio downstream of it, and mpv hands the
+#: output device ~0.2s before any of it is heard (the KAMP-508 lesson). Unloading
+#: on the ramp's nominal end would cut the tail that is still on its way out.
+FADE_OUT_SECS = 0.6
+
 IDLE = "idle"
 PREPARING = "preparing"
 PLAYING = "playing"
@@ -96,6 +103,7 @@ class PreviewPlayer:
         idle_timeout: float = IDLE_TIMEOUT_SECS,
         now: Callable[[], float] = _time.time,
         check_url: Callable[[str], int] | None = None,
+        fade_secs: float = FADE_OUT_SECS,
     ) -> None:
         self._index = index
         self._main = main_engine
@@ -103,6 +111,7 @@ class PreviewPlayer:
         self._source_factory = source_factory
         self._notify = notify
         self._idle_timeout = idle_timeout
+        self._fade_secs = fade_secs
         self._now = now
         # HEAD the URL before mpv sees it (KAMP-673). Injected so tests need no
         # network, and None simply skips the check — the retry path still catches
@@ -242,6 +251,55 @@ class PreviewPlayer:
         timer.daemon = True
         self._idle_timer = timer
         timer.start()
+
+    def _fade_out(self) -> None:
+        """Ring the record out, then unload it (KAMP-693).
+
+        ``unload()`` is mpv's raw ``stop`` — it drops the audio on the frame it
+        arrives, which is why the deck has always cut rather than faded. The
+        engine's only per-sample ramp is the Lua one behind ``pause()``
+        (KAMP-508), so a faded stop is that ramp followed by the unload rather
+        than a second ramp written alongside it. Nothing new to keep in tune.
+
+        The unload has to be deferred, and deferring it is the whole hazard here:
+        by the time the timer fires the user may have put another record on, and
+        unloading THEN would kill something they had just started, seconds after
+        an action they had already forgotten about. So the timer re-checks that
+        the deck is still idle before touching the engine — the same guard, and
+        the same reason, as ``_idle_kill`` above it.
+
+        Caller holds the lock.
+        """
+        engine = self._engine
+        if engine is None:
+            return
+        try:
+            engine.pause()
+        except Exception:  # noqa: BLE001 - falling back to the cut is fine
+            logger.warning("preview: fade-out failed, unloading now", exc_info=True)
+            try:
+                engine.unload()
+            except Exception:  # noqa: BLE001
+                logger.warning("preview: unload failed", exc_info=True)
+            return
+        timer = threading.Timer(self._fade_secs, self._finish_fade_out, args=(engine,))
+        timer.daemon = True
+        timer.start()
+
+    def _finish_fade_out(self, engine: "MpvPlaybackEngine") -> None:
+        with self._lock:
+            # Not merely "is this still the engine": a replayed preview reuses the
+            # same object, so identity alone would let this unload a record the
+            # user had started in the meantime. IDLE is the real question — it is
+            # the state stop() published, and anything that put a record back on
+            # the deck has left it.
+            if self._engine is not engine or self._state["state"] != IDLE:
+                logger.debug("preview: fade-out overtaken, leaving the deck alone")
+                return
+            try:
+                engine.unload()
+            except Exception:  # noqa: BLE001
+                logger.warning("preview: unload after fade failed", exc_info=True)
 
     def _cancel_idle_timer(self) -> None:
         if self._idle_timer is not None:
@@ -390,14 +448,24 @@ class PreviewPlayer:
     def toggle(self) -> dict[str, Any]:
         return self.pause() if self._state["state"] == PLAYING else self.resume()
 
-    def stop(self) -> dict[str, Any]:
-        """End the preview and give the main player back."""
+    def stop(self, fade: bool = False) -> dict[str, Any]:
+        """End the preview and give the main player back.
+
+        A hard cut by default, and *fade* is the exception rather than the other
+        way round: Escape and the deck's own stop are answers to "get off", where
+        a fade is a delay, not a courtesy. The one place it is wanted is a crate
+        being replaced under a record that is still playing (KAMP-693), which is
+        not the user asking for silence — it is the shop moving on.
+        """
         with self._lock:
             if self._engine is not None:
-                try:
-                    self._engine.unload()
-                except Exception:  # noqa: BLE001
-                    logger.warning("preview: unload failed", exc_info=True)
+                if fade and self._state["state"] == PLAYING:
+                    self._fade_out()
+                else:
+                    try:
+                        self._engine.unload()
+                    except Exception:  # noqa: BLE001
+                        logger.warning("preview: unload failed", exc_info=True)
             self._record_listened()
             self._hand_back_to_main()
             self._arm_idle_timer()

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -57,7 +57,7 @@ from .discovery_criteria import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - types only
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
 
     from .bandcamp import _AnySession
 
@@ -330,6 +330,7 @@ class BandcampDiscoverySource(DiscoverySource):
         profile: SeedProfile,
         budget: RequestBudget,
         state: "MutableMapping[str, Any] | None" = None,
+        on_seed: "Callable[[str, dict[str, Any]], None] | None" = None,
     ) -> list[Candidate]:
         """Collect candidates across the criteria that suit *profile*.
 
@@ -345,6 +346,18 @@ class BandcampDiscoverySource(DiscoverySource):
         behind a provider-neutral ABC and has no business holding a LibraryIndex;
         a plain dict also makes rotation and pagination assertable in a test with
         no network and no storage.
+
+        *on_seed* is called with ``(criterion_key, seed_data)`` immediately before
+        each seed is fetched, and is how the 15-30 seconds of a dig get narrated
+        (KAMP-693). This loop is the only thing that knows what a dig is actually
+        DOING, and it knew it all along — the seeds have carried their own
+        provenance since the first crate, because every pick has to explain
+        itself. Reporting it costs nothing extra.
+
+        One call per seed fetched, not per criterion: a criterion spans two seeds
+        and each is its own request, so per-criterion would leave the line still
+        for whole fetches. Skipped seeds are silent — announcing work that never
+        happens would name a genre the crate is not digging through.
         """
         out: list[Candidate] = []
         seen: set[str] = set()
@@ -372,7 +385,7 @@ class BandcampDiscoverySource(DiscoverySource):
         for criterion in criteria_for(profile):
             try:
                 found = self._run_criterion(
-                    criterion, profile, budget, owned, state, used=used
+                    criterion, profile, budget, owned, state, used=used, on_seed=on_seed
                 )
             except RateLimitedError as exc:
                 logger.warning("discovery: stopping gather early — %s", exc)
@@ -401,6 +414,7 @@ class BandcampDiscoverySource(DiscoverySource):
         owned: set[str] | None = None,
         state: "MutableMapping[str, Any] | None" = None,
         used: set[str] | None = None,
+        on_seed: "Callable[[str, dict[str, Any]], None] | None" = None,
     ) -> list[Candidate]:
         """One criterion's worth of candidates, spread over a few seeds.
 
@@ -458,6 +472,19 @@ class BandcampDiscoverySource(DiscoverySource):
                 continue
 
             consumed = step + 1
+            # Announced here and nowhere else: past every skip, so the line only
+            # ever names work that is actually about to happen, and BEFORE the
+            # fetch, so it describes what is being done rather than what has just
+            # finished — the last seed's line would otherwise never be seen.
+            if on_seed is not None:
+                try:
+                    on_seed(criterion.key, seed.seed_data)
+                except Exception:  # noqa: BLE001 - a status line cannot cost a crate
+                    logger.warning(
+                        "discovery: progress callback failed for %s",
+                        criterion.key,
+                        exc_info=True,
+                    )
             got, dropped = self._run_seed(
                 criterion, seed, budget, owned or set(), state
             )

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -733,9 +733,14 @@ export const getPreviewState = (): Promise<PreviewState> => get('/api/v1/discove
 export const previewPlay = (itemId: number, trackNum?: number): Promise<PreviewState> =>
   post('/api/v1/discovery/preview/play', { item_id: itemId, track_num: trackNum ?? null })
 
+// `fade` is read by 'stop' alone (KAMP-693): the crate moving on under a playing
+// record rings it out, while Escape and the deck's own stop cut, because those
+// are answers to "get off" and a fade there is a delay.
 export const previewAction = (
-  action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev'
-): Promise<PreviewState> => post(`/api/v1/discovery/preview/${action}`)
+  action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev',
+  opts?: { fade?: boolean }
+): Promise<PreviewState> =>
+  post(`/api/v1/discovery/preview/${action}`, opts?.fade ? { fade: true } : undefined)
 
 export const previewSeek = (position: number): Promise<PreviewState> =>
   post('/api/v1/discovery/preview/seek', { position })

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -610,6 +610,12 @@ export type CrateSnapshot = {
   exhausted: boolean
   paused_until: number // Unix seconds; 0 when running
   hints: string[] // the user's top genres, for the digging status lines
+  // What the gather is looking at RIGHT NOW, in the clerk's voice (KAMP-693) —
+  // "Seeing what sits next to Kid A…", "Pulling the Acid King shelf…". Pushed
+  // once per seed fetched, so it changes every couple of seconds and is the only
+  // thing that moves during the 15-30 seconds a dig takes. Empty except during a
+  // dig, and cleared the moment one ends.
+  digging: string
   thin: boolean // a library with no listening history yet — chart picks only
   items: CrateItem[]
   // KAMP-655: the digging history, computed on read and carried here so the

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -176,15 +176,50 @@
 
 /* Building: the streaming rail replaces the bin, and it needs the whole width
    rather than the middle third — ten sleeves do not fit in a column. */
+/* A dig re-columns the stage, but the DECK KEEPS ITS CELL — same row, same
+   column, same size as when a crate is on screen (KAMP-693).
+
+   Its area used to be dropped from this template entirely, from back when the
+   deck was not rendered during a build at all. Now that it is, an unresolvable
+   `grid-area: deck` falls through to auto-placement, which put the mini player in
+   an implicit row below the footer and blew the stage's height out — everything
+   else crushed into the top-left, and the dig button landing over the slots.
+
+   The third column stays empty in the header and footer rows rather than being
+   spanned into. That is what stops the deck moving a pixel between digging and
+   dug, which is the whole point: it is the thing you are still listening to. */
 .crate-stage--building {
   grid-template-areas:
-    'header header header'
-    'bin    bin    bin'
-    'footer footer footer';
+    'header header .   '
+    'bin    bin    deck'
+    'footer footer .   ';
 }
 
+/* Centred over the space the dig actually occupies — the two columns the rail
+   spans, not the full width, since the deck holds the third. The 62ch measure is
+   for a record's title and why-line; a single status sentence reads better
+   centred over the slots it describes. */
+.crate-stage--building .crate-header {
+  max-width: none;
+  align-items: center;
+  text-align: center;
+}
+
+/* Reserves the same band a record's header occupies, so the deck, the rail and
+   the footer sit at the same y whether a crate is being dug or is on screen
+   (KAMP-693). The header row is sized to `auto`, so anything here that differs
+   from the crate header's height moves everything below it — which is the same
+   reasoning that fixed the title box at two lines and reserved the clerk card.
+   It simply never applied across the two STATES before, because the deck was not
+   rendered during a dig at all.
+      artist   ~16px  (13px, normal line-height)
+    + title     62px  (2.4em at 26px)
+    + card      56px  (2.8em at 13px + 14px padding + 6px margin)
+    + position ~15px  (12px, normal line-height)
+    + gaps      18px  (3 x 6px)
+   Recompute this if any of those change; the arithmetic is the contract. */
 .crate-focus--digging {
-  min-height: 220px;
+  min-height: 167px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -726,9 +761,13 @@
 /* --- The rail ------------------------------------------------------------- */
 
 /* The build-time rail. Takes the bin's grid slot, which .crate-stage--building
-   widens to all three columns — ten sleeves plus their empty slots do not fit in
-   the middle third, and neither the titles list nor the deck is rendered while a
-   crate is still arriving. */
+   widens across the titles column as well — ten sleeves do not fit in the middle
+   third, and the titles list is not rendered while a crate is still arriving.
+   The deck IS rendered now (KAMP-693) and keeps the third column, so the rail
+   stops one column short of the full width and centres in what is left.
+
+   The row always holds exactly ten children — a record landing converts a slot
+   rather than adding one — so it cannot reflow mid-dig. */
 .crate-rail {
   grid-area: bin;
   align-self: center;

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -1343,6 +1343,40 @@
       opacity 160ms ease;
   }
 
+  /* The empty slots read as being worked rather than as ten dead outlines
+     (KAMP-693). A dig is 15-30 seconds and the row is empty for nearly all of
+     it; the changing status line carries the meaning, and this carries the fact
+     that something is still happening.
+
+     Opacity only. Nothing here goes near height, which Electron animates badly
+     enough that the file header forbids it outright, and nothing touches hue —
+     --accent swings from indigo to green across the eight palettes and a
+     coloured pulse would read as a state rather than as activity.
+
+     Staggered off the slot's own position so the row breathes along its length
+     instead of blinking in unison, which is what makes it read as digging rather
+     than as a loading indicator. Slow — 2.4s — because it sits under a line of
+     copy that is the thing to read; anything quicker competes with it.
+
+     The slots hold a stable position for the life of the dig (see CrateView), so
+     the delay is assigned once and a landing record does not restart anyone's
+     cycle. Under `reduce` there is simply no pulse, and the status line does the
+     whole job — which is the honest answer, not a lesser one. */
+  .crate-sleeve--empty .crate-sleeve-art {
+    animation: crate-slot-working 2.4s ease-in-out infinite;
+    animation-delay: calc(var(--crate-slot, 0) * 160ms);
+  }
+
+  @keyframes crate-slot-working {
+    0%,
+    100% {
+      opacity: 0.28;
+    }
+    50% {
+      opacity: 0.62;
+    }
+  }
+
   /* The header's own copy of the artwork is gone (KAMP-671) — the large art is
      now the bin's front record — so the fade that covered its swap goes with it.
      The deck's platter does not fade: a record arriving there arrives by flight,

--- a/kamp_ui/src/renderer/src/components/CrateBin.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateBin.tsx
@@ -18,7 +18,7 @@
 // broken promise, so it is a plain list now — roving tabindex and
 // aria-setsize/aria-posinset kept, aria-current in place of aria-selected, and
 // the titles list carries the crate as real buttons.
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { crateArtUrl } from '../api/client'
 import type { CrateItem } from '../api/client'
 
@@ -199,21 +199,22 @@ function BinSleeve({
 
 // How long the stock-in cascade needs to finish: the last record's delay plus
 // its own drop, with a little slack. Ten records at 70ms is 630ms + 260ms.
-const STOCK_IN_MS = 1200
+//
+// Exported for CrateView, which owns the timing now — see `stocking` below.
+export const STOCK_IN_MS = 1200
 
 export function CrateBin({
   items,
-  crateNo,
   focusIndex,
   awayItemId,
   spineName,
   railRef,
   onFocus,
   onPlay,
-  onDragStart
+  onDragStart,
+  stocking
 }: {
   items: CrateItem[]
-  crateNo: number | null
   focusIndex: number
   // The record currently out of the crate and on the deck, if any.
   awayItemId: number | null
@@ -222,32 +223,20 @@ export function CrateBin({
   onFocus: (index: number) => void
   onPlay: (item: CrateItem) => void
   onDragStart: (item: CrateItem, startX: number, startY: number) => void
-}): React.JSX.Element {
-  // Stock-in runs on a DELIVERY, not on every render that happens to have
-  // records in it. Arriving at a crate that already exists — switching to the
-  // tab, reloading the renderer — is not a delivery, and replaying the cascade
-  // there would turn a moment into a tic.
+  // Whether a crate is landing right now, decided by CrateView (KAMP-693).
   //
-  // So the first crate_no this component sees is seeded silently, and only a
-  // change from it counts. That also gets the first-ever crate right: mount
-  // seeds null, the build completes, null -> 1 is a change, and it plays.
-  const seenRef = useRef<number | null>(null)
-  const seededRef = useRef(false)
-  const [stocking, setStocking] = useState(false)
-
-  useEffect(() => {
-    if (!seededRef.current) {
-      seededRef.current = true
-      seenRef.current = crateNo
-      return
-    }
-    if (crateNo === null || crateNo === seenRef.current) return
-    seenRef.current = crateNo
-    setStocking(true)
-    const timer = window.setTimeout(() => setStocking(false), STOCK_IN_MS)
-    return () => window.clearTimeout(timer)
-  }, [crateNo])
-
+  // It used to be decided here, and it never once ran. This component is inside
+  // CrateView's `building ? rail : bin` ternary, so it UNMOUNTS the moment a dig
+  // starts and remounts when it ends — and a remounted component re-seeds its own
+  // "first crate_no I have seen" ref with the NEW number, which is precisely the
+  // silent branch. The seeding comment assumed the bin stayed mounted across a
+  // build; it does not, and on the first-ever crate it is not mounted at the start
+  // of one either. So the cascade this file describes has been dead on every path
+  // since it was written.
+  //
+  // The decision belongs to something that survives a dig. CrateView does.
+  stocking: boolean
+}): React.JSX.Element {
   return (
     <div className={`crate-bin${stocking ? ' crate-bin--stocking' : ''}`}>
       {/* The divider card, ABOVE the records — it stands at the back of the bin,

--- a/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateSleeve.tsx
@@ -91,12 +91,19 @@ export function CrateSleeve({
 
 // An unfilled slot, shown while a crate is being dug so the rail has its full
 // shape from the first moment rather than growing a sleeve at a time.
+//
+// `--crate-slot` is its position in the row, which the stylesheet staggers the
+// working-pulse off so the row breathes along its length rather than blinking in
+// unison (KAMP-693). The caller keys these by position for exactly this reason —
+// a slot that got re-keyed as the row shortened would restart its cycle.
 export function CrateSlot({ index }: { index: number }): React.JSX.Element {
   return (
     <li
       className="crate-sleeve crate-sleeve--empty"
       aria-hidden="true"
-      style={{ '--crate-tilt': `${tiltFor(index)}deg` } as React.CSSProperties}
+      style={
+        { '--crate-tilt': `${tiltFor(index)}deg`, '--crate-slot': index } as React.CSSProperties
+      }
     >
       <div className="crate-sleeve-art" />
     </li>

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -205,11 +205,28 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // deck without being live (KAMP-678) — it rides on the idle state as
   // `parked_item_id`, so every predicate that genuinely means "live" keeps
   // reading `state` and only this one falls back.
-  const deckItem = useMemo(() => {
-    const id = preview?.state === 'idle' ? preview?.parked_item_id : preview?.item_id
-    if (id == null) return null
-    return items.find((item) => item.id === id) ?? null
-  }, [items, preview?.item_id, preview?.parked_item_id, preview?.state])
+  //
+  // The lookup can fail while a dig runs, and that is not an error state: the
+  // crate is deliberately emptied the moment digging starts (KAMP-693), so the
+  // record ON the deck is one whose row has just left `items`. Falling to null
+  // there would put "Nothing on the deck" over audible music. So the last
+  // resolved item is held, and only a genuinely empty deck clears it.
+  const deckId = preview?.state === 'idle' ? preview?.parked_item_id : preview?.item_id
+  const inCrate = useMemo(
+    () => (deckId == null ? null : (items.find((item) => item.id === deckId) ?? null)),
+    [items, deckId]
+  )
+
+  // Held across the dig, and adjusted DURING RENDER rather than in an effect or a
+  // ref — the compiler forbids both, and this is React's documented pattern for
+  // it (the same one `endedCrate` uses below).
+  //
+  // Keyed on the id throughout, so a held record can never appear under a
+  // DIFFERENT one's preview. The crate it came from is gone; its identity is
+  // still what the daemon is playing.
+  const [heldDeckItem, setHeldDeckItem] = useState<CrateItem | null>(null)
+  const deckItem = inCrate ?? (heldDeckItem?.id === deckId ? heldDeckItem : null)
+  if (deckItem !== heldDeckItem) setHeldDeckItem(deckItem)
 
   // Where a record flies TO. Measured at the moment a flight starts rather than
   // held as state — the view scrolls, so a rect captured earlier is stale.
@@ -628,11 +645,19 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // with a null relatedTarget too, which is exactly what dropping a record does
   // (KAMP-670). Removing this on the strength of its old comment would have
   // broken a flow that shipped three commits ago.
+  //
+  // The rail itself is the fallback, and it is not a nicety (KAMP-693). A dig now
+  // empties the crate, so the focused sleeve unmounts with nothing to replace it
+  // — the empty slots are aria-hidden and carry no tabindex — and focus would
+  // land on document.body for the whole 15-30 seconds. Every key this view owns
+  // is on this container, so all of them would be dead exactly while the deck is
+  // still playing and Space is the thing you want.
   const onBlurCapture = (e: React.FocusEvent<HTMLDivElement>): void => {
     if (e.relatedTarget !== null || !active) return
     const rail = railRef.current
     const option = rail?.querySelectorAll<HTMLElement>('[data-crate-sleeve]')[focusIndex]
-    option?.focus()
+    if (option) option.focus()
+    else rail?.focus({ preventScroll: true })
   }
 
   // Claim focus when the view opens, so , and . work on arrival.
@@ -645,15 +670,21 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // preventScroll matters: the view scrolls, the bin sits below the focus card,
   // and a plain focus() scrolls the record into view, yanking the card off the
   // top of the screen the moment you arrive.
+  //
+  // No longer skips an empty crate (KAMP-693). It used to, because an empty crate
+  // meant "nothing dug yet" and there was nothing to focus — but a dig empties the
+  // crate now, and arriving in the view mid-dig has to leave the keys working.
+  // The rail takes it instead; it is already tabIndex={-1} for exactly this.
   useEffect(() => {
-    if (!active || items.length === 0) return
+    if (!active) return
     const rail = railRef.current
     if (!rail) return
     // Never steal focus from something already in use inside the view — a
     // pressed action button, or a record the user just clicked.
     if (rail.contains(document.activeElement)) return
     const option = rail.querySelectorAll<HTMLElement>('[data-crate-sleeve]')[focusIndex]
-    option?.focus({ preventScroll: true })
+    if (option) option.focus({ preventScroll: true })
+    else rail.focus({ preventScroll: true })
   }, [active, items.length, focusIndex])
 
   // ---------------------------------------------------------------------------
@@ -897,96 +928,101 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
             focused record — you can keep flipping while something plays, and the
             deck should not change under you when you do. It is also the flight's
             destination rect, which is why it keeps a fixed size rather than one
-            that depends on what is on it. */}
-        {!building && (
-          <div className="crate-deck-col">
-            <div
-              className={`crate-deck${dragOverDeck ? ' crate-deck--drop-target' : ''}`}
-              role="group"
-              aria-label="Preview deck"
-            >
-              <div
-                className={`crate-deck-platter${platterItem ? ' is-loaded' : ''}`}
-                ref={deckArtRef}
-                aria-hidden="true"
-              >
-                {platterItem?.art_url && (
-                  <img className="crate-deck-art" src={crateArtUrl(platterItem.id)} alt="" />
-                )}
-              </div>
+            that depends on what is on it.
 
-              <div className="crate-deck-body">
-                {/* The strip renders whether or not anything is on: its transport
+            Through a dig too, since KAMP-693. It used to be hidden while
+            `building`, which meant a record from the old crate went on playing
+            for the whole 15-30 seconds with no transport, nothing naming it and
+            no way to stop it — the exact outcome the comment above the
+            leave-the-view effect calls worse than no preview at all. Emptying the
+            crate made that worse rather than better, so the gate is gone: the
+            record you are listening to survives the dig, controls and all. */}
+        <div className="crate-deck-col">
+          <div
+            className={`crate-deck${dragOverDeck ? ' crate-deck--drop-target' : ''}`}
+            role="group"
+            aria-label="Preview deck"
+          >
+            <div
+              className={`crate-deck-platter${platterItem ? ' is-loaded' : ''}`}
+              ref={deckArtRef}
+              aria-hidden="true"
+            >
+              {platterItem?.art_url && (
+                <img className="crate-deck-art" src={crateArtUrl(platterItem.id)} alt="" />
+              )}
+            </div>
+
+            <div className="crate-deck-body">
+              {/* The strip renders whether or not anything is on: its transport
                     is what tells you the deck is there and ready (KAMP-678). It
                     also gives the error line below a home — every failure path
                     publishes state=idle, which used to unmount this whole block
                     and take the message with it. */}
-                <CratePreviewStrip
-                  preview={preview ?? IDLE_PREVIEW}
-                  item={deckItem}
-                  wishlistSaving={deckItem !== null && wishlistPending.includes(deckItem.id)}
-                  onToggle={toggleDeck}
-                  onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
-                  onSeek={(position) => void previewSeek(position)}
-                  onToggleWishlist={(item) => void toggleCrateWishlist(item)}
-                />
+              <CratePreviewStrip
+                preview={preview ?? IDLE_PREVIEW}
+                item={deckItem}
+                wishlistSaving={deckItem !== null && wishlistPending.includes(deckItem.id)}
+                onToggle={toggleDeck}
+                onStep={(delta) => void previewAction(delta > 0 ? 'next' : 'prev')}
+                onSeek={(position) => void previewSeek(position)}
+                onToggleWishlist={(item) => void toggleCrateWishlist(item)}
+              />
 
-                {deckItem && preview && preview.tracks.length > 0 && (
-                  <ol className="crate-tracklist">
-                    {preview.tracks.map((track) => (
-                      <li key={track.track_num}>
-                        <button
-                          className={`crate-track${
-                            track.track_num === preview.track_num ? ' crate-track--current' : ''
-                          }`}
-                          onClick={() => void previewPlay(deckItem.id, track.track_num)}
-                        >
-                          <span className="crate-track-num">{track.track_num}</span>
-                          <span className="crate-track-title">
-                            {track.title || `Track ${track.track_num}`}
-                          </span>
-                          <span className="crate-track-time">{formatClock(track.duration)}</span>
-                        </button>
-                      </li>
-                    ))}
-                  </ol>
-                )}
+              {deckItem && preview && preview.tracks.length > 0 && (
+                <ol className="crate-tracklist">
+                  {preview.tracks.map((track) => (
+                    <li key={track.track_num}>
+                      <button
+                        className={`crate-track${
+                          track.track_num === preview.track_num ? ' crate-track--current' : ''
+                        }`}
+                        onClick={() => void previewPlay(deckItem.id, track.track_num)}
+                      >
+                        <span className="crate-track-num">{track.track_num}</span>
+                        <span className="crate-track-title">
+                          {track.title || `Track ${track.track_num}`}
+                        </span>
+                        <span className="crate-track-time">{formatClock(track.duration)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ol>
+              )}
 
-                {/* Deliberately OUTSIDE the deckItem gate: every failure path
+              {/* Deliberately OUTSIDE the deckItem gate: every failure path
                     publishes state=idle, which empties the deck — so gating this
                     on an occupied deck is precisely why it has never once been
                     seen on screen. */}
-                {preview?.error && (
-                  <p className="crate-preview-error" role="status">
-                    {preview.error === 'rate_limited'
-                      ? 'Bandcamp asked us to slow down — try again shortly.'
-                      : preview.error === 'expired'
-                        ? // Distinct from the line below, because the record is
-                          // fine and only the link went stale — Bandcamp signs
-                          // them for about a day (KAMP-673). Saying "no preview
-                          // for this one" would send the user away from a record
-                          // that plays perfectly well on a second press.
-                          'That link went stale — press play again.'
-                        : 'No preview for this one.'}
-                  </p>
-                )}
+              {preview?.error && (
+                <p className="crate-preview-error" role="status">
+                  {preview.error === 'rate_limited'
+                    ? 'Bandcamp asked us to slow down — try again shortly.'
+                    : preview.error === 'expired'
+                      ? // Distinct from the line below, because the record is
+                        // fine and only the link went stale — Bandcamp signs
+                        // them for about a day (KAMP-673). Saying "no preview
+                        // for this one" would send the user away from a record
+                        // that plays perfectly well on a second press.
+                        'That link went stale — press play again.'
+                      : 'No preview for this one.'}
+                </p>
+              )}
 
-                {/* The strip's meta line already says "Nothing on the deck"; this
+              {/* The strip's meta line already says "Nothing on the deck"; this
                     keeps the part no icon conveys — how to put one on, and that
                     doing so does not disturb the user's own queue. It named only
                     Space until KAMP-679, which is a keyboard instruction shown to
                     people who could not find the keyboard route: the mouse one
                     goes first now. */}
-                {!deckItem && (
-                  <p className="crate-deck-empty">
-                    Double-click a record to put it on, or press Space — your queue stays where it
-                    is.
-                  </p>
-                )}
-              </div>
+              {!deckItem && (
+                <p className="crate-deck-empty">
+                  Double-click a record to put it on, or press Space — your queue stays where it is.
+                </p>
+              )}
             </div>
           </div>
-        )}
+        </div>
 
         {/* Statement, then offer, then the quiet register (KAMP-663). The tally
             used to sit UNDER the button, which read as a footnote to the next

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -122,7 +122,12 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // would not do it: ten records in, index 7 is perfectly legal and simply the
   // wrong place to be standing.
   const crateNo = crate?.crate_no ?? null
-  const focused = focus.crate === crateNo ? focus.index : 0
+  // `crateNo !== null` is not redundant (KAMP-693). null used to mean one thing,
+  // "no crate has ever been dug"; a build now reports null too, because the new
+  // crate has no number until the gather is over. Without this, a focus tag left
+  // over from before the first crate would match a dig in progress — and the tag
+  // is meant to be self-invalidating, which only works if null is not an identity.
+  const focused = crateNo !== null && focus.crate === crateNo ? focus.index : 0
 
   // Clamped during render rather than corrected in an effect: the crate grows
   // while a build streams, so the stored index can briefly point past the end.
@@ -860,7 +865,23 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
         ) : (
           <header className="crate-header">
             <div className="crate-focus crate-focus--digging">
-              <p className="crate-empty-hint">Digging through the racks…</p>
+              {/* What the gather is actually looking at, changing every couple of
+                  seconds (KAMP-693) — "Seeing what sits next to Kid A…",
+                  "Pulling the Acid King shelf…". A dig is 15-30 seconds and this
+                  is the only thing that moves in them; the static line below it
+                  was the whole of the wait before, over ten empty slots.
+
+                  aria-live so it is not a purely visual reassurance. `polite`,
+                  not `assertive`: it changes ten times a dig and interrupting a
+                  screen reader on every fetch would be worse than silence.
+
+                  The static line remains the fallback and is not dead code — it
+                  covers the moment between the dig starting and the first seed
+                  being reached, which spans a keychain read and the profile
+                  build, and any older daemon that publishes no line at all. */}
+              <p className="crate-empty-hint" role="status" aria-live="polite">
+                {crate?.digging || 'Digging through the racks…'}
+              </p>
             </div>
           </header>
         )}
@@ -900,8 +921,16 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
                 onFocus={focusSleeve}
               />
             ))}
+            {/* Keyed by POSITION IN THE ROW, not by offset into the slot list
+                (KAMP-693). The tilt was always derived from the absolute position
+                and was always stable; the key was not. As records landed, the
+                slot at position 1 went from `slot-1` to `slot-0`, so React reused
+                position 0's DOM node for it and its --crate-tilt changed under a
+                160ms transform transition — nine slots re-tilting on every record,
+                which is a row-wide wobble through the whole placement burst and
+                exactly what the pulse below would have been competing with. */}
             {Array.from({ length: slots }, (_unused, i) => (
-              <CrateSlot key={`slot-${i}`} index={items.length + i} />
+              <CrateSlot key={`slot-${items.length + i}`} index={items.length + i} />
             ))}
           </ul>
         ) : (

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -14,7 +14,7 @@ import { useStore } from '../store'
 import { crateArtUrl, IDLE_PREVIEW } from '../api/client'
 import type { CrateItem, DiggingStats } from '../api/client'
 import { CrateSleeve, CrateSlot } from './CrateSleeve'
-import { CrateBin } from './CrateBin'
+import { CrateBin, STOCK_IN_MS } from './CrateBin'
 import { CrateTitles } from './CrateTitles'
 import { crateSpineName } from './crateSpine'
 import { CratePreviewStrip } from './CratePreviewStrip'
@@ -193,6 +193,36 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // to go the moment the stage does. A 409 leaves the items in place and this
   // stays true, which is right — that crate is still on screen and still ended.
   const atCrateEnd = endedCrate !== null && endedCrate === crateNo && hasCrate && !building
+
+  // A crate LANDING, which is what the bin's stock-in cascade plays for
+  // (KAMP-656, fixed in KAMP-693).
+  //
+  // This lived in CrateBin and never once ran. The bin is inside the
+  // `building ? rail : bin` ternary below, so it unmounts the instant a dig
+  // starts and remounts when one ends — and a remounted component re-seeds its
+  // "first crate I have seen" ref with the NEW number, taking the silent branch
+  // every time. It has to be decided by something that survives a dig, and this
+  // component never unmounts: App renders every view and toggles a class.
+  //
+  // Seeded silently on first sight so arriving at a crate that already exists —
+  // launching, switching tabs — is not a delivery. A build reports crate_no null
+  // and is skipped, so the pair of changes a dig makes (N → null → N+1) is one
+  // delivery, not two.
+  const seenCrate = useRef<number | null>(null)
+  const seededCrate = useRef(false)
+  const [stocking, setStocking] = useState(false)
+  useEffect(() => {
+    if (!seededCrate.current) {
+      seededCrate.current = true
+      seenCrate.current = crateNo
+      return
+    }
+    if (crateNo === null || crateNo === seenCrate.current) return
+    seenCrate.current = crateNo
+    setStocking(true)
+    const timer = window.setTimeout(() => setStocking(false), STOCK_IN_MS)
+    return () => window.clearTimeout(timer)
+  }, [crateNo])
 
   // The name on the crate's divider card (KAMP-656). Derived from the snapshot
   // the view already has, because this story is skin only — no API changes. It
@@ -727,6 +757,32 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
          state with rows on screen, so it also sat over a crate that was already
          rebuilding from a profile that had since filled out. */
     }
+    {
+      /* A dig that failed now has to say so (KAMP-693).
+
+         It never did, and it never needed to: the old crate stayed on screen for
+         the whole build, so a failed one simply looked like nothing had happened.
+         Emptying the counter changes that — the crate goes, twenty-odd seconds of
+         empty slots pass, and then the old records reappear with no explanation
+         unless something accounts for them. The `error` copy in the early return
+         below is unreachable whenever a previous crate exists, which is almost
+         always.
+
+         Above the `ready` arms rather than among them, because these two are the
+         only states where the crate on screen is NOT the crate just dug. */
+    }
+    if (state === 'empty')
+      return (
+        <div className="crate-banner" role="status">
+          Nothing new came up that time — your last crate&rsquo;s still here.
+        </div>
+      )
+    if (state === 'error')
+      return (
+        <div className="crate-banner" role="status">
+          That dig didn&rsquo;t finish. Try another.
+        </div>
+      )
     if (state === 'ready' && crate?.thin && hasCrate)
       return (
         <div className="crate-banner" role="status">
@@ -937,7 +993,7 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           <div className="crate-bin-col">
             <CrateBin
               items={items}
-              crateNo={crate?.crate_no ?? null}
+              stocking={stocking}
               focusIndex={focusIndex}
               awayItemId={awayItemId}
               spineName={spineName}

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -16,6 +16,7 @@ import type {
   ConfigValues,
   CrateItem,
   CrateSnapshot,
+  CrateState,
   PreviewState,
   PurchasedPick,
   CriteriaDoc,
@@ -178,6 +179,11 @@ type PlayerStore = {
   // first snapshot arrives, which the view renders as "not dug yet" rather than
   // as an error.
   crate: CrateSnapshot | null
+  // Whether a dig THIS window started is still in flight, and so whether the
+  // record on the deck should be faded out when it lands (KAMP-693). Not derived
+  // from the crate state, which cannot tell a dig this client asked for from one
+  // it merely heard about.
+  crateStopArmed: boolean
   // KAMP-651: preview transport state. Daemon-owned — it survives a renderer
   // reload, so this is seeded from GET .../preview/state on every WS connect
   // and kept live by the `discovery.preview` event, never invented locally.
@@ -429,6 +435,12 @@ const _albumTracksKey = (albumArtist: string, album: string, trackId: number | n
 // concurrent calls measured at ~21s), so the fan-out — not any single call —
 // was the ~12s bug. The input text still updates synchronously; only the
 // network call is deferred. _searchAbort cancels a superseded in-flight request.
+// States a dig can end in — the client half of the daemon's _TERMINAL_STATES
+// (KAMP-693). Every one of them has to disarm the pending fade-and-stop, not
+// just `ready`: a flag left armed after a failed dig would fire on some
+// unrelated crate arriving later.
+const CRATE_TERMINAL_STATES = new Set<CrateState>(['ready', 'empty', 'error', 'paused', 'idle'])
+
 const SEARCH_DEBOUNCE_MS = 250
 let _searchTimer: ReturnType<typeof setTimeout> | null = null
 let _searchAbort: AbortController | null = null
@@ -611,6 +623,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
   downloadPausedUntil: 0,
   downloadBatch: null,
   crate: null,
+  crateStopArmed: false,
   crateWishlistPending: [],
   crateWishlistError: null,
   preview: null,
@@ -968,9 +981,37 @@ export const useStore = create<PlayerStore>((set, get) => ({
       // transition, and a crate that never loads renders as "not dug yet".
     }
   },
-  setCrate: (snapshot) => set({ crate: snapshot }),
+  // The WS entry point for a crate, and the only one (KAMP-693). `loadCrate`
+  // deliberately bypasses it with a direct set: that is the REST/reconnect path,
+  // and a reconnect re-delivering a `ready` snapshot must not read as a dig
+  // finishing. Same for a crate restored at launch.
+  setCrate: (snapshot) => {
+    // Fade the record out once the dig is DONE, not when it starts (KAMP-693).
+    // A dig is 15-30 seconds and the point is that you keep listening through it;
+    // the stop belongs at the moment the new crate is on the counter.
+    //
+    // Armed by this client's own dig and disarmed here, so it can only ever fire
+    // for a build this window started. Without that a reconnect, a second window,
+    // or a crate restored on launch would silently stop a preview the user had
+    // deliberately put on — a worse bug than the one being fixed.
+    if (get().crateStopArmed && CRATE_TERMINAL_STATES.has(snapshot.state)) {
+      set({ crateStopArmed: false })
+      // `ready` only. A 409, an error or an empty dig never replaced anything, so
+      // there is nothing to move on FROM — taking the record away would be a
+      // consolation prize for a dig that failed.
+      if (snapshot.state === 'ready' && get().preview?.state !== 'idle') {
+        void get().previewAction('stop', { fade: true })
+      }
+    }
+    set({ crate: snapshot })
+  },
   newCrate: async () => {
     try {
+      // Armed BEFORE the request, not after. The build's terminal publish can
+      // reach us before this promise resolves, and arming afterwards would then
+      // miss it — the record would simply play on with the new crate in front of
+      // it. Disarmed in the catch below, so a refused dig arms nothing.
+      set({ crateStopArmed: true })
       await api.newCrate()
       // Clear the old records once the dig is ACCEPTED (KAMP-672).
       //
@@ -987,6 +1028,7 @@ export const useStore = create<PlayerStore>((set, get) => ({
       const crate = get().crate
       if (crate) set({ crate: { ...crate, items: [], crate_stats: null } })
     } catch (err) {
+      set({ crateStopArmed: false })
       const msg = err instanceof Error ? err.message : 'Could not dig a crate'
       get().showFlashToast(msg)
     }

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -250,7 +250,10 @@ type PlayerStore = {
   loadPreview: () => Promise<void>
   setPreview: (state: PreviewState) => void
   previewPlay: (itemId: number, trackNum?: number) => Promise<void>
-  previewAction: (action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev') => Promise<void>
+  previewAction: (
+    action: 'pause' | 'resume' | 'toggle' | 'stop' | 'next' | 'prev',
+    opts?: { fade?: boolean }
+  ) => Promise<void>
   previewSeek: (position: number) => Promise<void>
   showFlashToast: (msg: string, tone?: 'error') => void
   setRecentlyAddedCount: (n: number) => void
@@ -1052,9 +1055,9 @@ export const useStore = create<PlayerStore>((set, get) => ({
       get().showFlashToast(msg, 'error')
     }
   },
-  previewAction: async (action) => {
+  previewAction: async (action, opts) => {
     try {
-      set({ preview: await api.previewAction(action) })
+      set({ preview: await api.previewAction(action, opts) })
     } catch {
       // A failed transport call leaves the daemon authoritative; re-read rather
       // than showing a state the preview engine does not agree with.

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -968,8 +968,9 @@ class FakePreview:
     def toggle(self) -> dict[str, Any]:
         return self._simple("toggle")
 
-    def stop(self) -> dict[str, Any]:
-        return self._simple("stop")
+    def stop(self, fade: bool = False) -> dict[str, Any]:
+        self.calls.append(("stop", fade))
+        return self.snapshot()
 
     def step(self, delta: int) -> dict[str, Any]:
         self.calls.append(("step", delta))
@@ -1011,12 +1012,26 @@ class TestPreviewRoutes:
         client = _preview_app(index, FakePreview())
         assert client.post("/api/v1/discovery/preview/play", json={}).status_code == 422
 
-    @pytest.mark.parametrize("action", ["pause", "resume", "toggle", "stop"])
+    @pytest.mark.parametrize("action", ["pause", "resume", "toggle"])
     def test_simple_actions(self, index: LibraryIndex, action: str) -> None:
         preview = FakePreview()
         client = _preview_app(index, preview)
         assert client.post(f"/api/v1/discovery/preview/{action}").status_code == 200
         assert preview.calls == [(action, None)]
+
+    def test_stop_cuts_unless_asked_to_fade(self, index: LibraryIndex) -> None:
+        """The default has to stay the cut (KAMP-693). Escape and the deck's own
+        stop are answers to "get off", and a fade there is a delay."""
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        assert client.post("/api/v1/discovery/preview/stop").status_code == 200
+        assert preview.calls == [("stop", False)]
+
+    def test_stop_can_be_asked_to_ring_it_out(self, index: LibraryIndex) -> None:
+        preview = FakePreview()
+        client = _preview_app(index, preview)
+        client.post("/api/v1/discovery/preview/stop", json={"fade": True})
+        assert preview.calls == [("stop", True)]
 
     @pytest.mark.parametrize("action,delta", [("next", 1), ("prev", -1)])
     def test_stepping(self, index: LibraryIndex, action: str, delta: int) -> None:

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -307,6 +307,31 @@ class TestCrateSnapshot:
         assert body["crate_no"] == 1
         assert len(body["items"]) == 10
 
+    def test_the_digging_line_reaches_the_client(self, harness: _Harness) -> None:
+        """What the gather is looking at right now (KAMP-693) — the only thing
+        that moves during the 15-30 seconds a dig takes."""
+        harness.publish(
+            {"state": "building", "digging": "Pulling the Acid King shelf…"}
+        )
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["digging"] == "Pulling the Acid King shelf…"
+
+    @pytest.mark.parametrize("state", ["ready", "empty", "error", "paused", "idle"])
+    def test_every_terminal_state_clears_the_digging_line(
+        self, harness: _Harness, state: str
+    ) -> None:
+        """The status MERGES, so a line left standing would sit under a finished
+        crate describing a fetch that ended minutes ago.
+
+        Cleared at the single release point rather than by each publisher, for the
+        same reason the build lock is: __main__'s error paths never touch the
+        builder's publish helper, so anything they had to remember would be
+        forgotten. This is the carry-over trap `exhausted` was fixed for.
+        """
+        harness.publish({"state": "building", "digging": "Seeing what's moving today…"})
+        harness.publish({"state": state})
+        assert harness.client.get("/api/v1/discovery/crate").json()["digging"] == ""
+
     def test_publishing_pushes_to_clients(self, harness: _Harness) -> None:
         harness.publish({"state": "building", "hints": ["dub techno"]})
         assert harness.events[-1]["state"] == "building"

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -243,6 +243,70 @@ class TestCrateSnapshot:
         body = harness.client.get("/api/v1/discovery/crate").json()
         assert body["filled"] == 3
 
+    def test_a_build_does_not_serve_the_previous_crate(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The counter is emptied the moment digging starts (KAMP-693).
+
+        The builder publishes crate_no=None because the new crate has no number
+        yet -- next_crate_no() is not called until the whole gather is over. The
+        fallback below then read that as "no crate named, use the latest", handed
+        back the PREVIOUS crate's ten records, and labelled them `building`. So a
+        15-30 second dig was spent showing the crate the user had just asked to
+        replace, and the first new record arrived among the old ten.
+        """
+        _stock(index, 1, count=10)
+        harness.publish({"state": "building", "crate_no": None, "filled": 0})
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["items"] == []
+        assert body["crate_no"] is None
+
+    def test_a_build_serves_its_own_records_once_they_land(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """The gate is on having no crate to name, not on building as such. Once
+        the placement loop publishes a real crate_no the rail fills from it, one
+        publish per record, which is the whole progressive fill."""
+        _stock(index, 1, count=10)
+        _stock(index, 2, count=3)
+        harness.publish({"state": "building", "crate_no": 2, "filled": 3})
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert [item["title"] for item in body["items"]] == [
+            "Title 0",
+            "Title 1",
+            "Title 2",
+        ]
+
+    def test_a_build_reports_no_crate_stats_before_it_has_a_crate(
+        self, index: LibraryIndex, harness: _Harness
+    ) -> None:
+        """crate_stats is scoped to the crate on screen, and during a dig there
+        is none -- reporting the previous crate's tally under a crate that is not
+        there is the same lie in a different field."""
+        _stock(index, 1, count=10)
+        harness.publish({"state": "building", "crate_no": None})
+        assert (
+            harness.client.get("/api/v1/discovery/crate").json()["crate_stats"] is None
+        )
+
+    @pytest.mark.parametrize("state", ["idle", "ready", "empty", "error", "paused"])
+    def test_every_other_state_still_falls_back_to_the_latest_crate(
+        self, index: LibraryIndex, harness: _Harness, state: str
+    ) -> None:
+        """The fallback is the reconnect path and must survive.
+
+        `idle` is the one that matters most: _status resets to it on every daemon
+        restart, so gating any wider than `building` would make a relaunch report
+        an empty crate. The failed-build states matter too -- they publish
+        crate_no=None as well, and there the previous crate genuinely IS what is
+        still on the counter.
+        """
+        _stock(index, 1, count=10)
+        harness.publish({"state": state, "crate_no": None})
+        body = harness.client.get("/api/v1/discovery/crate").json()
+        assert body["crate_no"] == 1
+        assert len(body["items"]) == 10
+
     def test_publishing_pushes_to_clients(self, harness: _Harness) -> None:
         harness.publish({"state": "building", "hints": ["dub techno"]})
         assert harness.events[-1]["state"] == "building"

--- a/tests/test_discovery_builder.py
+++ b/tests/test_discovery_builder.py
@@ -85,6 +85,8 @@ class _FakeSource(DiscoverySource):
         self._weights = weights or {}
         self._error = error
         self.gather_calls = 0
+        # (criterion_key, seed_data) pairs this source will announce as it works.
+        self.seeds: list[tuple[str, dict[str, Any]]] = []
 
     @property
     def criterion_caps(self) -> dict[str, int]:
@@ -99,11 +101,19 @@ class _FakeSource(DiscoverySource):
         profile: SeedProfile,
         budget: RequestBudget,
         state: Any = None,
+        on_seed: Any = None,
     ) -> list[Candidate]:
         self.gather_calls += 1
         self.last_state = state
         if self._error is not None:
             raise self._error
+        # A real source announces each seed before fetching it (KAMP-693). Empty
+        # by default so every pre-existing test is unchanged; a test that cares
+        # sets `seeds` and then gets to assert on what the builder published,
+        # rather than on the fact that a callback was handed over.
+        for criterion, seed in self.seeds:
+            if on_seed is not None:
+                on_seed(criterion, seed)
         return list(self._candidates)
 
 
@@ -128,6 +138,7 @@ class _PaginatingSource(DiscoverySource):
         profile: SeedProfile,
         budget: RequestBudget,
         state: Any = None,
+        on_seed: Any = None,
     ) -> list[Candidate]:
         state = {} if state is None else state
         self.states.append(dict(state))
@@ -167,6 +178,13 @@ class _Publisher:
     def __call__(self, fields: dict[str, Any]) -> None:
         self.raw.append(dict(fields))
         self.status.update(fields)
+        # Mirrors the real _publish, which clears the digging line on any
+        # terminal state (KAMP-693). Modelled rather than ignored because this
+        # merges exactly as the real one does, and a fake that merges but never
+        # clears would let a builder test assert a line still standing under a
+        # finished crate — the opposite of what ships.
+        if fields.get("state") in {"ready", "empty", "error", "paused", "idle"}:
+            self.status["digging"] = ""
         self.pushes.append(dict(self.status))
 
 
@@ -1267,6 +1285,21 @@ class TestPublication:
         _build(index, _FakeSource(_spread({"a": 12})), publish=publisher)
         assert publisher.pushes[0]["state"] == "building"
         assert publisher.pushes[-1]["state"] == "ready"
+
+    def test_the_gather_is_narrated_while_it_runs(self, index: LibraryIndex) -> None:
+        """KAMP-693. The gather is the 15-30 seconds of a dig and the only part
+        that knows what it is doing; without this the UI has a spinner over an
+        empty crate for the whole of it."""
+        publisher = _Publisher()
+        source = _FakeSource(_spread({"a": 12}))
+        source.seeds = [
+            ("also_like", {"kind": "album", "album": "Kid A"}),
+            ("favorite_artist", {"kind": "artist", "artist": "Acid King"}),
+        ]
+        _build(index, source, publish=publisher)
+        lines = [p["digging"] for p in publisher.raw if p.get("digging")]
+        assert "Kid A" in lines[0]
+        assert "Acid King" in lines[1]
 
     def test_each_item_is_published_as_it_lands(self, index: LibraryIndex) -> None:
         publisher = _Publisher()

--- a/tests/test_discovery_preview.py
+++ b/tests/test_discovery_preview.py
@@ -191,6 +191,7 @@ class Harness:
         source: FakeSource | None = None,
         main_playing: bool = False,
         check_url: Any = None,
+        fade_secs: float = 0.01,
     ) -> None:
         self.index = index
         self.main = FakeEngine()
@@ -223,6 +224,10 @@ class Harness:
             # Default None, so every pre-existing test keeps its exact behaviour
             # and no test reaches the network (KAMP-673).
             check_url=check_url,
+            # How long a fading stop waits before unloading (KAMP-693). Short by
+            # default so the suite does not sleep through real fades; a test that
+            # needs the fade still to be in flight sets it long instead.
+            fade_secs=fade_secs,
         )
 
     @property
@@ -579,6 +584,62 @@ class TestTransport:
         h.player.play(_item(index))
         assert h.player.pause()["state"] == PAUSED
         assert h.player.resume()["state"] == PLAYING
+
+    def test_stop_is_a_hard_cut_by_default(self, index: LibraryIndex) -> None:
+        """Escape and the deck's own stop stay immediate: they are answers to "get
+        off", and a fade there is a delay, not a courtesy."""
+        h = Harness(index)
+        h.player.play(_item(index))
+        assert h.player.stop()["state"] == IDLE
+        assert "unload" in h.engine.calls
+
+    def test_a_fading_stop_rides_the_pause_fade_out(self, index: LibraryIndex) -> None:
+        """KAMP-693 wants the record faded, not cut.
+
+        unload() is mpv's raw `stop` — it drops the audio on the frame it
+        arrives. The only per-sample fade in the engine is the Lua one behind
+        pause(), so a faded stop is that fade followed by the unload, rather than
+        a second ramp written next to it.
+        """
+        h = Harness(index)
+        h.player.play(_item(index))
+        h.player.stop(fade=True)
+        assert "pause" in h.engine.calls
+        assert "unload" not in h.engine.calls
+
+    def test_a_fading_stop_still_unloads_once_the_fade_is_over(
+        self, index: LibraryIndex
+    ) -> None:
+        """The fade only silences it. Without the unload behind it the engine
+        keeps the file loaded and the audio device open, which is the pinned-mpv
+        bug _idle_kill exists to prevent."""
+        h = Harness(index, fade_secs=0.01)
+        h.player.play(_item(index))
+        h.player.stop(fade=True)
+        assert _wait_for(lambda: "unload" in h.engine.calls)
+
+    def test_a_fading_stop_reports_idle_at_once(self, index: LibraryIndex) -> None:
+        """The UI must not wait on the fade. Holding the snapshot back would read
+        as a hang on the one gesture that is supposed to feel like letting go —
+        and the deck clearing while the last moment fades out IS the fade."""
+        h = Harness(index, fade_secs=30.0)
+        h.player.play(_item(index))
+        assert h.player.stop(fade=True)["state"] == IDLE
+
+    def test_a_record_played_after_a_fading_stop_is_not_cut_off_by_it(
+        self, index: LibraryIndex
+    ) -> None:
+        """The deferred unload is the hazard this whole path introduces: it fires
+        on a timer, and by then the user may have put something else on. Unloading
+        then would kill a record they had just started, seconds after an action
+        they had forgotten about."""
+        h = Harness(index, fade_secs=0.01)
+        h.player.play(_item(index))
+        h.player.stop(fade=True)
+        h.player.play(_item(index, "2"))
+        # Long enough for the deferred unload to have fired if it were going to.
+        assert not _wait_for(lambda: "unload" in h.engine.calls, timeout=0.2)
+        assert h.engine.state.playing is True
 
     def test_an_expired_cache_is_refetched(self, index: LibraryIndex) -> None:
         """Signed URLs die after about a day; a stale one would fail silently at

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -35,6 +35,7 @@ from kamp_daemon.discovery_criteria import (
     Seed,
     _genre_top_seeds,
     criteria_for,
+    digging_phrase,
     phrasings,
     seed_dimension,
 )
@@ -241,6 +242,53 @@ class TestCriteriaRegistry:
             assert line.strip()
 
     @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_every_seed_can_say_what_it_is_about_to_do(
+        self, criterion: Criterion
+    ) -> None:
+        """KAMP-693. A dig is 15-30 seconds and this line is what fills them, so
+        every seed of every criterion has to produce one -- a criterion that fell
+        through to a blank would freeze the line for its whole turn, which is the
+        symptom the ticket exists to remove."""
+        for seed in criterion.seeds(RICH_PROFILE):
+            phrase = digging_phrase(criterion.key, seed.seed_data)
+            assert phrase.strip()
+            assert phrase.endswith("…")
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_the_digging_line_names_the_thing_it_is_following(
+        self, criterion: Criterion
+    ) -> None:
+        """The point of the line is that it is specific. "Digging…" for twenty
+        seconds is a spinner with words; naming the record, band or genre being
+        followed is the shop actually being dug through."""
+        # kind -> the seed_data field carrying the subject. Not the same thing:
+        # `genre` and `genre_old` are two kinds naming one field, which is exactly
+        # what lets seed_dimension stop them both taking Rock.
+        fields = {
+            "album": "album",
+            "artist": "artist",
+            "genre": "genre",
+            "genre_old": "genre",
+            "chart": None,  # the chart is about nobody, and says so
+        }
+        subject = "Ambivalent Sausage"
+        for seed in criterion.seeds(RICH_PROFILE):
+            field = fields[seed.seed_data["kind"]]
+            if field is None:
+                continue
+            seeded = {**seed.seed_data, field: subject}
+            assert subject in digging_phrase(criterion.key, seeded)
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_the_digging_line_survives_a_seed_it_does_not_recognise(
+        self, criterion: Criterion
+    ) -> None:
+        """Same reason phrasings degrades rather than raising: this runs inside
+        the gather, and a KeyError here would cost the crate to decorate it."""
+        assert digging_phrase(criterion.key, {}).strip()
+        assert digging_phrase("no_such_criterion", {"kind": "album"}).strip()
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
     def test_thin_profile_never_raises(self, criterion: Criterion) -> None:
         """A brand-new library is the common first run, not an edge case."""
         list(criterion.seeds(SeedProfile()))
@@ -411,6 +459,74 @@ class TestGatherAgainstFixtures:
             "best_seller",
             "older_than_ten",
         }
+
+    def test_the_gather_says_what_it_is_about_to_fetch(self) -> None:
+        """KAMP-693: the 15-30 seconds of a dig, narrated.
+
+        One call per seed actually fetched, which is one per HTTP round trip —
+        that is what makes the line move at the pace the work does rather than on
+        a timer with nothing behind it.
+        """
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        seen: list[tuple[str, dict[str, Any]]] = []
+        _source(session).gather(
+            SeedProfile(top_genres=["ambient"]),
+            crate_budget(),
+            on_seed=lambda criterion, seed: seen.append((criterion, seed)),
+        )
+        assert seen
+        assert len(seen) == len(session.posts)
+        assert all(seed.get("kind") for _criterion, seed in seen)
+
+    def test_the_gather_reports_a_seed_before_fetching_it(self) -> None:
+        """Before, not after: a line that appears once a fetch has RETURNED
+        describes work that is already done, and the last one would never be seen
+        at all."""
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        order: list[str] = []
+        source = _source(session)
+
+        def _note(criterion: str, seed: dict[str, Any]) -> None:
+            order.append(f"say:{criterion}")
+
+        original = source._run_seed
+
+        def _watched(*args: Any, **kwargs: Any) -> Any:
+            order.append("fetch")
+            return original(*args, **kwargs)
+
+        source._run_seed = _watched  # type: ignore[method-assign]
+        source.gather(
+            SeedProfile(top_genres=["ambient"]), crate_budget(), on_seed=_note
+        )
+        assert order[0].startswith("say:")
+        assert order[1] == "fetch"
+
+    def test_a_broken_progress_callback_cannot_cost_the_crate(self) -> None:
+        """It is a line of copy. A criterion that raises is already best-effort
+        here; a narrator that raises must not be worse than that."""
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+
+        def _boom(criterion: str, seed: dict[str, Any]) -> None:
+            raise RuntimeError("no")
+
+        found = _source(session).gather(
+            SeedProfile(top_genres=["ambient"]), crate_budget(), on_seed=_boom
+        )
+        assert found
+
+    def test_a_skipped_seed_is_never_announced(self) -> None:
+        """A seed the crate already covers is skipped without spending a request,
+        so announcing it would put a line on screen for work that never happens —
+        and, worse, name a genre the crate is not actually digging through."""
+        session = FakeSession(post_body=_fixture("discover_web_ambient_top"))
+        seen: list[tuple[str, dict[str, Any]]] = []
+        _source(session).gather(
+            SeedProfile(top_genres=["ambient"]),
+            crate_budget(),
+            on_seed=lambda criterion, seed: seen.append((criterion, seed)),
+        )
+        assert len(seen) == len(session.posts)
 
     def test_discover_payload_matches_the_documented_shape(self) -> None:
         session = FakeSession(post_body=_fixture("discover_web_ambient_top"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1476,7 +1476,28 @@ class TestPlayerWebSocket:
     def test_websocket_sends_initial_state(
         self, mock_index: MagicMock, mock_engine: MagicMock, mock_queue: MagicMock
     ) -> None:
-        mock_engine.state = PlaybackState(playing=True, position=10.0, duration=200.0)
+        # No duration, and that is what makes this deterministic rather than
+        # fast-machine-dependent.
+        #
+        # _state_snapshot extrapolates position from wall-clock while playing,
+        # once position_updated_at is more than 0.3s stale AND duration > 0 —
+        # the KAMP-392 behaviour that test_extrapolates_position_when_time_pos_
+        # events_stale pins. position_updated_at defaults to the moment the state
+        # is CONSTRUCTED, so with a duration set this asserted a raw 10.0 while
+        # creating the exact conditions for it to be extrapolated: on a loaded CI
+        # runner, building the app and completing the websocket handshake took
+        # longer than 0.3s and it failed with 10.30.
+        #
+        # Pinning position_updated_at at construction does NOT fix it — verified,
+        # not assumed — because the staleness accrues between construction and the
+        # read, which is the very interval that varies. Only the duration gate is
+        # under the test's control.
+        #
+        # Dropping it costs nothing: this test asserts the type, playing, position
+        # and the current track, never the duration. playing with duration 0 is
+        # also a real state — it is what every track looks like between file-loaded
+        # and mpv's first duration event.
+        mock_engine.state = PlaybackState(playing=True, position=10.0)
         mock_queue.current.return_value = _track(1)
         app = create_app(index=mock_index, engine=mock_engine, queue=mock_queue)
         c = TestClient(app)


### PR DESCRIPTION
## What

A dig takes 15-30 seconds and the view spent all of them showing **the previous crate's ten records** under a static "Digging through the racks…", with the deck hidden while a record from that crate played on with no transport at all.

Two things in my own re-estimate on the ticket were wrong, and both changed the work. Both were settled by reading rather than argument:

**The wait is the gather, not the placement.** `crate_no = index.next_crate_no()` and the placement loop run *after* `source.gather()` returns, and placement is pure SQL — so the ten "one record at a time" publishes land within milliseconds of each other at the very end. "Populate the row as records are pulled" cannot be honoured literally: the picks do not exist until the gather is over.

**The old crate was not a race, it was the served answer.** The build publishes `crate_no=None` (the new crate has no number yet) and `_snapshot` read that as "use the latest", handing back the previous crate's rows labelled `building`. The client's clear was not merely losing a race — `_warm_wishlist` republishes partway through every build, and a wishlist walk is ~40s, so the old crate came back regardless of who won.

Two more things surfaced that the ticket did not know about, and this had to absorb both:

- **The bin's stock-in cascade has never run.** `CrateBin` is inside the `building ? rail : bin` ternary, so it unmounts when a dig starts and remounts when it ends; a remounted component re-seeds its "first crate I have seen" ref with the *new* number and takes the silent branch. The "records filed one at a time" beat was designed, tuned, and dead on every path since KAMP-656.
- **The preview's stop has never faded.** `PreviewPlayer.stop()` calls `engine.unload()` — mpv's raw `stop` — not the Lua-faded `engine.stop()`. Ask (3) was a daemon change, not a UI one.

Estimate corrected on the ticket: Side → **2xLP**.

## How

Six commits, each standing alone.

**1. Empty the counter** — `_snapshot` no longer falls back to `latest_crate_no()` while `state == "building"`. Scoped to exactly that: `idle` must keep the fallback or a relaunch reports an empty crate, and `empty`/`error` publish `crate_no=None` too, where the previous crate genuinely *is* still on the counter.

**2. Narrate the dig** — the gather already knew what it was doing, one seed at a time, and every seed carries its own provenance because each pick has to explain itself. `digging_phrase()` renders it in the clerk's voice — *"Seeing what sits next to Kid A…"*, *"Pulling the Acid King shelf…"*, *"Working through the top of the dub techno pile…"* — published per seed fetched, so it changes every couple of seconds. Fired **before** the fetch (after would describe finished work, and the last line would never be seen) and **after** the skip check (a skipped seed would name a genre the crate is not digging through). Best-effort: a raising narrator must not be worse than a raising criterion. Cleared at the API's single terminal-state release point, next to the build lock — the same carry-over trap `exhausted` was fixed for.

**3. Let a stop ring the record out** — the fade behind `pause()` followed by the unload, rather than a second ramp to keep in tune (the KAMP-508 lesson is that fade work is where sessions get burned). Opt-in: Escape and the deck's own stop stay cuts, because those are answers to "get off". `FADE_OUT_SECS` is 0.6, four times the 0.15s ramp, because what has to finish is the ~0.2s of already-buffered audio downstream of it. The deferred unload re-checks that the deck is still idle — otherwise it would kill a record the user started in the meantime, seconds after an action they had forgotten.

**4. The deck survives the dig** — the `{!building && …}` gate produced exactly the outcome the comment twenty lines above it calls *"worse than no preview at all"*. `deckItem` now holds the last resolved record across the emptied crate (keyed on the id, so it can never appear under a different one's preview), and `onBlurCapture` falls back to the rail — without it, focus lands on `document.body` and every key this view owns dies for the length of the dig, exactly while Space is what you want. The fade-and-stop hangs off the crate *arriving*, armed by this window's own dig: firing on any transition to `ready` would stop a preview the user deliberately started whenever a WS reconnected.

**5. Put the dig on screen** — the line renders in the header (`aria-live="polite"`, not assertive: it changes ten times a dig), and the empty slots pulse so the row reads as being worked. Opacity only, staggered along the row, 2.4s so it does not compete with the copy. Under `prefers-reduced-motion` there is no pulse and the changing line does the whole job — the honest answer, not a lesser one.

**6. File the records in, and account for a failed dig** — the stock-in decision moves to `CrateView`, which never unmounts. And `empty`/`error` get banners: they never needed one while the old crate stayed on screen, but now the counter empties, twenty seconds pass, and the old records reappear — which without a line reads as the crate having been thrown away and then not.

**7. Give the deck its cell back** (found in review). Keeping the mini player on screen exposed that `.crate-stage--building` had no `deck` area at all — it re-columned to `bin bin bin`, from back when the deck was not rendered during a dig. An unresolvable `grid-area: deck` falls through to auto-placement, so the player landed in an implicit row *below the footer*, the stage's height blew out, everything else crushed into the top-left, and the dig button ended up over the slots. The building template now names `deck` in exactly the cell the ready template uses, and leaves the third column empty in the header and footer rows rather than spanning into it — so the player does not move between digging and dug, which is the point of keeping it there. Header, rail and footer now share one axis over the two columns the dig occupies.

The digging block also reserved 220px against a crate header of ~167px. The header row is `auto`-sized, so that difference moved the deck, the rail and the footer vertically — the same reasoning that fixed the title box at two lines and reserved the clerk card, which had simply never applied *across* the two states before, because there was no deck on screen during a dig to be moved.

## One commit here is not KAMP-693

`test_websocket_sends_initial_state` was failing CI as `assert 10.301820993423462 == 10.0`. It is pre-existing and unrelated: the test is unchanged since the server shipped, this branch touches neither `server.py` nor `test_server.py`, and it passed on commit 6 then failed on commit 7 — which changed one CSS file. A latent flake that loaded runners now trip.

`_state_snapshot` extrapolates position from wall-clock while playing, once `position_updated_at` is >0.3s stale **and** `duration > 0` (the KAMP-392 behaviour that keeps the bar moving when mpv stops emitting `time-pos`). `position_updated_at` defaults to the moment the `PlaybackState` is *constructed* — so the test set a duration, asserted a raw `10.0`, and thereby created the exact conditions for that value to be extrapolated. It passed only while the machine got from construction to the websocket handshake in under 0.3s.

Pinning `position_updated_at` at construction does **not** fix it — verified rather than assumed. The staleness accrues *between* construction and the read, which is the interval that varies; reproduced locally with a 0.5s sleep before connecting, and both the shipped version and the pinned version failed. Only dropping the `duration` passed. Worth saying, because the pinned version looks correct and would have shipped a still-flaky test with a confident comment on it.

So the duration goes. It is the only half of the gate a test can control, and it costs nothing: this test asserts the type, `playing`, `position` and the current track, never the duration. The extrapolation keeps its own two tests, which set `position_updated_at` explicitly because they are about that behaviour.

## Testing

- `poetry run pytest` — **3404 passed**, 9 skipped, coverage 93.87%. 46 new tests.
- `poetry run black` / `mypy` — clean. `npm run typecheck` / `lint` — clean (one pre-existing prettier warning in an untouched file).
- README says nothing about the crate, so no drift.

`kamp_ui` has no test runner, which is why the copy lives in a pure Python function — `digging_phrase` is tested against every criterion's real seeds, including that each line names the thing it is following and that an unrecognised seed degrades rather than raising.

Two test-fake corrections, both the same recurring shape: `_FakeSource` now announces seeds so the builder tests assert what was *published* rather than that a callback was handed over, and `_Publisher` learned the terminal clear it stands in for — it merged exactly like the real publish but never cleared, which would have let a test assert a line still standing under a finished crate.

## Manual test plan

1. **Dig with a crate on screen.** The old ten go immediately and do not come back — watch the full 15-30s, since `_warm_wishlist` republishes partway through and that is exactly when they used to return.
2. **Watch the line.** It should change every couple of seconds and name real things — a record you played, a genre you listen to, a band you own one album by. Nothing invented, nothing repeated ten times.
3. **The slots** should read as being worked, and should not wobble as records land.
4. **Play a record, then dig.** The deck stays visible with working transport for the whole dig; the record keeps playing; when the crate lands it fades out and comes off the platter. It should not move — not sideways, and ideally not vertically either as the crate arrives.
5. **Press `,` `.` Space `w` during a dig** — the keys must still work with an empty crate.
6. **The arrival** — records should file into the bin one at a time. This has never worked, so it is new behaviour rather than a regression check.
7. **Dig twice quickly** (the 409) — the crate on screen must be untouched and nothing should stop playing.
8. **A failed or empty dig** must say so rather than silently restoring the old crate. Force one by pulling the network mid-dig.
9. **Reduced motion** — no pulse, no stock-in, but the line still changes and the crate still arrives.
10. **A non-default palette** — nothing new should introduce a hue.
11. **The main transport during a dig** — park a crate record to the main player (KAMP-678) and dig; the parked record must not be stopped by the completion fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
