### PR TITLE
KAMP-698: halve the time a crate takes to dig

### DIFF
--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -96,11 +96,6 @@ _SEEDS_PER_CRITERION = 2
 _SEEDS_FOR: dict[str, int] = {"also_like": 4}
 
 
-def _seeds_allowed(criterion: Criterion) -> int:
-    """How many seeds *criterion* may read in one crate."""
-    return _SEEDS_FOR.get(criterion.key, _SEEDS_PER_CRITERION)
-
-
 #: How many cards one criterion may contribute to a crate (KAMP-683).
 #:
 #: Module-level rather than inline in the property so a test can assert the crate
@@ -112,6 +107,30 @@ CRITERION_CAPS: dict[str, int] = {
     "genre_top": 1,
     "older_than_ten": 1,
 }
+
+
+def _seeds_allowed(criterion: Criterion) -> int:
+    """How many seeds *criterion* may read in one crate.
+
+    Never more than it can place (KAMP-698). SEED_CAP is 1, so a criterion's card
+    cap IS its seed ceiling — and `genre_top` and `older_than_ten` were each
+    reading two seeds against a cap of one. That second request was pure cost:
+    the backfill pass drops caps and can take a second card from the first seed's
+    remaining twenty-odd items, so the extra fetch bought a card the crate could
+    already have had, on the class that rate-limits hardest.
+
+    Derived from the cap rather than restated as a third list. There are already
+    two of these to keep in agreement, and the symptom of a third disagreeing —
+    a criterion quietly unable to fill its own cap — is invisible in any one
+    crate.
+
+    The cap is a ceiling, never a floor: an uncapped criterion keeps its full
+    allowance, which is what lets `also_like` read four.
+    """
+    allowed = _SEEDS_FOR.get(criterion.key, _SEEDS_PER_CRITERION)
+    cap = CRITERION_CAPS.get(criterion.key)
+    return allowed if cap is None else min(allowed, cap)
+
 
 #: Turns per round of the deal, for criteria worth more of a crate (KAMP-683).
 #: Module-level for the same reason as the caps: the builder suite's fake source

--- a/kamp_daemon/discovery_sources.py
+++ b/kamp_daemon/discovery_sources.py
@@ -15,7 +15,9 @@ document or nothing.
 from __future__ import annotations
 
 import logging
+import threading
 import time as _time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 from kamp_core.proxy_hosts import FETCHABLE_HOSTS, host_allowed
@@ -94,6 +96,13 @@ _SEEDS_PER_CRITERION = 2
 #: checks is exactly eight. No headroom, deliberately spent — the check degrades
 #: to unverified when the budget runs out rather than overrunning it.
 _SEEDS_FOR: dict[str, int] = {"also_like": 4}
+
+#: Gather workers, which is one per endpoint class and deliberately not more
+#: (KAMP-698). There are three classes; a fourth worker would have nothing to do
+#: but queue on a class's own spacing, and workers *within* a class would break
+#: the partition that keeps `used`, the rotation offsets and the budget correct
+#: without a lock between them.
+_GATHER_WORKERS = 3
 
 
 #: How many cards one criterion may contribute to a crate (KAMP-683).
@@ -350,6 +359,7 @@ class BandcampDiscoverySource(DiscoverySource):
         budget: RequestBudget,
         state: "MutableMapping[str, Any] | None" = None,
         on_seed: "Callable[[str, dict[str, Any]], None] | None" = None,
+        max_workers: int = _GATHER_WORKERS,
     ) -> list[Candidate]:
         """Collect candidates across the criteria that suit *profile*.
 
@@ -377,6 +387,13 @@ class BandcampDiscoverySource(DiscoverySource):
         and each is its own request, so per-criterion would leave the line still
         for whole fetches. Skipped seeds are silent — announcing work that never
         happens would name a genre the crate is not digging through.
+
+        With the classes overlapped it also interleaves between them, which is
+        honest: three things really are being looked at. Throttle the line before
+        re-serialising the gather if that ever reads as frantic.
+
+        *max_workers* exists for tests, which need a serial baseline to compare
+        against. 1 runs the classes in order, exactly as this did before KAMP-698.
         """
         out: list[Candidate] = []
         seen: set[str] = set()
