### PR TITLE
KAMP-699: drop the "that's the crate" line, always offer the way out

### DIFF
--- a/kamp_core/discovery_api.py
+++ b/kamp_core/discovery_api.py
@@ -283,14 +283,16 @@ def register_discovery_routes(
         # The digging history rides along rather than being fetched separately
         # (KAMP-655). Five COUNTs over two small indexed tables, against a
         # snapshot that already reads every row of the crate -- so the numbers
-        # are live with no second request and no staleness, and the end-of-crate
-        # tally cannot drift from the lifetime line.
+        # are live with no second request and no staleness.
+        #
+        # The crate-scoped tally that used to sit beside this is gone (KAMP-699)
+        # along with the end-of-crate line it fed. It was another five COUNTs, and
+        # this function runs once per placed record during a build plus on every
+        # reconnect -- fifty a build for a field the renderer no longer read.
+        # `GET /api/v1/discovery/stats` still serves the same aggregates, and
+        # LibraryIndex.discovery_stats keeps its crate_no parameter: the cost was
+        # in calling it, not in the WHERE clause existing.
         snap["stats"] = index.discovery_stats()
-        # Scoped to the crate on screen, which is always the LATEST one -- see
-        # crate_no above. If crate browsing ever arrives this has to follow it.
-        snap["crate_stats"] = (
-            index.discovery_stats(crate_no=crate_no) if crate_no is not None else None
-        )
         return snap
 
     def _publish(fields: dict[str, Any]) -> None:

--- a/kamp_ui/src/renderer/src/api/client.ts
+++ b/kamp_ui/src/renderer/src/api/client.ts
@@ -619,11 +619,9 @@ export type CrateSnapshot = {
   thin: boolean // a library with no listening history yet — chart picks only
   items: CrateItem[]
   // KAMP-655: the digging history, computed on read and carried here so the
-  // numbers are live without a second request. `crate_stats` is the same five
-  // counts scoped to this crate — null when there is no crate to tally, which is
-  // different from a crate of zero.
+  // numbers are live without a second request. The crate-scoped tally that used
+  // to sit beside this went with the end-of-crate line it fed (KAMP-699).
   stats: DiggingStats
-  crate_stats: DiggingStats | null
 }
 
 // Deliberately not mutually exclusive: a record you previewed, wishlisted and

--- a/kamp_ui/src/renderer/src/assets/crate.css
+++ b/kamp_ui/src/renderer/src/assets/crate.css
@@ -312,15 +312,6 @@
   text-align: center;
 }
 