@@ -393,29 +410,101 @@ class BandcampDiscoverySource(DiscoverySource):
         # ids, so no database access is needed here.
         owned = set(profile.purchase_dates)
 
-        # Seed dimensions already spoken for in THIS crate (KAMP-665). Criteria
-        # run in sequence here, which is what lets a later one be told what an
-        # earlier one took: genre_top and older_than_ten both read top_genres and
-        # both started at its head, so one genre covered two criteria in the same
-        # crate. Per gather, never persisted — it is about the shape of one crate,
-        # not about what previous crates did (that is rotation's job, KAMP-661).
+        # Seed dimensions already spoken for in THIS crate (KAMP-665): genre_top
+        # and older_than_ten both read top_genres and both start at its head, so
+        # without this one genre covers two criteria in the same crate. Per
+        # gather, never persisted — it is about the shape of one crate, not about
+        # what previous crates did (that is rotation's job, KAMP-661).
+        #
+        # Unsynchronised, and safe, because dimension kinds do not cross endpoint
+        # classes: album dimensions arise only in ALBUM_PAGE criteria, genre only
+        # in DISCOVER_API, artist only in ARTIST_PAGE. So the two criteria that
+        # genuinely collide are both DISCOVER_API and still run in one worker, in
+        # order, exactly as they did serially.
+        # `test_no_seed_dimension_is_shared_across_endpoint_classes` fails loudly
+        # if a future criterion breaks that, rather than leaving a crate to
+        # quietly repeat a genre now and then.
         used: set[str] = set()
 
+        # Created before any worker can race to build one. `_sub` is a
+        # check-then-create on this shared dict, so two workers arriving together
+        # would each make a fresh {} and one would clobber the other — losing a
+        # whole class's rotation, which reads as a criterion that never varies
+        # rather than as a bug.
+        _sub(state, "seeds")
+        _sub(state, "cursors")
+
+        # A 429 is account-wide, not that class's problem (KAMP-639). Serially
+        # this fell out of a bare `break`; concurrently it has to be said out
+        # loud, or the other workers keep hammering an account that has already
+        # been told to stop — turning one rate limit into three.
+        stop = threading.Event()
+
+        # Grouped by endpoint class, REGISTRY order preserved within each group.
+        #
+        # This is the whole change: _MIN_SPACING is keyed per class and wait_turn
+        # reserves its slot under a lock, explicitly so two threads in one class
+        # cannot both go — so the classes never needed to wait on each other. They
+        # did it anyway, purely because this loop was one thread. Serially that is
+        # 6x1.5 + 5x1.0 + 4x1.5 = 20s of enforced spacing; by class it is
+        # max(9, 5, 6) = 9s, with per-request latency parallelising alongside.
+        #
+        # One worker PER CLASS, never per criterion: two workers inside one class
+        # would just queue on that class's spacing, and every ordering property
+        # that matters — `used`, the rotation offsets, the budget — holds because
+        # a class is worked by exactly one thread.
+        groups: dict[str, list[Criterion]] = {}
         for criterion in criteria_for(profile):
-            try:
-                found = self._run_criterion(
-                    criterion, profile, budget, owned, state, used=used, on_seed=on_seed
-                )
-            except RateLimitedError as exc:
-                logger.warning("discovery: stopping gather early — %s", exc)
-                break
-            except Exception:  # noqa: BLE001 - a buggy criterion cannot break the crate
-                logger.warning(
-                    "discovery: criterion %s failed (best-effort)",
-                    criterion.key,
-                    exc_info=True,
-                )
-                continue
+            groups.setdefault(criterion.endpoint_class, []).append(criterion)
+
+        def _run_class(criteria: list[Criterion]) -> list[Candidate]:
+            found: list[Candidate] = []
+            for criterion in criteria:
+                if stop.is_set():
+                    break
+                try:
+                    found.extend(
+                        self._run_criterion(
+                            criterion,
+                            profile,
+                            budget,
+                            owned,
+                            state,
+                            used=used,
+                            on_seed=on_seed,
+                            stop=stop,
+                        )
+                    )
+                except RateLimitedError as exc:
+                    logger.warning("discovery: stopping gather early — %s", exc)
+                    stop.set()
+                    break
+                except Exception:  # noqa: BLE001 - one criterion cannot break the crate
+                    logger.warning(
+                        "discovery: criterion %s failed (best-effort)",
+                        criterion.key,
+                        exc_info=True,
+                    )
+                    continue
+            return found
+
+        if max_workers <= 1 or len(groups) <= 1:
+            results = [_run_class(criteria) for criteria in groups.values()]
+        else:
+            with ThreadPoolExecutor(
+                max_workers=min(max_workers, len(groups)),
+                thread_name_prefix="crate-gather",
+            ) as pool:
+                futures = [
+                    pool.submit(_run_class, criteria) for criteria in groups.values()
+                ]
+                # Collected in submission order, not completion order, so the
+                # dedupe below keeps the same winner every time. A crate assembled
+                # from whichever worker happened to finish first would differ run
+                # to run for no reason the user could see.
+                results = [future.result() for future in futures]
+
+        for found in results:
             for candidate in found:
                 # Dedupe within the gather: ~15% of recommendations recur across
                 # seeds (KAMP-644). Crate-level variety and caps are KAMP-648's.
@@ -434,6 +523,7 @@ class BandcampDiscoverySource(DiscoverySource):
         state: "MutableMapping[str, Any] | None" = None,
         used: set[str] | None = None,
         on_seed: "Callable[[str, dict[str, Any]], None] | None" = None,