-/* The closing beat when you reach the last record. One step less dim than the
-   lifetime line, because it is about what just happened. */
-.crate-tally {
-  margin: 10px 0 0;
-  color: var(--text);
-  font-size: 13px;
-  text-align: center;
-}
-
 /* --- The bin (KAMP-656, prototype) ---------------------------------------
  *
  * A three-quarter crate of records you flip through, rendering exactly the state

--- a/kamp_ui/src/renderer/src/components/CrateView.tsx
+++ b/kamp_ui/src/renderer/src/components/CrateView.tsx
@@ -50,18 +50,6 @@ function describeHistory(s: DiggingStats): string {
   return parts.join(' · ')
 }
 
-// One crate's tally. Omits the zeroes: "0 brought home" at the end of a crate
-// reads as a reprimand, which is the opposite of what this is for.
-function describeTally(s: DiggingStats): string {
-  const parts: string[] = []
-  if (s.previewed > 0) parts.push(`${s.previewed} previewed`)
-  if (s.wishlisted > 0) parts.push(`${s.wishlisted} set aside`)
-  if (s.purchased > 0) parts.push(`${s.purchased} brought home`)
-  return parts.length > 0
-    ? `${plural(s.records, 'record')} — ${parts.join(', ')}.`
-    : `${plural(s.records, 'record')}.`
-}
-
 export function CrateView({ active = false }: { active?: boolean }): React.JSX.Element {
   const crate = useStore((s) => s.crate)
   const newCrate = useStore((s) => s.newCrate)
@@ -148,51 +136,11 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   // *add* for something already owned (KAMP-654).
   const purchased = current?.state === 'purchased'
 
-  // KAMP-655. Both ride the crate snapshot, so they are live without a fetch and
-  // the tally cannot drift from the lifetime line.
+  // The lifetime line, riding the crate snapshot so it is live without a fetch
+  // (KAMP-655). The per-crate tally that used to sit beside it is gone with the
+  // closing line it fed (KAMP-699) — these counts belong to the register under
+  // the buttons, not to a moment.
   const history = crate?.stats ?? null
-  const crateTally = crate?.crate_stats ?? null
-
-  // Reaching the end of a crate is an EVENT, not a position (KAMP-663).
-  //
-  // This used to read the cursor live — `items.length > 1 && focusIndex ===
-  // items.length - 1` — so the closing line vanished the instant you flipped
-  // back a record and announced itself again on your way forward. The ticket
-  // asks for it once per crate; the shipped code gave it once per visit to the
-  // last sleeve. Recording the crate you have reached the end of fixes both,
-  // and self-invalidates the way `focus` does: a crate that is not the one
-  // recorded simply has no beat yet.
-  //
-  // A click straight to the last title COUNTS. Requiring the user to have
-  // stepped there was considered and rejected: jumping to the end of the crate
-  // is still going to the end of the crate, and the line reports what is in the
-  // crate — records, and ledger-derived counts — rather than narrating how
-  // diligently they arrived.
-  // Adjusted during render rather than in an effect. This is React's documented
-  // shape for "derive from what just changed" and the one the compiler's
-  // set-state-in-effect rule pushes you to: the re-render happens before
-  // anything commits, so there is no frame where the user is standing at the end
-  // of the crate with no line under it.
-  const [endedCrate, setEndedCrate] = useState<number | null>(null)
-  // `building` is load-bearing, not defensive. A build streams one record at a
-  // time, and with the first one placed `items.length - 1` is 0 — which is
-  // exactly where a new crate's focus sits, so without this the beat fires on
-  // record one of ten and then sits there for the rest of the dig.
-  if (
-    !building &&
-    crateNo !== null &&
-    items.length > 0 &&
-    focusIndex === items.length - 1 &&
-    endedCrate !== crateNo
-  ) {
-    setEndedCrate(crateNo)
-  }
-
-  // Not `endedCrate === crateNo` alone: newCrate() empties the items but leaves
-  // crate_no alone until the daemon says otherwise (store.ts), so the line has
-  // to go the moment the stage does. A 409 leaves the items in place and this
-  // stays true, which is right — that crate is still on screen and still ended.
-  const atCrateEnd = endedCrate !== null && endedCrate === crateNo && hasCrate && !building
 
   // A crate LANDING, which is what the bin's stock-in cascade plays for
   // (KAMP-656, fixed in KAMP-693).
@@ -253,8 +201,10 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
   )
 
   // Held across the dig, and adjusted DURING RENDER rather than in an effect or a
-  // ref — the compiler forbids both, and this is React's documented pattern for
-  // it (the same one `endedCrate` uses below).
+  // ref — the compiler forbids both (`set-state-in-effect`, and "Cannot access
+  // refs during render"), and this is React's documented pattern for deriving
+  // from what just changed. The re-render happens before anything commits, so
+  // there is no frame showing an empty deck under audible music.
   //
   // Keyed on the id throughout, so a held record can never appear under a
   // DIFFERENT one's preview. The crate it came from is gone; its identity is
@@ -1109,29 +1059,22 @@ export function CrateView({ active = false }: { active?: boolean }): React.JSX.E
           </div>
         </div>
 
-        {/* Statement, then offer, then the quiet register (KAMP-663). The tally
-            used to sit UNDER the button, which read as a footnote to the next
-            dig rather than as the close of this one. Order only — the row keeps
-            the footer exactly as tall either way, which matters because the beat
-            lands when nine records are on the flipped pile at its full extent
-            and the bin row has a fixed height inside a view that never
-            scrolls. */}
+        {/* Two offers over the quiet register.
+
+            KAMP-663 put a closing line above these — "That's the crate", plus
+            that crate's counts — and gated the way out until you reached the
+            last record. Both are gone (KAMP-699). The counts were superfluous
+            beside the lifetime register directly below them, and the way out is
+            useful whether or not you have finished: a shop you can only leave
+            from the back of the last rack is not offering much of an exit.
+
+            Nothing announces the end of a crate now, which also means nothing
+            has to remember where the end WAS — the sticky-beat state that
+            existed only to fire that line once per crate went with it. */}
         <div className="crate-footer">