+        stop: "threading.Event | None" = None,
     ) -> list[Candidate]:
         """One criterion's worth of candidates, spread over a few seeds.
 
@@ -480,6 +570,13 @@ class BandcampDiscoverySource(DiscoverySource):
         consumed = 0
         for step in range(len(seeds)):
             if productive >= _seeds_allowed(criterion):
+                break
+            # Another class was rate-limited (KAMP-698). Checked per SEED rather
+            # than only between criteria, so a 429 stops the other workers within
+            # one request instead of letting each finish its criterion first —
+            # which for also_like is four more album pages against an account
+            # that has already been told to slow down.
+            if stop is not None and stop.is_set():
                 break
             seed = seeds[(start + step) % len(seeds)]
             if not budget.allow(criterion.endpoint_class):

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -12,7 +12,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,8 +40,10 @@ from kamp_daemon.discovery_criteria import (
     seed_dimension,
 )
 from kamp_daemon.discovery_sources import (
+    CRITERION_CAPS,
     BandcampDiscoverySource,
     RateLimitedError,
+    _SEEDS_PER_CRITERION,
     _seeds_allowed,
 )
 from kamp_core.discovery_api import UNPERSONALISED_CRITERIA
@@ -298,6 +300,46 @@ class TestCriteriaRegistry:
         """crate_budget denies unknown classes, so an undeclared one would return
         empty forever and look exactly like parser drift."""
         assert crate_budget().allow(criterion.endpoint_class) is True
+
+    @pytest.mark.parametrize("criterion", REGISTRY, ids=lambda c: c.key)
+    def test_no_criterion_reads_more_seeds_than_it_can_place(
+        self, criterion: Criterion
+    ) -> None:
+        """A seed is one request against the endpoints that rate-limit hardest,
+        and SEED_CAP is 1, so a criterion's card cap IS its seed ceiling (KAMP-698).
+
+        genre_top and older_than_ten each read two seeds and are capped at one
+        card. The second was pure cost: the backfill pass drops caps and can take
+        a second card from the first seed's remaining twenty-odd items, so the
+        extra fetch bought a card the crate could already have had.
+        """
+        cap = CRITERION_CAPS.get(criterion.key)
+        if cap is None:
+            return
+        assert _seeds_allowed(criterion) <= cap
+
+    def test_the_seed_allowance_is_derived_from_the_cap_not_restated(self) -> None:
+        """Raising a cap must raise the seeds that serve it, with nothing to edit.
+
+        There are already two lists to keep in agreement (_SEEDS_FOR and
+        CRITERION_CAPS); a third hardcoded one would be a third chance for them to
+        disagree silently, and the symptom — a criterion quietly unable to fill
+        its own cap — is invisible in any single crate.
+        """
+        capped = next(c for c in REGISTRY if CRITERION_CAPS.get(c.key) == 1)
+        assert _seeds_allowed(capped) == 1
+        with patch.dict(
+            "kamp_daemon.discovery_sources.CRITERION_CAPS", {capped.key: 3}
+        ):
+            assert _seeds_allowed(capped) == _SEEDS_PER_CRITERION
+
+    def test_an_uncapped_criterion_keeps_its_full_allowance(self) -> None:
+        """The cap is a ceiling, never a floor. also_like is uncapped and reads
+        four seeds because KAMP-683 wants four also-like records off four
+        different album pages."""
+        also_like = next(c for c in REGISTRY if c.key == "also_like")
+        assert also_like.key not in CRITERION_CAPS
+        assert _seeds_allowed(also_like) == 4
 
     def test_thin_profile_still_yields_the_chart_criterion(self) -> None:
         """The un-personalised fallback: a new user gets a crate, not an apology."""
@@ -1123,6 +1165,31 @@ class TestACrateReflectsTheLibrarysRange:
         assert budget.spent[DISCOVER_API] <= budget.limits[DISCOVER_API]
         assert budget.spent.get(ARTIST_PAGE, 0) <= budget.limits[ARTIST_PAGE]
         assert budget.spent.get(FANCOLLECTION, 0) == 0
+
+    def test_a_capped_criterion_costs_one_request_not_two(self) -> None:
+        """The saving, pinned exactly rather than as an upper bound (KAMP-698).
+
+        The budget test above asserts `<= limits` and would stay green whichever
+        way this moved — in either direction, which is the more dangerous half.
+
+        Driven from a 25-genre profile because RICH_PROFILE carries ONE, and with
+        one genre both genre_top seeds name it: the second is skipped by the
+        `used` guard before it costs anything, so a single-genre profile cannot
+        see this change at all. That is exactly the trap that made the first
+        measurement of this ticket read "no saving".
+
+        Three DISCOVER_API requests for three criteria, each capped at one card.
+        It was five. The candidates gathered are unchanged.
+        """
+        budget = crate_budget()
+        session = FakeSession(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        profile = replace(RICH_PROFILE, top_genres=[f"genre-{i}" for i in range(25)])
+        found = _source(session).gather(profile, budget, {})
+        assert budget.spent[DISCOVER_API] == 3
+        assert found
 
     def test_no_criterion_is_starved_by_the_budget(self) -> None:
         """The failure the budget test above cannot see (KAMP-658).

--- a/tests/test_discovery_sources.py
+++ b/tests/test_discovery_sources.py
@@ -1037,6 +1037,160 @@ class TestSpreadWithinACrate:
         ), "genre_top consumed the whole discover allowance"
 
 
+class TestTheGatherOverlapsItsEndpointClasses:
+    """KAMP-698. A dig was 15-30 seconds and every request in it was serial.
+
+    `_MIN_SPACING` is keyed per endpoint class and `wait_turn` reserves its slot
+    under a lock -- explicitly so two threads in one class cannot both go -- so
+    the three classes never needed to wait on each other. They did it anyway,
+    purely because gather looped criteria in one thread.
+    """
+
+    def test_the_classes_run_at_the_same_time(self) -> None:
+        """The whole point, and it has to be asserted on OVERLAP rather than on
+        elapsed time, which would be a flaky way to say the same thing.
+
+        Each class records when it is inside a fetch. If the gather is serial, no
+        two classes are ever in one at the same moment.
+        """
+        import threading
+
+        inside: dict[str, int] = {}
+        overlapped: set[frozenset[str]] = set()
+        lock = threading.Lock()
+        gate = threading.Barrier(3, timeout=5)
+
+        class _Watched(FakeSession):
+            def _note(self, endpoint_class: str) -> None:
+                with lock:
+                    inside[endpoint_class] = inside.get(endpoint_class, 0) + 1
+                    live = {k for k, v in inside.items() if v > 0}
+                    if len(live) > 1:
+                        overlapped.add(frozenset(live))
+
+            def get(self, url: str, timeout: int = 30) -> Any:
+                cls = ARTIST_PAGE if url.endswith("/music") else ALBUM_PAGE
+                self._note(cls)
+                try:
+                    gate.wait()
+                except threading.BrokenBarrierError:
+                    pass
+                resp = super().get(url, timeout)
+                with lock:
+                    inside[cls] -= 1
+                return resp
+
+            def post(self, url: str, **kw: Any) -> Any:
+                self._note(DISCOVER_API)
+                try:
+                    gate.wait()
+                except threading.BrokenBarrierError:
+                    pass
+                resp = super().post(url, **kw)
+                with lock:
+                    inside[DISCOVER_API] -= 1
+                return resp
+
+        session = _Watched(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        _source(session).gather(RICH_PROFILE, crate_budget(), {})
+        # The barrier only releases when three different classes are waiting in a
+        # fetch at once, so reaching this line at all is the property. The
+        # recorded set makes the failure message say which classes made it.
+        assert overlapped, "no two endpoint classes were ever in flight together"
+
+    def test_the_same_candidates_come_back(self) -> None:
+        """Concurrency must not change WHAT a crate is offered, only when.
+
+        Compared against a deliberately serialised run of the same source, so
+        this stays true if the grouping or merge order is ever reworked.
+        """
+
+        def _gather(max_workers: int) -> list[str]:
+            session = FakeSession(
+                get_body=_fixture("album_page_with_recs"),
+                post_body=_fixture("discover_web_ambient_top"),
+            )
+            found = _source(session).gather(
+                RICH_PROFILE, crate_budget(), {}, max_workers=max_workers
+            )
+            return [c.provider_item_id for c in found]
+
+        assert _gather(1) == _gather(4)
+
+    def test_the_request_count_per_class_is_unchanged(self) -> None:
+        """The one number that must not move. These endpoints rate-limit hardest
+        and a 429 cascades account-wide (KAMP-639), so overlapping them is only
+        acceptable while it costs exactly what it cost before."""
+
+        def _spend(max_workers: int) -> dict[str, int]:
+            session = FakeSession(
+                get_body=_fixture("album_page_with_recs"),
+                post_body=_fixture("discover_web_ambient_top"),
+            )
+            budget = crate_budget()
+            _source(session).gather(RICH_PROFILE, budget, {}, max_workers=max_workers)
+            return dict(budget.spent)
+
+        assert _spend(4) == _spend(1)
+
+    def test_a_rate_limit_in_one_class_stops_every_class(self) -> None:
+        """A 429 is account-wide, not that class's problem (KAMP-639).
+
+        Serially this fell out of a bare `break`. Concurrently it has to be said
+        out loud, or the other two workers keep hammering an account that has
+        already been told to stop -- turning one rate limit into three.
+        """
+        session = FakeSession(get_body=_fixture("album_page_with_recs"))
+        session.post_status = 429
+        budget = crate_budget()
+        profile = replace(RICH_PROFILE, top_genres=[f"g{i}" for i in range(25)])
+        _source(session).gather(profile, budget, {}, max_workers=4)
+        # The discover worker hits the 429 on its first request; the album and
+        # artist workers must not spend their full allowance afterwards.
+        assert budget.spent.get(ALBUM_PAGE, 0) < budget.limits[ALBUM_PAGE]
+
+    def test_the_rotation_survives_concurrent_writers(self) -> None:
+        """`_sub` is a check-then-create on the shared state dict, so two workers
+        would each build a fresh {} and one would clobber the other's offsets --
+        losing a whole class's rotation silently, which reads as a criterion that
+        never varies rather than as a bug."""
+        state: dict[str, Any] = {}
+        session = FakeSession(
+            get_body=_fixture("album_page_with_recs"),
+            post_body=_fixture("discover_web_ambient_top"),
+        )
+        _source(session).gather(RICH_PROFILE, crate_budget(), state, max_workers=4)
+        ran = {c.key for c in criteria_for(RICH_PROFILE)}
+        recorded = set(state.get("seeds", {}))
+        assert ran <= recorded, f"lost rotation for {sorted(ran - recorded)}"
+
+    def test_no_seed_dimension_is_shared_across_endpoint_classes(self) -> None:
+        """The property that lets `used` be partitioned by worker.
+
+        Album dimensions arise only in ALBUM_PAGE criteria, genre only in
+        DISCOVER_API, artist only in ARTIST_PAGE -- so the two criteria that
+        genuinely collide over genres are both DISCOVER_API and stay in one
+        thread, in order, exactly as before.
+
+        `used` is locked anyway, so correctness does not rest on this. What this
+        guards is the REASONING: a future criterion that read genres off an album
+        page would make the guard order-dependent, and this fails loudly instead
+        of producing a crate that quietly repeats a genre now and then.
+        """
+        kinds: dict[str, set[str]] = {}
+        for criterion in REGISTRY:
+            for seed in criterion.seeds(RICH_PROFILE):
+                dimension = seed_dimension(seed.seed_data)
+                if dimension is not None:
+                    kind = dimension.split(":", 1)[0]
+                    kinds.setdefault(kind, set()).add(criterion.endpoint_class)
+        straddling = {k: v for k, v in kinds.items() if len(v) > 1}
+        assert not straddling, f"dimension kinds spanning classes: {straddling}"
+
+
 class TestGenreExclusionAcrossCriteria:
     def test_the_two_genre_criteria_do_not_take_the_same_genre(self) -> None:
         """Both read top_genres and both started at its head, so one genre


### PR DESCRIPTION
## Measured

Real governor spacing, fake network, 25-genre profile:

| | wall clock | requests | candidates |
|---|---|---|---|
| main | 10.04s | album 3, discover 5, artist 4 = **12** | 26 |
| this branch | **4.52s** | album 3, discover 3, artist 4 = **10** | 26 |

**55% faster, two fewer requests, the same 26 candidates.** That is spacing only — in production the per-request network latency parallelises on top of it, so a real 15-30 second dig should improve at least proportionally.

## The ticket changed shape, and why

KAMP-698 arrived as *"use buffered stock to reduce gather cost"*: pull 1-5 records from the KAMP-657 buffer per crate. Measuring before starting killed the mechanism and left the goal standing, so the ticket keeps the goal and the buffer work is re-filed as **KAMP-701**. Two findings did it:

**The gather cannot shrink to pay for stock.** I had proposed scaling `crate_budget()` down in proportion. The codebase had already written down why that fails, in a comment I should have read first — `_SEEDS_FOR`: *"the class is funded at 8: four here plus two for purchase_anniversary plus about two for KAMP-670's playability checks is exactly eight. **No headroom, deliberately spent.**"* `confirm_playable` gates on `budget.allow(ALBUM_PAGE)` and no other class, so shrinking that budget takes KAMP-670 first. The other two classes have zero slack at all, and cutting them is not a proportional dial — criteria run in REGISTRY order until their class budget says no, so it deletes `older_than_ten` and `lone_album_artist` outright.

**The buffer holds 19 usable cards, not 269.** Only 73 rows belong to criteria the caps can still accept (196 of 269 are the three impersonal criteria KAMP-683 capped at one card each, and the fresh pass already places one of each), and SEED_CAP collapses those 73 to 19 distinct seed dimensions. KAMP-701 carries the full measurements and the three defects that must be fixed before stock can be dealt at all.

## How

**1. Stop fetching seeds a criterion cannot place.** SEED_CAP is 1, so a criterion's card cap *is* its seed ceiling — and `genre_top` and `older_than_ten` were each reading two seeds against a cap of one. The second request was pure cost: the backfill pass drops caps, so it can take a second card from the first seed's remaining twenty-odd items whenever a crate needs one. `_seeds_allowed` now derives from the cap rather than being restated as a third list to keep in agreement.

*The measurement trap here is worth knowing:* `RICH_PROFILE` carries **one** genre, and with one genre both `genre_top` seeds name it — the second is skipped by the `used` guard before it costs anything. So a single-genre profile cannot see this change at all, and the first before/after came back identical. The new test drives 25 genres for exactly that reason, and pins the count **exactly**; the existing budget test asserts `spent <= limits` and would have stayed green whichever way this moved, including upward.

**2. Overlap the endpoint classes.** `_MIN_SPACING` is keyed per class (1.5 / 1.0 / 1.5s) and `wait_turn` reserves its slot under a lock, explicitly so two threads in one class cannot both go. The three classes have never needed to wait on each other — they did it anyway, purely because the loop was one thread.

**One worker per class, never per criterion.** That is not tuning; it is what makes the whole thing correct with no lock anywhere:

- **`used`** — dimension kinds do not cross classes (album only in ALBUM_PAGE, genre only in DISCOVER_API, artist only in ARTIST_PAGE), so the two criteria that genuinely collide over genres are both DISCOVER_API and still run in one worker, in order. A test asserts that partition rather than a comment claiming it.
- **The budget** — each class is spent by exactly one worker, and `confirm_playable`'s ALBUM_PAGE draw happens later in `select_crate`, after every worker has joined. **I wrote a lock for `SimpleBudget` first and threw it away**: the test I wrote to justify it passed without it, and no test I could write would fail, because there is no cross-thread access to protect.
- **The rotation** — `_sub` is a check-then-create on the shared state dict, so two workers arriving together would each build a fresh `{}` and one would clobber the other, losing a whole class's rotation. Both sub-dicts are created before any worker starts.

**A 429 stops every class.** Serially that fell out of a bare `break`; concurrently it has to be said out loud, or the other workers keep hammering an account already told to stop — the KAMP-639 cascade exactly. Checked per *seed*, so the stop lands within one request rather than after `also_like`'s remaining four album pages.

Results are collected in submission order, not completion order: the dedupe keeps the first of a duplicate, and a crate assembled from whichever worker finished first would differ run to run for no reason a user could see.

The `requests.Session` stays shared — it already is, with the `wishlist-warm` thread that walks ~9 pages concurrently with every build since KAMP-652.

## Testing

- `poetry run pytest` — **3420 passed**, 9 skipped, coverage 93.87%.
- `black` / `mypy` — clean. README has nothing about the crate, so no drift.

Nine new tests. The concurrency ones assert on *overlap* (a barrier that only releases when three classes are in a fetch at once) rather than on elapsed time, which would be a flaky way to say the same thing; and candidates and per-class request counts are compared against a genuine serial baseline via `max_workers=1` rather than against recorded expectations that would drift.

## Manual test plan

1. **Dig a crate and time it.** Should take roughly half as long — this is the whole ticket.
2. **Watch the digging line** (KAMP-693). It now interleaves between classes and changes faster. It should still name real records, bands and genres. If it reads as frantic, say so — the fix is throttling the line, not re-serialising the gather.
3. **Dig several crates in a row.** No rate-limit banner, no "the distributor's on the phone" countdown where there was none before.
4. **Check the crate's shape.** Ten records, and `older_than_ten` / `lone_album_artist` still turn up across a few crates — they run last in their classes and are the canaries for a budget or ordering mistake.
5. If a Windows build is cheap to get: dig there too. The Electron relay is the one place concurrency has bitten before (KAMP-640) and macOS cannot show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