-          {/* The closing beat, at the moment the user has actually just done the
-              digging rather than as a running score. A one-record crate gets one
-              too (KAMP-663) — reaching the end of a short crate is still
-              reaching the end, and the old `items.length > 1` guard denied a
-              closing line to exactly the crates that came up thin. */}
-          {atCrateEnd && crateTally && (
-            <p className="crate-tally" role="status">
-              That&rsquo;s the crate. {describeTally(crateTally)}
-            </p>
-          )}
-          {/* One row whether it holds one button or two, so offering the way out
-              costs no height at the moment there is none to spare. */}
           <div className="crate-actions">
             {digButton}
-            {atCrateEnd && enoughButton}
+            {enoughButton}
           </div>
           {history && <p className="crate-history">{describeHistory(history)}</p>}
         </div>

--- a/kamp_ui/src/renderer/src/store.ts
+++ b/kamp_ui/src/renderer/src/store.ts
@@ -1015,18 +1015,18 @@ export const useStore = create<PlayerStore>((set, get) => ({
       await api.newCrate()
       // Clear the old records once the dig is ACCEPTED (KAMP-672).
       //
-      // The daemon builds into a new crate_no and the snapshot serves
-      // latest_crate_no(), so until the first record of the new crate is placed
-      // the old one is still what comes back — it sat there looking live while a
-      // different crate was being dug, and the first new record then appeared
-      // among the previous ten.
+      // The daemon stopped serving the previous crate mid-build in KAMP-693, so
+      // this is no longer the fix for that — it covers the window between the
+      // POST resolving and the daemon's own `building` snapshot arriving, which
+      // is short but is the difference between the crate going now and going a
+      // moment after the click.
       //
       // AFTER the await, never before: a 409 ("a crate is already building") is a
       // real outcome, and clearing optimistically would empty the crate the user
       // is still reading for a request we lost. `state` is left alone so the
       // daemon's own 'building' stays authoritative; only the stale rows go.
       const crate = get().crate
-      if (crate) set({ crate: { ...crate, items: [], crate_stats: null } })
+      if (crate) set({ crate: { ...crate, items: [] } })
     } catch (err) {
       set({ crateStopArmed: false })
       const msg = err instanceof Error ? err.message : 'Could not dig a crate'

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -277,17 +277,17 @@ class TestCrateSnapshot:
             "Title 2",
         ]
 
-    def test_a_build_reports_no_crate_stats_before_it_has_a_crate(
-        self, index: LibraryIndex, harness: _Harness
-    ) -> None:
-        """crate_stats is scoped to the crate on screen, and during a dig there
-        is none -- reporting the previous crate's tally under a crate that is not
-        there is the same lie in a different field."""
-        _stock(index, 1, count=10)
-        harness.publish({"state": "building", "crate_no": None})
-        assert (
-            harness.client.get("/api/v1/discovery/crate").json()["crate_stats"] is None
-        )
+    def test_the_snapshot_carries_no_per_crate_tally(self, harness: _Harness) -> None:
+        """KAMP-699. The end-of-crate line these fed is gone, and nothing else
+        ever read them.
+
+        Asserted as an ABSENCE rather than just deleted, because the cost was in
+        computing them: five COUNT queries inside every _snapshot(), and a
+        snapshot is built once per placed record during a build plus on every
+        reconnect. A well-meaning re-add would be fifty COUNTs a build for a
+        field with no consumer, and nothing else would notice.
+        """
+        assert "crate_stats" not in harness.client.get("/api/v1/discovery/crate").json()
 
     @pytest.mark.parametrize("state", ["idle", "ready", "empty", "error", "paused"])
     def test_every_other_state_still_falls_back_to_the_latest_crate(
@@ -466,18 +466,15 @@ class TestDiggingHistoryRoutes:
     def test_the_snapshot_carries_the_history(
         self, index: LibraryIndex, harness: _Harness
     ) -> None:
-        """Riding the snapshot is what keeps the numbers live without a second
-        request, and what stops the tally and the lifetime line disagreeing."""
+        """Riding the snapshot is what keeps the lifetime line live without a
+        second request."""
         _stock(index, 1, count=2)
         body = harness.client.get("/api/v1/discovery/crate").json()
         assert body["stats"]["records"] == 2
-        assert body["crate_stats"]["records"] == 2
 
-    def test_an_empty_library_reports_no_crate_stats(self, harness: _Harness) -> None:
-        """There is no crate to tally, which is different from a crate of zero."""
+    def test_an_empty_library_reports_a_zeroed_history(self, harness: _Harness) -> None:
         body = harness.client.get("/api/v1/discovery/crate").json()
         assert body["stats"]["records"] == 0
-        assert body["crate_stats"] is None
 
     def test_the_endpoint_and_the_snapshot_agree(
         self, index: LibraryIndex, harness: _Harness


### PR DESCRIPTION
## What

Reaching the last record of a crate announced *"That's the crate"* with that crate's counts, and only then revealed the way out. Both were KAMP-663's, and this reverses about half of it.

The counts were superfluous — the lifetime register sits directly below them, so the closing line was a second, narrower set of the same numbers a line apart. And gating the exit on reaching the end made it useless exactly when someone wants it: a shop you can only leave from the back of the last rack is not offering much of an exit.

## How

**1. Delete the line, ungate the button.** Out go the `.crate-tally` paragraph, `describeTally`, `crateTally` and its CSS.

The interesting part is what stops being *needed*. The sticky-beat machinery — `endedCrate`, the adjust-during-render block recording which crate the user has reached the end of, and `atCrateEnd` — existed for one purpose: fire that line once per crate rather than every time the user flipped back to the last sleeve and forward again. With nothing to fire, there is nothing to remember, and a whole piece of derived state and its guards go with the paragraph. That state was not incidental complexity; it was the honest cost of the feature, and the feature is what was not worth it.

**Deliberately not in the empty/error state** (decided with you). That is a separate early return, reached when nothing has ever been dug or a dig failed with no previous crate. "That's enough for today" means *I have finished digging*, and there is nothing there to have had enough of — the dig button stays the single clear offer, with the sidebar and Escape still available.

The footer gets **shorter, never taller**, which is the safe direction: it lives in a view that never scrolls, above a bin row of fixed height, with a flipped pile that hangs well below its own box.

**2. Drop `crate_stats` from the wire.** The deletion left it with no reader at all — it was never a general-purpose field, it existed to feed that one paragraph. Worth removing rather than leaving because the cost is *per publish*: five COUNT queries inside every `_snapshot()`, and `_snapshot()` runs once per placed record during a build plus on every reconnect. **Fifty COUNTs a build for a field nothing reads.**

Nothing is lost — `GET /api/v1/discovery/stats` still serves the same aggregates, and it is the route that exists for the question. `LibraryIndex.discovery_stats` **keeps** its `crate_no` parameter: only tests pass it now, which usually argues for deletion, but the saving was in not *calling* it fifty times a build, not in the `WHERE` clause existing, and one function serving both scopes is deliberate so the two figures cannot disagree.

The new test asserts the field's **absence** rather than just dropping the old assertions — a well-meaning re-add would be fifty COUNTs a build again with nothing else in the suite to notice.

Three comments were corrected rather than left: `heldDeckItem` cited *"the same pattern `endedCrate` uses below"* as its precedent for adjusting state during render, which dies here; the snapshot claimed the crate tally "cannot drift from the lifetime line", a relationship that no longer has two sides; and `newCrate`'s clear said it existed because the daemon served the previous crate until the first new record was placed — true when KAMP-672 wrote it, fixed at the source in KAMP-693, and now covering only the shorter window before the `building` snapshot arrives.

## Testing

- `poetry run pytest` — **3420 passed**, 9 skipped, coverage 93.88%.
- `black` / `mypy` clean; `npm run typecheck` / `lint` clean (one pre-existing prettier warning in an untouched file).
- `test_rest_and_ws_snapshots_are_the_same_shape` compares whole payloads, so it guarded the field removal for free.
- README has nothing about the crate, so no drift.

`kamp_ui` has no test runner, so the UI half is verified by reading and by looking at it. The typecheck is what proves no reader of `crate_stats` was missed now that the type no longer has it.

## Manual test plan

1. **Open a crate.** Both buttons are there immediately — no waiting until the last record.
2. **Flip to the last record.** No "That's the crate" line, and the footer does not change height on arrival.
3. **Press "That's enough for today" from the _first_ record.** It should leave the Crate and stop any preview, exactly as it did from the last one.
4. **The lifetime line** under the buttons still reads correctly — those are the counts being kept.
5. **Dig a new crate.** The footer is unchanged throughout the build and after it lands.
6. **The empty and error states** still show only the dig button, with no exit.
7. **A one-record crate** — nothing special at its end either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
